### PR TITLE
feat(lexscm): spillover-aware treated selection (Vives-i-Bastida exclusion criteria)

### DIFF
--- a/docs/lexscm.rst
+++ b/docs/lexscm.rst
@@ -1035,6 +1035,56 @@ local solver (``status = FEASIBLE``), at which point the ``consensus``
 block under ``stats["search"]`` reports how many independent starts agreed
 on the incumbent.
 
+Example: spillover-aware selection
+==================================
+
+Suppose the markets sit inside larger regions and treating two markets in the
+same region would let the intervention spill across them (and onto each other's
+donors). Assign every unit a ``region`` and pass it as ``cluster_col``: LEXSCM
+then refuses to co-treat two markets from the same region (Stage 1) **and**
+refuses to build a treated market's synthetic control from its own-region peers
+(Stage 2).
+
+.. code-block:: python
+
+    import numpy as np
+
+    df = generate_synthetic_sales_panel(n_units=120, n_candidates=40,
+                                        n_time_periods=100, treatment_start=90,
+                                        seed=4545)
+
+    # assign each unit to one of 8 regions (constant within unit)
+    rng = np.random.default_rng(0)
+    region_of = rng.integers(0, 8, size=df["unitid"].nunique())
+    df["region"] = df["unitid"].map(lambda u: f"R{region_of[u]}")
+
+    config = {
+        "df": df, "outcome": "sales", "unitid": "unitid", "time": "time",
+        "candidate_col": "candidate", "m": 3, "post_col": "post",
+        "cluster_col": "region",        # <-- the only new line vs the budget example
+        "mde_horizon": "late", "top_K": 20,
+    }
+    results = LEXSCM(config).fit()
+
+    treated = list(results.selected_units)
+    treated_regions = {df.set_index("unitid")["region"].loc[int(u)] for u in treated}
+    donor_regions = {df.set_index("unitid")["region"].loc[int(d)]
+                     for d in results.design_weights.donor_weights}
+
+    print("treated markets :", treated)
+    print("treated regions :", treated_regions)       # all distinct -- one per region
+    print("donor regions   :", donor_regions)
+    assert treated_regions.isdisjoint(donor_regions)   # donors avoid treated regions
+
+Instead of clusters you can hand LEXSCM a **spillover/adjacency matrix** -- a
+``pandas.DataFrame`` indexed and columned by unit id, with a positive entry
+wherever two units interfere -- via ``adjacency=...`` and an optional
+``spillover_threshold`` (units conflict when the entry exceeds it). A
+``cluster_col`` and an ``adjacency`` may be supplied together; their conflicts
+combine. If the constraint admits no conflict-free ``m``-tuple (for instance
+``m`` larger than the number of regions), the fit raises
+:class:`~mlsynth.exceptions.MlsynthConfigError`.
+
 References
 ----------
 

--- a/docs/lexscm.rst
+++ b/docs/lexscm.rst
@@ -370,6 +370,43 @@ pure placebo noise; they are the raw material for the power analysis. This
 stage is identical to the pre-rebuild control path -- only the search and
 power stages around it changed.
 
+Spillover / interference exclusions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When treating a *set* of units, interference is a design concern, and
+Vives-i-Bastida (2022) handles it with two exclusion criteria that LEXSCM
+implements directly. Both read off **one conflict graph** -- a symmetric
+relation "units :math:`i` and :math:`j` interfere" -- supplied either as a
+``cluster_col`` (two units conflict iff they share a cluster, e.g. a state or
+province) or as an ``adjacency`` / spillover matrix (conflict iff the entry
+exceeds ``spillover_threshold``); the two combine by logical OR. The graph is
+aligned to the IndexSet, the single source of truth for unit identity.
+
+* **"No interference" (Stage 1, a treatment criterion).** The selected treated
+  :math:`m`-tuple must be an **independent set** of the conflict graph -- no two
+  treated units may interfere. This is a restriction on the admissible supports,
+  so it enters exactly where the :math:`\lVert w\rVert_0 = m` cardinality
+  constraint already lives -- as a filter on the candidate tuples, not a term in
+  the inner weight QP -- and only *shrinks* the search.
+
+* **"Exclusion restriction" (Stage 2, a control criterion).** For a treated set
+  :math:`S`, the donor pool drops not only :math:`S` but also its conflict
+  neighbours :math:`N(S)`, so a treated unit's spillover neighbours cannot enter
+  its synthetic control and contaminate the counterfactual.
+
+If no conflict-free :math:`m`-tuple exists (e.g. ``m`` exceeds the number of
+clusters), or the exclusions empty every donor pool, the fit raises
+:class:`~mlsynth.exceptions.MlsynthConfigError` rather than returning a degenerate
+design. With no ``cluster_col`` / ``adjacency`` supplied the behaviour is exactly
+the unconstrained search.
+
+.. code-block:: python
+
+   # at most one treated unit per state, and no treated unit's
+   # same-state neighbours used as its donors
+   LEXSCM({"df": df, "outcome": "y", "unitid": "unit", "time": "year",
+           "candidate_col": "eligible", "m": 2, "cluster_col": "state"}).fit()
+
 Stage 3 -- Power analysis (minimum detectable effect)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/mlsynth/estimators/lexscm.py
