### PR TITLE
Migrate MSQRT onto the two-family result contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Changed
+- **MSQRT migrated onto the two-family result contract.** `MSQRT.fit()` now
+  returns `MSQRTResults` as a frozen pydantic `EffectResult` with the
+  standardized sub-models built from the cross-treated-unit observed / synthetic
+  paths; `att` / `counterfactual` / `gap` / `att_ci` / `pre_rmse` resolve via
+  the inherited accessors, and the per-treated-unit PCR donor weights stay in
+  the `weights` slot. **Breaking surface changes:** `res.counterfactual` /
+  `res.gap` are now the **1-D treated paths**; the full `(T, m)` synthetic / gap
+  matrices moved to `res.counterfactual_matrix` / `res.gap_matrix`. The raw
+  SCPI prediction-interval object moved from `res.inference` to
+  `res.inference_intervals`; the `inference` slot now holds the standardized
+  `InferenceResults` (so `res.att_ci` resolves). Mutating the frozen result
+  raises pydantic `ValidationError`. MSQRT plots via `result.plot()` and is
+  pinned in `tests/test_result_contract.py`.
 - **SNN migrated onto the two-family result contract.** `SNN.fit()` now
   returns `SNNResults` as a frozen pydantic `EffectResult` with the
   standardized sub-models built from the cross-treated-unit observed / imputed

--- a/docs/msqrt.rst
+++ b/docs/msqrt.rst
@@ -234,10 +234,10 @@ recovers the ATT with a CFPT/scpi prediction band.
    }).fit()
 
    print(f"ATT (true 2.0)   = {res.att:+.3f}")
-   lo, hi = res.inference.taua.ci     # overall ATT (TAUA) band
+   lo, hi = res.att_ci                          # overall ATT (TAUA) band
    print(f"90% scpi band    = [{lo:+.3f}, {hi:+.3f}]")
-   # per-period (unit-averaged) effects with their bands
-   for period, band in res.inference.tsua.items():
+   # per-period (unit-averaged) effects with their bands (raw SCPI object)
+   for period, band in res.inference_intervals.tsua.items():
        print(f"  k={period}: {band.point:+.3f}  [{band.lower:+.3f}, {band.upper:+.3f}]")
    print(f"selected lambda  = {res.best_lambda:.3f}")
    print(f"avg active donors per treated = "

--- a/mlsynth/estimators/msqrt.py
+++ b/mlsynth/estimators/msqrt.py
@@ -47,7 +47,6 @@ from ..exceptions import (
     MlsynthEstimationError,
 )
 from ..utils.msqrt_helpers.pipeline import run_msqrt
-from ..utils.msqrt_helpers.plotter import plot_msqrt
 from ..utils.msqrt_helpers.setup import prepare_msqrt_inputs
 from ..utils.msqrt_helpers.structures import MSQRTResults
 
@@ -109,17 +108,17 @@ class MSQRT:
                 alpha=self.alpha,
                 time_dependence=self.time_dependence,
             )
+            # Attach plotting context so result.plot() is self-contained and
+            # styled from the (possibly nested) config; labels default to the
+            # column names when the user has not set them.
+            pc = self.config.resolved_plot()
+            if pc.xlabel is None:
+                pc.xlabel = self.time
+            if pc.ylabel is None:
+                pc.ylabel = self.outcome
+            object.__setattr__(results, "plot_config", pc)
             if self.display_graphs:
-                plot_msqrt(
-                    results,
-                    treated_color=self.treated_color,
-                    counterfactual_color=self.counterfactual_color,
-                    save=self.save,
-                    time_axis_label=self.time,
-                    treatment_label=self.treat,
-                    unit_label=self.unitid,
-                    outcome_label=self.outcome,
-                )
+                results.plot()
             return results
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/tests/test_msqrt.py
+++ b/mlsynth/tests/test_msqrt.py
@@ -17,6 +17,7 @@ import dataclasses
 import numpy as np
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 
 from mlsynth import MSQRT
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
@@ -199,9 +200,12 @@ class TestIntegration:
             "n_lambda": 4, "inference": True, "alpha": 0.1,
             "display_graphs": False,
         }).fit()
