### PR TITLE
VanillaSC: name the SCM variant in the plot title

### DIFF
--- a/mlsynth/tests/test_vanillasc_ascm.py
+++ b/mlsynth/tests/test_vanillasc_ascm.py
@@ -109,6 +109,20 @@ def test_display_graphs_show(monkeypatch):
     assert shown["n"] == 1
 
 
+def test_plot_title_names_the_variant():
+    # the plot title must say *which* SCM variant was run
+    from types import SimpleNamespace
+    from mlsynth.utils.vanillasc_helpers.pipeline import _variant_label
+    def cfg(**k):
+        return SimpleNamespace(**{"augment": None, "covariates": None,
+                                  "residualize": False, **k})
+    assert _variant_label(cfg()) == "Synthetic Control"
+    assert _variant_label(cfg(augment="ridge")) == "Ridge ASCM"
+    assert _variant_label(cfg(augment="ridge", covariates=["x1"])) == "Ridge ASCM (covariates)"
+    assert _variant_label(cfg(augment="ridge", covariates=["x1"],
+                              residualize=True)) == "Ridge ASCM (residualized covariates)"
+
+
 # --------------------------------------------------------------------------- #
 # Other inference modes (scpi, lto, placebo) + their edge knobs
 # --------------------------------------------------------------------------- #

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -396,6 +396,16 @@ def _full_band(arr, T: int, pre: int) -> np.ndarray:
     return full
 
 
+def _variant_label(config) -> str:
+    """Human-readable name of the SCM variant run, for plot titles."""
+    if getattr(config, "augment", None) != "ridge":
+        return "Synthetic Control"
+    if config.covariates:
+        return ("Ridge ASCM (residualized covariates)" if config.residualize
+                else "Ridge ASCM (covariates)")
+    return "Ridge ASCM"
+
+
 def _plot_vanillasc(config, y, counterfactual, time_labels, pre,
                     treated_name, backend, inference) -> None:
     """Render the observed-vs-synthetic plot through the shared Plotter,
@@ -420,7 +430,7 @@ def _plot_vanillasc(config, y, counterfactual, time_labels, pre,
             labels=[f"Synthetic {treated_name}"], treated_label=treated_name,
             intervention=intervention, interval=interval,
             outcome=config.outcome, time=config.time,
-            title=f"VanillaSC[{backend}]: {treated_name}",
+            title=f"{_variant_label(config)}: {treated_name}",
         )
         fig = ax.figure
         if config.save:


### PR DESCRIPTION
## Name the SCM variant in the VanillaSC plot title

The plot title was `VanillaSC[<backend>]: <unit>` — uninformative as to *which*
model produced the figure. Now it states the variant:

| config | title |
|---|---|
| plain | `Synthetic Control: <unit>` |
| `augment="ridge"` | `Ridge ASCM: <unit>` |
| `+ covariates` | `Ridge ASCM (covariates): <unit>` |
| `+ residualize=True` | `Ridge ASCM (residualized covariates): <unit>` |

Adds a small `_variant_label(config)` helper, used in
`observed_vs_counterfactual`'s title, covered by
`test_plot_title_names_the_variant`. (Branches off `main` after #58 merged.)

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_