### PR TITLE
Standardized plotting foundation: PlotConfig + Plotter archetypes + EffectResult.plot()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Added
+- **Standardized plotting foundation.** A nested `PlotConfig` on
+  `BaseEstimatorConfig` (`plot=...`) centralizes plot cosmetics — observed/
+  counterfactual color, linewidth, linestyle; intervention reference line;
+  axis-label and title overrides; a user-suppliable `theme` — with sensible
+  defaults and full back-compat (legacy `treated_color`/`counterfactual_color`/
+  `display_graphs`/`save` fold in via `config.resolved_plot()`). The shared
+  `utils.plotting.Plotter` gains `gap` and `event_study` archetypes alongside
+  `observed_vs_counterfactual`, all config-driven and rendered in the house
+  style. `EffectResult.plot(kind=...)` is the single entry point, driven by the
+  standardized `time_series` sub-model (+ `intervention_time`) and the
+  `PlotConfig` captured at fit time. FDID is migrated as the reference;
+  the event-study archetype is validated on SDID output.
 - **FDID validation (Path A + B), officially complete.** New
   `benchmarks/cases/fdid_hongkong.py` reproduces Li (2024)'s public Hong Kong
   GDP companion replication cell by cell (FDID ATT 0.0254 / 53.84% / pre-R² 0.843

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Any, Dict, Union, Literal
 import pandas as pd
 import numpy as np
 from pydantic import BaseModel, Field, field_validator, model_validator
-from mlsynth.exceptions import MlsynthDataError, MlsynthConfigError
+from mlsynth.exceptions import MlsynthDataError, MlsynthConfigError, MlsynthPlottingError
 import warnings
 
 class BaseMAREXConfig(BaseModel):
@@ -68,6 +68,45 @@ class BaseMAREXConfig(BaseModel):
 
 
 
+_DEFAULT_CF_COLORS = ["red", "blue", "green", "purple", "orange", "brown"]
+
+
+class PlotConfig(BaseModel):
+    """Cosmetic configuration for an estimator's plots.
+
+    The single, nested home for everything a user might tune about a figure --
+    colors, line thickness and pattern, axis labels, title, and theme -- so the
+    look is fully orchestrated from the top config with sensible defaults the
+    user never has to touch. Consumed by :meth:`EffectResult.plot` and the
+    shared :class:`mlsynth.utils.plotting.Plotter`.
+    """
+
+    # Observed (treated) series.
+    observed_color: str = Field(default="black", description="Color of the observed (treated) line.")
+    observed_linewidth: float = Field(default=1.6, description="Width of the observed line.")
+    observed_linestyle: str = Field(default="-", description="Matplotlib linestyle for the observed line.")
+    # Counterfactual series (cycled / broadcast across multiple counterfactuals).
+    counterfactual_colors: List[str] = Field(default_factory=lambda: list(_DEFAULT_CF_COLORS), description="Color cycle for counterfactual line(s).")
+    counterfactual_linewidth: float = Field(default=1.4, description="Width of counterfactual line(s).")
+    counterfactual_linestyle: str = Field(default="--", description="Matplotlib linestyle for counterfactual line(s).")
+    # Reference lines.
+    show_intervention_line: bool = Field(default=True, description="Draw a vertical line at the intervention.")
+    intervention_color: str = Field(default="grey", description="Color of the intervention reference line.")
+    # Labels / title (None => a sensible default derived from the data/method).
+    xlabel: Optional[str] = Field(default=None, description="X-axis label override.")
+    ylabel: Optional[str] = Field(default=None, description="Y-axis label override.")
+    title: Optional[str] = Field(default=None, description="Plot title override.")
+    # Theme: a dict of rcParams merged over the house style, or a named style.
+    theme: Optional[Union[dict, str]] = Field(default=None, description="Custom theme: rcParams dict (merged over the mlsynth style) or a named Matplotlib style.")
+    # Lifecycle.
+    display: bool = Field(default=True, description="Show the figure.")
+    save: Union[bool, str, dict] = Field(default=False, description="Save config: False, a filename, or a dict.")
+
+    class Config:
+        arbitrary_types_allowed = True
+        extra = "forbid"
+
+
 class BaseEstimatorConfig(BaseModel):
     """
     Base Pydantic model for estimator configurations.
@@ -80,12 +119,35 @@ class BaseEstimatorConfig(BaseModel):
     time: str = Field(..., description="Name of the time period column in the DataFrame.")
     display_graphs: bool = Field(default=True, description="Whether to display plots of results.")
     save: Union[bool, str] = Field(default=False, description="Configuration for saving plots. If False (default), plots are not saved. If True, plots are saved with default names. If a string, it's used as the base filename for saved plots.")
-    counterfactual_color: List[str] = Field(default_factory=lambda: ["red"],description="Color(s) for counterfactual line(s) in plots.")
-    treated_color: str = Field(default="black", description="Color for the treated unit line in plots.")
+    counterfactual_color: List[str] = Field(default_factory=lambda: ["red"],description="Color(s) for counterfactual line(s) in plots. (Legacy; prefer `plot`.)")
+    treated_color: str = Field(default="black", description="Color for the treated unit line in plots. (Legacy; prefer `plot`.)")
+    plot: PlotConfig = Field(default_factory=PlotConfig, description="Nested cosmetic plot configuration (colors, line styles, labels, theme).")
 
     class Config:
         arbitrary_types_allowed = True
         extra = 'forbid' # Forbid extra fields not defined in the model
+
+    def resolved_plot(self) -> "PlotConfig":
+        """Effective :class:`PlotConfig`, folding in the legacy flat fields.
+
+        If the user supplied a custom ``plot`` it is authoritative; otherwise
+        the legacy ``treated_color`` / ``counterfactual_color`` are mapped into
+        a fresh ``PlotConfig``. The behavioral ``display_graphs`` / ``save``
+        always apply unless overridden on ``plot``. This keeps every existing
+        config call working while routing plotting through the nested model.
+        """
+        if self.plot != PlotConfig():
+            pc = self.plot.model_copy()
+        else:
+            pc = PlotConfig(
+                observed_color=self.treated_color,
+                counterfactual_colors=list(self.counterfactual_color),
+            )
+        if pc.display is True:  # default untouched -> honor legacy flag
+            pc.display = self.display_graphs
+        if pc.save is False:  # default untouched -> honor legacy flag
+            pc.save = self.save
+        return pc
 
     @model_validator(mode='after')
     def check_df_and_columns(cls, values: Any) -> Any:
@@ -184,6 +246,7 @@ class TimeSeriesResults(BaseModel):
     counterfactual_outcome: Optional[np.ndarray] = Field(default=None, description="Estimated counterfactual outcome vector.")
     estimated_gap: Optional[np.ndarray] = Field(default=None, description="Estimated treatment effect vector (observed - counterfactual).")
     time_periods: Optional[np.ndarray] = Field(default=None, description="Array of time periods corresponding to the series.") # Retaining np.ndarray, TSSC will convert
+    intervention_time: Optional[Any] = Field(default=None, description="Time label at the pre/post boundary, for the plot's intervention reference line.")
 
     class Config:
         arbitrary_types_allowed = True
@@ -271,6 +334,9 @@ class BaseEstimatorResults(MlsynthResult):
     # To capture any errors or warnings encountered during fitting.
     execution_summary: Optional[Dict[str, Any]] = Field(default=None, description="Summary of execution, including any errors or warnings.")
 
+    # Resolved cosmetic config stored at fit time so ``plot()`` is self-contained.
+    plot_config: Optional[PlotConfig] = Field(default=None, exclude=True, description="Resolved PlotConfig captured at fit time; drives plot().")
+
 
     class Config:
         arbitrary_types_allowed = True
@@ -320,6 +386,84 @@ class BaseEstimatorResults(MlsynthResult):
     def pre_rmse(self) -> Optional[float]:
         """Pre-treatment root-mean-squared fit error."""
         return self.fit_diagnostics.rmse_pre if self.fit_diagnostics else None
+
+    # ------------------------------------------------------------------
+    # Standard plotting -- one entry point for every effect estimator,
+    # driven by the standardized ``time_series`` sub-model and the resolved
+    # ``PlotConfig`` captured at fit time. Bespoke estimators override.
+    # ------------------------------------------------------------------
+    def plot(self, kind: str = "auto", *, ax: Any = None, **overrides: Any) -> Any:
+        """Render the standard effect plot from the standardized result.
+
+        Parameters
+        ----------
+        kind : {"auto", "counterfactual", "gap"}, default "auto"
+            ``"auto"``/``"counterfactual"`` draw observed vs. counterfactual;
+            ``"gap"`` draws the per-period effect. (Event-study lives on the
+            staggered/multi-cohort estimators.)
+        ax : matplotlib Axes, optional
+            Draw into an existing axis (multi-panel composition).
+        **overrides
+            Per-call cosmetic overrides applied over the stored PlotConfig
+            (e.g. ``title=...``, ``observed_color=...``).
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+        """
+        import matplotlib.pyplot as plt
+
+        from .utils.plotting import Plotter, mlsynth_style
+
+        ts = self.time_series
+        if ts is None or ts.observed_outcome is None:
+            raise MlsynthPlottingError(
+                "Result has no time_series.observed_outcome to plot."
+            )
+
+        pc = (self.plot_config or PlotConfig())
+        pc = pc.model_copy(update=overrides) if overrides else pc
+
+        observed = np.asarray(ts.observed_outcome).reshape(-1)
+        times = (np.asarray(ts.time_periods) if ts.time_periods is not None
+                 else np.arange(observed.shape[0]))
+        intervention = ts.intervention_time if pc.show_intervention_line else None
+        method = self.method_details.method_name if self.method_details else None
+        xlabel = pc.xlabel if pc.xlabel is not None else "Time"
+        ylabel = pc.ylabel if pc.ylabel is not None else "Outcome"
+
+        with mlsynth_style(pc.theme):
+            plotter = Plotter.from_config(pc)
+            if kind in ("auto", "counterfactual"):
+                cf = ts.counterfactual_outcome
+                if cf is None:
+                    raise MlsynthPlottingError(
+                        "Result has no counterfactual_outcome to plot."
+                    )
+                ax = plotter.observed_vs_counterfactual(
+                    times, observed, np.asarray(cf).reshape(-1),
+                    treated_label=method or "Treated",
+                    intervention=intervention, outcome=ylabel, time=xlabel,
+                    title=pc.title or (f"{method}: observed vs. counterfactual"
+                                       if method else "Observed vs. counterfactual"),
+                    ax=ax,
+                )
+            elif kind == "gap":
+                ax = plotter.gap(
+                    times, np.asarray(ts.estimated_gap).reshape(-1),
+                    intervention=intervention, outcome=ylabel, time=xlabel,
+                    title=pc.title or "Estimated gap", ax=ax,
+                )
+            else:
+                raise MlsynthPlottingError(f"Unknown plot kind {kind!r}.")
+
+            fig = ax.figure
+            if pc.save:
+                fname = pc.save if isinstance(pc.save, str) else f"{method or 'mlsynth'}_plot.png"
+                fig.savefig(fname, bbox_inches="tight")
+            if pc.display:
+                plt.show()
+        return ax
 
 
 # ``EffectResult`` is the canonical, intention-revealing name for the

--- a/mlsynth/estimators/fdid.py
+++ b/mlsynth/estimators/fdid.py
@@ -27,7 +27,6 @@ from ..utils.fdid_helpers import (
     FDIDResults,
     assemble_fdid_results,
     forward_did_select,
-    plot_fdid,
     prepare_fdid_inputs,
 )
 
@@ -125,16 +124,23 @@ class FDID:
 
         results = assemble_fdid_results(selector_output, inputs)
 
-        if self.display_graphs:
-            plot_fdid(
-                results,
-                time=self.time,
-                unitid=self.unitid,
-                outcome=self.outcome,
-                treat=self.treated,
-                treated_color=self.treated_color,
-                counterfactual_color=self.counterfactual_color,
-                save=self.save,
+        # Attach plotting context so result.plot() is self-contained and styled
+        # from the (possibly nested) config. Fill axis labels from the column
+        # names only when the user has not set them.
+        pc = self.config.resolved_plot()
+        if pc.xlabel is None:
+            pc.xlabel = self.time
+        if pc.ylabel is None:
+            pc.ylabel = self.outcome
+        object.__setattr__(results, "plot_config", pc)
+        if results.time_series is not None:
+            pre = int(inputs.pre_periods)
+            labels = list(inputs.time_labels)
+            results.time_series.intervention_time = (
+                labels[pre] if pre < len(labels) else labels[-1]
             )
+
+        if self.display_graphs:
+            results.plot()
 
         return results

--- a/mlsynth/tests/test_plotting_foundation.py
+++ b/mlsynth/tests/test_plotting_foundation.py
@@ -1,0 +1,94 @@
+"""Smoke tests for the standardized plotting foundation (step 1).
+
+Covers the PlotConfig back-compat resolution, EffectResult.plot() end-to-end on
+FDID (observed-vs-counterfactual + gap, config-driven cosmetics), and the
+event-study archetype exercised on real SDID output.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from mlsynth import FDID, SDID
+from mlsynth.config_models import BaseEstimatorConfig, PlotConfig
+from mlsynth.utils.plotting import Plotter
+
+_BASE = Path(__file__).resolve().parents[2] / "basedata"
+
+
+# --- PlotConfig resolution / back-compat -----------------------------------
+
+def _hk():
+    return pd.read_csv(_BASE / "HongKong.csv")
+
+
+def test_resolved_plot_folds_legacy_fields():
+    cfg = BaseEstimatorConfig(
+        df=_hk(), outcome="GDP", treat="Integration", unitid="Country",
+        time="Time", treated_color="navy", counterfactual_color=["crimson"],
+    )
+    pc = cfg.resolved_plot()
+    assert pc.observed_color == "navy"
+    assert pc.counterfactual_colors == ["crimson"]
+
+
+def test_nested_plot_config_wins():
+    cfg = BaseEstimatorConfig(
+        df=_hk(), outcome="GDP", treat="Integration", unitid="Country",
+        time="Time", plot=PlotConfig(observed_color="green", title="custom"),
+    )
+    pc = cfg.resolved_plot()
+    assert pc.observed_color == "green"
+    assert pc.title == "custom"
+
+
+# --- FDID end-to-end through EffectResult.plot() ----------------------------
+
+@pytest.fixture(scope="module")
+def fdid_res():
+    return FDID({
+        "df": _hk(), "outcome": "GDP", "treat": "Integration",
+        "unitid": "Country", "time": "Time", "display_graphs": False,
+    }).fit()
+
+
+def test_fdid_plot_counterfactual(fdid_res):
+    ax = fdid_res.plot(display=False)
+    # observed + counterfactual + intervention reference line
+    assert len(ax.lines) >= 3
+    assert ax.get_xlabel() == "Time"
+    assert ax.get_ylabel() == "GDP"
+
+
+def test_fdid_plot_respects_cosmetic_override(fdid_res):
+    ax = fdid_res.plot(observed_color="navy", display=False)
+    assert ax.lines[0].get_color() == "navy"
+
+
+def test_fdid_plot_gap(fdid_res):
+    ax = fdid_res.plot(kind="gap", display=False)
+    assert len(ax.lines) >= 1
+
+
+# --- event-study archetype on real SDID output -----------------------------
+
+def test_event_study_archetype_on_sdid():
+    df = pd.read_csv(_BASE / "smoking_data.csv")
+    df["Proposition 99"] = df["Proposition 99"].astype(int)
+    res = SDID({
+        "df": df, "outcome": "cigsale", "treat": "Proposition 99",
+        "unitid": "state", "time": "year", "B": 0, "display_graphs": False,
+    }).fit()
+    es = res.event_study
+    ax = Plotter().event_study(
+        es.event_times, es.tau,
+        ci_lower=es.ci[:, 0], ci_upper=es.ci[:, 1],
+    )
+    assert len(ax.lines) >= 1  # effect line + reference lines

--- a/mlsynth/utils/plotting.py
+++ b/mlsynth/utils/plotting.py
@@ -69,8 +69,8 @@ MLSYNTH_RC = {
 }
 
 
-def mlsynth_style():
-    """Context manager applying :data:`MLSYNTH_RC` to plots created within it.
+def mlsynth_style(theme: Optional[Union[dict, str]] = None):
+    """Context manager applying the mlsynth plot style to plots created within.
 
     Scoped via ``matplotlib.rc_context`` so the user's global rcParams are
     untouched. Wrap the *entire* plotting block (figure creation included), as
@@ -79,10 +79,22 @@ def mlsynth_style():
         with mlsynth_style():
             fig, ax = plt.subplots()
             ...
+
+    Parameters
+    ----------
+    theme : dict or str, optional
+        ``None`` (default) uses the mlsynth house style :data:`MLSYNTH_RC`.
+        A dict of rcParams is merged *over* the house style. A string is
+        treated as a named Matplotlib style (``plt.style.context``), letting a
+        user drop in their own theme.
     """
     import matplotlib.pyplot as plt
 
-    return plt.rc_context(MLSYNTH_RC)
+    if theme is None:
+        return plt.rc_context(MLSYNTH_RC)
+    if isinstance(theme, str):
+        return plt.style.context(theme)
+    return plt.rc_context({**MLSYNTH_RC, **theme})
 
 
 def apply_mlsynth_style() -> None:
@@ -116,6 +128,10 @@ class Plotter:
         counterfactual_colors: Optional[Union[str, Sequence[str]]] = None,
         intervention_color: str = "grey",
         figsize: tuple = (7, 5),
+        treated_linewidth: float = 1.6,
+        treated_linestyle: str = "-",
+        counterfactual_linewidth: float = 1.4,
+        counterfactual_linestyle: str = "--",
     ) -> None:
         self.treated_color = treated_color
         if counterfactual_colors is None:
@@ -125,6 +141,28 @@ class Plotter:
         self.counterfactual_colors = list(counterfactual_colors)
         self.intervention_color = intervention_color
         self.figsize = figsize
+        self.treated_linewidth = treated_linewidth
+        self.treated_linestyle = treated_linestyle
+        self.counterfactual_linewidth = counterfactual_linewidth
+        self.counterfactual_linestyle = counterfactual_linestyle
+
+    @classmethod
+    def from_config(cls, pc: Any) -> "Plotter":
+        """Build a Plotter from a ``PlotConfig`` (duck-typed; no import).
+
+        Reads the cosmetic fields off ``pc`` so plotting stays decoupled from
+        :mod:`mlsynth.config_models`. Missing attributes fall back to defaults.
+        """
+        cf = getattr(pc, "counterfactual_colors", None)
+        return cls(
+            treated_color=getattr(pc, "observed_color", "black"),
+            counterfactual_colors=cf if cf else None,
+            intervention_color=getattr(pc, "intervention_color", "grey"),
+            treated_linewidth=getattr(pc, "observed_linewidth", 1.6),
+            treated_linestyle=getattr(pc, "observed_linestyle", "-"),
+            counterfactual_linewidth=getattr(pc, "counterfactual_linewidth", 1.4),
+            counterfactual_linestyle=getattr(pc, "counterfactual_linestyle", "--"),
+        )
 
     @staticmethod
     def _as_counterfactual_list(counterfactuals: CounterfactualLike) -> List[np.ndarray]:
@@ -195,16 +233,97 @@ class Plotter:
 
         times = np.asarray(times)
         ax.plot(times, np.asarray(observed).reshape(-1),
-                color=self.treated_color, label=f"Treated ({treated_label})")
+                color=self.treated_color, linewidth=self.treated_linewidth,
+                linestyle=self.treated_linestyle, label=f"Treated ({treated_label})")
         for i, cf in enumerate(cfs):
             color = self.counterfactual_colors[i % len(self.counterfactual_colors)]
-            ax.plot(times, np.asarray(cf).reshape(-1), linestyle="--",
+            ax.plot(times, np.asarray(cf).reshape(-1),
+                    linewidth=self.counterfactual_linewidth,
+                    linestyle=self.counterfactual_linestyle,
                     color=color, label=labels[i])
         if intervention is not None:
             ax.axvline(intervention, color=self.intervention_color,
-                       linestyle=":", linewidth=1)
+                       linestyle=":", linewidth=1.2, label="Intervention")
         ax.set_xlabel(time)
         ax.set_ylabel(outcome)
         ax.set_title(title)
         ax.legend()  # frame styling comes from the active rcParams
+        return ax
+
+    def gap(
+        self,
+        times: Sequence[Any],
+        gap: np.ndarray,
+        *,
+        intervention: Optional[Any] = None,
+        outcome: str = "",
+        time: str = "",
+        title: str = "Estimated gap",
+        color: Optional[str] = None,
+        ax: Optional["object"] = None,
+    ) -> "object":
+        """Plot the per-period effect ``tau_t`` (gap) with a zero reference line.
+
+        Draws the gap series against a horizontal zero line and an optional
+        vertical intervention marker -- the standard companion to the
+        observed-vs-counterfactual panel.
+        """
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            _, ax = plt.subplots(figsize=self.figsize)
+        times = np.asarray(times)
+        ax.plot(times, np.asarray(gap).reshape(-1),
+                color=color or self.counterfactual_colors[0],
+                linewidth=self.counterfactual_linewidth, label="Gap")
+        ax.axhline(0.0, color="black", linewidth=0.8)
+        if intervention is not None:
+            ax.axvline(intervention, color=self.intervention_color,
+                       linestyle=":", linewidth=1.2, label="Intervention")
+        ax.set_xlabel(time)
+        ax.set_ylabel(outcome or "Treated - counterfactual")
+        ax.set_title(title)
+        ax.legend()
+        return ax
+
+    def event_study(
+        self,
+        event_times: Sequence[Any],
+        effects: np.ndarray,
+        *,
+        ci_lower: Optional[np.ndarray] = None,
+        ci_upper: Optional[np.ndarray] = None,
+        outcome: str = "",
+        time: str = "Event time",
+        title: str = "Event study",
+        color: Optional[str] = None,
+        ax: Optional["object"] = None,
+    ) -> "object":
+        """Plot effects against event time with an optional CI band.
+
+        The archetype for staggered / multi-cohort designs (and SDID-style
+        pooled event studies): effects vs. event time, a horizontal zero line,
+        a vertical marker at event time 0, and a shaded confidence band when
+        ``ci_lower`` / ``ci_upper`` are supplied.
+        """
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            _, ax = plt.subplots(figsize=self.figsize)
+        et = np.asarray(event_times)
+        eff = np.asarray(effects).reshape(-1)
+        line_color = color or self.counterfactual_colors[0]
+        ax.plot(et, eff, marker="o", color=line_color,
+                linewidth=self.counterfactual_linewidth, label="Effect")
+        if ci_lower is not None and ci_upper is not None:
+            ax.fill_between(et, np.asarray(ci_lower).reshape(-1),
+                            np.asarray(ci_upper).reshape(-1),
+                            color=line_color, alpha=0.20, label="95% CI")
+        ax.axhline(0.0, color="black", linewidth=0.8)
+        ax.axvline(0.0, color=self.intervention_color, linestyle=":",
+                   linewidth=1.2, label="Intervention")
+        ax.set_xlabel(time)
+        ax.set_ylabel(outcome or "Treatment effect")
+        ax.set_title(title)
+        ax.legend()
         return ax


### PR DESCRIPTION
Step 1 of the plotting standardization — the shared foundation every estimator's plotting will route through. Additive and fully back-compatible.

## What's in it

**`PlotConfig` (nested cosmetic config on `BaseEstimatorConfig` as `plot=`)**
- observed / counterfactual `color`, `linewidth`, `linestyle`; intervention reference line; axis-label + title overrides; user-suppliable `theme`; `display` / `save`.
- All defaulted, so users never have to touch it; accepts a plain dict (`"plot": {...}`) too.
- `config.resolved_plot()` folds the legacy flat fields (`treated_color`, `counterfactual_color`, `display_graphs`, `save`) in — **no existing config call breaks**.

**`utils.plotting.Plotter`**
- `Plotter.from_config()` + cosmetic params.
- New `gap` and `event_study` archetypes alongside `observed_vs_counterfactual`; the latter gains a labeled intervention reference line.
- `mlsynth_style(theme)` accepts a custom rcParams dict or a named Matplotlib style; default = house style.

**Results**
- `TimeSeriesResults.intervention_time` and `BaseEstimatorResults.plot_config` (captured at fit time).
- `EffectResult.plot(kind="auto"|"counterfactual"|"gap", **overrides)` — one entry point, driven by the standardized `time_series` sub-model.

**FDID** migrated as the reference: `fit()` attaches the resolved `PlotConfig` + intervention time and renders via `result.plot()`.

## Validation
- New `tests/test_plotting_foundation.py` (6 tests): PlotConfig back-compat resolution, FDID end-to-end (counterfactual / gap / cosmetic override / axis labels), and the event-study archetype on **real SDID output**.
- Full suite: **2619 passed, 3 skipped**.

## Not in this PR (planned next)
- Step 2: migrate the `plot_estimates` wrappers (~12) to `result.plot()`.
- Step 3: the bespoke-but-standard estimators (~27).
- Step 4: SDID/SSC/PPSCM single-cohort observed-vs-fitted fix + staggered event-study; carve-outs (CTSC/ISCM/DSC/microsynth).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_