### PR TITLE
pda: prewhitened Newey-West LRV for fs + China luxury-watch Path-A benchmark

### DIFF
--- a/benchmarks/cases/pda_luxurywatch.py
+++ b/benchmarks/cases/pda_luxurywatch.py
@@ -1,0 +1,85 @@
+"""PDA Path-A: Shi & Huang (2023) China luxury-watch import study (fsPDA).
+
+Reproduces the paper's Example 2 / Section 5 empirical result -- the effect of
+China's 2012 anti-corruption campaign (the "Eight-Point Policy", effective
+January 2013) on the **monthly growth rate** of luxury-watch imports -- using
+forward-selected PDA on ``basedata/china_watches_long.csv`` (the treated
+``watches`` series plus 87 UN-Comtrade commodity-import growth-rate controls,
+Feb 2010 - Dec 2015, 35 pre / 36 post periods).
+
+Run as the released ``fsPDA`` package's application script does
+(``app1_luxury_watch/fsPDA.R``): forward selection **with an intercept**
+(``fs_intercept=True``) and the **prewhitened Newey-West** long-run variance for
+the post-selection t-test (mlsynth's default). The point estimate and fit match
+the paper cell-for-cell:
+
+  =====================  ===============  =====================
+  Quantity               mlsynth fs       Shi & Huang (Sec. 5)
+  =====================  ===============  =====================
+  selected controls      3                3
+  in-sample R-squared    0.777            0.7785
+  monthly ATE            -3.09%           -3.09%
+  t-statistic            -2.51            -2.457
+  =====================  ===============  =====================
+
+The t-statistic differs by ~0.06 only because mlsynth's native prewhitened-NW
+estimator and R's ``sandwich::lrvar`` differ in their exact bandwidth/recolor
+internals; both prewhiten the strongly mean-reverting growth-rate effects
+(lag-1 autocorrelation ~ -0.45), which a plain Bartlett kernel cannot handle --
+the released ``est.fsPDA`` package, which does *not* prewhiten, instead reports
+an insignificant t ~ -1.15 on this panel.
+
+Path A (scenario 3): the data is the authors' own; forward selection and the
+prewhitened-NW inference are ported from the application script. Deterministic
+(greedy selection, closed-form variance).
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..",
+                     "basedata", "china_watches_long.csv")
+
+
+def run() -> dict:
+    import numpy as np
+    import pandas as pd
+    from mlsynth import PDA
+
+    df = pd.read_csv(os.path.abspath(_DATA))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = PDA({
+            "df": df, "outcome": "y", "treat": "treat",
+            "unitid": "unit", "time": "time",
+            "methods": ["fs"], "fs_intercept": True,
+            "display_graphs": False,
+        }).fit()
+
+    fit = res.fits["fs"]
+    T0 = int((df[df.unit == "watches"]["treat"] == 0).sum())
+    y = df[df.unit == "watches"].sort_values("time")["y"].to_numpy()
+    pre_r2 = 1.0 - np.var(fit.gap[:T0]) / np.var(y[:T0])
+    t_stat = fit.att / fit.att_se
+
+    return {
+        "fs_ate_pct": float(fit.att * 100.0),
+        "fs_pre_r2": float(pre_r2),
+        "fs_n_controls": float(len(fit.selected_donors)),
+        "fs_abs_tstat": float(abs(t_stat)),
+        "fs_significant_5pct": 1.0 if fit.p_value < 0.05 else 0.0,
+    }
+
+
+# Deterministic (greedy forward selection + closed-form prewhitened-NW variance).
+# The estimate/fit cells match the paper exactly; the t-statistic is pinned with a
+# tolerance that covers the small gap to the paper's sandwich::lrvar internals
+# (mlsynth -2.51 vs paper -2.457) while still requiring 5% significance.
+EXPECTED = {
+    "fs_ate_pct": (-3.09, 0.10),          # paper -3.09%
+    "fs_pre_r2": (0.777, 0.02),           # paper 0.7785
+    "fs_n_controls": (3.0, 0.0),          # paper 3
+    "fs_abs_tstat": (2.51, 0.45),         # paper 2.457
+    "fs_significant_5pct": (1.0, 0.0),    # paper p = 0.0140
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -42,6 +42,7 @@ CASES = {
     "fscm_prop99": "benchmarks.cases.fscm_prop99",            # Path A: forward-selected SC (Prop 99)
     "pda_hongkong": "benchmarks.cases.pda_hongkong",          # Path A: PDA methods on HK CEPA (Shi-Wang App E.1)
     "pda_table1": "benchmarks.cases.pda_table1",              # Path B: Shi-Huang Table 1 fs-vs-LASSO size/power geometry
+    "pda_luxurywatch": "benchmarks.cases.pda_luxurywatch",    # Path A: Shi-Huang China luxury-watch fsPDA (prewhitened-NW)
     "mlsc_bottmer": "benchmarks.cases.mlsc_bottmer",          # cross-val vs Bottmer's mlSC_estimator (skips if absent)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }

--- a/docs/pda.rst
+++ b/docs/pda.rst
@@ -308,6 +308,24 @@ de-meaned post-period effects. **No first-stage variance term is needed** --
 the asymptotic independence absorbs it -- which makes fsPDA's inference the
 simplest of the three.
 
+.. note::
+
+   **Long-run-variance estimator.** ``mlsynth`` defaults to the **prewhitened
+   Newey-West** estimator (Andrews-Monahan VAR(1) prewhitening + Bartlett kernel
+   with the data-driven NW(1994) bandwidth + finite-sample adjustment) -- R's
+   ``sandwich::lrvar(..., prewhite = TRUE, adjust = TRUE)``, which Shi & Huang
+   use in their application scripts. Prewhitening is essential when the
+   treatment-effect series is strongly serially dependent: monthly growth rates
+   mean-revert (lag-1 autocorrelation around :math:`-0.45` in the luxury-watch
+   panel), and a plain Bartlett kernel cannot absorb that, leaving
+   :math:`\hat\rho` nearly double its true value and the test far too
+   conservative. Setting ``lrvar_lag`` instead switches to the released
+   ``est.fsPDA`` package's fixed-lag Bartlett estimator
+   (default lag :math:`\lfloor T_2^{1/4}\rfloor`, capped at
+   :math:`\lfloor\sqrt{T_2}\rfloor`); on the watch panel that no-prewhitening
+   form gives an insignificant :math:`t \approx -1.15`, versus the prewhitened
+   default's :math:`-2.51` (the paper reports :math:`-2.457`).
+
 **When to use.** A large candidate-control pool where the goal is to
 *synthesize an ensemble* that mimics the outcome (not to interpret which
 controls are "causal"); when computational efficiency and honest

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -270,7 +270,14 @@ High-dimensional donor pools
   matching the paper; both fully powered at ``D5`` (durable:
   ``pda_table1``). mlsynth's LASSO is cross-validated, not the
   paper's modified-BIC, so its LASSO cells are a CV variant, not
-  a cell-by-cell match.
+  a cell-by-cell match. **Path A (fsPDA):** the China luxury-watch
+  study (anti-corruption campaign, Jan-2013) on
+  ``china_watches_long.csv`` -- forward selection picks 3 controls,
+  in-sample :math:`R^2 = 0.777` and monthly ATE
+  :math:`-3.09\%`, matching Shi & Huang's Section 5 cell-for-cell;
+  with the prewhitened Newey-West variance from their application
+  script the effect is significant (:math:`t = -2.51` vs the paper's
+  :math:`-2.457`; durable: ``pda_luxurywatch``).
 * :doc:`fscm` -- Cerulli (2024) forward-selected SC. **Path A:**
   Proposition 99 --
   :math:`\widehat{\mathrm{ATT}} = -20.15`,

--- a/mlsynth/estimators/pda.py
+++ b/mlsynth/estimators/pda.py
@@ -95,7 +95,8 @@ class PDA:
         )
         methods = resolve_methods(self.config.method, self.config.methods)
         fits = run_pda(inputs, methods, tau=self.config.tau, alpha=self.config.alpha,
-                       fs_intercept=self.config.fs_intercept)
+                       fs_intercept=self.config.fs_intercept,
+                       lrvar_lag=self.config.lrvar_lag)
         results = assemble_pda_results(inputs, fits, selected_variant=methods[0])
 
         if self.display_graphs:

--- a/mlsynth/tests/test_pda.py
+++ b/mlsynth/tests/test_pda.py
@@ -219,6 +219,46 @@ def test_newey_west_lag_values():
     assert newey_west_lag(500) > newey_west_lag(50)
 
 
+def test_fspda_lrvar_lag_rule_and_cap():
+    from mlsynth.utils.pda_helpers.inference import fspda_lrvar_lag
+    # default rule: floor(T2 ** 1/4)
+    assert fspda_lrvar_lag(36) == 2          # floor(36**.25)=2
+    assert fspda_lrvar_lag(100) == 3         # floor(100**.25)=3
+    # explicit lag within the floor(sqrt(T2)) cap is accepted
+    assert fspda_lrvar_lag(100, 5) == 5
+    # over the cap or negative -> error
+    with pytest.raises(ValueError):
+        fspda_lrvar_lag(36, 99)
+    with pytest.raises(ValueError):
+        fspda_lrvar_lag(36, -1)
+
+
+def test_prewhitened_nw_lrvar_handles_negative_autocorr():
+    from mlsynth.utils.pda_helpers.inference import lrvar_prewhite_nw, hac_lrv
+    # Strongly mean-reverting (lag-1 autocorr ~ -1) series: prewhitening should
+    # shrink the long-run variance of the mean well below the iid 1/n level.
+    z = np.tile([1.0, -1.0], 30)
+    v_pw = lrvar_prewhite_nw(z)
+    assert v_pw >= 0 and np.isfinite(v_pw)
+    assert v_pw < np.var(z) / z.size          # below the naive var(mean)
+    # short series falls back gracefully
+    assert np.isfinite(lrvar_prewhite_nw(np.array([1.0, 2.0, 3.0])))
+
+
+def test_fs_lrvar_lag_override_changes_se(rng_panel_factory=None):
+    # Default fs (prewhitened NW) vs the fixed-lag Bartlett override should give
+    # different standard errors on a serially-dependent effect series.
+    from mlsynth.utils.pda_helpers.fs.inference import fs_ate_inference
+    rng = np.random.default_rng(0)
+    T0, T2 = 30, 24
+    y = np.r_[rng.normal(size=T0), 2.0 + np.tile([1.0, -1.0], T2 // 2)]
+    cf = np.r_[y[:T0], np.zeros(T2)]
+    _, se_default, _, _ = fs_ate_inference(y, cf, T0)
+    _, se_bartlett, _, _ = fs_ate_inference(y, cf, T0, lrvar_lag=2)
+    assert se_default > 0 and se_bartlett > 0
+    assert not np.isclose(se_default, se_bartlett)
+
+
 def test_hac_lrv_empty_is_nan():
     assert np.isnan(hac_lrv(np.array([])))
 

--- a/mlsynth/utils/pda_helpers/config.py
+++ b/mlsynth/utils/pda_helpers/config.py
@@ -18,3 +18,4 @@ class PDAConfig(BaseEstimatorConfig):
     tau: Optional[float] = Field(default=None, description="User-specified treatment effect value (used as tau_l2 for 'l2' method).")
     alpha: float = Field(default=0.05, gt=0.0, lt=1.0, description="Significance level for confidence intervals and ATE inference.")
     fs_intercept: bool = Field(default=False, description="Forward-selection only: include a constant in the donor regression. False (default) matches Shi & Huang's simulation (no intercept, valid size on mean-zero factor data); True matches the released fsPDA R package (intercept, for panels with genuine level differences).")
+    lrvar_lag: Optional[int] = Field(default=None, description="Forward-selection only: Bartlett-kernel truncation lag for the Newey-West long-run variance in the post-selection t-test. None (default) uses the released fsPDA package's rule floor(T2**(1/4)); a supplied value must be a non-negative integer no larger than floor(sqrt(T2)).")

--- a/mlsynth/utils/pda_helpers/fs/inference.py
+++ b/mlsynth/utils/pda_helpers/fs/inference.py
@@ -4,29 +4,42 @@ Because forward selection uses pre-treatment data only and the pre/post periods
 become asymptotically independent under weak dependence, the naive conditional
 t-statistic is valid:
 
-    Z_U = sqrt(T2) * Delta_bar / rho_hat_tau -> N(0, 1),
+    Z_U = Delta_bar / sqrt(lrvar_hat) -> N(0, 1),
 
-where ``rho_hat_tau^2`` is the HAC long-run variance of the (de-meaned)
-post-period treatment effects. No first-stage variance term is required.
+where ``lrvar_hat`` is the long-run variance of the sample mean of the
+(de-meaned) post-period treatment effects. By default mlsynth uses the
+**prewhitened** Newey-West estimator (``sandwich::lrvar(..., prewhite = TRUE,
+adjust = TRUE)``) that Shi & Huang use in their applications
+(``app1_luxury_watch/fsPDA.R``); on serially-dependent effects this is far less
+conservative than a plain Bartlett kernel. Supplying ``lrvar_lag`` instead
+switches to the released ``est.fsPDA`` package's fixed-lag Bartlett estimator
+(``floor(T2 ** (1/4))`` if the cap, see :func:`fspda_lrvar_lag`).
 """
 
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
-from ..inference import hac_lrv, normal_test
+from ..inference import fspda_lrvar_lag, hac_lrv, lrvar_prewhite_nw, normal_test
 
 
 def fs_ate_inference(
     y: np.ndarray, counterfactual: np.ndarray, T0: int, alpha: float = 0.05,
+    lrvar_lag: Optional[int] = None,
 ) -> Tuple[float, float, Tuple[float, float], float]:
     """Return ``(att, se, ci, p_value)`` for the forward-selected PDA ATE."""
     gap = np.asarray(y, dtype=float) - np.asarray(counterfactual, dtype=float)
     post_effect = gap[T0:]
     T2 = post_effect.shape[0]
     att = float(np.mean(post_effect))
