### PR TITLE
docs: render \coloneqq, keep GEOLIFT off the public index

### DIFF
--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 GeoLift Market Selection (GEOLIFT)
 ==================================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -234,7 +234,6 @@ headline numbers.
 
    lexscm
    marex
-   geolift
    syndes
    pangeo
    spcd

--- a/docs/static/custom_mathjax.js
+++ b/docs/static/custom_mathjax.js
@@ -1,7 +1,11 @@
 window.MathJax = {
     tex: {
         tags: 'ams',
-        inlineMath: [['$', '$'], ['\\(', '\\)']]
+        inlineMath: [['$', '$'], ['\\(', '\\)']],
+        macros: {
+            // mathtools/unicode commands MathJax doesn't ship by default
+            coloneqq: '\\mathrel{:=}'
+        }
     },
     options: {
         renderActions: {


### PR DESCRIPTION
Three docs-only corrections (no code changes):

- **`\coloneqq` now renders.** It's a `mathtools` command MathJax doesn't ship by default, so it showed as raw `\coloneqq`. Added a `coloneqq -> \mathrel{:=}` macro to `docs/static/custom_mathjax.js` — fixes it globally (also `fdid`, `spsydid`, `lexscm`) without touching any formula.
- **GEOLIFT kept off the public index.** Removed `geolift` from the index toctree and marked `docs/geolift.rst` `:orphan:`, so the page still builds and renders by direct URL but isn't listed yet (in development).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_