### PR TITLE
mlsc: implement the Section-5.2 cross-validation-over-time penalty selector

### DIFF
--- a/benchmarks/cases/mlsc_bottmer.py
+++ b/benchmarks/cases/mlsc_bottmer.py
@@ -16,7 +16,10 @@ effect is injected, so the true ATT is zero and Path B is an unbiasedness check.
 
 * **Path A** (one draw, ``rng=default_rng(42)``): the selected penalty and the
   reported ATT match the reference -- ``dtau`` is solver noise on the ATT,
-  ``dlambda`` is machine precision on the penalty.
+  ``dlambda`` is machine precision on the penalty. The ``path_a_cv_*`` cells
+  repeat the check for ``lambda_est="cross-validation"`` (the Section-5.2
+  rolling selector, a port of the reference ``get_lambda_cv``): both pick the
+  same grid penalty (316.23) and agree on the ATT.
 * **Path B** (``M = 200`` draws): both estimators are unbiased for the true zero
   ATT and stay in near-machine agreement throughout (worst-case ``|dtau|``).
 
@@ -39,7 +42,7 @@ SEED_A = 42      # Path A: the README's exact panel
 M = 200          # Path B: independent draws
 
 
-def _ml_fit(sample):
+def _ml_fit(sample, lambda_est="heuristic"):
     from mlsynth import MLSC
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -47,7 +50,7 @@ def _ml_fit(sample):
             "df_agg": sample.df_agg, "df_disagg": sample.df_disagg,
             "outcome": "y", "time": "time", "treat": "treated",
             "unitid_agg": "state", "unitid_disagg": "county",
-            "agg_id": "state", "lambda_est": "heuristic",
+            "agg_id": "state", "lambda_est": lambda_est,
             "display_graphs": False,
         }).fit()
 
@@ -60,13 +63,13 @@ def run() -> dict:
     ref = import_mlsc()
     mlSC_estimator = ref.mlSC_estimator
 
-    def ref_tau_lambda(sample):
+    def ref_tau_lambda(sample, lambda_est="heuristic"):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             try:
                 tau, lam, _ = mlSC_estimator(
                     sample.data_s, sample.data_c, sample.idx,
-                    sample.n_c, sample.t, sample.w_c, lambda_est="heuristic",
+                    sample.n_c, sample.t, sample.w_c, lambda_est=lambda_est,
                 )
             except Exception as exc:  # pragma: no cover - reference solve failure
                 raise BenchmarkSkipped(f"reference mlSC_estimator failed: {exc}")
@@ -80,6 +83,16 @@ def run() -> dict:
         "path_a_dtau": float(abs(res_a.att - tau_ref_a)),
         "path_a_dlambda": float(abs(res_a.design.lambda_used - lam_ref_a)),
     }
+
+    # --- Cross-validation-over-time path: the Section-5.2 selector --------
+    # mlsynth's ``lambda_est="cross-validation"`` ports the reference
+    # ``get_lambda_cv``; on the seed-42 panel both pick the same grid penalty.
+    tau_ref_cv, lam_ref_cv = ref_tau_lambda(s, lambda_est="cross-validation")
+    res_cv = _ml_fit(s, lambda_est="cross-validation")
+    out["path_a_cv_dtau"] = float(abs(res_cv.att - tau_ref_cv))
+    out["path_a_cv_lambda_rel"] = float(
+        abs(res_cv.design.lambda_used - lam_ref_cv) / max(lam_ref_cv, 1e-12)
+    )
 
     # --- Path B: M independent draws, unbiasedness + agreement -----------
     tau_ref = np.empty(M)
@@ -99,12 +112,15 @@ def run() -> dict:
 
 
 # Two independent implementations of the same penalized program on a shared DGP.
