### PR TITLE
Standardize results into a two-family contract (VanillaSC/FDID/TSSC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ dist/
 # Coverage files
 .coverage
 coverage.xml
+
+# Personal Claude Code overrides (not team-shared)
+.claude/settings.local.json
+
+# Stray plot artifact emitted by some tests
+y_lexplot.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,16 +32,24 @@ python benchmarks/run_benchmarks.py --all     # durable paper/reference validati
 1. **Every estimator has a dedicated Pydantic config** inheriting
    `BaseEstimatorConfig` (or `BaseMAREXConfig`), with `extra="forbid"`,
    `Field(...)` descriptions, and validators that fail early with
-   `MlsynthConfigError` / `MlsynthDataError`. No free-form kwargs.
+   `MlsynthConfigError` / `MlsynthDataError`. No free-form kwargs. The shared
+   bases live in `config_models.py`; per-estimator configs are being relocated
+   next to their helpers (`utils/<name>_helpers/config.py`) and re-exported
+   from `config_models.py` for backward compatibility.
 2. **Data ingestion goes through `mlsynth.utils.datautils.dataprep`** (or a
    `<name>_helpers/setup.py` that wraps it). Do not hand-pivot pandas in an
    estimator — `dataprep` returns the canonical `Ywide` / `y` / `donor_matrix`
    / `pre_periods` / `post_periods` contract.
-3. **Results use the standardized models** in `config_models.py`
-   (`BaseEstimatorResults`, `EffectsResults`, `FitDiagnosticsResults`,
-   `TimeSeriesResults`, `WeightsResults`, `InferenceResults`,
-   `MethodDetailsResults`) — or a frozen `<name>_helpers/structures.py`
-   dataclass that mirrors them. No ad-hoc dicts as the public return.
+3. **Results use the two-family contract** (see `agents/agents_results.md`):
+   every `fit()` returns an `EffectResult` (observational; alias of
+   `BaseEstimatorResults`) or a `DesignResult` (experimental design, whose
+   `report` is an `EffectResult`) — both subclass `MlsynthResult`. Result
+   containers are **Pydantic models** (frozen where practical) that populate
+   the standardized sub-models (`EffectsResults`, `FitDiagnosticsResults`,
+   `TimeSeriesResults`,
+   `WeightsResults`, `InferenceResults`, `MethodDetailsResults`) and keep
+   estimator-specific outputs as typed fields. No ad-hoc dicts as the public
+   return. Conformance is pinned in `tests/test_result_contract.py`.
 4. **One estimator = one package**: `estimators/<name>.py` (thin) +
    `utils/<name>_helpers/{setup,pipeline,structures,plotter,...}.py`. Dispatcher
    estimators (e.g. `SPILLSYNTH`) add a method subpackage, not a new top-level
@@ -77,6 +85,24 @@ linked from the estimator page's short "Verification" pointer (see
 - Develop on the assigned feature branch; commit with clear messages.
 - Commit author/committer email: `noreply@anthropic.com`.
 - Don't create a PR unless asked.
+
+### Merging PRs (standing authorization, with guardrails)
+
+Claude Code may merge a pull request **without re-asking** only when **all** of
+these hold:
+
+1. **Trigger** — the user explicitly says to merge it (e.g. "merge it",
+   "go ahead and merge"). Absent an explicit instruction, ask first.
+2. **Preconditions** — required CI is **green**, there are **no unresolved
+   review threads**, and the PR has **no merge conflicts** with its base.
+3. **Scope** — the PR originates from a `claude/*` branch produced in this
+   session, targeting `main`. Anything else: ask first.
+4. **Method** — **squash-merge**, and **delete the source branch** after a
+   successful merge.
+
+**Hard stops (never, even if asked):** do not force-merge or override a failing
+required check; do not merge if the diff has drifted from what was discussed;
+do not merge into anything other than the agreed base. When in doubt, ask.
 
 ## AI workflow (slash commands)
 

--- a/agents/agents_estimators.md
+++ b/agents/agents_estimators.md
@@ -266,26 +266,32 @@ Intermediate artifacts should remain interpretable and reusable.
 
 # Results Architecture
 
-Estimators should return typed structured result objects whenever possible.
+Estimators return one of **two** standardized, typed families — see
+**`agents_results.md`** for the full contract and the per-migration
+Definition of Done. In brief:
 
-Preferred result architecture:
-- `BaseEstimatorResults`
-- estimator-specific result structures
-- typed metadata containers
-- structured diagnostics
-- inference result objects
+- **Observational** estimators return an `EffectResult` (alias of
+  `BaseEstimatorResults`) or a frozen Pydantic subclass of it.
+- **Experimental / design** estimators return a `DesignResult`, whose
+  `report` is an `EffectResult`.
+
+Both subclass `MlsynthResult`. Result containers are **Pydantic models**
+(frozen where practical — freeze the leaf class, the shared base stays
+mutable); populate the standardized sub-models (`effects`, `time_series`,
+`weights`, `inference`, `fit_diagnostics`, `method_details`) and keep
+estimator-specific outputs as **typed fields** on the subclass. Nested helper
+containers (`FooInputs`, `FooMethodFit`) may remain frozen dataclasses.
 
 Avoid:
-- opaque nested dictionaries
+- opaque nested dictionaries as the public return
 - unnamed tuple returns
-- inconsistent field naming
+- inconsistent field naming for the same quantity
+- dumping typed outputs into `additional_outputs`
 
-Results should expose:
-- primary estimates
-- diagnostics
-- metadata
-- inference outputs
-- execution summaries
+Every result exposes:
+- primary estimates (flat `att`/`att_ci`/`counterfactual`/`gap`/
+  `donor_weights`/`pre_rmse` accessors)
+- diagnostics, metadata, inference outputs, execution summaries
 
 ---
 

--- a/agents/agents_results.md
+++ b/agents/agents_results.md
@@ -1,0 +1,165 @@
+# agents_results.md
+
+Agent-facing contract for **what an mlsynth estimator returns** and the
+**Definition of Done (DoD)** for migrating an estimator onto it. Read this
+together with `agents_estimators.md` (how an estimator is built),
+`agents_docs.md` (docs conventions), and `agents_tests.md` (testing layers).
+
+> **Status.** The contract is validated end-to-end on the three reference
+> estimators **VanillaSC, FDID, TSSC** (see `mlsynth/tests/test_result_contract.py`).
+> Roll it out one estimator (or one family) at a time, applying the DoD below
+> to each.
+
+---
+
+## 1. The two-family result contract
+
+mlsynth has exactly **two** output families, because panel causal inference
+has exactly two modes — *measure an effect*, or *design to measure one* — and
+the design mode resolves to the measurement mode. Every `fit()` returns one of
+two types, both subclassing `MlsynthResult` (in `config_models.py`, re-exported
+from `mlsynth/results.py`):
+
+| Family | Type | `fit()` returns | Meaning |
+|---|---|---|---|
+| **Observational** | `EffectResult` (alias of `BaseEstimatorResults`) | `EffectResult` or a subclass | An *observational report*: ATT, counterfactual, weights, inference. |
+| **Experimental / design** | `DesignResult` | `DesignResult` | A *research design*: assignment, selected units, design weights, power. Its `report` is an `EffectResult` once outcomes exist. |
+
+Invariant: `isinstance(result, MlsynthResult)` always holds, and every
+`DesignResult.report` (when set) is an `EffectResult`. The conformance test
+pins this.
+
+### How a result class should look
+
+- **The top-level container is a Pydantic model** subclassing the correct
+  base:
+  - observational → `class FooResults(BaseEstimatorResults):`
+  - design → `class FooResults(DesignResult):`
+  - **Freeze where practical**: set
+    `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` on
+    the leaf result class when the pipeline builds it in one shot. The shared
+    `BaseEstimatorResults` base is intentionally left mutable so it can serve
+    as a building block (e.g. an estimator that returns it directly, or holds
+    one as a `summary`); immutability is a leaf-class property, not a
+    hard requirement of the base.
+- **Estimator-specific outputs stay typed** as fields on the subclass (factor
+  matrices, QTE curves, selection trees, …). Do **not** dump them into
+  `additional_outputs: dict` — that loses typing.
+- **Nested helper containers may remain frozen dataclasses** (e.g.
+  `FooInputs`, `FooMethodFit`); the Pydantic container holds them via
+  `arbitrary_types_allowed`. No need to convert the whole tree.
+- **Populate the standardized sub-models** so the common surface is uniform:
+  `effects`, `time_series`, `weights`, `inference`, `fit_diagnostics`,
+  `method_details`. `WeightsResults` is the single weights container and
+  exposes `donor_weights` / `time_weights` / `unit_weights` — populate
+  whichever faces apply (donor mapping, SDID-style time weights, MCNNM-style
+  unit-weight arrays). **Prefer pipeline-native population** (the pipeline builds
+  these directly, so the object is *born standardized*); a `model_validator`
+  that back-fills from the primary fit is acceptable when a pipeline rewrite is
+  out of scope — if used, mutate via `object.__setattr__` (the model is frozen).
+- **Flat convenience accessors** (`att`, `att_ci`, `counterfactual`, `gap`,
+  `donor_weights`, `pre_rmse`) are inherited from `BaseEstimatorResults`;
+  override them only in dispatchers (see below).
+- **Dispatcher estimators** (multiple variants, e.g. TSSC/FDID/PDA/PROXIMAL/
+  CLUSTERSC) keep variants in `sub_method_results` (or a typed `variants`
+  field) and delegate the flat accessors / standard sub-models to the selected
+  variant. "Which variant" is an intra-`EffectResult` concern, **not** a third
+  family.
+- **CI / inference** always lands in `InferenceResults`
+  (`ci_lower`/`ci_upper`/`p_value`/`standard_error`/`method`); `att_ci` reads
+  from it. Do not invent a bespoke per-estimator CI field as the public surface.
+
+### Forbidden
+
+- ad-hoc `dict` or unnamed `tuple` as the public return,
+- inconsistent field naming for the same quantity (`counterfactual` vs
+  `counterfactual_full`; raw `weights` vector where a `donor_weights` mapping
+  is meant),
+- mutating a result after construction outside a validator.
+
+---
+
+## 2. Definition of Done — per-estimator migration
+
+A migration is **not** done when tests pass. It is done when **all** of the
+following hold. Use this as a literal checklist in the PR description.
+
+### A. Code
+
+- [ ] `fit()` return annotation is `EffectResult`/subclass (observational) or
+      `DesignResult` (design); no `dict`/`tuple` in the public return.
+- [ ] Result container is a Pydantic model subclassing the correct base with
+      `arbitrary_types_allowed=True`; **frozen where practical** (freeze the
+      leaf class when the pipeline builds it in one shot — the shared base may
+      stay mutable).
+- [ ] Standardized sub-models populated (`effects`, `time_series`, `weights`,
+      `inference`, `fit_diagnostics`, `method_details`), pipeline-native where
+      feasible.
+- [ ] Estimator-specific outputs retained as **typed** fields (no regression to
+      `additional_outputs` dicts).
+- [ ] **Back-compat preserved**: every previously public attribute/method still
+      resolves (add `@property` shims if internals moved). If a name *must*
+      change, keep the old one as a deprecated alias.
+- [ ] Design estimators: `report` is populated with the `EffectResult` (fold
+      any `post_fit`/`summary`/`SyntheticControlPostFit` into it).
+
+### B. Tests
+
+- [ ] Estimator added to the appropriate list in
+      `mlsynth/tests/test_result_contract.py` (`OBSERVATIONAL` or the design
+      list) and its conformance tests pass.
+- [ ] Existing estimator test file updated for any intentional surface change
+      (e.g. frozen-exception type: pydantic `ValidationError`, not
+      `FrozenInstanceError`).
+- [ ] Full suite green: `pytest mlsynth/tests/`.
+
+### C. Docs (`docs/<name>.rst`)
+
+- [ ] **Return-object documentation** reflects the standardized surface (what
+      `res.att` / `res.effects` / `res.weights` / `res.inference` expose).
+- [ ] The runnable **Example** uses the canonical accessors (`res.att`,
+      `res.att_ci`, `res.counterfactual`, …), not removed/internal paths.
+- [ ] `.. autoclass::` / `:class:` references point to the **actual** module
+      (configs now live in `utils/<name>_helpers/config.py`).
+
+### D. Replication / benchmarks
+
+- [ ] Replication **numbers are unchanged** (return-type refactors must not move
+      estimates); `benchmarks/cases/<name>.py` still passes
+      (`python benchmarks/run_benchmarks.py`).
+- [ ] Any code snippet in `docs/replications/<name>.rst` that reads the result
+      uses the canonical accessors.
+
+### E. Agent instructions & indices
+
+- [ ] If the public surface changed, regenerate `llms.txt`
+      (`python tools/gen_llms_txt.py`).
+- [ ] If a new pattern was introduced, update **this file** and the
+      "Results Architecture" pointer in `agents_estimators.md`.
+
+### F. Migration notes
+
+- [ ] A `CHANGELOG` entry records the migration: what the estimator now
+      returns, any renamed/aliased public attributes, and the back-compat
+      guarantee. (This is the user-facing record; B/C/D are the proof.)
+
+### G. Done means done
+
+- [ ] Working tree committed with a clear message on the assigned branch
+      (author/committer `noreply@anthropic.com`); no stray debug code.
+
+---
+
+## 3. Rollout order (suggested)
+
+1. **Reference set (done):** VanillaSC, FDID, TSSC — the contract + conformance
+   test live here.
+2. **Single-method observational** estimators (flat `att` already present):
+   cheapest; mostly add the conformance entry + verify sub-models.
+3. **Dispatchers** (PDA, PROXIMAL, CLUSTERSC, MUSC, SCMO, SIV): apply the
+   variant-delegation pattern.
+4. **Design family** (MAREX, PANGEO, SYNDES, SPCD, LEXSCM): migrate onto
+   `DesignResult`, folding `post_fit`/`summary` into `report`.
+
+Each estimator carries its own DoD checklist; do not batch-migrate without
+running the per-estimator docs/replication/conformance steps.

--- a/docs/fdid.rst
+++ b/docs/fdid.rst
@@ -727,7 +727,7 @@ Core API
 Configuration
 -------------
 
-.. autoclass:: mlsynth.config_models.FDIDConfig
+.. autoclass:: mlsynth.utils.fdid_helpers.config.FDIDConfig
    :members:
    :undoc-members:
 

--- a/docs/tssc.rst
+++ b/docs/tssc.rst
@@ -588,7 +588,7 @@ Core API
 Configuration
 -------------
 
-.. autoclass:: mlsynth.config_models.TSSCConfig
+.. autoclass:: mlsynth.utils.tssc_helpers.config.TSSCConfig
    :members:
    :undoc-members:
 

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -559,7 +559,7 @@ Core API
 Configuration
 -------------
 
-.. autoclass:: mlsynth.config_models.VanillaSCConfig
+.. autoclass:: mlsynth.utils.vanillasc_helpers.config.VanillaSCConfig
    :members:
    :undoc-members:
 

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -333,45 +333,9 @@ class BaseEstimatorConfig(BaseModel):
             )
         return values
 
