### PR TITLE
benchmarks: commit-pin the augsynth reference (stable bit-for-bit timestamp)

### DIFF
--- a/benchmarks/R/augsynth_geolift.R
+++ b/benchmarks/R/augsynth_geolift.R
@@ -5,7 +5,9 @@
 # and emits a machine-parseable dump (LAMBDA / ATT / PVAL / W <name> <weight>)
 # for benchmarks/cases/geolift_augsynth_ref.py to cross-check mlsynth against.
 #
-# Install the reference once with benchmarks/R/install_augsynth.sh.
+# Reference pinned to augsynth 0.2.0 @ 7a90ea4 (frozen 2026-06-12); install with
+# benchmarks/R/install_augsynth.sh, which fixes every source-compiled dep to a
+# commit SHA so this reference is byte-reproducible run to run.
 suppressMessages({library(augsynth); library(dplyr)})
 
 args <- commandArgs(trailingOnly = TRUE)

--- a/benchmarks/R/install_augsynth.sh
+++ b/benchmarks/R/install_augsynth.sh
@@ -6,7 +6,23 @@
 # GeoLift -> MarketMatching -> bsts -> Boom chain. Verified on Ubuntu + R 4.3.x
 # in a sandbox where CRAN is blocked but apt and GitHub are open: apt for the
 # prebuilt majority, compile the non-apt leaves from the GitHub cran mirror.
+#
+# COMMIT-PINNED (frozen 2026-06-12) so the bit-for-bit cross-check runs the SAME
+# reference code every time -- augsynth's master is active dev, and an unpinned
+# tip is exactly the version drift that made GeoLift's vignette ATT (155.556) go
+# stale. To refresh the reference, bump the SHAs below and re-pin the expected
+# numbers in benchmarks/cases/geolift_augsynth_ref.py.
+#
+#   augsynth   0.2.0     7a90ea48877fae7925a72cb50bc03a315bc7c042  (ebenmichael/augsynth)
+#   osqp       1.0.0     260dc73e1e3d07ccb7dbff85b62eaaf483672394  (cran/osqp)
+#   S7         0.2.2     33c8f3212c62cd2ebec79cd61d1315e9acc84128  (cran/S7)
+#   LiblineaR  2.10.24   07cca10ee74e2442a8726173bd52360c323ad07e  (cran/LiblineaR)
 set -euo pipefail
+
+AUGSYNTH_SHA=7a90ea48877fae7925a72cb50bc03a315bc7c042
+OSQP_SHA=260dc73e1e3d07ccb7dbff85b62eaaf483672394
+S7_SHA=33c8f3212c62cd2ebec79cd61d1315e9acc84128
+LIBLINEAR_SHA=07cca10ee74e2442a8726173bd52360c323ad07e
 
 DEBIAN_FRONTEND=noninteractive apt-get update -qq
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -17,19 +33,16 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
   r-cran-stringr r-cran-tibble r-cran-rcpparmadillo r-cran-rcppeigen r-cran-bh \
   r-cran-glmnet r-cran-mass r-cran-matrix
 