-# The cross-validation cells (dtau/dlambda/max_dtau/drmse) pin the agreement to
-# SCS solver precision; the unbiasedness cell pins the deterministic M=200 mean,
-# which sits within one MC SE (sigma/sqrt(200) ~ 0.012) of the true zero ATT.
+# The agreement cells (dtau/dlambda/cv/max_dtau/drmse) pin mlsynth to the
+# reference to SCS solver precision under both the heuristic and the
+# cross-validation penalty paths; the unbiasedness cell pins the deterministic
+# M=200 mean, within one MC SE (sigma/sqrt(200) ~ 0.012) of the true zero ATT.
 EXPECTED = {
     "path_a_dtau": (0.0, 5e-3),        # measured 1.5e-6 (ATT solver noise)
     "path_a_dlambda": (0.0, 1e-6),     # measured 4.4e-16 (machine precision)
+    "path_a_cv_dtau": (0.0, 5e-3),     # CV path: ATT agrees (measured ~1e-6)
+    "path_a_cv_lambda_rel": (0.0, 0.3),  # same grid penalty (316.23); 0.3 allows 1 grid step
     "path_b_max_dtau": (0.0, 5e-3),    # measured 5.76e-4 (worst of 200)
     "path_b_mean_ml": (-0.0103, 0.02), # ~0; |bias| < 1 MC SE
     "path_b_rmse_ml": (0.1662, 0.02),  # matches reference RMSE

--- a/docs/mlsc.rst
+++ b/docs/mlsc.rst
@@ -198,7 +198,7 @@ dependency.
 Selecting :math:`\lambda`: Heuristic and Fixed Modes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Two penalty-selection rules are exposed via
+Three penalty-selection rules are exposed via
 :class:`mlsynth.config_models.MLSCConfig.lambda_est`:
 
 * ``'heuristic'`` — the closed-form rule from Section 5.2 of the
@@ -222,9 +222,16 @@ Two penalty-selection rules are exposed via
   disaggregated-SC regimes) and for reproducing the paper's grid-
   search experiments.
 
-The cross-validation-over-time rule from Section 5.2 is not yet
-exposed in v1 of the :mod:`mlsynth` implementation; it is on the
-short-term roadmap.
+* ``'cross-validation'`` — the rolling cross-validation-over-time
+  rule from Section 5.2. The last ``cv_holdout_periods`` pre-treatment
+  periods are held out as a one-step-ahead forecast target; the
+  penalized program is refit over ``lambda_grid`` on the earlier
+  pre-period and the :math:`\lambda` with the smallest held-out
+  forecast MSE is selected (the ``0`` grid point recovers
+  fully-disaggregated SC). This is a faithful port of the reference
+  ``get_lambda_cv``; on the README DGP it selects the same grid
+  penalty as the reference (e.g. :math:`316.23` on the seed-42 panel),
+  and the cross-check is wired into the ``mlsc_bottmer`` benchmark.
 
 Variance Decomposition (Appendix G)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mlsynth/estimators/mlsc.py
+++ b/mlsynth/estimators/mlsc.py
@@ -37,6 +37,7 @@ from ..exceptions import (
     MlsynthEstimationError,
     MlsynthPlottingError,
 )
+from ..utils.mlsc_helpers.crossval import select_lambda_cv
 from ..utils.mlsc_helpers.inference import counterfactual_path, summarize_effects
 from ..utils.mlsc_helpers.optimization import solve_mlsc
 from ..utils.mlsc_helpers.penalty import build_penalty_matrix
@@ -108,6 +109,8 @@ class MLSC:
 
         self.lambda_est: str = config.lambda_est
         self.lambda_val: float = config.lambda_val
+        self.lambda_grid = config.lambda_grid
+        self.cv_holdout_periods: int = config.cv_holdout_periods
         self.solver: Any = config.solver
 
         self.display_graphs: bool = config.display_graphs
@@ -140,19 +143,28 @@ class MLSC:
         try:
             sigma_eps2, sigma_y2 = estimate_variance_components(inputs)
 
-            if self.lambda_est == "heuristic":
-                lambda_used = heuristic_lambda(sigma_eps2, sigma_y2)
-            elif self.lambda_est == "fixed":
-                lambda_used = float(self.lambda_val)
-            else:  # defensive; pydantic Literal should have caught this
-                raise MlsynthConfigError(
-                    f"Unsupported lambda_est value: {self.lambda_est!r}."
-                )
-
             Q = build_penalty_matrix(
                 v_population=inputs.v_population,
                 disagg_to_agg=inputs.disagg_to_agg,
             )
