### PR TITLE
ci: daily coverage-badge job (stop de-heading PRs)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,9 @@
 name: Test MLSYNTH
 
-# The full test suite runs ONCE per change -- on the pull request only.
-# Previously this workflow also ran on `push: [main]`, so every change was tested
-# twice (on the PR, then again on the merge to main: the same tree). The PR is the
-# gate; the post-merge re-run was pure duplication. The coverage badge, which used
-# to be produced by that main run, is now regenerated on the PR and committed to
-# the PR branch, so it lands on main via the (squash-)merge.
+# The full test suite runs ONCE per change -- on the pull request only (the gate).
+# It does NOT run on push: [main], so a merge never re-tests the identical tree.
+# The coverage badge is updated out-of-band by the daily `coverage-badge.yml`
+# workflow, so this gate never commits to / de-heads a PR.
 on:
   pull_request:
     branches: [main]
@@ -17,7 +15,7 @@ on:
         default: "all"
 
 permissions:
-  contents: write
+  contents: read
 
 # Cancel superseded runs on the same ref instead of piling up.
 concurrency:
@@ -35,12 +33,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          # Check out the PR head branch (not the detached merge ref) so the
-          # coverage badge can be committed back to it. On workflow_dispatch
-          # head_ref is empty, so fall back to the dispatched branch.
-          ref: ${{ github.head_ref || github.ref_name }}
-          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -52,7 +44,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-cov pytest-xdist coverage coverage-badge
+          pip install pytest pytest-cov pytest-xdist coverage
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
@@ -83,28 +75,6 @@ jobs:
             fi
             pytest -n auto "$MATCH" --tb=short
           fi
-
-      # Regenerate the coverage badge and commit it to the PR branch so it travels
-      # onto main with the merge. [skip ci] keeps this commit from re-triggering
-      # the workflow. PR-only (it needs a head branch to push to and fresh
-      # coverage data from the run above).
-      # The badge is cosmetic, so this step must never fail the test gate:
-      # continue-on-error + a tolerant push.
-      - name: Update coverage badge on the PR branch
-        if: ${{ github.event_name == 'pull_request' }}
-        continue-on-error: true
-        run: |
-          coverage report -m || true
-          coverage-badge -o coverage.svg -f
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add coverage.svg
-          if git diff --cached --quiet; then
-            echo "Coverage badge unchanged; nothing to commit."
-            exit 0
-          fi
-          git commit -m "Update coverage badge [skip ci]"
-          git push origin "HEAD:${{ github.head_ref }}" || echo "Badge push skipped (no write access or race); not fatal."
 
       - name: Build distribution
         run: python setup.py sdist

--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,0 +1,80 @@
+name: Daily coverage badge
+
+# Refresh coverage.svg on main once a day (and on demand), out-of-band from the
+# PR test gate (build.yml) so the badge never adds a commit to / de-heads a PR.
+# Skips the (expensive) suite run entirely when no mlsynth/ code changed in the
+# last day, so quiet days cost nothing.
+on:
+  schedule:
+    - cron: "0 0 * * *"     # 00:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: coverage-badge
+  cancel-in-progress: false
+
+env:
+  PYTHONUNBUFFERED: "1"
+  PYTHONWARNINGS: "ignore"
+  MPLBACKEND: "Agg"
+
+jobs:
+  badge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Skip if no code changed in the last day
+        id: guard
+        run: |
+          # Any commit touching mlsynth/ in the last ~26h (window > the daily
+          # cadence), ignoring the bot's own badge commits? If none, do nothing.
+          CHANGED=$(git log --since="26 hours ago" --pretty=format:%s -- mlsynth/ \
+                    | grep -vc "Update coverage badge" || true)
+          if [ "${CHANGED:-0}" -eq 0 ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No mlsynth/ changes in the last day -- skipping the suite."
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "$CHANGED mlsynth/ commit(s) since yesterday -- refreshing the badge."
+          fi
+
+      - name: Set up Python
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        if: steps.guard.outputs.run == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-xdist coverage coverage-badge
+
+      - name: Run tests with coverage
+        if: steps.guard.outputs.run == 'true'
+        run: PYTHONPATH="$(pwd)" pytest -n auto --cov=mlsynth --cov-report=term-missing --tb=short
+
+      - name: Regenerate + commit badge (only if it changed)
+        if: steps.guard.outputs.run == 'true'
+        run: |
+          coverage-badge -o coverage.svg -f
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add coverage.svg
+          if git diff --cached --quiet; then
+            echo "Coverage badge unchanged; nothing to commit."
+            exit 0
+          fi
+          git commit -m "Update coverage badge [skip ci]"
+          git pull --rebase --autostash origin main
+          git push

--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -78,3 +78,5 @@ jobs:
           git commit -m "Update coverage badge [skip ci]"
           git pull --rebase --autostash origin main
           git push
+
+# (daily badge refresh of coverage.svg on main)


### PR DESCRIPTION
Replaces the PR-time coverage badge (from #23) with a **daily scheduled** refresh, fixing the de-heading wart.

## Problem
#23 had the PR's CI regenerate `coverage.svg` and commit it back to the PR branch. That badge commit (`[skip ci]`) became the PR **head with no check of its own** — a de-headed PR — and coverage jitter triggered it on basically every PR (e.g. #24, which didn't even touch `mlsynth/`).

## Fix
- **`build.yml`**: drop the badge step — the PR job now *only* runs the suite (the gate), never commits to the PR. Restored the plain checkout (so it tests the head-merged-into-`main` ref, the better thing to gate) and downgraded `permissions` to `contents: read`.
- **`coverage-badge.yml`** (new): refresh `coverage.svg` on `main` at **00:00 UTC daily** (+ `workflow_dispatch`), committing with `[skip ci]`. A guard **skips the whole suite when no `mlsynth/` commit landed in the last ~26 h**, so quiet days cost nothing.

## Result
- **PRs:** suite runs once (the gate); CI never modifies the PR → no de-heading.
- **Badge:** tracks `main` daily, without a redundant per-merge test run.
- The earlier double-run fix (#23) stands: still no `push: [main]` test run.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_