-    se = float(np.sqrt(hac_lrv(post_effect - att) / T2))   # post-period HAC only
+    if lrvar_lag is None:
+        # Prewhitened Newey-West variance of the mean (the application default).
+        se = float(np.sqrt(lrvar_prewhite_nw(post_effect)))
+    else:
+        # Released-package fixed-lag Bartlett: se = sqrt(lrvar_series / T2).
+        lag = fspda_lrvar_lag(T2, lrvar_lag)
+        se = float(np.sqrt(hac_lrv(post_effect - att, lag=lag) / T2))
     p_value, ci = normal_test(att, se, alpha)
     return att, se, ci, p_value

--- a/mlsynth/utils/pda_helpers/inference.py
+++ b/mlsynth/utils/pda_helpers/inference.py
@@ -18,6 +18,25 @@ def newey_west_lag(n: int) -> int:
     return int(np.floor(4.0 * (n / 100.0) ** (2.0 / 9.0))) if n > 1 else 0
 
 
+def fspda_lrvar_lag(T2: int, lrvar_lag: int | None = None) -> int:
+    """Bartlett-kernel truncation lag for the fsPDA long-run variance.
+
+    Follows Shi & Huang's released ``fsPDA`` package (``est.fsPDA``): the default
+    is ``floor(T2 ** (1/4))`` and a user-supplied lag must be a non-negative
+    integer no larger than ``floor(sqrt(T2))``.
+    """
+    cap = int(np.floor(np.sqrt(T2))) if T2 > 0 else 0
+    if lrvar_lag is None:
+        return int(np.floor(T2 ** 0.25)) if T2 > 0 else 0
+    lrvar_lag = int(lrvar_lag)
+    if lrvar_lag < 0 or lrvar_lag > cap:
+        raise ValueError(
+            f"lrvar_lag must be a non-negative integer no larger than "
+            f"floor(sqrt(T2))={cap}; got {lrvar_lag}."
+        )
+    return lrvar_lag
+
+
 def hac_lrv(z: np.ndarray, lag: int | None = None, kernel: str = "bartlett") -> float:
     """HAC long-run variance of a mean-zero-able scalar series ``z``.
 
@@ -38,6 +57,58 @@ def hac_lrv(z: np.ndarray, lag: int | None = None, kernel: str = "bartlett") -> 
         w = (1.0 - l / (L + 1.0)) if kernel == "bartlett" else 1.0
         lrv += 2.0 * w * gl
     return max(lrv, 0.0)
+
+
+def lrvar_prewhite_nw(x: np.ndarray) -> float:
+    """Prewhitened Newey-West long-run variance of the **mean** of ``x``.
+
+    Andrews-Monahan (1992) VAR(1) prewhitening + a Bartlett kernel with the
+    Newey-West (1994) data-driven bandwidth + the finite-sample adjustment --
+    i.e. R's ``sandwich::lrvar(x, type = "Newey-West", prewhite = TRUE,
+    adjust = TRUE)``, which Shi & Huang use for the post-selection t-test in
+    their applications (``app1_luxury_watch/fsPDA.R``). Returns the variance of
+    the sample mean (so the t-statistic is ``mean(x) / sqrt(lrvar_prewhite_nw(x))``).
+
+    Prewhitening is what makes this differ sharply from the plain Bartlett
+    estimator on strongly serially-dependent effects (e.g. monthly growth
+    rates, which mean-revert): the VAR(1) step removes the bulk of the
+    dependence before the kernel smooths the remainder, then the long-run
+    factor ``1 / (1 - A)`` recolors it.
+    """
+    x = np.asarray(x, dtype=float)
+    n0 = x.shape[0]
+    h = x - x.mean()
+    if n0 < 4:
+        return float(np.dot(h, h) / max(n0 * n0, 1))     # fall back to var(mean)
+
+    # VAR(1) prewhitening (OLS, no intercept); cap |A| < 0.97 for stability.
+    h_lead, h_lag = h[1:], h[:-1]
+    denom = float(h_lag @ h_lag)
+    A = float(h_lag @ h_lead) / denom if denom > 0 else 0.0
+    A = float(np.clip(A, -0.97, 0.97))
+    e = h_lead - A * h_lag
+    n = e.shape[0]
+
+    def sig(j: int) -> float:
+        return float(np.sum(e[j:] * e[:n - j]) / n)
+
+    # Newey-West (1994) automatic bandwidth on the prewhitened residuals.
+    L0 = int(np.floor(4.0 * (n / 100.0) ** (2.0 / 9.0)))
+    s0 = sig(0) + 2.0 * sum(sig(j) for j in range(1, L0 + 1))
+    s1 = 2.0 * sum(j * sig(j) for j in range(1, L0 + 1))
+    if s0 > 0:
+        st = 1.1447 * ((s1 / s0) ** 2) ** (1.0 / 3.0) * n ** (1.0 / 3.0)
+    else:
+        st = float(L0)
+    L = int(min(np.floor(st), n - 1))
+
+    s_resid = sig(0) + 2.0 * sum((1.0 - j / (st + 1.0)) * sig(j)
+                                 for j in range(1, L + 1))
+    s_resid = max(s_resid, 0.0)
+    recolor = 1.0 / (1.0 - A)
+    omega = recolor * s_resid * recolor
+    omega *= n / (n - 1.0)                                # adjust = TRUE
+    return float(omega / n)                              # variance of the mean
 
 
 def normal_test(att: float, se: float, alpha: float = 0.05):

--- a/mlsynth/utils/pda_helpers/orchestration.py
+++ b/mlsynth/utils/pda_helpers/orchestration.py
@@ -27,7 +27,7 @@ def _weights_dict(beta: np.ndarray, labels: np.ndarray) -> Dict[Any, float]:
 
 def run_pda(
     inputs: PDAInputs, methods: List[str], tau: Optional[float], alpha: float,
-    fs_intercept: bool = False,
+    fs_intercept: bool = False, lrvar_lag: Optional[int] = None,
 ) -> Dict[str, PDAMethodFit]:
     """Fit each requested PDA variant with its own paper's inference."""
     y, X, T0 = inputs.y, inputs.X, inputs.T0
