### PR TITLE
Metric primitives + canonical result builder, FDID validation (Path A/B), and a binding docs notation canon

### DIFF
--- a/mlsynth/utils/effectutils.py
+++ b/mlsynth/utils/effectutils.py
@@ -1,0 +1,83 @@
+"""Vectorized treatment-*effect* primitives.
+
+Bite-sized, pure functions for the *effect* side of estimator reporting --
+ATT, percent ATT, total and standardized effects, and the per-period gap --
+kept separate from the goodness-of-fit / loss primitives in
+:mod:`mlsynth.utils.fitutils`. Each is a vectorized operation (dot products
+over outcome paths) returning *raw* (unrounded) values; callers round only for
+display. Higher layers compose effects + fit primitives together:
+
+* :func:`mlsynth.utils.results_helpers.build_effect_submodels` -- the
+  standardized ``EffectResult`` sub-models;
+* :meth:`mlsynth.utils.resultutils.effects.calculate` -- the legacy display
+  dictionaries.
+
+Notation (Shi--Huang): ``T0`` pre-treatment periods, ``T1`` post; ``r`` the
+gap vector ``y - y_hat``; ``s^2 = r_pre . r_pre / T0`` the pre-period
+residual mean square.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+
+def _ravel(x: np.ndarray) -> np.ndarray:
+    """Flatten to a 1-D float array (the common input shape)."""
+    return np.asarray(x, dtype=float).ravel()
+
+
+def gap(observed: np.ndarray, counterfactual: np.ndarray) -> np.ndarray:
+    """Per-period treatment effect ``observed - counterfactual``."""
+    return _ravel(observed) - _ravel(counterfactual)
+
+
+def split_pre_post(
+    arr: np.ndarray, n_pre: int, n_post: int
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Slice an array into its pre- and post-treatment segments."""
+    a = _ravel(arr)
+    return a[:n_pre], a[n_pre : n_pre + n_post]
+
+
+def att(post_gap: np.ndarray) -> float:
+    """Average treatment effect on the treated: mean post-period gap."""
+    g = _ravel(post_gap)
+    return float(g.mean()) if g.size else float("nan")
+
+
+def total_effect(post_gap: np.ndarray) -> float:
+    """Total treatment effect: summed post-period gap (``1 . r_post``)."""
+    g = _ravel(post_gap)
+    return float(g.sum()) if g.size else float("nan")
+
+
+def percent_att(att_value: float, counterfactual_post: np.ndarray) -> float:
+    """ATT as a percent of the mean post-period counterfactual."""
+    cf = _ravel(counterfactual_post)
+    mean_cf = float(cf.mean()) if cf.size else 0.0
+    return float(100.0 * att_value / mean_cf) if mean_cf != 0 else float("nan")
+
+
+def standardized_att(pre_gap: np.ndarray, post_gap: np.ndarray) -> float:
+    """Standardized ATT ``sqrt(T1) * att / sqrt((T1/T0) * s^2 + s^2)``."""
+    r_pre = _ravel(pre_gap)
+    r_post = _ravel(post_gap)
+    t0, t1 = r_pre.size, r_post.size
+    if t0 == 0 or t1 == 0:
+        return float("nan")
+    mean_sq_resid = float(r_pre @ r_pre / t0)
+    denom = np.sqrt((t1 / t0) * mean_sq_resid + mean_sq_resid)
+    return float(np.sqrt(t1) * r_post.mean() / denom) if denom != 0 else float("nan")
+
+
+def percent_gap(post_gap: np.ndarray, counterfactual_post: np.ndarray) -> np.ndarray:
+    """Per-period percent effect; ``nan`` where the counterfactual is zero."""
+    g = _ravel(post_gap)
+    cf = _ravel(counterfactual_post)
+    out = np.full_like(g, np.nan)
+    nonzero = cf != 0
+    out[nonzero] = 100.0 * g[nonzero] / cf[nonzero]
+    return out

