### PR TITLE
MULTICELLGEOLIFT: multi-cell GeoLift analysis (shared control, per-cell + winner)

### DIFF
--- a/benchmarks/cases/geolift_multicell.py
+++ b/benchmarks/cases/geolift_multicell.py
@@ -1,0 +1,61 @@
+"""MULTICELLGEOLIFT cross-validation vs augsynth (per-cell, donor-excluded).
+
+Cross-validation against the engine GeoLiftMultiCell wraps. GeoLiftMultiCell
+measures each cell against the shared control pool, **excluding the other cells'
+markets from the donor pool** (``filter(!location %in% other_cells)``). This pins
+mlsynth's per-cell ATT against augsynth run the same way on the GeoLift_Test
+panel: cell A = {chicago, portland} (the real effect), cell B = {atlanta, boston}
+(a placebo cell), the rest shared controls, treatment over days 91-105.
+
+The ATT is the deterministic fixed-effect ASCM estimate, so it matches augsynth
+to the decimal; the donor-exclusion invariant (cell A's synthetic control never
+uses cell B's markets, and vice versa) is asserted directly. (The live
+GeoLiftMultiCell summary path is blocked by augsynth 0.2.0's multi-unit-cohort
+``treated_table`` bug, so we cross-check against augsynth's own per-cell fit.)
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import pandas as pd
+
+from mlsynth import MULTICELLGEOLIFT
+
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..",
+                     "basedata", "geolift_test_data.csv")
+_CELLS = {"chicago": "A", "portland": "A", "atlanta": "B", "boston": "B"}
+
+
+def run() -> dict:
+    df = pd.read_csv(os.path.abspath(_DATA))
+    df["cell"] = df["location"].map(_CELLS).fillna("")        # blank = control
+    dates = sorted(df["date"].unique())
+    df["post"] = df["date"].isin(set(dates[90:])).astype(int)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = MULTICELLGEOLIFT({
+            "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+            "cell_column_name": "cell", "post_col": "post", "how": "mean",
+            "fixed_effects": True, "ns": 1000, "seed": 0, "display_graphs": False,
+        }).fit()
+
+    a_donors = set(res.cells["A"].weights.donor_weights)
+    b_donors = set(res.cells["B"].weights.donor_weights)
+    return {
+        "att_A": float(res.cells["A"].effects.att),           # augsynth 156.837
+        "att_B": float(res.cells["B"].effects.att),           # augsynth 119.383
+        # donor-exclusion: A never uses B's markets, B never uses A's
+        "donor_exclusion": float(
+            a_donors.isdisjoint({"atlanta", "boston"})
+            and b_donors.isdisjoint({"chicago", "portland"})),
+    }
+
+
+# ATT is the deterministic fixed-effect ASCM estimate -> matches augsynth exactly.
+EXPECTED = {
+    "att_A": (156.837, 0.05),     # augsynth {chicago, portland} excl. {atlanta, boston}
+    "att_B": (119.383, 0.05),     # augsynth {atlanta, boston} excl. {chicago, portland}
+    "donor_exclusion": (1.0, 0.5),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -71,6 +71,7 @@ CASES = {
     "geolift_walkthrough": "benchmarks.cases.geolift",  # cross-val vs GeoLift/augsynth: GeoLift_Walkthrough realized report (fixedeff ASCM + conformal)
     "geolift_augsynth_ref": "benchmarks.cases.geolift_augsynth_ref",  # cross-val vs LIVE augsynth (Rscript): lambda/weights/ATT (skips if absent)
     "geolift_cpic": "benchmarks.cases.geolift_cpic",  # cross-val vs GeoLiftMarketSelection: CPIC investment value-for-value
+    "geolift_multicell": "benchmarks.cases.geolift_multicell",  # cross-val vs augsynth: multi-cell per-cell ATT + donor exclusion
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -409,6 +409,72 @@ The synthetic tracks the test markets, :math:`\widehat{\tau} \approx 0`, and the
 joint conformal p-value is far from significant — the correct null over a placebo
 post period.
 
+Reading the results — plots, tables, and weights
+------------------------------------------------
+
+Everything the design and the realized report produce is on the result object,
+so you can use the built-in plot or pull the arrays and draw your own.
+
+**The built-in plot.** ``display_graphs=True`` (default) plots during ``fit``;
+you can also call it explicitly. In the **design** phase it shows the test
+markets vs their synthetic counterfactual over the pre-period; once a
+``post_col`` realizes the design, it shows **observed vs synthetic over pre+post
+with the conformal band, plus the effect (gap) underneath**:
+
+.. code-block:: python
+
+   from mlsynth.utils.geolift_helpers.marketselect.plotter import plot_design
+
+   plot_design(res, report=res.report, show=True)        # or save_path="design.png"
+
+**Power / MDE / budget table.** The ranked shortlist (one row per candidate ×
+duration) carries the power, the minimum detectable effect, and — when ``cpic``
+is set — the required investment:
+
+.. code-block:: python
+
+   res.power[["candidate", "duration", "mde", "power", "investment"]]
+   res.search.winner.mde, res.search.winner.power        # the recommended design
+
+**Observed vs predicted.** The realized report's time series are plain arrays:
+
+.. code-block:: python
+
+   import matplotlib.pyplot as plt
+
+   ts = res.report.time_series
+   plt.plot(ts.time_periods, ts.observed_outcome, color="black", label="observed")
+   plt.plot(ts.time_periods, ts.counterfactual_outcome, "r--", label="synthetic")
+   plt.axvline(ts.intervention_time, color="grey", ls=":"); plt.legend()
+
+**Gap (effect) with the conformal band.** The per-period effect and its
+conformal prediction interval come from ``inference.details``:
+
+.. code-block:: python
+
+   d = res.report.inference.details                      # post-period arrays
+   plt.plot(ts.time_periods, ts.estimated_gap, color="black")     # tau_hat_t
+   plt.fill_between(d["periods"], d["lower"], d["upper"], alpha=0.3)  # conformal CI
+   plt.axhline(0, color="grey", ls=":")
+   res.report.effects.att, res.report.inference.p_value  # ATT, joint conformal p
+
+**Donor weights.** The synthetic control's weights are a ``{market: weight}``
+dict — sort and bar-plot the contributors:
+
+.. code-block:: python
+
+   w = res.report.weights.donor_weights
+   top = dict(sorted(w.items(), key=lambda kv: -abs(kv[1]))[:10])
+   plt.bar(top.keys(), top.values()); plt.xticks(rotation=45, ha="right")
+
+**Budget (CPIC).** With ``cpic`` set, the realized spend is on the report; the
+design-time investment per candidate is the ``investment`` column above:
+
+.. code-block:: python
+
+   ss = res.report.weights.summary_stats
+   ss["cpic"], ss["cost"]                                # cost = cpic x incremental
+
 Verification
 ------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -238,6 +238,8 @@ headline numbers.
    pangeo
    spcd
    musc
+   geolift
+   multicellgeolift
 
 .. toctree::
    :hidden:

--- a/docs/multicellgeolift.rst
+++ b/docs/multicellgeolift.rst
@@ -66,6 +66,49 @@ Result
 :class:`EffectResult`, ``comparison`` is the pairwise table, ``winner`` the
 overall winner, and ``report`` is the representative (winner / largest) cell.
 
+Reading the results — per-cell plots and the comparison
+-------------------------------------------------------
+
+Each cell's report is a full GeoLift :class:`EffectResult`, so every single-cell
+view (observed vs synthetic, the gap with its conformal band, the donor weights —
+see :doc:`geolift`) works per cell. ``plot_multicell`` stacks the
+observed-vs-synthetic panels, one row per cell:
+
+.. code-block:: python
+
+   from mlsynth.utils.geolift_helpers.multicell.plotter import plot_multicell
+
+   plot_multicell(res, show=True)                        # one panel per cell
+
+   # per-cell numbers and views
+   res.cells["A"].effects.att, res.cells["A"].inference.p_value
+   res.cells["A"].time_series.estimated_gap              # cell A's gap path
+   res.cells["A"].weights.donor_weights                  # cell A's controls
+
+   # cross-cell comparison and the overall winner
+   res.comparison        # [{cell_a, cell_b, att_a, att_b, att_diff, winner}, ...]
+   res.winner            # the cell that wins every pairwise comparison, or None
+
+A ``winner`` of ``None`` is the honest, common outcome: each cell is measured
+well, but **declaring** one better needs its ATT interval to clear the other's
+(GeoLift's non-overlapping-CI rule), which a single test rarely supports.
+
+Not voodoo — one cell *is* the single-cell case
+-----------------------------------------------
+
+Multi-cell strictly generalizes single-cell: with one cell, every other unit is
+a control (no other cells to exclude), so ``MULTICELLGEOLIFT`` makes the *same*
+fit as the single-cell :doc:`geolift` realize — same treated set, same donor
+pool, hence the **same ATT, conformal p, and weights** (pinned in
+``test_multicell.py``):
+
+.. code-block:: python
+
+   # one cell A, everyone else control  ==  single-cell GEOLIFT on {chicago, portland}
+   res.cells["A"].effects.att        # 156.805165  (identical to the realize ATT)
+   res.cells["A"].inference.p_value  # 0.0115       (identical)
+   res.winner                        # None — nothing to compare against
+
 Verification
 ------------
 

--- a/docs/multicellgeolift.rst
+++ b/docs/multicellgeolift.rst
@@ -1,0 +1,87 @@
+.. _multicellgeolift:
+
+MULTICELLGEOLIFT — multi-cell GeoLift analysis
+==============================================
+
+When to use
+-----------
+
+A **multi-cell** geo experiment runs several treatments **at once** — different
+channels, budgets, or creative strategies — each on its own group of geos
+("cells" :math:`A, B, \dots`), all measured against a **shared** pool of control
+geos over the same window. Use ``MULTICELLGEOLIFT`` to measure each cell's
+incremental effect and to compare the cells. It is the analysis analogue of
+GeoLift's ``GeoLiftMultiCell`` (single-cell measurement is :doc:`geolift`).
+
+Data model
+----------
+
+A unit-level **cell-membership** column plus a treatment-window indicator:
+
+* ``cell_column_name`` — each geo's cell label (``"A"``, ``"B"``, …); **blank /
+  ``NaN``** (or an explicit ``control_label``) marks a **control** geo. The label
+  is a property of the geo, so it is constant over that geo's rows.
+* ``post_col`` — the (shared) ``0/1`` post-treatment window.
+
+.. code-block:: python
+
+   from mlsynth import MULTICELLGEOLIFT
+
+   res = MULTICELLGEOLIFT({
+       "df": panel, "outcome": "Y", "unitid": "location", "time": "date",
+       "cell_column_name": "cell",   # "A"/"B"/... ; blank = control
+       "post_col": "post",
+       "fixed_effects": True,         # augsynth/GeoLift default
+   }).fit()
+
+   res.cells["A"].effects.att        # cell A's ATT (per unit)
+   res.cells["A"].inference.p_value  # cell A's conformal p
+   res.comparison                    # pairwise cross-cell rows
+   res.winner                        # the cell that wins every comparison, or None
+
+Method
+------
+
+**Per cell.** Each cell is measured against the **shared control** pool with the
+fixed-effect Augmented SCM + conformal inference of :doc:`geolift` — *crucially,
+the other cells' geos are excluded from the donor pool*, because they are treated
+(with a different treatment) and so contaminated (GeoLift's
+``filter(!location %in% other_cells)``). So cell :math:`A`'s synthetic control is
+a combination of **control** geos only, never cell :math:`B`'s.
+
+**Cross-cell winner.** For each pair, a cell wins when its ATT confidence
+interval lies strictly above the other's (GeoLift's **non-overlapping-CI** rule;
+the ATT interval is the per-period conformal band averaged). The overall
+``winner`` wins every pairwise comparison, else ``None``. This is deliberately
+conservative: measuring each cell cleanly is well-powered, but *separating* two
+cells needs the difference to clear both intervals — so overlapping CIs (no
+declared winner) is common and correct, not a failure.
+
+Result
+------
+
+``MULTICELLGEOLIFT.fit`` returns a
+:class:`~mlsynth.utils.geolift_helpers.multicell.structures.MultiCellResults` (a
+:class:`~mlsynth.config_models.DesignResult`): ``cells`` maps each label to its
+:class:`EffectResult`, ``comparison`` is the pairwise table, ``winner`` the
+overall winner, and ``report`` is the representative (winner / largest) cell.
+
+Verification
+------------
+
+Cross-validated against **augsynth** (the engine ``GeoLiftMultiCell`` wraps) on
+the GeoLift_Test panel — cell A = {chicago, portland} (real effect), cell B =
+{atlanta, boston} (placebo), the rest shared controls: the per-cell ATT matches
+augsynth **to the decimal** (A ``156.84``, B ``119.38``), the conformal p-values
+agree (A ``≈0.01``, B ``≈0.8``), and the donor-exclusion invariant holds (A never
+uses B's markets). Durable case ``geolift_multicell``; unit tests
+``mlsynth/tests/test_multicell.py``.
+
+Core API
+--------
+
+.. autoclass:: mlsynth.MULTICELLGEOLIFT
+   :members: fit
+
+.. autoclass:: mlsynth.utils.geolift_helpers.multicell.config.MultiCellGeoLiftConfig
+   :members:

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -43,6 +43,7 @@ from .estimators.mcnnm import MCNNM
 from .estimators.pangeo import PANGEO
 from .estimators.hsc import HSC
 from .estimators.geolift import GEOLIFT
+from .estimators.multicellgeolift import MULTICELLGEOLIFT
 from .utils.spcd_helpers.plotter import (
     plot_spcd_design,
     plot_mde_bars,
@@ -56,6 +57,7 @@ __all__ = [
     "plot_power_curves",
     "plot_detectability",
     "GEOLIFT",
+    "MULTICELLGEOLIFT",
     "HSC",
     "TSSC",
     "FMA",

--- a/mlsynth/estimators/multicellgeolift.py
+++ b/mlsynth/estimators/multicellgeolift.py
@@ -1,0 +1,79 @@
+"""MULTICELLGEOLIFT: multi-cell GeoLift analysis (several treatment cells, one
+shared control pool)."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from pydantic import ValidationError
+
+from ..exceptions import MlsynthConfigError, MlsynthDataError, MlsynthEstimationError
+from ..utils.geolift_helpers.multicell import (
+    MultiCellGeoLiftConfig,
+    MultiCellResults,
+    analyze_multicell,
+    multicell_dataprep,
+)
+
+
+class MULTICELLGEOLIFT:
+    """Multi-cell GeoLift: measure several treatment cells at once.
+
+    Given a unit-level **cell-membership** column (``"A"``, ``"B"``, ... for
+    treated geos; blank / ``control_label`` for controls) and a ``post_col``
+    treatment window, each cell is measured against the **shared control** pool
+    with the fixed-effect Augmented SCM + conformal inference (the other cells
+    are excluded from each cell's donor pool), and the cells are compared
+    (GeoLift's non-overlapping-CI winner rule).
+
+    Parameters
+    ----------
+    config : MultiCellGeoLiftConfig or dict
+        See
+        :class:`mlsynth.utils.geolift_helpers.multicell.config.MultiCellGeoLiftConfig`.
+
+    Examples
+    --------
+    >>> from mlsynth import MULTICELLGEOLIFT
+    >>> res = MULTICELLGEOLIFT({"df": panel, "outcome": "Y", "unitid": "location",
+    ...     "time": "date", "cell_column_name": "cell", "post_col": "post"}).fit()  # doctest: +SKIP
+    >>> res.cells["A"].effects.att, res.winner                                      # doctest: +SKIP
+    """
+
+    def __init__(self, config: Union[MultiCellGeoLiftConfig, dict]) -> None:
+        if isinstance(config, dict):
+            try:
+                config = MultiCellGeoLiftConfig(**config)
+            except ValidationError as exc:  # pragma: no cover - passthrough
+                raise MlsynthConfigError(str(exc)) from exc
+        if not isinstance(config, MultiCellGeoLiftConfig):
+            raise MlsynthConfigError(
+                "config must be a MultiCellGeoLiftConfig or a dict of its fields."
+            )
+        self.config = config
+        self._result: Optional[MultiCellResults] = None
+
+    def fit(self) -> MultiCellResults:
+        """Resolve the cells, measure each against the shared control, compare."""
+        try:
+            prep = multicell_dataprep(
+                self.config.df, self.config.unitid, self.config.time,
+                self.config.outcome, cell_column_name=self.config.cell_column_name,
+                post_col=self.config.post_col, control_label=self.config.control_label,
+            )
+            result = analyze_multicell(
+                prep["Ywide"], prep["cell_map"], prep["control_units"],
+                prep["pre_periods"], how=self.config.how, augment=self.config.augment,
+                fixed_effects=self.config.fixed_effects, alpha=self.config.alpha,
+                ns=self.config.ns, seed=self.config.seed,
+                conformal_type=self.config.conformal_type, cpic=self.config.cpic,
+            )
+            if self.config.display_graphs:
+                from ..utils.geolift_helpers.multicell.plotter import plot_multicell
+                plot_multicell(result, show=True)
+            self._result = result
+            return result
+        except (MlsynthDataError, MlsynthConfigError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            raise MlsynthEstimationError(f"MULTICELLGEOLIFT failed: {exc}") from exc

--- a/mlsynth/tests/test_multicell.py
+++ b/mlsynth/tests/test_multicell.py
@@ -1,0 +1,144 @@
+"""Multi-cell GeoLift: dataprep, per-cell analysis, cross-cell winner, estimator."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import MULTICELLGEOLIFT
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.geolift_helpers.multicell import (
+    analyze_multicell, multicell_dataprep, MultiCellResults,
+)
+
+
+def _panel(T=34, pre=26, effA=8.0, effB=0.0, seed=0):
+    """Long panel: 6 controls, cells A (effect effA) and B (effect effB)."""
+    rng = np.random.default_rng(seed)
+    trend = np.arange(T) * 0.3
+    controls = {f"c{i}": trend + 5 * i + rng.normal(scale=0.4, size=T) for i in range(6)}
+    C = np.array(list(controls.values()))                       # (6, T)
+    def cell_unit(w, eff, s):
+        y = w @ C + rng.normal(scale=0.3, size=T)               # synth from controls
+        y[pre:] += eff                                          # post effect
+        return y
+    treated = {
+        "a0": cell_unit(np.array([.4, .3, .3, 0, 0, 0]), effA, 1),
+        "a1": cell_unit(np.array([.3, .3, .2, .2, 0, 0]), effA, 2),
+        "b0": cell_unit(np.array([0, 0, .3, .3, .4, 0]), effB, 3),
+        "b1": cell_unit(np.array([0, 0, 0, .3, .3, .4]), effB, 4),
+    }
+    cells = {**{u: "A" for u in ("a0", "a1")}, **{u: "B" for u in ("b0", "b1")},
+             **{u: "" for u in controls}}
+    rows = []
+    for unit, y in {**controls, **treated}.items():
+        for t in range(T):
+            rows.append({"location": unit, "time": t, "Y": y[t],
+                         "cell": cells[unit], "post": int(t >= pre)})
+    return pd.DataFrame(rows), pre
+
+
+# === dataprep ===
+
+def test_dataprep_resolves_cells_control_and_split():
+    df, pre = _panel()
+    prep = multicell_dataprep(df, "location", "time", "Y",
+                              cell_column_name="cell", post_col="post")
+    assert set(prep["cell_map"]) == {"A", "B"}
+    assert set(prep["cell_map"]["A"]) == {"a0", "a1"}
+    assert set(prep["control_units"]) == {f"c{i}" for i in range(6)}
+    assert prep["pre_periods"] == pre
+
+
+def test_dataprep_explicit_control_label():
+    df, _ = _panel()
+    df["cell"] = df["cell"].replace("", "ctrl")             # explicit control label
+    prep = multicell_dataprep(df, "location", "time", "Y",
+                              cell_column_name="cell", post_col="post",
+                              control_label="ctrl")
+    assert len(prep["control_units"]) == 6 and set(prep["cell_map"]) == {"A", "B"}
+
+
+def test_dataprep_cell_varies_within_unit_raises():
+    df, _ = _panel()
+    df.loc[(df["location"] == "a0") & (df["time"] == 0), "cell"] = "B"
+    with pytest.raises(MlsynthDataError, match="constant per unit"):
+        multicell_dataprep(df, "location", "time", "Y",
+                           cell_column_name="cell", post_col="post")
+
+
+def test_dataprep_no_control_raises():
+    df, _ = _panel()
+    df["cell"] = df["cell"].replace("", "A")                # everyone is treated
+    with pytest.raises(MlsynthDataError, match="no control"):
+        multicell_dataprep(df, "location", "time", "Y",
+                           cell_column_name="cell", post_col="post")
+
+
+def test_dataprep_missing_column_raises():
+    df, _ = _panel()
+    with pytest.raises(MlsynthConfigError, match="nope"):
+        multicell_dataprep(df, "location", "time", "Y",
+                           cell_column_name="nope", post_col="post")
+
+
+# === analyze ===
+
+def test_analyze_per_cell_reports_and_donor_exclusion():
+    df, pre = _panel(effA=8.0, effB=0.0)
+    prep = multicell_dataprep(df, "location", "time", "Y",
+                              cell_column_name="cell", post_col="post")
+    res = analyze_multicell(prep["Ywide"], prep["cell_map"], prep["control_units"],
+                            prep["pre_periods"], ns=200, seed=0)
+    assert isinstance(res, MultiCellResults)
+    assert set(res.cells) == {"A", "B"}
+    # the OTHER cell's markets are never donors (only controls can be)
+    for label, other in [("A", {"b0", "b1"}), ("B", {"a0", "a1"})]:
+        donors = set(res.cells[label].weights.donor_weights)
+        assert donors.isdisjoint(other)
+        assert donors <= {f"c{i}" for i in range(6)}
+
+
+def test_analyze_detects_effect_cell_not_null_cell():
+    df, pre = _panel(effA=10.0, effB=0.0)
+    prep = multicell_dataprep(df, "location", "time", "Y",
+                              cell_column_name="cell", post_col="post")
+    res = analyze_multicell(prep["Ywide"], prep["cell_map"], prep["control_units"],
+                            prep["pre_periods"], ns=400, seed=0)
+    assert res.cells["A"].inference.p_value < 0.10            # real effect detected
+    assert res.cells["B"].inference.p_value > 0.10            # null cell not rejected
+    assert res.cells["A"].effects.att > res.cells["B"].effects.att
+
+
+def test_analyze_winner_when_intervals_separate():
+    df, pre = _panel(effA=12.0, effB=0.0)
+    prep = multicell_dataprep(df, "location", "time", "Y",
+                              cell_column_name="cell", post_col="post")
+    res = analyze_multicell(prep["Ywide"], prep["cell_map"], prep["control_units"],
+                            prep["pre_periods"], ns=400, seed=0)
+    assert len(res.comparison) == 1
+    row = res.comparison[0]
+    assert {row["cell_a"], row["cell_b"]} == {"A", "B"}
+    # huge A effect, null B -> A's ATT CI should sit above B's -> A wins
+    assert res.winner == "A"
+
+
+# === estimator end-to-end ===
+
+def test_estimator_end_to_end():
+    df, _ = _panel(effA=10.0, effB=0.0)
+    res = MULTICELLGEOLIFT({
+        "df": df, "outcome": "Y", "unitid": "location", "time": "date" if False else "time",
+        "cell_column_name": "cell", "post_col": "post", "ns": 300,
+        "display_graphs": False,
+    }).fit()
+    assert isinstance(res, MultiCellResults)
+    assert set(res.cells) == {"A", "B"}
+    assert res.report is not None                            # DesignResult.report set
+
+
+def test_estimator_bad_config_raises():
+    df, _ = _panel()
+    with pytest.raises(MlsynthConfigError):
+        MULTICELLGEOLIFT({"df": df, "outcome": "Y", "unitid": "location",
+                          "time": "time", "cell_column_name": "cell",
+                          "post_col": "post", "how": "bogus"}).fit()

--- a/mlsynth/tests/test_multicell.py
+++ b/mlsynth/tests/test_multicell.py
@@ -136,6 +136,29 @@ def test_estimator_end_to_end():
     assert res.report is not None                            # DesignResult.report set
 
 
+def test_single_cell_reduces_to_single_realize():
+    """One cell is *identical* to the single-cell realize: same treated set, same
+    (all-other-units) donor pool, so the same fit, ATT, p, and weights."""
+    from mlsynth.utils.geolift_helpers.marketselect.realize import realize_design
+
+    df, pre = _panel(effA=8.0)
+    df = df.copy()
+    df.loc[df["cell"] == "B", "cell"] = ""                  # B -> control: one cell left
+    prep = multicell_dataprep(df, "location", "time", "Y",
+                              cell_column_name="cell", post_col="post")
+    assert set(prep["cell_map"]) == {"A"}
+    mc = analyze_multicell(prep["Ywide"], prep["cell_map"], prep["control_units"],
+                           prep["pre_periods"], how="mean", ns=200, seed=0)
+    single = realize_design(prep["Ywide"], frozenset(prep["cell_map"]["A"]),
+                            prep["pre_periods"], how="mean", fixed_effects=True,
+                            ns=200, seed=0)
+    a = mc.cells["A"]
+    assert a.effects.att == pytest.approx(single.effects.att)
+    assert a.inference.p_value == single.inference.p_value
+    assert a.weights.donor_weights == single.weights.donor_weights
+    assert mc.winner is None and mc.comparison == []        # nothing to compare
+
+
 def test_estimator_bad_config_raises():
     df, _ = _panel()
     with pytest.raises(MlsynthConfigError):

--- a/mlsynth/utils/geolift_helpers/multicell/__init__.py
+++ b/mlsynth/utils/geolift_helpers/multicell/__init__.py
@@ -1,0 +1,13 @@
+"""Multi-cell GeoLift analysis: per-cell effects against a shared control pool."""
+
+from .analyze import analyze_multicell
+from .config import MultiCellGeoLiftConfig
+from .dataprep import multicell_dataprep
+from .structures import MultiCellResults
+
+__all__ = [
+    "analyze_multicell",
+    "multicell_dataprep",
+    "MultiCellGeoLiftConfig",
+    "MultiCellResults",
+]

--- a/mlsynth/utils/geolift_helpers/multicell/analyze.py
+++ b/mlsynth/utils/geolift_helpers/multicell/analyze.py
@@ -1,0 +1,102 @@
+"""Multi-cell GeoLift analysis: per-cell effects + the cross-cell comparison.
+
+Each treatment cell is measured against the **shared control** pool with the
+(validated) fixed-effect Augmented SCM + conformal inference -- crucially
+excluding the *other* cells' markets from the donor pool, since they are treated
+(with a different treatment) and so contaminated (GeoLift's
+``filter(!location %in% other_cells)``). The cross-cell winner uses GeoLift's
+rule: a cell wins a pairwise comparison when its ATT confidence interval lies
+strictly above the other's (non-overlapping CIs).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from mlsynth.utils.geolift_helpers.marketselect.realize import realize_design
+
+from .structures import MultiCellResults
+
+
+def analyze_multicell(
+    Ywide: pd.DataFrame,
+    cell_map: Dict[str, List],
+    control_units: List,
+    pre_periods: int,
+    *,
+    how: str = "mean",
+    augment: Optional[str] = "ridge",
+    fixed_effects: bool = True,
+    alpha: float = 0.1,
+    q: float = 1.0,
+    ns: int = 1000,
+    seed: int = 0,
+    conformal_type: str = "iid",
+    cpic: Optional[float] = None,
+) -> MultiCellResults:
+    """Measure every cell against the shared control pool and compare them.
+
+    Parameters mirror :func:`realize_design`. Returns a :class:`MultiCellResults`
+    with the per-cell reports, the pairwise comparison, and the overall winner.
+    """
+    cells: Dict[str, object] = {}
+    cell_ci: Dict[str, tuple] = {}            # label -> (att, lower, upper)
+
+    for label in sorted(cell_map):
+        units = list(cell_map[label])
+        # Restrict the panel to this cell + the shared control pool, so the
+        # other cells are *excluded* from the donor matrix (they are treated).
+        sub = Ywide[list(control_units) + units]
+        report = realize_design(
+            sub, frozenset(units), pre_periods, how=how, augment=augment,
+            alpha=alpha, q=q, ns=ns, seed=seed, conformal_type=conformal_type,
+            fixed_effects=fixed_effects, cpic=cpic,
+        )
+        cells[label] = report
+        att = float(report.effects.att)
+        details = report.inference.details
+        # ATT confidence interval = the per-period conformal bounds averaged
+        # (contains the ATT, since each period's effect lies in its own band).
+        lower = float(np.nanmean(details["lower"]))
+        upper = float(np.nanmean(details["upper"]))
+        cell_ci[label] = (att, lower, upper)
+
+    labels = sorted(cell_map)
+    comparison: List[dict] = []
+    for i in range(len(labels)):
+        for j in range(i + 1, len(labels)):
+            a, b = labels[i], labels[j]
+            att_a, lo_a, hi_a = cell_ci[a]
+            att_b, lo_b, hi_b = cell_ci[b]
+            if lo_a > hi_b:
+                win = a
+            elif lo_b > hi_a:
+                win = b
+            else:
+                win = None                     # overlapping CIs -> no winner
+            comparison.append({
+                "cell_a": a, "cell_b": b,
+                "att_a": att_a, "att_b": att_b, "att_diff": att_a - att_b,
+                "winner": win,
+            })
+
+    # Overall winner: the cell that wins every pairwise comparison it is in.
+    winner = None
+    for label in labels:
+        involved = [c for c in comparison if label in (c["cell_a"], c["cell_b"])]
+        if involved and all(c["winner"] == label for c in involved):
+            winner = label
+            break
+
+    primary = winner or max(labels, key=lambda lab: abs(cell_ci[lab][0]))
+    return MultiCellResults(
+        report=cells[primary],
+        cells=cells,
+        comparison=comparison,
+        winner=winner,
+        assignment={label: list(units) for label, units in cell_map.items()},
+        selected_units=(list(cell_map[winner]) if winner else None),
+    )

--- a/mlsynth/utils/geolift_helpers/multicell/config.py
+++ b/mlsynth/utils/geolift_helpers/multicell/config.py
@@ -1,0 +1,54 @@
+"""Configuration for the multi-cell GeoLift analysis (MULTICELLGEOLIFT)."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import Field, model_validator
+
+from ....config_models import BaseMAREXConfig
+from ....exceptions import MlsynthConfigError
+
+
+class MultiCellGeoLiftConfig(BaseMAREXConfig):
+    """Configuration for the multi-cell GeoLift analysis."""
+
+    cell_column_name: str = Field(
+        ..., description="Unit-level column naming each geo's treatment cell "
+        "('A', 'B', ...); blank/NaN or `control_label` marks a control geo."
+    )
+    post_col: str = Field(
+        ..., description="0/1 column marking the (shared) post-treatment window."
+    )
+    control_label: Optional[str] = Field(
+        default=None,
+        description="Explicit value denoting a control geo (in addition to "
+        "blank/NaN), e.g. 'control' or '0'.",
+    )
+
+    # --- estimation / inference (mirrors GEOLIFT) ---
+    how: str = Field(default="mean", description="Treated aggregation per cell: 'sum' or 'mean'.")
+    augment: Optional[str] = Field(default="ridge", description="'ridge' (ASCM) or None (simplex).")
+    fixed_effects: bool = Field(default=True, description="Unit fixed effects (GeoLift default).")
+    alpha: float = Field(default=0.1, description="Significance level / CI level.")
+    cpic: Optional[float] = Field(default=None, description="Cost per incremental conversion (per-cell cost).")
+    ns: int = Field(default=1000, description="Conformal permutation count (iid).")
+    conformal_type: str = Field(default="iid", description="'iid' or 'block'.")
+    seed: int = Field(default=0, description="RNG seed for conformal permutations.")
+    display_graphs: bool = Field(default=True, description="Plot the per-cell effects during fit.")
+
+    @model_validator(mode="after")
+    def _check(self):
+        if self.how not in ("sum", "mean"):
+            raise MlsynthConfigError(f"how must be 'sum' or 'mean'; got {self.how!r}.")
+        if self.augment not in ("ridge", None):
+            raise MlsynthConfigError(f"augment must be 'ridge' or None; got {self.augment!r}.")
+        if not 0.0 < self.alpha < 1.0:
+            raise MlsynthConfigError(f"alpha must be in (0, 1); got {self.alpha}.")
+        if self.conformal_type not in ("iid", "block"):
+            raise MlsynthConfigError(
+                f"conformal_type must be 'iid' or 'block'; got {self.conformal_type!r}."
+            )
+        if self.cpic is not None and self.cpic < 0:
+            raise MlsynthConfigError(f"cpic must be >= 0; got {self.cpic}.")
+        return self

--- a/mlsynth/utils/geolift_helpers/multicell/dataprep.py
+++ b/mlsynth/utils/geolift_helpers/multicell/dataprep.py
@@ -1,0 +1,101 @@
+"""Data preparation for the multi-cell GeoLift analysis.
+
+Reads a unit-level **cell-membership** column (cell labels ``"A"``, ``"B"``, ...
+for treated geos; blank / a ``control_label`` for the shared donor pool) plus a
+``post_col`` marking the treatment window, and resolves the wide panel, the
+per-cell market lists, the shared control pool, and the pre/post split.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.datautils import geoex_dataprep
+
+
+def _is_control(value: Any, control_label: Optional[str]) -> bool:
+    """A unit is control if its cell value is blank/NaN or the ``control_label``."""
+    if pd.isna(value):
+        return True
+    s = str(value).strip()
+    if s == "":
+        return True
+    if control_label is not None and s == str(control_label).strip():
+        return True
+    return False
+
+
+def multicell_dataprep(
+    df: pd.DataFrame,
+    unit_id_column_name: str,
+    time_period_column_name: str,
+    outcome_column_name: str,
+    *,
+    cell_column_name: str,
+    post_col: str,
+    control_label: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Resolve a multi-cell geo panel from a cell-membership column.
+
+    Returns a dict with ``Ywide`` (full ``time x unit`` panel), ``cell_map``
+    (``{label: [units]}`` for each treatment cell), ``control_units`` (the shared
+    donor pool), ``pre_periods`` (the pre/post split from ``post_col``) and
+    ``time_labels``.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``cell_column_name`` or ``post_col`` is absent.
+    MlsynthDataError
+        If the cell label varies within a unit, or there are no treatment cells,
+        or no control units.
+    """
+    for col in (cell_column_name, post_col):
+        if col not in df.columns:
+            raise MlsynthConfigError(f"column {col!r} not found in df.")
+
+    full = geoex_dataprep(df, unit_id_column_name, time_period_column_name,
+                          outcome_column_name)
+    pre_periods = geoex_dataprep(
+        df, unit_id_column_name, time_period_column_name, outcome_column_name,
+        post_col=post_col)["pre_periods"]
+    Ywide = full["Ywide"]
+
+    # Cell membership is a per-unit attribute: it must be constant over time.
+    grp = df.groupby(unit_id_column_name)[cell_column_name]
+    varying = grp.nunique(dropna=False)
+    if (varying > 1).any():
+        bad = list(varying[varying > 1].index)[:5]
+        raise MlsynthDataError(
+            f"cell column {cell_column_name!r} must be constant per unit; it "
+            f"varies for units {bad}."
+        )
+    unit_cell = grp.first()
+
+    cell_map: Dict[str, List] = {}
+    control_units: List = []
+    for unit in Ywide.columns:
+        value = unit_cell.get(unit)
+        if _is_control(value, control_label):
+            control_units.append(unit)
+        else:
+            cell_map.setdefault(str(value).strip(), []).append(unit)
+
+    if not cell_map:
+        raise MlsynthDataError("no treatment cells found in the cell column.")
+    if not control_units:
+        raise MlsynthDataError(
+            "no control units found — every unit is assigned to a cell, leaving "
+            "no shared donor pool."
+        )
+
+    return {
+        "Ywide": Ywide,
+        "cell_map": cell_map,
+        "control_units": control_units,
+        "pre_periods": pre_periods,
+        "time_labels": full["time_labels"],
+    }

--- a/mlsynth/utils/geolift_helpers/multicell/plotter.py
+++ b/mlsynth/utils/geolift_helpers/multicell/plotter.py
@@ -1,0 +1,44 @@
+"""Minimal multi-cell plot: each cell's observed vs synthetic, gap below."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+
+def plot_multicell(result, *, show: bool = True, theme: Optional[dict] = None):
+    """Plot every cell's observed vs synthetic path (one row per cell).
+
+    Black = observed, red = synthetic counterfactual; a dashed line marks the
+    intervention. Uses the shared ``mlsynth`` house style.
+    """
+    import matplotlib
+    import matplotlib.pyplot as plt
+
+    from mlsynth.utils.plotting import mlsynth_style
+
+    cells = result.cells or {}
+    if not cells:
+        return None
+
+    labels = sorted(cells)
+    with plt.style.context(mlsynth_style() if theme is None else theme):
+        fig, axes = plt.subplots(len(labels), 1, figsize=(8, 2.6 * len(labels)),
+                                 squeeze=False)
+        for ax, label in zip(axes[:, 0], labels):
+            ts = cells[label].time_series
+            t = np.asarray(ts.time_periods)
+            ax.plot(t, np.asarray(ts.observed_outcome), color="black", label="observed")
+            ax.plot(t, np.asarray(ts.counterfactual_outcome), color="red",
+                    linestyle="--", label="synthetic")
+            if ts.intervention_time is not None:
+                ax.axvline(ts.intervention_time, color="grey", linestyle=":")
+            att = cells[label].effects.att
+            ax.set_title(f"Cell {label}"
+                         + (f"  (ATT {att:.1f})" if att is not None else ""))
+            ax.legend(loc="upper left", fontsize=8)
+        fig.tight_layout()
+    if show:
+        matplotlib.pyplot.show()
+    return fig

--- a/mlsynth/utils/geolift_helpers/multicell/structures.py
+++ b/mlsynth/utils/geolift_helpers/multicell/structures.py
@@ -1,0 +1,38 @@
+"""Result container for the multi-cell GeoLift analysis."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from mlsynth.config_models import BaseEstimatorResults, DesignResult
+
+
+class MultiCellResults(DesignResult):
+    """A multi-cell GeoLift analysis: a per-cell effect report plus the
+    cross-cell comparison.
+
+    Respects the two-family contract as a :class:`DesignResult` whose ``report``
+    is a representative cell's :class:`EffectResult` (the winner if one is
+    declared, else the largest-magnitude effect). The full breakdown lives in:
+
+    Attributes
+    ----------
+    cells : dict of str -> BaseEstimatorResults
+        Each treatment cell's realized effect report (ATT, lift, conformal
+        inference, weights, cost), measured against the **shared control** pool.
+    comparison : list of dict
+        Pairwise cross-cell rows: ``cell_a`` / ``cell_b`` / ``att_a`` / ``att_b``
+        / ``att_diff`` / ``winner`` (the cell whose ATT confidence interval lies
+        strictly above the other's, GeoLift's non-overlapping-CI rule; ``None``
+        when the intervals overlap).
+    winner : str or None
+        The cell that wins every pairwise comparison, else ``None``.
+    """
+
+    cells: Optional[Dict[str, BaseEstimatorResults]] = None
+    comparison: Optional[List[dict]] = None
+    winner: Optional[str] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+        extra = "allow"


### PR DESCRIPTION
## Summary

Adds **multi-cell GeoLift** — measuring several treatment cells at once (different channels/budgets/strategies) against one **shared control** pool — closing the last GeoLift feature gap. This is the analysis analogue of GeoLift's `GeoLiftMultiCell`.

**Data model** (as agreed): a unit-level **cell-membership** column (`"A"`/`"B"`/…; blank or `control_label` = control) + a `post_col` window.

**Method.** Each cell is measured against the shared controls with the (already bit-validated) fixed-effect Augmented SCM + conformal inference — *excluding the other cells' markets from the donor pool*, since they're treated and contaminated (GeoLift's `filter(!location %in% other_cells)`). The cross-cell **winner** uses GeoLift's non-overlapping-CI rule; overlapping CIs → no winner (the conservative, correct default — measuring each cell is well-powered, *separating* them needs the difference to clear both bands).

## Validated against augsynth (the engine `GeoLiftMultiCell` wraps)
GeoLift_Test, cell A = {chicago, portland} (real effect), cell B = {atlanta, boston} (placebo), rest shared controls:

| Cell | augsynth ATT | mlsynth ATT | augsynth p | mlsynth p |
|---|---|---|---|---|
| A | 156.837 | **156.837** | 0.017 | 0.011 |
| B | 119.383 | **119.383** | 0.813 | 0.823 |

Per-cell ATT matches **to the decimal**, p-values agree, and the **donor-exclusion invariant holds** (A never uses B's markets). The live `GeoLiftMultiCell` summary path is blocked by augsynth 0.2.0's multi-unit-cohort `treated_table` bug (a version mismatch), so the cross-check is against augsynth's own per-cell fit.

## Changes
- `utils/geolift_helpers/multicell/` — `dataprep` / `analyze` / `config` / `structures` (`MultiCellResults`: a `DesignResult` whose `report` is the representative cell, with `cells`/`comparison`/`winner`) / minimal `plotter`.
- `estimators/multicellgeolift.py` — `MULTICELLGEOLIFT`, exported.
- Tests `test_multicell.py` (10); durable benchmark `geolift_multicell`; docs `multicellgeolift.rst` (+ added `geolift`/`multicellgeolift` to the toctree).

With this, GeoLift's engine, market selection, budget planning, and multi-cell are all native Python in mlsynth — each cross-validated against the live R reference.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_