### PR TITLE
GEOLIFT: CPIC budget-planning layer (faithful to GeoLiftMarketSelection)

### DIFF
--- a/benchmarks/cases/geolift_cpic.py
+++ b/benchmarks/cases/geolift_cpic.py
@@ -1,0 +1,70 @@
+"""GEOLIFT CPIC cross-validation vs GeoLiftMarketSelection.
+
+Cross-validation against the reference. GeoLift's market-selection budget layer
+computes, per candidate, ``investment = cpic * sum(Y[D==1]) * es`` (cost per
+incremental conversion x effect size x summed treated volume over the window).
+This pins mlsynth's investment against the values GeoLift's ``GeoLiftMarketSelection``
+prints in its ``BestMarkets`` table for the walkthrough call
+
+    GeoLiftMarketSelection(data = GeoTestData_PreTest, treatment_periods = c(10,15),
+        N = c(2,3,4,5), effect_size = seq(0, 0.2, 0.05), include_markets = "chicago",
+        exclude_markets = "honolulu", cpic = 7.50, budget = 1e5, fixed_effects = TRUE, ...)
+
+run live (augsynth-sourced) on the GeoLift_PreTest panel. The investment is a
+deterministic data transform -- no model, no permutation -- so the agreement is
+exact to the cent at each candidate's (matching) MDE. The MDE and the augsynth
+fit themselves are pinned by ``geolift_augsynth_ref`` / ``geolift_walkthrough``.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from mlsynth.utils.datautils import geoex_dataprep
+from mlsynth.utils.geolift_helpers.marketselect.helpers.simulate import simulate_lookback
+from mlsynth.utils.geolift_helpers.marketselect.helpers.shaping import donor_matrix
+
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..",
+                     "basedata", "geolift_market_data.csv")
+_CPIC = 7.5
+_PRE_TOTAL = 90
+
+# (candidate, duration, MDE) at which GeoLiftMarketSelection reports Investment.
+_CASES = [
+    (("chicago", "portland"), 15, 0.10, 64563.75),
+    (("chicago", "portland"), 10, 0.10, 43646.25),
+    (("chicago", "cincinnati", "houston", "portland"), 15, 0.05, 74118.375),
+    (("chicago", "cincinnati", "houston", "portland"), 10, 0.10, 99027.75),
+]
+
+
+def run() -> dict:
+    Ywide = geoex_dataprep(pd.read_csv(os.path.abspath(_DATA)),
+                           "location", "date", "Y")["Ywide"]
+    out = {}
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for cand, dur, es, _gl in _CASES:
+            candset = frozenset(cand)
+            treated_mean = Ywide[list(cand)].mean(axis=1).to_numpy()
+            treated_total = Ywide[list(cand)].sum(axis=1).to_numpy()   # GeoLift sum(Y[D==1])
+            Y0 = donor_matrix(Ywide, candset).to_numpy()
+            rows = simulate_lookback(
+                treated_mean, Y0, _PRE_TOTAL, dur, 1, [es],
+                augment="ridge", ns=10, seed=0, fixed_effects=True,
+                cpic=_CPIC, treated_total=treated_total)
+            key = f"inv_{''.join(c[0] for c in cand)}_{dur}"
+            out[key] = float(rows[0]["investment"])
+    return out
+
+
+# Investment is deterministic (cpic x es x volume), so it matches GeoLift exactly.
+EXPECTED = {
+    "inv_cp_15": (64563.75, 0.01),     # chicago, portland
+    "inv_cp_10": (43646.25, 0.01),
+    "inv_cchp_15": (74118.375, 0.01),  # chicago, cincinnati, houston, portland
+    "inv_cchp_10": (99027.75, 0.01),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -70,6 +70,7 @@ CASES = {
     "augsynth_calibrated": "benchmarks.cases.augsynth_calibrated",  # Path B: ASCM near-nominal coverage + bias reduction (BMR 2021 Sec 7)
     "geolift_walkthrough": "benchmarks.cases.geolift",  # cross-val vs GeoLift/augsynth: GeoLift_Walkthrough realized report (fixedeff ASCM + conformal)
     "geolift_augsynth_ref": "benchmarks.cases.geolift_augsynth_ref",  # cross-val vs LIVE augsynth (Rscript): lambda/weights/ATT (skips if absent)
+    "geolift_cpic": "benchmarks.cases.geolift_cpic",  # cross-val vs GeoLiftMarketSelection: CPIC investment value-for-value
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -291,6 +291,28 @@ Identifying assumptions
    transports to the real experiment only if the pre-period dynamics resemble the
    experiment window — the usual SC stability assumption.
 
+Budget planning (CPIC)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Setting ``cpic`` (cost per incremental conversion) turns each candidate's MDE
+into a spend, faithful to ``GeoLiftMarketSelection``:
+
+.. math::
+
+   \mathrm{investment} \;=\; \mathrm{cpic} \times \delta \times
+   \sum_{i \in \mathcal{S}} \sum_{t \in \mathcal{W}} Y_{it},
+
+i.e. cost-per-incremental :math:`\times` effect size :math:`\times` the
+**summed** treated volume over the (lookback) window — the baseline outcome, on
+the total scale, independent of the mean-of-units fit. The shortlist carries an
+``investment`` column; supplying ``budget`` drops candidates whose detectable
+investment exceeds it (GeoLift's ``abs(budget) > abs(Investment)`` gate). The
+realized report adds the post-test ``cost`` :math:`= \mathrm{cpic} \times`
+incremental outcome. The investment is a deterministic data transform, so it
+matches ``GeoLiftMarketSelection`` **to the cent** (durable case
+``geolift_cpic``); ROI (a value/margin per conversion) is a planned extension
+beyond GeoLift's cost-only ``cpic``.
+
 Inference and the realized design
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mlsynth/estimators/geolift.py
+++ b/mlsynth/estimators/geolift.py
@@ -81,6 +81,7 @@ class GEOLIFT:
                         alpha=self.config.alpha, ns=self.config.ns, seed=self.config.seed,
                         conformal_type=self.config.conformal_type,
                         fixed_effects=self.config.fixed_effects,
+                        cpic=self.config.cpic,
                     )
                 if self.config.display_graphs:
                     plot_design(result, report=result.report, show=True)

--- a/mlsynth/tests/test_marketselect_batch.py
+++ b/mlsynth/tests/test_marketselect_batch.py
@@ -24,7 +24,7 @@ def test_run_simulations_smoke_and_columns():
     assert len(df) == 2 * 1 * 2 * 2                  # cands x durs x sims x es
     assert list(df.columns) == ["candidate", "duration", "sim", "effect_size",
                                 "p_value", "placebo_mean_effect", "detected_lift",
-                                "scaled_l2", "pre_rmspe"]
+                                "scaled_l2", "pre_rmspe", "investment"]
     assert ((df["p_value"] >= 0) & (df["p_value"] <= 1)).all()
 
 
@@ -83,4 +83,4 @@ def test_run_simulations_no_candidates_returns_empty_framed():
     assert df.empty
     assert list(df.columns) == ["candidate", "duration", "sim", "effect_size",
                                 "p_value", "placebo_mean_effect", "detected_lift",
-                                "scaled_l2", "pre_rmspe"]
+                                "scaled_l2", "pre_rmspe", "investment"]

--- a/mlsynth/tests/test_marketselect_cpic.py
+++ b/mlsynth/tests/test_marketselect_cpic.py
@@ -1,0 +1,162 @@
+"""CPIC (cost-per-incremental-conversion) budget layer for GEOLIFT.
+
+Faithful to GeoLift's ``pvalueCalc`` /  ``GeoLiftMarketSelection``:
+
+    investment <- cpic * sum(data_aux$Y[data_aux$D == 1]) * es
+
+i.e. investment = cpic x effect_size x (summed treated volume over the lookback
+window, baseline/pre-injection), then candidates whose investment exceeds the
+budget are dropped.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.geolift_helpers.marketselect.helpers.simulate import simulate_lookback
+from mlsynth.utils.geolift_helpers.marketselect.helpers.windows import (
+    lookback_treatment_window,
+)
+from mlsynth.utils.geolift_helpers.marketselect.helpers.aggregate import compute_rank
+
+
+def _sim_panel(n=20, J=3, seed=1):
+    rng = np.random.default_rng(seed)
+    Y0 = rng.normal(size=(n, J)) + np.arange(n)[:, None] * 0.3
+    treated = Y0 @ np.array([0.5, 0.3, 0.2]) + rng.normal(scale=0.05, size=n)
+    return treated, Y0
+
+
+# === investment formula (simulate) ===
+
+def test_investment_matches_geolift_formula():
+    """investment = cpic * es * sum(treated_total over the window)."""
+    treated, Y0 = _sim_panel()
+    treated_total = treated * 2.0                      # summed (2 units) vs the mean fit
+    cpic = 7.5
+    rows = simulate_lookback(treated, Y0, 20, 4, 1, [0.0, 0.05, 0.1],
+                             augment="ridge", ns=20, seed=0,
+                             cpic=cpic, treated_total=treated_total)
+    start, end = lookback_treatment_window(20, 4, 1)
+    window_vol = float(treated_total[start:end + 1].sum())
+    for r in rows:
+        assert r["investment"] == pytest.approx(cpic * r["effect_size"] * window_vol)
+
+
+def test_investment_uses_total_not_fit_series():
+    """The volume is the summed treated_total, not the (mean) fit series."""
+    treated, Y0 = _sim_panel()
+    treated_total = treated * 3.0
+    rows = simulate_lookback(treated, Y0, 20, 4, 1, [0.1],
+                             augment="ridge", ns=20, seed=0,
+                             cpic=2.0, treated_total=treated_total)
+    start, end = lookback_treatment_window(20, 4, 1)
+    assert rows[0]["investment"] == pytest.approx(
+        2.0 * 0.1 * float(treated_total[start:end + 1].sum()))
+    # would be 1/3 of that if it wrongly used the fit series
+    assert rows[0]["investment"] != pytest.approx(
+        2.0 * 0.1 * float(treated[start:end + 1].sum()))
+
+
+def test_investment_zero_effect_is_zero():
+    treated, Y0 = _sim_panel()
+    rows = simulate_lookback(treated, Y0, 20, 4, 1, [0.0],
+                             augment="ridge", ns=20, seed=0,
+                             cpic=7.5, treated_total=treated)
+    assert rows[0]["investment"] == 0.0
+
+
+def test_investment_nan_when_no_cpic():
+    treated, Y0 = _sim_panel()
+    rows = simulate_lookback(treated, Y0, 20, 4, 1, [0.1], augment="ridge", ns=20, seed=0)
+    assert np.isnan(rows[0]["investment"])
+
+
+# === budget gate (compute_rank) ===
+
+def _power_table_with_investment():
+    """Two candidates, both detectable at es=0.1; A cheap, B over budget."""
+    rows = []
+    for cand, inv in [(frozenset({"A"}), 5_000.0), (frozenset({"B"}), 500_000.0)]:
+        for es in (0.0, 0.05, 0.1):
+            rows.append({
+                "candidate": cand, "duration": 10, "effect_size": es,
+                "power": 0.0 if es < 0.1 else 0.9,
+                "placebo_mean_effect": es, "detected_lift": es,
+                "scaled_l2": 0.1, "pre_rmspe": 1.0,
+                "investment": inv * es / 0.1,           # scales with es
+            })
+    return pd.DataFrame(rows)
+
+
+def test_budget_drops_overbudget_candidate():
+    pt = _power_table_with_investment()
+    ranked = compute_rank(pt, power_threshold=0.8, budget=100_000.0)
+    cands = {next(iter(c)) for c in ranked["candidate"]}
+    assert "A" in cands and "B" not in cands           # B's MDE investment 500k > 100k
+
+
+def test_no_budget_keeps_all_detectable():
+    pt = _power_table_with_investment()
+    ranked = compute_rank(pt, power_threshold=0.8)     # budget=None
+    cands = {next(iter(c)) for c in ranked["candidate"]}
+    assert cands == {"A", "B"}
+
+
+def test_rank_table_carries_investment():
+    pt = _power_table_with_investment()
+    ranked = compute_rank(pt, power_threshold=0.8)
+    assert "investment" in ranked.columns
+    a = ranked[ranked["candidate"] == frozenset({"A"})].iloc[0]
+    assert a["investment"] == pytest.approx(5_000.0)   # at the MDE (es=0.1)
+
+
+# === config validation ===
+
+def _cfg(**kw):
+    from mlsynth.utils.geolift_helpers.config import GeoLiftConfig
+    base = dict(df=pd.DataFrame({"Y": [1.0, 2], "location": ["a", "a"], "date": [1, 2]}),
+                outcome="Y", unitid="location", time="date",
+                treatment_size=1, durations=[2], effect_sizes=[0.0, 0.1])
+    base.update(kw)
+    return GeoLiftConfig(**base)
+
+
+def test_config_accepts_cpic_and_budget():
+    cfg = _cfg(cpic=7.5, budget=100_000.0)
+    assert cfg.cpic == 7.5 and cfg.budget == 100_000.0
+
+
+def test_config_negative_cpic_raises():
+    with pytest.raises(MlsynthConfigError, match="cpic"):
+        _cfg(cpic=-1.0)
+
+
+def test_config_budget_requires_cpic():
+    with pytest.raises(MlsynthConfigError, match="budget requires cpic"):
+        _cfg(budget=100_000.0)
+
+
+def test_config_nonpositive_budget_raises():
+    with pytest.raises(MlsynthConfigError, match="budget"):
+        _cfg(cpic=7.5, budget=0.0)
+
+
+# === realize cost ===
+
+def test_realize_reports_cost():
+    from mlsynth.utils.geolift_helpers.marketselect.realize import realize_design
+    rng = np.random.default_rng(0)
+    T = 22
+    cols = {u: np.arange(T) * 0.3 + rng.normal(scale=0.5, size=T) + i
+            for i, u in enumerate("ABCDE")}
+    Ywide = pd.DataFrame(cols, index=pd.Index(range(T), name="time"))
+    rep = realize_design(Ywide, frozenset({"A", "B"}), pre_periods=18,
+                         how="sum", augment="ridge", ns=40, seed=0,
+                         fixed_effects=True, cpic=7.5)
+    ss = rep.weights.summary_stats
+    assert ss["cpic"] == 7.5
+    # cost = cpic * summed incremental over the post window
+    incr = float(np.sum(rep.time_series.estimated_gap[18:]))
+    assert ss["cost"] == pytest.approx(7.5 * incr, rel=1e-6)