-inst() {  # compile a CRAN package from the GitHub cran mirror (apt-blocked deps)
+# Compile a GitHub repo at a pinned commit:  inst <owner/repo> <sha> <dirslug>
+inst() {
   cd /tmp
-  curl -sL "https://codeload.github.com/cran/$1/tar.gz/refs/heads/master" -o "$1.tgz"
-  tar xzf "$1.tgz"
-  R CMD INSTALL --no-docs --no-help "$1-master"
+  curl -sL "https://codeload.github.com/$1/tar.gz/$2" -o "$3.tgz"
+  tar xzf "$3.tgz"
+  R CMD INSTALL --no-docs --no-help "$(basename "$1")-$2"
 }
-inst S7            # newer osqp needs it
-inst LiblineaR     # bundles liblinear C++
-inst osqp          # the SCM QP solver
+inst cran/S7        "$S7_SHA"        S7          # newer osqp needs it
+inst cran/LiblineaR "$LIBLINEAR_SHA" LiblineaR   # bundles liblinear C++
+inst cran/osqp      "$OSQP_SHA"      osqp        # the SCM QP solver
+inst ebenmichael/augsynth "$AUGSYNTH_SHA" augsynth
 
-cd /tmp
-curl -sL "https://codeload.github.com/ebenmichael/augsynth/tar.gz/refs/heads/master" \
-  -o augsynth.tgz && tar xzf augsynth.tgz
-R CMD INSTALL --no-docs --no-help augsynth-master
-
-Rscript -e 'suppressMessages(library(augsynth)); cat("augsynth OK\n")'
+Rscript -e 'suppressMessages(library(augsynth)); cat("augsynth", as.character(packageVersion("augsynth")), "OK\n")'

--- a/benchmarks/cases/geolift_augsynth_ref.py
+++ b/benchmarks/cases/geolift_augsynth_ref.py
@@ -9,10 +9,15 @@ panel -- the gold-standard cross-validation the replication contract asks for.
 It shells out to ``benchmarks/R/augsynth_geolift.R`` (install the reference once
 with ``benchmarks/R/install_augsynth.sh``) and compares the CV-selected ridge
 penalty, the donor weights, and the post-period ATT. mlsynth matches augsynth to
-floating-point on lambda (rel-diff ~1e-7), to ~5 decimals on every weight, and to
-4 sig figs on the ATT -- so the gaps are pinned near zero, not at the looser
+floating-point on lambda (rel-diff ~1e-11), to ~7 decimals on every weight, and
+to 4 sig figs on the ATT -- so the gaps are pinned near zero, not at the looser
 "published walkthrough" tolerances. (The vignette's printed ATT 155.556 is an
 older augsynth release; today's augsynth returns 156.8, which mlsynth reproduces.)
+
+The reference is **commit-pinned** -- the install script freezes augsynth (and
+every source-compiled dep) to a SHA -- so this is a stable timestamp, not a moving
+tip. Numbers below are augsynth ``0.2.0 @ 7a90ea4`` (frozen 2026-06-12); refresh
+by re-pinning ``install_augsynth.sh`` and updating ``EXPECTED``.
 
 Skips itself (``BenchmarkSkipped``) when ``Rscript`` or ``augsynth`` is absent, so
 it is a no-op in CI and runs only where the reference is installed.

--- a/docs/replications/geolift.rst
+++ b/docs/replications/geolift.rst
@@ -119,8 +119,13 @@ Donor weights (max ``Δ``)  13 non-zero           ``4.3e-7``
 
 Install the reference once with ``benchmarks/R/install_augsynth.sh`` (augsynth
 only — GeoLift's fit *is* augsynth, so the heavy ``MarketMatching`` → ``Boom``
-chain is not needed). The case skips itself when ``Rscript`` / ``augsynth`` is
-absent, so it is a no-op in CI and runs only where the reference is installed.
+chain is not needed). The install is **commit-pinned** — augsynth ``0.2.0 @
+7a90ea4`` and every source-compiled dependency frozen to a SHA (``S7``,
+``LiblineaR``, ``osqp``) as of 2026-06-12 — so the cross-check runs the *same*
+reference code every time, rather than a moving ``master`` tip (an unpinned tip
+is exactly the drift that staled the vignette's number). The case skips itself
+when ``Rscript`` / ``augsynth`` is absent, so it is a no-op in CI and runs only
+where the reference is installed.
 This is what licenses the strong claim above: ``mlsynth``'s ridge ASCM, its CV
 λ-selection (the 1-SE rule), and its fixed-effect conformal refit are not merely
 *close* to augsynth — they are the **same computation**, to ~7–11 significant


### PR DESCRIPTION
## Summary

Makes the augsynth bit-for-bit cross-check a **stable timestamp** instead of a moving target. The `geolift_augsynth_ref` reference was installing augsynth from `refs/heads/master` — the moving tip, the *same* version-drift mechanism that staled GeoLift's vignette ATT (155.556 → today's 156.8). This freezes the entire source-compiled reference build to commit SHAs so the cross-check runs identical reference code every run.

## Pinned reference (frozen 2026-06-12)
| package | version | commit |
|---|---|---|
| `ebenmichael/augsynth` | 0.2.0 | `7a90ea4` |
| `cran/osqp` | 1.0.0 | `260dc73` |
| `cran/S7` | 0.2.2 | `33c8f32` |
| `cran/LiblineaR` | 2.10.24 | `07cca10` |

## Changes
- `benchmarks/R/install_augsynth.sh` — pins every source-compiled dep by SHA (was `refs/heads/master`).
- `benchmarks/R/augsynth_geolift.R`, `benchmarks/cases/geolift_augsynth_ref.py`, `docs/replications/geolift.rst` — record `augsynth 0.2.0 @ 7a90ea4` and the freeze date.

## Verified
Reinstalling augsynth **at the pinned SHA** reproduces λ `1.6731016871e9` / ATT `156.8054`, and `geolift_augsynth_ref` passes against it (λ rel-diff `1.6e-11`, weights `4e-7`, ATT diff `2e-4`). The case still skips in CI when R/augsynth is absent. To refresh, bump the SHAs and re-pin `EXPECTED`.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_