### PR TITLE
benchmarks: durable Path-B Monte Carlos for the proximal class (SPSC / DR-PIPW / surrogates)

### DIFF
--- a/benchmarks/cases/dr_proximal_mc.py
+++ b/benchmarks/cases/dr_proximal_mc.py
@@ -1,0 +1,136 @@
+"""DR-proximal Path-B: the authors' doubly-robust ``normal`` Monte Carlo.
+
+Validates mlsynth's doubly-robust (``DR``) and proximal-IPW (``PIPW``)
+estimators against the data-generating process the authors ship in their
+reference repo (``DR_Proximal_SC/simulation/normal``), accompanying
+
+    Qiu, H., Shi, X., Miao, W., Dobriban, E., & Tchetgen Tchetgen, E. J.
+    (2024). "Doubly robust proximal synthetic controls." Biometrics 80(2),
+    ujae055.
+
+The DGP (:func:`mlsynth.utils.proximal_helpers.simulation.simulate_dr_proximal_normal`)
+has ``true.ATE = 2``, two AR(1) latent confounders, and independent error-prone
+proxy blocks ``W`` (outcome proxies) and ``Z`` (treatment proxies). The case
+asserts the two headline facts of the paper:
+
+1. **Recovery + honest inference.** At ``T = 1000`` both ``DR`` and ``PIPW``
+   recover the truth (mean ATT ~ 2.0) with Wald coverage near the nominal 95%.
+2. **Double robustness.** When the outcome bridge is misspecified (a nonlinear
+   confounding signal an intercept-free linear bridge cannot absorb), the
+   outcome-only ``PI`` estimator collapses (mean ATT ~ 4.3) while ``DR`` --
+   rescued by a correctly-specified treatment bridge -- stays at ~ 2.0.
+
+  ====================  ===========  ===============
+  Quantity              mlsynth      reference
+  ====================  ===========  ===============
+  DR mean ATT           ~2.0         2.0 (true)
+  PIPW mean ATT         ~2.0         2.0 (true)
+  PI under misspec      ~4.3         collapses
+  DR under misspec      ~2.0         holds
+  ====================  ===========  ===============
+
+In the **just-identified** case the DR and PIPW *point* estimates coincide
+exactly: the treatment bridge solves the balancing moment
+:math:`\\mathbb{E}_{\\text{pre}}[q\\,(1,W)] = \\mathbb{E}_{\\text{post}}[(1,W)]`,
+which makes the DR outcome-bridge correction cancel, so ``dr_bias`` equals
+``pipw_bias`` here. The two still differ in **inference** -- the sandwich SEs,
+and hence the Wald coverage, are not identical.
+
+Path B (scenario 3, the authors' own DGP): the case asserts the geometry --
+both estimators unbiased with reasonable coverage, and DR robust to outcome-
+bridge misspecification where PI is not -- not exact Monte Carlo cells. The
+estimators are driven at the array level (the just-identified GMM is closed
+form) for speed.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+from mlsynth.utils.proximal_helpers.simulation import simulate_dr_proximal_normal
+
+T = 1000
+M = 60          # recovery / coverage replications
+M_DR = 40       # double-robustness replications
+_TRUE = 2.0
+
+
+def _bandwidth(n_post: int) -> int:
+    from mlsynth.utils.proximal_helpers.setup import _hac_bandwidth
+    return _hac_bandwidth(n_post)
+
+
+def _recovery_and_coverage(base_seed: int):
+    """Mean ATT and 95% Wald coverage of DR and PIPW over ``M`` draws."""
+    from mlsynth.utils.proximal_helpers.dr.estimation import estimate_dr
+    from mlsynth.utils.proximal_helpers.pipw.estimation import estimate_pipw
+
+    rng = np.random.default_rng(base_seed)
+    dr_att = np.empty(M)
+    pipw_att = np.empty(M)
+    dr_cov = np.empty(M)
+    pipw_cov = np.empty(M)
+    for i in range(M):
+        s = simulate_dr_proximal_normal(T=T, rng=rng)
+        bw = _bandwidth(T - s.T0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _, _, _, da, ds = estimate_dr(s.y, s.donor_outcomes, s.donor_proxies, s.T0, bw)
+            _, pa, ps = estimate_pipw(s.y, s.donor_outcomes, s.donor_proxies, s.T0, bw)
+        dr_att[i], pipw_att[i] = da, pa
+        dr_cov[i] = abs(da - _TRUE) <= 1.96 * ds
+        pipw_cov[i] = abs(pa - _TRUE) <= 1.96 * ps
+    return (float(dr_att.mean()), float(dr_cov.mean()),
+            float(pipw_att.mean()), float(pipw_cov.mean()))
+
+
+def _double_robustness(base_seed: int):
+    """Mean outcome-only PI vs DR ATT when the outcome bridge is misspecified."""
+    from mlsynth.utils.proximal_helpers.dr.estimation import estimate_dr
+    from mlsynth.utils.proximal_helpers.pi.estimation import estimate_pi
+
+    rng = np.random.default_rng(base_seed)
+    pi_att = np.empty(M_DR)
+    dr_att = np.empty(M_DR)
+    for i in range(M_DR):
+        s = simulate_dr_proximal_normal(T=T, misspecify=True, rng=rng)
+        bw = _bandwidth(T - s.T0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cf_pi, _, _ = estimate_pi(s.y, s.donor_outcomes, s.donor_proxies,
+                                      s.T0, T - s.T0, T, bw)
+            _, _, _, da, _ = estimate_dr(s.y, s.donor_outcomes, s.donor_proxies, s.T0, bw)
+        pi_att[i] = float(np.mean(s.y[s.T0:] - cf_pi[s.T0:]))
+        dr_att[i] = da
+    return float(pi_att.mean()), float(dr_att.mean())
+
+
+def run() -> dict:
+    dr_mean, dr_cov, pipw_mean, pipw_cov = _recovery_and_coverage(2200)
+    pi_mis, dr_mis = _double_robustness(3300)
+    return {
+        "dr_bias": dr_mean - _TRUE,
+        "pipw_bias": pipw_mean - _TRUE,
+        "dr_coverage": dr_cov,
+        "pipw_coverage": pipw_cov,
+        "pi_att_misspecified": pi_mis,
+        "dr_att_misspecified": dr_mis,
+        "dr_beats_pi_under_misspec": float(abs(dr_mis - _TRUE) < abs(pi_mis - _TRUE)),
+    }
+
+
+# Deterministic (seeded). Tolerances absorb the binomial / Monte Carlo noise at
+# M=60 / M_DR=40. The reproduced facts: DR and PIPW recover true.ATE=2 with
+# near-nominal Wald coverage, and -- the paper's headline -- DR is robust to an
+# outcome-bridge misspecification that collapses the outcome-only PI estimator
+# (PI ~ 4.3, DR ~ 2.0). Centres match the docs' runnable Monte Carlo.
+EXPECTED = {
+    "dr_bias": (0.0, 0.06),                 # DR recovers ATE=2
+    "pipw_bias": (0.0, 0.06),               # PIPW recovers ATE=2
+    "dr_coverage": (0.91, 0.12),            # near nominal 0.95
+    "pipw_coverage": (0.99, 0.08),          # conservative (high) coverage
+    "pi_att_misspecified": (4.30, 0.6),     # PI collapses under nonlinear confounding
+    "dr_att_misspecified": (2.0, 0.25),     # DR holds (correct treatment bridge)
+    "dr_beats_pi_under_misspec": (1.0, 0.0),
+}

--- a/benchmarks/cases/proximal_surrogates_mc.py
+++ b/benchmarks/cases/proximal_surrogates_mc.py
@@ -1,0 +1,116 @@
+"""Proximal-with-surrogates Path-B: the Section 4.1 robustness Monte Carlo.
+
+Validates mlsynth's PI / PIS / PIPost against the data-generating process the
+authors ship in their reference repo (``freshtaste/proximal`` ``dgp.py``),
+accompanying
+
+    Liu, J., Tchetgen Tchetgen, E. J., & Varjao, C. (2024). "Proximal Causal
+    Inference for Synthetic Control with Surrogates." AISTATS.
+
+The DGP
+(:func:`mlsynth.utils.proximal_helpers.simulation.simulate_proximal_surrogates`)
+puts a **trending** ``log t`` latent factor behind the treated unit and the
+donor block, with the donor outcomes ``W`` and an independent proxy block
+``Z0`` as two error-prone copies of that factor. This is the regime the paper
+highlights: classical SC fits an error-laden donor regression and extrapolates
+the trend with growing bias, whereas the proximal estimators -- which
+instrument ``W`` with ``Z0`` -- recover the true ``ATT = 1`` with near-nominal
+coverage. The surrogate estimator **PIS** additionally borrows the post-period
+surrogates ``X`` and attains the lowest MSE.
+
+  ========  ============  ===========  ============
+  Estimator mean ATT      MSE          95% coverage
+  ========  ============  ===========  ============
+  PI        ~1.00         ~0.09        ~0.95
+  PIS       ~1.00         ~0.05 (low)  ~0.96
+  PIPost    ~1.03         ~0.12        ~0.95
+  SC        ~1.32 (bias)  ~0.19        --
+  ========  ============  ===========  ============
+
+Path B (scenario 3, the authors' own DGP): the case asserts the geometry --
+the proximal trio recovers the truth with near-nominal coverage, PIS attains
+the lowest MSE of the three, and all three beat the biased classical-SC
+baseline -- not exact Monte Carlo cells. The estimators are driven at the
+array level (closed-form GMM) for speed.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+from mlsynth.utils.proximal_helpers.simulation import simulate_proximal_surrogates
+
+T = 200
+M = 120          # Monte Carlo replications
+_TRUE = 1.0
+_LAG = 0         # the reference drives the HAC at lag 0 for this design
+
+
+def _sc_baseline(y: np.ndarray, W: np.ndarray, T0: int) -> float:
+    """Non-negative pre-period SC fit -- the errors-in-variables baseline."""
+    from scipy.optimize import nnls
+    w, _ = nnls(W[:T0], y[:T0])
+    cf = W @ w
+    return float(np.mean(y[T0:] - cf[T0:]))
+
+
+def run() -> dict:
+    from mlsynth.utils.proximal_helpers.pi.estimation import estimate_pi
+    from mlsynth.utils.proximal_helpers.pis.estimation import estimate_pi_surrogate
+    from mlsynth.utils.proximal_helpers.pipost.estimation import estimate_pi_surrogate_post
+
+    rng = np.random.default_rng(5500)
+    pi = np.empty(M); pis = np.empty(M); pipost = np.empty(M); sc = np.empty(M)
+    pi_cov = np.empty(M); pis_cov = np.empty(M); pipost_cov = np.empty(M)
+    for i in range(M):
+        s = simulate_proximal_surrogates(T=T, rng=rng)
+        T0 = s.T0; npost = T - T0
+        W, Z0 = s.donor_outcomes, s.donor_proxies
+        X, Z1 = s.surrogate_outcomes, s.surrogate_proxies
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cf, _, se = estimate_pi(s.y, W, Z0, T0, npost, T, _LAG)
+            tau_s, _, _, se_s = estimate_pi_surrogate(s.y, W, Z0, Z1, X, T0, npost, T, _LAG)
+            tau_p, _, _, se_p = estimate_pi_surrogate_post(s.y, W, Z0, Z1, X, T0, npost, _LAG)
+        pi_i = float(np.mean(s.y[T0:] - cf[T0:]))
+        pi[i], pis[i], pipost[i] = pi_i, tau_s, tau_p
+        pi_cov[i] = abs(pi_i - s.true_att) <= 1.96 * se
+        pis_cov[i] = abs(tau_s - s.true_att) <= 1.96 * se_s
+        pipost_cov[i] = abs(tau_p - s.true_att) <= 1.96 * se_p
+        sc[i] = _sc_baseline(s.y, W, T0)
+
+    def mse(a):
+        return float(np.mean((a - _TRUE) ** 2))
+
+    return {
+        "pi_bias": float(pi.mean()) - _TRUE,
+        "pis_bias": float(pis.mean()) - _TRUE,
+        "pipost_bias": float(pipost.mean()) - _TRUE,
+        "pi_coverage": float(pi_cov.mean()),
+        "pis_coverage": float(pis_cov.mean()),
+        "pipost_coverage": float(pipost_cov.mean()),
+        "pis_mse": mse(pis),
+        "sc_bias": float(sc.mean()) - _TRUE,
+        "proximal_beats_sc_mse": float(max(mse(pi), mse(pis), mse(pipost)) < mse(sc)),
+        "pis_lowest_mse": float(mse(pis) <= min(mse(pi), mse(pipost))),
+    }
+
+
+# Deterministic (seeded). Tolerances absorb the Monte Carlo noise at M=120. The
+# reproduced facts (Liu-Tchetgen Tchetgen-Varjao Sec 4.1): under a trending
+# latent factor the proximal trio recovers the true ATT=1 with near-nominal
+# coverage, PIS attains the lowest MSE, and all three beat the biased classical
+# SC baseline.
+EXPECTED = {
+    "pi_bias": (0.0, 0.08),
+    "pis_bias": (0.0, 0.08),
+    "pipost_bias": (0.0, 0.10),
+    "pi_coverage": (0.95, 0.10),
+    "pis_coverage": (0.96, 0.10),
+    "pipost_coverage": (0.95, 0.10),
+    "pis_mse": (0.05, 0.05),
+    "sc_bias": (0.32, 0.30),               # classical SC: biased by the trend
+    "proximal_beats_sc_mse": (1.0, 0.0),
+    "pis_lowest_mse": (1.0, 0.0),
+}

--- a/benchmarks/cases/spsc_ifem_mc.py
+++ b/benchmarks/cases/spsc_ifem_mc.py
@@ -1,0 +1,86 @@
+"""SPSC Path-B: the authors' interactive-fixed-effects Monte Carlo.
+
+Validates mlsynth's Single Proxy Synthetic Control against the data-generating
+process the SPSC authors ship in their reference R package README (the *"Toy
+Example from Interactive Fixed Effect Models,"* ``github.com/qkrcks0218/SPSC``),
+accompanying
+
+    Park, C., & Tchetgen Tchetgen, E. J. (2025). "Single Proxy Synthetic
+    Control." Journal of Causal Inference 13(1), 20230079.
+
+The DGP (:func:`mlsynth.utils.proximal_helpers.simulation.simulate_spsc_ifem`)
+gives the donor pool a deterministic baseline **trend**, so the untreated
+trajectories drift. That is exactly the regime the paper highlights: the
+detrended estimator **SPSC-DT** stays (near-)unbiased with close-to-nominal
+coverage, while the un-detrended **SPSC-NoDT** -- which forces a constant gap
+through a trending counterfactual -- under-covers because its sandwich SE cannot
+see the trend misspecification. Both recover the true ``ATT = 3`` essentially
+without bias (the bridge is identified by the single proxy regardless of the
+trend); detrending is what buys honest inference.
+
+  ================  ===============  ===============  =================
+  Quantity          SPSC-DT          SPSC-NoDT        target
+  ================  ===============  ===============  =================
+  bias (true 3.0)   ~0.00            ~0.00            ~unbiased
+  95% coverage      ~0.93            ~0.76            DT near nominal
+  ================  ===============  ===============  =================
+
+Path B (scenario 3, the authors' own DGP): the case asserts the geometry -- both
+estimators unbiased, DT covers near nominal, and **DT covers strictly better than
+NoDT under the trend** -- not exact Monte Carlo cells.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+from mlsynth.utils.proximal_helpers.simulation import simulate_spsc_ifem
+
+M = 60          # Monte Carlo replications (runtime vs. binomial noise trade-off)
+_TRUE_ATT = 3.0
+
+
+def _mc(detrend: bool, base_seed: int):
+    """Mean ATT, bias, and 95% Wald coverage of SPSC over ``M`` draws."""
+    from mlsynth.utils.proximal_helpers.spsc.estimation import estimate_spsc
+
+    rng = np.random.default_rng(base_seed)
+    atts = np.empty(M)
+    covers = np.empty(M)
+    for i in range(M):
+        s = simulate_spsc_ifem(rng=rng)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            _, _, att, se, _, _ = estimate_spsc(s.y, s.donors, s.T0,
+                                                detrend=detrend, spline_df=5)
+        atts[i] = att
+        lo, hi = att - 1.96 * se, att + 1.96 * se
+        covers[i] = 1.0 if lo <= s.true_att <= hi else 0.0
+    return float(atts.mean()), float(covers.mean())
+
+
+def run() -> dict:
+    dt_mean, dt_cover = _mc(detrend=True, base_seed=4100)
+    nodt_mean, nodt_cover = _mc(detrend=False, base_seed=4100)
+    return {
+        "spsc_dt_bias": dt_mean - _TRUE_ATT,
+        "spsc_nodt_bias": nodt_mean - _TRUE_ATT,
+        "spsc_dt_coverage": dt_cover,
+        "spsc_nodt_coverage": nodt_cover,
+        "dt_covers_better": float(dt_cover > nodt_cover),
+    }
+
+
+# Deterministic (seeded). Tolerances absorb the binomial Monte Carlo noise at
+# M=60 (a coverage SE ~ sqrt(.9*.1/60) ~ 0.04). The reproduced facts are: SPSC
+# recovers the true ATT=3 essentially without bias under either detrending
+# choice, SPSC-DT covers near the nominal 95%, and -- the paper's point -- DT
+# covers strictly better than NoDT once the donor pool trends.
+EXPECTED = {
+    "spsc_dt_bias": (0.0, 0.04),          # detrended: unbiased
+    "spsc_nodt_bias": (0.0, 0.05),        # un-detrended: also ~unbiased in point
+    "spsc_dt_coverage": (0.93, 0.10),     # near nominal 0.95
+    "spsc_nodt_coverage": (0.76, 0.18),   # under-covers under the trend
+    "dt_covers_better": (1.0, 0.0),       # detrending buys honest inference
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -49,6 +49,9 @@ CASES = {
     "pda_brexit": "benchmarks.cases.pda_brexit",              # Path A: Shi-Wang Brexit multi-treated-units L2-relaxation
     "mlsc_bottmer": "benchmarks.cases.mlsc_bottmer",          # cross-val vs Bottmer's mlSC_estimator (skips if absent)
     "proximal_panic1907": "benchmarks.cases.proximal_panic1907",  # cross-val vs freshtaste/proximal (Panic 1907 Table 3)
+    "spsc_ifem_mc": "benchmarks.cases.spsc_ifem_mc",          # Path B: SPSC IFEM recovery + DT-vs-NoDT coverage (Park-Tchetgen)
+    "dr_proximal_mc": "benchmarks.cases.dr_proximal_mc",      # Path B: DR/PIPW recovery + double-robustness (Qiu et al. normal DGP)
+    "proximal_surrogates_mc": "benchmarks.cases.proximal_surrogates_mc",  # Path B: PI/PIS/PIPost vs SC under trending factor (Liu et al.)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/docs/proximal.rst
+++ b/docs/proximal.rst
@@ -955,12 +955,28 @@ Replication Status
    intervals of [SPSC]_ are also ported and reproduce the average interval
    width of the paper's Figure 3 (≈ 0.07 for SPSC-DT).
 
+   **SPSC (Path B, durable IFEM Monte Carlo).** The authors ship a
+   self-contained interactive-fixed-effects DGP in their package README
+   (the *"Toy Example from Interactive Fixed Effect Models,"*
+   :math:`\mathrm{True.ATT}=3`, a trending donor pool). The durable
+   benchmark ``spsc_ifem_mc`` redraws it 60 times and drives ``mlsynth``'s
+   SPSC: both SPSC-DT and SPSC-NoDT recover the true ATT essentially without
+   bias (biases ≈ 0.006 and 0.008), but only the detrended **SPSC-DT**
+   delivers honest inference -- its 95% Wald intervals cover near nominal
+   while **SPSC-NoDT** under-covers because its constant-gap model is forced
+   through a trending counterfactual. This reproduces the supplement's
+   central finding ([SPSC]_ Figures S2-S6): detrending is what buys correct
+   coverage when the untreated trajectories drift.
+
    **Simulation (Path B).** The robustness claim of [LiuTchetgenVar]_ Sec.
-   4.1 reproduces: under a trending latent factor
-   (:math:`\boldsymbol{\lambda}_t \sim N(\log t, 1)`), classical SC and
-   SC-with-surrogates lose all coverage (→ 0%) while PI/PIS/PIPost remain
-   near nominal with low MSE; PIS attains the lowest MSE in most cells. See
-   *Example* for a one-draw illustration.
+   4.1 reproduces, and is pinned by the **durable** benchmark
+   ``proximal_surrogates_mc`` (the authors' ``freshtaste/proximal`` ``dgp.py``):
+   under a trending latent factor
+   (:math:`\boldsymbol{\lambda}_t \sim N(\log t, 1)`), classical SC is biased
+   by the trend (mean ATT ≈ 1.30 against the true 1.0, MSE ≈ 0.19) while
+   PI/PIS/PIPost recover the truth (biases ≲ 0.003) with near-nominal Wald
+   coverage and lower MSE; **PIS attains the lowest MSE** of the three
+   (≈ 0.05). See *Example* for a one-draw illustration.
 
    **DR & PIPW (Path B) -- runnable proof, not a claim.** The DR/PIPW
    agreement is demonstrated by the **runnable Monte Carlo above** (the
@@ -973,8 +989,11 @@ Replication Status
    misspecifying the outcome bridge (``Y`` nonlinear in the confounder)
    biases the outcome-only ``PI`` estimator (mean ATT ``≈ 4.3``) while
    ``DR`` stays at ``1.99``, rescued by the correct treatment-confounding
-   bridge. Copy-paste the block to re-derive these numbers. The
-   over-identified empirical analyses (Brazil/Florida/Kansas) are not
+   bridge. Copy-paste the block to re-derive these numbers, or run the
+   **durable** benchmark ``dr_proximal_mc`` -- it drives the same DGP through
+   the packaged estimators and pins recovery, coverage, and the
+   double-robustness collapse (PI ≈ 4.23 vs DR ≈ 1.96 under misspecification).
+   The over-identified empirical analyses (Brazil/Florida/Kansas) are not
    bit-reproducible cross-language (ill-conditioned GMM; see the admonition
    above), so DR/PIPW rest on this synthetic validation.
 

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -440,10 +440,25 @@ Identification under endogeneity
   PIPost :math:`-1.220` (matching the reference to ``1e-8``); the
   no-proxy SPSC (:math:`-0.892`), doubly-robust DR (:math:`-1.194`)
   and PIPW (:math:`-0.854`) are pinned alongside (durable:
-  ``proximal_panic1907``). **Path B:** Single-Proxy SC (SPSC) plus
-  Doubly-Robust and PIPW Monte Carlo --
-  SPSC-DT :math:`\widehat{\mathrm{ATT}} = -0.815` against
-  :math:`-0.816`.
+  ``proximal_panic1907``).
+  **Path B (PI/PIS/PIPost):** the authors' ``freshtaste/proximal``
+  surrogates DGP (Sec. 4.1, trending :math:`\log t` factor,
+  :math:`\mathrm{True.ATT}=1`) -- the proximal trio recovers the
+  truth with near-nominal coverage and PIS attains the lowest MSE,
+  while classical SC is biased by the trend (durable:
+  ``proximal_surrogates_mc``). **Path B (SPSC):** the authors' own
+  interactive-fixed-effects Monte Carlo (the ``qkrcks0218/SPSC``
+  README DGP, :math:`\mathrm{True.ATT}=3`) -- over 60 draws SPSC
+  recovers the truth essentially without bias under either
+  detrending choice, and the detrended **SPSC-DT** covers near the
+  nominal 95% while the un-detrended **SPSC-NoDT** under-covers under
+  the trend (durable: ``spsc_ifem_mc``). **Path B (DR/PIPW):** the
+  authors' ``DR_Proximal_SC/simulation/normal`` design
+  (:math:`\mathrm{True.ATE}=2`) -- DR and PIPW recover the truth with
+  near-nominal Wald coverage, and DR is robust to an outcome-bridge
+  misspecification that collapses the outcome-only PI
+  (:math:`\approx 4.2` vs. DR :math:`\approx 2.0`; durable:
+  ``dr_proximal_mc``).
 
 .. _replications-design:
 

--- a/mlsynth/tests/test_proximal_simulation.py
+++ b/mlsynth/tests/test_proximal_simulation.py
@@ -1,0 +1,211 @@
+"""Coverage + correctness tests for the proximal data-generating processes."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.proximal_helpers.simulation import (
+    DRSimSample,
+    ProxSurrogateSimSample,
+    SPSCSimSample,
+    _ar1_noise,
+    _ifem_factor,
+    simulate_dr_proximal_normal,
+    simulate_proximal_surrogates,
+    simulate_spsc_ifem,
+)
+
+
+class TestSimulateSpscIfem:
+    def test_default_shapes_and_fields(self):
+        s = simulate_spsc_ifem(seed=0)
+        assert isinstance(s, SPSCSimSample)
+        T = s.T0 + 50
+        assert s.y.shape == (T,)
+        assert s.donors.shape == (T, 16)          # 8 valid + 8 invalid
+        assert s.T0 == 50
+        assert s.n_valid == 8 and s.n_invalid == 8
+        assert s.true_effect.shape == (50,)
+        # true_att is the mean of the realised per-period effects
+        np.testing.assert_allclose(s.true_att, s.true_effect.mean())
+        # effect sits near the nominal 3.0 (small mean-zero perturbation)
+        assert abs(s.true_att - 3.0) < 0.1
+
+    def test_custom_dimensions(self):
+        s = simulate_spsc_ifem(T0=30, T1=20, n_valid=5, n_invalid=3, seed=1)
+        assert s.y.shape == (50,)
+        assert s.donors.shape == (50, 8)
+        assert s.T0 == 30 and s.n_valid == 5 and s.n_invalid == 3
+        assert s.true_effect.shape == (20,)
+
+    def test_zero_invalid_donors(self):
+        s = simulate_spsc_ifem(n_invalid=0, seed=2)
+        assert s.donors.shape[1] == 8
+
+    def test_true_att_override_shifts_post(self):
+        s0 = simulate_spsc_ifem(true_att=0.0, seed=3)
+        s5 = simulate_spsc_ifem(true_att=5.0, seed=3)
+        # pre-period identical; post-period shifted by exactly 5.0
+        np.testing.assert_allclose(s5.y[: s5.T0], s0.y[: s0.T0])
+        np.testing.assert_allclose(s5.y[s5.T0:], s0.y[s0.T0:] + 5.0)
+
+    def test_seed_is_deterministic(self):
+        a = simulate_spsc_ifem(seed=7).y
+        b = simulate_spsc_ifem(seed=7).y
+        np.testing.assert_array_equal(a, b)
+
+    def test_rng_takes_precedence_over_seed(self):
+        rng = np.random.default_rng(3)
+        s = simulate_spsc_ifem(rng=rng, seed=999, n_valid=4, n_invalid=2)
+        assert s.donors.shape[1] == 6
+
+    def test_corr_one_couples_treated_and_donor_errors(self):
+        # with corr=1 the idiosyncratic errors share the common shock entirely;
+        # the call must still produce a finite, correctly shaped draw
+        s = simulate_spsc_ifem(corr=1.0, seed=5)
+        assert np.all(np.isfinite(s.y)) and np.all(np.isfinite(s.donors))
+
+    @pytest.mark.parametrize("kwargs", [
+        {"n_valid": 0}, {"n_valid": 9},
+        {"n_invalid": -1},
+        {"T0": 0}, {"T1": 0},
+    ])
+    def test_invalid_inputs_raise(self, kwargs):
+        with pytest.raises(ValueError):
+            simulate_spsc_ifem(seed=0, **kwargs)
+
+
+class TestIfemFactor:
+    def test_shape_includes_warmup_rows(self):
+        baseline = np.ones(52)
+        f = _ifem_factor(50, np.random.default_rng(0), rho=0.5, sd=0.1,
+                         baseline=baseline)
+        assert f.shape == (52, 2)
+
+    def test_baseline_enters_additively(self):
+        # zero innovation scale -> factor equals the baseline (broadcast to 2 cols)
+        baseline = np.arange(12, dtype=float)
+        f = _ifem_factor(10, np.random.default_rng(0), rho=0.5, sd=0.0,
+                         baseline=baseline)
+        np.testing.assert_allclose(f, np.column_stack([baseline, baseline]))
+
+
+class TestSimulateDrProximalNormal:
+    def test_default_shapes_and_fields(self):
+        s = simulate_dr_proximal_normal(T=200, seed=0)
+        assert isinstance(s, DRSimSample)
+        assert s.y.shape == (200,)
+        assert s.donor_outcomes.shape == (200, 2)
+        assert s.donor_proxies.shape == (200, 2)
+        assert s.T0 == 100
+        assert s.true_att == 2.0
+        assert s.n_confounders == 2
+        assert s.misspecified is False
+
+    def test_custom_dimensions(self):
+        s = simulate_dr_proximal_normal(T=300, n_confounders=3, true_att=1.5, seed=1)
+        assert s.T0 == 150
+        assert s.donor_outcomes.shape == (300, 3)
+        assert s.donor_proxies.shape == (300, 3)
+        assert s.true_att == 1.5 and s.n_confounders == 3
+
+    def test_treatment_shift_in_post_mean(self):
+        # the post-period mean exceeds the pre-period mean by ~true_att (the only
+        # systematic pre/post difference; confounding is stationary)
+        s = simulate_dr_proximal_normal(T=4000, true_att=2.0, seed=2)
+        diff = s.y[s.T0:].mean() - s.y[: s.T0].mean()
+        assert abs(diff - 2.0) < 0.5
+
+    def test_misspecify_injects_nonlinear_signal(self):
+        lin = simulate_dr_proximal_normal(T=2000, misspecify=False, seed=3)
+        mis = simulate_dr_proximal_normal(T=2000, misspecify=True, seed=3)
+        assert mis.misspecified is True
+        # the proxies are drawn identically; only Y differs (the U^2 term)
+        np.testing.assert_array_equal(lin.donor_outcomes, mis.donor_outcomes)
+        assert not np.allclose(lin.y, mis.y)
+
+    def test_seed_is_deterministic(self):
+        a = simulate_dr_proximal_normal(T=300, seed=7).y
+        b = simulate_dr_proximal_normal(T=300, seed=7).y
+        np.testing.assert_array_equal(a, b)
+
+    def test_rng_takes_precedence_over_seed(self):
+        rng = np.random.default_rng(5)
+        s = simulate_dr_proximal_normal(T=120, n_confounders=4, rng=rng, seed=999)
+        assert s.donor_outcomes.shape == (120, 4)
+
+    @pytest.mark.parametrize("kwargs", [{"T": 1}, {"n_confounders": 0}])
+    def test_invalid_inputs_raise(self, kwargs):
+        with pytest.raises(ValueError):
+            simulate_dr_proximal_normal(seed=0, **kwargs)
+
+
+class TestSimulateProximalSurrogates:
+    def test_default_shapes_and_fields(self):
+        s = simulate_proximal_surrogates(T=200, seed=0)
+        assert isinstance(s, ProxSurrogateSimSample)
+        assert s.y.shape == (200,)
+        assert s.donor_outcomes.shape == (200, 1)
+        assert s.donor_proxies.shape == (200, 1)
+        assert s.surrogate_outcomes.shape == (200, 1)
+        assert s.surrogate_proxies.shape == (200, 1)
+        assert s.T0 == 100
+        assert s.n_donor_factors == 1 and s.n_surrogate_factors == 1
+        # the effect factor rho has mean ~1, so the realised ATT sits near 1
+        assert abs(s.true_att - 1.0) < 0.6
+
+    def test_custom_dimensions(self):
+        s = simulate_proximal_surrogates(
+            T=120, T0=80, n_donor_factors=2, n_surrogate_factors=3, seed=1)
+        assert s.T0 == 80
+        assert s.donor_outcomes.shape == (120, 2)
+        assert s.donor_proxies.shape == (120, 2)
+        assert s.surrogate_outcomes.shape == (120, 3)
+        assert s.surrogate_proxies.shape == (120, 3)
+
+    def test_donor_and_proxy_share_trend_not_noise(self):
+        # W and Z0 are two error-prone copies of the same trending factor:
+        # both trend up, but they are not identical (independent noise)
+        s = simulate_proximal_surrogates(T=400, seed=2)
+        assert s.donor_outcomes[-50:].mean() > s.donor_outcomes[:50].mean()
+        assert not np.allclose(s.donor_outcomes, s.donor_proxies)
+
+    def test_iid_errors_differ_from_ar(self):
+        kw = dict(T=200, seed=3)
+        ar = simulate_proximal_surrogates(ar_errors=True, **kw).y
+        iid = simulate_proximal_surrogates(ar_errors=False, **kw).y
+        assert not np.allclose(ar, iid)
+
+    def test_seed_is_deterministic(self):
+        a = simulate_proximal_surrogates(T=150, seed=7).y
+        b = simulate_proximal_surrogates(T=150, seed=7).y
+        np.testing.assert_array_equal(a, b)
+
+    def test_rng_takes_precedence_over_seed(self):
+        rng = np.random.default_rng(5)
+        s = simulate_proximal_surrogates(T=120, rng=rng, seed=999)
+        assert s.y.shape == (120,)
+
+    @pytest.mark.parametrize("kwargs", [
+        {"T": 1}, {"n_donor_factors": 0}, {"n_surrogate_factors": 0},
+        {"T": 100, "T0": 0}, {"T": 100, "T0": 100},
+    ])
+    def test_invalid_inputs_raise(self, kwargs):
+        with pytest.raises(ValueError):
+            simulate_proximal_surrogates(seed=0, **kwargs)
+
+
+class TestAr1Noise:
+    def test_iid_shape_and_randomness(self):
+        e = _ar1_noise(50, 3, np.random.default_rng(0), phi=0.1, ar=False)
+        assert e.shape == (50, 3)
+
+    def test_ar_starts_at_zero_state(self):
+        # first row is the raw innovation (no prior state); AR recursion builds up
+        rng = np.random.default_rng(0)
+        e = _ar1_noise(10, None, rng, phi=0.5, ar=True)
+        assert e.shape == (10,)
+        # a pure-AR series with phi differs from the same innovations i.i.d.
+        rng2 = np.random.default_rng(0)
+        iid = _ar1_noise(10, None, rng2, phi=0.5, ar=False)
+        assert not np.allclose(e, iid)