--- a/mlsynth/utils/fdid_helpers/structures.py
+++ b/mlsynth/utils/fdid_helpers/structures.py
@@ -31,13 +31,10 @@ from pydantic import ConfigDict, Field as PydField, model_validator
 
 from ...config_models import (
     BaseEstimatorResults,
-    EffectsResults,
-    FitDiagnosticsResults,
     InferenceResults,
-    MethodDetailsResults,
-    TimeSeriesResults,
     WeightsResults,
 )
+from ..results_helpers import build_effect_submodels
 
 
 # Public method names.
@@ -199,37 +196,39 @@ class FDIDResults(BaseEstimatorResults):
         """
         if self.effects is None:
             p = self._primary
-            derived = {
-                "effects": EffectsResults(
-                    att=float(p.att),
-                    att_percent=float(p.att_percent),
-                    att_std_err=float(p.att_se),
-                ),
-                "time_series": TimeSeriesResults(
-                    observed_outcome=np.asarray(self.inputs.y),
-                    counterfactual_outcome=np.asarray(p.counterfactual),
-                    estimated_gap=np.asarray(p.gap),
-                    time_periods=np.asarray(self.inputs.time_labels),
-                ),
-                "weights": WeightsResults(
+            derived = build_effect_submodels(
+                observed_outcome=np.asarray(self.inputs.y),
+                counterfactual_outcome=np.asarray(p.counterfactual),
+                n_pre_periods=int(self.inputs.pre_periods),
+                n_post_periods=int(self.inputs.post_periods),
+                time_periods=np.asarray(self.inputs.time_labels),
+                weights=WeightsResults(
                     donor_weights={
                         str(k): float(v) for k, v in p.donor_weights.items()
                     }
                 ),
-                "fit_diagnostics": FitDiagnosticsResults(
-                    rmse_pre=float(p.pre_rmse), r_squared_pre=float(p.r_squared)
-                ),
-                "inference": InferenceResults(
+                inference=InferenceResults(
                     p_value=float(p.p_value),
                     ci_lower=float(p.ci[0]),
                     ci_upper=float(p.ci[1]),
                     standard_error=float(p.att_se),
                     method="analytic (Li 2023)",
                 ),
-                "method_details": MethodDetailsResults(
-                    method_name=p.name, is_recommended=True
-                ),
-            }
+                method_name=p.name,
+                is_recommended=True,
+                att_std_err=float(p.att_se),
+                # FDID computes its ATT / %ATT / pre-RMSE / R^2 analytically
+                # (Li 2023); pin those authoritative values so the validated
+                # numbers are unchanged while the helper unifies the mapping.
+                effects_overrides={
+                    "att": float(p.att),
+                    "att_percent": float(p.att_percent),
+                },
+                fit_overrides={
+                    "rmse_pre": float(p.pre_rmse),
+                    "r_squared_pre": float(p.r_squared),
+                },
+            )
             for key, value in derived.items():
                 object.__setattr__(self, key, value)
         return self

--- a/mlsynth/utils/fitutils.py
+++ b/mlsynth/utils/fitutils.py
@@ -1,0 +1,46 @@
+"""Vectorized goodness-of-fit / loss primitives.
+
+Bite-sized, pure functions for the *loss* side of estimator reporting --
+how well the counterfactual tracks the treated unit -- kept separate from the
+treatment-*effect* primitives in :mod:`mlsynth.utils.effectutils`. Each is a
+dot-product over a residual/outcome vector and returns a raw (unrounded)
+value; callers round only for display.
+
+Notation (Shi--Huang): ``r`` is a residual (gap) vector ``y - y_hat``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _ravel(x: np.ndarray) -> np.ndarray:
+    """Flatten to a 1-D float array (the common input shape)."""
+    return np.asarray(x, dtype=float).ravel()
+
+
+def rmse(residuals: np.ndarray) -> float:
+    """Root-mean-square error of a residual vector, ``sqrt(r . r / n)``."""
+    r = _ravel(residuals)
+    return float(np.sqrt(r @ r / r.size)) if r.size else float("nan")
+
+
+def std(values: np.ndarray) -> float:
+    """Population standard deviation ``sqrt(Var)`` of a vector."""
+    v = _ravel(values)
+    return float(np.std(v)) if v.size else float("nan")
+
+
+def r_squared(observed: np.ndarray, residuals: np.ndarray) -> float:
+    """Coefficient of determination ``1 - r . r / (y_c . y_c)``.
+
+    ``y_c`` is the centered observed vector; returns ``nan`` when the observed
+    series is empty or has zero variance.
+    """
+    y = _ravel(observed)
+    r = _ravel(residuals)
+    if y.size == 0:
+        return float("nan")
+    y_c = y - y.mean()
+    denom = float(y_c @ y_c)
+    return float(1.0 - (r @ r) / denom) if denom != 0 else float("nan")

