### PR TITLE
benchmarks: graduate 5 simulation harnesses to durable Path-B cases (CTSC/SIV/FMA/PANGEO/SHC)

### DIFF
--- a/benchmarks/cases/ctsc_powell_mc.py
+++ b/benchmarks/cases/ctsc_powell_mc.py
@@ -1,0 +1,56 @@
+"""CTSC Path-B: Powell (2022) continuous-treatment SC vs two-way FE (Table 1).
+
+Validates mlsynth's ``CTSC`` (the paper's generalized synthetic control) against
+the calibrated Monte Carlo of Powell (2022), Section 5 / Table 1. The DGP
+(:func:`mlsynth.utils.ctsc_helpers.simulation.generate_model`) has a **continuous
+treatment correlated with the interactive fixed effects** and a true average
+effect of exactly zero each draw, so two-way fixed effects is badly biased while
+CTSC is not.
+
+  ========  =================  =================
+  Quantity  CTSC               two-way FE
+  ========  =================  =================
+  mean bias ~0.00              ~0.82-0.87
+  RMSE      small (~0.04)      ~0.85
+  ========  =================  =================
+
+Path B (the paper's simulation): the case asserts CTSC's near-zero bias and that
+it is an order of magnitude less biased than two-way FE on Models 1-2 -- the
+paper's headline -- not exact Monte Carlo cells. Deterministic (seeded).
+"""
+from __future__ import annotations
+
+import warnings
+
+
+def run() -> dict:
+    from mlsynth.utils.ctsc_helpers.simulation import run_simulation
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        s1 = run_simulation(1, n_sims=40, seed=0)
+        s2 = run_simulation(2, n_sims=25, seed=0)
+    return {
+        "ctsc_bias_m1": s1.ctsc_mean_bias,
+        "fe_bias_m1": s1.fe_mean_bias,
+        "ctsc_rmse_m1": s1.ctsc_rmse,
+        "ctsc_bias_m2": s2.ctsc_mean_bias,
+        "fe_bias_m2": s2.fe_mean_bias,
+        "ctsc_beats_fe_m1": float(abs(s1.ctsc_mean_bias) < 0.25 * abs(s1.fe_mean_bias)),
+        "ctsc_beats_fe_m2": float(abs(s2.ctsc_mean_bias) < 0.25 * abs(s2.fe_mean_bias)),
+    }
+
+
+# Deterministic (seeded). Tolerances absorb the Monte Carlo noise at n_sims=40/25.
+# Reproduces Powell (2022) Table 1: CTSC is ~unbiased (true effect 0) where
+# two-way FE carries a large bias (~0.82-0.87) from the treatment's correlation
+# with the interactive fixed effects.
+EXPECTED = {
+    "ctsc_bias_m1": (0.0, 0.08),
+    "fe_bias_m1": (0.82, 0.18),
+    "ctsc_rmse_m1": (0.04, 0.06),
+    "ctsc_bias_m2": (0.0, 0.06),
+    "fe_bias_m2": (0.87, 0.18),
+    "ctsc_beats_fe_m1": (1.0, 0.0),
+    "ctsc_beats_fe_m2": (1.0, 0.0),
+}

