### PR TITLE
Migrate TASC onto the two-family result contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Changed
+- **TASC migrated onto the two-family result contract.** `TASC.fit()` now
+  returns `TASCResults` as a frozen pydantic `EffectResult` with the
+  standardized sub-models built from the observed target vs the smoother-based
+  counterfactual; `att` / `counterfactual` / `gap` / `pre_rmse` resolve via the
+  inherited accessors. TASC is a state-space / EM estimator with **no donor
+  weights**, so the `weights` slot records the method rather than per-donor
+  weights. **Breaking surface change:** the raw inference object (counterfactual
+  + per-period posterior bands: `.counterfactual` / `.ci_lower` / `.ci_upper` /
+  `.posterior_variance` / `.alpha`) moved from `res.inference` to
+  `res.inference_detail`; the `inference` slot now holds the standardized
+  `InferenceResults` (with the raw object in `.details`). The flat `att` /
+  `pre_rmse` fields are now inherited accessors; `design` / `inference_detail`
+  remain typed fields. Mutating the frozen result raises pydantic
+  `ValidationError`. TASC plots via `result.plot()` and is pinned in
+  `tests/test_result_contract.py`.
 - **SparseSC migrated onto the two-family result contract.** `SparseSC.fit()`
   now returns `SparseSCResults` as a frozen pydantic `EffectResult` with the
   standardized sub-models built from the treated series via

--- a/docs/tasc.rst
+++ b/docs/tasc.rst
@@ -542,10 +542,11 @@ Example
    print(results.att)              # mean post-period gap, y_{0,t} - h_1' m_t^s
    print(results.pre_rmse)         # pre-period RMSE of the smoother's target fit
 
-   # Counterfactual path and posterior confidence band
-   cf = results.inference.counterfactual     # length-T vector
-   lo = results.inference.ci_lower           # length-T vector
-   hi = results.inference.ci_upper           # length-T vector
+   # Counterfactual path and posterior confidence band (raw TASC inference).
+   # ``results.counterfactual`` is the same series via the standardized accessor.
+   cf = results.inference_detail.counterfactual     # length-T vector
+   lo = results.inference_detail.ci_lower           # length-T vector
+   hi = results.inference_detail.ci_upper           # length-T vector
 
    # Learned model and EM diagnostics
    theta = results.design.parameters         # A, H, Q, R, m0, P0
@@ -601,7 +602,7 @@ paper's Figure 10 directly:
                 "time": "year", "treat": "treat", "d": 2,
                 "n_em_iter": 50, "em_tol": 1e-4, "alpha": 0.05,
                 "seed": 0, "display_graphs": False}).fit()
-   yhat = res.inference.counterfactual
+   yhat = res.inference_detail.counterfactual
    print(f"pre-RMSE = {res.pre_rmse:.3f}  ATT = {res.att:.3f}")
 
 prints::

--- a/mlsynth/estimators/tasc.py
+++ b/mlsynth/estimators/tasc.py
@@ -33,10 +33,12 @@ from __future__ import annotations
 
 from typing import Any, Optional, Union
 
+import numpy as np
 import pandas as pd
 from pydantic import ValidationError
 
-from ..config_models import TASCConfig
+from ..config_models import InferenceResults, TASCConfig, WeightsResults
+from ..utils.results_helpers import build_effect_submodels
 from ..exceptions import (
     MlsynthConfigError,
     MlsynthDataError,
@@ -45,7 +47,6 @@ from ..exceptions import (
 )
 from ..utils.datautils import balance
 from ..utils.tasc_helpers.orchestration import run_tasc, summarize_effects
-from ..utils.tasc_helpers.plotter import plot_tasc
 from ..utils.tasc_helpers.setup import prepare_tasc_inputs
 from ..utils.tasc_helpers.structures import TASCResults
 
@@ -188,26 +189,53 @@ class TASC:
                 f"TASC estimation failed: {exc}"
             ) from exc
 
+        # Standardized sub-models: observed target vs the smoother-based
+        # counterfactual. TASC is a state-space/EM estimator with no donor
+        # weights; the per-period posterior bands ride in inference.details.
+        std_inference = InferenceResults(
+            method="tasc_posterior",
+            confidence_level=(None if np.isnan(inference.alpha)
+                              else float(1.0 - inference.alpha)),
+            details=inference,
+        )
+        weights = WeightsResults(
+            donor_weights={},
+            summary_stats={"method": "TASC",
+                           "note": "state-space/EM; no donor weights"},
+        )
+        submodels = build_effect_submodels(
+            observed_outcome=np.asarray(inputs.y_target),
+            counterfactual_outcome=np.asarray(inference.counterfactual),
+            n_pre_periods=int(inputs.pre_periods),
+            n_post_periods=int(inputs.post_periods),
+            time_periods=np.asarray(inputs.time_labels),
+            weights=weights,
+            inference=std_inference,
+            method_name="TASC",
+            effects_overrides={"att": float(att)},
+            fit_overrides={"rmse_pre": float(pre_rmse)},
+            intervention_time=(inputs.time_labels[inputs.pre_periods]
+                               if inputs.pre_periods < len(inputs.time_labels)
+                               else inputs.time_labels[-1]),
+        )
         results = TASCResults(
+            **submodels,
             inputs=inputs,
             design=design,
-            inference=inference,
-            att=att,
-            pre_rmse=pre_rmse,
+            inference_detail=inference,
         )
 