--- a/mlsynth/utils/results_helpers.py
+++ b/mlsynth/utils/results_helpers.py
@@ -1,8 +1,9 @@
-"""Shared helper for building standardized :class:`WeightsResults`.
+"""Shared helpers for building standardized result sub-models.
 
-Lets each estimator expose the donor weights underlying its counterfactual
-through the same pydantic model (no black boxes), with consistent summary
-statistics.
+Lets each estimator expose its counterfactual, weights, and treatment-effect
+metrics through the same pydantic models (no black boxes), computed from one
+consistent source so ATT / %ATT / gap / pre+post RMSE / R-squared are derived
+identically across every estimator.
 """
 
 from __future__ import annotations
@@ -11,7 +12,14 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 
-from ..config_models import WeightsResults
+from ..config_models import (
+    EffectsResults,
+    FitDiagnosticsResults,
+    InferenceResults,
+    MethodDetailsResults,
+    TimeSeriesResults,
+    WeightsResults,
+)
 
 
 def make_weights_results(
@@ -49,3 +57,135 @@ def make_weights_results(
     if extra:
         summary.update(extra)
     return WeightsResults(donor_weights=donor_weights, summary_stats=summary)
+
+
+def effect_metrics(
+    observed_outcome: np.ndarray,
+    counterfactual_outcome: np.ndarray,
+    n_pre_periods: int,
+    n_post_periods: int,
+) -> Dict[str, Any]:
+    """Canonical treatment-effect / fit metrics from two outcome paths.
+
+    The single source of truth for the series-derived quantities every
+    effect estimator reports, so they are computed identically everywhere:
+    ATT (mean post-period gap), percent ATT, the per-period gap, pre- and
+    post-period RMSE, and pre-period R-squared.
+
+    Parameters
+    ----------
+    observed_outcome, counterfactual_outcome : np.ndarray
+        Treated-unit observed and counterfactual paths over all ``T`` periods.
+    n_pre_periods, n_post_periods : int
+        Number of pre- and post-treatment periods (``T0`` and ``T1``).
+
+    Returns
+    -------
+    dict
+        ``att``, ``att_percent``, ``rmse_pre``, ``rmse_post``,
+        ``r_squared_pre`` (floats; ``nan`` where undefined) and ``gap``
+        (the full-length ``observed - counterfactual`` array).
+    """
+    obs = np.asarray(observed_outcome, dtype=float).ravel()
+    cf = np.asarray(counterfactual_outcome, dtype=float).ravel()
+    gap = obs - cf
+    pre = slice(0, n_pre_periods)
+    post = slice(n_pre_periods, n_pre_periods + n_post_periods)
+
+    pre_resid = gap[pre]
+    rmse_pre = float(np.sqrt(np.mean(pre_resid ** 2))) if n_pre_periods > 0 else float("nan")
+    obs_pre = obs[pre]
+    var_pre = float(np.mean((obs_pre - obs_pre.mean()) ** 2)) if n_pre_periods > 0 else 0.0
+    r_squared_pre = (
+        float(1.0 - np.mean(pre_resid ** 2) / var_pre)
+        if n_pre_periods > 0 and var_pre != 0.0
+        else float("nan")
+    )
+
+    if n_post_periods > 0:
+        post_gap = gap[post]
+        att = float(np.mean(post_gap))
+        cf_post_mean = float(np.mean(cf[post]))
+        att_percent = float(100.0 * att / cf_post_mean) if cf_post_mean != 0.0 else float("nan")
+        rmse_post = float(np.sqrt(np.mean(post_gap ** 2)))
+    else:
+        att = att_percent = rmse_post = float("nan")
+
+    return {
+        "att": att,
+        "att_percent": att_percent,
+        "rmse_pre": rmse_pre,
+        "rmse_post": rmse_post,
+        "r_squared_pre": r_squared_pre,
+        "gap": gap,
+    }
+
+
+def build_effect_submodels(
+    observed_outcome: np.ndarray,
+    counterfactual_outcome: np.ndarray,
+    n_pre_periods: int,
+    n_post_periods: int,
+    *,
+    time_periods: Optional[np.ndarray] = None,
+    weights: Optional[WeightsResults] = None,
+    inference: Optional[InferenceResults] = None,
+    method_name: Optional[str] = None,
+    is_recommended: bool = True,
+    att_std_err: Optional[float] = None,
+    effects_overrides: Optional[Dict[str, Any]] = None,
+    fit_overrides: Optional[Dict[str, Any]] = None,
+    additional_effects: Optional[Dict[str, Any]] = None,
+    additional_metrics: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build the standardized EffectResult sub-models from two outcome paths.
+
+    Computes the series-derived metrics via :func:`effect_metrics` and maps
+    them into ``effects`` / ``time_series`` / ``fit_diagnostics``, attaching
+    the supplied ``weights`` / ``inference`` / ``method_details``. Returns a
+    ``{sub-model name: model}`` dict ready to splat onto a result container.
+
+    ``effects_overrides`` / ``fit_overrides`` let an estimator pin a value it
+    computes authoritatively (e.g. a method-specific ATT or R-squared) instead
+    of the canonical one, so validated numbers never drift.
+    """
+    m = effect_metrics(observed_outcome, counterfactual_outcome, n_pre_periods, n_post_periods)
+
+    effects_kwargs: Dict[str, Any] = {
+        "att": m["att"],
+        "att_percent": m["att_percent"],
+        "att_std_err": att_std_err,
+        "additional_effects": additional_effects,
+    }
+    if effects_overrides:
+        effects_kwargs.update(effects_overrides)
+
+    fit_kwargs: Dict[str, Any] = {
+        "rmse_pre": m["rmse_pre"],
+        "rmse_post": m["rmse_post"],
+        "r_squared_pre": m["r_squared_pre"],
+        "additional_metrics": additional_metrics,
+    }
+    if fit_overrides:
+        fit_kwargs.update(fit_overrides)
+
+    obs = np.asarray(observed_outcome, dtype=float).ravel()
+    submodels: Dict[str, Any] = {
+        "effects": EffectsResults(**effects_kwargs),
+        "time_series": TimeSeriesResults(
+            observed_outcome=obs,
+            counterfactual_outcome=np.asarray(counterfactual_outcome, dtype=float).ravel(),
+            estimated_gap=m["gap"],
+            time_periods=None if time_periods is None else np.asarray(time_periods),
+        ),
+        "fit_diagnostics": FitDiagnosticsResults(**fit_kwargs),
+    }
+    if weights is not None:
+        submodels["weights"] = weights
+    if inference is not None:
+        submodels["inference"] = inference
+    if method_name is not None:
+        submodels["method_details"] = MethodDetailsResults(
+            method_name=method_name, is_recommended=is_recommended
+        )
+    return submodels