-class TSSCConfig(BaseEstimatorConfig):
-    """Configuration for the Two-Step Synthetic Control (TSSC) estimator.
-
-    Implements:
-
-        Li, K. T., & Shankar, V. (2023). "A Two-Step Synthetic Control
-        Approach for Estimating Causal Effects of Marketing Events."
-        Management Science. https://doi.org/10.1287/mnsc.2023.4878
-
-    Parameters
-    ----------
-    alpha : float
-        Two-sided significance level for the Step-1 restriction tests
-        (the SC-pretrends test and the two single-restriction tests).
-        Default 0.05.
-    subsample_size : int or None
-        Subsample size ``m`` for the Step-1 subsampling procedure. When
-        ``None`` (default) it is set to ``T_1`` (the bootstrap special
-        case the paper's simulations validate). For genuine subsampling,
-        the paper's rule of thumb is ``m`` between ``T_1/2`` and ``T_1``
-        for moderate ``T_1`` (and smaller for large ``T_1``).
-    draws : int
-        Number of subsampling replications ``B`` for the Step-1 tests and
-        bootstrap replications for the per-variant ATT confidence
-        intervals. Default 500.
-    ci : float
-        Confidence level for the per-variant ATT confidence interval.
-        Default 0.95.
-    seed : int or None
-        Seed for the subsampling RNG (reproducibility). Default None.
-    """
-
-    alpha: float = Field(default=0.05, gt=0.0, lt=1.0,
-                         description="Significance level for Step-1 restriction tests.")
-    subsample_size: Optional[int] = Field(default=None, ge=2,
-                         description="Subsample size m; None uses T_1 (bootstrap).")
-    draws: int = Field(default=500, ge=1, description="Subsampling/bootstrap replications.")
-    ci: float = Field(default=0.95, gt=0.0, lt=1.0, description="ATT confidence level.")
-    seed: Optional[int] = Field(default=None, description="RNG seed for subsampling.")
+# TSSCConfig has been relocated to mlsynth/utils/tssc_helpers/config.py
+# (co-located with the estimator's helpers). It is re-exported from this
+# module for backward compatibility via the module-level __getattr__ below.
 
 # Placeholder for other estimator configs - to be added sequentially
 