@@ -47,7 +47,7 @@ def run_pda(
             selected = [labels[i] for i in np.where(support)[0]]
         elif m == FS:
             sel_idx, beta, intercept, cf = forward_select(y, X, T0, intercept=fs_intercept)
-            att, se, ci, p = fs_ate_inference(y, cf, T0, alpha=alpha)
+            att, se, ci, p = fs_ate_inference(y, cf, T0, alpha=alpha, lrvar_lag=lrvar_lag)
             selected = [labels[i] for i in sel_idx]
         else:
             raise ValueError(f"Unknown PDA method: {m!r}")


### PR DESCRIPTION
## What

Completes the PDA benchmark: the **China luxury-watch** Path-A reconstruction (Shi & Huang Section 5), which required matching the long-run-variance estimator the paper actually uses. Thanks for the watch data and the app script — they're what cracked it.

## The discovery

Tracing why mlsynth's fs t-stat (−1.31) didn't match the paper's −2.457:
- The watch effects are monthly **growth rates** — strongly mean-reverting (lag-1 autocorrelation ≈ −0.45).
- mlsynth and the **released `est.fsPDA` package** both use a plain Bartlett-kernel HAC, which can't absorb that negative dependence → ρ̂ nearly doubles → conservative t (the package itself gives ≈ −1.15 here).
- Shi & Huang's **application script** (`app1_luxury_watch/fsPDA.R`) instead uses `sandwich::lrvar(..., prewhite = TRUE, adjust = TRUE)` — a **prewhitened** Newey-West estimator. That's the source of their significant result.

## The change (per your call: prewhitened NW as the fs default)

- **`inference.py::lrvar_prewhite_nw`** — Andrews-Monahan VAR(1) prewhitening + Bartlett kernel with the NW(1994) data-driven bandwidth + finite-sample adjustment (mirrors `sandwich::lrvar`).
- **fs inference** now defaults to it; an explicit **`PDAConfig.lrvar_lag`** switches to the released package's fixed-lag Bartlett (`floor(T2^¼)`, capped at `floor(√T2)` — new `fspda_lrvar_lag` helper).

## Validation

**`pda_luxurywatch`** (new Path-A case) reproduces the paper cell-for-cell:

| | mlsynth fs | Shi & Huang |
|---|---|---|
| controls | 3 | 3 |
| in-sample R² | 0.777 | 0.7785 |
| monthly ATE | −3.09% | −3.09% |
| t-stat | −2.51 (sig.) | −2.457 (p=0.014) |

The ~0.06 t-gap is `sandwich`'s exact bandwidth/recolor internals.

**Existing benchmarks unaffected**: `pda_hongkong` and `pda_table1` both still pass (factor-DGP effects aren't strongly autocorrelated, so fs size barely moves: 0.090→0.095, 0.075→0.070). 3 new inference unit tests; `test_pda.py` 61 pass.

`docs/pda.rst` documents the LRV choice and the package-vs-application discrepancy; catalogue adds the luxury-watch Path A.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_