### PR TITLE
seq_sdid: warn on donor-starved cohorts that bias the pooled event study

### DIFF
--- a/docs/seq_sdid.rst
+++ b/docs/seq_sdid.rst
@@ -288,6 +288,22 @@ underdetermined; the practical recommendation is to use canonical
 :class:`SDID` for those panels and reserve Sequential SDiD for genuine
 staggered designs with multiple sizable cohorts.
 
+A second requirement is *donor balance*. Each treated cohort :math:`a` is
+balanced only against the cohorts adopting after it (:math:`j > a`) plus any
+never-treated cohort, so it needs at least **two** such donor cohorts to
+balance even a rank-one interactive fixed effect — matching a one-dimensional
+loading and the intercept spans :math:`(1, \lambda)`. With a single donor the
+sum-to-one constraint forces :math:`\omega = [1]` and the cohort effect
+collapses to an unbalanced DiD, biased whenever the loadings differ; that bias
+also cascades backward through the sequential imputation. On a *noiseless*
+rank-one factor the estimator recovers the effect **exactly** for every cohort
+that is balanced, and the entire residual bias is attributable to the
+donor-starved late cohorts. Because the latest cohorts are the most exposed
+(the default ``a_max`` is the last adopting cohort), :meth:`SequentialSDID.fit`
+emits a :class:`UserWarning` naming any donor-starved cohort and the largest
+``a_max`` that keeps every estimated cohort balanced — report, don't silently
+relax.
+
 Core API
 --------
 

--- a/mlsynth/estimators/seq_sdid.py
+++ b/mlsynth/estimators/seq_sdid.py
@@ -93,6 +93,16 @@ class SequentialSDID:
     single-treated-unit panels the algorithm still runs but the formal
     efficiency results don't apply.
 
+    Each treated cohort's counterfactual is balanced against the cohorts that
+    adopt *after* it (plus any never-treated cohort). A cohort therefore needs
+    at least two such donor cohorts to balance even a rank-one interactive
+    fixed effect -- with a single donor its effect collapses to an unbalanced
+    DiD and is biased under interactive fixed effects, a bias that also
+    cascades backward through the sequential imputation. The latest cohorts are
+    the most exposed; ``fit()`` emits a :class:`UserWarning` naming any
+    donor-starved cohort and the largest ``a_max`` that keeps every estimated
+    cohort balanced.
+
     References
     ----------
     Arkhangelsky, D., & Samkov, A. (2025). "Sequential Synthetic Difference

--- a/mlsynth/tests/test_seq_sdid.py
+++ b/mlsynth/tests/test_seq_sdid.py
@@ -7,6 +7,8 @@ Reference: Arkhangelsky & Samkov (2025), arXiv:2404.00164v2.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -15,6 +17,7 @@ from mlsynth import SequentialSDID
 from mlsynth.config_models import SequentialSDIDConfig
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 from mlsynth.utils.seq_sdid_helpers.algorithm import (
+    _warn_donor_starved_cohorts,
     pooled_event_study,
     run_sequential_sdid,
 )
@@ -301,3 +304,99 @@ class TestPublicAPI:
         r1 = SequentialSDID(cfg_dict).fit()
         r2 = SequentialSDID(cfg_obj).fit()
         assert np.allclose(r1.event_study.tau, r2.event_study.tau)