--- a/mlsynth/utils/geolift_helpers/config.py
+++ b/mlsynth/utils/geolift_helpers/config.py
@@ -61,6 +61,17 @@ class GeoLiftConfig(BaseMAREXConfig):
     )
     alpha: float = Field(default=0.1, description="Significance level for detection.")
     power_threshold: float = Field(default=0.8, description="Power needed to 'detect' an effect (MDE).")
+    cpic: Optional[float] = Field(
+        default=None,
+        description="Cost per incremental conversion. When set, each candidate's "
+        "required investment = cpic x effect_size x summed-treated-volume is "
+        "reported (GeoLift's budget-planning layer).",
+    )
+    budget: Optional[float] = Field(
+        default=None,
+        description="Spend cap. When set (with cpic), candidates whose detectable "
+        "investment exceeds the budget are dropped from the design.",
+    )
     ns: int = Field(default=1000, description="Conformal permutation count (iid only).")
     conformal_type: str = Field(
         default="iid",
@@ -103,4 +114,11 @@ class GeoLiftConfig(BaseMAREXConfig):
             raise MlsynthConfigError(
                 f"conformal_type must be 'iid' or 'block'; got {self.conformal_type!r}."
             )
+        if self.cpic is not None and self.cpic < 0:
+            raise MlsynthConfigError(f"cpic must be >= 0; got {self.cpic}.")
+        if self.budget is not None:
+            if self.budget <= 0:
+                raise MlsynthConfigError(f"budget must be > 0; got {self.budget}.")
+            if self.cpic is None:
+                raise MlsynthConfigError("budget requires cpic to be set.")
         return self

--- a/mlsynth/utils/geolift_helpers/marketselect/helpers/aggregate.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/helpers/aggregate.py
@@ -11,7 +11,7 @@ Pure array/groupby reductions on the long p-value cube from
 (The composite rank is built on top of these.)
 """
 
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -19,6 +19,7 @@ import pandas as pd
 _POWER_COLUMNS = [
     "candidate", "duration", "effect_size",
     "power", "placebo_mean_effect", "detected_lift", "scaled_l2", "pre_rmspe",
+    "investment",
 ]
 
 
@@ -46,16 +47,21 @@ def compute_power(cube: pd.DataFrame, *, alpha: float = 0.1) -> pd.DataFrame:
     if cube.empty:
         return pd.DataFrame(columns=_POWER_COLUMNS)
     tmp = cube.assign(_detected=(cube["p_value"] < alpha).astype(float))
-    # sort=False: candidate keys are frozensets (unorderable).
-    return tmp.groupby(
-        ["candidate", "duration", "effect_size"], as_index=False, sort=False
-    ).agg(
+    has_investment = "investment" in cube.columns
+    aggs = dict(
         power=("_detected", "mean"),
         placebo_mean_effect=("placebo_mean_effect", "mean"),
         detected_lift=("detected_lift", "mean"),
         scaled_l2=("scaled_l2", "mean"),
         pre_rmspe=("pre_rmspe", "mean"),
     )
+    if has_investment:
+        # investment = cpic * es * volume is constant across lookback placements.
+        aggs["investment"] = ("investment", "mean")
+    # sort=False: candidate keys are frozensets (unorderable).
+    return tmp.groupby(
+        ["candidate", "duration", "effect_size"], as_index=False, sort=False
+    ).agg(**aggs)
 
 
 def compute_mde(power_table: pd.DataFrame, *, power_threshold: float = 0.8) -> pd.DataFrame:
@@ -107,12 +113,13 @@ def compute_mde(power_table: pd.DataFrame, *, power_threshold: float = 0.8) -> p
 
 _RANK_COLUMNS = [
     "candidate", "duration", "mde", "power", "detected_lift", "abs_lift_in_zero",
-    "scaled_l2", "pre_rmspe",
+    "scaled_l2", "pre_rmspe", "investment",
     "rank_mde", "rank_pvalue", "rank_abszero", "rank",
 ]
 
 
-def compute_rank(power_table: pd.DataFrame, *, power_threshold: float = 0.8) -> pd.DataFrame:
+def compute_rank(power_table: pd.DataFrame, *, power_threshold: float = 0.8,
+                 budget: Optional[float] = None) -> pd.DataFrame:
     """Rank candidate designs, haircut-faithful to ``GeoLiftMarketSelection``.
 
     Builds the per-(candidate, duration) MDE row, then the GeoLift composite
@@ -137,12 +144,24 @@ def compute_rank(power_table: pd.DataFrame, *, power_threshold: float = 0.8) -> 
     if power_table.empty:
         return pd.DataFrame(columns=_RANK_COLUMNS)
 
+    # CPIC budget gate (GeoLift: filter abs(budget) > abs(Investment)). Drop the
+    # over-budget effect-size rows *before* the MDE, so a candidate whose
+    # cheapest detectable effect still busts the budget falls out entirely.
+    if budget is not None and "investment" in power_table.columns:
+        power_table = power_table[
+            power_table["investment"].abs() < abs(budget)
+        ].copy()
+        if power_table.empty:
+            return pd.DataFrame(columns=_RANK_COLUMNS)
+
     mde_table = compute_mde(power_table, power_threshold=power_threshold)
     merged = mde_table.merge(power_table, on=["candidate", "duration"])
     # Keep only each group's MDE row (drops NaN-MDE groups: NaN != any effect).
     at_mde = merged[merged["effect_size"] == merged["mde"]].copy()
     if at_mde.empty:
         return pd.DataFrame(columns=_RANK_COLUMNS)
+    if "investment" not in at_mde.columns:          # cpic not supplied
+        at_mde["investment"] = float("nan")
 
     at_mde["abs_lift_in_zero"] = (at_mde["detected_lift"] - at_mde["mde"]).abs().round(3)
 

--- a/mlsynth/utils/geolift_helpers/marketselect/helpers/batch.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/helpers/batch.py
@@ -19,6 +19,7 @@ from .simulate import simulate_lookback
 _COLUMNS = [
     "candidate", "duration", "sim", "effect_size",
     "p_value", "placebo_mean_effect", "detected_lift", "scaled_l2", "pre_rmspe",
+    "investment",
 ]
 
 
@@ -36,6 +37,7 @@ def run_simulations(
     seed: int = 0,
     conformal_type: str = "iid",
     fixed_effects: bool = False,
+    cpic: Optional[float] = None,
 ) -> pd.DataFrame:
     """Run the simulation grid and stack the results into one long table.
 
@@ -88,13 +90,16 @@ def run_simulations(
     records: List[dict] = []
     for candidate in candidates:
         treated = aggregate_treated(Ywide, candidate, how=fit_how)
+        # CPIC investment uses the *summed* treated volume (GeoLift's
+        # sum(Y[D==1])), independent of the fit aggregation.
+        treated_total = aggregate_treated(Ywide, candidate, how="sum").to_numpy()
         donors = donor_matrix(Ywide, candidate)
         for duration in durations:
             for sim in range(1, int(lookback_window) + 1):
                 for row in simulate_lookback(
                     treated, donors, n_periods, duration, sim, effect_sizes,
                     augment=augment, q=q, ns=ns, seed=seed, conformal_type=conformal_type,
-                    fixed_effects=fixed_effects,
+                    fixed_effects=fixed_effects, cpic=cpic, treated_total=treated_total,
                 ):
                     row["candidate"] = candidate
                     records.append(row)

--- a/mlsynth/utils/geolift_helpers/marketselect/helpers/simulate.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/helpers/simulate.py
@@ -56,6 +56,8 @@ def simulate_lookback(
     seed: int = 0,
     conformal_type: str = "iid",
     fixed_effects: bool = False,
+    cpic: Optional[float] = None,
+    treated_total: Optional[np.ndarray] = None,
 ) -> List[dict]:
     """Simulate one lookback placement across a grid of effect sizes.
 
@@ -108,6 +110,15 @@ def simulate_lookback(
                             fixed_effects=fixed_effects)
     counterfactual = fit.predict(donors_arr)
 
+    # CPIC investment volume: GeoLift's ``sum(data_aux$Y[D == 1])`` -- the
+    # *summed* treated outcome over the treatment window, on the baseline
+    # (pre-injection) series. ``treated_total`` carries that summed series (the
+    # fit series is the per-unit mean under fixed effects); fall back to the fit
+    # series when it is not supplied (e.g. an already-summed aggregate).
+    total_arr = (np.asarray(treated_total, dtype=float).ravel()
+                 if treated_total is not None else treated_arr)
+    window_volume = float(np.sum(total_arr[start : end + 1]))
+
     rows: List[dict] = []
     for es in effect_sizes:
         treated_injected = inject_effect(treated_arr, start, end, es)
@@ -130,6 +141,9 @@ def simulate_lookback(
                 "detected_lift": detected_lift,
                 "scaled_l2": fit.scaled_l2,
                 "pre_rmspe": fit.pre_rmspe,
+                # investment = cpic * es * summed-treated-volume (GeoLift pvalueCalc)
+                "investment": (cpic * float(es) * window_volume
+                               if cpic is not None else float("nan")),
             }
         )
     return rows

