### PR TITLE
benchmarks: durable, commit-stamped Panic-of-1907 proximal cross-validation

### DIFF
--- a/benchmarks/cases/proximal_panic1907.py
+++ b/benchmarks/cases/proximal_panic1907.py
@@ -1,0 +1,102 @@
+"""Proximal Path-A: the Panic of 1907 (proximal-inference synthetic control).
+
+Cross-validates mlsynth's ``PROXIMAL`` against the authors' Python reference
+(``freshtaste/proximal``, pinned commit ``a67d81e``) and the proximal-SC papers'
+Table 3 on the Knickerbocker Trust panic of 1907 (``basedata/trust.dta``): the
+effect of the panic on the Trust Company of America's stock price, using donor
+trusts as outcome proxies and the *affected* trusts (repurposed as surrogates)
+to instrument them. Following the paper, prices are logged, the bid price is the
+donor proxy, the ask price the surrogate proxy, and the intervention is the
+panic (after period 229).
+
+mlsynth reproduces the reference / Table-3 full-window ATTs closely:
+
+  ========  ===============  =====================
+  Method    mlsynth ATT      reference (Table 3)
+  ========  ===============  =====================
+  PI        -1.148           -1.138
+  PI-S      -1.148           -1.134
+  PI-Post   -1.220           -1.220
+  ========  ===============  =====================
+
+(The PI/PI-S gaps are ~0.01 implementation slack; PI-Post matches to the printed
+digits.) The case also pins the no-proxy SPSC, the doubly-robust DR, and the
+PIPW (weighting) estimators as regression guards. Path A (scenario 3): the data
+and reference are the authors'; cross-validation is mandatory and done here.
+The case **skips gracefully** when the reference clone is unavailable.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+_VARS = {"donorproxies": ["bid_itp"], "surrogatevars": ["ask_itp"]}
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..", "basedata", "trust.dta")
+
+
+def _panel():
+    import numpy as np
+    import pandas as pd
+
+    df = pd.read_stata(os.path.abspath(_DATA))
+    df = df[df["ID"] != 1]                                   # drop unbalanced unit
+    surrogates = df[df["introuble"] == 1]["ID"].unique().tolist()
+    donors = df[df["type"] == "normal"]["ID"].unique().tolist()
+    df[["bid_itp", "ask_itp"]] = df[["bid_itp", "ask_itp"]].apply(np.log)
+    df["Panic"] = np.where((df["time"] > 229) & (df["ID"] == 34), 1, 0)
+    return df, donors, surrogates
+
+
+def _att(df, donors, surrogates, methods):
+    from mlsynth import PROXIMAL
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = PROXIMAL({
+            "df": df, "treat": "Panic", "time": "date", "outcome": "prc_log",
+            "unitid": "ID", "vars": _VARS, "donors": donors,
+            "surrogates": surrogates, "methods": methods, "display_graphs": False,
+        }).fit()
+    return {k: float(v) for k, v in res.att_by_method().items()}
+
+
+def run() -> dict:
+    from benchmarks.reference.clone_proximal import reference_table3
+
+    ref = reference_table3()                                # skips if unavailable
+    df, donors, surrogates = _panel()
+    pi = _att(df, donors, surrogates, ["PI", "PIS", "PIPost"])
+    spsc = _att(df, donors, surrogates, ["SPSC"])["SPSC"]
+    dr = _att(df, donors, surrogates, ["DR"])["DR"]
+    pipw = _att(df, donors, surrogates, ["PIPW"])["PIPW"]
+    return {
+        "pi_att": pi["PI"],
+        "pis_att": pi["PIS"],
+        "pipost_att": pi["PIPost"],
+        "pi_vs_ref": abs(pi["PI"] - ref["PI"]),
+        "pis_vs_ref": abs(pi["PIS"] - ref["PIS"]),
+        "pipost_vs_ref": abs(pi["PIPost"] - ref["PIPost"]),
+        "spsc_att": spsc,
+        "dr_att": dr,
+        "pipw_att": pipw,
+        "n_donors": float(len(donors)),
+        "n_surrogates": float(len(surrogates)),
+    }
+
+
+# Deterministic (closed-form GMM / weights, no RNG). The ``*_vs_ref`` cells pin
+# mlsynth to the committed freshtaste reference (PI-Post to the digit; PI / PI-S
+# within ~0.015 implementation slack); the ``*_att`` cells pin each method as a
+# regression guard against the paper's Table-3 values.
+EXPECTED = {
+    "pi_att": (-1.148, 0.05),            # Table 3 PI -1.138
+    "pis_att": (-1.148, 0.05),           # Table 3 PI-S -1.134
+    "pipost_att": (-1.220, 0.05),        # Table 3 PI-P -1.220
+    "pi_vs_ref": (0.010, 0.03),          # reproduces freshtaste PI
+    "pis_vs_ref": (0.014, 0.03),         # reproduces freshtaste PI-S
+    "pipost_vs_ref": (0.0, 0.01),        # reproduces freshtaste PI-P exactly
+    "spsc_att": (-0.892, 0.12),          # single-proxy SC (no surrogates needed)
+    "dr_att": (-1.194, 0.12),            # doubly-robust
+    "pipw_att": (-0.854, 0.12),          # proximal IPW
+    "n_donors": (48.0, 0.0),
+    "n_surrogates": (3.0, 0.0),
+}

--- a/benchmarks/reference/clone_proximal.py
+++ b/benchmarks/reference/clone_proximal.py
@@ -1,0 +1,64 @@
+"""On-demand clone of the freshtaste/proximal reference repo (Panic of 1907).
+
+The proximal-inference SC papers (Liu, Tchetgen Tchetgen & Varjao; Shi et al.)
+ship a Python reference implementation at https://github.com/freshtaste/proximal,
+including the trust-company panel (``data/trust.dta``) and the committed
+empirical output ``empirical_results.csv`` -- whose full-window row is the
+paper's Table-3 estimate (PI / PI-surrogate / PI-surrogate-post). We clone it at
+a pinned commit and read that committed reference output; if git or the network
+is unavailable the benchmark skips gracefully.
+
+The pinned commit (``_COMMIT``) freezes the reference so the cross-check is
+reproducible; bump it deliberately, never silently.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import numpy as np
+
+from benchmarks.compare import BenchmarkSkipped
+
+_REPO = "https://github.com/freshtaste/proximal.git"
+_COMMIT = "a67d81e7abd33a491646db558afc0e0ffa120f28"
+_CACHE = Path(__file__).resolve().parent / ".cache" / "freshtaste-proximal"
+
+
+def _ensure_clone() -> Path:
+    """Clone (or reuse) the reference repo pinned at ``_COMMIT``."""
+    marker = _CACHE / "empirical_results.csv"
+    if marker.exists():
+        return _CACHE
+    _CACHE.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            ["git", "-c", "credential.helper=", "clone", "--quiet", _REPO, str(_CACHE)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(_CACHE), "checkout", "--quiet", _COMMIT],
+            check=True, capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:  # pragma: no cover
+        detail = getattr(exc, "stderr", b"")
+        msg = detail.decode(errors="ignore").strip() if detail else str(exc)
+        raise BenchmarkSkipped(
+            f"could not clone reference repo {_REPO} @ {_COMMIT[:7]}: {msg}"
+        ) from exc
+    if not marker.exists():  # pragma: no cover - defensive
+        raise BenchmarkSkipped("reference clone missing empirical_results.csv")
+    return _CACHE
+
+
+def reference_table3() -> dict:
+    """Return the reference full-window ATTs ``{PI, PIS, PIPost}``.
+
+    Reads the committed ``empirical_results.csv`` (columns
+    ``[OLS, OLS-surrogate, PI, PI-surrogate, PI-surrogate-post]``; estimate rows
+    interleaved with s.e. rows). The last estimate row is the full-window Table-3
+    estimate.
+    """
+    arr = np.loadtxt(_ensure_clone() / "empirical_results.csv", delimiter=",")
+    est = arr[-2]                      # last estimate row (full window)
+    return {"PI": float(est[2]), "PIS": float(est[3]), "PIPost": float(est[4])}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -47,6 +47,7 @@ CASES = {
     "pda_luxurywatch": "benchmarks.cases.pda_luxurywatch",    # Path A: Shi-Huang China luxury-watch fsPDA (prewhitened-NW)
     "pda_ppi": "benchmarks.cases.pda_ppi",                    # Path A: Shi-Wang China PPI L2-relaxation (real-estate policy)
     "mlsc_bottmer": "benchmarks.cases.mlsc_bottmer",          # cross-val vs Bottmer's mlSC_estimator (skips if absent)
+    "proximal_panic1907": "benchmarks.cases.proximal_panic1907",  # cross-val vs freshtaste/proximal (Panic 1907 Table 3)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -426,11 +426,15 @@ Identification under endogeneity
   calibrated Monte Carlo across :math:`r \in \{0.5, 0.7, 0.9\}`
   at 200 reps; TSLS-TWFE bias 0.111 / 0.228 / 0.387 matches the
   paper's 0.111 / 0.218 / 0.360 essentially exactly.
-* :doc:`proximal` -- Proximal SC. **Path A:** Panic of 1907 on
-  the Trust panel, reproduced across all six proximal variants
-  -- PI :math:`-1.148` vs. paper :math:`-1.138`; PIS
-  :math:`-1.148` vs. :math:`-1.134`; PIPost :math:`-1.220` vs.
-  :math:`-1.220`. **Path B:** Single-Proxy SC (SPSC) plus
+* :doc:`proximal` -- Proximal SC. **Path A (cross-validation):**
+  Panic of 1907 on the Trust panel, cross-validated against the
+  authors' Python reference (``freshtaste/proximal``, pinned commit
+  ``a67d81e``) and the papers' Table 3 -- PI :math:`-1.148` vs.
+  reference :math:`-1.138`; PIS :math:`-1.148` vs. :math:`-1.134`;
+  PIPost :math:`-1.220` (matching the reference to ``1e-8``); the
+  no-proxy SPSC (:math:`-0.892`), doubly-robust DR (:math:`-1.194`)
+  and PIPW (:math:`-0.854`) are pinned alongside (durable:
+  ``proximal_panic1907``). **Path B:** Single-Proxy SC (SPSC) plus
   Doubly-Robust and PIPW Monte Carlo --
   SPSC-DT :math:`\widehat{\mathrm{ATT}} = -0.815` against
   :math:`-0.816`.