+        # Standardized plotting: attach the resolved PlotConfig and route
+        # through result.plot().
+        pc = self.config.resolved_plot()
+        if pc.xlabel is None:
+            pc.xlabel = self.time
+        if pc.ylabel is None:
+            pc.ylabel = self.outcome
+        object.__setattr__(results, "plot_config", pc)
         if self.display_graphs:
             try:
-                plot_tasc(
-                    results=results,
-                    treated_color=self.treated_color,
-                    counterfactual_color=self.counterfactual_color,
-                    save=self.save,
-                    time_axis_label=self.time,
-                    outcome_label=self.outcome,
-                    treatment_label=self.treat,
-                    unit_label=self.unitid,
-                )
+                results.plot()
             except MlsynthPlottingError:
                 raise
             except Exception as exc:

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -20,7 +20,7 @@ import pandas as pd
 import pytest
 
 from mlsynth import (
-    FDID, MCNNM, MSQRT, RMSI, SNN, SparseSC, SPOTSYNTH, TSSC, VanillaSC,
+    FDID, MCNNM, MSQRT, RMSI, SNN, SparseSC, SPOTSYNTH, TASC, TSSC, VanillaSC,
 )
 from mlsynth.config_models import (
     BaseEstimatorResults,
@@ -70,6 +70,7 @@ OBSERVATIONAL = [
     pytest.param(MSQRT, {"lambda_": 0.5}, id="MSQRT"),
     pytest.param(MCNNM, {}, id="MCNNM"),
     pytest.param(SparseSC, {"outcome_lag_periods": [1, 2]}, id="SparseSC"),
+    pytest.param(TASC, {"d": 2, "n_em_iter": 2}, id="TASC"),
 ]
 
 

--- a/mlsynth/tests/test_tasc.py
+++ b/mlsynth/tests/test_tasc.py
@@ -28,7 +28,8 @@ import pandas as pd
 import pytest
 
 from mlsynth import TASC
-from mlsynth.config_models import TASCConfig
+from mlsynth.config_models import EffectResult, TASCConfig
+from pydantic import ValidationError
 from mlsynth.exceptions import (
     MlsynthConfigError,
     MlsynthDataError,
@@ -578,11 +579,21 @@ class TestTASCEstimator:
             "n_em_iter": 3,
         }).fit()
         assert isinstance(results, TASCResults)
+        assert isinstance(results, EffectResult)
         assert isinstance(results.design, TASCDesign)
-        assert isinstance(results.inference, TASCInference)
+        assert isinstance(results.inference_detail, TASCInference)
         assert isinstance(results.att, float)
         assert isinstance(results.pre_rmse, float)
         assert results.pre_rmse >= 0
+        # standardized sub-models populated; TASC has no donor weights
+        assert results.time_series is not None
+        assert results.time_series.counterfactual_outcome is not None
+        assert results.effects is not None and results.effects.att is not None
+        assert results.weights is not None
+        np.testing.assert_allclose(
+            np.asarray(results.counterfactual),
+            np.asarray(results.inference_detail.counterfactual),
+        )
 
     def test_fit_with_full_Q_R(self, panel_df):
         results = TASC({
@@ -687,5 +698,6 @@ class TestImmutability:
             "time": "time", "treat": "treat", "d": 2,
             "n_em_iter": 2,
         }).fit()
-        with pytest.raises(FrozenInstanceError):
-            results.att = 99.0   # type: ignore[misc]
+        # TASCResults is now a frozen pydantic EffectResult.
+        with pytest.raises(ValidationError):
+            results.inference_detail = None   # type: ignore[misc]