+
+
+# ---------------------------------------------------------------------------
+# Donor-balance diagnostic + the exact-recovery property it protects
+# ---------------------------------------------------------------------------
+
+def _rank1_ife_panel(
+    *, adoptions, n_never=30, n_per_cohort=6, T=40, seed=3, true_effect=0.0
+) -> pd.DataFrame:
+    """Noiseless rank-1 interactive-FE panel: y = a_i + b_t + lambda_i f_t.
+
+    With no idiosyncratic noise, Sequential SDiD must recover the planted
+    effect *exactly* for every cohort whose donor pool can span the
+    one-dimensional loading -- the property the donor-balance diagnostic
+    guards. ``f_t`` is a bounded (stationary) factor so the recovery does not
+    rely on a trend.
+    """
+    rng = np.random.default_rng(seed)
+    f = np.sin(np.linspace(0, 8, T)) + 0.4 * np.cos(np.linspace(0, 15, T))
+    lam = np.linspace(-2, 2, len(adoptions) * n_per_cohort + n_never)
+    rng.shuffle(lam)
+    records, uid, li = [], 0, 0
+    cohorts = [(a, n_per_cohort) for a in adoptions] + [(None, n_never)]
+    for adoption, n in cohorts:
+        for _ in range(n):
+            L = lam[li]; li += 1
+            for t in range(T):
+                y = 3.0 + 0.05 * t + L * f[t]
+                treated = int(adoption is not None and t >= adoption)
+                if treated:
+                    y += true_effect
+                records.append({"unit": uid, "year": t, "y": y, "treat": treated})
+            uid += 1
+    return pd.DataFrame(records)
+
+
+class TestDonorBalanceDiagnostic:
+    """A donor-starved late cohort biases the pooled estimate; we must warn."""
+
+    def test_exact_recovery_when_all_cohorts_balanced(self):
+        # Many cohorts; cap a_max so every estimated cohort keeps >= 2 donors.
+        df = _rank1_ife_panel(adoptions=list(range(20, 32)), true_effect=0.0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any donor warning would fail here
+            res = SequentialSDID({
+                "df": df, "outcome": "y", "treat": "treat", "unitid": "unit",
+                "time": "year", "mode": "ssdid", "eta": 1e-3, "K": 4,
+                "a_max": 26, "n_bootstrap": 0, "display_graphs": False,
+            }).fit()
+        # Noiseless rank-1 IFE, balanced donors -> machine-exact zero effect.
+        assert np.allclose(res.event_study.tau, 0.0, atol=1e-6)
+
+    def test_warns_and_names_starved_cohort_and_fix(self):
+        df = _rank1_ife_panel(adoptions=list(range(20, 32)))
+        with pytest.warns(UserWarning, match="fewer than 2 donor cohorts"):
+            res = SequentialSDID({
+                "df": df, "outcome": "y", "treat": "treat", "unitid": "unit",
+                "time": "year", "mode": "ssdid", "eta": 1e-3, "K": 4,
+                "n_bootstrap": 0, "display_graphs": False,
+            }).fit()
+        # The starved tail biases the pooled estimate away from zero.
+        assert not np.allclose(res.event_study.tau, 0.0, atol=1e-6)
+
+    def test_no_warning_when_capped(self):
+        df = _rank1_ife_panel(adoptions=list(range(20, 32)))
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            SequentialSDID({
+                "df": df, "outcome": "y", "treat": "treat", "unitid": "unit",
+                "time": "year", "mode": "ssdid", "eta": 1e-3, "K": 4,
+                "a_max": 26, "n_bootstrap": 0, "display_graphs": False,
+            }).fit()
+        assert not [w for w in caught
+                    if "donor cohorts" in str(w.message)]
+
+
+class TestWarnDonorStarvedHelper:
+    """Unit-level coverage of the warning helper's branches."""
+
+    def test_empty_is_noop(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _warn_donor_starved_cohorts({})
+
+    def test_no_starved_is_silent(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _warn_donor_starved_cohorts({10: 3, 12: 2})
+
+    def test_suggests_a_max_when_some_balanced(self):
+        with pytest.warns(UserWarning, match="Lower a_max to 12"):
+            _warn_donor_starved_cohorts({10: 3, 12: 2, 18: 1})
+
+    def test_suggests_adding_donors_when_all_starved(self):
+        with pytest.warns(UserWarning, match="Add later-adopting"):
+            _warn_donor_starved_cohorts({18: 1, 20: 1})

--- a/mlsynth/utils/seq_sdid_helpers/algorithm.py
+++ b/mlsynth/utils/seq_sdid_helpers/algorithm.py
@@ -12,12 +12,23 @@ the estimator its name.
 
 from __future__ import annotations
 
+import warnings
 from typing import Dict, Tuple
 
 import numpy as np
 
 from .structures import SeqSDIDCohortEffect
 from .weights import solve_time_qp, solve_unit_qp
+
+# A treated cohort needs at least this many donor cohorts (later-adopting plus
+# never-treated) for the unit-weight QP to balance even a rank-1 interactive
+# fixed effect: matching a one-dimensional loading plus the intercept spans
+# ``(1, lambda)``, which requires two affinely-independent donors. With a single
+# donor the sum-to-one constraint forces ``omega = [1]`` and the cohort effect
+# collapses to an unbalanced DiD against that lone donor -- biased whenever the
+# factor loadings differ. We surface that as a diagnostic rather than silently
+# averaging the biased cohort into the pooled event study.
+_MIN_DONORS_FOR_BALANCE = 2
 
 
 def run_sequential_sdid(
@@ -79,6 +90,9 @@ def run_sequential_sdid(
     A_to_idx = {int(period): col for col, period in zip(treated_indices_sorted, treated_periods_sorted)}
 
     cohort_effects: Dict[Tuple[int, int], SeqSDIDCohortEffect] = {}
+    # donor count per estimated cohort (constant across k; donors are the
+    # cohorts adopting strictly after a, plus never-treated).
+    donor_counts: Dict[int, int] = {}
 
     for k in range(K + 1):
         for a in range(a_min, a_max + 1):
@@ -107,6 +121,7 @@ def run_sequential_sdid(
             )
             if donor_cols.size == 0:
                 continue
+            donor_counts.setdefault(a, int(donor_cols.size))
 
             Y_pre_donors = Y[:pre_end, donor_cols]                # (pre_end, J)
             y_pre_treated = Y[:pre_end, a_col]                    # (pre_end,)
@@ -134,7 +149,47 @@ def run_sequential_sdid(
                 # counterfactual (Algorithm 1, line 7).
                 Y[event_period, a_col] = Y[event_period, a_col] - tau
 
+    _warn_donor_starved_cohorts(donor_counts)
+
     return Y, cohort_effects
+
+
+def _warn_donor_starved_cohorts(donor_counts: Dict[int, int]) -> None:
+    """Warn if any estimated cohort lacks enough donors to balance the factor.
+
+    Donor-starved late cohorts cannot balance their factor loadings, so their
+    effects reduce to an unbalanced DiD and bias the pooled event study (the
+    bias also cascades backward through the sequential imputation). We report
+    which cohorts are affected and the largest ``a_max`` that keeps every
+    estimated cohort balanced -- the minimal fix -- without silently dropping
+    them, mirroring the library's report-don't-relax stance.
+    """
+    if not donor_counts:
+        return
+    starved = sorted(a for a, n in donor_counts.items()
+                     if n < _MIN_DONORS_FOR_BALANCE)
+    if not starved:
+        return
+    balanced = [a for a, n in donor_counts.items()
+                if n >= _MIN_DONORS_FOR_BALANCE]
+    detail = ", ".join(f"{a} ({donor_counts[a]} donor"
+                       f"{'s' if donor_counts[a] != 1 else ''})"
+                       for a in starved)
+    if balanced:
+        fix = (f"Lower a_max to {max(balanced)} (the latest cohort with at "
+               f"least {_MIN_DONORS_FOR_BALANCE} donors)")
+    else:
+        fix = ("Add later-adopting or never-treated donor cohorts, or estimate "
+               "fewer horizons")
+    warnings.warn(
+        "Sequential SDiD: treated cohort(s) "
+        f"{detail} have fewer than {_MIN_DONORS_FOR_BALANCE} donor cohorts "
+        "(later-adopting plus never-treated). Their effects reduce to an "
+        "unbalanced DiD and can bias the pooled event study under interactive "
+        f"fixed effects. {fix}.",
+        UserWarning,
+        stacklevel=2,
+    )
 
 
 def pooled_event_study(


### PR DESCRIPTION
## What & why

This came out of investigating whether `SequentialSDID` reproduces Arkhangelsky & Samkov (2025). It does — **the estimator is correct.** A noiseless rank-1 interactive-FE sanity check (the exact structure the paper targets) shows it recovers the effect to **machine-exact precision** for every treated cohort that has ≥2 donor cohorts. Capping `a_max` to exclude the donor-starved tail turns a biased pooled `[0.045…0.21]` into a clean `[0,0,0,0,0]`.

The investigation surfaced a real **UX gap (not a bug):** a treated cohort is balanced only against cohorts adopting *after* it (plus any never-treated cohort). Matching a one-dimensional loading and the intercept spans `(1, λ)`, so a cohort needs **at least two** such donors. With a single donor the sum-to-one constraint forces `ω = [1]` and the cohort effect collapses to an **unbalanced DiD** — biased whenever the loadings differ, a bias that also **cascades backward** through the sequential imputation. Because the default `a_max` is the last adopter, the most exposed cohorts are estimated by default and can silently bias the pooled event study (it even fires on the existing test fixtures — cohort 21, 1 donor).

## The change

- `run_sequential_sdid` records each estimated cohort's donor count and emits **one itemized `UserWarning`** naming the starved cohort(s) and the largest `a_max` that keeps every estimated cohort balanced — *report, don't relax*, mirroring the feasibility-diagnostics stance from #33:
  > Sequential SDiD: treated cohort(s) 32 (1 donor) have fewer than 2 donor cohorts (later-adopting plus never-treated). Their effects reduce to an unbalanced DiD and can bias the pooled event study under interactive fixed effects. Lower a_max to 31 (the latest cohort with at least 2 donors).
- A **noiseless rank-1 IFE regression guard** establishing the property the diagnostic protects (balanced → machine-exact recovery; residual bias entirely attributable to the starved tail).
- 7 new tests (warns / silent-when-capped / helper branches / exact recovery), all passing. `algorithm.py` at 94% (only pre-existing defensive guards uncovered); result contract intact.
- Documents the requirement in the estimator `Notes` and the docs `Limitations` section.

## Scope

Estimator hardening only — no result-contract or benchmark changes. The SEQ_SDID Path-B benchmark (which this investigation de-risked) is a separate workstream/PR.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_