### PR TITLE
FDID validation (Path A/B), docs de-duplication, and a binding notation canon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Added
+- **FDID validation (Path A + B), officially complete.** New
+  `benchmarks/cases/fdid_hongkong.py` reproduces Li (2024)'s public Hong Kong
+  GDP companion replication cell by cell (FDID ATT 0.0254 / 53.84% / pre-R² 0.843
+  / 9 of 24 controls; DID 0.0317 / 77.62% / 0.505), guarded in CI by
+  `tests/test_fdid_replication.py`; the Table 5 simulation (`fdid_table5.py`)
+  remains the Path B check. Replication page updated to document both.
+- **Vectorized metric primitives.** `utils/effectutils.py` (treatment effects)
+  and `utils/fitutils.py` (goodness-of-fit / loss) split the former
+  `effects.calculate` blob into bite-sized pure functions; `effects.calculate`
+  and the new `results_helpers.build_effect_submodels` compose them so every
+  estimator computes ATT/%ATT/gap/RMSE/R² from one consistent source.
 - **Two-family result contract.** A common `MlsynthResult` base with two faces:
   `EffectResult` (alias of `BaseEstimatorResults`, the observational report)
   and `DesignResult` (the research design, whose `report` is an

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,8 @@ linked from the estimator page's short "Verification" pointer (see
 - One `docs/<name>.rst` per estimator: When-to-use → Notation → Assumptions
   (numbered, each with a Remark) → Inference/diagnostics → runnable Example →
   Verification pointer → Core API autodoc. Follow `agents/agents_docs.md`
-  (Shi–Huang notation canon).
+  — the **binding** math-notation canon (symbols derived from the `qdocs`
+  blog; Shi–Huang for expository structure).
 - Section underlines must be **≥** the title length (RST requirement).
 
 ## Git

--- a/agents/agents_docs.md
+++ b/agents/agents_docs.md
@@ -1,87 +1,151 @@
-# AGENTS.md — Documentation Notation & Style (Future Direction)
+# AGENTS.md — Documentation Math Notation (canonical & binding)
 
-> **Status: aspirational / future flag.** This file records the intended
-> direction for `docs/*.rst` mathematical writing. It does **not** mandate
-> an immediate rewrite of existing pages. Apply incrementally: when you
-> touch a docs page for another reason, migrate it toward the conventions
-> below. New estimator docs should follow them from the start.
+> **Status: binding.** This is the single source of truth for mathematical
+> notation in `docs/*.rst`. It is **mandatory** for every new estimator page
+> and for any page you touch. Existing pages migrate **incrementally** — when
+> you edit a page for any reason, convert its symbols to this canon (symbols
+> only; never alter the content of a derivation). An agent should be able to
+> read any page without re-learning symbols.
 
-## Motivation
+## Why this exists
 
-mlsynth's docs have accreted **mixed mathematical notation** across pages
-(different symbols for the treated unit, the donor pool, pre/post periods,
-expectations, etc.). The goal is a **single, unified notation and writing
-style** across every estimator page, so a reader who learns the conventions
-once can read any page without re-learning symbols.
+mlsynth's docs accreted **mixed notation** across pages — different symbols for
+the treated unit, the donor pool, pre/post periods, the treatment effect — so
+each page made the reader start over. The fix is one symbol set, used
+everywhere. The canon below is **derived from the author's own writing** in the
+`qdocs` blog (<https://github.com/jgreathouse9/jgreathouse9.github.io>, e.g.
+`fscm.qmd`, `shc.qmd`, `scexp.qmd`), so the docs speak in the same voice as the
+blog posts that motivate them.
 
-## Gold-standard reference
+Two references, two roles:
 
-Adopt the notation and expository style of:
+* **Symbol canon → the `qdocs` blog** (the table below). When in doubt about a
+  symbol, match the blog.
+* **Expository structure → Shi & Huang (2023),** *"Forward-selected panel data
+  approach for program evaluation,"* J. Econometrics 234(2): a dedicated
+  Notation block up front, numbered Assumptions each paired with a Remark, and
+  motivating examples that frame *when* the method is the right tool.
 
-> Shi, Z., & Huang, J. (2023). "Forward-selected panel data approach for
-> program evaluation." *Journal of Econometrics*, 234(2), 512–535.
+## The notation canon
 
-Its strengths, which we want to emulate:
+### Typography
 
-1. A dedicated **Notations** paragraph that fixes every symbol convention
-   up front, before any model is introduced.
-2. **Numbered Assumptions** (Assumption 1, 2, …), each stated formally with
-   labelled sub-conditions (a)/(b)/(c), and **each paired with a Remark**
-   that explains the intuition — *why* the assumption is reasonable and
-   what it buys you.
-3. Motivating **Examples** placed early that frame *when* the method is the
-   right tool (e.g. "nearly 200 countries... how to deal with a much larger
-   pool of control units?").
+| Object | Convention | Example |
+| --- | --- | --- |
+| scalar | plain lowercase | `t`, `N`, `T_0`, `\lambda` |
+| vector | **bold lowercase** | `\mathbf{y}`, `\mathbf{w}` |
+| matrix | **bold uppercase** | `\mathbf{Y}_0`, `\mathbf{X}` |
+| set | calligraphic uppercase | `\mathcal{N}`, `\mathcal{T}` |
+| estimate / fitted value | hat | `\widehat{y}_{1t}`, `\widehat{\tau}` |
+| optimiser | star superscript | `\mathbf{w}^\ast` |
+| transformed series (smoothed, de-meaned, …) | tilde | `\widetilde{\mathbf{y}}` |
+| "is defined as" | `\coloneqq` (`:=`) | `\mathcal{T} \coloneqq \{1,\dots,T\}` |
 
-## Three directives for future docs work
+Operators and symbols: norms `\|\cdot\|_1`, `\|\cdot\|_2`, squared
+`\|\cdot\|_2^2`; non-negative reals `\mathbb{R}_{\ge 0}`; unit simplex
+`\Delta^{N_0} \coloneqq \{\mathbf{w}\in\mathbb{R}_{\ge 0}^{N_0} : \|\mathbf{w}\|_1 = 1\}`;
+`\operatorname*{argmin}` / `\operatorname*{argmax}`; indicator
+`\mathbf{1}\{\cdot\}`; standard-normal CDF `\Phi(\cdot)`; expectation
+`\mathbb{E}[\cdot]`; Moore–Penrose pseudoinverse `(\cdot)^{+}`.
 
-### 1. One unified notation across all pages
+### Units
 
-Fix a canonical symbol set and use it everywhere. Proposed canon, mirroring
-Shi & Huang:
+* `\mathcal{N} \coloneqq \{1,\dots,N\}` — all `N` units.
+* **The treated unit is `j = 1`.** (State it once: "Let `j = 1` denote the
+  treated unit.")
+* Donor pool `\mathcal{N}_0 \coloneqq \mathcal{N}\setminus\{1\}`, with
+  cardinality `N_0`. Generic unit index `j`.
 
-- **Typography.** Plain letter `x` = scalar; bold lowercase `x` = column
-  vector; bold uppercase `X` = matrix. `I` identity; `1{·}` indicator;
-  `Φ(·)` standard-normal CDF; `⌈·⌉`/`⌊·⌋` ceiling/floor; `(·)⁻`
-  Moore–Penrose pseudoinverse; `φ_min`/`φ_max` min/max eigenvalue;
-  `‖·‖₁`, `‖·‖₂` the L1/L2 norms; `x_U := (x_j)_{j∈U}` a subvector.
-- **Units.** `N+1` units indexed by `𝒩₀ := {0, 1, …, N}`; `j = 0` is the
-  treated unit; `𝒩 := {1, …, N}` indexes the `N` control/donor units.
-- **Potential outcomes.** `y⁰_{jt}`, `y¹_{jt}`; observed
-  `y_{jt} = y⁰_{jt}(1 − d_{jt}) + y¹_{jt} d_{jt}`, with treatment dummy
-  `d_{jt}`. Treatment effect `Δ_t`.
-- **Time.** Series on `{−T₁, …, −1, 0, 1, …, T₂}`; intervention at `t = 0`;
-  pre-period `𝒯₁ := {−T₁, …, −1}`, post-period `𝒯₂ := {1, …, T₂}`,
-  `𝒯 := 𝒯₁ ∪ 𝒯₂`.
-- **Expectations.** `E[x_t]` population; time-averaged population means
-  `ℰ₍₁₎[x_t] := T₁⁻¹ Σ_{t∈𝒯₁} E[x_t]` (pre) and `ℰ₍₂₎` (post); sample
-  means `𝔼₍₁₎[x_t] := T₁⁻¹ Σ_{t∈𝒯₁} x_t`, `𝔼₍₂₎` (post).
+### Time
 
-When a paper an estimator implements uses different symbols, translate into
-this canon in the docs (a short "notation bridge" note is fine), rather than
-importing yet another symbol set.
+* `t \in \mathcal{T} \coloneqq \{1,\dots,T\}` — **1-indexed**; the intervention
+  takes effect **after** period `T_0`.
+* Pre-period `\mathcal{T}_1 \coloneqq \{t\in\mathcal{T} : t \le T_0\}`,
+  so `|\mathcal{T}_1| = T_0`.
+* Post-period `\mathcal{T}_2 \coloneqq \{t\in\mathcal{T} : t > T_0\}`,
+  so `|\mathcal{T}_2| = T - T_0`.
 
-### 2. Notations block + Assumptions-with-Remarks
+  (Do **not** use a `t = 0`-centered axis. `T_0` is the canonical split point.)
 
-Every estimator docs page should carry:
+### Outcomes  (subscript order: **unit, then time** — `y_{jt}`)
 
-- A short **Notation** subsection (or reuse a shared one) before the model.
-- Identification / inference requirements written as **numbered, formal
-  Assumptions**, each immediately followed by a plain-language **Remark**
-  giving the intuition. Do not bury assumptions inside prose.
+* Observed scalar `y_{jt}`; treated series
+  `\mathbf{y}_1 = (y_{11},\dots,y_{1T})^\top \in \mathbb{R}^T`; donor series
+  `\mathbf{y}_j \in \mathbb{R}^T`.
+* Donor matrix `\mathbf{Y}_0 \coloneqq [\mathbf{y}_j]_{j\in\mathcal{N}_0}
+  \in \mathbb{R}^{T\times N_0}` (one column per donor).
+* Potential outcomes (Abadie superscripts): `y_{jt}^N` without the
+  intervention, `y_{jt}^I` under it; the observed outcome is
+  `y_{jt} = y_{jt}^N + \bigl(y_{jt}^I - y_{jt}^N\bigr)\,d_{jt}` with treatment
+  dummy `d_{jt}`.
 
-### 3. A "When to use this estimator" section
+### Weights, counterfactual, and effects
 
-Each page should include, near the top, the **author's argument for when
-the method is the right choice** — the regime it targets and what problem it
-solves better than the alternatives — framed like Shi & Huang's motivating
-Examples. State the *use case*, not just the mechanics, with reference to real life examples from business or marketing.. (This complements
-the existing one-draw Monte Carlo Example requirement in
-`agents_intro.md §5`.)
+* Donor weights `\mathbf{w} \in \mathbb{R}^{N_0}` (on the simplex `\Delta^{N_0}`
+  when constrained); optimiser `\mathbf{w}^\ast`.
+* Counterfactual / synthetic estimate
+  `\widehat{\mathbf{y}}_1 \coloneqq \mathbf{Y}_0\,\mathbf{w}^\ast`, with entries
+  `\widehat{y}_{1t}`.
+* Per-period treatment effect
+  `\tau_t \coloneqq y_{1t} - \widehat{y}_{1t}` (it estimates
+  `y_{1t}^I - y_{1t}^N`).
+* **ATT** `\widehat{\tau} \coloneqq |\mathcal{T}_2|^{-1}\sum_{t\in\mathcal{T}_2}\tau_t`.
+
+> **Docs ↔ code share one vocabulary.** `\tau_t` is exactly the `gap` and
+> `\widehat{\tau}` the `att` computed in `utils/effectutils.py` /
+> `results_helpers.build_effect_submodels`; pre/post fit are `rmse_pre` /
+> `rmse_post` (`utils/fitutils.py`). Write the math so the symbols name the
+> quantities the result object returns.
+
+### Weight constraints and penalties (the SC family)
+
+Most mlsynth estimators pick `\mathbf{w}` by a constrained / penalized program.
+Write it in this common shape so every weighting page reads alike:
+
+```
+\mathbf{w}^\ast \in \operatorname*{argmin}_{\mathbf{w}\in\mathcal{C}}
+   \; \mathcal{L}(\mathbf{Y}_0,\mathbf{y}_1,\mathbf{w}) + \mathcal{P}(\mathbf{w})
+   \quad\text{s.t.}\quad \mathcal{B}(\mathbf{Y}_0,\mathbf{y}_1,\mathbf{w}) \le \boldsymbol{\delta}
+```
+
+* fit loss `\mathcal{L}`, penalty `\mathcal{P}`, balance map `\mathcal{B}`;
+* feasible set `\mathcal{C}` with descriptive subscripts —
+  `\mathcal{C}_{\text{simplex}}`, `\mathcal{C}_{\text{nonneg}}`,
+  `\mathcal{C}_{\text{affine}}`, `\mathcal{C}_{\text{unit}}`,
+  `\mathcal{C}_{\text{unconstrained}}`;
+* regularization strength `\lambda \ge 0`, elastic-net mix `\alpha \in [0,1]`,
+  norm order `q \in \{2,\infty\}` in `\|\mathbf{w}\|_q`;
+* optional unpenalized intercept / level shift `b_0`, balance slack `\gamma`.
+
+> **Reserve `\tau` for the treatment effect.** `\tau_t` and `\widehat{\tau}`
+> always denote the effect. For a relaxation / balance tolerance use
+> `\boldsymbol{\delta}` (or `\varepsilon`), never `\tau` — this is the one clash
+> that recurs across the source posts, so fix it here.
+
+### The bridge rule
+
+When the implemented paper uses other symbols — Shi & Huang's `j = 0` treated
+unit and `t = 0`-centered time; Li (2024)'s `y_{tr,t}`; Abadie's `\mathbf{Y}_1`
+for the treated matrix — **translate into the canon** and, if helpful, add a
+one-line *notation bridge* ("Li's `y_{tr,t}` is our `y_{1t}`"). Never carry a
+second symbol set into the page.
+
+## Page requirements
+
+Every estimator page carries, in this order near the top:
+
+1. **"When to use this estimator"** — the author's argument for the regime it
+   targets and what it solves better than the alternatives, with a concrete
+   business/marketing example (cf. the one-draw Monte Carlo Example in
+   `agents_intro.md §5`).
+2. A **Notation** block fixing the page's symbols (reuse the canon; only define
+   what is genuinely page-specific) before any model is introduced.
+3. **Numbered Assumptions** (Assumption 1, 2, …) with labelled sub-conditions
+   (a)/(b)/(c), **each immediately followed by a Remark** giving the intuition.
+   Do not bury assumptions in prose.
 
 ## Scope reminder
 
-This is a style/notation unification effort, not a mathematical revision.
-Do not change the *content* of any derivation when migrating notation. When
-in doubt about the canonical symbol for a concept, prefer the Shi & Huang
-choice above.
+This is a notation/style contract, not a license to revise mathematics. When
+migrating a page, change *symbols only* — leave every derivation's content
+intact. When a symbol is genuinely ambiguous, match the `qdocs` blog.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -21,6 +21,7 @@ Each estimator's replication follows one of three "paths" (same vocabulary as
       compare.py            # tolerance-based comparison + reporting
       cases/                # one module per benchmark (pure-Python where possible)
         fdid_table5.py      # Path B: Li (2024) Table 5 PMSE grid (no R needed)
+        fdid_hongkong.py    # Path A: Li (2024) Hong Kong GDP empirical (no R needed)
       R/                    # reference-implementation cross-checks
         requirements.R      # install the reference R packages
         synth_crosscheck.R  # run R's Synth on a dumped panel for cell-by-cell comparison

--- a/benchmarks/cases/fdid_hongkong.py
+++ b/benchmarks/cases/fdid_hongkong.py
@@ -1,0 +1,61 @@
+"""Path A benchmark: Li (2024) Forward DiD, Hong Kong GDP empirical result.
+
+Li's headline application uses a confidential retailer panel, but the author
+released a **public** companion replication on the Hsiao, Ching & Wan (2012)
+Hong Kong GDP panel (the political/economic integration of Hong Kong with
+mainland China). This case reproduces that released result cell by cell:
+mlsynth's :class:`~mlsynth.FDID` on ``basedata/HongKong.csv`` against the
+ATT / %ATT / pre-period R^2 / selected-control-count printed by the author's
+own MATLAB and R code (see ``ForwardDID_Readme.txt``).
+
+Pure Python (no R); deterministic (forward selection has no randomness), so
+tolerances only absorb the estimator's 3-4 dp display rounding.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from mlsynth import FDID
+
+# basedata/HongKong.csv lives at the repo root.
+_DATA = Path(__file__).resolve().parents[2] / "basedata" / "HongKong.csv"
+
+
+def run() -> dict:
+    df = pd.read_csv(_DATA)
+    res = FDID(
+        {
+            "df": df,
+            "outcome": "GDP",
+            "treat": "Integration",
+            "unitid": "Country",
+            "time": "Time",
+            "display_graphs": False,
+            "verbose": False,
+        }
+    ).fit()
+    f, d = res.fdid, res.did
+    return {
+        "fdid_att": float(f.att),
+        "fdid_att_pct": float(f.att_percent),
+        "fdid_r2_pre": float(f.r_squared),
+        "fdid_n_controls": float(len(f.selected_names)),
+        "did_att": float(d.att),
+        "did_att_pct": float(d.att_percent),
+        "did_r2_pre": float(d.r_squared),
+    }
+
+
+# Author's released MATLAB/R output (ForwardDID_Readme.txt); tol absorbs the
+# estimator's display rounding only -- the result is otherwise deterministic.
+EXPECTED = {
+    "fdid_att": (0.025405, 5e-4),
+    "fdid_att_pct": (53.843, 0.1),
+    "fdid_r2_pre": (0.84278, 2e-3),
+    "fdid_n_controls": (9.0, 0.0),
+    "did_att": (0.031721, 5e-4),
+    "did_att_pct": (77.62, 0.1),
+    "did_r2_pre": (0.50465, 2e-3),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -5,7 +5,8 @@ import importlib
 
 # name -> "benchmarks.cases.<module>"  (pure-Python unless noted needs_reference)
 CASES = {
-    "fdid_table5": "benchmarks.cases.fdid_table5",
+    "fdid_table5": "benchmarks.cases.fdid_table5",      # Path B: simulation
+    "fdid_hongkong": "benchmarks.cases.fdid_hongkong",  # Path A: HK GDP empirical
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/docs/fdid.rst
+++ b/docs/fdid.rst
@@ -475,61 +475,11 @@ tracks the population-optimal path.
 Example
 -------
 
-The block below is self-contained. It draws one panel from Li's Web
-Appendix E data-generating process (three common factors, 60 controls), in
-the configuration where **half the controls are the wrong comparison**:
-the treated unit and the first 30 controls load on the common factor with
-weight 1, while the last 30 load with weight 2 (Li's "DGP2"). The true ATT
-is zero. Forward DiD should select from the *matching* half and beat plain
-DiD, which is contaminated by the mismatched half.
-
-.. code-block:: python
-
-   import numpy as np
-   from mlsynth import FDID
-   from mlsynth.utils.fdid_helpers.simulation import simulate_fdid_sample
-
-   sample = simulate_fdid_sample(dgp=2, N=60, T1=24, T2=12,
-                                  rng=np.random.default_rng(0))
-
-   res = FDID({"df": sample.df, "outcome": "y", "treat": "treat",
-               "unitid": "unit", "time": "time",
-               "display_graphs": False}).fit()
-
-   sel = res.fdid.selected_names
-   matching = sum(int(s[1:]) < 60 // 2 for s in sel)
-   print(f"FDID: ATT={res.fdid.att:+.3f}  R2={res.fdid.r_squared:.3f}  "
-         f"selected {len(sel)} donors, {matching} from the matching group")
-   print(f"DID : ATT={res.did.att:+.3f}  R2={res.did.r_squared:.3f}  (all 60 donors)")
-
-A representative single draw prints::
-
-   FDID: ATT=-0.556  R2=0.918  selected 4 donors, 4 from the matching group
-   DID : ATT=-0.924  R2=0.632  (all 60 donors)
-
-Forward DiD picks **only** matching controls, lifting the pre-fit
-:math:`R^2` from 0.63 to 0.92 and landing closer to the true zero effect
-than DiD -- which is dragged off by the 30 mismatched controls it is forced
-to include. (A single draw is noisy; the averaged behaviour over many draws
-is in *Verification* below.)
-
-``res`` is an
-:class:`~mlsynth.utils.fdid_helpers.structures.FDIDResults`: ``res.fdid``
-and ``res.did`` are the two
-:class:`~mlsynth.utils.fdid_helpers.structures.FDIDMethodFit` objects, the
-convenience accessors (``res.att``, ``res.att_se``, ``res.counterfactual``,
-``res.donor_weights``) forward to the Forward DiD fit, and
-``res.att_by_method()`` / ``res.ci_by_method()`` return both side by side.
-
-Empirical Illustration: Hong Kong's economic integration
---------------------------------------------------------
-
-Forward DiD is the DiD analogue of the forward-selected panel-data approach
-([fsPDA]_), and it shines on exactly the data those methods target. We use
-the Hsiao, Ching and Wan ([HCW]_) panel of quarterly real-GDP growth for
-Hong Kong and 24 comparison economies, with Hong Kong's economic
-integration with mainland China as the intervention (44 pre-treatment
-quarters, 17 post).
+The block below fits Forward DiD on the Hsiao, Ching and Wan ([HCW]_) panel of
+quarterly real-GDP growth for Hong Kong and 24 comparison economies -- the
+canonical setting for the forward-selected panel-data approach ([fsPDA]_) that
+Forward DiD descends from -- with Hong Kong's economic integration with
+mainland China as the intervention (44 pre-treatment quarters, 17 post).
 
 .. code-block:: python
 
@@ -542,36 +492,38 @@ quarters, 17 post).
    res = FDID({"df": df, "outcome": "GDP", "treat": "Integration",
                "unitid": "Country", "time": "Time", "display_graphs": True}).fit()
 
-   print(f"FDID ATT {res.fdid.att:.4f}  SE {res.fdid.att_se:.4f}  "
-         f"R2 {res.fdid.r_squared:.3f}  ({len(res.fdid.selected_names)} of "
-         f"{res.inputs.n_donors} controls)")
-   print("selected:", res.fdid.selected_names)
-   print(f"DID  ATT {res.did.att:.4f}  SE {res.did.att_se:.4f}  R2 {res.did.r_squared:.3f}")
+   # Forward DiD fit and the all-controls DiD benchmark, side by side.
+   print(res.fdid.att, res.fdid.r_squared, res.fdid.selected_names)
+   print(res.did.att, res.did.r_squared)
 
-This prints::
+Forward DiD keeps a small, regionally sensible subset of Hong Kong's trading
+partners rather than averaging all 24 economies, so it tracks Hong Kong's
+pre-integration path far more closely (a higher pre-period :math:`R^2`) and
+estimates the post-integration GDP-growth effect more precisely than the
+all-controls DiD. The exact selected group and the cell-by-cell match to Li's
+released output are in :doc:`replications/fdid`.
 
-   FDID ATT 0.0254  SE 0.0046  R2 0.843  (9 of 24 controls)
-   selected: ['Philippines', 'Singapore', 'Thailand', 'Norway', 'Mexico',
-              'Korea', 'Indonesia', 'New Zealand', 'Malaysia']
-   DID  ATT 0.0317  SE 0.0082  R2 0.505
-
-Forward DiD keeps **9 of the 24** economies -- a regionally sensible mix of
-Hong Kong's trading partners -- and in doing so lifts the pre-intervention
-:math:`R^2` from 0.51 (all-controls DiD) to 0.84, roughly **halving the
-standard error**. The selected comparison group implies a post-integration
-GDP-growth effect of about +2.5 percentage points, more precisely estimated
-and better-fitting than the all-controls DiD's +3.2.
+``res`` is an
+:class:`~mlsynth.utils.fdid_helpers.structures.FDIDResults`: ``res.fdid``
+and ``res.did`` are the two
+:class:`~mlsynth.utils.fdid_helpers.structures.FDIDMethodFit` objects, the
+convenience accessors (``res.att``, ``res.att_se``, ``res.counterfactual``,
+``res.donor_weights``) forward to the Forward DiD fit, and
+``res.att_by_method()`` / ``res.ci_by_method()`` return both side by side.
 
 Verification
 ------------
 
-Forward DiD is validated by reproducing the paper's own Monte Carlo
-(Li 2024, Web Appendix E): the Table 5 PMSE grid reproduces cell by cell
-(e.g. cell :math:`(48, 24)` yields :math:`\mathrm{PMSE} = 0.084` against the
-paper's :math:`0.082`), confirming that Forward DiD pays only a small
-efficiency cost when ordinary DiD is valid and wins decisively when half the
-controls are mismatched. See the dedicated replication page,
-:doc:`replications/fdid`, for the full design, code, and cell-by-cell table.
+Forward DiD is validated on two fronts. **Path A** -- mlsynth reproduces the
+author's public Hong Kong GDP companion replication cell by cell (FDID ATT
+:math:`0.0254`, :math:`53.84\%`, pre-period :math:`R^2 = 0.843`, 9 of 24
+controls). **Path B** -- the paper's own Monte Carlo (Li 2024, Web Appendix E)
+reproduces cell by cell (e.g. cell :math:`(48, 24)` yields
+:math:`\mathrm{PMSE} = 0.084` against the paper's :math:`0.082`), confirming
+Forward DiD pays only a small efficiency cost when ordinary DiD is valid and
+wins decisively when half the controls are mismatched. See the dedicated
+replication page, :doc:`replications/fdid`, for the full design, code, and
+cell-by-cell tables.
 
 Core API
 --------

--- a/docs/fdid.rst
+++ b/docs/fdid.rst
@@ -23,8 +23,8 @@ hatches each have a catch:
   form -- exactly the regime of most marketing and macro panels.
 * **The panel-data approach** of Hsiao, Ching and Wan ([HCW]_) and its
   forward-selected variant ([fsPDA]_) fit an unrestricted regression on the
-  controls. When the number of controls :math:`N` exceeds the number of
-  pre-treatment periods :math:`T_1` -- common in store/geo studies -- they
+  controls. When the number of donors :math:`N_0` exceeds the number of
+  pre-treatment periods :math:`T_0` -- common in store/geo studies -- they
   **overfit** in-sample and predict poorly out-of-sample.
 
 Forward DiD (Li [Li2024]_) targets precisely this regime: **many candidate
@@ -39,10 +39,10 @@ Li's own summary:
 
 1. It is a **flexible drop-in for DiD**, usable even when DiD's
    all-controls parallel trend is too restrictive.
-2. It accommodates **any number of controls**, including :math:`N > T_1`.
+2. It accommodates **any number of controls**, including :math:`N_0 > T_0`.
 3. There are **no overfitting concerns** -- one parameter after selection.
-4. It is **computationally cheap**: a greedy :math:`O(N^2)` search rather
-   than the :math:`2^N` subsets of the optimal procedure.
+4. It is **computationally cheap**: a greedy :math:`O(N_0^2)` search rather
+   than the :math:`2^{N_0}` subsets of the optimal procedure.
 5. It has **inference theory valid for stationary and non-stationary
    data**, which SC and HCW lack.
 
@@ -102,39 +102,44 @@ not as a new weighting scheme.
 Notation
 --------
 
-Index the units by :math:`j`, with :math:`j = 0` the single **treated**
-unit and :math:`\mathcal{N} = \{1, \ldots, N\}` the **control** units. A
-selected subset :math:`\mathcal{D} \subseteq \mathcal{N}` is the
-**comparison group**; write its equal-weighted average outcome as
+Index the units by :math:`j`. Let :math:`j = 1` be the single **treated**
+unit and :math:`\mathcal{N} \coloneqq \{1, \ldots, N\}` all units; the
+**donor pool** is :math:`\mathcal{N}_0 \coloneqq \mathcal{N} \setminus \{1\}`,
+with :math:`|\mathcal{N}_0| = N_0`. A selected subset
+:math:`\mathcal{D} \subseteq \mathcal{N}_0` is the **comparison group**;
+write its equal-weighted average outcome as
 
 .. math::
 
    \bar{y}_{\mathcal{D}, t} = \frac{1}{|\mathcal{D}|}
        \sum_{j \in \mathcal{D}} y_{jt}.
 
-Time runs over :math:`t \in \{1, \ldots, T\}`; the intervention starts at
-:math:`T_1 + 1`, giving a pre-period :math:`\mathcal{T}_1 = \{1, \ldots,
-T_1\}` and a post-period :math:`\mathcal{T}_2 = \{T_1 + 1, \ldots, T\}` of
-length :math:`T_2 = T - T_1`. Potential outcomes are :math:`y^0_{jt}`
-(untreated) and :math:`y^1_{jt}` (treated); we observe :math:`y_{0t} =
-y^0_{0t}` for :math:`t \in \mathcal{T}_1` and :math:`y_{0t} = y^1_{0t}` for
-:math:`t \in \mathcal{T}_2`. The estimand is the average treatment effect
-on the treated,
+Time runs over :math:`t \in \mathcal{T} \coloneqq \{1, \ldots, T\}`; the
+intervention takes effect after :math:`T_0`, giving a pre-period
+:math:`\mathcal{T}_1 \coloneqq \{t \in \mathcal{T} : t \le T_0\}` (so
+:math:`|\mathcal{T}_1| = T_0`) and a post-period
+:math:`\mathcal{T}_2 \coloneqq \{t \in \mathcal{T} : t > T_0\}` (so
+:math:`|\mathcal{T}_2| = T - T_0`). Potential outcomes are :math:`y_{jt}^N`
+(without the intervention) and :math:`y_{jt}^I` (under it); for the treated
+unit we observe :math:`y_{1t} = y_{1t}^N` on :math:`\mathcal{T}_1` and
+:math:`y_{1t} = y_{1t}^I` on :math:`\mathcal{T}_2`. The estimand is the
+average treatment effect on the treated,
 
 .. math::
 
-   \mathrm{ATT} = \frac{1}{T_2} \sum_{t \in \mathcal{T}_2}
-       \bigl(y^1_{0t} - y^0_{0t}\bigr).
+   \mathrm{ATT} = \frac{1}{|\mathcal{T}_2|} \sum_{t \in \mathcal{T}_2}
+       \bigl(y_{1t}^I - y_{1t}^N\bigr).
 
 .. admonition:: Notation bridge
 
    Li [Li2024]_ writes the treated outcome :math:`y_{tr,t}`, the selected
-   control set :math:`\mathcal{N}_{co}` with size :math:`N_{co}`, the
-   control average :math:`\bar{y}_{\mathcal{N}_{co}, t}`, the intercept
-   :math:`\alpha`, and :math:`T_1` / :math:`T_2` for the pre/post counts
-   (treatment at :math:`T_1 + 1`). We keep :math:`j = 0` for the treated
-   unit, :math:`\mathcal{D}` for the selected comparison group, and
-   :math:`\bar{y}_{\mathcal{D}, t}` for its average.
+   control set :math:`\mathcal{N}_{co}` of size :math:`N_{co}`, its average
+   :math:`\bar{y}_{\mathcal{N}_{co}, t}`, the intercept :math:`\alpha`, and
+   uses :math:`T_1` / :math:`T_2` for the pre/post sample sizes (treatment
+   at :math:`T_1 + 1`). In the mlsynth canon these become the treated unit
+   :math:`j = 1` (hence :math:`y_{1t}`), the comparison group
+   :math:`\mathcal{D} \subseteq \mathcal{N}_0` with average
+   :math:`\bar{y}_{\mathcal{D}, t}`, and the single split point :math:`T_0`.
 
 Mathematical Formulation
 ------------------------
@@ -148,11 +153,11 @@ constant level shift:
 
 .. math::
 
-   y^0_{0t} = \alpha + \bar{y}_{\mathcal{D}, t} + v_t,
+   y_{1t}^N = \alpha + \bar{y}_{\mathcal{D}, t} + v_t,
    \qquad t = 1, \ldots, T,
 
 with :math:`\alpha` an unknown intercept and :math:`v_t` a zero-mean,
-weakly dependent error. Crucially, :math:`y^0_{0t}` and
+weakly dependent error. Crucially, :math:`y_{1t}^N` and
 :math:`\bar{y}_{\mathcal{D}, t}` may each be **non-stationary** (trending)
 provided their *difference* is stationary -- this is the Forward DiD
 parallel-trends condition. The intercept is estimated by least squares on
@@ -160,22 +165,23 @@ the pre-period,
 
 .. math::
 
-   \hat{\alpha} = \frac{1}{T_1} \sum_{t \in \mathcal{T}_1}
-       \bigl(y_{0t} - \bar{y}_{\mathcal{D}, t}\bigr),
+   \widehat{\alpha} = \frac{1}{T_0} \sum_{t \in \mathcal{T}_1}
+       \bigl(y_{1t} - \bar{y}_{\mathcal{D}, t}\bigr),
 
 so the in-sample fit and out-of-sample counterfactual are
 
 .. math::
 
-   \hat{y}^0_{0t} = \hat{\alpha} + \bar{y}_{\mathcal{D}, t},
+   \widehat{y}_{1t} = \widehat{\alpha} + \bar{y}_{\mathcal{D}, t},
    \qquad t = 1, \ldots, T,
 
-and the ATT is the mean post-period gap
+and the per-period effect is :math:`\tau_t = y_{1t} - \widehat{y}_{1t}`,
+whose post-period average is the ATT,
 
 .. math::
 
-   \widehat{\mathrm{ATT}} = \frac{1}{T_2}
-       \sum_{t \in \mathcal{T}_2} \bigl(y_{0t} - \hat{y}^0_{0t}\bigr).
+   \widehat{\tau} = \frac{1}{|\mathcal{T}_2|}
+       \sum_{t \in \mathcal{T}_2} \bigl(y_{1t} - \widehat{y}_{1t}\bigr).
 
 Because the model has a single parameter, the pre-treatment fit quality is
 summarized by an :math:`R^2` (identical to the adjusted :math:`R^2`, since
@@ -183,35 +189,43 @@ there is only one regressor coefficient):
 
 .. math::
 
-   R^2_{\mathcal{D}} = 1 - \frac{\sum_{t \in \mathcal{T}_1} \hat{v}_t^2}
-       {\sum_{t \in \mathcal{T}_1} (y_{0t} - \bar{y}_0)^2},
-   \qquad \hat{v}_t = y_{0t} - \bar{y}_{\mathcal{D}, t} - \hat{\alpha},
+   R^2_{\mathcal{D}} = 1 - \frac{\sum_{t \in \mathcal{T}_1} \widehat{v}_t^2}
+       {\sum_{t \in \mathcal{T}_1} (y_{1t} - \bar{y}_1)^2},
+   \qquad \widehat{v}_t = y_{1t} - \bar{y}_{\mathcal{D}, t} - \widehat{\alpha},
 
-where :math:`\bar{y}_0` is the treated unit's pre-period mean.
+where :math:`\bar{y}_1` is the treated unit's pre-period mean.
+
+.. note::
+
+   :math:`\tau_t` and :math:`\widehat{\tau}` are exactly the ``gap`` and
+   ``att`` the result object returns (computed in
+   :mod:`mlsynth.utils.effectutils`), and the pre/post fit are ``rmse_pre`` /
+   ``rmse_post`` (:mod:`mlsynth.utils.fitutils`) -- the math here names the
+   quantities :meth:`mlsynth.FDID.fit` reports.
 
 The forward-selection algorithm
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Maximizing :math:`R^2_{\mathcal{D}}` is equivalent to minimizing the
-pre-period residual variance :math:`T_1^{-1} \sum_{t \in \mathcal{T}_1}
-\hat{v}_t^2`. Forward DiD searches over comparison groups greedily:
+pre-period residual variance :math:`T_0^{-1} \sum_{t \in \mathcal{T}_1}
+\widehat{v}_t^2`. Forward DiD searches over comparison groups greedily:
 
-1. **Step 1.** For each single control :math:`i \in \mathcal{N}`, form the
+1. **Step 1.** For each single donor :math:`i \in \mathcal{N}_0`, form the
    one-unit comparison group and compute its pre-period :math:`R^2`. Keep
-   the best single control, :math:`\hat{c}_1`.
-2. **Step 2.** Add to :math:`\{\hat{c}_1\}` each of the remaining
-   :math:`N - 1` controls in turn; keep the two-unit group with the highest
+   the best single donor, :math:`\widehat{c}_1`.
+2. **Step 2.** Add to :math:`\{\widehat{c}_1\}` each of the remaining
+   :math:`N_0 - 1` donors in turn; keep the two-unit group with the highest
    :math:`R^2`.
-3. **Step 3.** Continue, adding one control at a time, until all :math:`N`
-   controls are in. This yields :math:`N` nested groups (sizes
-   :math:`1, 2, \ldots, N`); select the one,
-   :math:`\hat{\mathcal{D}} = \mathcal{N}_{co}`, with the largest
+3. **Step 3.** Continue, adding one donor at a time, until all
+   :math:`N_0` donors are in. This yields :math:`N_0` nested groups (sizes
+   :math:`1, 2, \ldots, N_0`); select the one,
+   :math:`\widehat{\mathcal{D}} = \mathcal{N}_{co}`, with the largest
    :math:`R^2`.
 
-The greedy search evaluates :math:`1 + 2 + \cdots + N = N(N+1)/2`
-sub-models rather than the :math:`2^N` of the exhaustive procedure (for
-:math:`N = 60`, that is 1,830 versus :math:`1.15 \times 10^{18}`). The
-final group :math:`\hat{\mathcal{D}}` is then plugged into the DiD formulas
+The greedy search evaluates :math:`1 + 2 + \cdots + N_0 = N_0(N_0+1)/2`
+sub-models rather than the :math:`2^{N_0}` of the exhaustive procedure (for
+:math:`N_0 = 60`, that is 1,830 versus :math:`1.15 \times 10^{18}`). The
+final group :math:`\widehat{\mathcal{D}}` is then plugged into the DiD formulas
 above for the ATT, its standard error, and the :math:`R^2`.
 
 How mlsynth computes this: incremental means and a batched :math:`R^2`
@@ -240,7 +254,7 @@ which is :math:`O(T)` rather than :math:`O(kT)`. This is
 (``current_mean + (control - current_mean) / (k + 1)``).
 
 **2. All candidate averages for a step are built in one matrix.** At step
-:math:`k`, let :math:`\mathbf{Y}_{\mathcal{R}} \in \mathbb{R}^{T_1 \times
+:math:`k`, let :math:`\mathbf{Y}_{\mathcal{R}} \in \mathbb{R}^{T_0 \times
 |\mathcal{R}|}` stack the *pre-period* columns of the remaining candidates
 :math:`\mathcal{R}`. Every candidate :math:`(k+1)`-average -- one per
 column -- is formed simultaneously by broadcasting the running pre-period
@@ -250,7 +264,7 @@ mean :math:`\mathbf{m}^{(k)}_{\mathcal{T}_1}`:
 
    \mathbf{M} = \frac{k\,\mathbf{m}^{(k)}_{\mathcal{T}_1}\mathbf{1}^\top
        + \mathbf{Y}_{\mathcal{R}}}{k + 1}
-   \in \mathbb{R}^{T_1 \times |\mathcal{R}|}.
+   \in \mathbb{R}^{T_0 \times |\mathcal{R}|}.
 
 In code this is the one line ``new_means = (current_mean_pre[:, None] * k +
 candidates) / (k + 1)`` inside
@@ -260,9 +274,9 @@ candidates) / (k + 1)`` inside
 products.** This is the step that removes the per-candidate regression
 entirely. Profiling out :math:`\alpha` from the DiD loss is exactly
 *centering*: the fitted residual for candidate column :math:`\ell` is
-:math:`\hat v_t = (y_{0t} - \bar y_0) - (M_{t\ell} - \bar M_\ell)`. Writing
-:math:`\tilde{\mathbf{y}} = \mathbf{y}_{0,\mathcal{T}_1} - \bar y_0`
-(precomputed once, with its norm :math:`\lVert\tilde{\mathbf{y}}\rVert^2 =
+:math:`\widehat{v}_t = (y_{1t} - \bar y_1) - (M_{t\ell} - \bar M_\ell)`. Writing
+:math:`\widetilde{\mathbf{y}} = \mathbf{y}_{1,\mathcal{T}_1} - \bar y_1`
+(precomputed once, with its norm :math:`\lVert\widetilde{\mathbf{y}}\rVert^2 =
 \mathrm{ss}_{\text{tot}}`), the residual sum of squares for *all*
 candidates is
 
@@ -270,20 +284,20 @@ candidates is
 
    \mathrm{SSR}_\ell = \mathrm{ss}_{\text{tot}}
        + \underbrace{\lVert \mathbf{M}_\ell - \bar M_\ell \rVert^2}_{\text{column SS}}
-       - 2\,\underbrace{\tilde{\mathbf{y}}^\top (\mathbf{M}_\ell - \bar M_\ell)}_{\text{one matrix--vector product}},
+       - 2\,\underbrace{\widetilde{\mathbf{y}}^\top (\mathbf{M}_\ell - \bar M_\ell)}_{\text{one matrix--vector product}},
    \qquad
    R^2_\ell = 1 - \frac{\mathrm{SSR}_\ell}{\mathrm{ss}_{\text{tot}}}.
 
 The cross term for the whole candidate set is the single matvec
-:math:`\tilde{\mathbf{y}}^\top(\mathbf{M} - \bar{\mathbf{M}})`; the column
+:math:`\widetilde{\mathbf{y}}^\top(\mathbf{M} - \bar{\mathbf{M}})`; the column
 sums of squares are one reduction. This is
 :func:`~mlsynth.utils.fdid_helpers.estimation._r2_batch` -- no candidate is
 ever regressed, and :math:`\alpha` is never explicitly solved during the
 search (it is recovered only once, for the winning group, in
 :func:`~mlsynth.utils.fdid_helpers.estimation.did_from_mean`).
 
-Taken together, a forward step costs :math:`O(T_1 |\mathcal{R}|)` and the
-entire search is :math:`O(T_1 N^2)`, with the inner loop expressed as a
+Taken together, a forward step costs :math:`O(T_0 |\mathcal{R}|)` and the
+entire search is :math:`O(T_0 N_0^2)`, with the inner loop expressed as a
 broadcast, a matrix--vector product, a column reduction, and an
 ``argmax`` -- no Python-level loop over candidates and no per-candidate
 solve. This is what lets the implementation run the selection over
@@ -294,8 +308,8 @@ Assumptions
 -----------
 
 **Assumption 1 (Forward DiD parallel trends).** There exists a subset
-:math:`\mathcal{D} \subseteq \mathcal{N}` and a constant :math:`\alpha`
-such that :math:`y^0_{0t} = \alpha + \bar{y}_{\mathcal{D}, t} + v_t` for all
+:math:`\mathcal{D} \subseteq \mathcal{N}_0` and a constant :math:`\alpha`
+such that :math:`y_{1t}^N = \alpha + \bar{y}_{\mathcal{D}, t} + v_t` for all
 :math:`t`, where :math:`v_t` is a weakly dependent process with zero mean
 and finite variance.
 
@@ -303,7 +317,7 @@ and finite variance.
 comparison group is **stable** across the pre- and post-periods up to a
 mean-zero shock. It is strictly weaker than DiD's requirement that *all*
 controls be parallel: it asks only that *some* equal-weighted subset be
-parallel. Both :math:`y^0_{0t}` and :math:`\bar{y}_{\mathcal{D}, t}` may
+parallel. Both :math:`y_{1t}^N` and :math:`\bar{y}_{\mathcal{D}, t}` may
 trend arbitrarily (even non-linearly), so long as their difference is
 trendless -- which is what makes the method valid under non-stationarity.
 
@@ -323,7 +337,7 @@ finite long-run variance.
 *Remark.* This is what delivers the asymptotic normality in Proposition
 2.1 below, and it holds for the broad class of stationary,
 weakly-dependent error processes -- it does **not** require :math:`v_t` to
-be i.i.d. or the levels :math:`y^0_{0t}` to be stationary.
+be i.i.d. or the levels :math:`y_{1t}^N` to be stationary.
 
 .. admonition:: When **not** to use Forward DiD
 
@@ -431,43 +445,44 @@ Inference
 ---------
 
 Because Forward DiD estimates a single parameter, its inference is the
-textbook DiD inference. Let :math:`\hat{\sigma}^2_{\mathcal{D}} = T_1^{-1}
-\sum_{t \in \mathcal{T}_1} \hat{v}_t^2` be the pre-period residual
+textbook DiD inference. Let :math:`\widehat{\sigma}^2_{\mathcal{D}} = T_0^{-1}
+\sum_{t \in \mathcal{T}_1} \widehat{v}_t^2` be the pre-period residual
 variance on the selected group. Li's Proposition 2.1 establishes
 
 .. math::
 
    \left| \Pr\!\left(
-       \frac{\sqrt{T_2}\,(\widehat{\mathrm{ATT}} - \mathrm{ATT})}
-            {\hat{\sigma}_{\mathcal{D}}} \le a \right) - \Phi(a) \right|
+       \frac{\sqrt{|\mathcal{T}_2|}\,(\widehat{\tau} - \mathrm{ATT})}
+            {\widehat{\sigma}_{\mathcal{D}}} \le a \right) - \Phi(a) \right|
    \to 0, \qquad a \in \mathbb{R},
 
-as :math:`T_1, T_2 \to \infty`, where :math:`\Phi` is the standard-normal
-CDF. mlsynth reports the **finite-sample** standard error that also carries
-the estimation error in :math:`\hat{\alpha}`:
+as :math:`T_0, |\mathcal{T}_2| \to \infty`, where :math:`\Phi` is the
+standard-normal CDF. mlsynth reports the **finite-sample** standard error
+that also carries the estimation error in :math:`\widehat{\alpha}`:
 
 .. math::
 
-   \mathrm{SE}(\widehat{\mathrm{ATT}}) =
-       \hat{\sigma}_{\mathcal{D}} \sqrt{\frac{1}{T_1} + \frac{1}{T_2}},
+   \mathrm{SE}(\widehat{\tau}) =
+       \widehat{\sigma}_{\mathcal{D}} \sqrt{\frac{1}{T_0} + \frac{1}{|\mathcal{T}_2|}},
 
-since :math:`\widehat{\mathrm{ATT}} - \mathrm{ATT} = -T_1^{-1}
-\sum_{\mathcal{T}_1} v_t + T_2^{-1} \sum_{\mathcal{T}_2} v_t` contributes
-one :math:`1/T_1` and one :math:`1/T_2` variance term. This collapses to
-Proposition 2.1's :math:`\hat{\sigma}_{\mathcal{D}} / \sqrt{T_2}` when
-:math:`T_1 \gg T_2`. The 95% Wald interval and two-sided p-value follow in
-the usual way.
+since :math:`\widehat{\tau} - \mathrm{ATT} = -T_0^{-1}
+\sum_{\mathcal{T}_1} v_t + |\mathcal{T}_2|^{-1} \sum_{\mathcal{T}_2} v_t`
+contributes one :math:`1/T_0` and one :math:`1/|\mathcal{T}_2|` variance
+term. This collapses to Proposition 2.1's
+:math:`\widehat{\sigma}_{\mathcal{D}} / \sqrt{|\mathcal{T}_2|}` when
+:math:`T_0 \gg |\mathcal{T}_2|`. The 95% Wald interval and two-sided
+p-value follow in the usual way.
 
 Consistency of the selection
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Li also shows the *greedy* search recovers a *valid* comparison group.
 Under Assumption 1 and the appendix's regularity conditions, with
-:math:`N` fixed, the empirical forward selection selects (one of) the same
+:math:`N_0` fixed, the empirical forward selection selects (one of) the same
 subset(s) the infeasible procedure based on true error variances would
-select, with probability approaching one as :math:`T_1 \to \infty`
+select, with probability approaching one as :math:`T_0 \to \infty`
 (Proposition 2.2; Proposition D.1 handles ties). Proposition D.2 extends
-this to the case where :math:`N` grows with :math:`T_1` under a latent
+this to the case where :math:`N_0` grows with :math:`T_0` under a latent
 group structure. Intuitively, by the law of large numbers each step's
 empirical :math:`R^2` converges to its population value, so the greedy path
 tracks the population-optimal path.

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -74,9 +74,12 @@ Canonical workhorses
   p-value relations.
   → dedicated page: :doc:`replications/vanillasc`.
 * :doc:`fdid` -- Li (2024) Forward Difference-in-Differences.
-  **Path B:** Table 5 PMSE grid across DGP1-DGP4 at four
-  :math:`(T_1, T_2)` configurations; cell :math:`(48, 24)` yields
-  :math:`\mathrm{PMSE} = 0.084` against the paper's :math:`0.082`.
+  **Path A:** the author's public Hong Kong GDP companion replication
+  reproduced cell by cell (FDID ATT :math:`0.0254`, :math:`53.84\%`,
+  pre-:math:`R^2 = 0.843`, 9 of 24 controls). **Path B:** Table 5 PMSE grid
+  across DGP1-DGP4 at four :math:`(T_1, T_2)` configurations; cell
+  :math:`(48, 24)` yields :math:`\mathrm{PMSE} = 0.084` against the paper's
+  :math:`0.082`.
   → dedicated page: :doc:`replications/fdid`.
 
 .. _replications-decomp:

--- a/docs/replications/fdid.rst
+++ b/docs/replications/fdid.rst
@@ -6,28 +6,94 @@ FDID — Forward Difference-in-Differences (Li 2024)
 :Estimator: :doc:`../fdid` — :class:`mlsynth.FDID`
 :Source: Li, Kathleen T. (2024), *"Frontiers: A Simple Forward
    Difference-in-Differences Method,"* Marketing Science 43(2) [Li2024]_.
-:Replication type: **Path B** — reproduce the paper's own Monte Carlo
-   (Web Appendix E, Table 5).
-:Status: **Fully verified** — Table 5 reproduced cell by cell.
+:Replication type: **Path A** — the author's released public empirical
+   (Hong Kong GDP) reproduced cell by cell — **and Path B** — the paper's
+   own Monte Carlo (Web Appendix E, Table 5).
+:Status: **Fully verified** — empirical *and* simulation reproduced.
 
-Why Path B
-----------
+Validation strategy
+-------------------
 
-Li's headline empirical application — the effect of opening physical stores
-on an online-first retailer's city-level sales — runs on a **confidential
-retailer dataset** that cannot be redistributed, so it cannot be reproduced
-value-for-value. Per the project's replication contract
-(``agents/agents_estimators.md``), Forward DiD is therefore validated by
-reproducing the paper's **own simulation** instead, which is fully specified
-in the Web Appendix.
+Li's *headline* application — the effect of opening physical stores on an
+online-first retailer's city-level sales — runs on a **confidential retailer
+dataset** that cannot be redistributed. For context, that study reports a
+Forward DiD effect of opening a store in Atlanta of about **+$75,143 in
+monthly sales (an 86% lift, pre-period** :math:`R^2 = 0.76`\ **)**, with
+ordinary DiD and synthetic control — which fit Atlanta's steep pre-trend
+poorly — overstating it.
 
-For context, Li's confidential study reports a Forward DiD effect of opening a
-store in Atlanta of about **+$75,143 in monthly sales (an 86% lift,
-pre-period** :math:`R^2 = 0.76`\ **)**, with ordinary DiD and synthetic
-control — which fit Atlanta's steep pre-trend poorly — overstating it.
+That headline number cannot be checked value-for-value, but it does not have
+to be: alongside the paper the author released a **public companion
+replication** (MATLAB and R) on the Hsiao, Ching & Wan (2012) Hong Kong GDP
+panel, which mlsynth reproduces cell by cell (**Path A**). We *additionally*
+reproduce the paper's own Monte Carlo (**Path B**), which exercises the
+mismatched-control regimes a single empirical case cannot.
 
-The simulation design
----------------------
+Path A — Hong Kong GDP
+----------------------
+
+The author's public dataset (``basedata/HongKong.csv`` — Hong Kong plus 24
+OECD / Asian control economies over 61 quarters, with treatment, the
+political and economic integration with mainland China, beginning at quarter
+44 so :math:`T_1 = 44`) is the Hsiao, Ching & Wan (2012) panel.
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import FDID
+
+   df = pd.read_csv("basedata/HongKong.csv")
+   res = FDID({"df": df, "outcome": "GDP", "treat": "Integration",
+               "unitid": "Country", "time": "Time",
+               "display_graphs": False, "verbose": False}).fit()
+   res.fdid.att, res.fdid.att_percent, res.fdid.r_squared, len(res.fdid.selected_names)
+
+Forward DiD selects **9 of the 24** controls and reproduces the author's
+released MATLAB/R output (``ForwardDID_Readme.txt``) cell by cell:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 18 18 18 18
+
+   * - Metric
+     - FDID (mlsynth)
+     - FDID (Li)
+     - DID (mlsynth)
+     - DID (Li)
+   * - ATT
+     - 0.0254
+     - 0.0254
+     - 0.0317
+     - 0.0317
+   * - % ATT
+     - 53.84
+     - 53.84
+     - 77.62
+     - 77.62
+   * - pre-period :math:`R^2`
+     - 0.843
+     - 0.843
+     - 0.505
+     - 0.505
+   * - controls used
+     - 9
+     - 9
+     - 24
+     - 24
+
+The 95% confidence interval ``(0.0163, 0.0345)`` and the standardized ATT
+(t-statistic) :math:`\approx 5.49` likewise match the released values.
+Forward DiD's far higher pre-period fit (:math:`R^2 = 0.84` versus DiD's
+:math:`0.50`) is the whole point: the all-controls average tracks Hong Kong's
+pre-integration path poorly, so plain DiD overstates the effect, while the
+forward search keeps only the 9 economies that co-move with Hong Kong.
+
+The durable check lives in ``benchmarks/cases/fdid_hongkong.py``::
+
+   python benchmarks/run_benchmarks.py --case fdid_hongkong
+
+Path B — the simulation design
+------------------------------
 
 The four DGPs and their factor structure are packaged in
 :func:`mlsynth.utils.fdid_helpers.simulation.simulate_fdid_sample`: three

--- a/mlsynth/tests/test_fdid_replication.py
+++ b/mlsynth/tests/test_fdid_replication.py
@@ -1,0 +1,56 @@
+"""Path-A replication of Li (2024) Forward DiD on the public Hong Kong panel.
+
+Li's headline application uses a confidential retailer dataset, but the author
+released a public companion replication (MATLAB/R) on the Hsiao, Ching & Wan
+(2012) Hong Kong GDP panel. This asserts mlsynth's :class:`~mlsynth.FDID`
+reproduces the released ATT / %ATT / pre-period R^2 / selected-control count
+cell by cell (forward selection is deterministic, so tolerances absorb only the
+estimator's 3-4 dp display rounding).
+
+The durable, paper-facing version lives in
+``benchmarks/cases/fdid_hongkong.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from mlsynth import FDID
+
+_HK = Path(__file__).resolve().parents[2] / "basedata" / "HongKong.csv"
+
+
+@pytest.fixture(scope="module")
+def hk_fit():
+    df = pd.read_csv(_HK)
+    return FDID(
+        {
+            "df": df,
+            "outcome": "GDP",
+            "treat": "Integration",
+            "unitid": "Country",
+            "time": "Time",
+            "display_graphs": False,
+            "verbose": False,
+        }
+    ).fit()
+
+
+def test_fdid_matches_released_output(hk_fit):
+    """Forward DiD: selects 9 controls, ATT 0.0254 (53.84%), pre-R^2 0.843."""
+    f = hk_fit.fdid
+    assert len(f.selected_names) == 9
+    assert f.att == pytest.approx(0.025405, abs=5e-4)
+    assert f.att_percent == pytest.approx(53.843, abs=0.1)
+    assert f.r_squared == pytest.approx(0.84278, abs=2e-3)
+
+
+def test_did_matches_released_output(hk_fit):
+    """Plain DiD (all 24 controls): ATT 0.0317 (77.62%), pre-R^2 0.505."""
+    d = hk_fit.did
+    assert d.att == pytest.approx(0.031721, abs=5e-4)
+    assert d.att_percent == pytest.approx(77.62, abs=0.1)
+    assert d.r_squared == pytest.approx(0.50465, abs=2e-3)


### PR DESCRIPTION
## Overview

Follow-up to #7 (the Phase 2 foundation, already merged). These four commits were pushed to the branch after #7 was merged, so they are **not** in `main` yet. Three units:

1. **FDID validation (Path A + B)** — completing FDID's validation, made durable.
2. **Docs de-duplication** — trim the FDID method page now that the replication page owns the validated numbers.
3. **Binding docs notation canon** — one mathematical notation across all docs, with FDID migrated as the worked example.

---

## 1. FDID validation (Path A + B) — officially complete

mlsynth's FDID reproduces Li (2024)'s public Hong Kong GDP companion replication cell by cell on `basedata/HongKong.csv`:

| | FDID (mlsynth / Li) | DID (mlsynth / Li) |
|---|---|---|
| ATT | 0.0254 / 0.0254 | 0.0317 / 0.0317 |
| % ATT | 53.84 / 53.84 | 77.62 / 77.62 |
| pre-R² | 0.843 / 0.843 | 0.505 / 0.505 |
| controls | 9 of 24 / 9 | all 24 |

(95% CI `(0.0163, 0.0345)`, SATT ≈ 5.49 also match.) Path B (Table 5 simulation direction) reproduces over M=400 reps.

- `benchmarks/cases/fdid_hongkong.py` (Path A, registered); `fdid_table5.py` (Path B).
- `tests/test_fdid_replication.py` (fast CI guard).
- `docs/replications/fdid.rst` documents both paths; index + CHANGELOG updated.

## 2. Docs de-duplication

`docs/fdid.rst` trimmed (655 → 607 lines): the two example sections fold into one lean Hong Kong **usage** example (no reproduced validation numbers); Verification cites both paths. Method exposition unchanged.

## 3. Binding docs notation canon

`agents/agents_docs.md` is now the **mandatory** notation contract (was an aspirational flag). The symbol canon is derived from the author's `qdocs` blog (`fscm`/`shc`/`scexp`/`shaemax.qmd`); Shi & Huang remains the reference for expository *structure*. It fixes typography (`\widehat`/`\widetilde`/`\coloneqq`, bold/calligraphic), units (treated `j=1`, donors `𝒩₀`), 1-indexed time split at `T₀`, Abadie potential outcomes `y^N`/`y^I`, the constrained-SC program (`𝓛`/`𝓟`/`𝓑`, `𝒞_*`), and reserves `τ` for the treatment effect — with `τ_t`/`τ̂` mapping 1:1 onto the foundation's primitives so docs and result objects share one vocabulary. `CLAUDE.md` pointer updated.

**FDID migrated** to the canon as the worked reference example (`docs/fdid.rst`): `j=0→1`, `𝒩→𝒩₀`, `T₁/T₂→T₀/|𝒯₂|`, `y⁰/y¹→y^N/y^I`, ATT→`τ̂`, `\hat→\widehat` — symbols only, no derivation changed. Other pages migrate incrementally when touched.

## Testing

Both FDID benchmarks + the new replication test pass; the foundation refactor (in #7) kept the full suite green at 2611 passed / 3 skipped. Units 2–3 are docs/agents only (no code).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_