@@ -470,19 +434,9 @@ class PDAConfig(BaseEstimatorConfig):
     alpha: float = Field(default=0.05, gt=0.0, lt=1.0, description="Significance level for confidence intervals and ATE inference.")
     fs_intercept: bool = Field(default=False, description="Forward-selection only: include a constant in the donor regression. False (default) matches Shi & Huang's simulation (no intercept, valid size on mean-zero factor data); True matches the released fsPDA R package (intercept, for panels with genuine level differences).")
 
-class FDIDConfig(BaseEstimatorConfig):
-    """
-    Configuration for the Forward Difference-in-Differences (FDID) estimator.
-    Inherits all common configuration parameters from BaseEstimatorConfig.
-
-    Additional Parameters
-    ---------------------
-    plot_did : bool, default=True
-        Whether to display a plot for the standard DID estimator.
-        Has no effect on FDID or ADID plots.
-    """
-    verbose: bool = Field(default=True, description="Whether to save intermediary Forward Selection Results.")
-
+# FDIDConfig has been relocated to mlsynth/utils/fdid_helpers/config.py
+# (co-located with the estimator's helpers). It is re-exported from this
+# module for backward compatibility via the module-level __getattr__ below.
 
 
 class GSCConfig(BaseEstimatorConfig):
@@ -1814,121 +1768,9 @@ class ISCMConfig(BaseEstimatorConfig):
     )
 
 
-class VanillaSCConfig(BaseEstimatorConfig):
-    """Configuration for the VanillaSC estimator (standard SCM, bilevel engine).
-
-    The ordinary single-treated synthetic control, built on the self-contained
-    bilevel machinery. With no covariates it reduces to the well-posed convex
-    outcome-matching problem; with covariates it routes through the bilevel
-    predictor-weight (``V``) optimisation, with a selectable, reliable backend.
-
-    Parameters
-    ----------
-    backend : {"auto", "outcome-only", "malo", "mscmt", "penalized"}
-        Predictor-weight backend. ``"auto"`` (default) uses ``"outcome-only"``
-        (convex simplex fit on pre-treatment outcomes) when no covariates are
-        given, and ``"mscmt"`` (global differential-evolution ``V`` search)
-        when they are. ``"malo"`` is the Malo et al. (2024) corner search,
-        ``"penalized"`` the Abadie-L'Hour (2021) unique/sparse estimator.
-    covariates : list of str, optional
-        Predictor columns. Each is averaged over its window (see
-        ``covariate_windows``) and scaled to unit variance, then matched via
-        the bilevel program. ``None`` -> outcome-only matching.
-    covariate_windows : dict, optional
-        Per-covariate inclusive ``(start, end)`` averaging window of time
-        labels (Abadie's special-predictor spec). Covariates not listed are
-        averaged over the full pre-treatment period.
-    canonical_v : bool or {"min.loss.w", "max.order"}
-        Canonicalise the (non-identified) predictor weights for ``mscmt``
-        (MSCMT ``determine_v``). The reported ``v_agreement`` is small when
-        ``V`` is well identified and large when it is fragile. Default False.
-    seed : int
-        RNG seed for the ``mscmt`` differential-evolution search.
-    mscmt_maxiter, mscmt_popsize : int
-        Differential-evolution budget for the ``mscmt`` backend.
-    inference : bool or {"placebo", "scpi", "lto"}
-        Inference method. ``True``/``"placebo"`` (default) runs Abadie in-space
-        placebo inference (refit treating each donor as pseudo-treated; the
-        p-value ranks the treated unit's post/pre RMSPE ratio). ``"scpi"`` runs
-        Cattaneo-Feng-Titiunik (2021) prediction intervals (in-sample
-        simulation + out-of-sample location-scale; exact for the simplex /
-        outcome-only synthetic control). ``"lto"`` runs the Lei-Sudijono (2025)
-        leave-two-out refined placebo test (O(J^2) reference comparisons; finer
-        granularity and non-zero size when ``alpha < 1/N``). ``False`` skips
-        inference.
-    alpha : float
-        Level. For placebo, the confidence statement; for SCPI, used as both
-        the in-sample (alpha1) and out-of-sample (alpha2) levels, giving a
-        prediction interval with coverage approximately ``1 - 2*alpha``.
-    scpi_sims : int
-        Number of Gaussian draws for the SCPI in-sample simulation.
-    scpi_e_method : {"gaussian", "empirical"}
-        Out-of-sample location-scale tabulation for SCPI.
-    lto_max_pairs : int, optional
-        Cap on the number of donor pairs evaluated by the ``"lto"`` test
-        (deterministic subsample via ``seed``). ``None`` (default) uses all
-        ``J*(J-1)/2`` pairs; set a cap to keep the O(J^2) cost tractable with
-        slow backends.
-    """
-
-    backend: Literal["auto", "outcome-only", "malo", "mscmt", "penalized"] = Field(
-        default="auto",
-        description="Predictor-weight backend (see class docstring).",
-    )
-    covariates: Optional[List[str]] = Field(
-        default=None,
-        description="Predictor columns; None -> outcome-only matching.",
-    )
-    covariate_windows: Optional[Dict[Any, Any]] = Field(
-        default=None,
-        description="Per-covariate inclusive (start, end) averaging window.",
-    )
-    canonical_v: Union[bool, str] = Field(
-        default=False,
-        description="Canonicalise mscmt predictor weights ('min.loss.w'/'max.order').",
-    )
-    seed: int = Field(default=0, description="RNG seed for the mscmt DE search.")
-    mscmt_maxiter: int = Field(
-        default=300, ge=1, description="mscmt differential-evolution max iterations.",
-    )
-    mscmt_popsize: int = Field(
-        default=15, ge=1, description="mscmt differential-evolution population size.",
-    )
-    mscmt_prune_shady: bool = Field(
-        default=True,
-        description="mscmt: drop shady donors (Becker-Kloessner sunny-donor "
-                    "reduction) before the outer search. Leaves the optimum "
-                    "unchanged; shrinks the inner solve.",
-    )
-    inference: Union[bool, str] = Field(
-        default=True,
-        description="Inference: True/'placebo' (in-space placebo), 'scpi' "
-                    "(Cattaneo-Feng-Titiunik prediction intervals), 'lto' "
-                    "(Lei-Sudijono leave-two-out refined placebo), or False.",
-    )
-    alpha: float = Field(
-        default=0.05, gt=0.0, lt=1.0,
-        description="Level (placebo confidence / SCPI alpha1 = alpha2).",
-    )
-    scpi_sims: int = Field(
-        default=200, ge=1,
-        description="Gaussian draws for the SCPI in-sample simulation.",
-    )
-    scpi_e_method: Literal["gaussian", "empirical"] = Field(
-        default="gaussian",
-        description="SCPI out-of-sample location-scale tabulation.",
-    )
-    lto_max_pairs: Optional[int] = Field(
-        default=None, ge=1,
-        description="Cap on donor pairs for the 'lto' test (None -> all pairs).",
-    )
-    penalized_cv: Literal["holdout", "loo", "pensynth"] = Field(
-        default="holdout",
-        description="Lambda selector for backend='penalized'. 'holdout'/'loo' "
-                    "are Abadie-L'Hour time-split criteria; 'pensynth' is van "
-                    "Kesteren's cv_pensynth (fit on covariates, validate on the "
-                    "held-out pre-period outcome path; needs covariates).",
-    )
+# VanillaSCConfig has been relocated to mlsynth/utils/vanillasc_helpers/config.py
+# (co-located with the estimator's helpers). It is re-exported from this
+# module for backward compatibility via the module-level __getattr__ below.
 
 
 class SPILLSYNTHConfig(BaseEstimatorConfig):
