### PR TITLE
benchmarks: durable DSCAR (Beijing PM2.5) + MSQRT (Section-6 sim) cases

### DIFF
--- a/benchmarks/cases/dscar_beijing.py
+++ b/benchmarks/cases/dscar_beijing.py
@@ -1,0 +1,90 @@
+"""DSCAR Path-A: Beijing air-pollution alerts (Zheng & Chen 2024).
+
+Reproduces the empirical application of Zheng & Chen (2024), *"Dynamic synthetic
+control method for evaluating treatment effects in auto-regressive processes"*
+(JRSS-B): the effect of Beijing's heavy-pollution **alerts** (mandatory emission
+cuts) on station-level PM2.5, with a time-varying AR(1) outcome model and exact
+covariate matching via empirical likelihood.
+
+**Orange alert** (17 Nov 2016, 94 stations, 20 treated; 48 h pre / 24 h post)
+reproduces the paper **value for value**:
+
+  ===============  ===============  ===============
+  Quantity         mlsynth          paper
+  ===============  ===============  ===============
+  ATT              -33.78           -33.8
+  reduction        24.3%            24.3%
+  treated mean     105.28           105.3
+  counterfactual   139.07           139.0
+  ===============  ===============  ===============
+
+**Red alert** (16 Dec 2016, 66 stations): mlsynth recovers a large negative
+effect (ATT -55.7, a ~22% reduction), but the magnitude differs from the paper's
+-70.4 / 26.2% -- the released code omits a per-unit pressure/humidity de-meaning
+step the paper's numbers appear to use (documented on the estimator's page). The
+case pins the **qualitative** red-alert finding and mlsynth's value as a
+regression guard, not the paper's exact magnitude.
+
+Path A: the orange alert is a faithful reproduction; the red alert is a
+qualitative + regression pin. Deterministic.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "basedata")
+
+
+def _fit(alert: str):
+    import pandas as pd
+
+    from mlsynth import DSCAR
+
+    df = pd.read_csv(os.path.join(_DIR, f"beijing_pm25_{alert}_alert.csv"))
+    df["treat_indicator"] = ((df["alert_if"] == 1) & (df["hour_eps"] > 48)).astype(int)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = DSCAR({
+            "df": df, "outcome": "pm25", "treat": "treat_indicator",
+            "unitid": "id_eps", "time": "hour_eps",
+            "exog_covariates": ["WSPM", "humi", "dewp", "pres"],
+            "lagged_outcome": "pm25_lag1", "display_graphs": False,
+        }).fit()
+    mu0 = float(res.fit.Y0_hat[48:].mean())
+    mu1 = float(res.fit.Y_treated_mean[48:].mean())
+    return float(res.att), abs(float(res.att_relative)), mu0, mu1
+
+
+def run() -> dict:
+    o_att, o_rel, o_mu0, o_mu1 = _fit("orange")
+    r_att, r_rel, _, _ = _fit("red")
+    return {
+        # orange alert -- faithful Path-A replication
+        "orange_att": o_att,
+        "orange_reduction": o_rel,
+        "orange_counterfactual": o_mu0,
+        "orange_treated_mean": o_mu1,
+        "orange_vs_paper_att": abs(o_att - (-33.8)),
+        # red alert -- qualitative + regression guard
+        "red_att": r_att,
+        "red_reduction": r_rel,
+        "red_large_negative": float(r_att < -30.0),
+    }
+
+
+# Deterministic (empirical-likelihood / closed-form weights, no RNG). The orange
+# cells reproduce Zheng & Chen's Table value for value (ATT to 0.05 ug/m^3); the
+# red cells pin mlsynth's value as a regression guard and the qualitative finding
+# (large negative ATT, ~20% reduction), the paper's exact -70.4 magnitude not
+# being reproducible from the released code.
+EXPECTED = {
+    "orange_att": (-33.78, 0.4),
+    "orange_reduction": (0.243, 0.01),
+    "orange_counterfactual": (139.07, 1.0),
+    "orange_treated_mean": (105.28, 1.0),
+    "orange_vs_paper_att": (0.02, 0.4),         # matches paper -33.8
+    "red_att": (-55.7, 3.0),
+    "red_reduction": (0.219, 0.03),
+    "red_large_negative": (1.0, 0.0),
+}

--- a/benchmarks/cases/msqrt_sim.py
+++ b/benchmarks/cases/msqrt_sim.py
@@ -1,0 +1,77 @@
+"""MSQRT Path-B: Shen, Song & Abadie (2025) Section-6 simulation.
+
+Validates mlsynth's ``MSQRT`` (multivariate square-root Lasso synthetic control)
+against the data-generating process of Shen, Song & Abadie (2025), *"Efficiently
+Learning Synthetic Control Models for High-dimensional Disaggregated Data"*
+(arXiv 2510.22828), Section 6. With a true ATT of zero, the harness
+(:func:`mlsynth.utils.msqrt_helpers.replication.run_msqrt_simulation`) reports, per
+number of treated units ``m`` and DGP setting:
+
+* the **ATT bias** (the first post-period treated gap; the truth is 0, so the gap
+  *is* the bias), and
+* the **RMSE** of the imputed counterfactual ``Y(0)`` over the post window.
+
+The paper's headline reproduces qualitatively: the estimator is **unbiased**
+(bias centred at zero) and the RMSE stays **near the noise floor** and roughly
+flat across ``m`` -- the property that makes the high-dimensional, many-treated
+regime work.
+
+  ===========  ==================  ==================
+  setting      bias (m=20 / 50)    RMSE (m=20 / 50)
+  ===========  ==================  ==================
+  1            -0.07 / +0.07       0.35 / 0.38
+  2            +0.07 / +0.07       0.28 / 0.20
+  ===========  ==================  ==================
+
+This runs a **reduced regime** (``n = 80`` donors, ``T0 = 50``, 12 reps, the
+penalty fixed once) so it finishes in ~2 min; the paper's exact ``n = 400``,
+500-replication study pins the RMSE level at ~0.72. The case asserts the
+*reproducible* facts -- the estimator is unbiased within Monte-Carlo noise and
+the RMSE sits near the ``sigma = 0.5`` noise floor (not blowing up with ``m``) --
+not the paper's exact large-``n`` cells. Deterministic (seeded).
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+
+def run() -> dict:
+    from mlsynth.utils.msqrt_helpers.replication import (
+        SimConfig, run_msqrt_simulation)
+
+    cfg = SimConfig(n=80, T0=50, T1=10, s=200, sigma=0.5,
+                    m_grid=[20, 50], n_reps=12)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = run_msqrt_simulation(cfg, settings=(1, 2), seed=0,
+                                   lambda_override=0.5, verbose=False)
+
+    biases, rmses = [], []
+    for setting in (1, 2):
+        biases += [r["bias_mean"] for r in out[setting]]
+        rmses += [r["rmse_mean"] for r in out[setting]]
+    biases = np.asarray(biases)
+    rmses = np.asarray(rmses)
+    return {
+        "abs_bias_max": float(np.max(np.abs(biases))),
+        "unbiased": float(np.all(np.abs(biases) < 0.2)),
+        "rmse_min": float(rmses.min()),
+        "rmse_max": float(rmses.max()),
+        "rmse_near_noise_floor": float(np.all((rmses > 0.05) & (rmses < 0.8))),
+    }
+
+
+# Deterministic (seeded). Tolerances absorb the Monte-Carlo noise at 12 reps.
+# Reproduces Shen-Song-Abadie's qualitative Section-6 finding: the square-root
+# Lasso SC is unbiased (bias centred at zero, |bias| <= ~0.1 here vs the paper's
+# ~0) and the counterfactual RMSE stays near the sigma=0.5 noise floor and
+# roughly flat in m (the paper's exact n=400 level is ~0.72).
+EXPECTED = {
+    "abs_bias_max": (0.074, 0.12),
+    "unbiased": (1.0, 0.0),
+    "rmse_min": (0.20, 0.15),
+    "rmse_max": (0.38, 0.20),
+    "rmse_near_noise_floor": (1.0, 0.0),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -64,6 +64,7 @@ CASES = {
     "fma_coverage_mc": "benchmarks.cases.fma_coverage_mc",      # Path B: FMA asymptotic-CI coverage robust to variance (Li-Sonnier)
     "pangeo_supergeo_mc": "benchmarks.cases.pangeo_supergeo_mc",  # Path B: PANGEO trajectory match vs scalar (Chen et al.)
     "shc_recovery_mc": "benchmarks.cases.shc_recovery_mc",      # Path B: SHC latent-confounder recovery (Chen-Yang-Yang Sec 3.1)
+    "dscar_beijing": "benchmarks.cases.dscar_beijing",      # Path A: DSCAR Beijing PM2.5 alerts (Zheng-Chen)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -65,6 +65,7 @@ CASES = {
     "pangeo_supergeo_mc": "benchmarks.cases.pangeo_supergeo_mc",  # Path B: PANGEO trajectory match vs scalar (Chen et al.)
     "shc_recovery_mc": "benchmarks.cases.shc_recovery_mc",      # Path B: SHC latent-confounder recovery (Chen-Yang-Yang Sec 3.1)
     "dscar_beijing": "benchmarks.cases.dscar_beijing",      # Path A: DSCAR Beijing PM2.5 alerts (Zheng-Chen)
+    "msqrt_sim": "benchmarks.cases.msqrt_sim",                # Path B: MSQRT unbiasedness + RMSE noise-floor (Shen-Song-Abadie Sec 6)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -322,6 +322,16 @@ High-dimensional donor pools
   :math:`[-21.3, -15.4]`) on the ADH donor pool (durable:
   ``sparse_sc_prop99``). See the
   :doc:`dedicated page <replications/sparse_sc>`.
+* :doc:`msqrt` -- Shen, Song & Abadie (2025) multivariate
+  square-root-Lasso SC for high-dimensional disaggregated data.
+  **Path B:** the Section-6 simulation (true ATT = 0) -- the
+  estimator is **unbiased** (mean bias within Monte-Carlo noise of
+  zero) and the imputed-counterfactual RMSE stays near the
+  :math:`\sigma = 0.5` noise floor and roughly flat in the number of
+  treated units :math:`m`, the property that makes the
+  many-treated regime work (durable: ``msqrt_sim``; run at a reduced
+  :math:`n = 80` regime -- the paper's exact :math:`n = 400` RMSE level
+  is :math:`\approx 0.72`).
 
 .. _replications-time:
 
@@ -481,6 +491,16 @@ Identification under endogeneity
   paper's 0.111 / 0.218 / 0.360 essentially exactly, with
   SIV's debiasing far below 2SLS at every level (durable:
   ``siv_syria_mc``).
