### PR TITLE
Migrate RMSI onto the two-family result contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Changed
+- **RMSI migrated onto the two-family result contract.** `RMSI.fit()` now
+  returns `RMSIResults` as a frozen pydantic `EffectResult` with the
+  standardized sub-models populated from the treated aggregate paths
+  (`treated_mean` / `synthetic_mean`); `att` / `counterfactual` / `gap` /
+  `pre_rmse` resolve via the inherited accessors. **Breaking surface change
+  (matrix-completion convention):** `res.counterfactual` is now the **1-D
+  treated counterfactual path** (was the full `(N, T)` imputed matrix); the
+  matrix moved to `res.counterfactual_matrix`, and the per-cell `effects`
+  matrix moved to `res.effects_matrix` (the `effects` slot now holds the
+  standardized `EffectsResults`). RMSI is a matrix-completion method with no
+  donor weights, so `weights` records the method/rank. Mutating the frozen
+  result raises pydantic `ValidationError`. RMSI plots via `result.plot()` and
+  is pinned in `tests/test_result_contract.py`.
 - **SPOTSYNTH migrated onto the two-family result contract.** `SPOTSYNTH.fit()`
   now returns `SpotSynthResults` as a frozen pydantic `EffectResult`: it
   populates the standardized sub-models (`effects`, `time_series`, `weights`,

--- a/mlsynth/estimators/rmsi.py
+++ b/mlsynth/estimators/rmsi.py
@@ -47,7 +47,6 @@ from ..exceptions import (
     MlsynthEstimationError,
 )
 from ..utils.rmsi_helpers.pipeline import run_rmsi
-from ..utils.rmsi_helpers.plotter import plot_rmsi
 from ..utils.rmsi_helpers.setup import prepare_rmsi_inputs
 from ..utils.rmsi_helpers.structures import RMSIResults
 
@@ -94,17 +93,17 @@ class RMSI:
                 time_covariates=self.time_covariates,
             )
             results = run_rmsi(inputs, J=self.sieve_order, rank=self.rank)
+            # Attach plotting context so result.plot() is self-contained and
+            # styled from the (possibly nested) config; labels default to the
+            # column names when the user has not set them.
+            pc = self.config.resolved_plot()
+            if pc.xlabel is None:
+                pc.xlabel = self.time
+            if pc.ylabel is None:
+                pc.ylabel = self.outcome
+            object.__setattr__(results, "plot_config", pc)
             if self.display_graphs:
-                plot_rmsi(
-                    results,
-                    treated_color=self.treated_color,
-                    counterfactual_color=self.counterfactual_color,
-                    save=self.save,
-                    time_axis_label=self.time,
-                    treatment_label=self.treat,
-                    unit_label=self.unitid,
-                    outcome_label=self.outcome,
-                )
+                results.plot()
             return results
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mlsynth import FDID, SPOTSYNTH, TSSC, VanillaSC
+from mlsynth import FDID, RMSI, SPOTSYNTH, TSSC, VanillaSC
 from mlsynth.config_models import (
     BaseEstimatorResults,
     DesignResult,
@@ -63,6 +63,7 @@ OBSERVATIONAL = [
     pytest.param(FDID, {}, id="FDID"),
     pytest.param(TSSC, {"draws": 80, "seed": 0}, id="TSSC"),
     pytest.param(SPOTSYNTH, {}, id="SPOTSYNTH"),
+    pytest.param(RMSI, {}, id="RMSI"),
 ]
 
 

--- a/mlsynth/tests/test_rmsi.py
+++ b/mlsynth/tests/test_rmsi.py
@@ -19,6 +19,7 @@ import pathlib
 import numpy as np
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 
 from mlsynth import RMSI
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
@@ -113,7 +114,8 @@ class TestIntegration:
                     "display_graphs": False}).fit()
         assert isinstance(res, RMSIResults)
         assert abs(res.att - 5.0) < 1.0
-        assert res.counterfactual.shape == (40, 31)
+        assert res.counterfactual_matrix.shape == (40, 31)
+        assert res.counterfactual.ndim == 1  # treated path (contract)
         assert res.rank >= 1
 
     def test_prop99_path_a(self):