+
+            if self.lambda_est == "heuristic":
+                lambda_used = heuristic_lambda(sigma_eps2, sigma_y2)
+            elif self.lambda_est == "fixed":
+                lambda_used = float(self.lambda_val)
+            elif self.lambda_est == "cross-validation":
+                lambda_used = select_lambda_cv(
+                    inputs=inputs,
+                    Q=Q,
+                    sigma_y2=sigma_y2,
+                    lambda_grid=self.lambda_grid,
+                    cv_holdout_periods=self.cv_holdout_periods,
+                    solver=self.solver,
+                )
+            else:  # defensive; pydantic Literal should have caught this
+                raise MlsynthConfigError(
+                    f"Unsupported lambda_est value: {self.lambda_est!r}."
+                )
 
             omega, aggregate_weights, status = solve_mlsc(
                 inputs=inputs,

--- a/mlsynth/tests/test_mlsc.py
+++ b/mlsynth/tests/test_mlsc.py
@@ -35,7 +35,11 @@ import pytest
 
 from mlsynth import MLSC
 from mlsynth.config_models import EffectResult, MLSCConfig, MlsynthResult
-from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.exceptions import (
+    MlsynthConfigError,
+    MlsynthDataError,
+    MlsynthEstimationError,
+)
 from mlsynth.utils.mlsc_helpers.penalty import build_block, build_penalty_matrix
 from mlsynth.utils.mlsc_helpers.setup import prepare_mlsc_inputs
 from mlsynth.utils.mlsc_helpers.structures import (
@@ -513,7 +517,7 @@ class TestPublicAPI:
         d = res.design
         assert d.omega.shape == (res.inputs.M,)
         assert d.aggregate_weights.shape == (res.inputs.S,)
-        assert d.lambda_est in ("heuristic", "fixed")
+        assert d.lambda_est in ("heuristic", "fixed", "cross-validation")
         assert isinstance(d.solver_status, str)
 
     def test_dict_config_round_trip(self):
@@ -525,3 +529,64 @@ class TestPublicAPI:
         res_obj = MLSC(cfg_obj).fit()
         assert res_dict.att == pytest.approx(res_obj.att)
         assert res_dict.pre_rmse == pytest.approx(res_obj.pre_rmse)
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: cross-validation-over-time penalty selection (Section 5.2)
+# ---------------------------------------------------------------------------
+class TestCrossValidation:
+    """``lambda_est='cross-validation'`` -- the Section-5.2 rolling CV."""
+
+    def test_config_accepts_cross_validation(self):
+        df_agg, df_disagg = _make_panel()
+        cfg = MLSCConfig(**_base_config(df_agg, df_disagg,
+                                        lambda_est="cross-validation"))
+        assert cfg.lambda_est == "cross-validation"
+        assert cfg.cv_holdout_periods == 1          # reference default
+        assert cfg.lambda_grid is None              # -> reference grid
+
+    def test_cv_runs_and_selects_grid_penalty(self):
+        from mlsynth.utils.mlsc_helpers.crossval import _DEFAULT_GRID
+        df_agg, df_disagg = _make_panel()
+        res = MLSC(_base_config(df_agg, df_disagg,
+                                lambda_est="cross-validation")).fit()
+        assert res.design.lambda_est == "cross-validation"
+        # The selected penalty is a member of the (default) grid.
+        assert np.min(np.abs(_DEFAULT_GRID - res.design.lambda_used)) < 1e-12
+        assert np.isclose(res.design.omega.sum(), 1.0)
+        assert np.all(res.design.omega >= -1e-8)
+
+    def test_custom_grid_is_respected(self):
+        df_agg, df_disagg = _make_panel()
+        grid = [0.01, 1.0, 100.0]
+        res = MLSC(_base_config(df_agg, df_disagg, lambda_est="cross-validation",
+                                lambda_grid=grid)).fit()
+        assert res.design.lambda_used in grid
+
+    def test_holdout_too_long_raises(self):
+        # T0 == 18 here; holding out all of it leaves no training period.
+        df_agg, df_disagg = _make_panel(T0=18)
+        with pytest.raises((MlsynthEstimationError, ValueError)):
+            MLSC(_base_config(df_agg, df_disagg, lambda_est="cross-validation",
+                              cv_holdout_periods=18)).fit()
+
+    def test_selector_unit_matches_objective_argmin(self):
+        # The helper returns the grid penalty minimizing the held-out MSE.
+        from mlsynth.utils.mlsc_helpers.crossval import select_lambda_cv
+        from mlsynth.utils.mlsc_helpers.penalty import build_penalty_matrix
+        from mlsynth.utils.mlsc_helpers.setup import prepare_mlsc_inputs
+        from mlsynth.utils.mlsc_helpers.variance import estimate_variance_components
+
+        df_agg, df_disagg = _make_panel(seed=3)
+        inputs = prepare_mlsc_inputs(
+            df_agg=df_agg, df_disagg=df_disagg, outcome="y", time="year",
+            treat="treated", unitid_agg="state", unitid_disagg="county",
+            agg_id="state", weight_col=None,
+        )
+        _, sigma_y2 = estimate_variance_components(inputs)
+        Q = build_penalty_matrix(v_population=inputs.v_population,
+                                 disagg_to_agg=inputs.disagg_to_agg)
+        grid = [0.01, 1.0, 50.0, 500.0]
+        lam = select_lambda_cv(inputs, Q, sigma_y2, lambda_grid=grid,
+                               cv_holdout_periods=2)
+        assert lam in grid

--- a/mlsynth/utils/mlsc_helpers/config.py
+++ b/mlsynth/utils/mlsc_helpers/config.py
@@ -27,8 +27,8 @@ class MLSCConfig(BaseModel):
     classical SC in the large-penalty limit and fully-disaggregated SC at
     penalty zero.
 
-    v1 implements only the heuristic and fixed-lambda penalty-selection
-    paths from Section 5.2 of the paper; cross-validation will follow.
+    Implements all three Section-5.2 penalty-selection paths: the heuristic
+    closed form, a fixed lambda, and rolling cross-validation over time.
     """
 
     df_agg: pd.DataFrame = Field(
@@ -86,19 +86,42 @@ class MLSCConfig(BaseModel):
             "simulation default)."
         ),
     )
-    lambda_est: Literal["heuristic", "fixed"] = Field(
+    lambda_est: Literal["heuristic", "fixed", "cross-validation"] = Field(
         default="heuristic",
         description=(
             "Penalty-selection rule. 'heuristic' uses the Appendix-B closed "
             "form ``lambda = 2 * sigma_eps^2 / sigma_y^2`` estimated from "
             "the disaggregate pre-treatment panel (Appendix G). 'fixed' uses "
-            "``lambda_val`` directly. Cross-validation is planned for v2."
+            "``lambda_val`` directly. 'cross-validation' implements the "
+            "Section-5.2 rolling cross-validation over time: it holds out the "
+            "last ``cv_holdout_periods`` pre-treatment periods, refits over "
+            "``lambda_grid``, and selects the penalty with the smallest "
+            "held-out forecast MSE."
         ),
     )
     lambda_val: float = Field(
         default=1e-4,
         ge=0.0,
         description="Penalty value used when ``lambda_est == 'fixed'``.",
+    )
+    lambda_grid: Optional[List[float]] = Field(
+        default=None,
+        description=(
+            "Candidate penalties for ``lambda_est == 'cross-validation'``. "
+            "``None`` (default) uses the reference grid "
+            "``[0] + logspace(1e-8, 5, 50) + logspace(10, 1000, 5)``; the "
+            "``0`` candidate corresponds to fully-disaggregated SC."
+        ),
+    )
+    cv_holdout_periods: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Number of trailing pre-treatment periods held out as the "
+            "cross-validation forecast target when "
+            "``lambda_est == 'cross-validation'`` (the reference "
+            "``t_cv_periods``)."
+        ),
     )
     solver: Any = Field(
         default=None,

--- a/mlsynth/utils/mlsc_helpers/crossval.py
+++ b/mlsynth/utils/mlsc_helpers/crossval.py
@@ -1,0 +1,130 @@
+"""Rolling cross-validation over time for the mlSC penalty (Section 5.2).
+
+Selects the penalty ``lambda`` by holding out the last ``cv_holdout_periods``
+pre-treatment periods, refitting the penalized state-county program over a grid
+of candidate penalties on the earlier pre-period, and choosing the penalty whose
+held-out one-step-ahead forecast MSE is smallest.
+
+This is a faithful port of ``get_lambda_cv`` in the author's reference
+implementation (``multi_level_sc_estimator.mlSC``): the same train/test split
+(``t_cv = T0 - cv_holdout_periods``), the same objective
+``||Y - X omega||^2 + lambda * sigma_y^2 * omega^T Q omega`` on the simplex, and
+the same default grid (with a ``0`` candidate that drops the penalty to recover
+fully-disaggregated SC, regularized by a tiny ridge for a unique solution).
+"""
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
+
+import cvxpy as cp
+import numpy as np
+
+from .structures import MLSCInputs
+
+# Reference default grid (``mlSC_estimator``'s ``lambda_grid`` argument).
+_DEFAULT_GRID = np.concatenate((
+    [0.0],
+    np.logspace(np.log10(1e-8), np.log10(5), 50),
+    np.logspace(np.log10(10), np.log10(1000), 5),
+))
+
+
+def _county_sc_holdout_mse(
+    X_train: np.ndarray, Y_train: np.ndarray,
+    X_test: np.ndarray, Y_test: np.ndarray, solver: Any,
+) -> float:
+    """``lambda = 0`` branch: fully-disaggregated SC with a tiny ridge.
+
+    Matches the reference ``synthetic_control_counties`` (a small ``1e-8``
+    L2 term keeps the simplex solution unique on a flat objective).
+    """
+    M = X_train.shape[1]
+    w = cp.Variable(M)
+    objective = cp.Minimize(
+        cp.sum_squares(Y_train - X_train @ w) + 1e-8 * cp.sum_squares(w)
+    )
+    problem = cp.Problem(objective, [cp.sum(w) == 1, w >= 0])
+    problem.solve(solver=solver or cp.SCS)
+    if w.value is None:
+        return float("inf")
+    return float(np.mean((Y_test - X_test @ np.asarray(w.value)) ** 2))
+
+
+def select_lambda_cv(
+    inputs: MLSCInputs,
+    Q: np.ndarray,
+    sigma_y2: float,
+    *,
+    lambda_grid: Optional[Sequence[float]] = None,
+    cv_holdout_periods: int = 1,
+    solver: Any = None,
+) -> float:
+    """Select the mlSC penalty by rolling cross-validation over time.
+
+    Parameters
+    ----------
+    inputs : MLSCInputs
+        Pre-processed two-level panel (uses the pre-period only).
+    Q : np.ndarray
+        Block-diagonal penalty matrix, shape ``(M, M)``.
+    sigma_y2 : float
+        Outcome-variance scale on the penalty (as in :func:`solve_mlsc`).
+    lambda_grid : sequence of float, optional
+        Candidate penalties. ``None`` -> the reference default grid.
+    cv_holdout_periods : int
+        Trailing pre-treatment periods held out as the forecast target.
+    solver : Any
+        cvxpy solver; ``None`` -> ``cp.SCS``.
+
+    Returns
+    -------
+    float
+        The grid penalty with the smallest held-out forecast MSE.
+    """
+    T0 = inputs.T0
+    t_cv = T0 - cv_holdout_periods
+    if t_cv < 1:
+        raise ValueError(
+            "cross-validation needs at least one training period: "
+            f"T0={T0} with cv_holdout_periods={cv_holdout_periods} leaves none."
+        )
+
+    Y = inputs.Y_agg_treated[:T0]
+    X = inputs.X_disagg[:T0, :]
+    X_train, Y_train = X[:t_cv], Y[:t_cv]
+    X_test, Y_test = X[t_cv:T0], Y[t_cv:T0]
+
+    grid = np.asarray(_DEFAULT_GRID if lambda_grid is None else lambda_grid, dtype=float)
+
+    # Build the penalized problem once and re-solve per lambda via a Parameter
+    # (the reference reuses a single cvxpy Problem across the grid).
+    M = X_train.shape[1]
+    omega = cp.Variable(M)
+    lambd = cp.Parameter(nonneg=True)
+    constraints = [cp.sum(omega) == 1, omega >= 0]
+    objective = cp.Minimize(
+        cp.sum_squares(Y_train - X_train @ omega)
+        + lambd * sigma_y2 * cp.quad_form(omega, cp.psd_wrap(Q))
+    )
+    problem = cp.Problem(objective, constraints)
+
+    cv_error = np.full(grid.shape[0], np.inf)
+    for i, v in enumerate(grid):
+        if v == 0.0:
+            cv_error[i] = _county_sc_holdout_mse(
+                X_train, Y_train, X_test, Y_test, solver
+            )
+            continue
+        lambd.value = float(v)
+        try:
+            problem.solve(solver=solver or cp.SCS)
+        except cp.error.SolverError:  # pragma: no cover - solver hiccup on a grid point
+            continue
+        if omega.value is None:
+            continue
+        cv_error[i] = float(np.mean((Y_test - X_test @ np.asarray(omega.value)) ** 2))
+
+    if not np.isfinite(cv_error).any():  # pragma: no cover - defensive
+        raise RuntimeError("mlSC cross-validation: no grid penalty was solvable.")
+
+    return float(grid[int(np.argmin(cv_error))])


### PR DESCRIPTION
## What

Implements the **last** of the queued threads: MLSC's **Section-5.2 cross-validation-over-time penalty selector**, porting the reference `get_lambda_cv` from Bottmer's `multi-level-sc-estimator`. Previously `lambda_est` only supported `heuristic`/`fixed`; now all three Section-5.2 paths are available.

## The selector
Hold out the last `cv_holdout_periods` pre-treatment periods as a one-step-ahead forecast target, refit the penalized state-county program over `lambda_grid` on the earlier pre-period, and pick the penalty with the smallest held-out forecast MSE (the `0` grid point recovers fully-disaggregated SC, regularized by a tiny ridge for uniqueness — matching the reference).

- **config**: `lambda_est` Literal gains `"cross-validation"`; new `lambda_grid` (defaults to the reference grid `[0] + logspace(1e-8,5,50) + logspace(10,1000,5)`) and `cv_holdout_periods` (reference `t_cv_periods`, default 1).
- **`mlsc_helpers/crossval.py::select_lambda_cv`**: faithful port — same split (`t_cv = T0 − cv_holdout_periods`), same objective, same grid, single reused cvxpy `Problem` over the grid.
- **estimator**: builds `Q` before λ-selection (CV needs it) and dispatches the new branch.
- **tests**: 5 new CV tests (`test_mlsc.py`: 38 pass).

## Validation — matches the reference
Extends the existing `mlsc_bottmer` durable case with `path_a_cv_*` cells. On the README seed-42 panel, mlsynth's CV selector picks the **same grid penalty as the reference (316.23)** and agrees on the ATT to ~1e-6. Cross-checked across seeds:

| seed | ref λ | mlsynth λ |
|---|---|---|
| 42 | 316.228 | 316.228 |
| 0 | 5 | 5 |
| 7 | 1000 | 1000 |
| 1 | 0 | 1e-8 (benign adjacent-grid tie — same fully-disaggregated solution, ATT agrees to 1e-4) |

`docs/mlsc.rst` documents the new rule and drops the stale "not yet exposed in v1" note. 140 tests pass (MLSC + result-contract).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_