--- a/mlsynth/utils/tasc_helpers/plotter.py
+++ b/mlsynth/utils/tasc_helpers/plotter.py
@@ -28,7 +28,7 @@ def plot_tasc(
     """Render the TASC counterfactual against the observed series."""
 
     inputs = results.inputs
-    inference = results.inference
+    inference = results.inference_detail
 
     counterfactuals = [inference.counterfactual]
     if isinstance(counterfactual_color, str):

--- a/mlsynth/utils/tasc_helpers/structures.py
+++ b/mlsynth/utils/tasc_helpers/structures.py
@@ -12,6 +12,9 @@ from dataclasses import dataclass
 from typing import Optional, Sequence
 
 import numpy as np
+from pydantic import ConfigDict
+
+from ...config_models import BaseEstimatorResults
 
 
 @dataclass(frozen=True)
@@ -190,9 +193,17 @@ class TASCDesign:
     smoothed: TASCSmoothedStates
 
 
-@dataclass(frozen=True)
-class TASCResults:
+class TASCResults(BaseEstimatorResults):
     """Public ``TASC.fit()`` return container.
+
+    An :class:`~mlsynth.config_models.EffectResult` (the observational report):
+    in addition to the TASC-specific fields below it exposes the standardized
+    sub-models (``effects``, ``time_series``, ``weights``, ``inference``,
+    ``fit_diagnostics``, ``method_details``) and the flat accessors ``att`` /
+    ``counterfactual`` / ``gap`` / ``pre_rmse``. TASC is a state-space / EM
+    estimator (no donor weights), so the ``weights`` slot records the method
+    rather than per-donor weights; the per-period posterior bands live in the
+    ``inference`` slot's ``details`` (and on ``inference_detail``).
 
     Parameters
     ----------
@@ -200,18 +211,16 @@ class TASCResults:
         Pre-processed panel data.
     design : TASCDesign
         Learned model, EM diagnostics, and filtered / smoothed state arrays.
-    inference : TASCInference
-        Counterfactual and posterior-based confidence intervals.
-    att : float
-        Average treatment effect on the treated across post-treatment periods.
-        ``mean(y_{0, t} - y_hat_{0, t})`` for ``t > T0``.
-    pre_rmse : float
-        Root mean squared error between the observed target and its
-        smoother-based fit over the pre-treatment window.
+    inference_detail : TASCInference
+        The raw counterfactual + posterior-based pointwise confidence bands
+        (``counterfactual`` / ``ci_lower`` / ``ci_upper`` / ``posterior_variance``
+        / ``alpha``). (Renamed from ``inference``; the standardized
+        :class:`~mlsynth.config_models.InferenceResults` is mirrored into the
+        ``inference`` slot.)
     """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     inputs: TASCInputs
     design: TASCDesign
-    inference: TASCInference
-    att: float
-    pre_rmse: float
+    inference_detail: TASCInference


### PR DESCRIPTION
Migrates **TASC** (Time-Aware Synthetic Control; state-space / EM Kalman estimator) onto the two-family result contract — eighth of the 9. Full suite green locally: **2648 passed, 3 skipped**.

## What changed
`TASCResults` is now a **frozen pydantic `EffectResult`** (was a frozen dataclass). Standardized sub-models are built from the observed target series vs the smoother-based counterfactual via `build_effect_submodels`; `att` / `counterfactual` / `gap` / `pre_rmse` resolve via the inherited surface. TASC is a state-space / EM estimator with **no donor weights**, so the `weights` slot records the method rather than per-donor weights. Plotting now goes through `result.plot()`.

## ⚠️ Breaking surface change
The raw inference object — the counterfactual plus per-period posterior bands (`.counterfactual` / `.ci_lower` / `.ci_upper` / `.posterior_variance` / `.alpha`) — moved from `res.inference` to **`res.inference_detail`**. The `inference` slot now holds the standardized `InferenceResults` (`method="tasc_posterior"`, `confidence_level = 1 − alpha`, raw object in `.details`). The flat `att` / `pre_rmse` fields are now inherited accessors; `design` / `inference_detail` remain typed fields.

## DoD checklist
**A. Code**
- [x] `fit()` returns an `EffectResult` subclass; no dict/tuple in the public return.
- [x] Frozen pydantic model (`frozen=True, arbitrary_types_allowed=True`).
- [x] Standardized sub-models populated; `weights` records the method (no donor weights), standardized inference mirrored into `inference`.
- [x] Estimator-specific outputs kept typed (`design`, `inference_detail`).
- [x] Back-compat accessors resolve; the `inference`→`inference_detail` rename documented above + in CHANGELOG.

**B. Tests**
- [x] TASC added to `test_result_contract.py` (`OBSERVATIONAL`, `{"d": 2, "n_em_iter": 2}`).
- [x] Field-type test asserts `EffectResult` + standardized sub-models + `res.counterfactual == res.inference_detail.counterfactual`; frozen test → pydantic `ValidationError` (the other immutability tests still target the frozen `TASCInputs`/`TASCParameters`/`TASCDesign` dataclasses).
- [x] Legacy `plot_tasc` repointed to `results.inference_detail`; its coverage test is unchanged.
- [x] Full suite green.

**C/D/E/F. Docs / replication / indices**
- [x] `TASCResults` docstring documents the standardized surface + rename; `docs/tasc.rst` (3 spots) now uses `res.inference_detail` for the raw bands. Return-type refactor only — replication numbers unchanged.
- [x] CHANGELOG entry added; `llms.txt` regenerated (unchanged).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_