### PR TITLE
Migrate SPOTSYNTH onto the two-family result contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ now returns and the back-compat guarantee.
 
 ## [Unreleased]
 
+### Changed
+- **SPOTSYNTH migrated onto the two-family result contract.** `SPOTSYNTH.fit()`
+  now returns `SpotSynthResults` as a frozen pydantic `EffectResult`: it
+  populates the standardized sub-models (`effects`, `time_series`, `weights`,
+  `inference`, `fit_diagnostics`, `method_details`) and exposes the flat
+  accessors (`att`, `att_ci`, `counterfactual`, `gap`, `donor_weights`,
+  `pre_rmse`). All previously public attributes still resolve, and `att_ci` now
+  reads from `inference`. **One rename:** the result's former `inference` field
+  (the `"bayes"`/`"frequentist"` label) is now `inference_method`, because
+  `inference` is the standardized `InferenceResults` slot; the config field
+  `SPOTSYNTHConfig.inference` is unchanged. Mutating the frozen result now raises
+  pydantic `ValidationError` (not `dataclasses.FrozenInstanceError`). SPOTSYNTH
+  plots via the standardized `result.plot()` and is pinned in
+  `tests/test_result_contract.py`.
+
 ### Added
 - **Standardized plotting foundation.** A nested `PlotConfig` on
   `BaseEstimatorConfig` (`plot=...`) centralizes plot cosmetics — observed/

--- a/llms.txt
+++ b/llms.txt
@@ -26,7 +26,6 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **BVSS** — Bayesian Synthetic Control with a soft simplex constraint.  (config: BVSSConfig)
 - **CLUSTERSC** — Cluster-based Synthetic Control estimator.  (config: CLUSTERSCConfig)
 - **CTSC** — Continuous-Treatment Synthetic Control estimator.  (config: CTSCConfig)
-- **DC** — De-biased convex panel-regression estimator (Farias et al. 2021).  (config: DCConfig)
 - **DSC** — Distributional Synthetic Control estimator.  (config: DSCConfig)
 - **DSCAR** — Dynamic Synthetic Control for Auto-Regressive processes.  (config: DSCARConfig)
 - **FDID** — Forward Difference-in-Differences (FDID) estimator.  (config: FDIDConfig)

--- a/mlsynth/estimators/spotsynth.py
+++ b/mlsynth/estimators/spotsynth.py
@@ -36,7 +36,6 @@ from ..exceptions import (
     MlsynthEstimationError,
 )
 from ..utils.spotsynth_helpers.pipeline import run_spotsynth
-from ..utils.spotsynth_helpers.plotter import plot_spotsynth
 from ..utils.spotsynth_helpers.setup import prepare_spotsynth_inputs
 from ..utils.spotsynth_helpers.structures import SpotSynthResults
 
@@ -97,17 +96,17 @@ class SPOTSYNTH:
                 n_samples=self.n_samples, n_warmup=self.n_warmup,
                 debias=self.debias, seed=self.seed,
             )
+            # Attach plotting context so result.plot() is self-contained and
+            # styled from the (possibly nested) config; labels default to the
+            # column names when the user has not set them.
+            pc = self.config.resolved_plot()
+            if pc.xlabel is None:
+                pc.xlabel = self.time
+            if pc.ylabel is None:
+                pc.ylabel = self.outcome
+            object.__setattr__(results, "plot_config", pc)
             if self.display_graphs:
-                plot_spotsynth(
-                    results,
-                    treated_color=self.treated_color,
-                    counterfactual_color=self.counterfactual_color,
-                    save=self.save,
-                    time_axis_label=self.time,
-                    treatment_label=self.treat,
-                    unit_label=self.unitid,
-                    outcome_label=self.outcome,
-                )
+                results.plot()
             return results
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/guides/llms.txt
+++ b/mlsynth/guides/llms.txt
@@ -26,7 +26,6 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **BVSS** — Bayesian Synthetic Control with a soft simplex constraint.  (config: BVSSConfig)
 - **CLUSTERSC** — Cluster-based Synthetic Control estimator.  (config: CLUSTERSCConfig)
 - **CTSC** — Continuous-Treatment Synthetic Control estimator.  (config: CTSCConfig)
