### PR TITLE
ci: run the test suite once per change (PR gate), not again on merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,8 +88,11 @@ jobs:
       # onto main with the merge. [skip ci] keeps this commit from re-triggering
       # the workflow. PR-only (it needs a head branch to push to and fresh
       # coverage data from the run above).
+      # The badge is cosmetic, so this step must never fail the test gate:
+      # continue-on-error + a tolerant push.
       - name: Update coverage badge on the PR branch
         if: ${{ github.event_name == 'pull_request' }}
+        continue-on-error: true
         run: |
           coverage report -m || true
           coverage-badge -o coverage.svg -f
@@ -101,7 +104,7 @@ jobs:
             exit 0
           fi
           git commit -m "Update coverage badge [skip ci]"
-          git push origin "HEAD:${{ github.head_ref }}"
+          git push origin "HEAD:${{ github.head_ref }}" || echo "Badge push skipped (no write access or race); not fatal."
 
       - name: Build distribution
         run: python setup.py sdist
@@ -111,5 +114,3 @@ jobs:
         with:
           name: mlsynth-dist
           path: dist/
-
-# (CI: re-trigger after workflow change)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,3 +111,5 @@ jobs:
         with:
           name: mlsynth-dist
           path: dist/
+
+# (CI: re-trigger after workflow change)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,12 @@
 name: Test MLSYNTH
 
+# The full test suite runs ONCE per change -- on the pull request only.
+# Previously this workflow also ran on `push: [main]`, so every change was tested
+# twice (on the PR, then again on the merge to main: the same tree). The PR is the
+# gate; the post-merge re-run was pure duplication. The coverage badge, which used
+# to be produced by that main run, is now regenerated on the PR and committed to
+# the PR branch, so it lands on main via the (squash-)merge.
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "coverage.svg"
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -17,7 +19,7 @@ on:
 permissions:
   contents: write
 
-# CHANGE: cancel superseded runs on the same ref instead of piling up
+# Cancel superseded runs on the same ref instead of piling up.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -25,7 +27,7 @@ concurrency:
 env:
   PYTHONUNBUFFERED: "1"
   PYTHONWARNINGS: "ignore"
-  MPLBACKEND: "Agg"          # CHANGE: headless matplotlib, belt-and-suspenders
+  MPLBACKEND: "Agg"          # headless matplotlib, belt-and-suspenders
 
 jobs:
   build:
@@ -33,27 +35,32 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Check out the PR head branch (not the detached merge ref) so the
+          # coverage badge can be committed back to it. On workflow_dispatch
+          # head_ref is empty, so fall back to the dispatched branch.
+          ref: ${{ github.head_ref || github.ref_name }}
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: pip          # CHANGE: cache pip downloads → faster installs
+          cache: pip          # cache pip downloads -> faster installs
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          # CHANGE: add pytest-xdist for parallelism
           pip install pytest pytest-cov pytest-xdist coverage coverage-badge
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
 
-      # CHANGE: no `continue-on-error` → a failing test now FAILS the job.
+      # A failing test FAILS the job (no continue-on-error). Parallel via -n auto.
       - name: Run tests
         run: |
-          # push/PR run the full suite (fast now via -n auto); dispatch honors the input
+          # PRs run the full suite; dispatch honors the input target.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TARGET="${{ github.event.inputs.test_target }}"
           else
@@ -69,7 +76,6 @@ jobs:
                    --cov-report=xml \
                    --cov-report=term-missing \
                    --tb=short
-                   # --cov-fail-under=90   # CHANGE (optional): gate so coverage can't regress
           else
             MATCH=$(find . -name "$TARGET" | head -n 1)
             if [ -z "$MATCH" ]; then
@@ -78,22 +84,24 @@ jobs:
             pytest -n auto "$MATCH" --tb=short
           fi
 
-      # Badge + push ONLY on a real push to main (not PRs/forks, which can't push)
-      - name: Coverage report + badge
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      # Regenerate the coverage badge and commit it to the PR branch so it travels
+      # onto main with the merge. [skip ci] keeps this commit from re-triggering
+      # the workflow. PR-only (it needs a head branch to push to and fresh
+      # coverage data from the run above).
+      - name: Update coverage badge on the PR branch
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
-          coverage report -m
+          coverage report -m || true
           coverage-badge -o coverage.svg -f
-
-      - name: Commit coverage badge
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add coverage.svg
-          git commit -m "Update coverage badge [skip ci]" || { echo "No changes"; exit 0; }
-          git pull --rebase --autostash origin main   # CHANGE: avoid push races
-          git push
+          if git diff --cached --quiet; then
+            echo "Coverage badge unchanged; nothing to commit."
+            exit 0
+          fi
+          git commit -m "Update coverage badge [skip ci]"
+          git push origin "HEAD:${{ github.head_ref }}"
 
       - name: Build distribution
         run: python setup.py sdist

--- a/.github/workflows/testinst.yml
+++ b/.github/workflows/testinst.yml
@@ -1,12 +1,14 @@
 name: Test mlsynth Installation
 
+# Post-merge install smoke check only. It installs mlsynth from the GitHub `main`
+# branch and imports it, so it is only meaningful AFTER a merge to main -- on a PR
+# it would install main (not the PR's code) and tell us nothing. The PR gate is
+# the full test suite in build.yml.
 on:
   push:
     branches:
-      - main  # Trigger this action when you push to the 'main' branch
-  pull_request:
-    branches:
-      - main  # Trigger this action for pull requests to the 'main' branch
+      - main  # validate that main pip-installs + imports after each merge
+  workflow_dispatch:
 
 jobs:
   install_and_test:


### PR DESCRIPTION
Fixes the CI double-run: the full pytest suite was executing **twice** per change, turning a ~20-min process into ~40.

## Cause
`build.yml` ("Test MLSYNTH") triggered on **both** `pull_request: [main]` **and** `push: [main]`. So the heavy job (`pytest -n auto --cov …`) ran on the PR, then **again** on the identical tree when the PR merged to `main`. The PR is the gate; the post-merge re-run was pure duplication.

## Fix
- **`build.yml`** now triggers on `pull_request` + `workflow_dispatch` only (drops `push: [main]`). The suite runs **once** — on the PR.
- The **coverage badge** used to be produced by that redundant `main` run. It's now regenerated on the PR and committed to the PR branch (`Update coverage badge [skip ci]`, pushing to the checked-out head ref), so it lands on `main` via the (squash-)merge — no second test run needed.
- **`testinst.yml`** (the `pip install git+…@main` import check) was running on PRs, where it installs **main**, not the PR — i.e. it told us nothing about the change. Made it **post-merge only** (`push: [main]` + `workflow_dispatch`).

## Result
- **PR:** full suite once (the gate) + badge commit.
- **Merge to `main`:** only the cheap install smoke check; **no suite re-run.**

This PR self-tests the change — its own CI runs under the new `build.yml` (PR trigger), and merging it will *not* re-run the suite on `main`.

Trade-offs worth noting: the suite now tests the **PR head branch** (needed so the badge can be pushed back), rather than the head-merged-into-main ref — so a rare semantic merge-skew between two concurrently-merged PRs wouldn't be caught by CI; and direct pushes to `main` (outside a PR) are no longer suite-tested. Both are acceptable under the PR-based workflow here.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_