### PR TITLE
benchmarks: Sequential SDiD Path-B (calibrated-panel coverage Monte Carlo)

### DIFF
--- a/benchmarks/cases/seq_sdid_mc.py
+++ b/benchmarks/cases/seq_sdid_mc.py
@@ -1,0 +1,117 @@
+"""Sequential SDiD Path-B: the calibrated-panel coverage/RMSE Monte Carlo.
+
+Path B (Monte Carlo, scenario 1 -- paper only). Reproduces the *geometry* of
+Arkhangelsky & Samkov (2025) Table 1 (Section 5.2.2, "Experiment 2: Calibrated
+State-Level Panel"): under an interactive-fixed-effects violation of parallel
+trends with adoption correlated to the leading factor loading,
+
+  * the **standard DiD** estimator (the eta -> infinity / Remark-2.2 limit,
+    ``mode="sdid_imputation"``) is severely biased and its 95% CIs
+    **under-cover** -- the paper reports coverage collapsing to ~0.70; and
+  * **Sequential SDiD** (``mode="ssdid"``) is approximately unbiased with
+    coverage near the nominal 0.95 and lower RMSE.
+
+We have the paper only -- no replication code, and the authors' CPS women's
+log-wage panel is not public -- so the DGP is re-implemented from the paper's
+description in the reusable :mod:`mlsynth.utils.seq_sdid_helpers.simulate`
+helper (a rank-one differential-trend IFE; structural truth fixed, only the
+AR(2) shocks redrawn per draw; units replicated x4 as in Section 5.2.1). The
+*standard-DiD comparator is the same estimator at eta -> infinity*, exactly the
+paper's "Original Results" line (Figure 1), so both arms share the Bayesian
+bootstrap and the comparison is apples-to-apples.
+
+Donor balance: a treated cohort needs >= 2 later-adopting / never-treated donor
+cohorts to balance its loading, so the design caps ``a_max`` at the
+``donor_tail``-th-latest cohort; the paper's many-cohort regime avoids
+starvation by construction.
+
+Determinism: structural seed 2024; per-draw shock seeds ``8000 + m`` for
+``M = 40`` draws; bootstrap seed 7 with ``B = 50`` -- fully reproducible.
+
+Provenance: arXiv:2404.00164v2, Section 5.2.2, Table 1 and Figures 4-5.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+# Locked parameters (calibrated to the paper's qualitative regime).
+_TAU = 1.0          # planted constant effect
+_K = 4              # horizons 0..4
+_M = 40             # Monte-Carlo draws (paper: 1000)
+_B = 50             # bootstrap reps per fit (paper: 100)
+_ETA = 0.05         # finite SSDiD penalty (eta -> inf gives the DiD comparator)
+_STRUCT_SEED = 2024
+_BOOT_SEED = 7
+
+
+def _fit(df, mode, a_max):
+    from mlsynth import SequentialSDID
+    res = SequentialSDID({
+        "df": df, "outcome": "y", "treat": "treat", "unitid": "unit",
+        "time": "year", "mode": mode, "eta": _ETA, "K": _K, "a_max": a_max,
+        "n_bootstrap": _B, "seed": _BOOT_SEED, "display_graphs": False,
+    }).fit()
+    return res.event_study.tau, res.event_study.ci
+
+
+def run() -> dict:
+    from mlsynth.utils.seq_sdid_helpers.simulate import (
+        calibrate_staggered_ife,
+        simulate_replication,
+    )
+
+    design = calibrate_staggered_ife(seed=_STRUCT_SEED)
+
+    arms = ("ssdid", "sdid_imputation")
+    sq = {m: [] for m in arms}      # squared error per draw, per horizon
+    cov = {m: [] for m in arms}     # coverage indicator per draw, per horizon
+    bias = {m: [] for m in arms}    # signed error per draw, per horizon
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for m in range(_M):
+            df = simulate_replication(
+                design, np.random.default_rng(8000 + m), tau=_TAU)
+            for mode in arms:
+                tau_hat, ci = _fit(df, mode, design.a_max)
+                sq[mode].append((tau_hat - _TAU) ** 2)
+                cov[mode].append(
+                    ((ci[:, 0] <= _TAU) & (_TAU <= ci[:, 1])).astype(float))
+                bias[mode].append(tau_hat - _TAU)
+
+    out = {"n_draws": float(_M), "n_cohorts": float(design.n_cohorts),
+           "a_max": float(design.a_max)}
+    for mode in arms:
+        rmse = float(np.sqrt(np.mean(sq[mode])))
+        coverage = float(np.mean(cov[mode]))
+        abs_bias = float(np.mean(np.abs(np.mean(bias[mode], axis=0))))
+        tag = "ssdid" if mode == "ssdid" else "did"
+        out[f"{tag}_mean_coverage"] = coverage
+        out[f"{tag}_mean_rmse"] = rmse
+        out[f"{tag}_mean_abs_bias"] = abs_bias
+    # Headline contrasts (the paper's "DiD severely biased, SSDiD reliable").
+    out["coverage_gap"] = out["ssdid_mean_coverage"] - out["did_mean_coverage"]
+    return out
+
+
+# Deterministic (fixed structural + shock + bootstrap seeds) => exact re-runs.
+# The cells reproduce Table 1's geometry at a small M: Sequential SDiD coverage
+# is near the nominal 0.95 while standard DiD collapses well below it (paper
+# ~0.70; this reconstruction lands ~0.4-0.5 because its differential-trend
+# violation is sharper than the CPS calibration), and SSDiD's bias is several
+# times smaller. Tolerances are wide enough to absorb the gap to the paper's
+# M = 1000 / B = 100 (coverage SE ~ sqrt(p(1-p)/(M*5)) ~ 0.03) and tight enough
+# to catch a regression that flips the geometry (e.g. SSDiD under-covering or
+# DiD recovering nominal coverage).
+EXPECTED = {
+    "n_draws": (40.0, 0.0),
+    "ssdid_mean_coverage": (0.945, 0.085),  # near nominal; fails below ~0.86
+    "did_mean_coverage": (0.45, 0.16),      # collapsed; fails above ~0.61
+    "ssdid_mean_abs_bias": (0.062, 0.055),  # ~unbiased
+    "did_mean_abs_bias": (0.305, 0.13),     # severely biased
+    "ssdid_mean_rmse": (0.252, 0.09),
+    "did_mean_rmse": (0.346, 0.11),
+    "coverage_gap": (0.495, 0.18),          # SSDiD covers, DiD does not
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -10,6 +10,7 @@ CASES = {
     "sdid_prop99": "benchmarks.cases.sdid_prop99",      # cross-val vs causaltensor
     "mcnnm_prop99": "benchmarks.cases.mcnnm_prop99",    # cross-val vs causaltensor
     "spsydid_state_mc": "benchmarks.cases.spsydid_state_mc",  # cross-val vs authors' repo
+    "seq_sdid_mc": "benchmarks.cases.seq_sdid_mc",            # Path B: SSDiD vs DiD coverage/RMSE
     "clustersc_subgroups": "benchmarks.cases.clustersc_subgroups",      # Path B: ClusterSC vs RSC
     "clustersc_subgroups_ref": "benchmarks.cases.clustersc_subgroups_ref",  # cross-val vs authors' repo
     "clustersc_rpca_germany": "benchmarks.cases.clustersc_rpca_germany",  # Path A: RPCA-SC West Germany

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -11,11 +11,10 @@ from the paper's simulation section ("Path B"), or matching the
 output of an authoritative reference implementation
 ("cross-validation").
 
-This page catalogues those replications. Thirty-two of the
-thirty-six estimators are currently fully verified, three carry
+This page catalogues those replications. Thirty-three of the
+thirty-six estimators are currently fully verified, and three carry
 partial replications (one-draw illustrations or empirical
-applications without an explicit number-match), and one has no
-replication content yet.
+applications without an explicit number-match).
 
 * The :ref:`replications-canonical` section covers the workhorse
   SC variants you would reach for first.
@@ -54,6 +53,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    replications/sdid
    replications/mcnnm
    replications/spsydid
+   replications/seq_sdid
    replications/clustersc
    replications/lexscm
    replications/scmo
@@ -306,6 +306,19 @@ Staggered adoption
   the reference. **Path B:** the paper's staggered AR(1)-factor DGP
   (Section 3) -- the event-time ATT path :math:`\tau = 1 + e` is
   recovered, using all units (including not-yet-treated) as donors.
+* :doc:`seq_sdid` -- Arkhangelsky & Samkov (2025) Sequential
+  Synthetic DiD. **Path B:** the Section-5.2.2 calibrated-panel
+  Monte Carlo (Table 1) reconstructed from the paper's description
+  (the authors' CPS log-wage panel is not public) -- under an
+  interactive-fixed-effects violation of parallel trends, standard
+  DiD's 95% CI coverage collapses (:math:`\approx 0.45`, paper
+  :math:`\approx 0.70`) while Sequential SDiD stays near nominal
+  (:math:`0.945`) with roughly five-times-smaller bias and lower
+  RMSE -- the paper's "DiD severely biased, Sequential SDiD reliable"
+  headline (durable: ``seq_sdid_mc``). A noiseless rank-one IFE
+  corollary pins exact machine-precision recovery for every
+  donor-balanced cohort.
+  → dedicated page: :doc:`replications/seq_sdid`.
 
 .. _replications-missing:
 
@@ -434,9 +447,9 @@ Coverage summary
      - 2
      - Complete (FMA, TASC)
    * - Staggered adoption
-     - 4
      - 5
-     - SDID, SpSyDiD, PPSCM, SSC ✓; SEQ_SDID queued
+     - 5
+     - Complete (SDID, SpSyDiD, PPSCM, SSC, SEQ_SDID)
    * - Spillover-aware (donor screening)
      - 1
      - 1
@@ -454,12 +467,11 @@ Coverage summary
      - 5
      - Complete (LEXSCM, MAREX, SYNDES, PANGEO, SPCD)
 
-Of mlsynth's 36 estimators, 32 (89%) carry a strong or solid
+Of mlsynth's 36 estimators, 33 (92%) carry a strong or solid
 replication against their source paper or against an
 authoritative reference implementation. ISCM, NSC, and
 SPARSE_SC carry partial replications -- one-draw illustrations
-or empirical applications without an explicit number-match --
-and SEQ_SDID is the single estimator still in queue.
+or empirical applications without an explicit number-match.
 
 Contributing a replication
 --------------------------

--- a/docs/replications/seq_sdid.rst
+++ b/docs/replications/seq_sdid.rst
@@ -1,0 +1,143 @@
+.. _replication-seq_sdid:
+
+SEQ_SDID — Sequential Synthetic DiD (Arkhangelsky & Samkov 2025)
+================================================================
+
+:Estimator: :doc:`../seq_sdid` — :class:`mlsynth.SequentialSDID`
+:Source: Arkhangelsky, D. & Samkov, A. (2025), *"Sequential Synthetic
+   Difference in Differences,"* arXiv:2404.00164v2.
+:Replication type: **Path B** — the paper's Monte Carlo (Section 5.2.2,
+   "Experiment 2: Calibrated State-Level Panel"; Table 1 and Figures 4-5).
+:Status: **Verified (geometry)** — the headline coverage/RMSE contrast is
+   reproduced; the exact Table-1 cells require the authors' (non-public) CPS
+   panel.
+
+Validation strategy
+-------------------
+
+The paper's central empirical claim is about *inference*: when parallel trends
+fail because adoption timing is correlated with unobserved interactive fixed
+effects, **standard difference-in-differences is severely biased and its
+confidence intervals under-cover**, whereas **Sequential SDiD stays
+approximately unbiased with near-nominal coverage**. Table 1 quantifies this on
+a state-by-year panel calibrated to March-CPS women's log wages: 95% CI
+coverage of ~0.95 for Sequential SDiD against ~0.70 for DiD, with lower RMSE at
+every lag.
+
+That panel is not public, so the cells cannot be matched value-for-value.
+Instead we re-implement the *design* from the paper's description (scenario 1,
+paper only) and reproduce its **geometry**: the same qualitative ranking and an
+even sharper version of the same coverage collapse.
+
+A convenient feature of the method makes the comparison airtight: the paper's
+standard-DiD comparator is *the same estimator at* :math:`\eta \to \infty` (the
+"Original Results" line in Figure 1; the stacked-DiD limit of Remark 2.2),
+exposed as ``mode="sdid_imputation"``. Both arms therefore share the Bayesian
+bootstrap and differ only in the weighting.
+
+The data-generating process
+---------------------------
+
+The DGP is packaged in
+:mod:`mlsynth.utils.seq_sdid_helpers.simulate`. Following the paper's recipe:
+
+* **Structural truth is fixed, only shocks are redrawn.** The authors freeze
+  the estimated structural components (two-way FE plus a low-rank interactive
+  fixed effect) and generate new draws by resampling the idiosyncratic AR
+  shocks. :func:`~mlsynth.utils.seq_sdid_helpers.simulate.calibrate_staggered_ife`
+  draws the structure once; each draw of
+  :func:`~mlsynth.utils.seq_sdid_helpers.simulate.simulate_replication` redraws
+  only the AR(2) noise. This is what makes the within-panel bootstrap a valid
+  measure of the sampling variability the Monte Carlo averages.
+* **The IFE is a differential linear trend** — the canonical rank-one
+  interactive fixed effect, :math:`\lambda_i \, f_t` with :math:`f_t = t/T`.
+  Adoption is tilted toward high-loading (steeper-trending) units, so treatment
+  timing is correlated with the unobserved trend. DiD assumes a common trend
+  and is biased; Sequential SDiD balances the loading against later-adopting
+  and never-treated donors and is not.
+* **Cohorts are enlarged** by replicating each unit four times (Section 5.2.1),
+  so cohort aggregates concentrate.
+* **Only donor-balanced cohorts are estimated.** A cohort needs at least two
+  later / never-treated donor cohorts to balance its loading, so ``a_max`` is
+  capped to the sixth-latest cohort (the latest cohorts are donor-starved — see
+  the estimator's :doc:`../seq_sdid` "Limitations").
+
+Reproducing Table 1's geometry
+------------------------------
+
+.. code-block:: python
+
+   import warnings
+   import numpy as np
+   from mlsynth import SequentialSDID
+   from mlsynth.utils.seq_sdid_helpers.simulate import (
+       calibrate_staggered_ife, simulate_replication)
+
+   design = calibrate_staggered_ife(seed=2024)
+   tau, K, M, B = 1.0, 4, 40, 50
+
+   def fit(df, mode):
+       res = SequentialSDID({"df": df, "outcome": "y", "treat": "treat",
+           "unitid": "unit", "time": "year", "mode": mode, "eta": 0.05,
+           "K": K, "a_max": design.a_max, "n_bootstrap": B, "seed": 7,
+           "display_graphs": False}).fit()
+       return res.event_study.tau, res.event_study.ci
+
+   cov = {"ssdid": [], "sdid_imputation": []}
+   with warnings.catch_warnings():
+       warnings.simplefilter("ignore")
+       for m in range(M):
+           df = simulate_replication(design, np.random.default_rng(8000 + m), tau=tau)
+           for mode in cov:
+               tau_hat, ci = fit(df, mode)
+               cov[mode].append(((ci[:, 0] <= tau) & (tau <= ci[:, 1])).mean())
+   print("SSDiD coverage", np.mean(cov["ssdid"]))
+   print("DiD   coverage", np.mean(cov["sdid_imputation"]))
+
+Results
+-------
+
+At :math:`M = 40` draws, :math:`B = 50` bootstrap reps (the paper uses
+:math:`M = 1000`, :math:`B = 100`):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 22 22 22
+
+   * - Metric
+     - Sequential SDiD
+     - Standard DiD
+     - Paper (SSDiD / DiD)
+   * - 95% CI coverage
+     - 0.945
+     - 0.45
+     - ~0.95 / ~0.70
+   * - mean :math:`|\mathrm{bias}|`
+     - 0.062
+     - 0.305
+     - —
+   * - RMSE
+     - 0.252
+     - 0.346
+     - SSDiD < DiD
+
+What it confirms
+----------------
+
+* **Sequential SDiD delivers valid inference** — coverage 0.945, essentially
+  the nominal 0.95 — under an IFE violation that breaks DiD.
+* **Standard DiD's coverage collapses** to 0.45 and its bias is about five
+  times larger; its CIs are unreliable in exactly the regime the method
+  targets. (The collapse is sharper than the paper's ~0.70 because the
+  reconstructed differential-trend violation is stronger than the CPS
+  calibration; the *direction and ranking* are the paper's.)
+* **Sequential SDiD has lower RMSE**, the second half of Table 1's finding.
+
+A noiseless corollary, pinned in ``test_seq_sdid.py``, underlies the result:
+on a noiseless rank-one IFE the estimator recovers the effect to machine
+precision for every donor-balanced cohort, so the design's reliability is not a
+tolerance artifact.
+
+The durable check lives in ``benchmarks/cases/seq_sdid_mc.py``::
+
+   python benchmarks/run_benchmarks.py --case seq_sdid_mc

--- a/docs/seq_sdid.rst
+++ b/docs/seq_sdid.rst
@@ -304,6 +304,21 @@ emits a :class:`UserWarning` naming any donor-starved cohort and the largest
 ``a_max`` that keeps every estimated cohort balanced — report, don't silently
 relax.
 
+Verification
+------------
+
+**Path B** — the paper's Section-5.2.2 calibrated-panel Monte Carlo (Table 1)
+is reconstructed from its description (the authors' CPS log-wage panel is not
+public). Under an interactive-fixed-effects violation of parallel trends with
+adoption correlated to the leading loading, standard DiD's 95% CI coverage
+collapses (:math:`\approx 0.45`; paper :math:`\approx 0.70`) while Sequential
+SDiD stays near nominal (:math:`0.945`) with roughly five-times-smaller bias
+and lower RMSE — the paper's "DiD severely biased, Sequential SDiD reliable"
+result. A noiseless rank-one IFE corollary pins exact machine-precision
+recovery for every donor-balanced cohort. The durable check is
+``benchmarks/cases/seq_sdid_mc.py``; see the dedicated replication page,
+:doc:`replications/seq_sdid`, for the design, code, and the full table.
+
 Core API
 --------
 

--- a/mlsynth/tests/test_seq_sdid_simulation.py
+++ b/mlsynth/tests/test_seq_sdid_simulation.py
@@ -1,0 +1,82 @@
+"""Coverage tests for mlsynth.utils.seq_sdid_helpers.simulate (pure DGP).
+
+The DGP backs the Path-B benchmark ``seq_sdid_mc``; these tests exercise its
+structure (determinism, staggered/absorbing treatment, donor-balance cap)
+without invoking the estimator.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.utils.seq_sdid_helpers.simulate import (
+    _NEVER,
+    _ar2_noise,
+    CalibratedDesign,
+    calibrate_staggered_ife,
+    simulate_replication,
+)
+
+
+def test_ar2_noise_shape_burn_and_determinism():
+    a = _ar2_noise(20, 5, (0.5, -0.1), 1.0, np.random.default_rng(0))
+    b = _ar2_noise(20, 5, (0.5, -0.1), 1.0, np.random.default_rng(0))
+    assert a.shape == (20, 5)
+    assert np.all(np.isfinite(a))
+    np.testing.assert_array_equal(a, b)        # seeded => identical
+
+
+def test_calibrate_returns_design_with_consistent_counts():
+    d = calibrate_staggered_ife(seed=2024)
+    assert isinstance(d, CalibratedDesign)
+    assert d.base.shape == (d.T, d.S)
+    assert d.n_treated + d.n_never == d.S
+    assert d.n_treated > 0 and d.n_never > 0
+    # a_max caps below the latest adopting cohort so donors remain.
+    treated_dates = sorted({int(a) for a in d.adopt if a != _NEVER})
+    assert d.a_max <= treated_dates[-1]
+    assert d.n_cohorts == len(treated_dates)
+
+
+def test_calibrate_is_deterministic():
+    d1 = calibrate_staggered_ife(seed=7)
+    d2 = calibrate_staggered_ife(seed=7)
+    np.testing.assert_array_equal(d1.base, d2.base)
+    np.testing.assert_array_equal(d1.adopt, d2.adopt)
+    assert d1.a_max == d2.a_max
+
+
+def test_calibrate_few_cohorts_falls_back_to_first():
+    # donor_tail >= number of cohorts exercises the ``else treated_dates[0]`` arm.
+    d = calibrate_staggered_ife(seed=1, n_cohorts_span=3, donor_tail=50)
+    treated_dates = sorted({int(a) for a in d.adopt if a != _NEVER})
+    assert d.a_max == treated_dates[0]
+
+
+def test_simulate_replication_shape_and_absorbing_treatment():
+    d = calibrate_staggered_ife(seed=2024)
+    df = simulate_replication(d, np.random.default_rng(0), tau=1.0, n_copies=3)
+    assert set(df.columns) == {"unit", "year", "y", "treat"}
+    assert df["unit"].nunique() == d.S * 3
+    assert df["year"].nunique() == d.T
+    # treatment is staggered and absorbing within every unit.
+    for _, g in df.sort_values("year").groupby("unit"):
+        tr = g["treat"].to_numpy()
+        assert tr.tolist() == sorted(tr.tolist())   # non-decreasing 0..1
+    # at least one never-treated unit (all-zero treat) exists.
+    per_unit_max = df.groupby("unit")["treat"].max()
+    assert (per_unit_max == 0).any() and (per_unit_max == 1).any()
+
+
+def test_simulate_replication_effect_shifts_treated_cells():
+    d = calibrate_staggered_ife(seed=2024)
+    rng_seed = 123
+    base = simulate_replication(d, np.random.default_rng(rng_seed), tau=0.0)
+    bumped = simulate_replication(d, np.random.default_rng(rng_seed), tau=5.0)
+    # Same noise draw (same seed) => treated cells differ by exactly tau, others equal.
+    treated = bumped["treat"] == 1
+    np.testing.assert_allclose(
+        (bumped.loc[treated, "y"] - base.loc[treated, "y"]).to_numpy(), 5.0)
+    np.testing.assert_allclose(
+        bumped.loc[~treated, "y"].to_numpy(), base.loc[~treated, "y"].to_numpy())