+++ b/mlsynth/estimators/lexscm.py
@@ -25,6 +25,7 @@ from ..utils.fast_scm_helpers.fast_scm_setup import (
 # Utilities - Search and Evaluation
 from ..utils.fast_scm_helpers.lexsearch import select_treated_designs
 from ..utils.fast_scm_helpers.fast_scm_control import evaluate_candidates
+from ..utils.fast_scm_helpers.conflict import build_conflict_matrix
 # Utilities - Power and Ranking
 from ..utils.fast_scm_helpers.lexpower import detectability_curve
 from ..utils.fast_scm_helpers.lexselect import DesignMetrics, select_design
@@ -177,6 +178,9 @@ class LEXSCM:
         self.weight_col: Optional[str] = config.weight_col
         self.unit_cost_col: Optional[str] = config.unit_cost_col
         self.budget: Optional[float] = config.budget
+        self.cluster_col: Optional[str] = config.cluster_col
+        self.adjacency = config.adjacency
+        self.spillover_threshold: float = config.spillover_threshold
         self.frac_E: float = config.frac_E
 
         # =========================================================
@@ -371,6 +375,21 @@ class LEXSCM:
         # If no budget is provided, set to infinity so no pruning occurs
         effective_budget = self.budget if self.budget is not None else np.inf
 
+        # --- Spillover conflict graph (Vives-i-Bastida interference exclusions) ---
+        # The IndexSet is the source of truth, so build the (J, J) conflict matrix
+        # aligned to it; one graph drives both Stage-1 (no co-treating conflicting
+        # units) and Stage-2 (no conflicting unit as a treated unit's donor).
+        cluster_of = None
+        if self.cluster_col is not None:
+            cluster_of = (self.df.groupby(self.unitid)[self.cluster_col]
+                          .first().to_dict())
+        conflict = build_conflict_matrix(
+            unit_index,
+            cluster_of=cluster_of,
+            adjacency=self.adjacency,
+            spillover_threshold=self.spillover_threshold,
+        )
+
         # ---------- Stage 1: treated-tuple selection (lexsearch) ----------
         search = select_treated_designs(
             G=G,
@@ -382,6 +401,7 @@ class LEXSCM:
             unit_index=unit_index,
             method="auto",
             random_state=self.seed,
+            conflict=conflict,
         )
         selection_results = {"top_tuples": search["top_designs"], "stats": search["stats"]}
 
@@ -394,7 +414,8 @@ class LEXSCM:
             f=self.f,
             E_idx=E_idx,
             B_idx=B_idx,
-            lambda_penalty=self.lambda_penalty, index_set=unit_index
+            lambda_penalty=self.lambda_penalty, index_set=unit_index,
+            conflict=conflict,
         )
 
         # ----- Stage 3: power / MDE (moving-block placebo null) -----------