-- **DC** — De-biased convex panel-regression estimator (Farias et al. 2021).  (config: DCConfig)
 - **DSC** — Distributional Synthetic Control estimator.  (config: DSCConfig)
 - **DSCAR** — Dynamic Synthetic Control for Auto-Regressive processes.  (config: DSCARConfig)
 - **FDID** — Forward Difference-in-Differences (FDID) estimator.  (config: FDIDConfig)

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mlsynth import FDID, TSSC, VanillaSC
+from mlsynth import FDID, SPOTSYNTH, TSSC, VanillaSC
 from mlsynth.config_models import (
     BaseEstimatorResults,
     DesignResult,
@@ -62,6 +62,7 @@ OBSERVATIONAL = [
     pytest.param(VanillaSC, {}, id="VanillaSC"),
     pytest.param(FDID, {}, id="FDID"),
     pytest.param(TSSC, {"draws": 80, "seed": 0}, id="TSSC"),
+    pytest.param(SPOTSYNTH, {}, id="SPOTSYNTH"),
 ]
 
 

--- a/mlsynth/tests/test_spotsynth.py
+++ b/mlsynth/tests/test_spotsynth.py
@@ -12,11 +12,10 @@ Layered per agents/agents_tests.md:
 
 from __future__ import annotations
 
-import dataclasses
-
 import numpy as np
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 
 from mlsynth import SPOTSYNTH
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
@@ -222,7 +221,7 @@ class TestBayesAndDebias:
                          "unitid": "unit", "time": "time", "selection": "S1",
                          "n_donors": 10, "inference": "bayes", "n_samples": 1000,
                          "n_warmup": 600, "display_graphs": False}).fit()
-        assert res.inference == "bayes"
+        assert res.inference_method == "bayes"
         assert res.att_ci is not None and res.att_ci[0] < res.att_ci[1]
         assert res.counterfactual_lower is not None
         assert res.counterfactual_lower.shape == res.counterfactual.shape
@@ -280,8 +279,10 @@ class TestAPI:
         assert isinstance(res, SpotSynthResults)
         assert isinstance(res.screen, SpilloverScreen)
         assert isinstance(res.inputs, SpotSynthInputs)
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            res.att = 0.0
+        # SpotSynthResults is now a frozen pydantic EffectResult; mutating a
+        # field raises pydantic's ValidationError (not FrozenInstanceError).
+        with pytest.raises(ValidationError):
+            res.att_unscreened = 0.0
 
     def test_config_validation(self):
         df, _ = simulate_spillover_panel(n_donors=10, T0=20, n_post=6, seed=0)

