### PR TITLE
benchmarks: graduate FSCM (Prop 99) and PDA (Hong Kong, all 3 methods) to durable cases

### DIFF
--- a/benchmarks/cases/fscm_prop99.py
+++ b/benchmarks/cases/fscm_prop99.py
@@ -1,0 +1,58 @@
+"""FSCM Path-A: Forward-Selected Synthetic Control on Proposition 99.
+
+Path A (empirical, scenario: the canonical ADH panel). Cerulli (2024)'s
+forward-selected synthetic control greedily grows the donor set, choosing its
+size by cross-validated RMSPE. On California's Proposition 99 tobacco panel it
+selects a small donor pool whose pre-period fit beats the full-pool synthetic
+control. This makes that result durable (it previously lived only in the
+catalogue / test suite).
+
+Outcome-only matching on the shipped ``basedata/smoking_data.csv``; the fit is
+deterministic, so the cells below are exact re-runs.
+
+Provenance: Cerulli (2024), forward-selected SC; the ADH Proposition 99 panel.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import pandas as pd
+
+_DATA = os.path.join(
+    os.path.dirname(__file__), "..", "..", "basedata", "smoking_data.csv")
+
+
+def run() -> dict:
+    from mlsynth import FSCM
+
+    d = pd.read_csv(os.path.abspath(_DATA))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = FSCM({
+            "df": d, "outcome": "cigsale", "treat": "Proposition 99",
+            "unitid": "state", "time": "year", "display_graphs": False,
+        }).fit()
+
+    diag = res.diagnostics
+    import numpy as np
+    return {
+        "att": float(res.att),
+        "pre_r_squared": float(diag["pre_r_squared"]),
+        "cv_rmspe_at_optimum": float(diag["cv_rmspe_at_optimum"]),
+        "cv_rmspe_full_pool": float(diag["cv_rmspe_full_pool"]),
+        "n_donors_selected": float((np.asarray(res.weights_vector) > 1e-6).sum()),
+    }
+
+
+# Deterministic (greedy selection + CV, no RNG) => exact re-runs. FSCM selects a
+# three-donor pool whose cross-validated RMSPE (1.61) roughly halves the
+# full-pool baseline (2.92), with a strong pre-period fit (R^2 ~ 0.97) and the
+# canonical Proposition 99 effect (ATT -20.15).
+EXPECTED = {
+    "att": (-20.15, 0.6),
+    "pre_r_squared": (0.970, 0.02),
+    "cv_rmspe_at_optimum": (1.605, 0.15),
+    "cv_rmspe_full_pool": (2.916, 0.25),
+    "n_donors_selected": (3.0, 1.0),
+}

--- a/benchmarks/cases/pda_hongkong.py
+++ b/benchmarks/cases/pda_hongkong.py
@@ -1,0 +1,78 @@
+"""PDA Path-A: the Hong Kong / CEPA handover study (Hsiao-Ching-Wan; Shi-Wang).
+
+Path A (empirical, scenario: the authors' canonical application + data). The
+panel data approach is validated on the Hsiao, Ching & Wan (2012) Hong Kong
+study -- the effect of the 2004 Closer Economic Partnership Arrangement (CEPA)
+with mainland China on Hong Kong's quarterly YoY real GDP growth (1 treated unit,
+24 controls, T1 = 44). Shi & Wang (L2-relaxation, arXiv) revisit it in their
+Appendix E.1: the L2-relaxation panel data approach estimates a CEPA effect of
+**+2.65%** with t-statistic **8.35**, decisively rejecting the no-effect null.
+
+This runs all three of mlsynth's PDA methods -- L2-relaxation (``l2``), the
+LASSO PDA (``LASSO``) and forward selection (``fs``; Shi & Huang 2023) -- on the
+shipped ``basedata/HongKong.csv`` (the HCW panel). All three recover a positive,
+highly significant CEPA effect; the L2 estimate (2.48%) lands close to the
+paper's 2.65%, the small gap reflecting the L2-relaxation tuning. The fit is
+deterministic, so the cells below are exact re-runs.
+
+Provenance: Shi & Wang, *"L2-Relaxation for Economic Prediction,"* Appendix E.1
+(Table E.1 and the L2 headline); Hsiao, Ching & Wan (2012) for the study/data.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import numpy as np
+
+_DATA = os.path.join(
+    os.path.dirname(__file__), "..", "..", "basedata", "HongKong.csv")
+
+
+def _fit(method):
+    from mlsynth import PDA
+    import pandas as pd
+
+    d = pd.read_csv(os.path.abspath(_DATA))
+    res = PDA({
+        "df": d, "outcome": "GDP", "treat": "Integration",
+        "unitid": "Country", "time": "Time", "method": method,
+        "display_graphs": False,
+    }).fit()
+    att = float(res.att)
+    lo = res.inference.ci_lower
+    se = (att - float(lo)) / 1.96 if lo is not None else float("nan")
+    return att, (att / se if se else float("nan")), float(res.inference.p_value)
+
+
+def run() -> dict:
+    out = {}
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        atts = {}
+        for method in ("l2", "LASSO", "fs"):
+            key = method.lower()
+            att, t, p = _fit(method)
+            atts[key] = (att, p)
+            out[f"{key}_ate_pct"] = att * 100.0         # GDP is decimal growth
+            out[f"{key}_pvalue"] = p
+        out["l2_abs_tstat"] = abs(_fit("l2")[1])
+        # All methods agree the CEPA effect is positive and significant.
+        out["n_methods_positive_sig"] = float(sum(
+            1 for a, p in atts.values() if a > 0 and p < 0.01))
+    return out
+
+
+# Deterministic (convex L2 / greedy fs / fixed-grid LASSO, no RNG) => exact
+# re-runs. All three PDA methods recover a positive, highly significant CEPA
+# effect on Hong Kong's GDP growth; the L2-relaxation estimate (2.48%) reproduces
+# the paper's +2.65% (t ~ 7.7 vs 8.35) -- the small gap is the L2 tuning. The
+# LASSO and forward-selection estimates (3.3%, 3.9%) bracket it.
+EXPECTED = {
+    "l2_ate_pct": (2.48, 0.5),                 # paper L2: 2.65%
+    "lasso_ate_pct": (3.30, 0.6),
+    "fs_ate_pct": (3.95, 0.7),
+    "l2_pvalue": (0.0, 0.01),                  # rejects no-effect null
+    "l2_abs_tstat": (7.75, 1.5),               # paper L2: 8.35
+    "n_methods_positive_sig": (3.0, 0.0),      # all three agree
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -40,6 +40,7 @@ CASES = {
     "masc_basque": "benchmarks.cases.masc_basque",            # Path A: MASC Basque/ETA (KMPT Sec 5)
     "tasc_mc": "benchmarks.cases.tasc_mc",                    # Path B: TASC vs SC state-space ablation (Rho et al.)
     "fscm_prop99": "benchmarks.cases.fscm_prop99",            # Path A: forward-selected SC (Prop 99)
+    "pda_hongkong": "benchmarks.cases.pda_hongkong",          # Path A: PDA methods on HK CEPA (Shi-Wang App E.1)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -39,6 +39,7 @@ CASES = {
     "vanillasc_prop99": "benchmarks.cases.vanillasc_prop99",  # Path A: canonical ADH 2010 Prop 99
     "masc_basque": "benchmarks.cases.masc_basque",            # Path A: MASC Basque/ETA (KMPT Sec 5)
     "tasc_mc": "benchmarks.cases.tasc_mc",                    # Path B: TASC vs SC state-space ablation (Rho et al.)
+    "fscm_prop99": "benchmarks.cases.fscm_prop99",            # Path A: forward-selected SC (Prop 99)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -251,7 +251,13 @@ High-dimensional donor pools
   :math:`\max |\Delta| = 5.76 \times 10^{-4}`.
 * :doc:`pda` -- Shi & Huang (2023) panel data approach.
   **Path A:** Hong Kong economic integration (HCW 24-economy
-  panel, quarterly GDP growth). **Path B:** Table 1
+  panel, quarterly GDP growth) -- all three methods recover a
+  positive, highly significant CEPA effect, with the
+  L2-relaxation estimate (2.48%, :math:`t \approx 7.7`)
+  reproducing Shi & Wang's Appendix-E.1 headline of
+  :math:`+2.65\%` (:math:`t = 8.35`); LASSO and forward
+  selection bracket it at 3.3% and 3.9% (durable:
+  ``pda_hongkong``). **Path B:** Table 1
   forward-selection vs. LASSO at 300 reps -- size = 0.047 vs.
   the paper's :math:`\approx 0.05`; power = 0.98 at D5 vs.
   :math:`1.0`.

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -259,7 +259,7 @@ High-dimensional donor pools
   Proposition 99 --
   :math:`\widehat{\mathrm{ATT}} = -20.15`,
   pre-:math:`R^2 = 0.970`, CV RMSPE :math:`= 1.605` vs. the
-  full-pool baseline 2.916.
+  full-pool baseline 2.916 (durable: ``fscm_prop99``).
 * :doc:`sparse_sc` -- Sparse SC. **Path A:** California
   Proposition 99 with an over-rich augmented predictor set, with
   conformal inference -- the L1 penalty prunes to 6 of 33 predictors


### PR DESCRIPTION
## What

Graduates two more estimators' validations from prose/tests into runnable durable benchmark cases.

### `fscm_prop99` — Path A
Forward-selected SC (Cerulli 2024) on the ADH Proposition 99 panel. Reproduces the catalogue cells exactly: **ATT −20.15, pre-R² 0.970, CV RMSPE 1.605** at the 3-donor optimum vs the 2.92 full-pool baseline. Deterministic, 38s.

### `pda_hongkong` — Path A
Validates **all three PDA methods** (L2-relaxation, LASSO, forward selection) on the HCW Hong Kong panel against **Shi & Wang's Appendix E.1**. Each recovers a positive, highly significant CEPA effect on HK GDP growth; the L2 estimate (**2.48%, t~7.7**) reproduces the paper's **+2.65% (t 8.35)**, with LASSO/fs bracketing at 3.3%/3.9%. Deterministic, 4s.

## Notes on the others in this round (not included)

While scoping, I confirmed these are genuine reconstruction projects, not quick graduations:

- **BVSS** — the full 3000-iteration MCMC on the 87-donor China panel times out past 9 min; needs a deliberate fast-MCMC config to be a practical durable case.
- **MLSC** — the catalogue's `+0.011930 / λ=1.970185` is a placebo cross-validation against Bottmer's reference implementation at a specific DGP/seed; doing it right means running the `leabottmer` reference to emit a dump (the `NSC.R` pattern).
- **PDA luxury-watch (E.2)** — the shipped `china_watches` panel isn't in the paper's YoY-growth / T1=24 form, so PDA gives −3.4% not the paper's −27.92% without re-deriving the series.
- **PDA Table-1 size/power (Path B)** — I extracted the fsPDA sparse DGP from the repo; a self-contained size/power simulation is feasible as a follow-up.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_