+* :doc:`dscar` -- Zheng & Chen (2024) dynamic SC for
+  auto-regressive processes. **Path A:** Beijing heavy-pollution
+  **alerts** on station-level PM2.5 -- the *orange* alert reproduces
+  the paper value for value (ATT :math:`-33.78` vs :math:`-33.8`, a
+  24.3% reduction; counterfactual 139.1 vs 139.0, treated mean 105.3
+  vs 105.3), while the *red* alert recovers a large negative effect
+  (:math:`-55.7`, ~22% reduction) whose magnitude differs from the
+  paper's :math:`-70.4` (the released code omits a per-unit de-meaning
+  step), pinned as a qualitative + regression guard (durable:
+  ``dscar_beijing``).
 * :doc:`proximal` -- Proximal SC. **Path A (cross-validation):**
   Panic of 1907 on the Trust panel, cross-validated against the
   authors' Python reference (``freshtaste/proximal``, pinned commit


### PR DESCRIPTION
## What

Two more durable graduations (coverage **30 → 32/44**), from the docs-validated tier:

### `dscar_beijing` — Path A (Zheng & Chen 2024, qkad103)
DSCAR (dynamic SC for auto-regressive processes) on the Beijing heavy-pollution **alerts**:
- **Orange alert** reproduces the paper *value for value* — ATT **−33.78 vs −33.8**, 24.3% reduction, counterfactual 139.1 vs 139.0, treated mean 105.3 vs 105.3.
- **Red alert** recovers a large negative effect (−55.7, ~22%) whose magnitude differs from the paper's −70.4 (the released code omits a per-unit de-meaning step) — pinned as a **qualitative + regression guard**, matching the honest framing already on the estimator page.

### `msqrt_sim` — Path B (Shen, Song & Abadie 2025, 2510.22828)
MSQRT (multivariate square-root-Lasso SC) on the Section-6 DGP (true ATT = 0):
- the estimator is **unbiased** (|bias| within MC noise of 0), and
- the imputed-`Y(0)` **RMSE sits near the σ=0.5 noise floor** and stays flat in the number of treated units `m`.
- Run at a reduced `n=80` regime so it finishes in ~3 min; the paper's exact `n=400` RMSE level (~0.72) needs the full 500-rep study — noted in the case.

Both deterministic (seeded), both pass. Registry + replications catalogue updated (new high-dim / endogeneity entries).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_