@@ -4634,6 +4476,34 @@ class SIVConfig(BaseEstimatorConfig):
 
 # --- Pydantic Models for Standardized Estimator Results ---
 
+class MlsynthResult(BaseModel):
+    """Common base for every ``fit()`` return value in mlsynth.
+
+    mlsynth has exactly two output families, because panel causal inference
+    has exactly two modes:
+
+    * :class:`EffectResult` -- an *observational report*: measure a treatment
+      effect on already-observed data (ATT, counterfactual, weights,
+      inference).
+    * :class:`DesignResult` -- a *research design*: choose which units to
+      treat before any intervention. A design resolves to the same effect
+      report once outcomes exist (see :attr:`DesignResult.report`).
+
+    Every estimator returns one of these two types, so library behaviour is
+    simple and predictable: ``isinstance(result, MlsynthResult)`` always
+    holds, and the two faces share serialization and validation config.
+    """
+
+    class Config:
+        arbitrary_types_allowed = True
+        extra = "forbid"
+        json_encoders = {
+            np.ndarray: lambda arr: [None if pd.isna(x) else x for x in arr.tolist()]
+            if arr is not None
+            else None
+        }
+
+
 class EffectsResults(BaseModel):
     """Standardized model for reporting treatment effects."""
     att: Optional[float] = Field(default=None, description="Average Treatment Effect on the Treated.")
@@ -4666,13 +4536,27 @@ class TimeSeriesResults(BaseModel):
         extra = 'allow'
 
 class WeightsResults(BaseModel):
-    """Standardized model for reporting donor weights."""
+    """Standardized model for reporting estimator weights.
+
+    The single weights container for the whole library. ``weights`` are not
+    one thing across synthetic-control methods, so this model exposes the
+    real variety as optional faces; an estimator populates whichever apply:
+
+    * ``donor_weights`` -- ``{donor label: weight}`` (most SCMs);
+    * ``time_weights``  -- ``{period: weight}`` (e.g. SDID's lambda, DSC
+      period weights);
+    * ``unit_weights``  -- a weight matrix / array (e.g. MCNNM / ISCM unit
+      factors, per-unit weight matrices).
+    """
     donor_weights: Optional[Dict[str, float]] = Field(default=None, description="Dictionary mapping donor unit names/IDs to their weights.")
+    time_weights: Optional[Dict[Any, float]] = Field(default=None, description="Dictionary mapping time periods to weights (e.g. SDID lambda, DSC period weights).")
+    unit_weights: Optional[np.ndarray] = Field(default=None, description="Unit weight matrix/array for estimators whose weights are not a donor mapping (e.g. MCNNM/ISCM).")
     summary_stats: Optional[Dict[str, Any]] = Field(default=None, description="Summary statistics about weights (e.g., cardinality).")
     # For estimators returning multiple sets of weights (e.g. TSSC sub-methods), this might be part of a list or dict structure.
     # donor_names is removed as it's incorporated into donor_weights dict keys
 
     class Config:
+        arbitrary_types_allowed = True
         extra = 'allow'
 
 class InferenceResults(BaseModel):
@@ -4699,10 +4583,15 @@ class MethodDetailsResults(BaseModel):
     class Config:
         extra = 'allow'
 