-        scpi = res.inference
+        scpi = res.inference_intervals
         assert scpi is not None
         assert scpi.method == "cfpt_scpi"
+        # standardized inference mirrored into the contract slot
+        assert res.inference is not None
+        assert res.att_ci == pytest.approx((scpi.taua.lower, scpi.taua.upper))
         # in-sample omitted for MSQRT
         assert scpi.in_sample_included is False
         assert scpi.alpha_out == 0.1 and scpi.alpha_in == 0.0
@@ -228,8 +232,8 @@ class TestIntegration:
                   "inference": True, "display_graphs": False}
         iid = MSQRT({**common, "time_dependence": "iid"}).fit()
         gen = MSQRT({**common, "time_dependence": "general"}).fit()
-        w_iid = iid.inference.taua.upper - iid.inference.taua.lower
-        w_gen = gen.inference.taua.upper - gen.inference.taua.lower
+        w_iid = iid.inference_intervals.taua.upper - iid.inference_intervals.taua.lower
+        w_gen = gen.inference_intervals.taua.upper - gen.inference_intervals.taua.lower
         assert w_gen >= w_iid - 1e-9
 
     def test_fixed_lambda_skips_cv(self):
@@ -255,8 +259,9 @@ class TestAPI:
             "n_lambda": 3, "display_graphs": False,
         }).fit()
         assert isinstance(res, MSQRTResults)
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            res.att = 0.0
+        # MSQRTResults is now a frozen pydantic EffectResult.
+        with pytest.raises(ValidationError):
+            res.best_lambda = 0.0
 
     def test_bad_config_raises(self):
         df = _block_panel()

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mlsynth import FDID, RMSI, SNN, SPOTSYNTH, TSSC, VanillaSC
+from mlsynth import FDID, MSQRT, RMSI, SNN, SPOTSYNTH, TSSC, VanillaSC
 from mlsynth.config_models import (
     BaseEstimatorResults,
     DesignResult,
@@ -65,6 +65,7 @@ OBSERVATIONAL = [
     pytest.param(SPOTSYNTH, {}, id="SPOTSYNTH"),
     pytest.param(RMSI, {}, id="RMSI"),
     pytest.param(SNN, {}, id="SNN"),
+    pytest.param(MSQRT, {"lambda_": 0.5}, id="MSQRT"),
 ]
 
 

--- a/mlsynth/utils/msqrt_helpers/pipeline.py
+++ b/mlsynth/utils/msqrt_helpers/pipeline.py
@@ -12,7 +12,8 @@ from typing import Optional, Sequence
 
 import numpy as np
 
-from ...config_models import WeightsResults
+from ...config_models import InferenceResults, WeightsResults
+from ..results_helpers import build_effect_submodels
 from ..scpi_helpers import out_of_sample_intervals
 from .optimization import fit_msqrt_weights, select_lambda_cv
 from .structures import MSQRTInputs, MSQRTResults
@@ -151,10 +152,33 @@ def run_msqrt(
         "estimator": "MSQRT",
         "objective": "(1/sqrt(T0))||Y - X Theta||_* + lambda ||Theta||_1",
     }
+    # Standardized InferenceResults mirrored from the SCPI overall ATT band.
+    std_inference = None
+    if inf is not None:
+        std_inference = InferenceResults(
+            method=inf.method,
+            ci_lower=float(inf.taua.lower), ci_upper=float(inf.taua.upper),
+            confidence_level=float(1.0 - alpha),
+            details=inf,
+        )
+    submodels = build_effect_submodels(
+        observed_outcome=treated_mean,
+        counterfactual_outcome=synthetic_mean,
+        n_pre_periods=int(inputs.T0),
+        n_post_periods=int(inputs.n_post),
+        time_periods=np.asarray(inputs.time_labels),
+        weights=weights,
+        inference=std_inference,
+        method_name="MSQRT",
+        effects_overrides={"att": float(att), "att_percent": float(att_percent)},
+        fit_overrides={"rmse_pre": float(pre_rmse)},
+        intervention_time=inputs.time_labels[inputs.T0],
+    )
     return MSQRTResults(
-        inputs=inputs, att=att, att_percent=att_percent, theta=theta,
-        weights=weights, counterfactual=synthetic, gap=gap, att_t=att_t,
+        **submodels,
+        inputs=inputs, att_percent=att_percent, theta=theta,
+        counterfactual_matrix=synthetic, gap_matrix=gap, att_t=att_t,
         unit_att=unit_att, treated_mean=treated_mean,
         synthetic_mean=synthetic_mean, best_lambda=best_lambda,
-        sparsity=sparsity, pre_rmse=pre_rmse, inference=inf, metadata=metadata,
+        sparsity=sparsity, inference_intervals=inf, metadata=metadata,
     )

--- a/mlsynth/utils/msqrt_helpers/structures.py
+++ b/mlsynth/utils/msqrt_helpers/structures.py
@@ -14,6 +14,9 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import numpy as np
+from pydantic import ConfigDict, Field as PydField
+
+from ...config_models import BaseEstimatorResults
 
 
 @dataclass(frozen=True)
@@ -58,29 +61,34 @@ class MSQRTInputs:
         return self.Y_post.shape[0]
 
 
-@dataclass(frozen=True)
-class MSQRTResults:
+class MSQRTResults(BaseEstimatorResults):
     """Top-level container returned by :meth:`mlsynth.MSQRT.fit`.
 
-    Attributes
+    An :class:`~mlsynth.config_models.EffectResult` (the observational report):
+    in addition to the MSQRT-specific fields below it exposes the standardized
+    sub-models (``effects``, ``time_series``, ``weights``, ``inference``,
+    ``fit_diagnostics``, ``method_details``) and the flat accessors ``att`` /
+    ``counterfactual`` / ``gap`` / ``att_ci`` / ``pre_rmse``. The treated
+    counterfactual path (``res.counterfactual``) is the cross-treated-unit
+    synthetic mean; the full ``(T, m)`` synthetic / gap matrices live in
+    ``counterfactual_matrix`` / ``gap_matrix``. The per-treated-unit PCR donor
+    weights live in the standardized ``weights`` slot.
+
+    Parameters
     ----------
     inputs : MSQRTInputs
-    att : float
-        Average treatment effect on the treated (mean post-period gap over all
-        treated units).
     att_percent : float
         ``att`` as a percentage of the mean synthetic counterfactual on the
         post window.
     theta : np.ndarray
         Estimated donor-weight matrix ``Theta``, shape ``(n, m)``.
-    weights : object
-        :class:`mlsynth.config_models.WeightsResults` -- per-treated-unit donor
-        weight dicts plus aggregate sparsity stats.
-    counterfactual : np.ndarray
+    counterfactual_matrix : np.ndarray
         Synthetic (untreated) outcome for the treated units, shape
-        ``(T0 + T_post, m)``.
-    gap : np.ndarray
-        Observed minus synthetic for the treated units, same shape.
+        ``(T0 + T_post, m)``. (Renamed from ``counterfactual``, which now
+        returns the 1-D treated path per the result contract.)
+    gap_matrix : np.ndarray
+        Observed minus synthetic for the treated units, same shape. (Renamed
+        from ``gap``, which now returns the 1-D treated gap path.)
     att_t : np.ndarray
         Mean treated gap at each post-treatment period, shape ``(T_post,)``.
     unit_att : Dict
@@ -92,28 +100,27 @@ class MSQRTResults:
         Selected (or supplied) L1 penalty.
     sparsity : np.ndarray
         Per-treated-unit count of active donors (``|Theta_ij| > tol``).
-    pre_rmse : float
-        Root-mean-square pre-period gap (overall fit quality).
-    inference : SCPIResults, optional
+    inference_intervals : SCPIResults, optional
         CFPT/scpi prediction intervals (Cattaneo, Feng, Palomba & Titiunik
         2025); see :mod:`mlsynth.utils.scpi_helpers`. For MSQRT only the
-        out-of-sample error is modelled.
+        out-of-sample error is modelled. (Renamed from ``inference``; the
+        standardized :class:`~mlsynth.config_models.InferenceResults` is
+        mirrored into the ``inference`` slot so ``res.att_ci`` resolves.)
     metadata : dict
     """
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     inputs: MSQRTInputs
-    att: float
     att_percent: float
     theta: np.ndarray
-    weights: Any
-    counterfactual: np.ndarray
-    gap: np.ndarray
+    counterfactual_matrix: np.ndarray
+    gap_matrix: np.ndarray
     att_t: np.ndarray
     unit_att: Dict[Any, float]
     treated_mean: np.ndarray
     synthetic_mean: np.ndarray
     best_lambda: float
     sparsity: np.ndarray
-    pre_rmse: float
-    inference: Optional[Any] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    inference_intervals: Optional[Any] = None
+    metadata: Dict[str, Any] = PydField(default_factory=dict)


### PR DESCRIPTION
Migrates **MSQRT** (Multivariate Square-root Lasso synthetic control; Shen, Song & Abadie 2025) onto the two-family result contract — fourth of the 9. Full suite green locally: **2635 passed, 3 skipped**.

## What changed
`MSQRTResults` is now a **frozen pydantic `EffectResult`** (was a frozen dataclass). Standardized sub-models are built from the cross-treated-unit observed / synthetic paths via `build_effect_submodels`; `att` / `counterfactual` / `gap` / `att_ci` / `pre_rmse` resolve via the inherited surface (`pre_rmse` preserved exactly via `fit_overrides`). The per-treated-unit PCR donor weights stay in the standardized `weights` slot. Plotting now goes through `result.plot()`.

## ⚠️ Breaking surface changes
- **Matrix-completion convention:** `res.counterfactual` / `res.gap` are now the **1-D treated paths**; the full `(T, m)` synthetic / gap matrices moved to `res.counterfactual_matrix` / `res.gap_matrix`.
- **Inference:** the raw SCPI prediction-interval object (CFPT/scpi; `.taua` / `.tsus` / `.tsua` / `.simultaneous`) moved from `res.inference` to `res.inference_intervals`; the `inference` slot now holds the standardized `InferenceResults` (so `res.att_ci` resolves).

## DoD checklist
**A. Code**
- [x] `fit()` returns an `EffectResult` subclass; no dict/tuple in the public return.
- [x] Frozen pydantic model (`frozen=True, arbitrary_types_allowed=True`).
- [x] Standardized sub-models populated; donor weights in `weights`, standardized inference mirrored into `inference`, `rmse_pre` preserved via `fit_overrides`.
- [x] Estimator-specific outputs kept typed (`att_percent`, `theta`, `counterfactual_matrix`, `gap_matrix`, `att_t`, `unit_att`, `treated_mean`, `synthetic_mean`, `best_lambda`, `sparsity`, `inference_intervals`, `metadata`).
- [x] Back-compat accessors resolve; renames documented above + in CHANGELOG.

**B. Tests**
- [x] MSQRT added to `test_result_contract.py` (`OBSERVATIONAL`, fixed `lambda_` to skip CV).
- [x] SCPI asserts read `inference_intervals` (raw) **and** the standardized `inference` / `att_ci`; frozen-mutation test → pydantic `ValidationError`.
- [x] Legacy `plot_msqrt` (driven by `treated_mean` / `synthetic_mean`) untouched, so its coverage test still passes.
- [x] Full suite green.

**C/D/E/F. Docs / replication / indices**
- [x] `MSQRTResults` docstring documents the standardized surface + renames; `docs/msqrt.rst` example uses `res.att_ci` / `res.inference_intervals`. Return-type refactor only — replication numbers unchanged.
- [x] CHANGELOG entry added; `llms.txt` regenerated (unchanged).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_