### PR TITLE
Migrate SNN onto the two-family result contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Changed
+- **SNN migrated onto the two-family result contract.** `SNN.fit()` now
+  returns `SNNResults` as a frozen pydantic `EffectResult` with the
+  standardized sub-models built from the cross-treated-unit observed / imputed
+  paths; `att` / `counterfactual` / `gap` / `att_ci` / `pre_rmse` resolve via
+  the inherited accessors, and the PCR donor weights stay in the `weights`
+  slot. **Breaking surface change (matrix-completion convention):**
+  `res.counterfactual` is now the **1-D treated counterfactual path** (was the
+  full `(N, T)` imputed matrix); the matrix moved to
+  `res.counterfactual_matrix`, and the per-cell `effects` matrix to
+  `res.effects_matrix` (the `effects` slot now holds `EffectsResults`). The raw
+  jackknife object moved from `res.inference` to `res.inference_jackknife`; the
+  `inference` slot now holds the standardized `InferenceResults` (so
+  `res.att_ci` resolves). Mutating the frozen result raises pydantic
+  `ValidationError`. SNN plots via `result.plot()` and is pinned in
+  `tests/test_result_contract.py`.
 - **RMSI migrated onto the two-family result contract.** `RMSI.fit()` now
   returns `RMSIResults` as a frozen pydantic `EffectResult` with the
   standardized sub-models populated from the treated aggregate paths

--- a/docs/snn.rst
+++ b/docs/snn.rst
@@ -197,7 +197,7 @@ counterfactual by matrix completion, and reports the ATT. With
    }).fit()
 
    print(f"ATT (avg 1989-2000) = {res.att:+.2f} packs/capita")
-   lo, hi = res.inference.ci
+   lo, hi = res.att_ci               # standardized; jackknife when inference=True
    print(f"jackknife 95% CI    = [{lo:+.2f}, {hi:+.2f}]")
    print(f"gap by 2000         = {res.att_by_period[2000]:+.2f}")
 

--- a/mlsynth/estimators/snn.py
+++ b/mlsynth/estimators/snn.py
@@ -41,7 +41,6 @@ from ..exceptions import (
     MlsynthEstimationError,
 )
 from ..utils.snn_helpers.pipeline import run_snn
-from ..utils.snn_helpers.plotter import plot_snn
 from ..utils.snn_helpers.setup import prepare_snn_inputs
 from ..utils.snn_helpers.structures import SNNResults
 
@@ -100,17 +99,17 @@ class SNN:
                 alpha_level=self.alpha,
                 random_state=self.random_state,
             )
+            # Attach plotting context so result.plot() is self-contained and
+            # styled from the (possibly nested) config; labels default to the
+            # column names when the user has not set them.
+            pc = self.config.resolved_plot()
+            if pc.xlabel is None:
+                pc.xlabel = self.time
+            if pc.ylabel is None:
+                pc.ylabel = self.outcome
+            object.__setattr__(results, "plot_config", pc)
             if self.display_graphs:
