### PR TITLE
Migrate MCNNM onto the two-family result contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Changed
+- **MCNNM migrated onto the two-family result contract.** `MCNNM.fit()` now
+  returns `MCNNMResults` as a frozen pydantic `EffectResult` with the
+  standardized sub-models built from the cross-treated-unit observed / imputed
+  paths (T0 the common adoption reference); `att` / `counterfactual` / `gap` /
+  `att_ci` / `pre_rmse` resolve via the inherited accessors, and the *implied*
+  (non-unique) donor weights stay in the `weights` slot. **Breaking surface
+  change (matrix-completion convention):** `res.counterfactual` is now the
+  **1-D treated counterfactual path** (was the full `(N, T)` fitted matrix);
+  the matrix moved to `res.counterfactual_matrix`, and the per-cell `effects`
+  matrix to `res.effects_matrix` (the `effects` slot now holds
+  `EffectsResults`). The raw jackknife object moved from `res.inference` to
+  `res.inference_jackknife`; the `inference` slot now holds the standardized
+  `InferenceResults` (so `res.att_ci` resolves). The staggered-adoption extras
+  (`cohort_att`, `event_study`) and the factor diagnostics (`L`, `gamma`,
+  `delta`, `unit_factors`, `time_factors`, `singular_values`, `rank`) remain
+  typed fields. Mutating the frozen result raises pydantic `ValidationError`.
+  MCNNM plots via `result.plot()` and is pinned in
+  `tests/test_result_contract.py`.
 - **MSQRT migrated onto the two-family result contract.** `MSQRT.fit()` now
   returns `MSQRTResults` as a frozen pydantic `EffectResult` with the
   standardized sub-models built from the cross-treated-unit observed / synthetic

--- a/docs/mcnnm.rst
+++ b/docs/mcnnm.rst
@@ -197,7 +197,7 @@ observed-vs-counterfactual chart.
    }).fit()
 
    print(f"ATT (avg 1989-2000) = {res.att:+.2f} packs/capita")
-   lo, hi = res.inference.ci
+   lo, hi = res.att_ci               # standardized; jackknife when inference=True
    print(f"jackknife 95% CI    = [{lo:+.2f}, {hi:+.2f}]")
    print(f"gap by 2000         = {res.att_by_period[2000]:+.2f}")
    print(f"selected lambda     = {res.best_lambda:.2f}")

--- a/mlsynth/estimators/mcnnm.py
+++ b/mlsynth/estimators/mcnnm.py
@@ -52,7 +52,6 @@ from ..exceptions import (
     MlsynthEstimationError,
 )
 from ..utils.mcnnm_helpers.pipeline import run_mcnnm
-from ..utils.mcnnm_helpers.plotter import plot_mcnnm
 from ..utils.mcnnm_helpers.setup import prepare_mcnnm_inputs
 from ..utils.mcnnm_helpers.structures import MCNNMResults
 
@@ -110,17 +109,17 @@ class MCNNM:
                 alpha_level=self.alpha,
                 random_state=self.random_state,
             )
+            # Attach plotting context so result.plot() is self-contained and
+            # styled from the (possibly nested) config; labels default to the
+            # column names when the user has not set them.
+            pc = self.config.resolved_plot()
+            if pc.xlabel is None:
+                pc.xlabel = self.time
+            if pc.ylabel is None:
+                pc.ylabel = self.outcome
+            object.__setattr__(results, "plot_config", pc)
             if self.display_graphs:
-                plot_mcnnm(
-                    results,
-                    treated_color=self.treated_color,
-                    counterfactual_color=self.counterfactual_color,
-                    save=self.save,
-                    time_axis_label=self.time,
-                    treatment_label=self.treat,
-                    unit_label=self.unitid,
-                    outcome_label=self.outcome,
-                )
+                results.plot()
             return results
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/tests/test_mcnnm.py
+++ b/mlsynth/tests/test_mcnnm.py
@@ -136,7 +136,7 @@ class TestEstimator:
         ca = res.inputs.unit_names.index("California")
         T0 = res.inputs.T0
         pre_rmse = float(np.sqrt(np.mean(
-            (res.inputs.Y[ca, :T0] - res.counterfactual[ca, :T0]) ** 2)))
+            (res.inputs.Y[ca, :T0] - res.counterfactual_matrix[ca, :T0]) ** 2)))
         assert pre_rmse < 3.0
 
     def test_exposes_factors_and_implied_weights(self):
