### PR TITLE
refactor(lexscm): rename vestigial 'bnb' search surface to 'selection'

### DIFF
--- a/docs/lexscm.rst
+++ b/docs/lexscm.rst
@@ -764,8 +764,8 @@ report. The surface is small and grouped -- one obvious home for each thing.
   -- *how* the design was chosen: ``shortlist`` (the ranked table),
   ``candidates`` (every evaluated design), ``winner`` (the chosen
   :class:`~mlsynth.utils.fast_scm_helpers.structure.SEDCandidate` with its
-  weights / predictions / losses / raw MDE curve), and ``bnb`` (the Stage-1
-  branch-and-bound diagnostics).
+  weights / predictions / losses / raw MDE curve), and ``selection`` (the
+  Stage-1 treated-design selection diagnostics).
 * ``res.panel`` (:class:`~mlsynth.utils.fast_scm_helpers.structure.LEXSCMPanel`)
   -- the panel structure: ``time``, ``units``, ``outcome``, ``population_mean``.
 
@@ -969,7 +969,7 @@ Run LEXSCM and inspect the design
     results = LEXSCM(config).fit()
 
     # --- Stage 1: solver-style search diagnostics ---
-    stats = results.search.bnb["stats"]
+    stats = results.search.selection["stats"]
     print("status        :", stats["termination"]["status"])      # OPTIMAL / FEASIBLE
     print("method        :", stats["search"]["method"])
     print("subsets scored :", stats["search"]["subsets_evaluated"])
@@ -977,7 +977,7 @@ Run LEXSCM and inspect the design
     print("best imbalance :", round(stats["incumbent"]["imbalance"], 4))
 
     # --- Stage 4: lexicographic recommendation tuple ---
-    rec = results.search.bnb["recommendation"]
+    rec = results.search.selection["recommendation"]
     print("rec status    :", rec["status"])      # OK / POWER_NOT_ESTABLISHED
     print("winner        :", rec["winner"])
     print("pareto ids    :", rec["pareto_ids"])

--- a/mlsynth/estimators/lexscm.py
+++ b/mlsynth/estimators/lexscm.py
@@ -98,9 +98,10 @@ class LEXSCM:
 
         **Search / Optimization Budget**
 
-        - ``top_K`` (int): Number of top candidate tuples returned by
-          branch-and-bound.
-        - ``top_P`` (int): Number of seed units used for BnB initialization.
+        - ``top_K`` (int): Number of top candidate tuples returned by the
+          treated-design selection search.
+        - ``top_P`` (int): Deprecated/unused (the multi-start search seeds
+          itself); retained for backward-compatible configs.
 
         **Inference / Power Analysis**
 
@@ -266,7 +267,7 @@ class LEXSCM:
             - summary : ranked table of candidate designs
             - best_candidate : selected experimental design
             - all_candidates : full evaluated set