--- a/mlsynth/tests/test_lexscm_spillover.py
+++ b/mlsynth/tests/test_lexscm_spillover.py
@@ -1,0 +1,326 @@
+"""Exhaustive tests for LEXSCM spillover / interference exclusions.
+
+Validates the two Vives-i-Bastida (2022) exclusion criteria end to end:
+
+* **Stage 1 -- "No interference":** the selected treated ``m``-tuple is an
+  *independent set* of the conflict graph (no two treated units in the same
+  cluster / sharing a spillover edge).
+* **Stage 2 -- "Exclusion restriction":** a treated unit's conflict neighbours
+  ``N(S)`` are excluded from its donor pool.
+
+Layers covered: the IndexSet-aligned conflict-graph builder, the graph
+utilities, the Stage-1 search (exact enumeration *and* multi-start heuristic),
+the Stage-2 control QP, feasibility errors on both stages, and the full LEXSCM
+estimator for both specification surfaces (``cluster_col``, ``adjacency``) and
+both unit-id types (``str``, ``int``).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.estimators.lexscm import LEXSCM
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.fast_scm_helpers.structure import IndexSet
+from mlsynth.utils.fast_scm_helpers.conflict import (
+    build_conflict_matrix,
+    is_independent,
+    max_independent_set_size_at_least,
+    neighbours,
+)
+from mlsynth.utils.fast_scm_helpers.fast_scm_control_helpers import solve_control_qp
+from mlsynth.utils.fast_scm_helpers.lexsearch import select_treated_designs
+
+
+# =========================================================================
+# Fixtures / helpers
+# =========================================================================
+
+# clusters for 15 units: 8 candidates paired into A,B,C,D; the 7 non-candidates Z
+CLUSTERS = ["A", "A", "B", "B", "C", "C", "D", "D"] + ["Z"] * 7
+
+BASE = dict(
+    outcome="y", unitid="unitid", time="time", candidate_col="candidate",
+    m=2, post_col="post", top_K=4, n_sims=30, verbose=False,
+)
+
+
+def make_panel(*, clusters=None, n_units=15, T=40, T_post=12, n_cand=8, L=2,
+               seed=0, str_ids=False):
+    rng = np.random.default_rng(seed)
+    gamma = rng.standard_normal((n_units, L))
+    nu = rng.standard_normal((T, L))
+    Y = 100.0 + nu @ gamma.T + 0.1 * rng.standard_normal((T, n_units))
+    rows = []
+    for i in range(n_units):
+        uid = f"u{i:02d}" if str_ids else i
+        for t in range(T):
+            r = {"unitid": uid, "time": t, "y": float(Y[t, i]),
+                 "post": int(t >= T - T_post), "candidate": int(i < n_cand),
+                 "cost": 1.0 + i}
+            if clusters is not None:
+                r["state"] = clusters[i]
+            rows.append(r)
+    return pd.DataFrame(rows)
+
+
+def _small_gram(J=10, T=8, seed=0):
+    rng = np.random.default_rng(seed)
+    Xt = rng.normal(size=(T, J))
+    return Xt.T @ Xt
+
+
+# clique conflict for clusters 0-3=A, 4-6=B, 7-9=C (3 cliques)
+def _clique_conflict(codes):
+    codes = np.asarray(codes)
+    A = (codes[:, None] == codes[None, :])
+    np.fill_diagonal(A, False)
+    return A
+
+
+# =========================================================================
+# Conflict-graph builder
+# =========================================================================
+
+class TestConflictBuilder:
+
+    def test_cluster_is_clique_per_cluster(self):
+        ui = IndexSet.from_labels([0, 1, 2, 3, 4])
+        A = build_conflict_matrix(ui, cluster_of={0: "A", 1: "A", 2: "B", 3: "B", 4: "C"})
+        assert A[0, 1] and A[1, 0] and A[2, 3]
+        assert not A[0, 2] and not A[0, 4]
+        assert not A[4].any()                      # singleton cluster conflicts with no one
+
+    def test_diagonal_false_and_symmetric(self):
+        ui = IndexSet.from_labels(list(range(6)))
+        A = build_conflict_matrix(ui, cluster_of={i: i % 2 for i in range(6)})
+        assert not np.any(np.diag(A))
+        assert np.array_equal(A, A.T)
+
+    def test_cluster_missing_value_raises(self):
+        ui = IndexSet.from_labels([0, 1, 2])
+        with pytest.raises(MlsynthDataError, match="no cluster value"):
+            build_conflict_matrix(ui, cluster_of={0: "A", 1: "A"})   # 2 missing
+
+    def test_cluster_nan_conflicts_with_no_one(self):
+        ui = IndexSet.from_labels([0, 1, 2])
+        A = build_conflict_matrix(ui, cluster_of={0: np.nan, 1: np.nan, 2: "B"})
+        assert not A.any()                          # NaN never matches, even another NaN
+
+    def test_adjacency_array(self):
+        ui = IndexSet.from_labels([0, 1, 2, 3])
+        M = np.zeros((4, 4)); M[0, 2] = 1.0
+        A = build_conflict_matrix(ui, adjacency=M, spillover_threshold=0.5)
+        assert A[0, 2] and A[2, 0]                   # symmetrised
+        assert not A[0, 1]
+
+    def test_adjacency_threshold(self):
+        ui = IndexSet.from_labels([0, 1, 2])
+        M = np.array([[0, 0.2, 0.9], [0.2, 0, 0], [0.9, 0, 0]])
+        A = build_conflict_matrix(ui, adjacency=M, spillover_threshold=0.5)
+        assert A[0, 2] and not A[0, 1]               # 0.2 < 0.5, 0.9 > 0.5
+
+    def test_adjacency_dataframe_realigns_to_indexset(self):
+        # DataFrame given in SCRAMBLED label order must be reindexed to the IndexSet.
+        ui = IndexSet.from_labels([10, 20, 30])
+        df = pd.DataFrame(0.0, index=[30, 10, 20], columns=[30, 10, 20])
+        df.loc[10, 30] = 1.0; df.loc[30, 10] = 1.0
+        A = build_conflict_matrix(ui, adjacency=df, spillover_threshold=0.5)
+        # unit 10 is row 0, unit 30 is row 2 in the IndexSet
+        assert A[0, 2] and A[2, 0] and not A[0, 1]
+
+    def test_adjacency_wrong_shape_raises(self):
+        ui = IndexSet.from_labels([0, 1, 2, 3])
+        with pytest.raises(MlsynthConfigError, match="shape"):
+            build_conflict_matrix(ui, adjacency=np.zeros((3, 3)))
+
+    def test_adjacency_dataframe_missing_label_raises(self):
+        ui = IndexSet.from_labels([0, 1, 2])
+        df = pd.DataFrame(0.0, index=[0, 1], columns=[0, 1])   # missing unit 2
+        with pytest.raises(MlsynthDataError, match="missing"):
+            build_conflict_matrix(ui, adjacency=df)
+
+    def test_adjacency_nonfinite_raises(self):
+        ui = IndexSet.from_labels([0, 1])
+        M = np.array([[0.0, np.inf], [np.inf, 0.0]])
+        with pytest.raises(MlsynthDataError, match="finite"):
+            build_conflict_matrix(ui, adjacency=M)
+
+    def test_combined_cluster_and_adjacency_or(self):
+        ui = IndexSet.from_labels([0, 1, 2, 3])
+        M = np.zeros((4, 4)); M[0, 3] = 1.0
+        A = build_conflict_matrix(ui, cluster_of={0: "A", 1: "A", 2: "B", 3: "B"},
+                                  adjacency=M, spillover_threshold=0.5)
+        assert A[0, 1]     # from clusters
+        assert A[0, 3]     # from adjacency
+        assert A[2, 3]     # from clusters
+
+    def test_none_when_no_inputs(self):
+        ui = IndexSet.from_labels([0, 1, 2])
+        assert build_conflict_matrix(ui) is None
+
+
+# =========================================================================
+# Graph utilities
+# =========================================================================
+
+class TestGraphUtils:
+
+    def test_neighbours_union_and_excludes_self(self):
+        A = _clique_conflict([0, 0, 0, 1, 1, 2])     # {0,1,2}, {3,4}, {5}
+        assert set(neighbours(A, [0]).tolist()) == {1, 2}
+        assert set(neighbours(A, [0, 3]).tolist()) == {1, 2, 4}
+        assert neighbours(A, [5]).size == 0          # isolated
+        assert neighbours(A, []).size == 0
+
+    def test_is_independent(self):
+        A = _clique_conflict([0, 0, 1, 2])
+        assert is_independent(None, [0, 1, 2])       # no graph -> always independent
+        assert is_independent(A, [0])                # singleton
+        assert is_independent(A, [0, 2, 3])          # one per clique
+        assert not is_independent(A, [0, 1])         # same clique
+
+    def test_feasibility_cluster_exact(self):
+        A = _clique_conflict([0, 0, 0, 1, 1, 2])     # 3 cliques
+        assert max_independent_set_size_at_least(A, range(6), 3)
+        assert not max_independent_set_size_at_least(A, range(6), 4)
+
+    def test_feasibility_none_graph(self):
+        assert max_independent_set_size_at_least(None, range(6), 6)
+
+
+# =========================================================================
+# Stage 1 -- independent-set constraint in the search
+# =========================================================================
+
+class TestStage1:
+
+    @pytest.mark.parametrize("method", ["enumerate", "heuristic"])
+    def test_returns_only_independent_sets(self, method):
+        G = _small_gram(10)
+        A = _clique_conflict([0, 0, 0, 0, 1, 1, 1, 2, 2, 2])   # cliques A,B,C
+        res = select_treated_designs(G, list(range(10)), m=3, top_K=5,
+                                     method=method, conflict=A, random_state=1)
+        designs = res["top_designs"]
+        assert len(designs) > 0
+        for d in designs:
+            assert is_independent(A, d.indices)
+
+    @pytest.mark.parametrize("method", ["enumerate", "heuristic"])
+    def test_empty_graph_equals_unconstrained(self, method):
+        G = _small_gram(10)
+        empty = np.zeros((10, 10), dtype=bool)
+        r0 = select_treated_designs(G, list(range(10)), m=3, top_K=5,
+                                    method=method, random_state=1)
+        rA = select_treated_designs(G, list(range(10)), m=3, top_K=5,
+                                    method=method, conflict=empty, random_state=1)
+        assert r0["top_designs"][0].indices == rA["top_designs"][0].indices
+
+    def test_infeasible_raises(self):
+        G = _small_gram(10)
+        A = _clique_conflict([0, 0, 0, 0, 1, 1, 1, 2, 2, 2])   # only 3 cliques
+        with pytest.raises(MlsynthConfigError, match="no interference|independent set"):
+            select_treated_designs(G, list(range(10)), m=4, method="enumerate", conflict=A)
+
+    def test_conflict_composes_with_budget(self):
+        G = _small_gram(10)
+        A = _clique_conflict([0, 0, 1, 1, 2, 2, 3, 3, 4, 4])   # 5 cliques
+        costs = np.arange(10, dtype=float)
+        res = select_treated_designs(G, list(range(10)), m=2, top_K=5,
+                                     method="enumerate", conflict=A,
+                                     unit_costs=costs, budget=6.0)
+        for d in res["top_designs"]:
+            assert is_independent(A, d.indices)
+            assert costs[d.indices].sum() <= 6.0 + 1e-9
+
+
+# =========================================================================
+# Stage 2 -- donor exclusion in the control QP
+# =========================================================================
+
+class TestStage2:
+
+    def test_exclude_idx_zeros_neighbours(self):
+        rng = np.random.default_rng(0)
+        X_E = rng.normal(size=(8, 10))
+        treated_idx = [0]
+        treated_vec = X_E[:, 0]
+        v = solve_control_qp(X_E, treated_vec, treated_idx, lambda_penalty=0.1,
+                             exclude_idx=[1, 2])
+        assert v is not None
+        assert np.allclose(v[[0, 1, 2]], 0.0, atol=1e-8)     # treated + neighbours excluded
+        assert v[3:].sum() > 0                                # remaining donors carry the weight
+
+    def test_empty_donor_pool_returns_none(self):
+        rng = np.random.default_rng(0)
+        X_E = rng.normal(size=(8, 4))
+        # exclude everything but one donor's complement -> exclude all donors
+        v = solve_control_qp(X_E, X_E[:, 0], treated_idx=[0],
+                             exclude_idx=[1, 2, 3])
+        assert v is None
+
+    def test_no_exclude_matches_baseline(self):
+        rng = np.random.default_rng(1)
+        X_E = rng.normal(size=(8, 6))
+        v0 = solve_control_qp(X_E, X_E[:, 0], treated_idx=[0])
+        v1 = solve_control_qp(X_E, X_E[:, 0], treated_idx=[0], exclude_idx=None)
+        assert np.allclose(v0, v1)
+
+
+# =========================================================================
+# End-to-end LEXSCM
+# =========================================================================
+
+class TestLEXSCMSpilloverEndToEnd:
+
+    @pytest.mark.parametrize("str_ids", [False, True])
+    def test_cluster_treated_in_distinct_clusters(self, str_ids):
+        df = make_panel(clusters=CLUSTERS, str_ids=str_ids)
+        res = LEXSCM({"df": df, **BASE, "cluster_col": "state"}).fit()
+        cmap = {(f"u{i:02d}" if str_ids else i): CLUSTERS[i] for i in range(15)}
+        sel_clusters = [cmap[u if str_ids else int(u)] for u in res.selected_units]
+        assert len(set(sel_clusters)) == len(sel_clusters)    # all distinct
+
+    @pytest.mark.parametrize("str_ids", [False, True])
+    def test_cluster_donors_exclude_treated_clusters(self, str_ids):
+        df = make_panel(clusters=CLUSTERS, str_ids=str_ids)
+        res = LEXSCM({"df": df, **BASE, "cluster_col": "state"}).fit()
+        cmap = {(f"u{i:02d}" if str_ids else i): CLUSTERS[i] for i in range(15)}
+        treated_clusters = {cmap[u if str_ids else int(u)] for u in res.selected_units}
+        donor_clusters = {cmap[d if str_ids else int(d)]
+                          for d in res.design_weights.donor_weights}
+        assert treated_clusters.isdisjoint(donor_clusters)
+
+    def test_adjacency_mode_respects_conflict(self):
+        df = make_panel()
+        adj = pd.DataFrame(0.0, index=range(15), columns=range(15))
+        adj.loc[0, 1] = adj.loc[1, 0] = 1.0          # forbid co-treating 0 & 1
+        res = LEXSCM({"df": df, **BASE, "adjacency": adj,
+                      "spillover_threshold": 0.5}).fit()
+        sel = {int(u) for u in res.selected_units}
+        assert not ({0, 1} <= sel)
+
+    def test_baseline_unchanged_without_spillover(self):
+        # Empty conflict (each unit its own cluster) must reproduce the no-spillover pick.
+        df = make_panel()
+        res0 = LEXSCM({"df": df, **BASE}).fit()
+        df_c = make_panel(clusters=[f"c{i}" for i in range(15)])   # all distinct
+        res1 = LEXSCM({"df": df_c, **BASE, "cluster_col": "state"}).fit()
+        assert list(res0.selected_units) == list(res1.selected_units)
+
+    def test_infeasible_m_exceeds_clusters_raises(self):
+        # 8 candidates but only 4 candidate-clusters (A,B,C,D); m=5 is infeasible.
+        df = make_panel(clusters=CLUSTERS)
+        with pytest.raises(MlsynthConfigError, match="no interference|independent set"):
+            LEXSCM({"df": df, **{**BASE, "m": 5}, "cluster_col": "state"}).fit()
+
+    @pytest.mark.parametrize("str_ids", [False, True])
+    def test_label_invariant_holds_with_spillover(self, str_ids):
+        # The returned labels are still keys in treated_weights (the #27 invariant),
+        # now under the spillover constraint.
+        df = make_panel(clusters=CLUSTERS, str_ids=str_ids)
+        res = LEXSCM({"df": df, **BASE, "cluster_col": "state"}).fit()
+        tw = res.design_weights.summary_stats["treated_weights"]
+        for label in res.selected_units:
+            assert label in tw

--- a/mlsynth/utils/fast_scm_helpers/config.py
+++ b/mlsynth/utils/fast_scm_helpers/config.py
@@ -6,7 +6,7 @@ Co-located with the helper package; re-exported from
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Any, List, Literal, Optional
 from pydantic import Field
 from ...config_models import BaseMAREXConfig
 
@@ -51,6 +51,35 @@ class LEXSCMConfig(BaseMAREXConfig):
         gt=0,
         description="Hard total budget for the sum of treatment costs of the "
                     "selected treated units."
+    )
+
+    # =========================================================
+    # SPILLOVER / INTERFERENCE EXCLUSIONS (Vives-i-Bastida 2022)
+    # =========================================================
+
+    cluster_col: Optional[str] = Field(
+        default=None,
+        description="Optional column assigning each unit to a spillover cluster "
+                    "(e.g. state/province; constant within unit). Enforces the "
+                    "Vives-i-Bastida (2022) interference exclusions: treated units "
+                    "may not share a cluster (Stage-1 'no interference'), and a "
+                    "treated unit's same-cluster units are barred from its donor "
+                    "pool (Stage-2 'exclusion restriction')."
+    )
+
+    adjacency: Optional[Any] = Field(
+        default=None,
+        description="Optional spillover/adjacency matrix: a (J, J) array in sorted "
+                    "unit-id order, or a pandas DataFrame indexed and columned by "
+                    "unit id (preferred -- order-independent). Two units conflict "
+                    "when their entry exceeds `spillover_threshold`. Combined with "
+                    "`cluster_col` via logical OR."
+    )
+
+    spillover_threshold: float = Field(
+        default=0.0, ge=0.0,
+        description="Adjacency entries strictly above this value count as a "
+                    "spillover conflict (default 0.0: any positive entry)."
     )
 
     seed: int = 42

--- a/mlsynth/utils/fast_scm_helpers/conflict.py
+++ b/mlsynth/utils/fast_scm_helpers/conflict.py
@@ -1,0 +1,183 @@
+"""Spillover/interference conflict graph for LEXSCM treated-unit selection.
+
+Implements the two exclusion criteria of Vives-i-Bastida (2022, "Synthetic
+Experimental Design for a UBI pilot study"), which extend Abadie & Zhao (2021):
+
+* **"No interference" (treatment criterion)** -- treated units may not belong to
+  the same cluster (the paper: "the same province"). In Stage 1 this restricts
+  the admissible treated ``m``-tuples to **independent sets** of the conflict
+  graph.
+* **"Exclusion restriction" (control criterion)** -- a treated unit's
+  spillover-neighbours may not serve as its donors (the paper: controls "can not
+  be within the same labour market ... as the treated units"). In Stage 2 this
+  drops ``N(S)`` from the donor pool.
+
+Both criteria read off **one** boolean conflict matrix ``A`` (``A[i, j]`` True iff
+units ``i`` and ``j`` interfere), which this module builds from either a cluster
+assignment, an adjacency/spillover matrix, or both. The matrix is **aligned to
+the IndexSet** -- the single source of truth for unit identity (rows/columns are
+in ``unit_index.labels`` order) -- so every downstream consumer indexes it the
+same way as ``G`` and the candidate indices.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+import numpy as np
+import pandas as pd
+
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+
+
+def _cluster_conflict(labels: np.ndarray, cluster_of: Mapping[Any, Any]) -> np.ndarray:
+    """``A[i, j] = (cluster(i) == cluster(j))`` off-diagonal (clique per cluster).
+
+    ``labels`` are the IndexSet labels in order; ``cluster_of`` maps each label to
+    its cluster. A unit with a missing/``NaN`` cluster conflicts with no one.
+    """
+    J = len(labels)
+    clusters = []
+    for lab in labels:
+        if lab not in cluster_of:
+            raise MlsynthDataError(
+                f"Unit {lab!r} has no cluster value in the cluster column."
+            )
+        clusters.append(cluster_of[lab])
+    # Encode clusters as integers; NaN/None -> a unique sentinel that matches no one.
+    codes = np.empty(J, dtype=object)
+    for i, c in enumerate(clusters):
+        codes[i] = None if (c is None or (isinstance(c, float) and np.isnan(c))) else c
+    A = np.zeros((J, J), dtype=bool)
+    for i in range(J):
+        if codes[i] is None:
+            continue
+        for j in range(i + 1, J):
+            if codes[j] is not None and codes[i] == codes[j]:
+                A[i, j] = A[j, i] = True
+    return A
+
+
+def _adjacency_conflict(labels: np.ndarray, adjacency: Any, threshold: float) -> np.ndarray:
+    """``A[i, j] = (adjacency[i, j] > threshold)`` off-diagonal, aligned to ``labels``.
+
+    ``adjacency`` may be a square ``(J, J)`` array in IndexSet order, or a
+    ``pd.DataFrame`` indexed/columned by unit labels (reindexed to ``labels``).
+    The matrix is symmetrised (``A or A.T``) so direction does not matter.
+    """
+    J = len(labels)
+    if isinstance(adjacency, pd.DataFrame):
+        missing = [l for l in labels if l not in adjacency.index or l not in adjacency.columns]
+        if missing:
+            raise MlsynthDataError(
+                f"Adjacency DataFrame is missing rows/columns for units: {missing[:5]}"
+                + (" ..." if len(missing) > 5 else "")
+            )
+        M = adjacency.reindex(index=labels, columns=labels).to_numpy(dtype=float)
+    else:
+        M = np.asarray(adjacency, dtype=float)
+        if M.shape != (J, J):
+            raise MlsynthConfigError(
+                f"Adjacency matrix has shape {M.shape}, expected ({J}, {J}) to align "
+                f"with the {J} units. Pass a pandas DataFrame indexed by unit id to "
+                f"avoid relying on ordering."
+            )
+    if not np.all(np.isfinite(M)):
+        raise MlsynthDataError("Adjacency matrix contains non-finite entries.")
+    A = M > threshold
+    A = A | A.T                       # symmetrise: spillover is mutual
+    np.fill_diagonal(A, False)
+    return A
+
+
+def build_conflict_matrix(
+    unit_index: Any,
+    *,
+    cluster_of: Optional[Mapping[Any, Any]] = None,
+    adjacency: Optional[Any] = None,
+    spillover_threshold: float = 0.0,
+) -> Optional[np.ndarray]:
+    """Build the ``(J, J)`` boolean conflict matrix aligned to ``unit_index``.
+
+    Parameters
+    ----------
+    unit_index : IndexSet
+        The source of truth for unit identity; ``unit_index.labels`` fixes the
+        row/column order of the returned matrix.
+    cluster_of : mapping label -> cluster, optional
+        Cluster assignment (e.g. from ``cluster_col``). Two units conflict iff
+        they share a (non-missing) cluster.
+    adjacency : array or DataFrame, optional
+        Spillover/adjacency matrix; two units conflict iff their entry exceeds
+        ``spillover_threshold``.
+    spillover_threshold : float
+        Threshold for the adjacency mode.
+
+    Returns
+    -------
+    np.ndarray of bool, shape (J, J), or None
+        Symmetric, zero-diagonal conflict matrix. If both inputs are given the
+        two graphs are combined with logical OR. Returns ``None`` when neither
+        input is supplied (no spillover constraint).
+    """
+    labels = np.asarray(unit_index.labels)
+    J = len(labels)
+    A: Optional[np.ndarray] = None
+    if cluster_of is not None:
+        A = _cluster_conflict(labels, cluster_of)
+    if adjacency is not None:
+        Aa = _adjacency_conflict(labels, adjacency, spillover_threshold)
+        A = Aa if A is None else (A | Aa)
+    if A is None:
+        return None
+    np.fill_diagonal(A, False)
+    return A
+
+
+def neighbours(conflict: np.ndarray, idx) -> np.ndarray:
+    """Indices that conflict with ANY unit in ``idx`` (the spillover set ``N(S)``).
+
+    Excludes the members of ``idx`` themselves; returns a sorted int array.
+    """
+    idx = np.asarray(list(idx), dtype=int)
+    if idx.size == 0:
+        return np.empty(0, dtype=int)
+    nbr = np.any(conflict[idx, :], axis=0)
+    nbr[idx] = False
+    return np.flatnonzero(nbr)
+
+
+def is_independent(conflict: Optional[np.ndarray], idx) -> bool:
+    """True iff no two members of ``idx`` share a conflict edge (an independent set)."""
+    if conflict is None:
+        return True
+    idx = np.asarray(list(idx), dtype=int)
+    if idx.size < 2:
+        return True
+    sub = conflict[np.ix_(idx, idx)]
+    return not bool(np.any(np.triu(sub, k=1)))
+
+
+def max_independent_set_size_at_least(conflict: Optional[np.ndarray], candidate_idx, m: int) -> bool:
+    """Cheap sufficient feasibility check: can a size-``m`` independent set exist
+    among ``candidate_idx``?
+
+    Uses a greedy minimum-degree construction (sound as a *lower* bound on the
+    maximum independent set): if the greedy set already reaches ``m`` the answer
+    is certainly yes. Greedy can undercount, so a ``False`` is only advisory; the
+    search itself raises the definitive infeasibility error if it finds nothing.
+    """
+    if conflict is None:
+        return True
+    cand = np.asarray(list(candidate_idx), dtype=int)
+    if len(cand) < m:
+        return False
+    sub = conflict[np.ix_(cand, cand)]
+    remaining = list(range(len(cand)))
+    chosen = 0
+    while remaining and chosen < m:
+        deg = sub[np.ix_(remaining, remaining)].sum(axis=1)
+        pick = remaining[int(np.argmin(deg))]
+        chosen += 1
+        # drop pick and all its neighbours within the remaining set
+        remaining = [r for r in remaining if r != pick and not sub[pick, r]]
+    return chosen >= m

--- a/mlsynth/utils/fast_scm_helpers/fast_scm_control.py
+++ b/mlsynth/utils/fast_scm_helpers/fast_scm_control.py
@@ -1,13 +1,15 @@
 
 # mlsynth/experimental_design/fast_scm_control.py
 
-from typing import List
+from typing import List, Optional
 import numpy as np
 
 from .fast_scm_bb_helpers import Solution
 from .structure import SEDCandidate, WeightVectors, PredictionVectors, Losses, Identification
 from .fast_scm_control_helpers import solve_control_qp
 from .fast_scm_setup import IndexSet
+from .conflict import neighbours
+from ...exceptions import MlsynthConfigError
 
 def _zero_small_weights(weights: np.ndarray, threshold: float = 1e-8) -> np.ndarray:
     """
@@ -44,7 +46,8 @@ def evaluate_candidates(
     E_idx: np.ndarray,
     B_idx: np.ndarray,
     lambda_penalty: float,
-    index_set: IndexSet
+    index_set: IndexSet,
+    conflict: Optional[np.ndarray] = None,
 ) -> List[SEDCandidate]:
 
 
@@ -116,13 +119,26 @@ def evaluate_candidates(
 
         w = sol.weights[treated_idx] if len(sol.weights) != m else sol.weights
 
+        # Spillover "exclusion restriction": drop the treated units' conflict
+        # neighbours N(S) from the donor pool so the treatment cannot contaminate
+        # the synthetic control.
+        spill = neighbours(conflict, treated_idx) if conflict is not None else None
+
         treated_vec_E = X_E[:, treated_idx] @ w
-        v = solve_control_qp(X_E, treated_vec_E, treated_idx, lambda_penalty)
+        v = solve_control_qp(X_E, treated_vec_E, treated_idx, lambda_penalty,
+                             exclude_idx=spill)
+        if v is None:
+            # The exclusions (treated + N(S)) emptied / over-constrained the donor
+            # pool for this candidate; skip it rather than crash.
+            continue
 
         v = _zero_small_weights(v, threshold=1e-8)
 
-        assert np.allclose(v[treated_idx], 0.0, atol=1e-8), \
-            "Control QP violated exclusion constraint: treated units have nonzero weight"
+        excluded_idx = treated_idx if spill is None or len(spill) == 0 \
+            else np.concatenate([treated_idx, np.asarray(spill, dtype=int)])
+        assert np.allclose(v[excluded_idx], 0.0, atol=1e-8), \
+            "Control QP violated exclusion constraint: a treated unit or its " \
+            "spillover neighbour has nonzero control weight"
         
 
         # label mapping (THIS is the fix)
@@ -203,6 +219,14 @@ def evaluate_candidates(
         )
 
         results.append(candidate)
+
+    if not results and candidates and conflict is not None:
+        raise MlsynthConfigError(
+            "Every candidate design had its donor pool emptied by the spillover "
+            "'exclusion restriction' (treated units plus their conflict "
+            "neighbours leave too few controls). Relax the adjacency/cluster "
+            "constraint or widen the donor pool."
+        )
 
     return results
 

--- a/mlsynth/utils/fast_scm_helpers/fast_scm_control_helpers.py
+++ b/mlsynth/utils/fast_scm_helpers/fast_scm_control_helpers.py
@@ -118,7 +118,8 @@ def solve_control_qp(
     X_E: np.ndarray,
     treated_vec: np.ndarray,
     treated_idx: List[int],
-    lambda_penalty: float = 0.1
+    lambda_penalty: float = 0.1,
+    exclude_idx: Optional[List[int]] = None,
 ) -> Optional[np.ndarray]:
     """
     Solve for synthetic control weights given a treated trajectory.
@@ -133,12 +134,18 @@ def solve_control_qp(
         Indices of treated units to exclude from the control.
     lambda_penalty : float, default=0.1
         Regularization strength for mismatch penalties.
+    exclude_idx : list of int, optional
+        Additional indices to drop from the donor pool -- the spillover
+        neighbours ``N(S)`` of the treated units (Vives-i-Bastida "exclusion
+        restriction": a treated unit's same-cluster/adjacent units may not serve
+        as its controls, so the treatment cannot contaminate the counterfactual).
 
     Returns
     -------
     v : np.ndarray, shape (N,) or None
-        Synthetic control weights over all units. Entries at treated
-        indices are zero. Returns None if optimization fails.
+        Synthetic control weights over all units. Entries at treated AND excluded
+        indices are exactly zero. Returns None if optimization fails (including
+        when the exclusions empty the donor pool).
 
     Notes
     -----
@@ -156,8 +163,10 @@ def solve_control_qp(
     # submatrix is mathematically identical to constraining the treated weights
     # to zero, since the penalty term is separable in ``v`` and a zero weight
     # contributes nothing.
-    treated_set = {int(j) for j in treated_idx}
-    control_idx = np.array([i for i in range(N) if i not in treated_set], dtype=int)
+    excluded = {int(j) for j in treated_idx}
+    if exclude_idx is not None:
+        excluded |= {int(j) for j in exclude_idx}
+    control_idx = np.array([i for i in range(N) if i not in excluded], dtype=int)
     if control_idx.size == 0:
         return None
 

--- a/mlsynth/utils/fast_scm_helpers/lexsearch.py
+++ b/mlsynth/utils/fast_scm_helpers/lexsearch.py
@@ -47,6 +47,9 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import numpy as np
 
+from .conflict import is_independent
+from ...exceptions import MlsynthConfigError
+
 
 # ======================================================================
 # Inner simplex-QP solvers (Away-step Frank-Wolfe; pure numpy)
@@ -179,7 +182,8 @@ def _budget_feasible_candidates(candidate_idx, m, unit_costs, budget):
 # Exact enumeration (small C(M, m))
 # ======================================================================
 
-def _enumerate(G, cand, m, top_K, unit_costs, budget, iters, chunk=300_000):
+def _enumerate(G, cand, m, top_K, unit_costs, budget, iters, chunk=300_000,
+               conflict=None):
     cand = np.sort(np.asarray(cand))
     from itertools import combinations, chain
     combs = np.fromiter(chain.from_iterable(combinations(cand.tolist(), m)), dtype=int)
@@ -187,6 +191,12 @@ def _enumerate(G, cand, m, top_K, unit_costs, budget, iters, chunk=300_000):
     if unit_costs is not None and budget is not None and not np.isinf(budget):
         feasible = unit_costs[combs].sum(1) <= budget
         combs = combs[feasible]
+    # Spillover "No interference": keep only m-tuples that are independent sets of
+    # the conflict graph (no two members interfere). Vectorised over all pairs.
+    if conflict is not None and len(combs):
+        iu = np.triu_indices(m, k=1)
+        pair_conf = conflict[combs[:, iu[0]], combs[:, iu[1]]]   # (N, n_pairs)
+        combs = combs[~pair_conf.any(axis=1)]
     if len(combs) == 0:
         return [], 0
     losses = np.empty(len(combs))
@@ -206,15 +216,21 @@ def _cost_ok(idx_list, unit_costs, budget):
     return float(unit_costs[list(idx_list)].sum()) <= budget + 1e-12
 
 def _local_search(G, cand, m, top_K, unit_costs, budget, n_starts, rng, iters,
-                  n_kicks=4):
+                  n_kicks=4, conflict=None):
     """Multi-start best-improvement swap search with basin-hopping kicks.
 
     Returns (ranked_designs, n_distinct_subsets, consensus) where ``consensus``
     carries the multi-start diagnostics that stand in for a solver's MIP gap:
     how many independent starts converged to the incumbent, how many distinct
     local optima were seen, and the incumbent-improvement trail.
+
+    Every generated tuple is required to be both budget-feasible and an
+    independent set of ``conflict`` (the spillover "No interference" constraint).
     """
     cand = list(np.sort(np.asarray(cand)))
+
+    def _ok(S):
+        return _cost_ok(S, unit_costs, budget) and is_independent(conflict, S)
     diag = np.diag(G)
     pool: Dict[tuple, float] = {}
     work = [0]                      # total subsets scored ("simplex iterations")
@@ -237,12 +253,12 @@ def _local_search(G, cand, m, top_K, unit_costs, budget, n_starts, rng, iters,
     def greedy(start):
         S = [start]
         while len(S) < m:
-            rem = [j for j in cand if j not in S and _cost_ok(S + [j], unit_costs, budget)]
+            rem = [j for j in cand if j not in S and _ok(S + [j])]
             if not rem:
                 return None
             cands = [sorted(S + [j]) for j in rem]
             S = sorted(S + [rem[int(score(cands).argmin())]])
-        return S if _cost_ok(S, unit_costs, budget) else None
+        return S if _ok(S) else None
 
     def descend(S):
         improved = True
@@ -250,7 +266,7 @@ def _local_search(G, cand, m, top_K, unit_costs, budget, n_starts, rng, iters,
             improved = False
             moves = [sorted(S[:a] + S[a + 1:] + [j])
                      for a in range(m) for j in cand
-                     if j not in S and _cost_ok(S[:a] + S[a + 1:] + [j], unit_costs, budget)]
+                     if j not in S and _ok(S[:a] + S[a + 1:] + [j])]
             if not moves:
                 break
             L = score(moves)
@@ -266,7 +282,7 @@ def _local_search(G, cand, m, top_K, unit_costs, budget, n_starts, rng, iters,
                 free = [j for j in cand if j not in T]
                 if free:
                     T = sorted(T[:a] + T[a + 1:] + [int(rng.choice(free))])
-            if len(set(T)) == m and _cost_ok(T, unit_costs, budget):
+            if len(set(T)) == m and _ok(T):
                 return T
         return S
 
@@ -321,6 +337,7 @@ def select_treated_designs(
     iters: int = 80,
     random_state: int = 0,
     unit_index: Optional[Any] = None,
+    conflict: Optional[np.ndarray] = None,
 ) -> Dict[str, Any]:
     """Select the ``top_K`` treated m-tuples with smallest imbalance.
 
@@ -357,14 +374,28 @@ def select_treated_designs(
 
     consensus = None
     if method == "enumerate":
-        raw, n_eval = _enumerate(G, cand, m, top_K, unit_costs, budget, iters)
+        raw, n_eval = _enumerate(G, cand, m, top_K, unit_costs, budget, iters,
+                                 conflict=conflict)
         exact = True
     elif method == "heuristic":
         raw, n_eval, consensus = _local_search(G, cand, m, top_K, unit_costs,
-                                               budget, n_starts, rng, iters)
+                                               budget, n_starts, rng, iters,
+                                               conflict=conflict)
         exact = False
     else:
         raise ValueError(f"unknown method {method!r}")
+
+    # Spillover feasibility: with the "No interference" constraint active, an
+    # admissible design must be a size-m independent set of the conflict graph.
+    # If the search found none, that constraint (alone or with the budget) is
+    # infeasible -- fail loudly rather than silently returning an empty design.
+    if conflict is not None and not raw:
+        raise MlsynthConfigError(
+            f"No conflict-free treated {m}-tuple exists among the {M} candidate "
+            f"units: the spillover 'no interference' constraint admits no "
+            f"independent set of size m={m}. Reduce m, relax the cluster/adjacency "
+            f"constraint, or widen the candidate pool."
+        )
 
     # finalise weights to high precision for the returned designs
     designs: List[TreatedDesign] = []


### PR DESCRIPTION
Adds **spillover-/interference-aware treated-unit selection** to LEXSCM, implementing the two exclusion criteria from **Vives-i-Bastida (2022)** — the very paper LEXSCM is built on — so this is a faithful extension, not a novel bolt-on.

## Design: one conflict graph, two insertion points
A single symmetric **conflict graph** ("units i and j interfere") drives both stages, specified by **`cluster_col`** (two units conflict iff they share a cluster) and/or an **`adjacency`** matrix + **`spillover_threshold`** (conflict iff the entry exceeds it); the two combine via logical **OR**. The graph is built once, **aligned to the IndexSet** (the source of truth for unit identity).

| paper criterion | stage | mechanism |
|---|---|---|
| **"No interference"** (treatment) | **1** | the treated `m`-tuple must be an **independent set** — a filter on the candidate supports (where `‖w‖₀=m` already lives), *not* a term in the inner QP; only shrinks the search |
| **"Exclusion restriction"** (control) | **2** | the donor pool drops `treated ∪ N(S)`, so a treated unit's neighbours can't enter its synthetic control |

Infeasibility (no conflict-free `m`-tuple; or donors exhausted) raises `MlsynthConfigError` rather than returning a degenerate design. With neither field supplied, behaviour is **identical** to the unconstrained search.

## Touchpoints (8 files, +730/−20)
- `conflict.py` (new): the IndexSet-aligned conflict-matrix builder + independent-set / neighbour helpers.
- `config.py`: `cluster_col`, `adjacency`, `spillover_threshold` (validated).
- `lexsearch.py`: independent-set filter in `_enumerate` + gated greedy/descend/kick in `_local_search` + feasibility presolve.
- `fast_scm_control{,_helpers}.py`: `exclude_idx = N(S)` widens the donor exclusion; assertion extended.
- `lexscm.py`: builds the graph, threads it to both stages.

## Tests — the bejeesus (34 new, all green)
Conflict builder (cluster↔clique, adjacency array + **DataFrame realignment** + threshold, combined OR, IndexSet alignment, symmetry, **every error path**); Stage-1 independence under **both** exact enumeration *and* the heuristic, **empty-graph ≡ unconstrained**, infeasibility, budget composition; Stage-2 neighbours-zeroed / emptied-pool → `None` / baseline-match; end-to-end LEXSCM across cluster + adjacency × **str/int unit ids** (distinct treated clusters, donors disjoint from treated clusters, infeasibility, and the #27 label invariant under spillover).

**Existing LEXSCM suites: 108 passed (zero regression).** Docs: a "Spillover / interference exclusions" section + a worked regions example.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_