### PR TITLE
benchmarks: graduate MLSC cross-validation to a durable case (mlsc_bottmer)

### DIFF
--- a/benchmarks/cases/mlsc_bottmer.py
+++ b/benchmarks/cases/mlsc_bottmer.py
@@ -1,0 +1,112 @@
+"""Cross-validation: mlsynth ``MLSC`` vs the author's ``mlSC_estimator``.
+
+Matches mlsynth's multi-level SC engine against the reference implementation of
+Bottmer (2024/2025) -- the ``multi-level-sc-estimator`` repository
+(https://github.com/leabottmer/multi-level-sc-estimator) -- cell by cell on the
+hierarchical-factor DGP from the author's README. Both estimators solve the same
+penalized state-county program (classical-SC warm start, block penalty matrix
+``Q``, heuristic penalty :math:`\\lambda = 2\\sigma^2_\\varepsilon/\\sigma^2_y`)
+with ``cvxpy`` + ``SCS``, so they agree to solver precision.
+
+The README DGP is :func:`mlsynth.utils.mlsc_helpers.simulation.simulate_mlsc_sample`
+(``N_s = 10`` states, ``C_s = 10`` counties, ``T = 20``), which feeds *both*
+sides: the reference takes the raw ``(data_s, data_c, idx, n_c, t, w_c)`` arrays,
+mlsynth takes the equivalent long ``df_agg`` / ``df_disagg`` frames. No treatment
+effect is injected, so the true ATT is zero and Path B is an unbiasedness check.
+
+* **Path A** (one draw, ``rng=default_rng(42)``): the selected penalty and the
+  reported ATT match the reference -- ``dtau`` is solver noise on the ATT,
+  ``dlambda`` is machine precision on the penalty.
+* **Path B** (``M = 200`` draws): both estimators are unbiased for the true zero
+  ATT and stay in near-machine agreement throughout (worst-case ``|dtau|``).
+
+Provenance / scenario
+---------------------
+* Full repo (scenario 3): cross-validation is mandatory and done here.
+* Reference: ``multi-level-sc-estimator`` pinned at commit ``0fb2639``; solves
+  with ``cvxpy`` + ``SCS`` (open source). Its unused top-level ``import ray`` is
+  stubbed by the clone helper.
+* The case **skips gracefully** (``BenchmarkSkipped``) when the reference clone
+  or its deps are unavailable.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+SEED_A = 42      # Path A: the README's exact panel
+M = 200          # Path B: independent draws
+
+
+def _ml_fit(sample):
+    from mlsynth import MLSC
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return MLSC({
+            "df_agg": sample.df_agg, "df_disagg": sample.df_disagg,
+            "outcome": "y", "time": "time", "treat": "treated",
+            "unitid_agg": "state", "unitid_disagg": "county",
+            "agg_id": "state", "lambda_est": "heuristic",
+            "display_graphs": False,
+        }).fit()
+
+
+def run() -> dict:
+    from benchmarks.compare import BenchmarkSkipped
+    from benchmarks.reference.clone_mlsc import import_mlsc
+    from mlsynth.utils.mlsc_helpers.simulation import simulate_mlsc_sample
+
+    ref = import_mlsc()
+    mlSC_estimator = ref.mlSC_estimator
+
+    def ref_tau_lambda(sample):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            try:
+                tau, lam, _ = mlSC_estimator(
+                    sample.data_s, sample.data_c, sample.idx,
+                    sample.n_c, sample.t, sample.w_c, lambda_est="heuristic",
+                )
+            except Exception as exc:  # pragma: no cover - reference solve failure
+                raise BenchmarkSkipped(f"reference mlSC_estimator failed: {exc}")
+        return float(tau), float(lam)
+
+    # --- Path A: the README panel, value for value -----------------------
+    s = simulate_mlsc_sample(rng=np.random.default_rng(SEED_A))
+    tau_ref_a, lam_ref_a = ref_tau_lambda(s)
+    res_a = _ml_fit(s)
+    out = {
+        "path_a_dtau": float(abs(res_a.att - tau_ref_a)),
+        "path_a_dlambda": float(abs(res_a.design.lambda_used - lam_ref_a)),
+    }
+
+    # --- Path B: M independent draws, unbiasedness + agreement -----------
+    tau_ref = np.empty(M)
+    tau_ml = np.empty(M)
+    for i in range(M):
+        si = simulate_mlsc_sample(rng=np.random.default_rng(i))
+        tau_ref[i], _ = ref_tau_lambda(si)
+        tau_ml[i] = float(_ml_fit(si).att)
+
+    out["path_b_max_dtau"] = float(np.abs(tau_ml - tau_ref).max())
+    out["path_b_mean_ml"] = float(tau_ml.mean())
+    out["path_b_rmse_ml"] = float(np.sqrt((tau_ml ** 2).mean()))
+    out["path_b_drmse"] = float(
+        abs(np.sqrt((tau_ml ** 2).mean()) - np.sqrt((tau_ref ** 2).mean()))
+    )
+    return out
+
+
+# Two independent implementations of the same penalized program on a shared DGP.
+# The cross-validation cells (dtau/dlambda/max_dtau/drmse) pin the agreement to
+# SCS solver precision; the unbiasedness cell pins the deterministic M=200 mean,
+# which sits within one MC SE (sigma/sqrt(200) ~ 0.012) of the true zero ATT.
+EXPECTED = {
+    "path_a_dtau": (0.0, 5e-3),        # measured 1.5e-6 (ATT solver noise)
+    "path_a_dlambda": (0.0, 1e-6),     # measured 4.4e-16 (machine precision)
+    "path_b_max_dtau": (0.0, 5e-3),    # measured 5.76e-4 (worst of 200)
+    "path_b_mean_ml": (-0.0103, 0.02), # ~0; |bias| < 1 MC SE
+    "path_b_rmse_ml": (0.1662, 0.02),  # matches reference RMSE
+    "path_b_drmse": (0.0, 2e-3),       # ml vs ref RMSE agreement
+}

--- a/benchmarks/reference/clone_mlsc.py
+++ b/benchmarks/reference/clone_mlsc.py
@@ -1,0 +1,71 @@
+"""On-demand clone of the Bottmer (2024/2025) multi-level SC reference repo.
+
+The author's implementation
+(https://github.com/leabottmer/multi-level-sc-estimator) is a small pip
+package (``multi-levelSC``), but to keep the cross-check reproducible and free
+of an extra install we clone it at a pinned commit into a local cache and import
+``multi_level_sc_estimator.mlSC`` -- exposing ``mlSC_estimator`` -- from there.
+If git or the network is unavailable the benchmark skips gracefully.
+
+The reference solves the penalized state-county program with ``cvxpy`` + ``SCS``
+(open source -- no commercial solver required). Its module imports ``ray`` at
+top level but never uses it, so we stub ``ray`` to avoid that optional, heavy
+dependency.
+
+The pinned commit (``_COMMIT``) freezes the reference so the cross-check is
+reproducible; bump it deliberately, never silently.
+"""
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+import types
+from pathlib import Path
+from types import ModuleType
+
+from benchmarks.compare import BenchmarkSkipped
+
+_REPO = "https://github.com/leabottmer/multi-level-sc-estimator.git"
+_COMMIT = "0fb26391a21840085d7cb4d7b1aa257e7360f9ea"
+_CACHE = Path(__file__).resolve().parent / ".cache" / "multi-level-sc-estimator"
+
+
+def _ensure_clone() -> Path:
+    """Clone (or reuse) the reference repo pinned at ``_COMMIT``. Returns its path."""
+    marker = _CACHE / "multi_level_sc_estimator" / "mlSC.py"
+    if marker.exists():
+        return _CACHE
+    _CACHE.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            ["git", "-c", "credential.helper=", "clone", "--quiet", _REPO, str(_CACHE)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(_CACHE), "checkout", "--quiet", _COMMIT],
+            check=True, capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:  # pragma: no cover
+        detail = getattr(exc, "stderr", b"")
+        msg = detail.decode(errors="ignore").strip() if detail else str(exc)
+        raise BenchmarkSkipped(
+            f"could not clone reference repo {_REPO} @ {_COMMIT[:7]}: {msg}"
+        ) from exc
+    if not marker.exists():  # pragma: no cover - defensive
+        raise BenchmarkSkipped("reference clone missing multi_level_sc_estimator/mlSC.py")
+    return _CACHE
+
+
+def import_mlsc() -> ModuleType:
+    """Import the author's ``mlSC`` module (exposes ``mlSC_estimator``)."""
+    root = _ensure_clone()
+    # ``ray`` is imported at module top but never used; stub it so the optional
+    # dependency is not required.
+    sys.modules.setdefault("ray", types.ModuleType("ray"))
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    try:
+        return importlib.import_module("multi_level_sc_estimator.mlSC")
+    except Exception as exc:  # pragma: no cover - import-time deps (cvxpy/scs)
+        raise BenchmarkSkipped(f"could not import reference mlSC module: {exc}")

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -41,6 +41,7 @@ CASES = {
     "tasc_mc": "benchmarks.cases.tasc_mc",                    # Path B: TASC vs SC state-space ablation (Rho et al.)
     "fscm_prop99": "benchmarks.cases.fscm_prop99",            # Path A: forward-selected SC (Prop 99)
     "pda_hongkong": "benchmarks.cases.pda_hongkong",          # Path A: PDA methods on HK CEPA (Shi-Wang App E.1)
+    "mlsc_bottmer": "benchmarks.cases.mlsc_bottmer",          # cross-val vs Bottmer's mlSC_estimator (skips if absent)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/docs/mlsc.rst
+++ b/docs/mlsc.rst
@@ -845,6 +845,11 @@ The Monte Carlo standard error of the mean at :math:`M = 200` is
 :math:`\hat\lambda` does not introduce systematic bias, and ``mlsynth``
 and the reference impl produce statistically identical samples.
 
+Both checks are wired as the durable benchmark ``mlsc_bottmer``, which
+clones the author's repository (pinned commit ``0fb2639``) at run time,
+runs both estimators on the README DGP, and skips gracefully when the
+reference or its dependencies are unavailable.
+
 Empirical application
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -244,12 +244,16 @@ High-dimensional donor pools
   coverage for all three estimands where a single-source CI drops to
   :math:`63\%`.
   → dedicated page: :doc:`replications/clustersc`.
-* :doc:`mlsc` -- Bottmer (2024) multi-level SC. **Path A:**
-  matched to the reference implementation on the README DGP --
-  :math:`\widehat{\mathrm{ATT}} = +0.011930`,
-  :math:`\lambda = 1.970185`, equal to six decimals.
-  **Path B:** 200 independent draws,
-  :math:`\max |\Delta| = 5.76 \times 10^{-4}`.
+* :doc:`mlsc` -- Bottmer (2024) multi-level SC.
+  **Cross-validation** against the author's ``mlSC_estimator``
+  (``multi-level-sc-estimator``, pinned commit ``0fb2639``) on the
+  README hierarchical-factor DGP. **Path A** (one draw):
+  :math:`\widehat{\mathrm{ATT}} = +0.011930` vs the reference
+  :math:`+0.011928`, :math:`\lambda = 1.970185` to machine precision.
+  **Path B** (200 independent draws): both unbiased for the true zero
+  ATT and in near-machine agreement, :math:`\max |\Delta| = 5.76
+  \times 10^{-4}`. The case clones the reference at run time and skips
+  gracefully when it is unavailable (durable: ``mlsc_bottmer``).
 * :doc:`pda` -- Shi & Huang (2023) panel data approach.
   **Path A:** Hong Kong economic integration (HCW 24-economy
   panel, quarterly GDP growth) -- all three methods recover a


### PR DESCRIPTION
## What

Closes the MLSC gap from the earlier triage. MLSC's replication matched the author's reference *numerically*, but the check lived only in `docs/mlsc.rst` as a live example that imports the author's package — so it wasn't a re-runnable CI guard. This promotes it to a durable cross-validation case, mirroring the existing reference-clone pattern (`linf_crossval_ref` / `clone_linfinitysc`).

You gave me the reference repo: https://github.com/leabottmer/multi-level-sc-estimator

## The case

- **`benchmarks/reference/clone_mlsc.py`** — clones the reference at pinned commit `0fb2639` into the gitignored `.cache`, stubs the unused top-level `import ray`, and imports `multi_level_sc_estimator.mlSC`. Skips gracefully (`BenchmarkSkipped`) when git/network/deps are unavailable (verified the skip path fires on a bad URL).
- **`benchmarks/cases/mlsc_bottmer.py`** — runs mlsynth `MLSC` and the reference `mlSC_estimator` on the README hierarchical-factor DGP (`simulate_mlsc_sample`, the same generator that feeds both sides):

| | result | tol |
|---|---|---|
| Path A `dtau` (seed 42) | 1.5e-6 | 5e-3 |
| Path A `dlambda` | 4.4e-16 | 1e-6 |
| Path B `max|dtau|` (200 draws) | 5.76e-4 | 5e-3 |
| Path B `mean_ml` (unbiased, true ATT=0) | −0.0103 | 0.02 |
| Path B `rmse_ml` (= reference) | 0.1662 | 0.02 |

These reproduce the docs Verification numbers exactly. Two independent implementations of the same penalized state-county program (cvxpy/SCS both sides) agreeing to solver precision.

- **registry**: `mlsc_bottmer` registered; the docs catalogue entry + `docs/mlsc.rst` Verification now point at the durable case.

Runs in ~18s on a fresh clone; the cloned repo is gitignored under `.cache`.

## Not in scope
The Section-5.2 cross-validation-over-time λ-selector is still unimplemented in mlsynth (the reference has `get_lambda_cv`); this case validates the heuristic-λ path the docs already cover. That selector remains a separate feature item.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_