-            - bnb_metadata : search diagnostics
+            - selection_metadata : search diagnostics
             - additional dataset and inference diagnostics
         """
 
@@ -382,7 +383,7 @@ class LEXSCM:
             method="auto",
             random_state=self.seed,
         )
-        bbresults = {"top_tuples": search["top_designs"], "stats": search["stats"]}
+        selection_results = {"top_tuples": search["top_designs"], "stats": search["stats"]}
 
         # --------------- Stage 2: control fit (unchanged) -----------------
         candidate_results = evaluate_candidates(
@@ -436,7 +437,7 @@ class LEXSCM:
             max_shortlist=self.max_shortlist,
         )
         shortlist = pd.DataFrame(recommendation.table)
-        bbresults["recommendation"] = {
+        selection_results["recommendation"] = {
             "status": recommendation.status,
             "winner": recommendation.winner.design_id if recommendation.winner else None,
             "pareto_ids": recommendation.pareto_ids,
@@ -568,7 +569,7 @@ class LEXSCM:
                 method_name="LEXSCM", donor_weights=design_donor_weights)
             if pf is not None else None
         )
-        rec = bbresults.get("recommendation", {})
+        rec = selection_results.get("recommendation", {})
 
         # =========================================================
         # FINAL RESULTS OBJECT -- a small, grouped surface.
@@ -593,7 +594,7 @@ class LEXSCM:
                 shortlist=shortlist,
                 candidates=candidate_results,
                 winner=best_candidate,
-                bnb=bbresults,
+                selection=selection_results,
             ),
             panel=LEXSCMPanel(
                 time=time_info,

--- a/mlsynth/tests/test_lexscm_pipeline.py
+++ b/mlsynth/tests/test_lexscm_pipeline.py
@@ -34,7 +34,7 @@ def _cfg(df, **over):
 
 def test_full_pipeline_m4():
     res = LEXSCM(_cfg(_panel())).fit()
-    meta = res.search.bnb
+    meta = res.search.selection
     assert meta["stats"]["search"]["method"] in ("enumeration", "multistart_local_search")
     assert meta["recommendation"]["status"] == "OK"
     assert meta["recommendation"]["winner"] is not None
@@ -51,14 +51,14 @@ def test_late_horizon_does_not_require_horizon_8():
     # old pipeline hardcoded mde_8w under "late" and crashed when 8 not in grid;
     # new pipeline uses max(n_post_grid).
     res = LEXSCM(_cfg(_panel(), mde_horizon="late", n_post_grid=[2, 3, 4])).fit()
-    assert res.search.bnb["recommendation"]["status"] in ("OK", "POWER_NOT_ESTABLISHED")
+    assert res.search.selection["recommendation"]["status"] in ("OK", "POWER_NOT_ESTABLISHED")
 
 
 def test_zero_mean_outcome_is_graceful():
     # old pipeline divided by the outcome level (floored 1e-8) and produced
     # all-NaN MDEs -> empty Pareto -> IndexError; new MDE is SD-based.
     res = LEXSCM(_cfg(_panel(level=0.0))).fit()
-    assert res.search.bnb["recommendation"]["status"] in ("OK", "POWER_NOT_ESTABLISHED")
+    assert res.search.selection["recommendation"]["status"] in ("OK", "POWER_NOT_ESTABLISHED")
     assert res.search.winner is not None
 
 

--- a/mlsynth/utils/fast_scm_helpers/structure.py
+++ b/mlsynth/utils/fast_scm_helpers/structure.py
@@ -263,14 +263,15 @@ class LEXSCMSearch:
     winner : SEDCandidate
         The selected design (winner of the lexicographic search), with its
         weights / predictions / losses / inference / raw MDE curve.
-    bnb : dict
-        Branch-and-bound search diagnostics plus the recommendation record.
+    selection : dict
+        Treated-design selection diagnostics (the imbalance-minimizing
+        enumerate-or-local-search) plus the recommendation record.
     """
 
     shortlist: Any
     candidates: List[SEDCandidate]
     winner: SEDCandidate
-    bnb: Dict[str, Any]
+    selection: Dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -317,7 +318,7 @@ class LEXSCMResults(DesignResult):
     **Grouped detail.**
 
     * ``search`` -- the candidate search (:class:`LEXSCMSearch`): ``shortlist``,
-      ``candidates``, ``winner``, ``bnb``.
+      ``candidates``, ``winner``, ``selection``.
     * ``panel`` -- the panel structure (:class:`LEXSCMPanel`): ``time``,
       ``units``, ``outcome``, ``population_mean``.
     """

--- a/mlsynth/utils/helperutils.py
+++ b/mlsynth/utils/helperutils.py
@@ -1006,7 +1006,7 @@ def lexplot(
     rmse_est_ctrl = rmse(synthetic_control[est_slice], synthetic_treated[est_slice])
 
     tuplename = best.identification.tuple_id
-    w = results.search.bnb['top_tuples'][0].full_weights
+    w = results.search.selection['top_tuples'][0].full_weights
     m = np.sum(w > 0)
 
     # =========================================================


### PR DESCRIPTION
Precursor cleanup for the spillover-aware selection work. The Stage-1 treated-design search is an **imbalance-minimizing enumerate-or-local-search** (Abadie–Zhao / Vives-i-Bastida), *not* branch-and-bound — the `bb`/`bnb` names are leftovers from the B&B implementation that `lexsearch` replaced.

Renames the vestigial surface:
- **`LEXSCMSearch.bnb → .selection`** (the one real API change) + its docstrings
- `bbresults → selection_results`, `bnb_metadata → selection_metadata` (`lexscm.py`)
- stale `branch-and-bound`/`BnB` docstrings fixed
- consumers updated: `helperutils.py` (a real code ref), `docs/lexscm.rst`, `test_lexscm_pipeline.py`

Pure rename, no behaviour change. **`test_lexscm.py` + `test_lexscm_pipeline.py`: 108 passed.**

(The internal `fast_scm_bb_helpers` module keeps its name — renaming it sprawls into many stale line-number comments for no user-facing gain; deferred.)

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_