### PR TITLE
Migrate MLSC onto the two-family result contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Changed
+- **MLSC migrated onto the two-family result contract.** `MLSC.fit()` now
+  returns `MLSCResults` as a frozen pydantic `EffectResult` with the
+  standardized sub-models built from the aggregate treated series
+  (`observed = counterfactual + gap`, `T0` the adoption reference); `att` /
+  `counterfactual` / `gap` / `pre_rmse` / `donor_weights` resolve via the
+  inherited accessors, and the disaggregate donor weights live in the `weights`
+  slot (`aggregate_donor_weights` in `summary_stats`). mlSC has no statistical
+  inference, so the `inference` slot is `None`. **Breaking surface change:** the
+  old `res.inference` field (which carried the fitted *paths*, not statistical
+  inference — it clashed with the contract's `inference` slot) is renamed to
+  `res.paths` (still `.counterfactual` / `.gap`; the same series are exposed
+  flat as `res.counterfactual` / `res.gap`). The flat `att` / `pre_rmse` /
+  `donor_weights` fields are now inherited accessors. `design` and
+  `aggregate_donor_weights` remain typed fields. Plotting routes through
+  `result.plot()` (the `PlotConfig` is built from MLSCConfig's legacy color
+  fields, since `MLSCConfig` is a plain `BaseModel`). Conformance is pinned in
+  `test_mlsc.py::test_two_family_result_contract` (MLSC's two-level panel can't
+  join the single-df loop in `test_result_contract.py`).
 - **MCNNM migrated onto the two-family result contract.** `MCNNM.fit()` now
   returns `MCNNMResults` as a frozen pydantic `EffectResult` with the
   standardized sub-models built from the cross-treated-unit observed / imputed

--- a/docs/mlsc.rst
+++ b/docs/mlsc.rst
@@ -717,8 +717,8 @@ Example
    print(results.aggregate_donor_weights)      # {state:        w_s = sum_c omega_sc}
 
    # Counterfactual trajectory (length T) and the observed - counterfactual gap.
-   cf  = results.inference.counterfactual
-   gap = results.inference.gap
+   cf  = results.counterfactual          # standardized accessor (== results.paths.counterfactual)
+   gap = results.gap                     # == results.paths.gap
 
    # Sensitivity: sweep lambda by hand.
    for lam in [0.0, 1e-2, 1e-1, 1.0, 10.0, 1e6]:

--- a/mlsynth/estimators/mlsc.py
+++ b/mlsynth/estimators/mlsc.py
@@ -25,10 +25,12 @@ from __future__ import annotations
 
 from typing import Any, Optional, Union
 
+import numpy as np
 import pandas as pd
 from pydantic import ValidationError
 
-from ..config_models import MLSCConfig
+from ..config_models import MLSCConfig, PlotConfig, WeightsResults
+from ..utils.results_helpers import build_effect_submodels
 from ..exceptions import (
     MlsynthConfigError,
     MlsynthDataError,
@@ -38,7 +40,6 @@ from ..exceptions import (
 from ..utils.mlsc_helpers.inference import counterfactual_path, summarize_effects
 from ..utils.mlsc_helpers.optimization import solve_mlsc
 from ..utils.mlsc_helpers.penalty import build_penalty_matrix
-from ..utils.mlsc_helpers.plotter import plot_mlsc
 from ..utils.mlsc_helpers.setup import prepare_mlsc_inputs
 from ..utils.mlsc_helpers.structures import MLSCDesign, MLSCResults
 from ..utils.mlsc_helpers.variance import (
@@ -177,8 +178,8 @@ class MLSC:
             solver_status=status,
         )
 
-        inference = counterfactual_path(inputs, omega)
-        att, pre_rmse = summarize_effects(inputs, inference)
+        paths = counterfactual_path(inputs, omega)
+        att, pre_rmse = summarize_effects(inputs, paths)
 
         donor_weights = {
             str(label): float(w)
@@ -189,28 +190,53 @@ class MLSC:
             for label, w in zip(inputs.agg_labels, aggregate_weights)
         }
 
+        # Standardized sub-models built from the aggregate treated series:
+        # observed = counterfactual + gap. mlSC has no statistical inference.
+        observed = np.asarray(paths.counterfactual) + np.asarray(paths.gap)
+        weights = WeightsResults(
+            donor_weights=donor_weights,
+            summary_stats={"aggregate_donor_weights": aggregate_donor_weights},
+        )
+        submodels = build_effect_submodels(
+            observed_outcome=observed,
+            counterfactual_outcome=np.asarray(paths.counterfactual),
+            n_pre_periods=int(inputs.T0),
+            n_post_periods=int(len(inputs.time_labels) - inputs.T0),
+            time_periods=np.asarray(inputs.time_labels),
+            weights=weights,
+            method_name="MLSC",
+            effects_overrides={"att": float(att)},
+            fit_overrides={"rmse_pre": float(pre_rmse)},
+            intervention_time=(inputs.time_labels[inputs.T0]
+                               if inputs.T0 < len(inputs.time_labels)
+                               else inputs.time_labels[-1]),
+        )
+
         results = MLSCResults(
+            **submodels,
             inputs=inputs,
             design=design,
-            inference=inference,
-            att=att,
-            pre_rmse=pre_rmse,
-            donor_weights=donor_weights,
+            paths=paths,
             aggregate_donor_weights=aggregate_donor_weights,
         )
 
+        # Standardized plotting (MLSCConfig is a plain BaseModel without
+        # resolved_plot(), so build the PlotConfig from its legacy fields).
+        cf_colors = ([self.counterfactual_color]
+                     if isinstance(self.counterfactual_color, str)
+                     else list(self.counterfactual_color))
+        pc = PlotConfig(
+            observed_color=self.treated_color,
+            counterfactual_colors=cf_colors,
+            xlabel=self.time,
+            ylabel=self.outcome,
+            display=self.display_graphs,
+            save=self.save,
+        )
+        object.__setattr__(results, "plot_config", pc)
         if self.display_graphs:
             try:
-                plot_mlsc(
-                    results=results,
-                    treated_color=self.treated_color,
-                    counterfactual_color=self.counterfactual_color,
-                    save=self.save,
-                    time_axis_label=self.time,
-                    outcome_label=self.outcome,
-                    treatment_label=self.treat,
-                    unit_label=self.unitid_agg,
-                )
+                results.plot()
             except MlsynthPlottingError:
                 raise
             except Exception as exc:

--- a/mlsynth/tests/test_mlsc.py
+++ b/mlsynth/tests/test_mlsc.py
@@ -34,7 +34,7 @@ import pandas as pd
 import pytest
 
 from mlsynth import MLSC
-from mlsynth.config_models import MLSCConfig
+from mlsynth.config_models import EffectResult, MLSCConfig, MlsynthResult
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 from mlsynth.utils.mlsc_helpers.penalty import build_block, build_penalty_matrix
 from mlsynth.utils.mlsc_helpers.setup import prepare_mlsc_inputs
@@ -393,8 +393,11 @@ class TestEstimatorIntegration:
     def test_counterfactual_length_matches_T(self):
         df_agg, df_disagg = _make_panel(T=30, T0=20)
         res = MLSC(_base_config(df_agg, df_disagg)).fit()
-        assert res.inference.counterfactual.shape == (30,)
-        assert res.inference.gap.shape == (30,)
+        assert res.paths.counterfactual.shape == (30,)
+        assert res.paths.gap.shape == (30,)
+        # standardized accessors expose the same series
+        assert res.counterfactual.shape == (30,)
+        assert res.gap.shape == (30,)
 
     def test_high_lambda_recovers_classical_sc_structure(self):
         # When lambda is enormous, within each aggregate block the
@@ -470,11 +473,33 @@ class TestPublicAPI:
         assert isinstance(res, MLSCResults)
         assert isinstance(res.inputs, MLSCInputs)
         assert isinstance(res.design, MLSCDesign)
-        assert isinstance(res.inference, MLSCInference)
+        assert isinstance(res.paths, MLSCInference)
         assert isinstance(res.att, float)
         assert isinstance(res.pre_rmse, float)
         assert isinstance(res.donor_weights, dict)
         assert isinstance(res.aggregate_donor_weights, dict)
+
+    def test_two_family_result_contract(self):
+        """MLSC conforms to the observational (EffectResult) contract.
+
+        MLSC takes a two-level panel, so it cannot join the single-df loop in
+        test_result_contract.py; pin the contract here instead.
+        """
+        df_agg, df_disagg = _make_panel()
+        res = MLSC(_base_config(df_agg, df_disagg)).fit()
+        assert isinstance(res, MlsynthResult)
+        assert isinstance(res, EffectResult)
+        # standardized sub-models populated
+        assert res.effects is not None and res.effects.att is not None
+        assert res.time_series is not None
+        assert res.time_series.counterfactual_outcome is not None
+        assert res.weights is not None
+        assert res.method_details is not None and res.method_details.method_name
+        # flat accessors resolve; donor weights served from the weights slot
+        assert res.att == pytest.approx(res.effects.att)
+        assert set(res.donor_weights.keys()) == set(res.inputs.disagg_labels)
+        # mlSC has no statistical inference
+        assert res.inference is None
 
     def test_design_object_has_diagnostics(self):
         df_agg, df_disagg = _make_panel()

--- a/mlsynth/utils/mlsc_helpers/plotter.py
+++ b/mlsynth/utils/mlsc_helpers/plotter.py
@@ -26,7 +26,7 @@ def plot_mlsc(
     """Render the mlSC aggregate counterfactual against the observed series."""
 
     inputs = results.inputs
-    inference = results.inference
+    inference = results.paths
 
     if isinstance(counterfactual_color, str):
         cf_colors = [counterfactual_color]

--- a/mlsynth/utils/mlsc_helpers/structures.py
+++ b/mlsynth/utils/mlsc_helpers/structures.py
@@ -7,9 +7,12 @@ columns = unit), matching ``datautils.dataprep``.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 import numpy as np
+from pydantic import ConfigDict, Field as PydField
+
+from ...config_models import BaseEstimatorResults
 
 
 @dataclass(frozen=True)
@@ -138,9 +141,15 @@ class MLSCInference:
     gap: np.ndarray
 
 
-@dataclass(frozen=True)
-class MLSCResults:
+class MLSCResults(BaseEstimatorResults):
     """Public ``MLSC.fit()`` return container.
+
+    An :class:`~mlsynth.config_models.EffectResult` (the observational report):
+    in addition to the mlSC-specific fields below it exposes the standardized
+    sub-models (``effects``, ``time_series``, ``weights``, ``fit_diagnostics``,
+    ``method_details``) and the flat accessors ``att`` / ``counterfactual`` /
+    ``gap`` / ``pre_rmse`` / ``donor_weights``. mlSC has no statistical
+    inference (no SE/CI), so the ``inference`` slot is ``None``.
 
     Parameters
     ----------
@@ -148,26 +157,21 @@ class MLSCResults:
         Pre-processed two-level panel.
     design : MLSCDesign
         Optimization outputs and variance-decomposition diagnostics.
-    inference : MLSCInference
-        Counterfactual path and gap.
-    att : float
-        Mean post-period gap.
-    pre_rmse : float
-        Pre-period RMSE of the aggregate counterfactual against the observed
-        treated series.
-    donor_weights : dict
-        Mapping from disaggregate-unit label to its weight. Convenience view
-        of ``design.omega``.
+    paths : MLSCInference
+        Counterfactual path and gap. (Renamed from ``inference`` — it carries
+        the fitted series, not statistical inference, and the contract reserves
+        the ``inference`` slot for :class:`~mlsynth.config_models.InferenceResults`.
+        The same series are exposed flat as ``res.counterfactual`` / ``res.gap``.)
     aggregate_donor_weights : dict
         Mapping from aggregate-unit label to its implied weight
         ``w_s = sum_c omega_sc``. Convenience view of
-        ``design.aggregate_weights``.
+        ``design.aggregate_weights``. (The disaggregate ``donor_weights`` live
+        in the standardized ``weights`` slot, served by ``res.donor_weights``.)
     """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     inputs: MLSCInputs
     design: MLSCDesign
-    inference: MLSCInference
-    att: float
-    pre_rmse: float
-    donor_weights: dict
-    aggregate_donor_weights: dict
+    paths: MLSCInference
+    aggregate_donor_weights: Dict[Any, float]


### PR DESCRIPTION
Migrates **MLSC** (multilevel / hierarchical synthetic control on a two-level panel) onto the two-family result contract — sixth of the 9. Full suite green locally: **2640 passed, 3 skipped**.

## What changed
`MLSCResults` is now a **frozen pydantic `EffectResult`** (was a frozen dataclass). Standardized sub-models are built from the aggregate treated series (`observed = counterfactual + gap`, with `T0` as the adoption reference) via `build_effect_submodels`; `att` / `counterfactual` / `gap` / `pre_rmse` / `donor_weights` resolve via the inherited accessors. The disaggregate donor weights live in the standardized `weights` slot (with `aggregate_donor_weights` in `summary_stats`). mlSC has **no statistical inference**, so the `inference` slot is `None`. Plotting routes through `result.plot()`.

## ⚠️ Breaking surface change
The old `res.inference` field was **misnamed** — it carried the fitted *paths* (`.counterfactual` / `.gap`), not statistical inference, and it collided with the contract's `inference` slot (reserved for `InferenceResults`). It is renamed to **`res.paths`** (same `.counterfactual` / `.gap`; the series are also exposed flat as `res.counterfactual` / `res.gap`). The flat `att` / `pre_rmse` / `donor_weights` fields are now inherited accessors; `design` and `aggregate_donor_weights` remain typed fields.

## DoD checklist
**A. Code**
- [x] `fit()` returns an `EffectResult` subclass; no dict/tuple in the public return.
- [x] Frozen pydantic model (`frozen=True, arbitrary_types_allowed=True`).
- [x] Standardized sub-models populated; disaggregate donor weights in `weights`, `inference` slot `None` (no SE/CI for mlSC).
- [x] Estimator-specific outputs kept typed (`design`, `paths`, `aggregate_donor_weights`).
- [x] Back-compat accessors resolve; the `inference`→`paths` rename documented above + in CHANGELOG.

**B. Tests**
- [x] Conformance pinned in `test_mlsc.py::test_two_family_result_contract` — MLSC's two-level panel (`df_agg`/`df_disagg`) can't join the single-`df` loop in `test_result_contract.py`, so it's checked in-file.
- [x] Path-shape asserts use `res.paths` **and** the standardized `res.counterfactual` / `res.gap`; field-type test uses `res.paths`.
- [x] Legacy `plot_sparse_sc`-style coverage: `plot_mlsc` repointed to `results.paths`, its test still passes.
- [x] Full suite green.

**C/D/E/F. Docs / replication / indices**
- [x] `MLSCResults` docstring documents the standardized surface + `paths` rename; `docs/mlsc.rst` example uses `results.counterfactual` / `results.gap`. Return-type refactor only — replication numbers unchanged.
- [x] CHANGELOG entry added; `llms.txt` regenerated (unchanged).

**Note on plotting:** `MLSCConfig` is a plain `BaseModel` (not `BaseEstimatorConfig`), so it has no `resolved_plot()`; the `PlotConfig` is built directly from its legacy `treated_color` / `counterfactual_color` / `save` fields before calling `result.plot()`.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_