@@ -147,8 +149,10 @@ class TestAPI:
         res = RMSI({"df": df, "outcome": "Y", "treat": "treated",
                     "unitid": "unit", "time": "time",
                     "unit_covariates": ["x0", "x1"], "display_graphs": False}).fit()
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            res.att = 0.0
+        # RMSIResults is now a frozen pydantic EffectResult; mutating a field
+        # raises pydantic's ValidationError (not FrozenInstanceError).
+        with pytest.raises(ValidationError):
+            res.rank = 0
 
     def test_bad_config_raises(self):
         df = simulate_rmsi_panel(n_units=12)

--- a/mlsynth/utils/rmsi_helpers/pipeline.py
+++ b/mlsynth/utils/rmsi_helpers/pipeline.py
@@ -8,6 +8,8 @@ import numpy as np
 
 from .core import algorithm3
 from .structures import RMSIInputs, RMSIResults
+from ...config_models import WeightsResults
+from ..results_helpers import build_effect_submodels
 
 
 def run_rmsi(inputs: RMSIInputs, *, J: int = 2, rank: Optional[int] = None,
@@ -53,8 +55,27 @@ def run_rmsi(inputs: RMSIInputs, *, J: int = 2, rank: Optional[int] = None,
         "d_unit_cov": int(inputs.X.shape[1]), "d_time_cov": int(inputs.Z.shape[1]),
         "sieve_order": int(J), "estimator": "RMSI",
     }
+    # Standardized EffectResult sub-models from the treated aggregate paths.
+    # RMSI is a matrix-completion estimator (no donor weights); the weights
+    # slot records the method/rank so the standardized surface is populated.
+    submodels = build_effect_submodels(
+        observed_outcome=treated_mean,
+        counterfactual_outcome=synthetic_mean,
+        n_pre_periods=int(T0),
+        n_post_periods=int(T - T0),
+        time_periods=np.asarray(inputs.time_labels),
+        weights=WeightsResults(summary_stats={
+            "constraint": "matrix completion (no donor weights)",
+            "rank": int(used_rank),
+        }),
+        method_name="RMSI",
+        effects_overrides={"att": float(att)},
+        intervention_time=(inputs.time_labels[T0] if T0 < T
+                           else inputs.time_labels[-1]),
+    )
     return RMSIResults(
-        inputs=inputs, att=att, counterfactual=M_hat, effects=effects,
+        **submodels,
+        inputs=inputs, counterfactual_matrix=M_hat, effects_matrix=effects,
         att_by_period=att_by_period, treated_mean=treated_mean,
         synthetic_mean=synthetic_mean, rank=used_rank, metadata=metadata,
     )

--- a/mlsynth/utils/rmsi_helpers/structures.py
+++ b/mlsynth/utils/rmsi_helpers/structures.py
@@ -12,6 +12,9 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import numpy as np
+from pydantic import ConfigDict, Field as PydField
+
+from ...config_models import BaseEstimatorResults
 
 
 @dataclass(frozen=True)
@@ -58,21 +61,28 @@ class RMSIInputs:
         return self.Y.shape[1]
 
 
-@dataclass(frozen=True)
-class RMSIResults:
+class RMSIResults(BaseEstimatorResults):
     """Top-level container returned by :meth:`mlsynth.RMSI.fit`.
 
-    Attributes
+    An :class:`~mlsynth.config_models.EffectResult` (the observational report):
+    in addition to the RMSI-specific fields below it exposes the standardized
+    sub-models (``effects``, ``time_series``, ``weights``, ``inference``,
+    ``fit_diagnostics``, ``method_details``) and the flat accessors ``att`` /
+    ``counterfactual`` / ``gap`` / ``pre_rmse``. The treated counterfactual path
+    (``res.counterfactual``) is the cross-treated-unit synthetic mean; the full
+    imputed ``(N, T)`` matrix lives in ``counterfactual_matrix``.
+
+    Parameters
     ----------
     inputs : RMSIInputs
-    att : float
-        Average treatment effect on the treated (mean post-period gap over
-        treated cells).
-    counterfactual : np.ndarray
+    counterfactual_matrix : np.ndarray
         Estimated untreated potential outcomes ``M_hat``, shape ``(N, T)``.
-    effects : np.ndarray
+        (Renamed from ``counterfactual``, which now returns the 1-D treated
+        path per the result contract.)
+    effects_matrix : np.ndarray
         Observed minus imputed on treated cells (NaN elsewhere), shape
-        ``(N, T)``.
+        ``(N, T)``. (Renamed from ``effects``, which is now the standardized
+        :class:`~mlsynth.config_models.EffectsResults` slot.)
     att_by_period : dict
         ``{time_label: ATT}`` over the post-treatment periods.
     treated_mean, synthetic_mean : np.ndarray
@@ -85,13 +95,14 @@ class RMSIResults:
     metadata : dict
     """
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     inputs: RMSIInputs
-    att: float
-    counterfactual: np.ndarray
-    effects: np.ndarray
+    counterfactual_matrix: np.ndarray
+    effects_matrix: np.ndarray
     att_by_period: Dict[Any, float]
     treated_mean: np.ndarray
     synthetic_mean: np.ndarray
     rank: int
     components: Optional[Dict[str, np.ndarray]] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = PydField(default_factory=dict)


### PR DESCRIPTION
Migrates **RMSI** onto the two-family result contract — the second of the 9 `plot_estimates`-wrapper estimators, and the reference for the **matrix-completion convention** (RMSI/SNN/MSQRT/MCNNM). Full suite green locally: **2627 passed, 3 skipped**.

## What changed
`RMSIResults` is now a **frozen pydantic `EffectResult`** (was a frozen dataclass). Standardized sub-models are built from the treated aggregate paths (`treated_mean` / `synthetic_mean`) via `build_effect_submodels`; the flat accessors `att` / `counterfactual` / `gap` / `pre_rmse` resolve via the inherited surface. Plotting now goes through `result.plot()`.

## ⚠️ Breaking surface change (matrix-completion convention)
Per the result contract, `res.counterfactual` must be the **1-D treated counterfactual path**. RMSI previously returned the full `(N, T)` imputed matrix there. So:
- `res.counterfactual` → now the **treated synthetic path** (1-D).
- `res.counterfactual_matrix` → the full `(N, T)` imputed matrix `M_hat` (renamed from `counterfactual`).
- `res.effects_matrix` → the per-cell `(N, T)` effects (renamed from `effects`; the `effects` slot now holds the standardized `EffectsResults`).

This is the convention the other matrix-completion estimators will follow (agreed with @jgreathouse9).

## DoD checklist
**A. Code**
- [x] `fit()` returns an `EffectResult` subclass; no dict/tuple in the public return.
- [x] Frozen pydantic model subclassing `BaseEstimatorResults` (`frozen=True, arbitrary_types_allowed=True`).
- [x] Standardized sub-models populated. RMSI is matrix completion (no donor weights), so the `weights` slot records the method/rank rather than per-donor weights.
- [x] Estimator-specific outputs kept **typed** (`counterfactual_matrix`, `effects_matrix`, `att_by_period`, `treated_mean`, `synthetic_mean`, `rank`, `components`, `metadata`).
- [x] Back-compat accessors (`att`/`counterfactual`/`gap`/`pre_rmse`) resolve; the two matrix renames are documented above and in CHANGELOG.

**B. Tests**
- [x] RMSI added to `test_result_contract.py` (`OBSERVATIONAL`); conformance passes.
- [x] Frozen-mutation test → pydantic `ValidationError`; matrix-shape assert → `counterfactual_matrix` (plus a 1-D `counterfactual` assert).
- [x] Full suite green.

**C/D/E/F. Docs / replication / indices**
- [x] `RMSIResults` docstring documents the standardized surface and the renames; runnable examples (`res.att`, `res.rank`) unchanged and valid. Return-type refactor only — replication numbers unchanged.
- [x] CHANGELOG entry added; `llms.txt` regenerated (unchanged — it indexes estimators, not result fields).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_