--- a/mlsynth/utils/proximal_helpers/simulation.py
+++ b/mlsynth/utils/proximal_helpers/simulation.py
@@ -1,0 +1,496 @@
+r"""Reference data-generating processes for the proximal estimators.
+
+Reusable simulators behind the durable proximal Path-B benchmarks, each a
+faithful port of an authors' own reference data-generating code:
+
+* :func:`simulate_spsc_ifem` -- the *"Toy Example from Interactive Fixed Effect
+  Models"* shipped in the README of the SPSC R package
+  (``github.com/qkrcks0218/SPSC``), accompanying Park & Tchetgen Tchetgen
+  (2025), *"Single Proxy Synthetic Control,"* JCI 13(1), 20230079. Drives the
+  ``spsc_ifem_mc`` benchmark.
+* :func:`simulate_dr_proximal_normal` -- the ``DR_Proximal_SC/simulation/normal``
+  design of Qiu, Shi, Miao, Dobriban & Tchetgen Tchetgen (2024), *"Doubly robust
+  proximal synthetic controls,"* Biometrics 80(2), ujae055. Drives the
+  ``dr_proximal_mc`` benchmark.
+* :func:`simulate_proximal_surrogates` -- the ``freshtaste/proximal`` ``dgp.py``
+  (Section 4.1 robustness) of Liu, Tchetgen Tchetgen & Varjao (2024), *"Proximal
+  Causal Inference for Synthetic Control with Surrogates,"* AISTATS. Drives the
+  ``proximal_surrogates_mc`` benchmark.
+
+The SPSC interactive-fixed-effects DGP follows.
+
+The DGP
+-------
+One treated unit and ``n_valid + n_invalid`` donors are observed over
+``T = T0 + T1`` periods. Two latent factors drive a *valid* donor block ``W`` and
+an *invalid* donor block ``V``; only ``W`` shares the treated unit's factors, so a
+**single proxy** (the donor outcomes) suffices to identify the bridge while the
+invalid donors act as noise the estimator must down-weight.
+
+.. math::
+
+   \lambda_t = b_t + \xi_t, \qquad
+   \xi_t = \rho\,\xi_{t-1} + \tfrac{\rho}{2}\,\xi_{t-2} + \nu_t,
+
+with a deterministic baseline trend ``b_t = 1 + t / T0`` (so the untreated
+trajectories drift -- the regime where detrending, SPSC-DT, matters). The valid
+donors load on ``lambda`` via ``W_coef``; the treated unit loads on the column
+means of ``W_coef`` (so a convex-ish combination of valid donors reproduces the
+treated factor); the invalid donors load on an independent factor ``zeta``. Idiosyncratic
+errors are correlated across the treated unit and the valid donors through a
+common shock (``corr``), making the SC problem non-trivial:
+
+.. math::
+
+   Y^{(0)}_t = \lambda_t' \mu_{Y} + e_{Yt}, \quad
+   W_t = \lambda_t' \mathrm{Wcoef} + e_{Wt}, \quad
+   V_t = \zeta_t' \mathrm{Vcoef} + e_{Vt}.
+
+The post-treatment effect is a constant ``true_att`` perturbed by a small
+mean-zero noise (``beta_eps``), matching the reference's *error-prone* treatment
+effect. The donor matrix handed to the estimator stacks ``[W, V]`` -- the single
+proxy group -- and the treated unit's own (optionally detrended) pre-period path
+is the instrument.
+
+Determinism
+-----------
+Every random draw comes from one :class:`numpy.random.Generator`, so a fixed
+``seed`` reproduces a draw bit-for-bit. Factor innovations and idiosyncratic
+errors are redrawn on each call, so repeated calls are independent draws from the
+sampling distribution -- the correct design for a bias / coverage study.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+__all__ = [
+    "SPSCSimSample",
+    "simulate_spsc_ifem",
+    "DRSimSample",
+    "simulate_dr_proximal_normal",
+    "ProxSurrogateSimSample",
+    "simulate_proximal_surrogates",
+]
+
+_RHO = 0.5            # latent-factor serial dependence
+_CORR = 0.5          # corr(treated error, valid-donor error)
+_SD = 0.1            # idiosyncratic error scale
+_TRUE_ATT = 3.0
+
+
+@dataclass(frozen=True)
+class SPSCSimSample:
+    """One draw from the SPSC interactive-fixed-effects DGP.
+
+    Attributes
+    ----------
+    y : np.ndarray
+        Observed treated path ``(T,)`` -- pre-period treatment-free, post-period
+        with the (noisy) effect added.
+    donors : np.ndarray
+        Single-proxy donor matrix ``(T, n_valid + n_invalid)`` -- the valid block
+        ``W`` followed by the invalid block ``V``.
+    T0 : int
+        Number of pre-treatment periods.
+    true_att : float
+        Average post-treatment effect actually realised on this draw (the mean of
+        the per-period error-prone effects); the estimand a consistent SPSC ATT
+        should recover.
+    true_effect : np.ndarray
+        Per-post-period error-prone effects ``(T1,)`` (``mean == true_att``).
+    n_valid, n_invalid : int
+        Counts of valid (factor-sharing) and invalid donors.
+    """
+
+    y: np.ndarray
+    donors: np.ndarray
+    T0: int
+    true_att: float
+    true_effect: np.ndarray
+    n_valid: int
+    n_invalid: int
+
+
+def _ifem_factor(Tt: int, rng: np.random.Generator, rho: float, sd: float,
+                 baseline: np.ndarray) -> np.ndarray:
+    """Two-dimensional latent factor with a baseline trend, shape ``(Tt + 2, 2)``.
+
+    ``xi_t = rho * xi_{t-1} + (rho / 2) * xi_{t-2} + nu_t`` (innovation scale
+    ``sd``), seeded by two ``N(0, sd^2)`` draws, plus the deterministic baseline.
+    """
+    eps = np.zeros((Tt + 2, 2))
+    eps[:2, :] = rng.standard_normal((2, 2)) * sd
+    for t in range(Tt):
+        eps[t + 2, :] = rho * eps[t + 1, :] + (rho / 2.0) * eps[t, :] + rng.standard_normal(2) * sd
+    return eps + baseline[:, None]
+
+
+def simulate_spsc_ifem(
+    T0: int = 50,
+    T1: int = 50,
+    n_valid: int = 8,
+    n_invalid: int = 8,
+    rho: float = _RHO,
+    corr: float = _CORR,
+    sd: float = _SD,
+    true_att: float = _TRUE_ATT,
+    rng: Optional[np.random.Generator] = None,
+    seed: Optional[int] = None,
+) -> SPSCSimSample:
+    """Draw one sample from the SPSC interactive-fixed-effects DGP.
+
+    Parameters
+    ----------
+    T0, T1 : int, default 50
+        Pre- and post-treatment period counts.
+    n_valid, n_invalid : int, default 8
+        Number of valid (factor-sharing) and invalid donors. ``n_valid`` may not
+        exceed 8 (the reference fixes eight valid-donor loadings).
+    rho : float, default 0.5
+        Latent-factor serial-dependence coefficient.
+    corr : float, default 0.5
+        Correlation between the treated unit's and the valid donors'
+        idiosyncratic errors (a shared common shock).
+    sd : float, default 0.1
+        Idiosyncratic / innovation error scale.
+    true_att : float, default 3.0
+        Mean post-treatment effect (the reference's ``True.ATT``).
+    rng : numpy.random.Generator, optional
+        Generator; takes precedence over ``seed``.
+    seed : int, optional
+        Convenience seed used to build a generator when ``rng`` is None.
+
+    Returns
+    -------
+    SPSCSimSample
+        The observed treated path, the stacked ``[W, V]`` donor matrix, ``T0``,
+        and the realised effect.
+    """
+    if rng is None:
+        rng = np.random.default_rng(seed)
+    if not 1 <= n_valid <= 8:
+        raise ValueError("n_valid must be in 1..8 (reference fixes 8 loadings).")
+    if n_invalid < 0:
+        raise ValueError("n_invalid must be non-negative.")
+    if T0 < 1 or T1 < 1:
+        raise ValueError("T0 and T1 must be positive.")
+
+    Tt = T0 + T1
+    # Reference factor loadings (2 x 8 each).
+    W_coef = np.vstack([np.arange(8, 0, -1) / 4.0,
+                        np.repeat([0.8, 0.6, 0.4, 0.2], 2)])
+    V_coef = np.vstack([np.ones(8), np.full(8, 0.5)])
+    Y0_coef = W_coef[:, :n_valid] @ np.full(n_valid, 1.0 / n_valid)   # treated loadings
+    # Baseline trend b_t = 1 + t / T0 (first two warm-up rows held flat at 1).
+    baseline = np.concatenate([[0.0, 0.0], np.arange(1, Tt + 1) / T0]) + 1.0
+
+    lam = _ifem_factor(Tt, rng, rho, sd, baseline)       # valid-donor / treated factor
+    zeta = _ifem_factor(Tt, rng, rho, sd, baseline)      # invalid-donor factor
+
+    common = rng.standard_normal(Tt + 2)
+    y0_idio = rng.standard_normal(Tt + 2)
+    w_idio = rng.standard_normal((Tt + 2, n_valid))
+    v_idio = rng.standard_normal((Tt + 2, n_invalid))
+    mix = np.sqrt(1.0 - corr ** 2)
+    y0_eps = sd * (corr * common + mix * y0_idio)
+    w_eps = sd * (corr * common[:, None] + mix * w_idio)
+    v_eps = sd * v_idio
+
+    Y0 = lam @ Y0_coef + y0_eps
+    W = lam @ W_coef[:, :n_valid] + w_eps
+    V = zeta @ V_coef[:, :n_invalid] + v_eps
+
+    beta_eps = np.concatenate([np.zeros(T0 + 2), rng.standard_normal(T1)])
+    beta = np.concatenate([np.zeros(T0 + 2), np.full(T1, true_att)])
+    beta_noisy = beta + beta_eps * sd
+    Y1 = Y0 + beta_noisy
+
+    Yobs = np.empty(Tt + 2)
+    Yobs[: 2 + T0] = Y0[: 2 + T0]
+    Yobs[2 + T0:] = Y1[2 + T0:]
+
+    # Drop the two warm-up rows; donors are the single proxy group [W, V].
+    donors = np.hstack([W, V])[2:]
+    y = Yobs[2:]
+    true_effect = beta_noisy[2 + T0:]
+    return SPSCSimSample(
+        y=y,
+        donors=donors,
+        T0=T0,
+        true_att=float(np.mean(true_effect)),
+        true_effect=true_effect,
+        n_valid=n_valid,
+        n_invalid=n_invalid,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Qiu, Shi, Miao, Dobriban & Tchetgen Tchetgen (2024) doubly-robust proximal
+# Monte Carlo -- the authors' ``DR_Proximal_SC/simulation/normal`` design.
+# --------------------------------------------------------------------------- #
+_DR_TRUE_ATE = 2.0
+
+
+@dataclass(frozen=True)
+class DRSimSample:
+    """One draw from the doubly-robust proximal ``normal`` DGP.
+
+    Attributes
+    ----------
+    y : np.ndarray
+        Treated outcome ``Y``, shape ``(T,)`` (post-period carries ``true_att``).
+    donor_outcomes : np.ndarray
+        Outcome proxies ``W`` (negative-control outcomes), shape ``(T, nU)``.
+    donor_proxies : np.ndarray
+        Treatment proxies ``Z`` (negative-control exposures), shape ``(T, nU)``.
+    T0 : int
+        Number of pre-treatment periods (``T // 2``).
+    true_att : float
+        The data-generating ATE (constant post-period shift).
+    n_confounders : int
+        Number of latent confounders ``nU``.
+    misspecified : bool
+        Whether the outcome bridge is misspecified (a nonlinear ``U`` signal was
+        injected into ``Y``, breaking a linear outcome model while the treatment
+        bridge stays correct -- the double-robustness stress test).
+    """
+
+    y: np.ndarray
+    donor_outcomes: np.ndarray
+    donor_proxies: np.ndarray
+    T0: int
+    true_att: float
+    n_confounders: int
+    misspecified: bool
+
+
+def simulate_dr_proximal_normal(
+    T: int = 1000,
+    n_confounders: int = 2,
+    true_att: float = _DR_TRUE_ATE,
+    misspecify: bool = False,
+    rng: Optional[np.random.Generator] = None,
+    seed: Optional[int] = None,
+) -> DRSimSample:
+    r"""Draw one sample from the DR-proximal ``normal`` DGP (Qiu et al. 2024).
+
+    A faithful port of the reference ``DR_Proximal_SC/simulation/normal``
+    data-generating code:
+
+    .. math::
+
+        U_t = 0.1\,U_{t-1} + 0.9\,\nu_t, \quad
+        Y_t = \tau\,\mathbb{1}\{t > T_0\} + 2\,s(U_t) + e_t, \\
+        W_{tj} = 2 U_{tj} + \varepsilon^W_{tj}, \qquad
+        Z_{tj} = 2 U_{tj} + \varepsilon^Z_{tj},
+
+    with ``nU`` latent AR(1) confounders, ``T0 = T // 2``, and unit-variance
+    Gaussian noise throughout. The donor outcomes ``W`` and the donor proxies
+    ``Z`` are independent error-prone shadows of the confounder. By default the
+    confounding signal is linear, ``s(U) = sum_j U_j``; with ``misspecify=True``
+    it is ``s(U) = sum_j U_j + 0.7 (sum_j U_j)^2`` -- a nonlinearity an
+    intercept-free linear outcome bridge cannot absorb, so the outcome-only PI
+    estimator is biased while the doubly-robust estimator (with a correct
+    treatment bridge) stays consistent.
+
+    Parameters
+    ----------
+    T : int, default 1000
+        Total number of periods (pre-period is ``T // 2``).
+    n_confounders : int, default 2
+        Number of latent confounders ``nU`` (and the donor / proxy count).
+    true_att : float, default 2.0
+        Constant post-period treatment effect (the reference's ``true.ATE``).
+    misspecify : bool, default False
+        Inject the nonlinear confounding signal that breaks a linear outcome
+        bridge (the double-robustness stress test).
+    rng : numpy.random.Generator, optional
+        Generator; takes precedence over ``seed``.
+    seed : int, optional
+        Convenience seed used to build a generator when ``rng`` is None.
+
+    Returns
+    -------
+    DRSimSample
+        The treated outcome, the ``W`` / ``Z`` proxy blocks, ``T0``, and the
+        truth.
+    """
+    if rng is None:
+        rng = np.random.default_rng(seed)
+    if T < 2:
+        raise ValueError("T must be at least 2.")
+    if n_confounders < 1:
+        raise ValueError("n_confounders must be positive.")
+
+    nU = n_confounders
+    T0 = T // 2
+    U = np.empty((T, nU))
+    U[0] = rng.standard_normal(nU)
+    for t in range(1, T):
+        U[t] = 0.1 * U[t - 1] + 0.9 * rng.standard_normal(nU)
+    sig = U.sum(1)
+    signal = sig + 0.7 * sig ** 2 if misspecify else sig
+    post = (np.arange(1, T + 1) > T0).astype(float)
+    y = true_att * post + 2.0 * signal + rng.standard_normal(T)
+    W = 2.0 * U + rng.standard_normal((T, nU))
+    Z = 2.0 * U + rng.standard_normal((T, nU))
+    return DRSimSample(
+        y=y,
+        donor_outcomes=W,
+        donor_proxies=Z,
+        T0=T0,
+        true_att=float(true_att),
+        n_confounders=nU,
+        misspecified=bool(misspecify),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Liu, Tchetgen Tchetgen & Varjao (2024) proximal-with-surrogates Monte Carlo
+# -- the authors' ``freshtaste/proximal`` ``dgp.py`` (Section 4.1 robustness).
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ProxSurrogateSimSample:
+    """One draw from the proximal-with-surrogates DGP (Liu et al. 2024).
+
+    Attributes
+    ----------
+    y : np.ndarray
+        Treated outcome ``Y``, shape ``(T,)``.
+    donor_outcomes : np.ndarray
+        Donor outcomes ``W`` (negative-control outcomes), shape ``(T, F)``.
+    donor_proxies : np.ndarray
+        Donor proxies ``Z0`` -- a second error-prone copy of the latent factor
+        that instruments ``W``, shape ``(T, F)``.
+    surrogate_outcomes : np.ndarray
+        Post-period surrogates ``X`` (correlates of the effect), shape ``(T, K)``.
+    surrogate_proxies : np.ndarray
+        Surrogate proxies ``Z1`` instrumenting ``X``, shape ``(T, K)``.
+    T0 : int
+        Number of pre-treatment periods.
+    true_att : float
+        Realised average post-treatment effect (mean of the per-period effects).
+    n_donor_factors, n_surrogate_factors : int
+        Factor counts ``F`` and ``K``.
+    """
+
+    y: np.ndarray
+    donor_outcomes: np.ndarray
+    donor_proxies: np.ndarray
+    surrogate_outcomes: np.ndarray
+    surrogate_proxies: np.ndarray
+    T0: int
+    true_att: float
+    n_donor_factors: int
+    n_surrogate_factors: int
+
+
+def _ar1_noise(T: int, cols: Optional[int], rng: np.random.Generator,
+               phi: float, ar: bool) -> np.ndarray:
+    """AR(1) (``ar=True``) or i.i.d. Gaussian noise, shape ``(T,)`` or ``(T, cols)``."""
+    shape = (T,) if cols is None else (T, cols)
+    nu = rng.standard_normal(shape)
+    if not ar:
+        return nu
+    e = np.zeros_like(nu)
+    for t in range(1, T):
+        e[t] = phi * e[t - 1] + nu[t]
+    return e
+
+
+def simulate_proximal_surrogates(
+    T: int = 200,
+    T0: Optional[int] = None,
+    n_donor_factors: int = 1,
+    n_surrogate_factors: int = 1,
+    ar_errors: bool = True,
+    ar_phi: float = 0.1,
+    rng: Optional[np.random.Generator] = None,
+    seed: Optional[int] = None,
+) -> ProxSurrogateSimSample:
+    r"""Draw one sample from the proximal-with-surrogates DGP (Liu et al. 2024).
+
+    A faithful port of the authors' reference ``freshtaste/proximal`` ``dgp.py``
+    used in their Section 4.1 robustness study. A **trending** latent factor
+    drives the treated outcome and the donor block; a second factor drives the
+    post-period surrogates:
+
+    .. math::
+
+        \lambda_t = \log t + \nu_t, \quad
+        Y_t = \lambda_t' \boldsymbol{1} + e_{Yt}
+              + \mathbb{1}\{t > T_0\}(\rho_t' \boldsymbol{1} + \delta_t), \\
+        W_t = \lambda_t + e^W_t, \quad Z0_t = \lambda_t + e^{Z0}_t, \quad
+        X_t = \rho_t + e^X_t, \quad Z1_t = \rho_t + e^{Z1}_t,
+
+    with AR(1) (or i.i.d.) idiosyncratic errors. ``W`` and ``Z0`` are two
+    independent error-prone copies of the donor factor (so ``Z0`` instruments
+    ``W``); ``X`` and ``Z1`` are two copies of the effect factor ``rho``. The
+    trending ``log t`` factor is the regime where classical SC, fitting an
+    error-laden donor regression, extrapolates with growing bias while the
+    proximal estimators stay consistent.
+
+    Parameters
+    ----------
+    T : int, default 200
+        Total periods.
+    T0 : int, optional
+        Pre-period length; defaults to ``T // 2``.
+    n_donor_factors, n_surrogate_factors : int, default 1
+        Factor counts ``F`` and ``K`` (and the donor / surrogate block widths).
+    ar_errors : bool, default True
+        Use AR(1) idiosyncratic errors (the reference's robustness regime).
+    ar_phi : float, default 0.1
+        AR(1) coefficient.
+    rng : numpy.random.Generator, optional
+        Generator; takes precedence over ``seed``.
+    seed : int, optional
+        Convenience seed used to build a generator when ``rng`` is None.
+
+    Returns
+    -------
+    ProxSurrogateSimSample
+        The treated outcome, the donor / surrogate outcome and proxy blocks,
+        ``T0``, and the realised effect.
+    """
+    if rng is None:
+        rng = np.random.default_rng(seed)
+    if T < 2:
+        raise ValueError("T must be at least 2.")
+    if n_donor_factors < 1 or n_surrogate_factors < 1:
+        raise ValueError("factor counts must be positive.")
+    T0 = T // 2 if T0 is None else int(T0)
+    if not 1 <= T0 < T:
+        raise ValueError("T0 must satisfy 1 <= T0 < T.")
+    F, K = n_donor_factors, n_surrogate_factors
+
+    epsY = _ar1_noise(T, None, rng, ar_phi, ar_errors)
+    epsW = _ar1_noise(T, F * 2, rng, ar_phi, ar_errors)
+    epsX = _ar1_noise(T, K * 2, rng, ar_phi, ar_errors)
+    delta = _ar1_noise(T, None, rng, ar_phi, ar_errors)
+
+    lam = np.log(np.linspace(1, T, T))[:, None] + rng.standard_normal((T, F))  # trending
+    rho = rng.standard_normal((T, K))
+    rho[:, 0] += 1.0
+
+    y = lam @ np.ones(F) + epsY
+    effect = rho[T0:] @ np.ones(K)
+    y[T0:] += effect + delta[T0:]
+    W = lam + epsW[:, :F]
+    Z0 = lam + epsW[:, F:]
+    X = rho + epsX[:, :K]
+    Z1 = rho + epsX[:, K:]
+    return ProxSurrogateSimSample(
+        y=y,
+        donor_outcomes=W,
+        donor_proxies=Z0,
+        surrogate_outcomes=X,
+        surrogate_proxies=Z1,
+        T0=T0,
+        true_att=float(np.mean(effect)),
+        n_donor_factors=F,
+        n_surrogate_factors=K,
+    )


### PR DESCRIPTION
## What

Finishes the **Path-B** coverage of the proximal class. Three reusable simulators (`mlsynth/utils/proximal_helpers/simulation.py`), each a value-for-value port of an authors' own reference DGP, drive three durable benchmarks:

| case | DGP (reference) | pins |
|---|---|---|
| `spsc_ifem_mc` | `qkrcks0218/SPSC` README IFEM (`True.ATT=3`) | SPSC-DT recovers the ATT with ~nominal coverage; SPSC-NoDT under-covers under the trend |
| `dr_proximal_mc` | `DR_Proximal_SC/simulation/normal` (Qiu et al., `true.ATE=2`) | DR & PIPW recover the truth with near-nominal coverage; **double robustness** — PI collapses to ≈4.2 under outcome-bridge misspecification while DR holds at ≈2.0 |
| `proximal_surrogates_mc` | `freshtaste/proximal` `dgp.py` (Liu et al. Sec 4.1, `True.ATT=1`) | PI/PIS/PIPost recover the truth with near-nominal coverage, **PIS attains the lowest MSE**, all three beat a biased classical-SC baseline |

Together with the already-merged Path-A cross-validation (`proximal_panic1907`, #48), every PROXIMAL method now carries a durable benchmark.

## Notes

- Each helper has a **100%-covered** test (`test_proximal_simulation.py`).
- Estimators are driven at the array level (closed-form / GMM), so the cases run in ≤ 1 s each (`spsc_ifem_mc` ~48 s for the CV-tuned SPSC).
- Catalogue + estimator-page docs updated to cite the durable cases.
- Benchmark-only PR (no estimator changes), per the project's separate-workstream rule.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_