--- a/mlsynth/utils/seq_sdid_helpers/simulate.py
+++ b/mlsynth/utils/seq_sdid_helpers/simulate.py
@@ -1,0 +1,193 @@
+"""Data-generating process for the Sequential SDiD Path-B benchmark.
+
+Re-implements the *design* of Arkhangelsky & Samkov (2025), Section 5.2.2
+("Experiment 2: Calibrated State-Level Panel") from the paper's description --
+we have the paper only (no replication code, and the authors' CPS women's
+log-wage panel is not public), so this is a faithful reconstruction of the
+**model**, not a port of their exact calibrated panel.
+
+The paper's recipe, and how each piece maps here:
+
+* **Structural truth treated as fixed.** The authors decompose a real
+  state-by-year panel into a two-way fixed-effects part (~94% of variation), a
+  low-rank interactive-fixed-effects (IFE) part (~5%), and an AR idiosyncratic
+  remainder, then *freeze* the structural components and redraw only the
+  shocks. We mirror that: :func:`calibrate_staggered_ife` draws the structural
+  truth **once** (unit/time FE + a rank-one interactive fixed effect), and
+  :func:`simulate_replication` redraws only the AR(2) idiosyncratic noise per
+  replication. Fixing the structure is what makes the bootstrap -- which only
+  resamples units within one panel -- a valid measure of the sampling
+  variability the Monte Carlo averages over.
+
+* **A parallel-trends violation correlated with treatment timing.** We use the
+  canonical rank-one IFE: a *differential linear trend* (loading ``lambda_i``
+  on the rising factor ``f_t = t / T``). Adoption is tilted toward high-loading
+  units (steeper trends), so treated and comparison units have systematically
+  different unobserved trends -- exactly the IFE confounding the paper induces
+  by tying adoption to the leading factor loading. Standard DiD assumes a
+  common trend and is therefore biased; Sequential SDiD balances the loading
+  using later-adopting / never-treated donors and is not.
+
+* **Large cohorts.** The paper replicates each unit four times (Section 5.2.1)
+  so cohort aggregates concentrate and the low-noise asymptotics apply. We
+  expose ``n_copies`` (default 4) and do the same.
+
+* **Donor balance.** A cohort needs at least two later-adopting / never-treated
+  donor cohorts to balance even a rank-one loading; the latest cohorts are
+  donor-starved. :func:`calibrate_staggered_ife` reports ``a_max`` -- the
+  largest cohort that keeps a healthy donor pool -- so the benchmark estimates
+  only well-balanced cohorts (the paper's many-cohort regime avoids starvation
+  by construction).
+
+Inferred / not-pinned-by-the-paper details (scenario-1 disclosure): the exact
+panel dimensions, the IFE rank (we use the minimal rank one), the
+adoption-probability link, the trend magnitude, and the replication count's
+interaction with the cohort spread are calibrated here to land in the paper's
+qualitative regime, not read from their data.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+
+_NEVER = 10**9  # adoption sentinel for never-treated units
+
+
+@dataclass(frozen=True)
+class CalibratedDesign:
+    """Fixed structural truth for the calibrated state-panel design.
+
+    Parameters
+    ----------
+    base : np.ndarray
+        ``(T, S)`` noise-free structural mean ``alpha_i + beta_t +
+        trend_strength * (t / T) * lambda_i`` -- unit/time FE plus the
+        rank-one differential-trend interactive fixed effect.
+    adopt : np.ndarray
+        Length-``S`` adoption period (0-based time index) per unit;
+        never-treated units carry the sentinel ``_NEVER``.
+    a_max : int
+        Largest treated cohort (1-based time index, matching the estimator's
+        ``a_max`` config) that still has a healthy donor pool. Estimating up to
+        here keeps every cohort donor-balanced.
+    T, S, T0 : int
+        Periods, units, and the first possible adoption period.
+    n_treated, n_never, n_cohorts : int
+        Counts describing the realized staggered design.
+    """
+
+    base: np.ndarray
+    adopt: np.ndarray
+    a_max: int
+    T: int
+    S: int
+    T0: int
+    n_treated: int
+    n_never: int
+    n_cohorts: int
+
+
+def calibrate_staggered_ife(
+    *,
+    seed: int = 2024,
+    S: int = 90,
+    T: int = 48,
+    T0: int = 18,
+    n_cohorts_span: int = 16,
+    trend_strength: float = 2.8,
+    p_slope: float = 3.4,
+    adopt_slope: float = 4.5,
+    adopt_sd: float = 2.5,
+    donor_tail: int = 6,
+) -> CalibratedDesign:
+    """Draw the fixed structural truth once (FE + rank-one differential trend).
+
+    The leading loading ``lambda_i`` both sets each unit's trend slope and tilts
+    its adoption (probability rises with ``lambda_i`` via a logistic link, and
+    adoption *time* rises with it too), so treatment timing is correlated with
+    the unobserved trend -- the parallel-trends violation. ``a_max`` is capped to
+    the ``donor_tail``-th-latest cohort so the estimated cohorts keep enough
+    later / never-treated donors to balance the loading.
+    """
+    rng = np.random.default_rng(seed)
+    alpha = rng.normal(0.0, 1.0, S)             # unit FE
+    beta = np.linspace(0.0, 1.0, T)             # common time trend (FE)
+    lam = rng.normal(0.0, 1.0, S)               # trend loading
+    f = np.arange(T) / T                        # rising factor, f_t = t / T
+    base = alpha[None, :] + beta[:, None] + trend_strength * np.outer(f, lam)
+
+    z = (lam - lam.mean()) / lam.std()
+    p = 1.0 / (1.0 + np.exp(-(p_slope * z)))    # ever-treated probability
+    ever = rng.random(S) < p
+
+    adopt = np.full(S, _NEVER, dtype=int)
+    lo, hi = T0, T0 + n_cohorts_span - 1
+    mid = (lo + hi) // 2
+    for j in range(S):
+        if ever[j]:
+            a = int(round(mid + adopt_slope * z[j] + rng.normal(0.0, adopt_sd)))
+            adopt[j] = min(max(a, lo), hi)
+
+    treated_dates = sorted({int(a) for a in adopt if a != _NEVER})
+    a_max = (treated_dates[-donor_tail]
+             if len(treated_dates) > donor_tail else treated_dates[0])
+
+    return CalibratedDesign(
+        base=base,
+        adopt=adopt,
+        a_max=int(a_max),
+        T=T,
+        S=S,
+        T0=T0,
+        n_treated=int((adopt != _NEVER).sum()),
+        n_never=int((adopt == _NEVER).sum()),
+        n_cohorts=len(treated_dates),
+    )
+
+
+def simulate_replication(
+    design: CalibratedDesign,
+    rng: np.random.Generator,
+    *,
+    tau: float = 1.0,
+    n_copies: int = 4,
+    ar: Tuple[float, float] = (0.5, -0.1),
+    sigma: float = 1.0,
+) -> pd.DataFrame:
+    """One Monte-Carlo draw: fixed structure + fresh AR(2) shocks + effect.
+
+    Each structural unit is replicated ``n_copies`` times (same FE, loading and
+    adoption, independent noise) to enlarge cohorts, and a constant effect
+    ``tau`` is added to every treated post-period cell. Returns the long panel
+    (``unit, year, y, treat``) the estimator consumes.
+    """
+    base, adopt, T, S = design.base, design.adopt, design.T, design.S
+    n_total = S * n_copies
+    y = np.repeat(base, n_copies, axis=1) + _ar2_noise(T, n_total, ar, sigma, rng)
+    treat = np.zeros((T, n_total), dtype=int)
+    adv = np.repeat(adopt, n_copies)
+    for u in range(n_total):
+        if adv[u] != _NEVER:
+            y[adv[u]:, u] += tau
+            treat[adv[u]:, u] = 1
+    return pd.DataFrame({
+        "unit": np.repeat(np.arange(n_total), T),
+        "year": np.tile(np.arange(T), n_total),
+        "y": y.T.ravel(),
+        "treat": treat.T.ravel(),
+    })
+
+
+def _ar2_noise(
+    T: int, n: int, ar: Tuple[float, float], sigma: float,
+    rng: np.random.Generator, burn: int = 50,
+) -> np.ndarray:
+    """Stationary AR(2) idiosyncratic noise, shape ``(T, n)``, with burn-in."""
+    e = np.zeros((T + burn, n))
+    innov = rng.normal(0.0, sigma, size=(T + burn, n))
+    for t in range(2, T + burn):
+        e[t] = ar[0] * e[t - 1] + ar[1] * e[t - 2] + innov[t]
+    return e[burn:]


### PR DESCRIPTION
**Stacked on #34** (base = `claude/seq-sdid-donor-diagnostic`). GitHub will auto-retarget this to `main` once #34 merges, leaving only the benchmark commit. Review/merge #34 first.

## What

The durable **Path-B** replication for **SEQ_SDID** — the last estimator in the library with no replication content. Reproduces the geometry of Arkhangelsky & Samkov (2025) **Table 1** (Section 5.2.2, "Calibrated State-Level Panel"):

| Metric | Sequential SDiD | Standard DiD | Paper |
|---|---|---|---|
| 95% CI coverage | **0.945** | **0.45** | ~0.95 / ~0.70 |
| mean \|bias\| | 0.062 | 0.305 | — |
| RMSE | 0.252 | 0.346 | SSDiD < DiD |

Under an interactive-fixed-effects violation of parallel trends with adoption correlated to the leading loading, **standard DiD's CI coverage collapses while Sequential SDiD stays near nominal with ~5× smaller bias and lower RMSE** — the paper's "DiD severely biased, Sequential SDiD reliable" headline.

## How (scenario 1 — paper only)

The authors' CPS women's log-wage panel isn't public, so the DGP is re-implemented from the paper's description in a reusable helper, `seq_sdid_helpers/simulate.py`:

- a **rank-1 differential-trend IFE** (the canonical parallel-trends violation);
- **structural truth fixed, only AR(2) shocks redrawn** per draw — the paper's "treat estimated components as fixed, resample shocks" device, and what makes the within-panel bootstrap a valid coverage measure (this was the key fix — redrawing structure per draw inflates variance the bootstrap can't see);
- units **replicated ×4** (Section 5.2.1) so cohort aggregates concentrate;
- `a_max` **capped to donor-balanced cohorts** (see #34 — the donor-starved tail is where bias enters).

The standard-DiD comparator is *the same estimator at η→∞* (the paper's Figure-1 "Original Results" line), so both arms share the Bayesian bootstrap — an apples-to-apples comparison.

## Determinism & checks

- Fully seeded (structural seed 2024; shock seeds `8000+m`; bootstrap seed 7; `M=40`, `B=50`) → exact re-runs. `python benchmarks/run_benchmarks.py --case seq_sdid_mc` passes.
- `simulate.py` at **100%** coverage via `test_seq_sdid_simulation.py`.
- Dedicated `docs/replications/seq_sdid.rst`; catalogue + estimator-page Verification pointer updated (now **33/36 verified**, staggered family complete).

A noiseless rank-1 IFE corollary (pinned in #34's tests) underlies the result: the estimator recovers the effect to machine precision for every donor-balanced cohort, so the coverage is not a tolerance artifact.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_