--- a/mlsynth/utils/geolift_helpers/marketselect/orchestration.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/orchestration.py
@@ -81,9 +81,11 @@ def run_design(config: GeoLiftConfig) -> GEOLIFTResults:
         Ywide, candidates, config.durations, config.lookback_window, config.effect_sizes,
         how=config.how, augment=config.augment, ns=config.ns, seed=config.seed,
         conformal_type=config.conformal_type, fixed_effects=config.fixed_effects,
+        cpic=config.cpic,
     )
     power_table = compute_power(cube, alpha=config.alpha)
-    shortlist = compute_rank(power_table, power_threshold=config.power_threshold)
+    shortlist = compute_rank(power_table, power_threshold=config.power_threshold,
+                             budget=config.budget)
 
     # Per-candidate deployable design fit (full pre-period).
     designs = {

--- a/mlsynth/utils/geolift_helpers/marketselect/realize.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/realize.py
@@ -40,6 +40,7 @@ def realize_design(
     seed: int = 0,
     conformal_type: str = "iid",
     fixed_effects: bool = False,
+    cpic: Optional[float] = None,
 ) -> BaseEstimatorResults:
     """Realize one candidate design on the full (pre+post) panel.
 
@@ -101,6 +102,11 @@ def realize_design(
     intervention = time_labels[pre_periods] if pre_periods < n_periods else None
     att = float(np.mean(gap[pre_periods:])) if pre_periods < n_periods else None
 
+    # CPIC: realized spend = cpic x summed incremental outcome over the post window.
+    incremental_summed = (float(np.sum(gap_fit[pre_periods:])) * n_units
+                          if pre_periods < n_periods else 0.0)
+    cost = float(cpic) * incremental_summed if cpic is not None else None
+
     donor_weights = {
         str(name): float(w)
         for name, w in zip(donors.columns, fit.weights)
@@ -134,6 +140,8 @@ def realize_design(
                 "intercept": float(fit.intercept),
                 "augment": augment,
                 "fixed_effects": fixed_effects,
+                "cpic": cpic,
+                "cost": cost,
             },
         ),
         fit_diagnostics=FitDiagnosticsResults(


### PR DESCRIPTION
## Summary

Adds GeoLift's **CPIC** (cost-per-incremental-conversion) budget-planning layer to `GEOLIFT` — faithful, cost-only (ROI extension to follow once the baseline exists).

The one formula, lifted verbatim from GeoLift's `pvalueCalc`:
```
investment = cpic × es × sum(data_aux$Y[D == 1])
```
i.e. **cost-per-incremental × effect_size × summed treated volume over the window** — the *original* (pre-injection) outcome on the *total* (summed) scale, independent of the mean-of-units fit. Supplying a `budget` drops candidates whose detectable investment exceeds it (GeoLift's `abs(budget) > abs(Investment)` gate); the realized report adds post-test `cost = cpic × incremental`.

## Validated value-for-value against live `GeoLiftMarketSelection`
Ran the exact call you gave (GeoLift_PreTest, `treatment_periods=c(10,15)`, `N=c(2,3,4,5)`, include `chicago`, exclude `honolulu`, `cpic=7.5`, `budget=1e5`, `fixed_effects=TRUE`) — GeoLift's R sourced directly (the selection path is augsynth-only). **Investment matches to the cent:**

| candidate | dur | GeoLift | mlsynth |
|---|---|---|---|
| chicago, portland | 15 | $64,563.75 | $64,563.75 |
| chicago, portland | 10 | $43,646.25 | $43,646.25 |
| chi, cin, hou, por | 15 | $74,118.38 | $74,118.38 |
| chi, cin, hou, por | 10 | $99,027.75 | $99,027.75 |

…at the same MDE, with the budget gate holding (max surviving investment < $100k). ScaledL2 matches to ~3 decimals (the augsynth engine itself is already pinned bit-for-bit).

## Changes
- `GeoLiftConfig`: `cpic` (≥0), `budget` (>0, requires `cpic`).
- `simulate_lookback` → `investment` per effect-size row; `batch`/`aggregate`/`orchestration`/estimator thread it; budget gate before the MDE.
- `realize_design`: post-test `cost`.
- Tests `test_marketselect_cpic.py`; durable benchmark `geolift_cpic` (deterministic, matches GeoLift exactly); docs.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_