@@ -190,10 +190,14 @@ class TestEstimator:
         res = MCNNM({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
                      "time": "time", "inference": True,
                      "display_graphs": False}).fit()
-        assert res.inference is not None
-        assert res.inference.method == "jackknife"
-        lo, hi = res.inference.ci
+        # Raw jackknife object preserved under inference_jackknife; the
+        # standardized InferenceResults is mirrored into the `inference` slot.
+        assert res.inference_jackknife is not None
+        assert res.inference_jackknife.method == "jackknife"
+        lo, hi = res.inference_jackknife.ci
         assert lo <= res.att <= hi
+        assert res.inference is not None
+        assert res.att_ci == pytest.approx((lo, hi))
 
 
 # ----------------------------------------------------------------------

--- a/mlsynth/tests/test_mcnnm_plotter.py
+++ b/mlsynth/tests/test_mcnnm_plotter.py
@@ -10,6 +10,7 @@ from mlsynth.utils.mcnnm_helpers.plotter import (
     _plot_event_study,
     _is_staggered,
 )
+from mlsynth.config_models import EffectsResults
 from mlsynth.utils.mcnnm_helpers.structures import MCNNMInputs, MCNNMResults
 
 
@@ -48,9 +49,9 @@ def _make_results(inputs, event_study=None):
     effects = np.full((N, T), np.nan)
     return MCNNMResults(
         inputs=inputs,
-        att=1.234,
-        counterfactual=counterfactual,
-        effects=effects,
+        effects=EffectsResults(att=1.234),
+        counterfactual_matrix=counterfactual,
+        effects_matrix=effects,
         att_by_period={},
         cohort_att={},
         event_study=event_study or {},

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mlsynth import FDID, MSQRT, RMSI, SNN, SPOTSYNTH, TSSC, VanillaSC
+from mlsynth import FDID, MCNNM, MSQRT, RMSI, SNN, SPOTSYNTH, TSSC, VanillaSC
 from mlsynth.config_models import (
     BaseEstimatorResults,
     DesignResult,
@@ -66,6 +66,7 @@ OBSERVATIONAL = [
     pytest.param(RMSI, {}, id="RMSI"),
     pytest.param(SNN, {}, id="SNN"),
     pytest.param(MSQRT, {"lambda_": 0.5}, id="MSQRT"),
+    pytest.param(MCNNM, {}, id="MCNNM"),
 ]
 
 

--- a/mlsynth/utils/mcnnm_helpers/pipeline.py
+++ b/mlsynth/utils/mcnnm_helpers/pipeline.py
@@ -6,7 +6,8 @@ from typing import Optional
 
 import numpy as np
 
-from ...config_models import WeightsResults
+from ...config_models import InferenceResults, WeightsResults
+from ..results_helpers import build_effect_submodels
 from .completion import mcnnm_cv, mcnnm_fit
 from .structures import MCNNMInference, MCNNMInputs, MCNNMResults
 
@@ -184,14 +185,42 @@ def run_mcnnm(
         "estimate_unit_fe": est_u, "estimate_time_fe": est_v,
         "n_missing": int((1.0 - mask).sum()),
     }
+    # Cross-treated-unit observed / imputed paths drive the standardized time
+    # series (and result.plot()); T0 is the common adoption reference.
+    tr = inputs.treated_idx
+    observed_path = Y[tr].mean(axis=0)
+    counterfactual_path = completed[tr].mean(axis=0)
+    std_inference = None
+    if inf is not None:
+        lo, hi = inf.ci
+        std_inference = InferenceResults(
+            method=inf.method, standard_error=float(inf.se),
+            ci_lower=float(lo), ci_upper=float(hi),
+            confidence_level=float(1.0 - inf.alpha_level),
+            details={"n_jackknife": int(inf.n_jackknife)},
+        )
+    submodels = build_effect_submodels(
+        observed_outcome=observed_path,
+        counterfactual_outcome=counterfactual_path,
+        n_pre_periods=int(T0),
+        n_post_periods=int(inputs.T - T0),
+        time_periods=np.asarray(inputs.time_labels),
+        weights=weights,
+        inference=std_inference,
+        method_name="MCNNM",
+        effects_overrides={"att": float(att)},
+        intervention_time=(inputs.time_labels[T0] if T0 < inputs.T
+                           else inputs.time_labels[-1]),
+    )
     return MCNNMResults(
-        inputs=inputs, att=att, counterfactual=completed, effects=effects,
+        **submodels,
+        inputs=inputs, counterfactual_matrix=completed, effects_matrix=effects,
         att_by_period=att_by_period, cohort_att=cohort_att,
         event_study=event_study, L=fit["L"], gamma=fit["gamma"],
         delta=fit["delta"], best_lambda=float(fit["best_lambda"]), rank=rank,
         unit_factors=unit_factors, time_factors=time_factors,
-        singular_values=singular_values, weights=weights,
-        inference=inf, metadata=metadata,
+        singular_values=singular_values, inference_jackknife=inf,
+        metadata=metadata,
     )
 
 

--- a/mlsynth/utils/mcnnm_helpers/plotter.py
+++ b/mlsynth/utils/mcnnm_helpers/plotter.py
@@ -94,11 +94,11 @@ def plot_mcnnm(
     if treated.size == 1:
         i = int(treated[0])
         observed = inputs.Y[i]
-        counterfactual = results.counterfactual[i]
+        counterfactual = results.counterfactual_matrix[i]
         treated_name = str(inputs.unit_names[i])
     else:
         observed = inputs.Y[treated].mean(axis=0)
-        counterfactual = results.counterfactual[treated].mean(axis=0)
+        counterfactual = results.counterfactual_matrix[treated].mean(axis=0)
         treated_name = f"Treated mean (n={treated.size})"
 
     ywide = pd.DataFrame(

--- a/mlsynth/utils/mcnnm_helpers/structures.py
+++ b/mlsynth/utils/mcnnm_helpers/structures.py
@@ -13,6 +13,9 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import numpy as np
+from pydantic import ConfigDict, Field as PydField
+
+from ...config_models import BaseEstimatorResults
 
 
 @dataclass(frozen=True)
@@ -53,22 +56,30 @@ class MCNNMInputs:
         return self.Y.shape[1]
 
 
-@dataclass(frozen=True)
-class MCNNMResults:
+class MCNNMResults(BaseEstimatorResults):
     """Top-level container returned by :meth:`mlsynth.MCNNM.fit`.
 
-    Attributes
+    An :class:`~mlsynth.config_models.EffectResult` (the observational report):
+    in addition to the MC-NNM-specific fields below it exposes the standardized
+    sub-models (``effects``, ``time_series``, ``weights``, ``inference``,
+    ``fit_diagnostics``, ``method_details``) and the flat accessors ``att`` /
+    ``counterfactual`` / ``gap`` / ``att_ci`` / ``pre_rmse``. The treated
+    counterfactual path (``res.counterfactual``) is the cross-treated-unit mean
+    of the imputed untreated outcome; the full ``(N, T)`` fitted matrix lives in
+    ``counterfactual_matrix``.
+
+    Parameters
     ----------
     inputs : MCNNMInputs
-    att : float
-        Average treatment effect on the treated (observed minus imputed
-        over the treated cells).
-    counterfactual : np.ndarray
+    counterfactual_matrix : np.ndarray
         Full fitted matrix ``L + Gamma + Delta``, shape ``(N, T)``; on
         treated cells this is the imputed untreated potential outcome.
-    effects : np.ndarray
+        (Renamed from ``counterfactual``, which now returns the 1-D treated
+        path per the result contract.)
+    effects_matrix : np.ndarray
         Per-cell effects (observed minus imputed) on treated cells; ``NaN``
-        elsewhere, shape ``(N, T)``.
+        elsewhere, shape ``(N, T)``. (Renamed from ``effects``, which is now
+        the standardized ``EffectsResults`` slot.)
     att_by_period : dict
         ``{period_label: mean effect across treated units}`` post-treatment
         (calendar time -- pools cohorts at each period).
@@ -98,20 +109,19 @@ class MCNNMResults:
         Time factors :math:`V \\Sigma^{1/2}`, shape ``(T, rank)``.
     singular_values : np.ndarray
         Singular values of ``L`` (the nuclear-norm spectrum).
-    weights : WeightsResults, optional
-        *Implied* per-treated-unit donor weights, obtained by projecting
-        the treated unit's low-rank row onto the control rows. MC-NNM is a
-        factorisation (not a weighting) estimator, so these are a derived,
-        **non-unique** diagnostic -- flagged as such in ``summary_stats``.
-    inference : object, optional
-        :class:`MCNNMInference` when ``inference=True``; else ``None``.
+    inference_jackknife : MCNNMInference, optional
+        The raw leave-one-control jackknife object (``method`` / ``se`` /
+        ``ci``) when ``inference=True``; else ``None``. The standardized
+        :class:`~mlsynth.config_models.InferenceResults` is mirrored into the
+        ``inference`` slot (so ``res.att_ci`` resolves).
     metadata : dict
     """
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     inputs: MCNNMInputs
-    att: float
-    counterfactual: np.ndarray
-    effects: np.ndarray
+    counterfactual_matrix: np.ndarray
+    effects_matrix: np.ndarray
     att_by_period: Dict[Any, float]
     cohort_att: Dict[Any, float]
     event_study: Dict[int, float]
@@ -123,9 +133,8 @@ class MCNNMResults:
     unit_factors: Optional[np.ndarray] = None
     time_factors: Optional[np.ndarray] = None
     singular_values: Optional[np.ndarray] = None
-    weights: Optional[Any] = None
-    inference: Optional["MCNNMInference"] = None
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    inference_jackknife: Optional["MCNNMInference"] = None
+    metadata: Dict[str, Any] = PydField(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -147,3 +156,7 @@ class MCNNMInference:
     ci: tuple
     alpha_level: float
     n_jackknife: int
+
+
+# Resolve the forward reference to MCNNMInference now that it is defined.
+MCNNMResults.model_rebuild()


### PR DESCRIPTION
Migrates **MCNNM** (Matrix Completion with Nuclear-Norm Minimization; Athey, Bayati, Doudchenko, Imbens & Khosravi 2021) onto the two-family result contract — fifth of the 9, completing the matrix-completion tier (RMSI/SNN/MSQRT/MCNNM). Full suite green locally: **2639 passed, 3 skipped**.

## What changed
`MCNNMResults` is now a **frozen pydantic `EffectResult`** (was a frozen dataclass). Standardized sub-models are built from the cross-treated-unit observed / imputed paths (with `T0` as the common adoption reference) via `build_effect_submodels`; `att` / `counterfactual` / `gap` / `att_ci` / `pre_rmse` resolve via the inherited surface. The *implied* (non-unique) donor weights stay in the standardized `weights` slot. Plotting now goes through `result.plot()`.

## ⚠️ Breaking surface changes
- **Matrix-completion convention** (as in RMSI/SNN): `res.counterfactual` is now the **1-D treated counterfactual path**; the full `(N, T)` fitted matrix `L + Γ + Δ` moved to `res.counterfactual_matrix`, and the per-cell `(N, T)` effects matrix to `res.effects_matrix` (the `effects` slot now holds the standardized `EffectsResults`).
- **Inference:** the raw jackknife object moved from `res.inference` to `res.inference_jackknife` (still `.method` / `.se` / `.ci`); the `inference` slot now holds the standardized `InferenceResults`, so `res.att_ci` resolves.

The staggered-adoption extras (`cohort_att`, `event_study`) and the factor diagnostics (`L`, `gamma`, `delta`, `unit_factors`, `time_factors`, `singular_values`, `rank`) remain typed fields.

## DoD checklist
**A. Code**
- [x] `fit()` returns an `EffectResult` subclass; no dict/tuple in the public return.
- [x] Frozen pydantic model (`frozen=True, arbitrary_types_allowed=True`); forward-ref to `MCNNMInference` resolved via `model_rebuild()`.
- [x] Standardized sub-models populated; implied donor weights in `weights`, standardized inference mirrored into `inference`.
- [x] Estimator-specific outputs kept typed (matrices, staggered extras, factor diagnostics, `metadata`).
- [x] Back-compat accessors resolve; renames documented above + in CHANGELOG.

**B. Tests**
- [x] MCNNM added to `test_result_contract.py` (`OBSERVATIONAL`); conformance passes.
- [x] Jackknife test reads `inference_jackknife` (raw) **and** the standardized `inference` / `att_ci`; pre-period RMSE assert uses `counterfactual_matrix`.
- [x] Legacy `plot_mcnnm` repointed to `counterfactual_matrix`; plotter-test fixture updated to the new schema (populates the `effects` submodel so the event-study title's ATT resolves).
- [x] Full suite green.

**C/D/E/F. Docs / replication / indices**
- [x] `MCNNMResults` docstring documents the standardized surface + renames; `docs/mcnnm.rst` example uses `res.att_ci`. Return-type refactor only — replication numbers unchanged.
- [x] CHANGELOG entry added; `llms.txt` regenerated (unchanged).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_