-                plot_snn(
-                    results,
-                    treated_color=self.treated_color,
-                    counterfactual_color=self.counterfactual_color,
-                    save=self.save,
-                    time_axis_label=self.time,
-                    treatment_label=self.treat,
-                    unit_label=self.unitid,
-                    outcome_label=self.outcome,
-                )
+                results.plot()
             return results
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mlsynth import FDID, RMSI, SPOTSYNTH, TSSC, VanillaSC
+from mlsynth import FDID, RMSI, SNN, SPOTSYNTH, TSSC, VanillaSC
 from mlsynth.config_models import (
     BaseEstimatorResults,
     DesignResult,
@@ -64,6 +64,7 @@ OBSERVATIONAL = [
     pytest.param(TSSC, {"draws": 80, "seed": 0}, id="TSSC"),
     pytest.param(SPOTSYNTH, {}, id="SPOTSYNTH"),
     pytest.param(RMSI, {}, id="RMSI"),
+    pytest.param(SNN, {}, id="SNN"),
 ]
 
 

--- a/mlsynth/tests/test_snn.py
+++ b/mlsynth/tests/test_snn.py
@@ -142,11 +142,16 @@ class TestEstimator:
         df, effect, *_ = _low_rank_panel()
         res = SNN({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
                    "time": "time", "max_rank": 3, "inference": True, "display_graphs": False}).fit()
-        assert res.inference is not None
-        assert res.inference.method == "jackknife"
-        assert res.inference.se >= 0
-        lo, hi = res.inference.ci
+        # Raw jackknife object preserved under inference_jackknife; the
+        # standardized InferenceResults is mirrored into the `inference` slot.
+        assert res.inference_jackknife is not None
+        assert res.inference_jackknife.method == "jackknife"
+        assert res.inference_jackknife.se >= 0
+        lo, hi = res.inference_jackknife.ci
         assert lo <= res.att <= hi
+        assert res.inference is not None
+        assert res.inference.standard_error == pytest.approx(res.inference_jackknife.se)
+        assert res.att_ci == pytest.approx((lo, hi))
 
 
 # ----------------------------------------------------------------------

--- a/mlsynth/utils/snn_helpers/pipeline.py
+++ b/mlsynth/utils/snn_helpers/pipeline.py
@@ -12,7 +12,8 @@ from typing import Optional
 
 import numpy as np
 
-from ...config_models import WeightsResults
+from ...config_models import InferenceResults, WeightsResults
+from ..results_helpers import build_effect_submodels
 from .completion import snn_complete, snn_donor_weights
 from .structures import SNNInference, SNNInputs, SNNResults
 
@@ -168,10 +169,38 @@ def run_snn(
         "imputed_cells": int(treated_post.sum()),
         "infeasible_cells": int(((D > 0) & ~feasible).sum()),
     }
+    # Cross-treated-unit observed / imputed paths drive the standardized
+    # time series (and result.plot()).
+    tr = inputs.treated_idx
+    observed_path = inputs.Y[tr].mean(axis=0)
+    counterfactual_path = counterfactual[tr].mean(axis=0)
+    std_inference = None
+    if inf is not None:
+        lo, hi = inf.ci
+        std_inference = InferenceResults(
+            method=inf.method, standard_error=float(inf.se),
+            ci_lower=float(lo), ci_upper=float(hi),
+            confidence_level=float(1.0 - inf.alpha_level),
+            details={"n_jackknife": int(inf.n_jackknife)},
+        )
+    submodels = build_effect_submodels(
+        observed_outcome=observed_path,
+        counterfactual_outcome=counterfactual_path,
+        n_pre_periods=int(T0),
+        n_post_periods=int(inputs.T - T0),
+        time_periods=np.asarray(inputs.time_labels),
+        weights=weights,
+        inference=std_inference,
+        method_name="SNN",
+        effects_overrides={"att": float(att)},
+        intervention_time=(inputs.time_labels[T0] if T0 < inputs.T
+                           else inputs.time_labels[-1]),
+    )
     return SNNResults(
-        inputs=inputs, att=att, counterfactual=counterfactual, effects=effects,
-        att_by_period=att_by_period, feasible=feasible, weights=weights,
-        inference=inf, metadata=metadata,
+        **submodels,
+        inputs=inputs, counterfactual_matrix=counterfactual,
+        effects_matrix=effects, att_by_period=att_by_period,
+        feasible=feasible, inference_jackknife=inf, metadata=metadata,
     )
 
 

--- a/mlsynth/utils/snn_helpers/plotter.py
+++ b/mlsynth/utils/snn_helpers/plotter.py
@@ -43,12 +43,12 @@ def plot_snn(
     if treated.size == 1:
         i = int(treated[0])
         observed = inputs.Y[i]
-        counterfactual = results.counterfactual[i]
+        counterfactual = results.counterfactual_matrix[i]
         treated_name = str(inputs.unit_names[i])
     else:
         # Average observed and counterfactual across treated units.
         observed = inputs.Y[treated].mean(axis=0)
-        counterfactual = results.counterfactual[treated].mean(axis=0)
+        counterfactual = results.counterfactual_matrix[treated].mean(axis=0)
         treated_name = f"Treated mean (n={treated.size})"
 
     ywide = pd.DataFrame(

--- a/mlsynth/utils/snn_helpers/structures.py
+++ b/mlsynth/utils/snn_helpers/structures.py
@@ -17,6 +17,9 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import numpy as np
+from pydantic import ConfigDict, Field as PydField
+
+from ...config_models import BaseEstimatorResults
 
 
 @dataclass(frozen=True)
@@ -55,49 +58,61 @@ class SNNInputs:
         return self.Y.shape[1]
 
 
-@dataclass(frozen=True)
-class SNNResults:
+class SNNResults(BaseEstimatorResults):
     """Top-level container returned by :meth:`mlsynth.SNN.fit`.
 
-    Attributes
+    An :class:`~mlsynth.config_models.EffectResult` (the observational report):
+    in addition to the SNN-specific fields below it exposes the standardized
+    sub-models (``effects``, ``time_series``, ``weights``, ``inference``,
+    ``fit_diagnostics``, ``method_details``) and the flat accessors ``att`` /
+    ``counterfactual`` / ``gap`` / ``att_ci`` / ``pre_rmse``. The treated
+    counterfactual path (``res.counterfactual``) is the cross-treated-unit mean
+    of the imputed :math:`Y(0)`; the full imputed ``(N, T)`` matrix lives in
+    ``counterfactual_matrix``.
+
+    Parameters
     ----------
     inputs : SNNInputs
         Preprocessed panel.
-    att : float
-        Average treatment effect on the treated, over imputed
-        treated post-treatment cells.
-    counterfactual : np.ndarray
+    counterfactual_matrix : np.ndarray
         Outcome matrix with treated post-treatment :math:`Y(0)` imputed,
-        shape ``(N, T)``.
-    effects : np.ndarray
+        shape ``(N, T)``. (Renamed from ``counterfactual``, which now returns
+        the 1-D treated path per the result contract.)
+    effects_matrix : np.ndarray
         Per-cell treatment effects (observed minus imputed) for treated
-        post cells; ``NaN`` elsewhere, shape ``(N, T)``.
+        post cells; ``NaN`` elsewhere, shape ``(N, T)``. (Renamed from
+        ``effects``, which is now the standardized ``EffectsResults`` slot.)
     att_by_period : dict
         ``{period_label: mean effect across treated units}`` for
         post-treatment periods.
     feasible : np.ndarray
         Boolean mask of cells SNN could impute, shape ``(N, T)``.
-    weights : WeightsResults, optional
-        Per-treated-unit donor weights (the PCR coefficients that build the
-        counterfactual as a linear combination of the donor units). For a
-        single treated unit, ``donor_weights`` maps donor name -> weight;
-        with multiple treated units it holds the cross-unit average and the
-        per-unit weights live in ``summary_stats['per_unit_donor_weights']``.
-    inference : object, optional
-        :class:`SNNInference` when ``inference=True``; ``None`` otherwise.
+    inference_jackknife : SNNInference, optional
+        The raw jackknife inference object (``method`` / ``se`` / ``ci``) when
+        ``inference=True``; ``None`` otherwise. The standardized
+        :class:`~mlsynth.config_models.InferenceResults` is mirrored into the
+        ``inference`` slot (so ``res.att_ci`` resolves).
     metadata : dict
         Free-form diagnostics.
+
+    Notes
+    -----
+    The PCR donor weights (the linear combination that builds the
+    counterfactual) live in the standardized ``weights`` slot: for a single
+    treated unit ``donor_weights`` maps donor name -> weight; with multiple
+    treated units it holds the cross-unit average and the per-unit weights live
+    in ``summary_stats['per_unit_donor_weights']``.
     """
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     inputs: SNNInputs
-    att: float
-    counterfactual: np.ndarray
-    effects: np.ndarray
+    counterfactual_matrix: np.ndarray
+    effects_matrix: np.ndarray
     att_by_period: Dict[Any, float]
     feasible: np.ndarray
-    weights: Optional[Any] = None
-    inference: Optional["SNNInference"] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    inference_jackknife: Optional["SNNInference"] = None
+    metadata: Dict[str, Any] = PydField(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -127,3 +142,7 @@ class SNNInference:
     ci: tuple
     alpha_level: float
     n_jackknife: int
+
+
+# Resolve the forward reference to SNNInference now that it is defined.
+SNNResults.model_rebuild()


### PR DESCRIPTION
Migrates **SNN** (Synthetic Nearest Neighbors / causal matrix completion) onto the two-family result contract — third of the 9, following the matrix-completion convention set by RMSI. Full suite green locally: **2631 passed, 3 skipped**.

## What changed
`SNNResults` is now a **frozen pydantic `EffectResult`** (was a frozen dataclass). Standardized sub-models are built from the cross-treated-unit observed / imputed paths via `build_effect_submodels`; `att` / `counterfactual` / `gap` / `att_ci` / `pre_rmse` resolve via the inherited surface. The PCR donor weights stay in the standardized `weights` slot. Plotting now goes through `result.plot()`.

## ⚠️ Breaking surface changes
- **Matrix-completion convention** (as in RMSI): `res.counterfactual` is now the **1-D treated counterfactual path**; the full `(N, T)` imputed matrix moved to `res.counterfactual_matrix`, and the per-cell `(N, T)` effects matrix to `res.effects_matrix` (the `effects` slot now holds the standardized `EffectsResults`).
- **Inference:** the raw jackknife object moved from `res.inference` to `res.inference_jackknife` (still `.method` / `.se` / `.ci`); the `inference` slot now holds the standardized `InferenceResults`, so `res.att_ci` resolves.

## DoD checklist
**A. Code**
- [x] `fit()` returns an `EffectResult` subclass; no dict/tuple in the public return.
- [x] Frozen pydantic model (`frozen=True, arbitrary_types_allowed=True`); forward-ref to `SNNInference` resolved via `model_rebuild()`.
- [x] Standardized sub-models populated; donor weights in `weights`, standardized inference mirrored into `inference`.
- [x] Estimator-specific outputs kept typed (`counterfactual_matrix`, `effects_matrix`, `att_by_period`, `feasible`, `inference_jackknife`, `metadata`).
- [x] Back-compat accessors resolve; renames documented above + in CHANGELOG.

**B. Tests**
- [x] SNN added to `test_result_contract.py` (`OBSERVATIONAL`); conformance passes.
- [x] Jackknife test reads `inference_jackknife` (raw) **and** the standardized `inference` / `att_ci`.
- [x] Legacy `plot_snn` repointed to `counterfactual_matrix` so its coverage test (`test_snn_plotter`) still exercises it.
- [x] Full suite green.

**C/D/E/F. Docs / replication / indices**
- [x] `SNNResults` docstring documents the standardized surface + renames; `docs/snn.rst` example uses `res.att_ci`. Return-type refactor only — replication numbers unchanged.
- [x] CHANGELOG entry added; `llms.txt` regenerated (unchanged).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_