### PR DESCRIPTION
## What

First durable benchmark for the **proximal class** — promotes the docs' Panic-of-1907 example to a **commit-stamped cross-validation** against the authors' Python reference, as you asked.

## Commit-stamped reference
`benchmarks/reference/clone_proximal.py` clones **`freshtaste/proximal` @ `a67d81e`** and reads its committed `empirical_results.csv` (whose full-window row is the proximal-SC papers' Table-3 PI / PI-surrogate / PI-surrogate-post estimate). Skips gracefully if the clone is unavailable.

## The case (`proximal_panic1907`)
Runs mlsynth's `PROXIMAL` on `basedata/trust.dta` (48 donor trusts as outcome proxies + 3 affected trusts repurposed as surrogates) and cross-validates against the reference:

| method | mlsynth | reference / Table 3 |
|---|---|---|
| PI | −1.148 | −1.138 |
| PI-S | −1.148 | −1.134 |
| PI-Post | −1.220 | −1.220 (match to **1e-8**) |

The no-proxy **SPSC** (−0.892), **DR** (−1.194), and **PIPW** (−0.854) are pinned alongside as regression guards. ~13 s on a fresh clone; `.cache` gitignored; deterministic. Catalogue updated to cite the durable case + the commit pin.

## Head start on the rest
The other two reference repos are cloned and pinned for the follow-on cross-validations: **SPSC** (`qkrcks0218/SPSC` — California) and **DR** (`QIU-Hongxiang-David/DR_Proximal_SC` — Kansas/Florida), plus the proximal simulations (the papers `liu24a` / `ujae055` you provided). Those are the next durable cases.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_