-class BaseEstimatorResults(BaseModel):
-    """
-    Base Pydantic model for standardized estimator `fit()` method results.
-    This model aims to provide a common structure for the primary outputs.
+class BaseEstimatorResults(MlsynthResult):
+    """The observational report: standardized result of an effect estimator.
+
+    Aliased as :class:`EffectResult`. Carries the standardized sub-models
+    (:class:`EffectsResults`, :class:`TimeSeriesResults`,
+    :class:`WeightsResults`, :class:`InferenceResults`,
+    :class:`FitDiagnosticsResults`) plus flat convenience accessors
+    (``att``, ``att_ci``, ``counterfactual``, ``gap``, ``donor_weights``,
+    ``pre_rmse``) so every effect estimator exposes one predictable surface.
     """
     # Core components, all optional as not all estimators produce all parts.
     effects: Optional[EffectsResults] = None
@@ -4737,3 +4626,117 @@ class BaseEstimatorResults(BaseModel):
             np.ndarray: lambda arr: [None if pd.isna(x) else x for x in arr.tolist()] if arr is not None else None
             # This explicitly converts np.nan (which becomes float('nan') in tolist()) to Python None.
         }
+
+    # ------------------------------------------------------------------
+    # Flat convenience accessors -- the minimum read contract every effect
+    # estimator satisfies, delegating to the standardized sub-models. Adding
+    # them here brings *every* estimator that returns a BaseEstimatorResults
+    # into compliance at once; subclasses may override (e.g. dispatchers that
+    # delegate to a selected variant).
+    # ------------------------------------------------------------------
+    @property
+    def att(self) -> Optional[float]:
+        """Average treatment effect on the treated."""
+        return self.effects.att if self.effects else None
+
+    @property
+    def att_ci(self) -> Optional[tuple]:
+        """``(lower, upper)`` confidence interval for the ATT, if available."""
+        inf = self.inference
+        if inf is not None and inf.ci_lower is not None and inf.ci_upper is not None:
+            return (inf.ci_lower, inf.ci_upper)
+        return None
+
+    @property
+    def counterfactual(self) -> Optional[np.ndarray]:
+        """Estimated counterfactual outcome path."""
+        return self.time_series.counterfactual_outcome if self.time_series else None
+
+    @property
+    def gap(self) -> Optional[np.ndarray]:
+        """Estimated gap (observed minus counterfactual)."""
+        return self.time_series.estimated_gap if self.time_series else None
+
+    @property
+    def donor_weights(self) -> Optional[Dict[str, float]]:
+        """Donor weights ``{label: weight}``."""
+        return self.weights.donor_weights if self.weights else None
+
+    @property
+    def pre_rmse(self) -> Optional[float]:
+        """Pre-treatment root-mean-squared fit error."""
+        return self.fit_diagnostics.rmse_pre if self.fit_diagnostics else None
+
+
+# ``EffectResult`` is the canonical, intention-revealing name for the
+# observational report. ``BaseEstimatorResults`` is retained as an alias for
+# backward compatibility (it is referenced throughout the library and docs).
+EffectResult = BaseEstimatorResults
+
+
+class DesignResult(MlsynthResult):
+    """The research design: an experimental-design estimator's output.
+
+    Experimental/design methods (e.g. MAREX, PANGEO, SYNDES, SPCD) choose
+    which units to treat *before* any intervention. A design is not disjoint
+    from an effect report -- it *resolves* to one: once outcomes are observed,
+    the design is realized as an :class:`EffectResult`, exposed via
+    :attr:`report` (today's per-estimator ``post_fit`` / ``summary``).
+
+    This is a skeleton for the two-family contract; design estimators are
+    migrated onto it after the observational family is validated.
+    """
+
+    report: Optional[BaseEstimatorResults] = Field(
+        default=None,
+        description="The effect report once the design is realized (the "
+        "design's `post_fit`/`summary`). Same type the observational "
+        "family returns.",
+    )
+    assignment: Optional[Any] = Field(
+        default=None, description="Treatment assignment chosen by the design."
+    )
+    selected_units: Optional[Any] = Field(
+        default=None, description="Units selected for treatment by the design."
+    )
+    design_weights: Optional[WeightsResults] = Field(
+        default=None, description="Synthetic-control weights implied by the design."
+    )
+    power: Optional[Any] = Field(
+        default=None, description="Power / MDE analysis for the design."
+    )
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None, description="Free-form design diagnostics."
+    )
+
+    class Config:
+        arbitrary_types_allowed = True
+        extra = "allow"
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatibility shims for relocated per-estimator configs.
+#
+# Per-estimator config classes are being moved next to their helper packages
+# (``mlsynth/utils/<name>_helpers/config.py``) to shrink this module. The
+# shared bases (BaseEstimatorConfig, BaseMAREXConfig) and the standardized
+# result models stay here. A module-level ``__getattr__`` (PEP 562) lazily
+# re-exports the relocated classes so existing imports such as
+# ``from mlsynth.config_models import VanillaSCConfig`` keep working. The
+# import is lazy to avoid a circular import (the relocated module imports
+# BaseEstimatorConfig from here).
+# ---------------------------------------------------------------------------
+_RELOCATED_CONFIGS = {
+    "VanillaSCConfig": "mlsynth.utils.vanillasc_helpers.config",
+    "FDIDConfig": "mlsynth.utils.fdid_helpers.config",
+    "TSSCConfig": "mlsynth.utils.tssc_helpers.config",
+}
+
+
+def __getattr__(name: str):  # PEP 562 module-level attribute hook
+    module_path = _RELOCATED_CONFIGS.get(name)
+    if module_path is not None:
+        import importlib
+
+        return getattr(importlib.import_module(module_path), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/mlsynth/estimators/fdid.py
+++ b/mlsynth/estimators/fdid.py
@@ -21,8 +21,8 @@ from typing import List, Union
 
 import pandas as pd
 
-from ..config_models import FDIDConfig
 from ..exceptions import MlsynthEstimationError
+from ..utils.fdid_helpers.config import FDIDConfig
 from ..utils.fdid_helpers import (
     FDIDResults,
     assemble_fdid_results,
@@ -39,7 +39,7 @@ class FDID:
     ----------
     config : FDIDConfig or dict
         Validated configuration (or a compatible dictionary). See
-        :class:`mlsynth.config_models.FDIDConfig` for the available
+        :class:`mlsynth.utils.fdid_helpers.config.FDIDConfig` for the available
         fields (``df``, ``outcome``, ``treat``, ``unitid``, ``time``,
         ``display_graphs``, ``save``, ``counterfactual_color``,
         ``treated_color``, ``verbose``).

--- a/mlsynth/estimators/tssc.py
+++ b/mlsynth/estimators/tssc.py
@@ -29,7 +29,6 @@ import numpy as np
 import pandas as pd
 from pydantic import ValidationError
 
-from ..config_models import TSSCConfig
 from ..exceptions import (
     MlsynthConfigError,
     MlsynthDataError,
@@ -37,6 +36,7 @@ from ..exceptions import (
     MlsynthPlottingError,
 )
 from ..utils.datautils import balance
+from ..utils.tssc_helpers.config import TSSCConfig
 from ..utils.tssc_helpers.estimation import fit_variant
 from ..utils.tssc_helpers.plotter import plot_tssc
 from ..utils.tssc_helpers.results_assembly import build_summary
@@ -51,7 +51,8 @@ class TSSC:
     Parameters
     ----------
     config : TSSCConfig or dict
-        Configuration object. See :class:`mlsynth.config_models.TSSCConfig`.
+        Configuration object. See
+        :class:`mlsynth.utils.tssc_helpers.config.TSSCConfig`.
 
     Returns
     -------

--- a/mlsynth/estimators/vanillasc.py
+++ b/mlsynth/estimators/vanillasc.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 
 from typing import Union
 
-from ..config_models import BaseEstimatorResults, VanillaSCConfig
+from ..config_models import BaseEstimatorResults
+from ..utils.vanillasc_helpers.config import VanillaSCConfig
 from ..exceptions import MlsynthConfigError, MlsynthDataError, MlsynthEstimationError
 from ..utils.vanillasc_helpers.pipeline import run_vanillasc
 
@@ -38,7 +39,8 @@ class VanillaSC:
     Parameters
     ----------
     config : VanillaSCConfig or dict
-        Configuration. See :class:`mlsynth.config_models.VanillaSCConfig`.
+        Configuration. See
+        :class:`mlsynth.utils.vanillasc_helpers.config.VanillaSCConfig`.
 
     Examples
     --------

--- a/mlsynth/results.py
+++ b/mlsynth/results.py
@@ -1,0 +1,47 @@
+"""Standardized result types for mlsynth.
+
+mlsynth has exactly two output families, because panel causal inference has
+exactly two modes -- measure an effect, or design to measure one -- and the
+design mode resolves to the measurement mode:
+
+* :class:`EffectResult` (an alias of :class:`BaseEstimatorResults`) -- the
+  *observational report* returned by effect estimators (ATT, counterfactual,
+  weights, inference).
+* :class:`DesignResult` -- the *research design* returned by experimental
+  design estimators; its :attr:`~DesignResult.report` is an
+  :class:`EffectResult`.
+
+Both share the common base :class:`MlsynthResult`. Estimators populate the
+standardized sub-models (:class:`EffectsResults`, :class:`TimeSeriesResults`,
+:class:`WeightsResults`, :class:`InferenceResults`,
+:class:`FitDiagnosticsResults`, :class:`MethodDetailsResults`); every
+:class:`EffectResult` additionally exposes the flat convenience accessors
+``att``, ``att_ci``, ``counterfactual``, ``gap``, ``donor_weights`` and
+``pre_rmse``.
+"""
+
+from .config_models import (
+    BaseEstimatorResults,
+    DesignResult,
+    EffectResult,
+    EffectsResults,
+    FitDiagnosticsResults,
+    InferenceResults,
+    MethodDetailsResults,
+    MlsynthResult,
+    TimeSeriesResults,
+    WeightsResults,
+)
+
+__all__ = [
+    "MlsynthResult",
+    "EffectResult",
+    "DesignResult",
+    "BaseEstimatorResults",
+    "EffectsResults",
+    "TimeSeriesResults",
+    "WeightsResults",
+    "InferenceResults",
+    "FitDiagnosticsResults",
+    "MethodDetailsResults",
+]

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -1,0 +1,142 @@
+"""Conformance tests for the standardized two-family result contract.
+
+mlsynth has exactly two output families:
+
+* :class:`~mlsynth.config_models.EffectResult` -- the observational report
+  returned by effect estimators (ATT, counterfactual, weights, inference);
+* :class:`~mlsynth.config_models.DesignResult` -- the research design returned
+  by experimental-design estimators, whose ``report`` is an ``EffectResult``.
+
+Both inherit :class:`~mlsynth.config_models.MlsynthResult`. This module pins
+the contract on the three reference estimators (VanillaSC, FDID, TSSC -- all
+observational) so that the unified-results claim is machine-checked. As the
+migration rolls out, every estimator should be added to ``OBSERVATIONAL``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import FDID, TSSC, VanillaSC
+from mlsynth.config_models import (
+    BaseEstimatorResults,
+    DesignResult,
+    EffectResult,
+    MlsynthResult,
+)
+
+
+def _make_panel(n_units=6, T=30, T0=20, seed=0, rho=0.6):
+    """Factor + AR(1) panel with a single treated unit (unit 0)."""
+    rng = np.random.default_rng(seed)
+    common = np.zeros(T)
+    for t in range(1, T):
+        common[t] = rho * common[t - 1] + rng.standard_normal()
+    Y = np.zeros((T, n_units))
+    for i in range(n_units):
+        load = rng.standard_normal()
+        Y[:, i] = 10.0 + load * common + rng.standard_normal(T) * 0.4
+    rows = []
+    for i in range(n_units):
+        for t in range(T):
+            rows.append({"unitid": f"u{i:02d}", "time": t, "y": Y[t, i],
+                         "treat": int(i == 0 and t >= T0)})
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture(scope="module")
+def panel_df():
+    return _make_panel()
+
+
+def _base_cfg(panel_df):
+    return {"df": panel_df, "outcome": "y", "unitid": "unitid",
+            "time": "time", "treat": "treat", "display_graphs": False}
+
+
+# Estimators that should return an EffectResult (the observational family).
+# Extend this list as the migration proceeds.
+OBSERVATIONAL = [
+    pytest.param(VanillaSC, {}, id="VanillaSC"),
+    pytest.param(FDID, {}, id="FDID"),
+    pytest.param(TSSC, {"draws": 80, "seed": 0}, id="TSSC"),
+]
+
+
+@pytest.fixture(scope="module")
+def fitted(panel_df):
+    """Fit each observational estimator once and cache the result."""
+    out = {}
+    for param in OBSERVATIONAL:
+        Est, extra = param.values
+        cfg = {**_base_cfg(panel_df), **extra}
+        out[param.id] = Est(cfg).fit()
+    return out
+
+
+@pytest.mark.parametrize("Est, extra", OBSERVATIONAL)
+def test_is_effect_result(Est, extra, fitted):
+    res = fitted[Est.__name__]
+    assert isinstance(res, MlsynthResult)
+    assert isinstance(res, BaseEstimatorResults)
+    assert isinstance(res, EffectResult)  # EffectResult is BaseEstimatorResults
+
+
+@pytest.mark.parametrize("Est, extra", OBSERVATIONAL)
+def test_standard_submodels_populated(Est, extra, fitted):
+    """Every observational result exposes the shared sub-models."""
+    res = fitted[Est.__name__]
+    assert res.effects is not None and res.effects.att is not None
+    assert res.time_series is not None
+    assert res.time_series.counterfactual_outcome is not None
+    assert res.weights is not None
+    assert res.method_details is not None and res.method_details.method_name
+
+
+@pytest.mark.parametrize("Est, extra", OBSERVATIONAL)
+def test_flat_accessor_contract(Est, extra, fitted):
+    """The flat read contract: att / att_ci / counterfactual / gap /
+    donor_weights / pre_rmse behave identically across estimators."""
+    res = fitted[Est.__name__]
+
+    assert isinstance(res.att, float)
+    assert res.att == pytest.approx(res.effects.att)
+
+    cf = np.asarray(res.counterfactual)
+    gap = np.asarray(res.gap)
+    assert cf.shape == gap.shape
+    assert cf.ndim == 1
+
+    dw = res.donor_weights
+    assert dw is None or isinstance(dw, dict)
+
+    assert res.pre_rmse is None or isinstance(res.pre_rmse, float)
+
+    ci = res.att_ci
+    assert ci is None or (len(ci) == 2 and ci[0] <= ci[1])
+
+
+@pytest.mark.parametrize("Est, extra", OBSERVATIONAL)
+def test_serializable(Est, extra, fitted):
+    """A standardized result serializes through pydantic (reproducibility)."""
+    res = fitted[Est.__name__]
+    dumped = res.model_dump(include={"effects", "fit_diagnostics", "inference"})
+    assert "effects" in dumped
+    assert dumped["effects"]["att"] is not None
+
+
+# --- the design family (skeleton; design estimators migrate onto this) -----
+
+def test_design_result_is_mlsynth_result():
+    assert issubclass(DesignResult, MlsynthResult)
+    assert not issubclass(DesignResult, EffectResult)
+
+
+def test_design_report_is_effect_result():
+    """A design resolves to an EffectResult via `report`."""
+    report = EffectResult()
+    design = DesignResult(report=report)
+    assert isinstance(design.report, EffectResult)
+    assert isinstance(design, MlsynthResult)

--- a/mlsynth/tests/test_tssc.py
+++ b/mlsynth/tests/test_tssc.py
@@ -22,6 +22,7 @@ from dataclasses import FrozenInstanceError
 import numpy as np
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 
 from mlsynth import TSSC
 from mlsynth.config_models import TSSCConfig
@@ -287,5 +288,7 @@ class TestImmutability:
         res = TSSC({"df": panel_df, "outcome": "y", "unitid": "unitid",
                     "time": "time", "treat": "treat", "draws": 80,
                     "seed": 0, "display_graphs": False}).fit()
-        with pytest.raises(FrozenInstanceError):
+        # TSSCResults is now a frozen Pydantic EffectResult; attribute
+        # assignment raises pydantic's ValidationError ("frozen_instance").
+        with pytest.raises(ValidationError):
             res.summary = None

--- a/mlsynth/utils/fdid_helpers/config.py
+++ b/mlsynth/utils/fdid_helpers/config.py
@@ -1,0 +1,30 @@
+"""Configuration for the Forward Difference-in-Differences (FDID) estimator.
+
+Co-located with the FDID helper package. The shared
+:class:`~mlsynth.config_models.BaseEstimatorConfig` remains central; only the
+per-estimator config lives here. Re-exported from
+:mod:`mlsynth.config_models` for backward compatibility.
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from ...config_models import BaseEstimatorConfig
+
+
+class FDIDConfig(BaseEstimatorConfig):
+    """
+    Configuration for the Forward Difference-in-Differences (FDID) estimator.
+    Inherits all common configuration parameters from BaseEstimatorConfig.
+
+    Additional Parameters
+    ---------------------
+    verbose : bool, default=True
+        Whether to save intermediary Forward Selection results.
+    """
+
+    verbose: bool = Field(
+        default=True,
+        description="Whether to save intermediary Forward Selection Results.",
+    )

--- a/mlsynth/utils/fdid_helpers/structures.py
+++ b/mlsynth/utils/fdid_helpers/structures.py
@@ -27,6 +27,17 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
+from pydantic import ConfigDict, Field as PydField, model_validator
+
+from ...config_models import (
+    BaseEstimatorResults,
+    EffectsResults,
+    FitDiagnosticsResults,
+    InferenceResults,
+    MethodDetailsResults,
+    TimeSeriesResults,
+    WeightsResults,
+)
 
 
 # Public method names.
@@ -146,9 +157,15 @@ class FDIDMethodFit:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
-@dataclass(frozen=True)
-class FDIDResults:
+class FDIDResults(BaseEstimatorResults):
     """Top-level container returned by :meth:`mlsynth.FDID.fit`.
+
+    An :class:`~mlsynth.config_models.EffectResult` (the observational
+    report): in addition to the FDID-specific fields below, it exposes the
+    standardized sub-models (``effects``, ``time_series``, ``weights``,
+    ``inference``, ``fit_diagnostics``, ``method_details``) -- derived from
+    the selected variant -- and the flat accessors ``att``/``att_ci``/
+    ``counterfactual``/``gap``/``donor_weights``/``pre_rmse``.
 
     Parameters
     ----------
@@ -166,11 +183,55 @@ class FDIDResults:
         Free-form pipeline diagnostics.
     """
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     inputs: FDIDInputs
     fdid: FDIDMethodFit
     did: FDIDMethodFit
     selected_variant: str = FDID
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = PydField(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _populate_standard_submodels(self) -> "FDIDResults":
+        """Derive the standardized EffectResult sub-models from the primary
+        variant, so every FDID result exposes the common surface. Uses
+        ``object.__setattr__`` because the model is frozen."""
+        if self.effects is None:
+            p = self._primary
+            derived = {
+                "effects": EffectsResults(
+                    att=float(p.att),
+                    att_percent=float(p.att_percent),
+                    att_std_err=float(p.att_se),
+                ),
+                "time_series": TimeSeriesResults(
+                    observed_outcome=np.asarray(self.inputs.y),
+                    counterfactual_outcome=np.asarray(p.counterfactual),
+                    estimated_gap=np.asarray(p.gap),
+                    time_periods=np.asarray(self.inputs.time_labels),
+                ),
+                "weights": WeightsResults(
+                    donor_weights={
+                        str(k): float(v) for k, v in p.donor_weights.items()
+                    }
+                ),
+                "fit_diagnostics": FitDiagnosticsResults(
+                    rmse_pre=float(p.pre_rmse), r_squared_pre=float(p.r_squared)
+                ),
+                "inference": InferenceResults(
+                    p_value=float(p.p_value),
+                    ci_lower=float(p.ci[0]),
+                    ci_upper=float(p.ci[1]),
+                    standard_error=float(p.att_se),
+                    method="analytic (Li 2023)",
+                ),
+                "method_details": MethodDetailsResults(
+                    method_name=p.name, is_recommended=True
+                ),
+            }
+            for key, value in derived.items():
+                object.__setattr__(self, key, value)
+        return self
 
     @property
     def methods(self) -> Dict[str, FDIDMethodFit]:

--- a/mlsynth/utils/tssc_helpers/config.py
+++ b/mlsynth/utils/tssc_helpers/config.py
@@ -1,0 +1,56 @@
+"""Configuration for the Two-Step Synthetic Control (TSSC) estimator.
+
+Co-located with the TSSC helper package. The shared
+:class:`~mlsynth.config_models.BaseEstimatorConfig` remains central; only the
+per-estimator config lives here. Re-exported from
+:mod:`mlsynth.config_models` for backward compatibility.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import Field
+
+from ...config_models import BaseEstimatorConfig
+
+
+class TSSCConfig(BaseEstimatorConfig):
+    """Configuration for the Two-Step Synthetic Control (TSSC) estimator.
+
+    Implements:
+
+        Li, K. T., & Shankar, V. (2023). "A Two-Step Synthetic Control
+        Approach for Estimating Causal Effects of Marketing Events."
+        Management Science. https://doi.org/10.1287/mnsc.2023.4878
+
+    Parameters
+    ----------
+    alpha : float
+        Two-sided significance level for the Step-1 restriction tests
+        (the SC-pretrends test and the two single-restriction tests).
+        Default 0.05.
+    subsample_size : int or None
+        Subsample size ``m`` for the Step-1 subsampling procedure. When
+        ``None`` (default) it is set to ``T_1`` (the bootstrap special
+        case the paper's simulations validate). For genuine subsampling,
+        the paper's rule of thumb is ``m`` between ``T_1/2`` and ``T_1``
+        for moderate ``T_1`` (and smaller for large ``T_1``).
+    draws : int
+        Number of subsampling replications ``B`` for the Step-1 tests and
+        bootstrap replications for the per-variant ATT confidence
+        intervals. Default 500.
+    ci : float
+        Confidence level for the per-variant ATT confidence interval.
+        Default 0.95.
+    seed : int or None
+        Seed for the subsampling RNG (reproducibility). Default None.
+    """
+
+    alpha: float = Field(default=0.05, gt=0.0, lt=1.0,
+                         description="Significance level for Step-1 restriction tests.")
+    subsample_size: Optional[int] = Field(default=None, ge=2,
+                         description="Subsample size m; None uses T_1 (bootstrap).")
+    draws: int = Field(default=500, ge=1, description="Subsampling/bootstrap replications.")
+    ci: float = Field(default=0.95, gt=0.0, lt=1.0, description="ATT confidence level.")
+    seed: Optional[int] = Field(default=None, description="RNG seed for subsampling.")

--- a/mlsynth/utils/tssc_helpers/structures.py
+++ b/mlsynth/utils/tssc_helpers/structures.py
@@ -25,12 +25,12 @@ imposed on ``beta``:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Optional, Sequence, Tuple
+from typing import Dict, Optional, Sequence, Tuple
 
 import numpy as np
+from pydantic import ConfigDict, model_validator
 
-if TYPE_CHECKING:
-    from ...config_models import BaseEstimatorResults
+from ...config_models import BaseEstimatorResults
 
 
 # Public (paper) method names.
@@ -186,9 +186,16 @@ class TSSCVariantFit:
     r2_pre: float
 
 
-@dataclass(frozen=True)
-class TSSCResults:
+class TSSCResults(BaseEstimatorResults):
     """Public ``TSSC.fit()`` return container.
+
+    An :class:`~mlsynth.config_models.EffectResult` (the observational
+    report): besides the TSSC-specific fields below, it exposes the
+    standardized sub-models (``effects``, ``time_series``, ``weights``,
+    ``inference``, ``fit_diagnostics``, ``method_details``) -- lifted from
+    the recommended variant's ``summary`` -- and the flat accessors
+    ``att``/``att_ci``/``counterfactual``/``gap``/``donor_weights``/
+    ``pre_rmse``.
 
     Parameters
     ----------
@@ -202,10 +209,30 @@ class TSSCResults:
         Standardized result bundle for the recommended variant.
     """
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     inputs: TSSCInputs
     variants: Dict[str, TSSCVariantFit]
     selection: TSSCSelection
-    summary: Optional["BaseEstimatorResults"] = None
+    summary: Optional[BaseEstimatorResults] = None
+
+    @model_validator(mode="after")
+    def _populate_standard_submodels(self) -> "TSSCResults":
+        """Lift the recommended variant's standardized sub-models to the top
+        level so a TSSC result exposes the same surface as every other
+        EffectResult. Uses ``object.__setattr__`` because the model is
+        frozen."""
+        if self.effects is None and self.summary is not None:
+            for key in (
+                "effects",
+                "time_series",
+                "weights",
+                "inference",
+                "fit_diagnostics",
+                "method_details",
+            ):
+                object.__setattr__(self, key, getattr(self.summary, key))
+        return self
 
     @property
     def mode(self) -> str:

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -1,0 +1,133 @@
+"""Configuration for the VanillaSC estimator.
+
+Co-located with the VanillaSC helper package. The shared
+:class:`~mlsynth.config_models.BaseEstimatorConfig` remains central (it is
+common to every estimator); only the per-estimator config lives here, next to
+the code it configures. Re-exported from :mod:`mlsynth.config_models` for
+backward compatibility.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from pydantic import Field
+
+from ...config_models import BaseEstimatorConfig
+
+
+class VanillaSCConfig(BaseEstimatorConfig):
+    """Configuration for the VanillaSC estimator (standard SCM, bilevel engine).
+
+    The ordinary single-treated synthetic control, built on the self-contained
+    bilevel machinery. With no covariates it reduces to the well-posed convex
+    outcome-matching problem; with covariates it routes through the bilevel
+    predictor-weight (``V``) optimisation, with a selectable, reliable backend.
+
+    Parameters
+    ----------
+    backend : {"auto", "outcome-only", "malo", "mscmt", "penalized"}
+        Predictor-weight backend. ``"auto"`` (default) uses ``"outcome-only"``
+        (convex simplex fit on pre-treatment outcomes) when no covariates are
+        given, and ``"mscmt"`` (global differential-evolution ``V`` search)
+        when they are. ``"malo"`` is the Malo et al. (2024) corner search,
+        ``"penalized"`` the Abadie-L'Hour (2021) unique/sparse estimator.
+    covariates : list of str, optional
+        Predictor columns. Each is averaged over its window (see
+        ``covariate_windows``) and scaled to unit variance, then matched via
+        the bilevel program. ``None`` -> outcome-only matching.
+    covariate_windows : dict, optional
+        Per-covariate inclusive ``(start, end)`` averaging window of time
+        labels (Abadie's special-predictor spec). Covariates not listed are
+        averaged over the full pre-treatment period.
+    canonical_v : bool or {"min.loss.w", "max.order"}
+        Canonicalise the (non-identified) predictor weights for ``mscmt``
+        (MSCMT ``determine_v``). The reported ``v_agreement`` is small when
+        ``V`` is well identified and large when it is fragile. Default False.
+    seed : int
+        RNG seed for the ``mscmt`` differential-evolution search.
+    mscmt_maxiter, mscmt_popsize : int
+        Differential-evolution budget for the ``mscmt`` backend.
+    inference : bool or {"placebo", "scpi", "lto"}
+        Inference method. ``True``/``"placebo"`` (default) runs Abadie in-space
+        placebo inference (refit treating each donor as pseudo-treated; the
+        p-value ranks the treated unit's post/pre RMSPE ratio). ``"scpi"`` runs
+        Cattaneo-Feng-Titiunik (2021) prediction intervals (in-sample
+        simulation + out-of-sample location-scale; exact for the simplex /
+        outcome-only synthetic control). ``"lto"`` runs the Lei-Sudijono (2025)
+        leave-two-out refined placebo test (O(J^2) reference comparisons; finer
+        granularity and non-zero size when ``alpha < 1/N``). ``False`` skips
+        inference.
+    alpha : float
+        Level. For placebo, the confidence statement; for SCPI, used as both
+        the in-sample (alpha1) and out-of-sample (alpha2) levels, giving a
+        prediction interval with coverage approximately ``1 - 2*alpha``.
+    scpi_sims : int
+        Number of Gaussian draws for the SCPI in-sample simulation.
+    scpi_e_method : {"gaussian", "empirical"}
+        Out-of-sample location-scale tabulation for SCPI.
+    lto_max_pairs : int, optional
+        Cap on the number of donor pairs evaluated by the ``"lto"`` test
+        (deterministic subsample via ``seed``). ``None`` (default) uses all
+        ``J*(J-1)/2`` pairs; set a cap to keep the O(J^2) cost tractable with
+        slow backends.
+    """
+
+    backend: Literal["auto", "outcome-only", "malo", "mscmt", "penalized"] = Field(
+        default="auto",
+        description="Predictor-weight backend (see class docstring).",
+    )
+    covariates: Optional[List[str]] = Field(
+        default=None,
+        description="Predictor columns; None -> outcome-only matching.",
+    )
+    covariate_windows: Optional[Dict[Any, Any]] = Field(
+        default=None,
+        description="Per-covariate inclusive (start, end) averaging window.",
+    )
+    canonical_v: Union[bool, str] = Field(
+        default=False,
+        description="Canonicalise mscmt predictor weights ('min.loss.w'/'max.order').",
+    )
+    seed: int = Field(default=0, description="RNG seed for the mscmt DE search.")
+    mscmt_maxiter: int = Field(
+        default=300, ge=1, description="mscmt differential-evolution max iterations.",
+    )
+    mscmt_popsize: int = Field(
+        default=15, ge=1, description="mscmt differential-evolution population size.",
+    )
+    mscmt_prune_shady: bool = Field(
+        default=True,
+        description="mscmt: drop shady donors (Becker-Kloessner sunny-donor "
+                    "reduction) before the outer search. Leaves the optimum "
+                    "unchanged; shrinks the inner solve.",
+    )
+    inference: Union[bool, str] = Field(
+        default=True,
+        description="Inference: True/'placebo' (in-space placebo), 'scpi' "
+                    "(Cattaneo-Feng-Titiunik prediction intervals), 'lto' "
+                    "(Lei-Sudijono leave-two-out refined placebo), or False.",
+    )
+    alpha: float = Field(
+        default=0.05, gt=0.0, lt=1.0,
+        description="Level (placebo confidence / SCPI alpha1 = alpha2).",
+    )
+    scpi_sims: int = Field(
+        default=200, ge=1,
+        description="Gaussian draws for the SCPI in-sample simulation.",
+    )
+    scpi_e_method: Literal["gaussian", "empirical"] = Field(
+        default="gaussian",
+        description="SCPI out-of-sample location-scale tabulation.",
+    )
+    lto_max_pairs: Optional[int] = Field(
+        default=None, ge=1,
+        description="Cap on donor pairs for the 'lto' test (None -> all pairs).",
+    )
+    penalized_cv: Literal["holdout", "loo", "pensynth"] = Field(
+        default="holdout",
+        description="Lambda selector for backend='penalized'. 'holdout'/'loo' "
+                    "are Abadie-L'Hour time-split criteria; 'pensynth' is van "
+                    "Kesteren's cv_pensynth (fit on covariates, validate on the "
+                    "held-out pre-period outcome path; needs covariates).",
+    )


### PR DESCRIPTION
## What & why

Introduces the **two-family result contract** and applies it to the three reference estimators as a validated testing ground, plus the agent-facing docs that make it the standard going forward.

A common `MlsynthResult` base with two faces:
- **`EffectResult`** (alias of `BaseEstimatorResults`) — the observational report.
- **`DesignResult`** — the research design, whose `report` is an `EffectResult`.

## Changes

- **`config_models.py`**: add `MlsynthResult` base, `DesignResult`, `EffectResult` alias, and flat convenience accessors on `BaseEstimatorResults` (`att`, `att_ci`, `counterfactual`, `gap`, `donor_weights`, `pre_rmse`). Enrich `WeightsResults` into the single weights container exposing `donor_weights` / `time_weights` / `unit_weights`.
- **VanillaSC / FDID / TSSC** migrated onto the contract: FDID/TSSC result containers are now frozen Pydantic `EffectResult` subclasses that populate the standardized sub-models; all previously public attributes/methods are preserved. VanillaSC gains the flat accessors via the base.
- **Config relocation**: `VanillaSCConfig` / `FDIDConfig` / `TSSCConfig` moved next to their helpers in `utils/<name>_helpers/config.py`, re-exported from `mlsynth.config_models` via a lazy `__getattr__` so existing imports keep working unchanged.
- **New**: `mlsynth/results.py` (public surface) and `tests/test_result_contract.py` (machine-checks the contract on the three estimators).
- **Docs/agents**: `agents/agents_results.md` documents the contract + the per-estimator migration Definition of Done; wired into `agents_estimators.md` and `CLAUDE.md`. `CLAUDE.md` also gains PR-merge standing-authorization guidelines.
- **`CHANGELOG.md`**: migration entry (already on `main`).

## Backward compatibility

No public estimator API removed. Config imports from `mlsynth.config_models` still resolve to the same classes. The only intentional surface change: assigning to a frozen FDID/TSSC result now raises pydantic's `ValidationError` instead of the dataclass `FrozenInstanceError`.

## Testing

Full suite green: **2613 passed, 3 skipped** (`pytest mlsynth/tests/`).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_