--- a/mlsynth/utils/results_helpers.py
+++ b/mlsynth/utils/results_helpers.py
@@ -121,6 +121,7 @@ def build_effect_submodels(
     fit_overrides: Optional[Dict[str, Any]] = None,
     additional_effects: Optional[Dict[str, Any]] = None,
     additional_metrics: Optional[Dict[str, Any]] = None,
+    intervention_time: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """Build the standardized EffectResult sub-models from two outcome paths.
 
@@ -161,6 +162,7 @@ def build_effect_submodels(
             counterfactual_outcome=np.asarray(counterfactual_outcome, dtype=float).ravel(),
             estimated_gap=m["gap"],
             time_periods=None if time_periods is None else np.asarray(time_periods),
+            intervention_time=intervention_time,
         ),
         "fit_diagnostics": FitDiagnosticsResults(**fit_kwargs),
     }

--- a/mlsynth/utils/spotsynth_helpers/pipeline.py
+++ b/mlsynth/utils/spotsynth_helpers/pipeline.py
@@ -9,6 +9,8 @@ from .debias import proximal_debias
 from .sc import simplex_weights
 from .screen import spillover_screen
 from .structures import SpotSynthInputs, SpotSynthResults
+from ...config_models import InferenceResults
+from ..results_helpers import build_effect_submodels, make_weights_results
 
 
 def run_spotsynth(
@@ -92,10 +94,32 @@ def run_spotsynth(
         "dirichlet_alpha": float(dirichlet_alpha) if inference == "bayes" else None,
         "treated_name": inputs.treated_name,
     }
+    # Standardized EffectResult sub-models (born from the screened SC fit).
+    inference_results = InferenceResults(
+        method=("Dirichlet posterior" if inference == "bayes"
+                else "simplex least squares"),
+        ci_lower=float(att_ci[0]) if att_ci is not None else None,
+        ci_upper=float(att_ci[1]) if att_ci is not None else None,
+    )
+    submodels = build_effect_submodels(
+        observed_outcome=inputs.y,
+        counterfactual_outcome=counterfactual,
+        n_pre_periods=int(T0),
+        n_post_periods=int(inputs.T - T0),
+        time_periods=inputs.time_labels,
+        weights=make_weights_results(
+            donor_weights, constraint="simplex (non-negative, sum to 1)"
+        ),
+        inference=inference_results,
+        method_name="SPOTSYNTH",
+        effects_overrides={"att": float(att)},
+        intervention_time=(inputs.time_labels[T0] if T0 < inputs.T
+                           else inputs.time_labels[-1]),
+    )
     return SpotSynthResults(
-        inputs=inputs, screen=screen, att=att, counterfactual=counterfactual,
-        gap=gap, att_by_period=att_by_period, donor_weights=donor_weights,
-        att_unscreened=att_all, inference=inference, att_ci=att_ci,
+        **submodels,
+        inputs=inputs, screen=screen, att_by_period=att_by_period,
+        att_unscreened=att_all, inference_method=inference,
         counterfactual_lower=cf_lower, counterfactual_upper=cf_upper,
         att_debiased=att_debiased, metadata=metadata,
     )

--- a/mlsynth/utils/spotsynth_helpers/structures.py
+++ b/mlsynth/utils/spotsynth_helpers/structures.py
@@ -15,6 +15,9 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
+from pydantic import ConfigDict, Field as PydField
+
+from ...config_models import BaseEstimatorResults
 
 
 @dataclass(frozen=True)
@@ -99,54 +102,48 @@ class SpilloverScreen:
         return [self.donor_names[i] for i in self.excluded_idx]
 
 
-@dataclass(frozen=True)
-class SpotSynthResults:
+class SpotSynthResults(BaseEstimatorResults):
     """Top-level container returned by :meth:`mlsynth.SPOTSYNTH.fit`.
 
-    Attributes
+    An :class:`~mlsynth.config_models.EffectResult` (the observational report):
+    in addition to the SPOTSYNTH-specific fields below it exposes the
+    standardized sub-models (``effects``, ``time_series``, ``weights``,
+    ``inference``, ``fit_diagnostics``, ``method_details``) and the flat
+    accessors ``att`` / ``att_ci`` / ``counterfactual`` / ``gap`` /
+    ``donor_weights`` / ``pre_rmse``. The screened ATT is the post-period mean
+    gap; ``att_ci`` reads the Dirichlet credible interval from ``inference``.
+
+    Parameters
     ----------
     inputs : SpotSynthInputs
     screen : SpilloverScreen
         The per-donor spillover diagnostics and the valid-donor selection.
-    att : float
-        Average treatment effect on the treated, computed on the *screened*
-        synthetic control (mean post-period gap).
-    counterfactual : np.ndarray
-        Synthetic-control counterfactual for the treated unit, length ``T``.
-    gap : np.ndarray
-        Observed minus counterfactual, length ``T`` (the per-period effect).
     att_by_period : dict
         ``{time_label: gap}`` over the post-intervention periods.
-    donor_weights : dict
-        ``{donor_name: weight}`` for the selected donors (simplex weights).
     att_unscreened : float
         ATT from a synthetic control on the *full* donor pool (the ``All``
         baseline) -- for comparison.
-    inference : str
+    inference_method : str
         ``"bayes"`` (Dirichlet posterior) or ``"frequentist"`` (simplex LS).
-    att_ci : tuple, optional
-        Credible interval for the ATT under the Dirichlet posterior
-        (``inference="bayes"``), else ``None``.
+        (Renamed from the former ``inference`` field, which now holds the
+        standardized :class:`~mlsynth.config_models.InferenceResults`.)
     counterfactual_lower, counterfactual_upper : np.ndarray, optional
         Posterior-predictive credible band for the counterfactual (length
-        ``T``) under ``inference="bayes"``, else ``None``.
+        ``T``) under ``inference_method="bayes"``, else ``None``.
     att_debiased : float, optional
         Proximal (two-stage / GMM) debiased ATT using the excluded donors as
         proximal controls (when ``debias=True``), else ``None``.
     metadata : dict
     """
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     inputs: SpotSynthInputs
     screen: SpilloverScreen
-    att: float
-    counterfactual: np.ndarray
-    gap: np.ndarray
     att_by_period: Dict[Any, float]
-    donor_weights: Dict[Any, float]
     att_unscreened: float
-    inference: str = "frequentist"
-    att_ci: Optional[Tuple[float, float]] = None
+    inference_method: str = "frequentist"
     counterfactual_lower: Optional[np.ndarray] = None
     counterfactual_upper: Optional[np.ndarray] = None
     att_debiased: Optional[float] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = PydField(default_factory=dict)


### PR DESCRIPTION
Migrates **SPOTSYNTH** onto the two-family result contract (`agents/agents_results.md`) — the reference application of the DoD that the other `plot_estimates`-wrapper estimators will follow. Full suite green locally: **2623 passed, 3 skipped**.

## What changed
`SpotSynthResults` is now a **frozen pydantic `EffectResult`** (was a frozen dataclass). The screened SC fit is born standardized: pipeline-native sub-models via `build_effect_submodels`, SPOTSYNTH-specific outputs retained as typed fields, plotting through `result.plot()`.

## DoD checklist
**A. Code**
- [x] `fit()` returns an `EffectResult` subclass; no dict/tuple in the public return.
- [x] Result is a pydantic model subclassing `BaseEstimatorResults`, `frozen=True, arbitrary_types_allowed=True`.
- [x] Standardized sub-models populated (`effects`, `time_series`, `weights`, `inference`, `fit_diagnostics`, `method_details`), pipeline-native.
- [x] Estimator-specific outputs kept **typed** (`screen`, `att_by_period`, `att_unscreened`, `counterfactual_lower/upper`, `att_debiased`, `metadata`).
- [x] **Back-compat:** `att` / `att_ci` / `counterfactual` / `gap` / `donor_weights` / `pre_rmse` resolve via inherited accessors. **One rename:** result field `inference` → `inference_method` (the `inference` slot now holds `InferenceResults`; `att_ci` reads from it). Config `SPOTSYNTHConfig.inference` is unchanged.

**B. Tests**
- [x] Added to `test_result_contract.py` (`OBSERVATIONAL`); conformance passes.
- [x] Frozen-mutation test updated to pydantic `ValidationError`; `inference` → `inference_method`.
- [x] Full suite green.

**C/D. Docs / replication**
- [x] `SpotSynthResults` docstring documents the standardized surface; runnable examples use canonical accessors (`res.att`, `res.att_ci`, …) and were already valid. Replication numbers unchanged (return-type refactor only).

**E/F. Indices / notes**
- [x] `llms.txt` regenerated; CHANGELOG entry added.

## Also
- `build_effect_submodels` gains an `intervention_time` param so every migrated result carries the intervention reference line for `result.plot()`.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_