--- a/benchmarks/cases/fma_coverage_mc.py
+++ b/benchmarks/cases/fma_coverage_mc.py
@@ -1,0 +1,80 @@
+"""FMA Path-B: Li & Sonnier (2023) asymptotic-CI coverage (Web Appendix E).
+
+Validates mlsynth's ``FMA`` (factor-model approach) against the paper's own Monte
+Carlo. The methodological contribution is that the asymptotic confidence interval
+of Theorem 3.1 attains **nominal coverage regardless of whether the treated and
+control idiosyncratic variances are equal** -- the regime where the Xu (2017)
+interval breaks. The DGP
+(:func:`mlsynth.utils.fma_helpers.simulation.simulate_fma_sample`) has a zero true
+effect, so coverage is whether the CI contains 0.
+
+Across the three variance regimes (``equal`` / ``treated_smaller`` /
+``treated_larger``) FMA's 95% CI covers at ~0.95-0.97 -- near nominal in every
+cell:
+
+  =================  ===============
+  variance regime    FMA coverage
+  =================  ===============
+  equal              ~0.95
+  treated_smaller    ~0.95
+  treated_larger     ~0.95
+  =================  ===============
+
+Path B (the paper's simulation): the case asserts every cell covers near the
+nominal 95% -- the paper's headline that coverage is robust to variance
+inequality -- not exact cells (fewer reps than the paper's 100,000).
+Deterministic (seeded).
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+M = 40
+
+
+def _coverage(dgp: str, variance_case: str) -> float:
+    from mlsynth import FMA
+    from mlsynth.utils.fma_helpers.simulation import simulate_fma_sample
+
+    covers = np.empty(M)
+    for j in range(M):
+        s = simulate_fma_sample(dgp=dgp, N_co=30, T1=30, T2=20,
+                                variance_case=variance_case,
+                                rng=np.random.default_rng(j))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = FMA({"df": s.df, "outcome": "y", "treat": "D",
+                       "unitid": "unit", "time": "time",
+                       "display_graphs": False}).fit()
+        d = res.inference_detail
+        covers[j] = 1.0 if d.asymptotic_att_lower <= 0.0 <= d.asymptotic_att_upper else 0.0
+    return float(covers.mean())
+
+
+def run() -> dict:
+    cells = {
+        "cov_equal": _coverage("dgp1", "equal"),
+        "cov_treated_smaller": _coverage("dgp1", "treated_smaller"),
+        "cov_treated_larger": _coverage("dgp1", "treated_larger"),
+        "cov_dgp2_equal": _coverage("dgp2", "equal"),
+    }
+    cells["min_coverage"] = float(min(cells.values()))
+    cells["all_near_nominal"] = float(all(c >= 0.88 for c in
+                                          list(cells.values())[:4]))
+    return cells
+
+
+# Deterministic (seeded). Tolerances absorb the Monte Carlo noise at M=40 (the
+# paper uses 100,000). Reproduces Li & Sonnier's headline: the asymptotic CI
+# covers near the nominal 95% in every variance regime, including when the treated
+# and control variances differ (where Xu's interval fails).
+EXPECTED = {
+    "cov_equal": (0.95, 0.10),
+    "cov_treated_smaller": (0.95, 0.10),
+    "cov_treated_larger": (0.95, 0.10),
+    "cov_dgp2_equal": (0.95, 0.12),
+    "min_coverage": (0.92, 0.10),
+    "all_near_nominal": (1.0, 0.0),
+}

--- a/benchmarks/cases/pangeo_supergeo_mc.py
+++ b/benchmarks/cases/pangeo_supergeo_mc.py
@@ -1,0 +1,116 @@
+"""PANGEO Path-B: trajectory-matched supergeo design vs scalar matching.
+
+Validates mlsynth's ``PANGEO`` geo-experiment design on the paper's motivating
+scenario (Chen, Doudchenko, Jiang, Stein & Ying 2023): six geos form three
+parallel pairs (up-trend / down-trend / cycle), each **demeaned over the
+pre-period so all baseline means are identical**. A scalar (Google-style) match on
+the baseline mean is therefore blind to the shape and pairs geos essentially at
+random; PANGEO matches on the full pre-treatment trajectory and recovers the
+three parallel pairs.
+
+Injecting a true effect ``tau = 4`` and running the downstream
+difference-in-differences, PANGEO estimates the effect **~30x more precisely**
+than the scalar match:
+
+  =========================  ===============
+  design                     DiD RMSE
+  =========================  ===============
+  PANGEO (trajectory)        ~0.2
+  scalar matched-pairs       ~6
+  =========================  ===============
+
+Path B (the paper's design scenario): the case asserts PANGEO's RMSE is far below
+the scalar match's (an order of magnitude or more) -- the supergeo idea carried
+into the panel world (match on *how series move*, not a single number).
+Deterministic (seeded); the six-geo MIP is instantaneous.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+
+R = 30
+_TAU = 4.0
+
+
+def _make_panel(rng, T_pre=20, S=6, level=100.0, noise=0.6):
+    T = T_pre + S
+    t = np.arange(T)
+    up = (t - t.mean()) / t.std()
+    cyc = np.sin(2 * np.pi * t / 5.0)
+    shapes = [5 * up, 5 * up, -5 * up, -5 * up, 5 * cyc, 5 * cyc]
+    cols = []
+    for s in shapes:
+        s = s - s[:T_pre].mean()                 # equal pre-means => scalar-blind
+        cols.append(level + s + rng.normal(0, noise, T))
+    return np.column_stack(cols), T_pre
+
+
+def _did(Y, T_pre, treated, control):
+    Yo = Y.copy()
+    Yo[T_pre:, treated] += _TAU
+    t_eff = Yo[T_pre:, treated].mean() - Yo[:T_pre, treated].mean()
+    c_eff = Yo[T_pre:, control].mean() - Yo[:T_pre, control].mean()
+    return (t_eff - c_eff) - _TAU
+
+
+def _pangeo_design(Y, T_pre):
+    from mlsynth import PANGEO
+
+    df = pd.DataFrame(
+        {"geo": f"g{g}", "t": int(t), "y": Y[t, g], "arm": "A"}
+        for g in range(6) for t in range(T_pre)
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        a = PANGEO({"df": df, "outcome": "y", "unitid": "geo", "time": "t",
+                    "arm": "arm", "max_supergeo_size": 1,
+                    "compute_power": False, "display_graphs": False}).fit().assignment
+    T = [int(g[1:]) for g, v in a.items() if v == "treatment"]
+    C = [int(g[1:]) for g, v in a.items() if v == "control"]
+    return T, C
+
+
+def _scalar_match(Y, T_pre, rng):
+    order = np.argsort(Y[:T_pre].mean(0))
+    T, C = [], []
+    for k in range(0, 6, 2):
+        a, b = order[k], order[k + 1]
+        if rng.random() < 0.5:
+            T.append(a); C.append(b)
+        else:
+            T.append(b); C.append(a)
+    return T, C
+
+
+def run() -> dict:
+    rng = np.random.default_rng(1)
+    pe, se = np.empty(R), np.empty(R)
+    for i in range(R):
+        Y, T_pre = _make_panel(rng)
+        Tp, Cp = _pangeo_design(Y, T_pre)
+        pe[i] = _did(Y, T_pre, Tp, Cp)
+        Ts, Cs = _scalar_match(Y, T_pre, rng)
+        se[i] = _did(Y, T_pre, Ts, Cs)
+    rmse_p = float(np.sqrt((pe ** 2).mean()))
+    rmse_s = float(np.sqrt((se ** 2).mean()))
+    return {
+        "rmse_pangeo": rmse_p,
+        "rmse_scalar": rmse_s,
+        "precision_ratio": rmse_s / rmse_p,
+        "pangeo_beats_scalar_10x": float(rmse_p < 0.1 * rmse_s),
+    }
+
+
+# Deterministic (seeded). Tolerances absorb the Monte Carlo noise at R=30.
+# Reproduces the paper's design scenario: PANGEO's trajectory match recovers the
+# parallel pairs and estimates the effect an order of magnitude (~30x) more
+# precisely than a scalar baseline match, which is blind to the equal-mean shapes.
+EXPECTED = {
+    "rmse_pangeo": (0.22, 0.18),
+    "rmse_scalar": (6.1, 2.5),
+    "precision_ratio": (28.0, 22.0),       # ~30x; assert well above 10x
+    "pangeo_beats_scalar_10x": (1.0, 0.0),
+}

--- a/benchmarks/cases/shc_recovery_mc.py
+++ b/benchmarks/cases/shc_recovery_mc.py
@@ -1,0 +1,61 @@
+"""SHC Path-B: latent-confounder recovery (Chen, Yang & Yang 2024, Sec 3.1).
+
+Validates mlsynth's ``SHC`` against the paper's simulation design. The DGP
+(:func:`mlsynth.utils.shc_helpers.simulation`) is a single series
+``y_t = ell_t + delta_t d_t + eps_t`` with **no intervention effect**
+(``delta_t = 0``), so the exercise measures how well SHC recovers the latent
+time-varying confounder ``ell_t`` in the post-intervention period. The latent is a
+globally C^1 curve of alternating cosine local-trends and cubic-Hermite
+connectors; the treated block's shape is a convex combination of the historical
+shapes (Assumption 2(b)).
+
+With ``delta_t = 0``, both the pre-period matching error (``MSE_pre``, Eq. 31) and
+the post-period prediction error against the *true* latent (``MSE_post(k)``, Eq.
+38) are near zero, and ``MSE_post`` rises mildly with the horizon -- consistent
+with the paper's bias bound (Proposition 1) growing with the horizon but staying
+small for a smooth, regularly-recurring latent at low noise:
+
+  ============  ===============
+  Quantity      value
+  ============  ===============
+  MSE_pre       ~0.001
+  MSE_post(1)   ~0.001
+  MSE_post(25)  ~0.002
+  ============  ===============
+
+Path B (the paper's simulation): the case asserts SHC recovers the latent to
+near-zero error pre and post -- the recovery property the method rests on -- not
+exact cells. Deterministic (seeded).
+"""
+from __future__ import annotations
+
+
+def run() -> dict:
+    from mlsynth.utils.shc_helpers import monte_carlo_shc
+
+    out = monte_carlo_shc(
+        n_reps=5, m=25, h=4, n=25, P=10, sigma=0.1,
+        w_f=(1, 0, 0, 0), regular=True, k_grid=(1, 5, 10, 25), seed=0,
+    )
+    mse_pre = float(out["mse_pre"])
+    mp = {int(k): float(v) for k, v in out["mse_post"].items()}
+    return {
+        "mse_pre": mse_pre,
+        "mse_post_1": mp[1],
+        "mse_post_25": mp[25],
+        "recovery_near_zero": float(mse_pre < 0.02 and mp[1] < 0.02 and mp[25] < 0.02),
+        "post_at_least_pre": float(mp[25] >= 0.5 * mse_pre),
+    }
+
+
+# Deterministic (seeded). Tolerances absorb the Monte Carlo noise at n_reps=5.
+# Reproduces Chen-Yang-Yang Sec 3.1 (Regular-l, sigma=0.1): SHC recovers the
+# latent confounder to ~1e-3 matching error pre and post, with the post-period
+# prediction error rising only mildly with the horizon.
+EXPECTED = {
+    "mse_pre": (0.0011, 0.01),
+    "mse_post_1": (0.0011, 0.01),
+    "mse_post_25": (0.0017, 0.015),
+    "recovery_near_zero": (1.0, 0.0),
+    "post_at_least_pre": (1.0, 0.0),
+}

--- a/benchmarks/cases/siv_syria_mc.py
+++ b/benchmarks/cases/siv_syria_mc.py
@@ -1,0 +1,99 @@
+"""SIV Path-B: Gulek & Vives (2024) Syrian-calibrated Monte Carlo (Table 1).
+
+Validates mlsynth's ``SIV`` (Synthetic IV) against the paper's Section-6 Table-1
+simulation. The DGP
+(:func:`mlsynth.utils.siv_helpers.simulation.simulate_siv_sample`) couples the
+treatment to the outcome through both a common factor *and* an idiosyncratic
+correlation ``r`` swept across the bivariate-normal shock pairs, so 2SLS-TWFE is
+biased even with valid post-period instrument assignment. SIV's interactive-factor
+debiasing removes that bias.
+
+At the true coefficient ``theta = -0.16``, over Monte Carlo draws at each
+``r in {0.5, 0.7, 0.9}`` SIV has **substantially lower absolute bias** than
+2SLS-TWFE (the paper's headline ranking):
+
+  =====  ===============  ===============
+  r      |bias| SIV       |bias| 2SLS
+  =====  ===============  ===============
+  0.5    ~0.02            ~0.11
+  0.7    ~0.09            ~0.22
+  0.9    ~0.24            ~0.38
+  =====  ===============  ===============
+
+Path B (the paper's simulation): the case asserts SIV beats 2SLS-TWFE at every
+correlation level and that the 2SLS bias matches the paper's Table-1 cells, not
+exact SIV cells (fewer reps than the paper's 1,000). Deterministic (seeded).
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+M = 80
+_THETA = -0.16
+_RS = (0.5, 0.7, 0.9)
+
+
+def _tsls_twfe(Y, R, Z, T0):
+    """Two-way-FE 2SLS slope -- the biased baseline the paper benchmarks against."""
+    T = Y.shape[1]
+
+    def demean(X):
+        X = X - X.mean(axis=1, keepdims=True)
+        return X - X.mean(axis=0, keepdims=True)
+
+    Yd, Rd, Zd = demean(Y), demean(R), demean(Z)
+    mask = np.arange(T) >= T0
+    y, r, z = Yd[:, mask].flatten(), Rd[:, mask].flatten(), Zd[:, mask].flatten()
+    z_c = np.column_stack([np.ones_like(z), z])
+    b_fs, *_ = np.linalg.lstsq(z_c, r, rcond=None)
+    rhat = z_c @ b_fs
+    r_c = np.column_stack([np.ones_like(y), rhat])
+    b_ss, *_ = np.linalg.lstsq(r_c, y, rcond=None)
+    return float(b_ss[1])
+
+
+def _bias_pair(r: float):
+    from mlsynth import SIV
+    from mlsynth.utils.siv_helpers.simulation import simulate_siv_sample
+
+    siv, tsls = np.empty(M), np.empty(M)
+    for s in range(M):
+        sample = simulate_siv_sample(r=r, rng=np.random.default_rng(s))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            est = SIV({"df": sample.df, "outcome": "y", "treat": "r",
+                       "instrument": "z", "unitid": "unit", "time": "time",
+                       "T0": sample.T0, "mode": "siv",
+                       "display_graphs": False}).fit()
+        siv[s] = float(est.theta_hat)
+        tsls[s] = _tsls_twfe(sample.Y, sample.R, sample.Z, sample.T0)
+    return abs(float(siv.mean()) - _THETA), abs(float(tsls.mean()) - _THETA)
+
+
+def run() -> dict:
+    out = {}
+    siv_wins = 0
+    for r in _RS:
+        sb, tb = _bias_pair(r)
+        out[f"siv_bias_r{int(r*10)}"] = sb
+        out[f"tsls_bias_r{int(r*10)}"] = tb
+        siv_wins += int(sb < tb)
+    out["siv_beats_tsls_all"] = float(siv_wins == len(_RS))
+    return out
+
+
+# Deterministic (seeded). Tolerances absorb the Monte Carlo noise at M=80 (the
+# paper uses 1,000). Reproduces Gulek & Vives Table 1: SIV's debiasing yields
+# substantially lower bias than 2SLS-TWFE at every correlation level; the 2SLS
+# baseline matches the paper's cells (0.111 / 0.218 / 0.360).
+EXPECTED = {
+    "siv_bias_r5": (0.02, 0.08),
+    "tsls_bias_r5": (0.111, 0.05),
+    "siv_bias_r7": (0.09, 0.10),
+    "tsls_bias_r7": (0.218, 0.06),
+    "siv_bias_r9": (0.24, 0.14),
+    "tsls_bias_r9": (0.360, 0.08),
+    "siv_beats_tsls_all": (1.0, 0.0),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -59,6 +59,11 @@ CASES = {
     "spillsynth_grossi_germany": "benchmarks.cases.spillsynth_grossi_germany",  # Path A: grossi direct+spillover German reunification (Grossi et al.)
     "spillsynth_iterative_germany": "benchmarks.cases.spillsynth_iterative_germany",  # Path A: iterative waterfall SCM German reunification (Melnychuk)
     "spillsynth_sar_mc": "benchmarks.cases.spillsynth_sar_mc",  # Path B: SAR spillover recovery + SCM nesting (Sakaguchi-Tagawa)
+    "ctsc_powell_mc": "benchmarks.cases.ctsc_powell_mc",      # Path B: CTSC vs two-way FE bias (Powell 2022 Table 1)
+    "siv_syria_mc": "benchmarks.cases.siv_syria_mc",          # Path B: SIV vs 2SLS-TWFE bias (Gulek-Vives Table 1)
+    "fma_coverage_mc": "benchmarks.cases.fma_coverage_mc",      # Path B: FMA asymptotic-CI coverage robust to variance (Li-Sonnier)
+    "pangeo_supergeo_mc": "benchmarks.cases.pangeo_supergeo_mc",  # Path B: PANGEO trajectory match vs scalar (Chen et al.)
+    "shc_recovery_mc": "benchmarks.cases.shc_recovery_mc",      # Path B: SHC latent-confounder recovery (Chen-Yang-Yang Sec 3.1)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -171,7 +171,14 @@ Generalising the estimand, treatment, or unit
   Table 1 Monte Carlo across Models 1-4 with factor structure and
   true average effect :math:`= 0`; CTSC bias :math:`\approx 0.00`
   against the paper's :math:`0.005`-:math:`0.011` range, vs.
-  fixed-effects bias :math:`\approx 0.80`.
+  fixed-effects bias :math:`\approx 0.80` (durable: ``ctsc_powell_mc``).
+* :doc:`shc` -- Chen, Yang & Yang (2024) Synthetic Historical
+  Control. **Path B:** the Section-3.1 effect-free simulation --
+  with :math:`\delta_t = 0`, SHC recovers the latent confounder
+  :math:`\ell_t` to :math:`\approx 10^{-3}` matching error pre and
+  post (``MSE_pre`` / ``MSE_post`` near zero, rising only mildly with
+  the horizon, as the bias bound predicts; durable:
+  ``shc_recovery_mc``).
 * :doc:`dsc` -- Distributional SC. **Path B:** Gunsilius (2023)
   Figure 4 reproduction -- the 2-Wasserstein-squared distance
   collapses at :math:`J = 30` against the rough fit at
@@ -324,7 +331,9 @@ Time-aware and factor models
 * :doc:`fma` -- Li & Sonnier (2023) factor model approach.
   **Path B:** coverage study under DGP1 (stationary) and DGP2
   (non-stationary), 1000 reps; coverage at :math:`M = 1000`
-  equals 0.947 against the nominal 0.95.
+  equals 0.947 against the nominal 0.95 -- and stays near nominal
+  across the equal / treated-smaller / treated-larger variance
+  regimes where Xu's interval fails (durable: ``fma_coverage_mc``).
 * :doc:`tasc` -- Rho et al. (2026) time-aware SC. **Path A:**
   Proposition 99 -- pre-RMSE 0.767, ATT -16.793, gap of -24
   packs by 2000 against the paper's Figure 10 gap of -25 to -30.
@@ -469,7 +478,9 @@ Identification under endogeneity
   :math:`-0.89 / -0.72 / -0.75`. **Path B:** Section 6 Syrian-
   calibrated Monte Carlo across :math:`r \in \{0.5, 0.7, 0.9\}`
   at 200 reps; TSLS-TWFE bias 0.111 / 0.228 / 0.387 matches the
-  paper's 0.111 / 0.218 / 0.360 essentially exactly.
+  paper's 0.111 / 0.218 / 0.360 essentially exactly, with
+  SIV's debiasing far below 2SLS at every level (durable:
+  ``siv_syria_mc``).
 * :doc:`proximal` -- Proximal SC. **Path A (cross-validation):**
   Panic of 1907 on the Trust panel, cross-validated against the
   authors' Python reference (``freshtaste/proximal``, pinned commit
@@ -519,7 +530,7 @@ Experimental design
   trajectories; PANGEO RMSE :math:`\approx 0.2` against scalar-
   matching RMSE :math:`\approx 6` at :math:`\tau = 4` (a
   :math:`30\times` improvement); pre-period parallelism
-  :math:`R^2 \in [0.90, 0.98]`.
+  :math:`R^2 \in [0.90, 0.98]` (durable: ``pangeo_supergeo_mc``).
 * :doc:`spcd` -- Synthetic Principal Component Design.
   **Path B:** Lu-Li-Ying-Blanchet linear-factor model with
   :math:`\tau = 1`, :math:`\sigma = 1` -- SPCD mean


### PR DESCRIPTION
## What

Graduates five estimators' existing simulators into durable, commit-stamped Path-B registry benchmarks — each a "method unbiased / valid where the naive is biased" reproduction:

| case | reproduces | headline |
|---|---|---|
| `ctsc_powell_mc` | Powell (2022) Table 1 | CTSC bias ~0 vs two-way FE ~0.82/0.87 |
| `siv_syria_mc` | Gulek-Vives (2024) Table 1 | SIV bias ≪ 2SLS-TWFE at every `r`; 2SLS = 0.11/0.22/0.38 |
| `fma_coverage_mc` | Li-Sonnier (2023) | asymptotic CI ~0.95 across equal / treated-smaller / treated-larger variance |
| `pangeo_supergeo_mc` | Chen et al. (2023) | trajectory match DiD RMSE ~0.22 vs scalar ~6.1 (~28×) |
| `shc_recovery_mc` | Chen-Yang-Yang (2024) §3.1 | latent recovery MSE_pre/post ~1e-3 with δ=0 |

All deterministic (seeded). Registry + replications catalogue updated (durable-case pointers + a new SHC catalogue entry).

This moves durable benchmark coverage from **24/44 → 29/44** estimators.

## Note

`shc_recovery_mc` runs ~119 s — the SHC fit is dominated by ~1,870 per-fit cvxpy QP solves (mostly cvxpy canonicalization overhead). A custom OSQP solver for that QP is coming as a **separate follow-up PR** (estimator change), after which the benchmark can use more reps.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_