--- a/mlsynth/utils/results_helpers.py
+++ b/mlsynth/utils/results_helpers.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, Optional
 
 import numpy as np
 
+from . import effectutils as em
+from . import fitutils as fm
 from ..config_models import (
     EffectsResults,
     FitDiagnosticsResults,
@@ -86,38 +88,20 @@ def effect_metrics(
         ``r_squared_pre`` (floats; ``nan`` where undefined) and ``gap``
         (the full-length ``observed - counterfactual`` array).
     """
-    obs = np.asarray(observed_outcome, dtype=float).ravel()
-    cf = np.asarray(counterfactual_outcome, dtype=float).ravel()
-    gap = obs - cf
-    pre = slice(0, n_pre_periods)
-    post = slice(n_pre_periods, n_pre_periods + n_post_periods)
+    obs = em._ravel(observed_outcome)
+    full_gap = em.gap(obs, counterfactual_outcome)
+    pre_gap, post_gap = em.split_pre_post(full_gap, n_pre_periods, n_post_periods)
+    obs_pre, _ = em.split_pre_post(obs, n_pre_periods, n_post_periods)
+    _, cf_post = em.split_pre_post(counterfactual_outcome, n_pre_periods, n_post_periods)
 
-    pre_resid = gap[pre]
-    rmse_pre = float(np.sqrt(np.mean(pre_resid ** 2))) if n_pre_periods > 0 else float("nan")
-    obs_pre = obs[pre]
-    var_pre = float(np.mean((obs_pre - obs_pre.mean()) ** 2)) if n_pre_periods > 0 else 0.0
-    r_squared_pre = (
-        float(1.0 - np.mean(pre_resid ** 2) / var_pre)
-        if n_pre_periods > 0 and var_pre != 0.0
-        else float("nan")
-    )
-
-    if n_post_periods > 0:
-        post_gap = gap[post]
-        att = float(np.mean(post_gap))
-        cf_post_mean = float(np.mean(cf[post]))
-        att_percent = float(100.0 * att / cf_post_mean) if cf_post_mean != 0.0 else float("nan")
-        rmse_post = float(np.sqrt(np.mean(post_gap ** 2)))
-    else:
-        att = att_percent = rmse_post = float("nan")
-
+    att_value = em.att(post_gap)
     return {
-        "att": att,
-        "att_percent": att_percent,
-        "rmse_pre": rmse_pre,
-        "rmse_post": rmse_post,
-        "r_squared_pre": r_squared_pre,
-        "gap": gap,
+        "att": att_value,
+        "att_percent": em.percent_att(att_value, cf_post),
+        "rmse_pre": fm.rmse(pre_gap) if n_pre_periods > 0 else float("nan"),
+        "rmse_post": fm.rmse(post_gap) if n_post_periods > 0 else float("nan"),
+        "r_squared_pre": fm.r_squared(obs_pre, pre_gap) if n_pre_periods > 0 else float("nan"),
+        "gap": full_gap,
     }
 
 

--- a/mlsynth/utils/resultutils.py
+++ b/mlsynth/utils/resultutils.py
@@ -347,6 +347,10 @@ def plot_estimates(
         plt.close() # Close the plot figure to free up memory, especially in loops or batch processing.
 
 
+from . import effectutils as _eff
+from . import fitutils as _fit
+
+
 class effects:
     @staticmethod
     def calculate(
@@ -383,58 +387,43 @@ class effects:
         >>> # Placeholder example
         >>> pass
         """
-        # --- Pre-treatment Fit Statistics ---
-        # Calculate residuals in the pre-treatment period.
-        pre_treatment_residuals = observed_outcome_series[:num_pre_treatment_periods] - counterfactual_outcome_series[:num_pre_treatment_periods]
-        
-        # Calculate the denominator for R-squared: variance of observed outcomes in pre-treatment.
-        mean_sq_error_pre_treatment_denom = np.mean((observed_outcome_series[:num_pre_treatment_periods] - np.mean(observed_outcome_series[:num_pre_treatment_periods]))**2)
-        
-        # Calculate R-squared for the pre-treatment period.
-        # R-squared = 1 - (MSE_residuals / Var_observed_outcomes)
-        # Handle cases with no pre-periods or zero variance in observed outcomes.
-        r_squared_pre_treatment = 1 - (np.mean(pre_treatment_residuals**2)) / mean_sq_error_pre_treatment_denom if num_pre_treatment_periods > 0 and mean_sq_error_pre_treatment_denom != 0 else np.nan
+        # All series-derived quantities come from the vectorized primitives in
+        # effectutils (treatment effects) and fitutils (goodness-of-fit / loss),
+        # so every estimator computes them identically; the rounding below is
+        # for display / back-compat only.
+        obs = _fit._ravel(observed_outcome_series)
+        cf = _fit._ravel(counterfactual_outcome_series)
+        gap_series = _eff.gap(obs, cf)
+        pre_gap, post_gap = _eff.split_pre_post(
+            gap_series, num_pre_treatment_periods, num_actual_post_periods
+        )
+        obs_pre, _ = _eff.split_pre_post(
+            obs, num_pre_treatment_periods, num_actual_post_periods
+        )
+        _, cf_post = _eff.split_pre_post(
+            cf, num_pre_treatment_periods, num_actual_post_periods
+        )
 
-        # --- Post-treatment Effect Calculations ---
+        # --- Goodness-of-fit (loss) ---
+        r_squared_pre_treatment = (
+            _fit.r_squared(obs_pre, pre_gap) if num_pre_treatment_periods > 0 else np.nan
+        )
+        t0_rmse = _fit.rmse(pre_gap) if num_pre_treatment_periods > 0 else np.nan
+
+        # --- Treatment effects ---
         if num_actual_post_periods > 0:
-            # Define the slice for the post-treatment period.
-            post_period_slice = slice(num_pre_treatment_periods, num_pre_treatment_periods + num_actual_post_periods)
-            
-            # Average Treatment Effect on the Treated (ATT)
-            average_treatment_effect_treated = np.mean(observed_outcome_series[post_period_slice] - counterfactual_outcome_series[post_period_slice])
-            
-            # Mean of the counterfactual in the post-treatment period (for Percent ATT).
-            mean_counterfactual_post_treatment = np.mean(counterfactual_outcome_series[post_period_slice])
-            # Percent ATT: ATT as a percentage of the mean counterfactual.
-            average_treatment_effect_treated_percent = (100 * average_treatment_effect_treated / mean_counterfactual_post_treatment) if mean_counterfactual_post_treatment != 0 else np.nan
-            
-            # Components for Standardized ATT (SATT)
-            # Scaled mean squared pre-treatment residuals.
-            scaled_mean_sq_pre_treatment_residuals = (num_actual_post_periods / num_pre_treatment_periods) * np.mean(pre_treatment_residuals**2) if num_pre_treatment_periods > 0 else np.nan
-            mean_sq_pre_treatment_residuals = np.mean(pre_treatment_residuals**2) if num_pre_treatment_periods > 0 else np.nan
-            # Denominator for SATT, based on pre-treatment residual variance.
-            standard_error_denominator_for_satt = np.sqrt(scaled_mean_sq_pre_treatment_residuals + mean_sq_pre_treatment_residuals) if not (np.isnan(scaled_mean_sq_pre_treatment_residuals) or np.isnan(mean_sq_pre_treatment_residuals)) else np.nan
-            
-            # Standardized ATT.
-            standardized_average_treatment_effect = (np.sqrt(num_actual_post_periods) * average_treatment_effect_treated / standard_error_denominator_for_satt) if standard_error_denominator_for_satt != 0 and not np.isnan(standard_error_denominator_for_satt) else np.nan
-            
-            # Total Treatment Effect (TTE): sum of differences in the post-period.
-            total_treatment_effect = np.sum(observed_outcome_series[post_period_slice] - counterfactual_outcome_series[post_period_slice])
-            
-            # Time series of ATT for each post-treatment period.
-            att_time_series = observed_outcome_series[post_period_slice] - counterfactual_outcome_series[post_period_slice]
-            # Time series of Percent ATT.
-            percent_att_time_series = np.full_like(att_time_series, np.nan) # Initialize with NaNs.
-            non_zero_cf_post_mask = counterfactual_outcome_series[post_period_slice] != 0 # Avoid division by zero.
-            percent_att_time_series[non_zero_cf_post_mask] = 100 *\
-                att_time_series[non_zero_cf_post_mask] / counterfactual_outcome_series[post_period_slice][non_zero_cf_post_mask]
-            # Time series of SATT (currently a placeholder, as per-period SATT might need different scaling).
-            satt_time_series = np.full_like(att_time_series, np.nan) 
-            
-            # RMSE of the gap in the post-treatment period (T1 RMSE).
-            post_treatment_rmse = round(np.std(observed_outcome_series[post_period_slice] - counterfactual_outcome_series[post_period_slice]), 3)
-
-        else: # Handle case with no post-treatment periods.
+            average_treatment_effect_treated = _eff.att(post_gap)
+            average_treatment_effect_treated_percent = _eff.percent_att(
+                average_treatment_effect_treated, cf_post
+            )
+            standardized_average_treatment_effect = _eff.standardized_att(pre_gap, post_gap)
+            total_treatment_effect = _eff.total_effect(post_gap)
+            att_time_series = post_gap
+            percent_att_time_series = _eff.percent_gap(post_gap, cf_post)
+            satt_time_series = np.full_like(att_time_series, np.nan)
+            # "T1 RMSE" is historically the std dev of the post-treatment gap.
+            post_treatment_rmse = round(_fit.std(post_gap), 3)
+        else:  # No post-treatment periods.
             average_treatment_effect_treated = np.nan
             average_treatment_effect_treated_percent = np.nan
             standardized_average_treatment_effect = np.nan
@@ -447,9 +436,9 @@ class effects:
         # --- Compile Results into Dictionaries ---
         # Dictionary for goodness-of-fit statistics.
         fit_statistics_dict = {
-            "T0 RMSE": round(np.sqrt(np.mean(pre_treatment_residuals**2)), 3) if num_pre_treatment_periods > 0 else np.nan, # Pre-treatment RMSE
-            "T1 RMSE": post_treatment_rmse, # Post-treatment RMSE (std dev of post-treatment gap)
-            "R-Squared": round(r_squared_pre_treatment, 3), # Pre-treatment R-squared
+            "T0 RMSE": round(t0_rmse, 3) if not np.isnan(t0_rmse) else np.nan,
+            "T1 RMSE": post_treatment_rmse,
+            "R-Squared": round(r_squared_pre_treatment, 3) if not np.isnan(r_squared_pre_treatment) else np.nan,
             "Pre-Periods": num_pre_treatment_periods,
             "Post-Periods": num_actual_post_periods,
         }
@@ -462,30 +451,18 @@ class effects:
             "TTE": round(total_treatment_effect, 3) if not np.isnan(total_treatment_effect) else np.nan,
             "ATT_Time": np.round(att_time_series, 3),
             "PercentATT_Time": np.round(percent_att_time_series, 3),
-            "SATT_Time": np.round(satt_time_series, 3), # Placeholder SATT time series
+            "SATT_Time": np.round(satt_time_series, 3),  # Placeholder SATT time series
         }
 
-        # Calculate the gap series (observed - counterfactual) for all periods.
-        gap_series = observed_outcome_series - counterfactual_outcome_series
-
-        # Create a relative time column: 0 for treatment start, negative for pre, positive for post.
+        # Relative time column: 0 at treatment start, negative pre, positive post.
         relative_time_column_for_gap = np.arange(gap_series.shape[0]) - num_pre_treatment_periods + 1
-        # Combine gap series and relative time into a 2-column matrix.
         gap_matrix = np.column_stack((gap_series, relative_time_column_for_gap))
 
-        # Dictionary for key time series vectors.
-        cf_series_for_dict = np.full_like(observed_outcome_series, np.nan, dtype=float) # Default to NaNs, ensure float
-        if counterfactual_outcome_series is not None and\
-           isinstance(counterfactual_outcome_series, np.ndarray) and\
-           counterfactual_outcome_series.size == observed_outcome_series.size:
-            try:
-                # Ensure counterfactual_outcome_series is 1D before reshape
-                reshaped_cf = counterfactual_outcome_series.flatten().reshape(-1, 1)
-                cf_series_for_dict = np.round(reshaped_cf, 3)
-            except Exception: # Broad catch if reshape/round fails
-                # If error, cf_series_for_dict remains as NaNs
-                pass
-        
+        # Counterfactual column vector (NaNs if shapes are incompatible).
+        cf_series_for_dict = np.full_like(obs, np.nan, dtype=float)
+        if cf.size == obs.size:
+            cf_series_for_dict = np.round(cf.reshape(-1, 1), 3)
+
         time_series_vectors_dict = {
             "Observed Unit": np.round(observed_outcome_series.reshape(-1, 1), 3), # Reshape to column vector
             "Counterfactual": cf_series_for_dict, # Use the robustly prepared series


### PR DESCRIPTION
## Overview

Four related units on this branch:

1. **Metric primitives + canonical result builder** — bite-sized, vectorized effect/fit functions and one builder for the standardized results.
2. **FDID validation (Path A + B)** — the Hong Kong empirical made durable, completing FDID's validation.
3. **Docs de-duplication** — trim the FDID method page now that the replication page owns the validated numbers.
4. **Binding docs notation canon** — one mathematical notation across all docs (derived from the author's blog), with FDID migrated as the worked example.

---

## 1. Metric primitives + canonical result builder

`effects.calculate` mixed treatment **effects** with goodness-of-fit / **loss**. Split into two vectorized, pure-function modules returning raw (unrounded) values:

- **`utils/effectutils.py`** — `gap`, `att`, `total_effect`, `percent_att`, `standardized_att`, `percent_gap`, `split_pre_post`.
- **`utils/fitutils.py`** — `rmse`, `std`, `r_squared`.

Consumers recomposed on these, **behavior-preserving**: `resultutils.effects.calculate` (same outputs/edge-cases; TSSC/SHC/RESCM/laxscm consumers pass), and a new `results_helpers.build_effect_submodels` / `effect_metrics` that map them into the standardized `EffectResult` sub-models — so every estimator computes ATT/%ATT/gap/RMSE/R² from one source. `effects_overrides`/`fit_overrides` let an estimator pin authoritative values so validated numbers never drift. FDID's result is rebuilt via the helper (pure refactor).

## 2. FDID validation (Path A + B) — officially complete

mlsynth's FDID reproduces Li (2024)'s public Hong Kong GDP companion replication cell by cell on `basedata/HongKong.csv`:

| | FDID (mlsynth / Li) | DID (mlsynth / Li) |
|---|---|---|
| ATT | 0.0254 / 0.0254 | 0.0317 / 0.0317 |
| % ATT | 53.84 / 53.84 | 77.62 / 77.62 |
| pre-R² | 0.843 / 0.843 | 0.505 / 0.505 |
| controls | 9 of 24 / 9 | all 24 |

(95% CI `(0.0163, 0.0345)`, SATT ≈ 5.49 also match.) Path B (Table 5 simulation direction) reproduces over M=400 reps.

- `benchmarks/cases/fdid_hongkong.py` (Path A, registered); `fdid_table5.py` (Path B).
- `tests/test_fdid_replication.py` (fast CI guard).
- `docs/replications/fdid.rst` documents both paths; index + CHANGELOG updated.

## 3. Docs de-duplication

`docs/fdid.rst` trimmed (655 → 607 lines): the two example sections fold into one lean Hong Kong **usage** example (no reproduced validation numbers); Verification cites both paths. Method exposition unchanged.

## 4. Binding docs notation canon

`agents/agents_docs.md` is now the **mandatory** notation contract (was an aspirational flag). The symbol canon is derived from the author's `qdocs` blog (`fscm`/`shc`/`scexp`/`shaemax.qmd`); Shi & Huang remains the reference for expository *structure*. It fixes typography (`\widehat`/`\widetilde`/`\coloneqq`, bold/calligraphic), units (treated `j=1`, donors `𝒩₀`), 1-indexed time split at `T₀`, Abadie potential outcomes `y^N`/`y^I`, the constrained-SC program (`𝓛`/`𝓟`/`𝓑`, `𝒞_*`), and reserves `τ` for the treatment effect — with `τ_t`/`τ̂` mapping 1:1 onto the primitives in (1) so docs and result objects share one vocabulary. `CLAUDE.md` pointer updated.

**FDID migrated** to the canon as the worked reference example (`docs/fdid.rst`): `j=0→1`, `𝒩→𝒩₀`, `T₁/T₂→T₀/|𝒯₂|`, `y⁰/y¹→y^N/y^I`, ATT→`τ̂`, `\hat→\widehat` — symbols only, no derivation changed. Other pages migrate incrementally when touched (per the canon's own rule).

## Testing

Full suite green on the foundation refactor: **2611 passed, 3 skipped** — identical to `main` (behavior-neutral). Both FDID benchmarks + the replication test pass. Units 3–4 are docs/agents only (no code).

## Up next

Continue migrating estimators onto `build_effect_submodels` (TSSC, SparseSC, …); migrate remaining docs pages to the canon incrementally; close the benchmark-coverage gap beyond FDID.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX