### PR TITLE
fix(lexscm): returned labels are always keys in the treated_weights dict (+ regression test)

### DIFF
--- a/mlsynth/estimators/lexscm.py
+++ b/mlsynth/estimators/lexscm.py
@@ -488,8 +488,15 @@ class LEXSCM:
         # =========================================================
         best = best_candidate
 
-        treated_labels = list(best.treated_weight_dict.keys())
-        control_labels = list(best.control_weight_dict.keys())
+        # The IndexSet is the single source of truth for unit identity: the
+        # weight dicts are already keyed by its labels (fast_scm_control /
+        # lexsearch). The result contract serializes weight-dict keys as ``str``
+        # (and ``UnitInfo.treated_labels`` is typed ``List[str]``), so canonicalize
+        # the returned labels the SAME way -- otherwise selected_units /
+        # assignment keep the raw label type (e.g. ``np.int64``) and fall out of
+        # lock-step with the str-keyed ``treated_weights`` dict below.
+        treated_labels = [str(k) for k in best.treated_weight_dict.keys()]
+        control_labels = [str(k) for k in best.control_weight_dict.keys()]
 
         unit_info = UnitInfo(
             n_units_total=self.Y.shape[1],

--- a/mlsynth/tests/test_lexscm.py
+++ b/mlsynth/tests/test_lexscm.py
@@ -1568,3 +1568,57 @@ class TestStructDerivedProps:
         assert c.treated_size == 2
         # control_idx picks nonzero entries of weights.control
         assert c.control_size >= 1
+
+
+# =========================================================================
+# Identity invariant: returned labels are ALWAYS in the weight dicts.
+#
+# The IndexSet is the single source of truth for unit identity. The result
+# contract serializes weight-dict keys as ``str`` (and ``UnitInfo.treated_labels``
+# is typed ``List[str]``), so the labels surfaced to the user -- ``selected_units``
+# and ``assignment`` -- must be canonicalized the SAME way. If they keep the raw
+# IndexSet label type (e.g. ``np.int64`` for integer unit ids) they fall out of
+# lock-step with the str-keyed ``treated_weights`` dict, and a consumer doing
+# ``treated_weights[unit]`` gets a KeyError. Integer ids are the case that
+# exposed the divergence.
+# =========================================================================
+
+def _panel_with_unit_labels(kind: str):
+    """``_make_panel`` relabelled with str (``"u00"``) or int (``0``) unit ids."""
+    df, _ = _make_panel()
+    if kind == "int":
+        df = df.copy()
+        df["unitid"] = df["unitid"].str.slice(1).astype(int)   # "u07" -> 7
+    return df
+
+
+class TestLEXSCMLabelWeightInvariant:
+
+    @pytest.mark.parametrize("unit_id_kind", ["str", "int"])
+    def test_returned_labels_always_in_treated_weights(self, unit_id_kind):
+        df = _panel_with_unit_labels(unit_id_kind)
+        res = LEXSCM({
+            "df": df, "outcome": "y", "unitid": "unitid", "time": "time",
+            "candidate_col": "candidate", "m": 2, "post_col": "post",
+            "top_K": 3, "n_sims": 30, "verbose": False,
+        }).fit()
+
+        treated_weights = res.design_weights.summary_stats["treated_weights"]
+        donor_weights = res.design_weights.donor_weights
+
+        # There IS a selected design, and selected_units == assignment["treated"].
+        assert len(res.selected_units) > 0
+        assert list(res.assignment["treated"]) == list(res.selected_units)
+
+        # Every returned treated label is a key in the treated_weights dict.
+        for label in res.selected_units:
+            assert label in treated_weights, (
+                f"selected treated unit {label!r} ({type(label).__name__}) is not a "
+                f"key in treated_weights {list(treated_weights)}"
+            )
+        # ...and every returned control label is a key in donor_weights.
+        for label in res.assignment["control"]:
+            assert label in donor_weights, (
+                f"control unit {label!r} ({type(label).__name__}) is not a key in "
+                f"donor_weights {list(donor_weights)}"
+            )


### PR DESCRIPTION
## The bug
For LEXSCM, the labels returned to the user (`selected_units`, `assignment["treated"]`) were **not guaranteed to be keys in the `treated_weights` dict**. The IndexSet is the source of truth for unit identity, and the weight dicts are already keyed by its labels — but the results layer serialized the dict keys as `str` (matching the `WeightsResults` contract; `UnitInfo.treated_labels` is even typed `List[str]`) while leaving the returned labels as the **raw** IndexSet type.

With **integer unit ids** this diverges:
```
selected_units      = [np.int64(1), np.int64(6)]
treated_weights keys = ['1', '6']
→ every returned label missing from the dict; treated_weights[unit] → KeyError
```
(String ids happened to mask it, since `str("u00") == "u00"`.)

## The fix
Canonicalize the returned treated/control labels the **same** way the contract serializes the weight-dict keys (`str`), so `selected_units` / `assignment` stay in lock-step with `treated_weights` / `donor_weights`. One-line-per-label change in the results assembly of `lexscm.py`; string ids are unaffected (no-op).

## The test (the ask)
`TestLEXSCMLabelWeightInvariant`, **parametrized over `str` and `int` unit ids** (int is the case that exposed the divergence), asserts every returned treated label is a key in `treated_weights` and every control label is a key in `donor_weights`. It fails on the old code with integer ids and passes now.

## Validation
- New test: 2/2 pass; **full `test_lexscm.py`: 104/104**; `test_result_contract.py`: 102/102. No other code depends on the raw label type (`result_contract` and the Walmart benchmark only use the count).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_