### PR TITLE
augsynth: reproduce all four Kansas cells through the public API + ASCM theory/inference docs

### DIFF
--- a/docs/replications/ascm_kansas.rst
+++ b/docs/replications/ascm_kansas.rst
@@ -43,20 +43,33 @@ with each covariate transformed per row and aggregated to a pre-period mean per
 unit (rows carrying a missing — sparsely reported — revenue value are dropped
 before averaging, R's ``model.frame`` ``na.omit`` default).
 
+The whole ladder is reproduced **through mlsynth's public API** -- Augmented SCM
+is a mode of :class:`~mlsynth.estimators.vanillasc.VanillaSC` (``augment="ridge"``).
+Covariates are passed by column name; the user applies augsynth's per-row ``log``
+transforms to the DataFrame first (mlsynth's covariate convention), and the
+shared-window aggregation drops a pre-period whenever *any* covariate is missing
+there, matching augsynth's ``na.omit``. ``residualize=True`` selects the
+residualized variant:
+
 .. code-block:: python
 
    import numpy as np, pandas as pd
-   from mlsynth.utils.bilevel import simplex_qp, build_matching
-   from mlsynth.utils.bilevel.ridge_augment import ridge_augment_weights
+   from mlsynth import VanillaSC
 
-   df = pd.read_csv("basedata/kansas_ascm.csv")
-   # ... pivot to (unit x time), split pre/post, build the covariate matrix Z ...
-   B, A = build_matching(y_pre, Y0_pre)
-   w_scm = simplex_qp(B, A)                                            # classic SCM
-   w_ridge = ridge_augment_weights(y_pre, Y0_pre).W                   # ridge ASCM
-   w_cov = ridge_augment_weights(y_pre, Y0_pre, Z0=Z0, z1=z1).W       # + covariates
-   w_res = ridge_augment_weights(y_pre, Y0_pre, Z0=Z0, z1=z1,
-                                 residualize=True).W                  # residualized
+   df = pd.read_csv("basedata/kansas_ascm.csv")          # long fips x quarter panel
+   for c in ("revstatecapita", "revlocalcapita", "avgwklywagecapita"):
+       df[c] = np.log(df[c])                             # augsynth's log transforms
+   covs = ["lngdpcapita", "revstatecapita", "revlocalcapita",
+           "avgwklywagecapita", "estabscapita", "emplvlcapita"]
+   base = dict(df=df, outcome="lngdpcapita", treat="treated",
+               unitid="fips", time="year_qtr")
+
+   att = lambda cfg: VanillaSC({**base, **cfg}).fit().effects.att
+   att({})                                               # classic SCM    -0.029
+   att({"augment": "ridge"})                             # ridge ASCM     -0.040
+   att({"augment": "ridge", "covariates": covs})         # covariate ASCM -0.063
+   att({"augment": "ridge", "covariates": covs,
+        "residualize": True})                            # residualized   -0.057
 
 The reproduced ladder (mlsynth vs ``augsynth``):
 

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -105,7 +105,7 @@ over-interpreted.
 Inference
 ---------
 
-Two inference modes are available via ``inference=``:
+Four inference modes are available via ``inference=``:
 
 ``"placebo"`` (default, ``inference=True``)
     Abadie's in-space placebo test: the synthetic control is refit treating
@@ -113,6 +113,33 @@ Two inference modes are available via ``inference=``:
     is ranked against the placebo distribution to give a p-value. Simple and
     assumption-light, but the smallest achievable p-value is about
     :math:`1/(J+1)`.
+
+``"conformal"`` -- prediction intervals (Chernozhukov, Wüthrich & Zhu 2021)
+    The ``augsynth`` default for Augmented SCM, and a *distribution-free* test
+    by inversion. For a sharp null :math:`H_0:\ \tau_t = \tau_0` the post-period
+    treated outcome is adjusted by :math:`\tau_0`, the weights are refit on the
+    adjusted data, and the post-period residual is checked for whether it
+    **conforms** with the pre-treatment residuals -- its rank among them is the
+    :math:`p`-value,
+
+    .. math::
+
+       p(\tau_0) = \frac{1 + \#\{\,t \le T_0 : |\hat u_t| \ge
+       |\hat u_{\mathrm{post}}(\tau_0)|\,\}}{T_0 + 1}.
+
+    Inverting the test (the :math:`\tau_0` not rejected at level :math:`\alpha`)
+    gives a **per-period prediction interval** for the random counterfactual
+    :math:`Y_{1T}(0)`; the same machinery returns one joint-null :math:`p`-value
+    for the whole effect path. It is *exactly valid* when the residuals are
+    exchangeable, and finite-sample bounded otherwise -- the ridge penalty
+    controls the SCM-vs-ASCM weight difference, so validity holds as
+    :math:`T_0 \to \infty`. Unlike the placebo test it needs no donor pool, and
+    unlike asymptotic intervals no normality; in the Kansas calibrations its
+    intervals attain near-nominal coverage where plain SCM under-covers from
+    poor-fit bias. The bands are returned in
+    ``res.inference.details["counterfactual_lower" / "counterfactual_upper"]``
+    (shaded on the plot) alongside the joint ``["joint_p_value"]`` --
+    :func:`mlsynth.utils.bilevel.ridge_inference.conformal_intervals`.
 
 ``"scpi"`` -- prediction intervals (Cattaneo, Feng & Titiunik 2021)
     Treats :math:`\tau_T` as a *predictand* (a random variable) and builds
@@ -473,11 +500,90 @@ leave-one-period-out cross-validation (augsynth's 1-SE rule); inference is by
 the conformal permutation test of Chernozhukov, Wüthrich & Zhu (2021)
 (:func:`mlsynth.utils.bilevel.ridge_inference.conformal_pvalue`).
 
+When to prefer augmentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Plain SCM is justified only when the pre-treatment fit is **excellent**: when
+the treated unit lies inside the convex hull of the donors' lagged outcomes the
+simplex weights balance :math:`X_1` exactly and the estimator is (near) unbiased
+(Abadie, Diamond & Hainmueller 2010). Outside the hull -- few donors, a long or
+high-dimensional pre-period, an outlying treated unit -- no convex combination
+fits, and the residual imbalance :math:`X_1 - X_0^\top\hat\gamma^{\mathrm{scm}}`
+turns into bias. SCM has no way to correct it.
+
+Augmented SCM is the middle ground. With :math:`\hat m` the ridge outcome model,
+the ASCM estimate is the SCM estimate **plus an estimate of that bias**,
+
+.. math::
+
+   \hat Y_{1T}^{\mathrm{aug}}(0) = \underbrace{\textstyle\sum_{W_i=0}
+   \hat\gamma_i^{\mathrm{scm}} Y_{iT}}_{\text{SCM}}
+   + \Big( \hat m_T - \textstyle\sum_{W_i=0}\hat\gamma_i^{\mathrm{scm}}
+   \hat m_{iT} \Big),
+
+exactly analogous to bias correction for inexact matching (Abadie & Imbens 2011)
+and connected to doubly-robust estimation (Robins, Rotnitzky & Zhao 1994). Ridge
+ASCM is itself a *penalized* SCM whose penalty is on **deviations from the
+simplex weights**: it starts at the SCM solution and extrapolates beyond the
+hull (admitting negative weights) only as far as needed. :math:`\lambda` sets the
+amount -- :math:`\lambda \to \infty` recovers plain SCM (no extrapolation),
+:math:`\lambda \to 0` drives the pre-fit to zero (full extrapolation). That is a
+bias-variance dial: augmentation removes imbalance bias at the cost of a larger
+weight norm / extrapolation variance, and :math:`\lambda` (leave-one-period-out
+CV, one-standard-error rule) negotiates it.
+
+The authors' practical rule -- and ours -- is to **decide from the estimated bias
+itself**: it is the imbalance term above, in the units of the estimand, and the
+first quantity ASCM computes. If it is large relative to the effect you expect,
+augment; if pre-fit is already excellent the correction is negligible and ASCM
+and SCM coincide. Two diagnostics accompany it: the pre-treatment RMSE
+(:math:`\lVert X_1 - X_0^\top\hat\gamma\rVert/\sqrt{T_0}`, the imbalance that
+remains) and the extrapolation distance
+(:math:`\lVert\hat\gamma^{\mathrm{aug}} - \hat\gamma^{\mathrm{scm}}\rVert
+/\sqrt{N_0}`, how far the weights left the simplex). Across the paper's calibrated
+DGPs, ASCM has both lower bias *and* lower RMSE than SCM -- gains largest under
+misspecification and poor fit, modest when SCM already fits well.
+
 Auxiliary covariates enter in either of augsynth's two ways: **parallel**
 (``residualize=False``, the default) standardizes the covariates to the
 outcome scale and stacks them as extra matching rows; **residualized**
 (``residualize=True``) regresses the covariates out of the outcomes, matches on
 the residuals, and restores covariate balance with an add-back on the weights.
+
+Example
+^^^^^^^
+
+Augmented SCM is a *mode* of :class:`~mlsynth.estimators.vanillasc.VanillaSC` --
+set ``augment="ridge"`` (and ``inference="conformal"`` for the CWZ prediction
+intervals). Covariates are passed by column name; following mlsynth's
+convention, apply any transforms (e.g. ``log``) to the DataFrame yourself first.
+``residualize=True`` switches parallel inclusion for the residualized variant.
+The four-cell augsynth Kansas ladder, reproduced **through the public API**:
+
+.. code-block:: python
+
+   import numpy as np, pandas as pd
+   from mlsynth import VanillaSC
+
+   df = pd.read_csv("basedata/kansas_ascm.csv")          # long fips x quarter panel
+   for c in ("revstatecapita", "revlocalcapita", "avgwklywagecapita"):
+       df[c] = np.log(df[c])                             # log the covariates up front
+   covs = ["lngdpcapita", "revstatecapita", "revlocalcapita",
+           "avgwklywagecapita", "estabscapita", "emplvlcapita"]
+   base = dict(df=df, outcome="lngdpcapita", treat="treated",
+               unitid="fips", time="year_qtr")
+
+   VanillaSC({**base}).fit().effects.att                              # -0.029  classic SCM
+   VanillaSC({**base, "augment": "ridge"}).fit().effects.att          # -0.040  ridge ASCM
+   VanillaSC({**base, "augment": "ridge",
+              "covariates": covs}).fit().effects.att                  # -0.063  covariate ASCM
+   VanillaSC({**base, "augment": "ridge", "covariates": covs,
+              "residualize": True}).fit().effects.att                 # -0.057  residualized
+
+   # conformal prediction intervals (and a plotted band with display_graphs=True):
+   res = VanillaSC({**base, "augment": "ridge", "inference": "conformal"}).fit()
+   res.inference.ci_lower, res.inference.ci_upper        # ATT prediction interval
+   res.inference.details["joint_p_value"]                # conformal joint-null p-value
 
 .. _vanillasc-ascm-verification:
 
@@ -491,9 +597,12 @@ classic SCM (ATT :math:`-0.029`), ridge ASCM (:math:`-0.040`), covariate ASCM
 value-for-value, with pre-fit :math:`L_2` imbalance falling monotonically from
 :math:`0.083` to :math:`0.054`. The paper's Section-7 thesis (near-nominal
 coverage and bias reduction across calibrated DGPs) is reproduced as a Path-B
-simulation. See the dedicated page :doc:`replications/ascm_kansas`; durable
-cases ``ascm_kansas`` (cross-validation vs augsynth) and ``augsynth_calibrated``
-(Path B), locked in ``mlsynth/tests/test_bilevel_ridge.py``.
+simulation. The full ladder is reproduced **through the public API** -- pinned
+in ``mlsynth/tests/test_vanillasc_ascm.py::test_augsynth_kansas_ladder_public_api``
+-- not just at the engine level. See the dedicated page
+:doc:`replications/ascm_kansas`; durable cases ``ascm_kansas`` (cross-validation
+vs augsynth) and ``augsynth_calibrated`` (Path B), locked in
+``mlsynth/tests/test_bilevel_ridge.py``.
 
 Core API
 --------

--- a/mlsynth/tests/test_vanillasc_ascm.py
+++ b/mlsynth/tests/test_vanillasc_ascm.py
@@ -136,6 +136,18 @@ def test_placebo_with_covariates():
 # --------------------------------------------------------------------------- #
 # Edge cases
 # --------------------------------------------------------------------------- #
+def test_per_covariate_windows_use_independent_means():
+    # two covariates with *different* windows -> the joint-na.omit path can't
+    # apply, so means are taken independently (per-covariate fallback).
+    df = _panel(seed=3).copy()
+    df["x2"] = df["x1"] + 0.5
+    res = VanillaSC({"df": df, **_BASE, "covariates": ["x1", "x2"],
+                     "covariate_windows": {"x1": (0, 6), "x2": (0, 10)},
+                     "backend": "mscmt", "mscmt_maxiter": 5, "mscmt_popsize": 5,
+                     "inference": False}).fit()
+    assert np.isfinite(res.effects.att)
+
+
 def test_covariate_window_out_of_range_falls_back():
     # a window outside the pre-period range -> no years match -> fall back to all
     res = VanillaSC({"df": _panel(), **_BASE, "covariates": ["x1"],
@@ -255,3 +267,40 @@ def test_scpi_direct_no_misspecification_and_degenerate_donors():
     # u_missp=False also exercises the zero-mean residual branch.
     sc = scpi_intervals(y, Y0, pre, W, sims=30, u_missp=False, seed=0)
     assert sc.lower.shape == sc.upper.shape
+
+
+# --------------------------------------------------------------------------- #
+# augsynth Kansas ladder -- reproduced through the PUBLIC API (not the engine).
+# This is the definition of done for the augsynth port: all four cells must
+# match augsynth via VanillaSC(...).fit(), with the user log-transforming the
+# covariates beforehand (mlsynth's covariate convention -- plain column names).
+# --------------------------------------------------------------------------- #
+_KANSAS = os.path.join(os.path.dirname(__file__), "..", "..", "basedata", "kansas_ascm.csv")
+
+
+@pytest.mark.skipif(not os.path.exists(_KANSAS), reason="Kansas data not present")
+def test_augsynth_kansas_ladder_public_api():
+    df = pd.read_csv(_KANSAS)
+    # augsynth Kansas spec: lngdpcapita + log(revstate/revlocal/avgwkly) +
+    # estabs + emplvl. The user logs the three columns before input.
+    for c in ("revstatecapita", "revlocalcapita", "avgwklywagecapita"):
+        df[c] = np.log(df[c])
+    covs = ["lngdpcapita", "revstatecapita", "revlocalcapita",
+            "avgwklywagecapita", "estabscapita", "emplvlcapita"]
+    base = dict(df=df, outcome="lngdpcapita", treat="treated", unitid="fips",
+                time="year_qtr", display_graphs=False, inference=False)
+
+    def att(cfg):
+        return float(VanillaSC({**base, **cfg}).fit().effects.att)
+
+    scm = att({})
+    ridge = att({"augment": "ridge"})
+    cov = att({"augment": "ridge", "covariates": covs})
+    rez = att({"augment": "ridge", "covariates": covs, "residualize": True})
+
+    assert abs(scm - (-0.0294)) < 0.003, f"SCM {scm}"
+    assert abs(ridge - (-0.0401)) < 0.003, f"ridge {ridge}"
+    assert abs(cov - (-0.0629)) < 0.004, f"covariate {cov}"
+    assert abs(rez - (-0.0572)) < 0.004, f"residualized {rez}"
+    # the de-biasing ladder is monotone in |ATT|
+    assert abs(scm) < abs(ridge) < abs(cov)

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -35,23 +35,50 @@ def _covariate_means(
     unitid: str,
     time: str,
 ) -> np.ndarray:
-    """Per-unit covariate means over each covariate's window -> ``(P, N)``."""
-    rows = []
+    """Per-unit covariate means over each covariate's window -> ``(K, N)``.
+
+    With a single shared window (the default, and augsynth's covariate spec) the
+    aggregation is a joint ``na.omit``: a pre-period contributes to the means
+    only if *every* covariate is observed there, matching augsynth's
+    ``X <- na.omit(...)`` (which drops a row carrying any missing covariate
+    before averaging). Per-covariate windows fall back to independent means.
+    """
     for cov in covariates:
         if cov not in df.columns:
             raise MlsynthDataError(f"Covariate {cov!r} not in DataFrame.")
+
+    def _years(cov):
         win = windows.get(cov)
         if win is None:
-            years = pre_labels
-        else:
-            lo, hi = win
-            years = [t for t in pre_labels if lo <= t <= hi]
-            if not years:
-                years = pre_labels
+            return list(pre_labels)
+        lo, hi = win
+        return [t for t in pre_labels if lo <= t <= hi] or list(pre_labels)
+
+    year_sets = [_years(c) for c in covariates]
+
+    if all(ys == year_sets[0] for ys in year_sets):
+        # joint na.omit over the shared window (augsynth convention)
+        years = year_sets[0]
         sub = df[df[time].isin(years)]
-        g = sub.groupby(unitid)[cov].mean()
-        rows.append([float(g.get(u, np.nan)) for u in units])
-    X = np.asarray(rows, dtype=float)
+        stack = np.stack(
+            [sub.pivot_table(index=unitid, columns=time, values=cov)
+                .reindex(index=units, columns=years).to_numpy()
+             for cov in covariates],
+            axis=2,
+        )                                            # (N, T_win, K)
+        row_ok = ~np.isnan(stack).any(axis=2)        # period kept iff no NA
+        means = np.full((len(units), len(covariates)), np.nan)
+        for u in range(len(units)):
+            if row_ok[u].any():
+                means[u] = stack[u][row_ok[u]].mean(0)
+        X = means.T                                  # (K, N)
+    else:
+        rows = []
+        for cov, years in zip(covariates, year_sets):
+            g = df[df[time].isin(years)].groupby(unitid)[cov].mean()
+            rows.append([float(g.get(u, np.nan)) for u in units])
+        X = np.asarray(rows, dtype=float)
+
     if not np.all(np.isfinite(X)):
         raise MlsynthDataError("Covariate means contain NaN (check windows/coverage).")
     return X


### PR DESCRIPTION
## Finish the augsynth port at the public API

The definition of done for the augsynth port is that the **public `VanillaSC`
API** reproduces all four Kansas ladder cells — not just the engine. It didn't:
the covariate cells were off (−0.0515 vs −0.063) and that gap hid behind a green
suite because the benchmark validated the covariate cells at the *engine* level.

### Root cause (one function)
`_covariate_means` averaged each covariate **independently**, whereas augsynth
drops a pre-period when **any** covariate is missing there (joint `na.omit`)
*before* averaging. The fix makes the shared-window aggregation joint-`na.omit`
(per-covariate windows keep independent means). The unit-variance scaling was a
red herring — `ridge_augment` re-standardizes to the outcome scale, so it's
neutralized. All four cells now match through `VanillaSC(...).fit()`:

| cell | public API | augsynth |
|---|---|---|
| Classic SCM | −0.0294 | −0.029 |
| Ridge ASCM | −0.0401 | −0.040 |
| Covariate ASCM | −0.0629 | −0.061 |
| Residualized ASCM | −0.0572 | −0.055 |

### Tests (the guard that was missing)
- `test_augsynth_kansas_ladder_public_api` pins all four cells **through the
  public API** — the regression guard the engine-level benchmark lacked.
- A per-covariate-window test covers the fallback branch; `pipeline.py` is back
  to **100% coverage**. No regression in the mscmt covariate path (Prop99 green).

### Docs
- **Replication page** now reproduces the full ladder through the public API.
- **Estimator page** gains, grounded in Ben-Michael, Feller & Rothstein (2021):
  - a **"When to prefer augmentation"** section — convex-hull / extrapolation,
    ASCM as SCM + an estimate of the imbalance bias (matching-style correction /
    doubly-robust), λ as the bias-variance dial, the **estimated-bias decision
    rule**, and the pre-fit-RMSE + extrapolation-distance diagnostics;
  - a detailed **conformal inference** mode — test inversion, the rank p-value,
    per-period prediction intervals for the random counterfactual + a joint
    p-value, exact validity under exchangeability, and near-nominal coverage
    where plain SCM under-covers.

Follows the test-first convention (red public-API ladder → fix → green).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_