### PR TITLE
GEOLIFT design constraints (geography / coverage / size) + 100% coverage

### DIFF
--- a/agents/future_integrations.md
+++ b/agents/future_integrations.md
@@ -313,6 +313,15 @@ open-end DTW.
 
 ## 4. Design constraints for GEOLIFT (geography / coverage / size)
 
+> **Status: implemented** (steps 1-4 below are done; whole GeoLift package at
+> 100% coverage). Constraint primitives live in
+> ``geolift_helpers/marketselect/helpers/constraints.py``; wired through
+> ``config.py`` / ``orchestration.py`` / ``shaping.py`` / ``design.py`` /
+> ``batch.py``; documented in ``docs/geolift.rst`` ("Design constraints"). The
+> **only** remaining item is the optional step 5 -- cross-family consolidation
+> into a shared ``utils/design_constraints/`` module. LEXSCM was **not**
+> modified. Learnings below are kept for that future consolidation.
+
 ### Source / motivation
 
 Meta's GeoLift exposes only **hard market lists** on the treated side

--- a/agents/future_integrations.md
+++ b/agents/future_integrations.md
@@ -389,14 +389,18 @@ the number of clusters (no conflict-free `k`-tuple); `min_per_stratum` is impose
 over more strata than `k`; fewer than `k` markets lie inside the size band; or the
 spillover exclusions empty a candidate's donor pool.
 
-### Shared module (the architectural payoff)
+### LEXSCM is reference-only -- do not modify it
 
 LEXSCM already implements all of these primitives (conflict graph, independent-set
-filter, stratum-quota validator, size-band mask, aligned to its IndexSet). The
-durable move is to **extract them into `utils/design_constraints/`** -- a reusable
-"design-constraint algebra" -- and have both LEXSCM and GEOLIFT consume it (and
-later SYNDES / MAREX / PANGEO). Refactor LEXSCM onto it **behavior-preserving
-first** (its replication tests are the guard), then wire GEOLIFT in.
+filter, stratum-quota validator, size-band mask, aligned to its IndexSet). **Read
+it for the logic; do not touch its code, tests, or behaviour.** It is
+replication-pinned and there is no reason to disturb a working estimator. GEOLIFT
+gets its **own self-contained** constraint primitives inside `geolift_helpers/`
+(informed by LEXSCM, copying nothing structural). A little duplication is the
+accepted price for zero risk to LEXSCM. Consolidating the two implementations into
+a shared `utils/design_constraints/` algebra across the MAREX family (LEXSCM,
+GEOLIFT, later SYNDES / MAREX / PANGEO) is a **deliberate later step**, taken only
+once both are stable and with LEXSCM's replication tests as the guard.
 
 ### Test plan (test-first, per the contract)
 
@@ -406,18 +410,20 @@ Per constraint: a **smoke** test (constraint on, runs, design respects it), an
 exactly one feasible region), a **failure** test (each infeasibility above raises
 the translated error and the failure is *reported*), and a **no-op** test
 (constraint columns present but trivially satisfied → identical shortlist to the
-unconstrained run). Plus a cross-check that LEXSCM's outputs are unchanged after
-the shared-module refactor.
+unconstrained run).
 
 ### Suggested implementation order
 
-1. Extract `utils/design_constraints/` from LEXSCM; refactor LEXSCM onto it
-   (no behaviour change; replication tests green).
+1. Build GEOLIFT's **own** constraint primitives in `geolift_helpers/`
+   (conflict graph, independent-set filter, stratum-quota validator, size-band
+   mask), test-first. **LEXSCM is not modified.**
 2. Wire the **cluster/spillover pair** into GEOLIFT (highest-value geographic
    constraint), with docs + tests.
 3. Add **coverage quotas**, then **size bands**.
 4. Docs: extend `docs/geolift.rst` with a "Design constraints" section paralleling
    the LEXSCM treatment, each example a full MRE.
+5. *(Later, optional)* consolidate GEOLIFT's and LEXSCM's primitives into a shared
+   `utils/design_constraints/` module once both are stable.
 
 ### Out of scope / caveats
 

--- a/agents/future_integrations.md
+++ b/agents/future_integrations.md
@@ -311,6 +311,124 @@ open-end DTW.
 
 ---
 
+## 4. Design constraints for GEOLIFT (geography / coverage / size)
+
+### Source / motivation
+
+Meta's GeoLift exposes only **hard market lists** on the treated side
+(`include_markets` / `exclude_markets`, mirrored today by `to_be_treated` /
+`not_to_be_treated`). LEXSCM already carries a richer, *rule-based* constraint
+vocabulary -- spillover/cluster non-interference, coverage quotas, treated-unit
+size bands (see `docs/lexscm.rst`, "Spillover / interference exclusions" and
+"Coverage quotas and size bands"). Bringing that vocabulary to GEOLIFT makes
+mlsynth's market selection strictly **more expressive than the upstream R
+package**, and is the thing that makes our GeoLift genuinely *ours* rather than a
+faithful port.
+
+### The idea in one line
+
+Every design restriction reduces to **where the optimizer is allowed to look**:
+LEXSCM's constraints never enter the inner weight solve -- they are *filters on
+admissible treated supports* ("treatment criteria") and *pins in the control
+program* ("control criteria"). GEOLIFT has the same two seams, so the same
+constraint layer drops straight in.
+
+### Why this is attractive
+
+- **Two clean seams already exist.** Stage 1 (candidate nomination,
+  `marketselect/helpers/candidates.py` + `similarity.py`) builds each region
+  `S = {anchor} ∪ top-(k-1) correlated`, deduped, honoring the forced in/out
+  sets -- exactly where *treatment* criteria belong. Stage 2 (the SCM, donor pool
+  `N \ S`, in `fit.py` / `shaping.py`) is exactly where *control* criteria
+  belong.
+- **The geometry already justifies one of them.** A treated market far larger
+  than the donors cannot be reproduced by a convex combination of them -- which
+  is *precisely* what GeoLift's scaled-L2 imbalance `κ` measures post-hoc. So a
+  `max_size` ceiling is an **a-priori** version of `κ → 1`. The method's own
+  diagnostic motivates the constraint.
+- **Purely subtractive.** With none of the new fields supplied, behaviour is
+  byte-identical to today's GEOLIFT. Constraints only ever *shrink* the candidate
+  set / donor pool.
+
+### The mapping (treatment vs control criteria)
+
+| Constraint | GEOLIFT seam | Effect |
+|---|---|---|
+| **`cluster_col` no-interference** -- the treated set must be an *independent set* of the cluster conflict graph | Stage 1: when extending an anchor with correlated neighbours, skip any sharing a cluster with an already-chosen member | "at most one treated geo per DMA / state"; still `O(N)` candidates, just a shrunk neighbour set |
+| **`adjacency` / spillover exclusion** -- the donor pool drops `S ∪ A(S)` | Stage 2: pin spillover neighbours out of the donor matrix for that candidate | a treated geo's neighbours cannot contaminate its own synthetic control |
+| **`stratum_col` + `min_per_stratum` / `max_per_stratum`** (coverage quotas) | Stage 1: admit only regions meeting the per-stratum counts | "test in every region"; "≤ 2 from the Northeast" |
+| **`size_col` + `min_size` / `max_size`** (treated size bands) | Stage 1: restrict the *eligible nomination pool* (markets stay available as donors) | floor = power / operational minimum; ceiling = synthesizability (the `κ` argument above) |
+
+The conflict graph is the same object in both rows 1-2: a symmetric
+`A ∈ {0,1}^{N×N}` from `cluster_col` (`A_ij = 1` iff same cluster) **or** an
+`adjacency` matrix thresholded at `spillover_threshold`, combined by logical OR
+-- identical to LEXSCM's construction.
+
+### Config surface (additive to `GeoLiftConfig`)
+
+All optional; each defaults to `None` / off:
+
+```
+cluster_col, adjacency, spillover_threshold      # no-interference + donor exclusion
+stratum_col, min_per_stratum, max_per_stratum    # coverage quotas
+size_col, min_size, max_size                     # treated size bands
+```
+
+### Where it plugs in
+
+- `candidates.py` -- after correlation nomination, filter nominees to satisfy
+  independent-set + stratum quota + size band (all *treatment* criteria; act on
+  the support, never the weight program).
+- `fit.py` / `shaping.py` -- when assembling a candidate's donor matrix, drop
+  `A(S)` (the lone *control* criterion).
+
+### Failure modes (mirror LEXSCM exactly)
+
+Raise `MlsynthConfigError`, never return a degenerate design, when: `k` exceeds
+the number of clusters (no conflict-free `k`-tuple); `min_per_stratum` is imposed
+over more strata than `k`; fewer than `k` markets lie inside the size band; or the
+spillover exclusions empty a candidate's donor pool.
+
+### Shared module (the architectural payoff)
+
+LEXSCM already implements all of these primitives (conflict graph, independent-set
+filter, stratum-quota validator, size-band mask, aligned to its IndexSet). The
+durable move is to **extract them into `utils/design_constraints/`** -- a reusable
+"design-constraint algebra" -- and have both LEXSCM and GEOLIFT consume it (and
+later SYNDES / MAREX / PANGEO). Refactor LEXSCM onto it **behavior-preserving
+first** (its replication tests are the guard), then wire GEOLIFT in.
+
+### Test plan (test-first, per the contract)
+
+Per constraint: a **smoke** test (constraint on, runs, design respects it), an
+**invariant** test (independent-set holds / quota satisfied / sizes in band /
+`A(S)` absent from donor weights), an **edge** test (constraint that admits
+exactly one feasible region), a **failure** test (each infeasibility above raises
+the translated error and the failure is *reported*), and a **no-op** test
+(constraint columns present but trivially satisfied → identical shortlist to the
+unconstrained run). Plus a cross-check that LEXSCM's outputs are unchanged after
+the shared-module refactor.
+
+### Suggested implementation order
+
+1. Extract `utils/design_constraints/` from LEXSCM; refactor LEXSCM onto it
+   (no behaviour change; replication tests green).
+2. Wire the **cluster/spillover pair** into GEOLIFT (highest-value geographic
+   constraint), with docs + tests.
+3. Add **coverage quotas**, then **size bands**.
+4. Docs: extend `docs/geolift.rst` with a "Design constraints" section paralleling
+   the LEXSCM treatment, each example a full MRE.
+
+### Out of scope / caveats
+
+GEOLIFT's nomination is a cheap correlation heuristic, not LEXSCM's QP search, so
+constraints are applied as *post-nomination filters* -- a heavily-constrained
+problem could shrink the shortlist sharply (acceptable, and surfaced via the
+diagnostics). ROI / cost interactions with `cpic` + `budget` already exist and are
+orthogonal to these support constraints.
+
+---
+
 ## Done
 
 *(empty -- move completed items here, preserving their Learnings subsection.)*

--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -624,6 +624,69 @@ rather than returning a degenerate design.
    prune many nominees, and a very dense border graph can leave none (a reported
    infeasibility, not a silent degenerate design).
 
+**A worked design on real borders.** The example below is fully self-contained:
+it pulls the real DMA contiguity map and metadata, simulates a **grouped linear
+factor model** of seasonal weekly sales — latent group structure in the loadings
+(groups = census divisions), in the spirit of Liao, Shi & Zheng (2025) — over a
+real Southeast / Mid-South DMA footprint, then designs a 3-market geo test that is
+**non-adjacent on the map** and spread across regions (at most two per division).
+It runs in a few seconds.
+
+.. code-block:: python
+
+   import numpy as np
+   import pandas as pd
+   from mlsynth import GEOLIFT
+
+   base = ("https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
+           "refs/heads/main/basedata/markets")
+   A_full = pd.read_csv(f"{base}/dma_adjacency.csv", index_col=0)   # 206x206 borders
+   meta = pd.read_csv(f"{base}/dma_metadata.csv")                   # dma_name, state, ...
+
+   # Restrict to a real Southeast / Mid-South footprint; groups = census divisions.
+   division = {"GA": "S. Atlantic", "FL": "S. Atlantic",
+               "TN": "E.S. Central", "AL": "E.S. Central"}
+   meta = meta[meta["state"].isin(division)].copy()
+   meta["division"] = meta["state"].map(division)
+   names = [n for n in meta["dma_name"] if n in A_full.index]
+   meta = meta[meta["dma_name"].isin(names)].reset_index(drop=True)
+   A = A_full.loc[names, names]                                     # real contiguity
+
+   # Grouped linear factor model of seasonal weekly sales: the loadings carry a
+   # latent group structure (one loading per division), plus a shared seasonal
+   # swing and idiosyncratic noise.
+   rng = np.random.default_rng(0)
+   div = meta.set_index("dma_name").loc[names, "division"].to_numpy()
+   n, r, T = len(names), 3, 60
+   group_loading = {g: rng.normal(size=r) for g in sorted(set(div))}
+   Lambda = np.array([group_loading[g] for g in div]) + 0.1 * rng.normal(size=(n, r))
+   F = np.cumsum(rng.normal(size=(T, r)), axis=0)                   # common factors
+   season = 12 * np.sin(2 * np.pi * np.arange(T) / 52)             # annual seasonality
+   sales = (1000 + rng.normal(0, 40, n)                            # market base level
+            + F @ Lambda.T                                         # grouped factor structure
+            + season[:, None]                                      # shared seasonal swing
+            + rng.normal(0, 5, (T, n)))                            # idiosyncratic noise
+   df = pd.DataFrame([
+       {"dma": names[j], "week": t, "sales": float(sales[t, j]), "division": div[j]}
+       for j in range(n) for t in range(T)
+   ])
+
+   res = GEOLIFT({
+       "df": df, "outcome": "sales", "unitid": "dma", "time": "week",
+       "treatment_size": 3, "durations": [8], "effect_sizes": [0.0, 0.05, 0.10],
+       "lookback_window": 1, "how": "mean", "ns": 50, "seed": 0,
+       "adjacency": A,                          # true DMA borders -> non-adjacent markets
+       "stratum_col": "division", "max_per_stratum": 2,   # spread across regions
+       "display_graphs": False,
+   }).fit()
+
+   print("recommended test markets:", res.selected_units)
+   print(res.search.shortlist[["candidate", "duration", "mde", "power"]].head())
+
+   # the design honours the geography: no two test markets border each other
+   treated = res.selected_units
+   assert all(A.loc[a, b] == 0 for a in treated for b in treated if a != b)
+
 **Cluster non-interference + spillover donor exclusion.** Treat markets in
 different regions, and never let a treated market's same-region neighbours into
 its synthetic control:

--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -340,6 +340,9 @@ driven by the data and config (a ``post_col`` triggers realization;
   :math:`\{\delta\}`, ``lookback_window`` :math:`L`.
 * ``to_be_treated`` / ``not_to_be_treated`` —
   :math:`\mathcal{S}_{\mathrm{in}}` / :math:`\mathcal{S}_{\mathrm{out}}`.
+* ``cluster_col`` / ``adjacency`` / ``spillover_threshold``, ``stratum_col`` /
+  ``min_per_stratum`` / ``max_per_stratum``, ``size_col`` / ``min_size`` /
+  ``max_size`` — rule-based design constraints (see *Design constraints* below).
 * ``post_col`` — a 0/1 column marking post-treatment periods; the design slices to
   :math:`\mathcal{T}_1`, so it is **identical** whether you pass the full
   post-treatment panel or a pre-only one (the "rerun after treatment"
@@ -567,6 +570,103 @@ the scoring helpers directly:
    plt.axhline(0.8, ls="--", color="grey")                # power threshold -> MDE crossing
    plt.xlabel("injected lift"); plt.ylabel("power"); plt.show()
 
+
+Design constraints (geography, coverage, size)
+----------------------------------------------
+
+Upstream GeoLift restricts the treated side only through **hard market lists**
+(``to_be_treated`` / ``not_to_be_treated``). ``mlsynth`` adds a **rule-based**
+constraint layer so the candidate nomination and donor pool can encode geography
+and other design considerations. Every restriction is one of two kinds (the
+LEXSCM vocabulary, see :doc:`lexscm`): a **treatment criterion** filtering which
+candidate test regions are admissible, or a **control criterion** restricting a
+candidate's donor pool. Neither touches the inner weight solve — they only change
+*where the design is allowed to look*. With none of these fields set, the design
+is identical to the unconstrained run.
+
+* ``cluster_col`` — a per-market cluster label (DMA / state). Markets in the same
+  cluster **interfere**: at most one may be treated per candidate (treatment
+  criterion, the *independent-set* rule) **and** a treated market's same-cluster
+  geos are dropped from its donor pool (control criterion, the *spillover
+  exclusion*). An ``adjacency`` matrix of pairwise spillover strengths, thresholded
+  by ``spillover_threshold`` and combined with ``cluster_col`` by logical OR, is
+  the continuous alternative.
+* ``stratum_col`` + ``min_per_stratum`` / ``max_per_stratum`` — **coverage
+  quotas**: require at least ``min`` treated markets in every stratum that has an
+  eligible market ("test in every region"), and/or at most ``max`` per stratum (a
+  quota). A treatment criterion.
+* ``size_col`` + ``min_size`` / ``max_size`` — a **treated-unit size band**: only
+  in-band markets are eligible for *treatment* (they remain available as donors).
+  The floor is a power / operational minimum; the ceiling encodes
+  synthesizability — a market far larger than the donors cannot sit inside their
+  convex hull, which is exactly what the scaled-L2 imbalance :math:`\kappa`
+  measures, so ``max_size`` is an a-priori version of :math:`\kappa \to 1`.
+
+When the constraints admit no candidate region (e.g. ``treatment_size`` exceeds
+the number of clusters or strata to cover, or the size band leaves too few
+markets), :meth:`GEOLIFT.fit` raises :class:`~mlsynth.exceptions.MlsynthConfigError`
+rather than returning a degenerate design.
+
+**Cluster non-interference + spillover donor exclusion.** Treat markets in
+different regions, and never let a treated market's same-region neighbours into
+its synthetic control:
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import GEOLIFT
+
+   url = ("https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
+          "refs/heads/main/basedata/geolift_market_data.csv")
+   df = pd.read_csv(url)                                   # 40 markets x 90 days
+
+   # Per-market geography. In practice these come from your own region table /
+   # spend data; here they are derived from the panel so the example runs as-is.
+   markets = sorted(df["location"].unique())
+   region = {m: f"R{i % 4}" for i, m in enumerate(markets)}   # 4 illustrative regions
+   df["region"] = df["location"].map(region)
+
+   res = GEOLIFT({
+       "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+       "treatment_size": 2, "durations": [14], "effect_sizes": [0.0, 0.1],
+       "lookback_window": 1, "how": "mean", "ns": 50, "seed": 0,
+       "cluster_col": "region", "display_graphs": False,
+   }).fit()
+
+   print(res.selected_units)                              # markets in distinct regions
+   # invariant: no candidate's donors share a region with its treated markets
+   cd = res.search.candidates[0]
+   treated_regions = {region[str(u)] for u in cd.candidate}
+   assert all(region[str(d)] not in treated_regions for d in cd.weights.donor_weights)
+
+**Coverage quota + size band.** Cover distinct regions (at most one treated market
+each) and treat only mid-sized markets (drop the largest and smallest):
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import GEOLIFT
+
+   url = ("https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
+          "refs/heads/main/basedata/geolift_market_data.csv")
+   df = pd.read_csv(url)
+   markets = sorted(df["location"].unique())
+   df["region"] = df["location"].map({m: f"R{i % 4}" for i, m in enumerate(markets)})
+   size = df.groupby("location")["Y"].mean()              # avg daily volume = "size"
+   df["size"] = df["location"].map(size)
+   lo, hi = float(size.quantile(0.2)), float(size.quantile(0.8))
+
+   res = GEOLIFT({
+       "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+       "treatment_size": 3, "durations": [14], "effect_sizes": [0.0, 0.1],
+       "lookback_window": 1, "how": "mean", "ns": 50, "seed": 0,
+       "stratum_col": "region", "max_per_stratum": 1,     # <= 1 treated per region
+       "size_col": "size", "min_size": lo, "max_size": hi,  # mid-sized only
+       "display_graphs": False,
+   }).fit()
+
+   print(res.selected_units)                              # 3 markets, 3 distinct regions
+   print(res.search.shortlist[["candidate", "duration", "mde", "power"]].head())
 
 Multi-cell designs
 ------------------

--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -607,6 +607,23 @@ the number of clusters or strata to cover, or the size band leaves too few
 markets), :meth:`GEOLIFT.fit` raises :class:`~mlsynth.exceptions.MlsynthConfigError`
 rather than returning a degenerate design.
 
+.. admonition:: Real geography — the bundled DMA contiguity map
+
+   ``adjacency`` is where you "literally take geography into account": pass a
+   real **bordering** matrix and treated markets are forced apart while each
+   one's neighbours are barred from its donor pool. The package ships the
+   Nielsen US market-area map at ``basedata/markets/dma_adjacency.csv`` — a
+   ``206 × 206`` symmetric 0/1 contiguity matrix indexed by DMA name (with
+   ``dma_metadata.csv`` carrying state, division, and lat/long) — so a panel
+   keyed by DMA can use true borders directly:
+   ``GEOLIFT({..., "adjacency": pd.read_csv(".../dma_adjacency.csv", index_col=0)})``.
+   The same artifact powers LEXSCM's spillover designs. A worked end-to-end check
+   on real borders lives in ``mlsynth/tests/test_geolift_dma_borders.py``. Note
+   the tension this exposes: correlation nomination favours *similar* (often
+   *bordering*) markets, so the independent-set filter does real work — it can
+   prune many nominees, and a very dense border graph can leave none (a reported
+   infeasibility, not a silent degenerate design).
+
 **Cluster non-interference + spillover donor exclusion.** Treat markets in
 different regions, and never let a treated market's same-region neighbours into
 its synthetic control:

--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -101,6 +101,77 @@ unioned with the forced-in set, so every candidate satisfies
 :math:`\mathcal{S}_{\mathrm{in}} \subseteq \mathcal{S}` and
 :math:`\mathcal{S} \cap \mathcal{S}_{\mathrm{out}} = \varnothing`.
 
+Stage 1b — Design constraints
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Beyond hard forcing lists, the rule-based constraints restrict the admissible
+regions and donor pools (the prose walkthrough with runnable examples is in
+*Design constraints (geography, coverage, size)* below). Each is one of two kinds,
+following the LEXSCM constraint algebra (:doc:`lexscm`): a **treatment
+criterion** filtering admissible :math:`\mathcal{S}`, or a **control criterion**
+restricting the donor pool. None enters the inner weight program of Stage 2.
+
+**Interference graph.** Encode market interference by a symmetric
+:math:`\mathbf{A} = [A_{ij}] \in \{0,1\}^{N \times N}` with zero diagonal, where
+:math:`A_{ij} = 1` iff markets :math:`i, j` interfere. It is built from a cluster
+labelling :math:`c : \mathcal{N} \to \mathcal{C}` (``cluster_col``,
+:math:`A_{ij} = 1` iff :math:`c(i) = c(j)`) and/or a spillover matrix
+:math:`\mathbf{W}` (``adjacency``, :math:`A_{ij} = 1` iff
+:math:`W_{ij} > \theta`, the ``spillover_threshold``), combined entrywise by
+logical OR. The **conflict-neighbours** of a region are
+
+.. math::
+
+   \mathcal{A}(\mathcal{S}) \coloneqq
+   \bigl\{\, k \in \mathcal{N} : A_{jk} = 1 \ \text{for some}\ j \in \mathcal{S}
+   \,\bigr\} \setminus \mathcal{S}.
+
+*Treatment criterion — no interference.* The treated region must be an
+**independent set** of :math:`\mathbf{A}`:
+:math:`A_{ij} = 0 \ \forall\, i, j \in \mathcal{S}` (at most one market per
+cluster). *Control criterion — spillover exclusion.* The donor pool drops the
+conflict-neighbours, refining the Stage-2 pool to
+
+.. math::
+
+   \mathcal{N}_0(\mathcal{S}) \;=\;
+   \mathcal{N} \setminus \bigl(\mathcal{S} \cup \mathcal{A}(\mathcal{S})\bigr),
+
+so a treated market's interferers can be neither co-treated nor used as its own
+donors.
+
+**Coverage quotas.** With a stratum labelling :math:`g : \mathcal{N} \to
+\mathcal{G}` (``stratum_col``) and the strata that contain an eligible market
+:math:`\mathcal{G}_{\mathrm{elig}}`, the region must satisfy, for the bounds
+:math:`q_{\min}` (``min_per_stratum``) and :math:`q_{\max}` (``max_per_stratum``),
+
+.. math::
+
+   q_{\min} \le \bigl|\{\, j \in \mathcal{S} : g(j) = s \,\}\bigr|
+   \quad \forall\, s \in \mathcal{G}_{\mathrm{elig}},
+   \qquad
+   \bigl|\{\, j \in \mathcal{S} : g(j) = s \,\}\bigr| \le q_{\max}
+   \quad \forall\, s \in \mathcal{G}.
+
+**Size band.** With market sizes :math:`z_j` (``size_col``) and bounds
+:math:`[\underline{z}, \overline{z}]` (``min_size`` / ``max_size``), only in-band
+markets are **treatment-eligible**,
+:math:`\mathcal{N}_{\mathrm{size}} \coloneqq \{\, j : \underline{z} \le z_j \le
+\overline{z} \,\}`, so :math:`\mathcal{S} \subseteq \mathcal{N}_{\mathrm{size}}`;
+out-of-band markets remain available as donors. The ceiling
+:math:`\overline{z}` is the a-priori analogue of the synthesizability the scaled
+L2 imbalance :math:`\kappa(\mathcal{S})` (below) measures post-hoc.
+
+All three treatment criteria act on the admissible supports — they sit exactly
+where the cardinality constraint :math:`|\mathcal{S}| = k` already lives and only
+*shrink* the candidate set. If no region satisfies them (e.g.
+:math:`k` exceeds :math:`|\mathcal{C}|` or :math:`|\mathcal{G}_{\mathrm{elig}}|`,
+or :math:`|\mathcal{N}_{\mathrm{size}}| < k`) the design reports infeasibility
+(:class:`~mlsynth.exceptions.MlsynthConfigError`) rather than returning a
+degenerate region. With none of the constraints supplied,
+:math:`\mathbf{A} = \mathbf{0}` and every region is admissible — the unconstrained
+nomination.
+
 Stage 2 — The synthetic control
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mlsynth/estimators/multicellgeolift.py
+++ b/mlsynth/estimators/multicellgeolift.py
@@ -44,7 +44,7 @@ class MULTICELLGEOLIFT:
         if isinstance(config, dict):
             try:
                 config = MultiCellGeoLiftConfig(**config)
-            except ValidationError as exc:  # pragma: no cover - passthrough
+            except ValidationError as exc:
                 raise MlsynthConfigError(str(exc)) from exc
         if not isinstance(config, MultiCellGeoLiftConfig):
             raise MlsynthConfigError(

--- a/mlsynth/tests/test_geolift_constraints.py
+++ b/mlsynth/tests/test_geolift_constraints.py
@@ -355,3 +355,99 @@ def test_run_design_no_cluster_col_unchanged():
     again = run_design(GeoLiftConfig(df=df, **common))
     assert {cd.candidate for cd in base.search.candidates} == \
            {cd.candidate for cd in again.search.candidates}
+
+
+# === orchestration: coverage quotas + size bands (end-to-end) ===
+
+_REGION_OF = {"u0": "R1", "u1": "R1", "u2": "R2", "u3": "R2", "u4": "R3", "u5": "R3"}
+_SIZE_OF = {"u0": 10.0, "u1": 50.0, "u2": 60.0, "u3": 70.0, "u4": 500.0, "u5": 80.0}
+
+
+def _stratified_long(seed=5, T=24):
+    rng = np.random.default_rng(seed)
+    base = np.arange(T) * 0.3
+    rows = []
+    for i in range(6):
+        u = f"u{i}"
+        s = base + rng.normal(scale=1.0, size=T) + i
+        for t in range(T):
+            rows.append({"unit": u, "time": t, "Y": float(s[t]),
+                         "region": _REGION_OF[u], "size": _SIZE_OF[u]})
+    return pd.DataFrame(rows)
+
+
+def test_run_design_size_band_restricts_treatment_not_donors():
+    cfg = GeoLiftConfig(df=_stratified_long(), outcome="Y", unitid="unit", time="time",
+                        treatment_size=2, durations=[4], effect_sizes=[0.0, 0.5],
+                        lookback_window=1, ns=20, seed=0,
+                        size_col="size", min_size=40.0, max_size=100.0)
+    res = run_design(cfg)
+    treated_ever = set()
+    for cd in res.search.candidates:
+        treated_ever |= {str(u) for u in cd.candidate}
+    assert "u0" not in treated_ever and "u4" not in treated_ever   # out of band
+    # but the out-of-band markets remain available as donors somewhere
+    donors_seen = set()
+    for cd in res.search.candidates:
+        donors_seen |= {str(d) for d in cd.weights.donor_weights}
+    assert "u0" in donors_seen or "u4" in donors_seen
+
+
+def test_run_design_max_per_stratum():
+    cfg = GeoLiftConfig(df=_stratified_long(), outcome="Y", unitid="unit", time="time",
+                        treatment_size=2, durations=[4], effect_sizes=[0.0, 0.5],
+                        lookback_window=1, ns=20, seed=0,
+                        stratum_col="region", max_per_stratum=1)
+    res = run_design(cfg)
+    for cd in res.search.candidates:
+        regions = [_REGION_OF[str(u)] for u in cd.candidate]
+        assert len(regions) == len(set(regions))         # never two from one region
+
+
+def test_run_design_min_per_stratum_covers_every_region():
+    cfg = GeoLiftConfig(df=_stratified_long(), outcome="Y", unitid="unit", time="time",
+                        treatment_size=3, durations=[4], effect_sizes=[0.0, 0.5],
+                        lookback_window=1, ns=20, seed=0,
+                        stratum_col="region", min_per_stratum=1)
+    res = run_design(cfg)
+    assert len(res.search.candidates) >= 1
+    for cd in res.search.candidates:
+        assert {_REGION_OF[str(u)] for u in cd.candidate} == {"R1", "R2", "R3"}
+
+
+def test_run_design_min_per_stratum_infeasible_raises():
+    """Cover 3 regions but only treat 2 -> impossible -> reported."""
+    with pytest.raises(MlsynthConfigError, match="constraint"):
+        run_design(GeoLiftConfig(
+            df=_stratified_long(), outcome="Y", unitid="unit", time="time",
+            treatment_size=2, durations=[4], effect_sizes=[0.0],
+            lookback_window=1, ns=20, seed=0,
+            stratum_col="region", min_per_stratum=1))
+
+
+def test_run_design_size_band_too_tight_raises():
+    with pytest.raises(MlsynthConfigError, match="size"):
+        run_design(GeoLiftConfig(
+            df=_stratified_long(), outcome="Y", unitid="unit", time="time",
+            treatment_size=2, durations=[4], effect_sizes=[0.0],
+            lookback_window=1, ns=20, seed=0,
+            size_col="size", min_size=1000.0))
+
+
+# === config validation for the new constraint fields ===
+
+@pytest.mark.parametrize("kwargs,msg", [
+    ({"stratum_col": "region", "min_per_stratum": 0}, "min_per_stratum"),
+    ({"stratum_col": "region", "max_per_stratum": 0}, "max_per_stratum"),
+    ({"min_per_stratum": 1}, "stratum_col"),               # quota without stratum_col
+    ({"max_per_stratum": 1}, "stratum_col"),
+    ({"min_size": 5.0}, "size_col"),                       # band without size_col
+    ({"max_size": 5.0}, "size_col"),
+    ({"size_col": "size", "min_size": 100.0, "max_size": 10.0}, "max_size"),
+])
+def test_constraint_config_validation(kwargs, msg):
+    base = dict(df=_stratified_long(), outcome="Y", unitid="unit", time="time",
+                treatment_size=2, durations=[4], effect_sizes=[0.0])
+    base.update(kwargs)
+    with pytest.raises(MlsynthConfigError, match=msg):
+        GeoLiftConfig(**base)

--- a/mlsynth/tests/test_geolift_constraints.py
+++ b/mlsynth/tests/test_geolift_constraints.py
@@ -1,0 +1,228 @@
+"""Design-constraint primitives for GeoLift market selection.
+
+Self-contained constraint layer (GeoLift owns it; LEXSCM is untouched). These
+are pure, label-based helpers that decide which candidate test regions are
+admissible (treatment criteria: cluster non-interference, coverage quotas, size
+bands) and which donors a candidate may use (control criterion: spillover
+exclusion). Tested test-first per the repo contract.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.geolift_helpers.marketselect.helpers.constraints import (
+    build_conflict_graph,
+    conflict_neighbors,
+    is_independent_set,
+    eligible_by_size,
+    satisfies_quota,
+    admissible_candidates,
+)
+
+
+# === build_conflict_graph ===
+
+def test_conflict_graph_from_clusters():
+    units = ["a", "b", "c", "d"]
+    cluster_map = {"a": "NE", "b": "NE", "c": "S", "d": "S"}
+    g = build_conflict_graph(units, cluster_map=cluster_map)
+    assert g["a"] == frozenset({"b"})           # same cluster -> conflict
+    assert g["c"] == frozenset({"d"})
+    assert "a" not in g["c"]                     # different cluster -> no conflict
+    assert "a" not in g["a"]                     # never self
+
+
+def test_conflict_graph_singleton_cluster_has_no_conflicts():
+    units = ["a", "b", "c"]
+    g = build_conflict_graph(units, cluster_map={"a": "X", "b": "Y", "c": "Z"})
+    assert all(g[u] == frozenset() for u in units)
+
+
+def test_conflict_graph_missing_cluster_label_no_conflict():
+    """A unit absent from the cluster map simply has no cluster conflicts."""
+    units = ["a", "b", "c"]
+    g = build_conflict_graph(units, cluster_map={"a": "X", "b": "X"})  # c missing
+    assert g["a"] == frozenset({"b"})
+    assert g["c"] == frozenset()
+
+
+def test_conflict_graph_from_adjacency_threshold_and_symmetry():
+    units = ["a", "b", "c"]
+    adj = pd.DataFrame(
+        [[0.0, 0.9, 0.1],
+         [0.9, 0.0, 0.4],
+         [0.1, 0.4, 0.0]],
+        index=units, columns=units,
+    )
+    g = build_conflict_graph(units, adjacency=adj, spillover_threshold=0.5)
+    assert g["a"] == frozenset({"b"})           # 0.9 > 0.5
+    assert g["b"] == frozenset({"a"})           # symmetric
+    assert g["c"] == frozenset()                # 0.1, 0.4 both <= 0.5
+
+
+def test_conflict_graph_clusters_and_adjacency_combine_by_or():
+    units = ["a", "b", "c"]
+    cluster_map = {"a": "X", "b": "Y", "c": "X"}   # a~c by cluster
+    adj = pd.DataFrame(
+        [[0.0, 0.8, 0.0],
+         [0.8, 0.0, 0.0],
+         [0.0, 0.0, 0.0]],
+        index=units, columns=units,
+    )                                              # a~b by adjacency
+    g = build_conflict_graph(units, cluster_map=cluster_map, adjacency=adj,
+                             spillover_threshold=0.5)
+    assert g["a"] == frozenset({"b", "c"})         # union of both sources
+
+
+def test_conflict_graph_no_inputs_is_empty():
+    units = ["a", "b"]
+    g = build_conflict_graph(units)
+    assert g == {"a": frozenset(), "b": frozenset()}
+
+
+def test_conflict_graph_adjacency_must_cover_units():
+    units = ["a", "b", "c"]
+    adj = pd.DataFrame([[0.0, 0.9], [0.9, 0.0]], index=["a", "b"], columns=["a", "b"])
+    with pytest.raises(MlsynthConfigError, match="adjacency"):
+        build_conflict_graph(units, adjacency=adj)
+
+
+# === is_independent_set / conflict_neighbors ===
+
+def _graph():
+    units = ["a", "b", "c", "d"]
+    # a~b (cluster NE), c~d (cluster S)
+    return build_conflict_graph(units, cluster_map={"a": "NE", "b": "NE",
+                                                    "c": "S", "d": "S"})
+
+
+def test_is_independent_set_true_when_conflict_free():
+    g = _graph()
+    assert is_independent_set(frozenset({"a", "c"}), g)      # different clusters
+    assert is_independent_set(frozenset({"a"}), g)           # singleton
+    assert is_independent_set(frozenset(), g)                # empty
+
+
+def test_is_independent_set_false_when_members_conflict():
+    g = _graph()
+    assert not is_independent_set(frozenset({"a", "b"}), g)  # same cluster
+
+
+def test_conflict_neighbors_union_minus_members():
+    g = _graph()
+    # neighbours of {a} are {b}; exclude the treated members themselves
+    assert conflict_neighbors(frozenset({"a"}), g) == frozenset({"b"})
+    assert conflict_neighbors(frozenset({"a", "c"}), g) == frozenset({"b", "d"})
+
+
+def test_conflict_neighbors_excludes_treated_members():
+    g = _graph()
+    # b is a neighbour of a, but b is itself treated -> not in A(S)
+    assert conflict_neighbors(frozenset({"a", "b"}), g) == frozenset()
+
+
+def test_conflict_neighbors_empty_graph():
+    g = build_conflict_graph(["a", "b", "c"])
+    assert conflict_neighbors(frozenset({"a"}), g) == frozenset()
+
+
+# === eligible_by_size ===
+
+def test_eligible_by_size_both_bounds_inclusive():
+    size_map = {"a": 10, "b": 50, "c": 100, "d": 200}
+    elig = eligible_by_size(size_map.keys(), size_map, min_size=50, max_size=100)
+    assert elig == frozenset({"b", "c"})            # bounds inclusive
+
+
+def test_eligible_by_size_min_only_and_max_only():
+    size_map = {"a": 10, "b": 50, "c": 100}
+    assert eligible_by_size(size_map, size_map, min_size=50) == frozenset({"b", "c"})
+    assert eligible_by_size(size_map, size_map, max_size=50) == frozenset({"a", "b"})
+
+
+def test_eligible_by_size_no_bounds_is_all():
+    size_map = {"a": 10, "b": 50}
+    assert eligible_by_size(size_map, size_map) == frozenset({"a", "b"})
+
+
+def test_eligible_by_size_unit_missing_size_is_ineligible():
+    size_map = {"a": 10, "b": 50}
+    assert eligible_by_size(["a", "b", "c"], size_map, min_size=0) == frozenset({"a", "b"})
+
+
+# === satisfies_quota ===
+
+def _strata():
+    return {"a": "NE", "b": "NE", "c": "S", "d": "W"}
+
+
+def test_satisfies_quota_max_per_stratum():
+    sm = _strata()
+    # at most 1 per stratum: {a,b} both NE -> violates
+    assert not satisfies_quota(frozenset({"a", "b"}), sm, max_per_stratum=1)
+    assert satisfies_quota(frozenset({"a", "c"}), sm, max_per_stratum=1)
+
+
+def test_satisfies_quota_min_per_required_stratum():
+    sm = _strata()
+    required = {"NE", "S", "W"}
+    # must cover every required stratum at least once
+    assert not satisfies_quota(frozenset({"a", "c"}), sm, min_per_stratum=1,
+                               required_strata=required)          # misses W
+    assert satisfies_quota(frozenset({"a", "c", "d"}), sm, min_per_stratum=1,
+                           required_strata=required)
+
+
+def test_satisfies_quota_both_bounds():
+    sm = _strata()
+    required = {"NE", "S"}
+    ok = frozenset({"a", "c"})          # 1 NE, 1 S
+    assert satisfies_quota(ok, sm, min_per_stratum=1, max_per_stratum=1,
+                           required_strata=required)
+    bad = frozenset({"a", "b", "c"})    # 2 NE > max
+    assert not satisfies_quota(bad, sm, min_per_stratum=1, max_per_stratum=1,
+                               required_strata=required)
+
+
+def test_satisfies_quota_no_quota_is_true():
+    sm = _strata()
+    assert satisfies_quota(frozenset({"a", "b", "c", "d"}), sm)
+
+
+def test_satisfies_quota_ignores_market_without_stratum():
+    """A treated market absent from the stratum map is not counted in any
+    stratum (it contributes to no quota)."""
+    sm = {"a": "NE", "b": "NE"}                  # c, d have no stratum
+    assert satisfies_quota(frozenset({"a", "c", "d"}), sm, max_per_stratum=1)
+    assert not satisfies_quota(frozenset({"a", "b", "c"}), sm, max_per_stratum=1)
+
+
+# === admissible_candidates (composition) ===
+
+def test_admissible_candidates_filters_conflicts_and_quota():
+    g = build_conflict_graph(["a", "b", "c", "d"],
+                             cluster_map={"a": "NE", "b": "NE", "c": "S", "d": "W"})
+    sm = {"a": "NE", "b": "NE", "c": "S", "d": "W"}
+    cands = [
+        frozenset({"a", "b"}),      # conflict (both NE) -> drop
+        frozenset({"a", "c"}),      # ok
+        frozenset({"c", "d"}),      # ok
+    ]
+    out = admissible_candidates(cands, conflict=g, stratum_map=sm, max_per_stratum=1)
+    assert frozenset({"a", "b"}) not in out
+    assert frozenset({"a", "c"}) in out and frozenset({"c", "d"}) in out
+
+
+def test_admissible_candidates_drops_on_quota_alone():
+    """A conflict-free candidate that violates the quota is still dropped."""
+    sm = {"a": "NE", "b": "NE", "c": "S"}
+    cands = [frozenset({"a", "b"}), frozenset({"a", "c"})]
+    out = admissible_candidates(cands, stratum_map=sm, max_per_stratum=1)
+    assert out == [frozenset({"a", "c"})]       # {a,b} both NE -> dropped
+
+
+def test_admissible_candidates_no_constraints_returns_all():
+    cands = [frozenset({"a", "b"}), frozenset({"c"})]
+    assert admissible_candidates(cands) == cands

--- a/mlsynth/tests/test_geolift_constraints.py
+++ b/mlsynth/tests/test_geolift_constraints.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 from mlsynth.utils.geolift_helpers.marketselect.helpers.constraints import (
     build_conflict_graph,
     conflict_neighbors,
@@ -19,7 +19,11 @@ from mlsynth.utils.geolift_helpers.marketselect.helpers.constraints import (
     eligible_by_size,
     satisfies_quota,
     admissible_candidates,
+    unit_attribute_map,
 )
+from mlsynth.utils.geolift_helpers.marketselect.helpers.shaping import donor_matrix
+from mlsynth.utils.geolift_helpers.config import GeoLiftConfig
+from mlsynth.utils.geolift_helpers.marketselect.orchestration import run_design
 
 
 # === build_conflict_graph ===
@@ -226,3 +230,128 @@ def test_admissible_candidates_drops_on_quota_alone():
 def test_admissible_candidates_no_constraints_returns_all():
     cands = [frozenset({"a", "b"}), frozenset({"c"})]
     assert admissible_candidates(cands) == cands
+
+
+# === unit_attribute_map ===
+
+def test_unit_attribute_map_constant_per_unit():
+    df = pd.DataFrame({"unit": ["a", "a", "b", "b"], "t": [0, 1, 0, 1],
+                       "g": ["X", "X", "Y", "Y"]})
+    assert unit_attribute_map(df, "unit", "g") == {"a": "X", "b": "Y"}
+
+
+def test_unit_attribute_map_varying_raises():
+    df = pd.DataFrame({"unit": ["a", "a"], "t": [0, 1], "g": ["X", "Y"]})
+    with pytest.raises(MlsynthDataError, match="constant per unit"):
+        unit_attribute_map(df, "unit", "g")
+
+
+def test_unit_attribute_map_missing_col_raises():
+    df = pd.DataFrame({"unit": ["a"], "t": [0]})
+    with pytest.raises(MlsynthConfigError, match="nope"):
+        unit_attribute_map(df, "unit", "nope")
+
+
+# === donor_matrix spillover exclusion ===
+
+def _wide(units, T=20, seed=1):
+    rng = np.random.default_rng(seed)
+    base = np.arange(T) * 0.3
+    return pd.DataFrame({u: base + rng.normal(scale=1.0, size=T) + i
+                         for i, u in enumerate(units)})
+
+
+def test_donor_matrix_exclude_drops_extra_units():
+    Yw = _wide(["a", "b", "c", "d"])
+    dm = donor_matrix(Yw, frozenset({"a"}), exclude={"b"})
+    assert list(dm.columns) == ["c", "d"]            # candidate a + excluded b gone
+
+
+def test_donor_matrix_exclude_none_is_unchanged():
+    Yw = _wide(["a", "b", "c", "d"])
+    assert list(donor_matrix(Yw, frozenset({"a"})).columns) == ["b", "c", "d"]
+
+
+def test_donor_matrix_exclude_emptying_pool_raises():
+    Yw = _wide(["a", "b"])
+    with pytest.raises(MlsynthDataError):
+        donor_matrix(Yw, frozenset({"a"}), exclude={"b"})
+
+
+# === orchestration: cluster / spillover wiring (end-to-end) ===
+
+def _clustered_long(seed=3, T=24):
+    """6 units in 3 clusters of 2: u0,u1 -> C0; u2,u3 -> C1; u4,u5 -> C2."""
+    rng = np.random.default_rng(seed)
+    base = np.arange(T) * 0.3
+    rows = []
+    for i in range(6):
+        s = base + rng.normal(scale=1.0, size=T) + i
+        for t in range(T):
+            rows.append({"unit": f"u{i}", "time": t, "Y": float(s[t]),
+                         "cluster": f"C{i // 2}"})
+    return pd.DataFrame(rows)
+
+
+_CLUSTER_OF = {f"u{i}": f"C{i // 2}" for i in range(6)}
+
+
+def test_run_design_cluster_constraint_yields_independent_sets():
+    cfg = GeoLiftConfig(df=_clustered_long(), outcome="Y", unitid="unit", time="time",
+                        treatment_size=2, durations=[4], effect_sizes=[0.0, 0.5],
+                        lookback_window=1, ns=20, seed=0, cluster_col="cluster")
+    res = run_design(cfg)
+    assert len(res.search.candidates) >= 1
+    for cd in res.search.candidates:
+        cl = [_CLUSTER_OF[str(u)] for u in cd.candidate]
+        assert len(cl) == len(set(cl))               # never two from one cluster
+
+
+def test_run_design_spillover_excludes_same_cluster_donors():
+    cfg = GeoLiftConfig(df=_clustered_long(), outcome="Y", unitid="unit", time="time",
+                        treatment_size=2, durations=[4], effect_sizes=[0.0, 0.5],
+                        lookback_window=1, ns=20, seed=0, cluster_col="cluster")
+    res = run_design(cfg)
+    for cd in res.search.candidates:
+        treated_clusters = {_CLUSTER_OF[str(u)] for u in cd.candidate}
+        for donor in cd.weights.donor_weights:       # nonzero donors only
+            assert _CLUSTER_OF[str(donor)] not in treated_clusters
+
+
+def test_run_design_infeasible_cluster_raises():
+    """Treat 4 with one-per-cluster but only 3 clusters -> no admissible region."""
+    with pytest.raises(MlsynthConfigError, match="constraint"):
+        run_design(GeoLiftConfig(
+            df=_clustered_long(), outcome="Y", unitid="unit", time="time",
+            treatment_size=4, durations=[4], effect_sizes=[0.0],
+            lookback_window=1, ns=20, seed=0, cluster_col="cluster"))
+
+
+def test_run_design_adjacency_excludes_spillover_donor():
+    """A thresholded adjacency edge u0~u1 forbids them together and drops u1
+    from u0's donor pool."""
+    units = [f"u{i}" for i in range(6)]
+    adj = pd.DataFrame(0.0, index=units, columns=units)
+    adj.loc["u0", "u1"] = adj.loc["u1", "u0"] = 0.9   # only this pair conflicts
+    cfg = GeoLiftConfig(df=_clustered_long(), outcome="Y", unitid="unit", time="time",
+                        treatment_size=2, durations=[4], effect_sizes=[0.0, 0.5],
+                        lookback_window=1, ns=20, seed=0,
+                        adjacency=adj, spillover_threshold=0.5)
+    res = run_design(cfg)
+    cands = {cd.candidate for cd in res.search.candidates}
+    assert frozenset({"u0", "u1"}) not in cands       # adjacency forbids the pair
+    for cd in res.search.candidates:
+        if "u0" in cd.candidate:
+            assert "u1" not in cd.weights.donor_weights   # u1 excluded as donor
+
+
+def test_run_design_no_cluster_col_unchanged():
+    """Without constraint fields the design is identical to the baseline run."""
+    common = dict(outcome="Y", unitid="unit", time="time", treatment_size=2,
+                  durations=[4], effect_sizes=[0.0, 0.5], lookback_window=1,
+                  ns=20, seed=0)
+    df = _clustered_long()
+    base = run_design(GeoLiftConfig(df=df, **common))
+    again = run_design(GeoLiftConfig(df=df, **common))
+    assert {cd.candidate for cd in base.search.candidates} == \
+           {cd.candidate for cd in again.search.candidates}

--- a/mlsynth/tests/test_geolift_dma_borders.py
+++ b/mlsynth/tests/test_geolift_dma_borders.py
@@ -1,0 +1,131 @@
+"""GEOLIFT spillover-aware selection on the bundled Nielsen DMA map.
+
+The parallel of ``test_lexscm_dma_demo`` for GEOLIFT: validate the
+``basedata/markets/`` real US market-area contiguity together with GeoLift's
+``adjacency`` / ``cluster_col`` constraints. We synthesise a division-driven,
+border-smoothed panel over a real DMA subset and check the two guarantees the
+conflict graph must enforce — on **real borders**:
+
+* no two **treated** DMAs share a border (Stage-1 independent-set rule);
+* no **donor** borders any treated DMA (Stage-2 spillover exclusion).
+
+There is a genuine tension worth recording: GeoLift nominates candidates by
+*correlation*, and a border-smoothed panel makes bordering DMAs the most
+correlated, so the independent-set filter removes many nominees — the test
+confirms admissible regions still remain and every one honours the borders.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import GEOLIFT
+
+_MARKETS = Path(__file__).resolve().parents[2] / "basedata" / "markets"
+
+# A handful of census divisions, enough DMAs that border-free regions exist.
+_DIVISION = {
+    "FL": "S. Atlantic", "GA": "S. Atlantic", "NC": "S. Atlantic", "SC": "S. Atlantic",
+    "TN": "E.S. Central", "MS": "E.S. Central", "AL": "E.S. Central",
+    "OH": "E.N. Central", "IN": "E.N. Central", "IL": "E.N. Central",
+    "MI": "E.N. Central", "WI": "E.N. Central",
+    "MN": "W.N. Central", "MO": "W.N. Central",
+}
+
+
+@pytest.fixture(scope="module")
+def dma_adjacency():
+    return pd.read_csv(_MARKETS / "dma_adjacency.csv", index_col=0)
+
+
+@pytest.fixture(scope="module")
+def dma_metadata():
+    return pd.read_csv(_MARKETS / "dma_metadata.csv")
+
+
+def _geo_panel(adj, meta, seed=7, T=40):
+    """Division-driven factor panel with mild border smoothing over real DMAs."""
+    meta = meta[meta.state.isin(_DIVISION)].copy()
+    meta["division"] = meta.state.map(_DIVISION)
+    names = [n for n in meta.dma_name if n in adj.index]
+    meta = meta[meta.dma_name.isin(names)].reset_index(drop=True)
+    A = adj.loc[names, names]
+    W = A.values.astype(float)
+    n, r = len(names), 4
+    rng = np.random.default_rng(seed)
+    div = meta.set_index("dma_name").loc[names, "division"].values
+    Lam_div = {d: rng.normal(size=r) for d in sorted(set(div))}
+    lam = np.array([Lam_div[d] for d in div]) + 0.15 * rng.normal(size=(n, r))
+    lam = 0.85 * lam + 0.15 * (W @ lam) / np.maximum(W.sum(1, keepdims=True), 1)
+    F = np.cumsum(rng.normal(size=(T, r)), 0)
+    Y = 100 + rng.normal(0, 5, n) + F @ lam.T + rng.normal(0, 1.0, (T, n))
+    df = pd.DataFrame([
+        {"location": names[j], "date": t, "Y": float(Y[t, j]),
+         "division": div[j]}
+        for j in range(n) for t in range(T)
+    ])
+    return df, A
+
+
+def test_geolift_spillover_on_real_dma_borders(dma_adjacency, dma_metadata):
+    df, A = _geo_panel(dma_adjacency, dma_metadata)
+    res = GEOLIFT({
+        "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+        "treatment_size": 3, "durations": [8], "effect_sizes": [0.0, 0.1],
+        "lookback_window": 1, "how": "mean", "ns": 30, "seed": 0,
+        "adjacency": A, "display_graphs": False,
+    }).fit()
+
+    assert len(res.search.candidates) >= 1                  # the filter leaves regions
+    for cd in res.search.candidates:
+        members = [str(u) for u in cd.candidate]
+        # Guarantee 1: no two treated DMAs border each other.
+        for i, a in enumerate(members):
+            for b in members[i + 1:]:
+                assert A.loc[a, b] == 0, f"treated {a!r} and {b!r} share a border"
+        # Guarantee 2: no donor borders any treated DMA.
+        neighbours = {x for t in members for x in A.columns[A.loc[t] == 1]}
+        assert neighbours.isdisjoint(cd.weights.donor_weights)
+
+    # the recommended design honours the borders too
+    if res.selected_units is not None:
+        treated = list(res.selected_units)
+        for i, a in enumerate(treated):
+            for b in treated[i + 1:]:
+                assert A.loc[a, b] == 0
+
+
+def test_geolift_adjacency_forbids_a_known_border(dma_adjacency, dma_metadata):
+    """A specific real border (Atlanta, GA ~ Macon, GA) is never co-treated."""
+    df, A = _geo_panel(dma_adjacency, dma_metadata)
+    assert A.loc["Atlanta, GA", "Macon, GA"] == 1            # the border exists
+    res = GEOLIFT({
+        "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+        "treatment_size": 3, "durations": [8], "effect_sizes": [0.0, 0.1],
+        "lookback_window": 1, "how": "mean", "ns": 30, "seed": 0,
+        "adjacency": A, "display_graphs": False,
+    }).fit()
+    for cd in res.search.candidates:
+        members = {str(u) for u in cd.candidate}
+        assert not {"Atlanta, GA", "Macon, GA"} <= members
+
+
+def test_geolift_cluster_col_state_no_two_treated_same_state(dma_adjacency, dma_metadata):
+    """cluster_col on real state labels: at most one treated DMA per state."""
+    df, A = _geo_panel(dma_adjacency, dma_metadata)
+    state = (dma_metadata.set_index("dma_name")["state"]
+             .loc[[c for c in A.index]])
+    df["state"] = df["location"].map(state)
+    res = GEOLIFT({
+        "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+        "treatment_size": 3, "durations": [8], "effect_sizes": [0.0, 0.1],
+        "lookback_window": 1, "how": "mean", "ns": 30, "seed": 0,
+        "cluster_col": "state", "display_graphs": False,
+    }).fit()
+    smap = state.to_dict()
+    for cd in res.search.candidates:
+        states = [smap[str(u)] for u in cd.candidate]
+        assert len(states) == len(set(states))              # one per state

--- a/mlsynth/tests/test_marketselect_aggregate.py
+++ b/mlsynth/tests/test_marketselect_aggregate.py
@@ -6,6 +6,7 @@ from mlsynth.utils.geolift_helpers.marketselect.helpers.aggregate import (
     compute_power,
     compute_mde,
     compute_rank,
+    _RANK_COLUMNS,
 )
 
 
@@ -163,4 +164,14 @@ def test_compute_rank_all_nondetectable_returns_empty():
     weak = _rank_power_table().assign(power=0.1)   # nothing detectable
     out = compute_rank(weak, power_threshold=0.8)
     assert out.empty
+
+
+def test_compute_rank_budget_excludes_every_candidate_returns_empty():
+    """A budget smaller than every candidate's investment filters the table to
+    empty *before* the MDE, returning the empty ranked frame (GeoLift's
+    abs(budget) > abs(Investment) gate emptying the pool)."""
+    pt = _rank_power_table().assign(investment=500_000.0)
+    out = compute_rank(pt, power_threshold=0.8, budget=1.0)
+    assert out.empty
+    assert list(out.columns) == _RANK_COLUMNS
     assert "rank" in out.columns

--- a/mlsynth/tests/test_multicell.py
+++ b/mlsynth/tests/test_multicell.py
@@ -202,3 +202,111 @@ def test_estimator_display_graphs_does_not_raise():
         "display_graphs": True,
     }).fit()
     assert isinstance(res, MultiCellResults)
+
+
+def test_plot_multicell_empty_cells_returns_none():
+    """The empty-result guard: nothing to plot -> None, no figure."""
+    import types
+    from mlsynth.utils.geolift_helpers.multicell.plotter import plot_multicell
+    assert plot_multicell(types.SimpleNamespace(cells={}), show=False) is None
+
+
+# === config validation (each invalid field is reported, not swallowed) ===
+
+def _cfg(df, **over):
+    base = dict(df=df, outcome="Y", unitid="location", time="time",
+                cell_column_name="cell", post_col="post")
+    base.update(over)
+    return base
+
+
+def test_config_invalid_augment_raises():
+    df, _ = _panel()
+    with pytest.raises(MlsynthConfigError, match="augment"):
+        MULTICELLGEOLIFT(_cfg(df, augment="bogus"))
+
+
+def test_config_invalid_alpha_raises():
+    df, _ = _panel()
+    with pytest.raises(MlsynthConfigError, match="alpha"):
+        MULTICELLGEOLIFT(_cfg(df, alpha=1.5))
+
+
+def test_config_invalid_conformal_type_raises():
+    df, _ = _panel()
+    with pytest.raises(MlsynthConfigError, match="conformal_type"):
+        MULTICELLGEOLIFT(_cfg(df, conformal_type="bogus"))
+
+
+def test_config_negative_cpic_raises():
+    df, _ = _panel()
+    with pytest.raises(MlsynthConfigError, match="cpic"):
+        MULTICELLGEOLIFT(_cfg(df, cpic=-1.0))
+
+
+def test_config_unknown_field_translates_validation_error():
+    """An unknown key trips pydantic's extra='forbid'; the estimator translates
+    that ValidationError into the library's MlsynthConfigError."""
+    df, _ = _panel()
+    with pytest.raises(MlsynthConfigError):
+        MULTICELLGEOLIFT(_cfg(df, not_a_real_field=1))
+
+
+def test_estimator_rejects_non_config_non_dict():
+    """A config that is neither a dict nor a MultiCellGeoLiftConfig is rejected."""
+    with pytest.raises(MlsynthConfigError, match="MultiCellGeoLiftConfig or a dict"):
+        MULTICELLGEOLIFT(42)
+
+
+def test_estimator_fit_reraises_data_error():
+    """A data error raised inside dataprep surfaces from fit() untranslated
+    (re-raised as MlsynthDataError, not wrapped as an estimation error)."""
+    df, _ = _panel()
+    df.loc[(df["location"] == "a0") & (df["time"] == 0), "cell"] = "B"   # varies within unit
+    with pytest.raises(MlsynthDataError):
+        MULTICELLGEOLIFT(_cfg(df)).fit()
+
+
+# === dataprep edge cases ===
+
+def test_dataprep_nan_marks_control():
+    """A NaN cell value (not just blank '') marks a control geo."""
+    df, _ = _panel()
+    df.loc[df["cell"] == "", "cell"] = np.nan       # controls as NaN instead of ""
+    prep = multicell_dataprep(df, "location", "time", "Y",
+                              cell_column_name="cell", post_col="post")
+    assert set(prep["control_units"]) == {f"c{i}" for i in range(6)}
+    assert set(prep["cell_map"]) == {"A", "B"}
+
+
+def test_dataprep_no_treatment_cells_raises():
+    """Every unit a control -> no treatment cells -> reported, not a degenerate run."""
+    df, _ = _panel()
+    df["cell"] = ""                                 # everyone is a control
+    with pytest.raises(MlsynthDataError, match="no treatment cells"):
+        multicell_dataprep(df, "location", "time", "Y",
+                           cell_column_name="cell", post_col="post")
+
+
+# === cross-cell winner: the symmetric branches ===
+
+def test_analyze_winner_is_b_when_b_dominates():
+    """Mirror of A-wins: a large B effect, null A -> B's CI clears A's -> B wins."""
+    df, _ = _panel(effA=0.0, effB=8.0)
+    prep = multicell_dataprep(df, "location", "time", "Y",
+                              cell_column_name="cell", post_col="post")
+    res = analyze_multicell(prep["Ywide"], prep["cell_map"], prep["control_units"],
+                            prep["pre_periods"], ns=400, seed=0)
+    assert res.winner == "B"
+    assert res.comparison[0]["winner"] == "B"
+
+
+def test_analyze_overlapping_cis_no_winner():
+    """Both cells null -> overlapping ATT CIs -> the comparison declares no winner."""
+    df, _ = _panel(effA=0.0, effB=0.0)
+    prep = multicell_dataprep(df, "location", "time", "Y",
+                              cell_column_name="cell", post_col="post")
+    res = analyze_multicell(prep["Ywide"], prep["cell_map"], prep["control_units"],
+                            prep["pre_periods"], ns=400, seed=0)
+    assert res.comparison[0]["winner"] is None
+    assert res.winner is None

--- a/mlsynth/utils/geolift_helpers/config.py
+++ b/mlsynth/utils/geolift_helpers/config.py
@@ -49,6 +49,31 @@ class GeoLiftConfig(BaseMAREXConfig):
         description="Off-diagonal `adjacency` entries strictly above this mark an "
         "interfering pair.",
     )
+    stratum_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit column of stratum labels (region / tier / segment) for "
+        "coverage quotas via `min_per_stratum` / `max_per_stratum`.",
+    )
+    min_per_stratum: Optional[int] = Field(
+        default=None,
+        description="Require at least this many treated markets from every stratum "
+        "that contains a treatment-eligible market ('test in every region').",
+    )
+    max_per_stratum: Optional[int] = Field(
+        default=None,
+        description="Allow at most this many treated markets from any stratum (a quota).",
+    )
+    size_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit column of market sizes for a treated-unit size band; "
+        "out-of-band markets stay available as donors.",
+    )
+    min_size: Optional[float] = Field(
+        default=None, description="Lower bound of the treated-unit size band (inclusive)."
+    )
+    max_size: Optional[float] = Field(
+        default=None, description="Upper bound of the treated-unit size band (inclusive)."
+    )
 
     # --- power-simulation grid ---
     durations: List[int] = Field(
@@ -142,4 +167,22 @@ class GeoLiftConfig(BaseMAREXConfig):
                 raise MlsynthConfigError(f"budget must be > 0; got {self.budget}.")
             if self.cpic is None:
                 raise MlsynthConfigError("budget requires cpic to be set.")
+        # design constraints
+        if self.min_per_stratum is not None and self.min_per_stratum < 1:
+            raise MlsynthConfigError(
+                f"min_per_stratum must be >= 1; got {self.min_per_stratum}.")
+        if self.max_per_stratum is not None and self.max_per_stratum < 1:
+            raise MlsynthConfigError(
+                f"max_per_stratum must be >= 1; got {self.max_per_stratum}.")
+        if (self.min_per_stratum is not None or self.max_per_stratum is not None) \
+                and self.stratum_col is None:
+            raise MlsynthConfigError(
+                "min_per_stratum / max_per_stratum require stratum_col.")
+        if (self.min_size is not None or self.max_size is not None) \
+                and self.size_col is None:
+            raise MlsynthConfigError("min_size / max_size require size_col.")
+        if self.min_size is not None and self.max_size is not None \
+                and self.min_size > self.max_size:
+            raise MlsynthConfigError(
+                f"min_size ({self.min_size}) must be <= max_size ({self.max_size}).")
         return self

--- a/mlsynth/utils/geolift_helpers/config.py
+++ b/mlsynth/utils/geolift_helpers/config.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
+import pandas as pd
 from pydantic import Field, model_validator
 
 from ...config_models import BaseMAREXConfig
@@ -27,6 +28,26 @@ class GeoLiftConfig(BaseMAREXConfig):
     )
     not_to_be_treated: Optional[List] = Field(
         default=None, description="Units forbidden from any candidate (stay donors)."
+    )
+
+    # --- design constraints (geography / interference) ---
+    cluster_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit column of cluster labels (e.g. DMA / state). Markets "
+        "in the same cluster interfere: at most one per candidate (treatment "
+        "criterion), and a treated market's same-cluster geos are dropped from its "
+        "donor pool (control criterion).",
+    )
+    adjacency: Optional[pd.DataFrame] = Field(
+        default=None,
+        description="Square unit-by-unit spillover matrix (index/columns are market "
+        "labels). Pairs above `spillover_threshold` interfere, combined with "
+        "`cluster_col` by logical OR.",
+    )
+    spillover_threshold: float = Field(
+        default=0.0,
+        description="Off-diagonal `adjacency` entries strictly above this mark an "
+        "interfering pair.",
     )
 
     # --- power-simulation grid ---

--- a/mlsynth/utils/geolift_helpers/marketselect/helpers/batch.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/helpers/batch.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 from mlsynth.exceptions import MlsynthConfigError
 
+from .constraints import ConflictGraph, conflict_neighbors
 from .shaping import aggregate_treated, donor_matrix
 from .simulate import simulate_lookback
 
@@ -38,6 +39,7 @@ def run_simulations(
     conformal_type: str = "iid",
     fixed_effects: bool = False,
     cpic: Optional[float] = None,
+    conflict: Optional[ConflictGraph] = None,
 ) -> pd.DataFrame:
     """Run the simulation grid and stack the results into one long table.
 
@@ -60,6 +62,9 @@ def run_simulations(
         Effect sizes to inject.
     how, augment, q, ns, seed
         Forwarded to the shaping / fit / inference layers.
+    conflict : ConflictGraph, optional
+        Market interference graph; when given, each candidate's conflict-
+        neighbours are excluded from its donor pool (spillover exclusion).
 
     Returns
     -------
@@ -93,7 +98,8 @@ def run_simulations(
         # CPIC investment uses the *summed* treated volume (GeoLift's
         # sum(Y[D==1])), independent of the fit aggregation.
         treated_total = aggregate_treated(Ywide, candidate, how="sum").to_numpy()
-        donors = donor_matrix(Ywide, candidate)
+        exclude = conflict_neighbors(candidate, conflict) if conflict else None
+        donors = donor_matrix(Ywide, candidate, exclude=exclude)
         for duration in durations:
             for sim in range(1, int(lookback_window) + 1):
                 for row in simulate_lookback(

--- a/mlsynth/utils/geolift_helpers/marketselect/helpers/constraints.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/helpers/constraints.py
@@ -1,0 +1,239 @@
+"""Design-constraint primitives for GeoLift market selection.
+
+GeoLift's upstream surface restricts the treated side only through **hard market
+lists** (``to_be_treated`` / ``not_to_be_treated``). This module adds the
+*rule-based* constraint vocabulary -- cluster / spillover non-interference,
+coverage quotas, and treated-unit size bands -- so the candidate nomination and
+donor pool can encode geography and other design considerations.
+
+Every constraint reduces to *where the optimizer may look*: it is either a
+**treatment criterion** (a filter on which candidate test regions are
+admissible -- independent set, quota, size band) or a **control criterion** (a
+restriction on a candidate's donor pool -- spillover exclusion). None of them
+touch the inner weight solve.
+
+The logic mirrors LEXSCM's design constraints (see ``docs/lexscm.rst``), but is
+**re-implemented here** so GeoLift owns its constraint layer; LEXSCM is not
+modified. Cross-family consolidation into a shared module is a deliberate later
+step. All helpers are pure and **label-based**: they operate on the ``Ywide``
+market labels and the candidate :class:`frozenset`\\s directly, never on
+positional indices.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Hashable, Iterable, List, Mapping, Optional
+
+import pandas as pd
+
+from mlsynth.exceptions import MlsynthConfigError
+
+# A conflict graph maps each market label to the frozenset of labels it
+# conflicts with (interferes with). Symmetric, with no self-loops.
+ConflictGraph = Dict[Hashable, frozenset]
+
+
+def build_conflict_graph(
+    units: Iterable[Hashable],
+    *,
+    cluster_map: Optional[Mapping[Hashable, Hashable]] = None,
+    adjacency: Optional[pd.DataFrame] = None,
+    spillover_threshold: float = 0.0,
+) -> ConflictGraph:
+    """Build the symmetric market conflict (interference) graph.
+
+    Two markets *conflict* when treating both would create interference. The
+    graph is assembled from either or both of:
+
+    * ``cluster_map`` -- a ``{market: cluster}`` mapping; markets in the **same**
+      cluster conflict (e.g. two geos in one DMA / state). A market absent from
+      the map simply has no cluster conflicts.
+    * ``adjacency`` -- a square :class:`~pandas.DataFrame` of pairwise spillover
+      strengths indexed and columned by market label; markets ``i, j`` conflict
+      when ``adjacency.loc[i, j] > spillover_threshold`` (the diagonal is
+      ignored).
+
+    When both are supplied the two conflict sets are combined by logical **OR**.
+    With neither, every market's conflict set is empty (the unconstrained case).
+
+    Parameters
+    ----------
+    units : iterable of hashable
+        The market labels the graph is defined over (the ``Ywide`` columns).
+    cluster_map : mapping, optional
+        ``{market: cluster}``; same-cluster markets conflict.
+    adjacency : pandas.DataFrame, optional
+        Square spillover matrix; its index/columns must cover ``units``.
+    spillover_threshold : float, default 0.0
+        Off-diagonal entries strictly above this mark a conflict.
+
+    Returns
+    -------
+    ConflictGraph
+        ``{market: frozenset(conflicting markets)}`` for every market in
+        ``units``, symmetric and self-free.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``adjacency`` does not cover every unit on both axes.
+    """
+    units = list(units)
+    neighbours: Dict[Hashable, set] = {u: set() for u in units}
+
+    if cluster_map is not None:
+        # Group units by cluster; all pairs within a (non-null) cluster conflict.
+        by_cluster: Dict[Hashable, List[Hashable]] = {}
+        for u in units:
+            label = cluster_map.get(u)
+            if label is None or (isinstance(label, float) and pd.isna(label)):
+                continue
+            by_cluster.setdefault(label, []).append(u)
+        for members in by_cluster.values():
+            for u in members:
+                neighbours[u].update(m for m in members if m != u)
+
+    if adjacency is not None:
+        missing = [u for u in units
+                   if u not in adjacency.index or u not in adjacency.columns]
+        if missing:
+            raise MlsynthConfigError(
+                "adjacency matrix must cover every unit on both axes; missing "
+                f"{sorted(map(str, missing))}."
+            )
+        sub = adjacency.reindex(index=units, columns=units)
+        for u in units:
+            row = sub.loc[u]
+            for v in units:
+                if u != v and float(row[v]) > spillover_threshold:
+                    neighbours[u].add(v)
+                    neighbours[v].add(u)         # enforce symmetry
+
+    return {u: frozenset(neigh) for u, neigh in neighbours.items()}
+
+
+def is_independent_set(markets: Iterable[Hashable], conflict: ConflictGraph) -> bool:
+    """True iff no two ``markets`` conflict (the set is conflict-free).
+
+    The Stage-1 "no interference" treatment criterion: a candidate test region
+    must be an *independent set* of the conflict graph.
+    """
+    markets = list(markets)
+    for i, u in enumerate(markets):
+        neigh = conflict.get(u, frozenset())
+        for v in markets[i + 1:]:
+            if v in neigh:
+                return False
+    return True
+
+
+def conflict_neighbors(
+    markets: Iterable[Hashable], conflict: ConflictGraph
+) -> frozenset:
+    """The conflict-neighbours ``A(S)`` of a treated set, **excluding** ``S``.
+
+    The Stage-2 "exclusion restriction" control criterion: these markets are a
+    treated geo's spillover neighbours and must be dropped from its donor pool.
+    """
+    markets = frozenset(markets)
+    out: set = set()
+    for u in markets:
+        out.update(conflict.get(u, frozenset()))
+    return frozenset(out - markets)
+
+
+def eligible_by_size(
+    units: Iterable[Hashable],
+    size_map: Mapping[Hashable, float],
+    *,
+    min_size: Optional[float] = None,
+    max_size: Optional[float] = None,
+) -> frozenset:
+    """The markets eligible for **treatment** under a size band ``[min, max]``.
+
+    A treated-unit size band (both bounds inclusive): the floor is a power /
+    operational minimum, the ceiling encodes synthesizability (a market far
+    larger than the donors cannot sit inside their convex hull -- GeoLift's
+    scaled-L2 imbalance would blow up). Markets outside the band stay available
+    as **donors**; only their *treatment* eligibility is removed. A market with
+    no recorded size is treated as ineligible.
+    """
+    out: set = set()
+    for u in units:
+        if u not in size_map:
+            continue
+        s = size_map[u]
+        if min_size is not None and s < min_size:
+            continue
+        if max_size is not None and s > max_size:
+            continue
+        out.add(u)
+    return frozenset(out)
+
+
+def satisfies_quota(
+    markets: Iterable[Hashable],
+    stratum_map: Mapping[Hashable, Hashable],
+    *,
+    min_per_stratum: Optional[int] = None,
+    max_per_stratum: Optional[int] = None,
+    required_strata: Optional[Iterable[Hashable]] = None,
+) -> bool:
+    """True iff a candidate meets the coverage quota over strata.
+
+    ``max_per_stratum`` caps the treated count in **any** stratum present;
+    ``min_per_stratum`` requires at least that many treated markets in **every**
+    ``required_stratum`` (the strata that contain at least one eligible market,
+    supplied by the caller). With neither bound set, always ``True``.
+    """
+    markets = list(markets)
+    counts: Dict[Hashable, int] = {}
+    for u in markets:
+        s = stratum_map.get(u)
+        if s is None:
+            continue
+        counts[s] = counts.get(s, 0) + 1
+
+    if max_per_stratum is not None:
+        if any(c > max_per_stratum for c in counts.values()):
+            return False
+
+    if min_per_stratum is not None and required_strata is not None:
+        for s in required_strata:
+            if counts.get(s, 0) < min_per_stratum:
+                return False
+
+    return True
+
+
+def admissible_candidates(
+    candidates: List[frozenset],
+    *,
+    conflict: Optional[ConflictGraph] = None,
+    stratum_map: Optional[Mapping[Hashable, Hashable]] = None,
+    min_per_stratum: Optional[int] = None,
+    max_per_stratum: Optional[int] = None,
+    required_strata: Optional[Iterable[Hashable]] = None,
+) -> List[frozenset]:
+    """Filter candidate test regions to those satisfying the treatment criteria.
+
+    Keeps a candidate iff it is an independent set of ``conflict`` (when given)
+    **and** satisfies the stratum quota (when given). Order is preserved. This
+    composes the Stage-1 treatment criteria; the size band is applied earlier as
+    a restriction on the eligible nomination pool, and the spillover exclusion is
+    a Stage-2 control criterion (:func:`conflict_neighbors`), so neither belongs
+    here. Returns the (possibly empty) admissible list; the caller decides
+    whether an empty result is an infeasibility to report.
+    """
+    has_quota = min_per_stratum is not None or max_per_stratum is not None
+    out: List[frozenset] = []
+    for cand in candidates:
+        if conflict is not None and not is_independent_set(cand, conflict):
+            continue
+        if has_quota and stratum_map is not None and not satisfies_quota(
+            cand, stratum_map, min_per_stratum=min_per_stratum,
+            max_per_stratum=max_per_stratum, required_strata=required_strata,
+        ):
+            continue
+        out.append(cand)
+    return out

--- a/mlsynth/utils/geolift_helpers/marketselect/helpers/constraints.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/helpers/constraints.py
@@ -26,11 +26,40 @@ from typing import Dict, Hashable, Iterable, List, Mapping, Optional
 
 import pandas as pd
 
-from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 
 # A conflict graph maps each market label to the frozenset of labels it
 # conflicts with (interferes with). Symmetric, with no self-loops.
 ConflictGraph = Dict[Hashable, frozenset]
+
+
+def unit_attribute_map(
+    df: pd.DataFrame, unit_id_column_name: str, attr_col: str
+) -> Dict[Hashable, Hashable]:
+    """Resolve a **per-unit constant** attribute column to a ``{unit: value}`` map.
+
+    Cluster / stratum / size constraints all read a per-unit attribute (a market's
+    region, tier, or size) from a column of the long panel. The attribute is a
+    property of the market, so it must be constant over that market's rows.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``attr_col`` is not a column of ``df``.
+    MlsynthDataError
+        If the attribute varies within any unit.
+    """
+    if attr_col not in df.columns:
+        raise MlsynthConfigError(f"column {attr_col!r} not found in df.")
+    grp = df.groupby(unit_id_column_name)[attr_col]
+    varying = grp.nunique(dropna=False)
+    if (varying > 1).any():
+        bad = list(varying[varying > 1].index)[:5]
+        raise MlsynthDataError(
+            f"column {attr_col!r} must be constant per unit; it varies for "
+            f"units {bad}."
+        )
+    return {unit: value for unit, value in grp.first().items()}
 
 
 def build_conflict_graph(

--- a/mlsynth/utils/geolift_helpers/marketselect/helpers/design.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/helpers/design.py
@@ -59,6 +59,7 @@ def design_fit(
     how: str = "sum",
     augment: Optional[str] = "ridge",
     fixed_effects: bool = False,
+    exclude: Optional[frozenset] = None,
 ) -> CandidateDesign:
     """Fit the deployable synthetic control for one candidate on the pre-period.
 
@@ -75,6 +76,10 @@ def design_fit(
     fixed_effects : bool, default False
         Unit fixed effects (augsynth ``fixed_effects=TRUE``). When set, the SCM
         is fit on the mean of the treated units (matching the realized report).
+    exclude : frozenset, optional
+        Extra units to drop from the donor pool (the candidate's spillover
+        conflict-neighbours); ``None`` leaves the donor pool as the candidate
+        complement.
 
     Returns
     -------
@@ -83,7 +88,7 @@ def design_fit(
         fit diagnostics).
     """
     treated = aggregate_treated(Ywide, candidate, how=("mean" if fixed_effects else how))
-    donors = donor_matrix(Ywide, candidate)
+    donors = donor_matrix(Ywide, candidate, exclude=exclude)
     y = treated.to_numpy()
     Y0 = donors.to_numpy()
 

--- a/mlsynth/utils/geolift_helpers/marketselect/helpers/shaping.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/helpers/shaping.py
@@ -6,7 +6,7 @@ treated series and the donor pool. Each helper does a single trivial reshaping
 step — and nothing else — so they stay easy to reason about, debug, and test.
 """
 
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 import pandas as pd
 
@@ -52,8 +52,16 @@ def aggregate_treated(
     return treated
 
 
-def donor_matrix(Ywide: pd.DataFrame, candidate: Iterable) -> pd.DataFrame:
+def donor_matrix(
+    Ywide: pd.DataFrame, candidate: Iterable, exclude: Optional[Iterable] = None
+) -> pd.DataFrame:
     """The donor pool: every unit NOT in the candidate, in panel-column order.
+
+    ``exclude`` drops additional units beyond the candidate — the spillover
+    "exclusion restriction": a treated geo's conflict-neighbours
+    (:func:`~mlsynth.utils.geolift_helpers.marketselect.helpers.constraints.conflict_neighbors`)
+    must not enter its synthetic control. ``None`` (the default) leaves the donor
+    pool exactly as the candidate complement.
 
     Raises
     ------
@@ -61,11 +69,11 @@ def donor_matrix(Ywide: pd.DataFrame, candidate: Iterable) -> pd.DataFrame:
         If the candidate is empty.
     MlsynthDataError
         If any candidate unit is absent from ``Ywide``, or if removing the
-        candidate leaves no donors.
+        candidate (and any excluded units) leaves no donors.
     """
     _validate_candidate(Ywide, candidate)
-    candidate_set = set(candidate)
-    donors = [unit for unit in Ywide.columns if unit not in candidate_set]
+    removed = set(candidate) | set(exclude or ())
+    donors = [unit for unit in Ywide.columns if unit not in removed]
     if len(donors) == 0:
         raise MlsynthDataError(
             "No donor units remain after removing the candidate from the panel."

--- a/mlsynth/utils/geolift_helpers/marketselect/orchestration.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/orchestration.py
@@ -13,6 +13,7 @@ from typing import List, Optional
 import pandas as pd
 
 from mlsynth.config_models import DesignResult
+from mlsynth.exceptions import MlsynthConfigError
 from mlsynth.utils.datautils import geoex_dataprep
 
 from ..config import GeoLiftConfig
@@ -20,6 +21,12 @@ from .helpers.similarity import rank_markets_by_correlation
 from .helpers.candidates import generate_candidate_markets
 from .helpers.batch import run_simulations
 from .helpers.aggregate import compute_power, compute_rank
+from .helpers.constraints import (
+    admissible_candidates,
+    build_conflict_graph,
+    conflict_neighbors,
+    unit_attribute_map,
+)
 from .helpers.design import design_fit, CandidateDesign
 
 
@@ -77,20 +84,47 @@ def run_design(config: GeoLiftConfig) -> GEOLIFTResults:
         rng=config.seed,
     )
 
+    # Design constraints (geography / interference). The conflict graph drives
+    # both the Stage-1 no-interference filter on candidates (treatment criterion)
+    # and the Stage-2 spillover donor exclusion (control criterion). Absent any
+    # constraint config the graph is empty and nothing changes.
+    conflict = None
+    if config.cluster_col is not None or config.adjacency is not None:
+        cluster_map = (
+            unit_attribute_map(config.df, config.unitid, config.cluster_col)
+            if config.cluster_col is not None else None
+        )
+        conflict = build_conflict_graph(
+            Ywide.columns, cluster_map=cluster_map, adjacency=config.adjacency,
+            spillover_threshold=config.spillover_threshold,
+        )
+        candidates = admissible_candidates(candidates, conflict=conflict)
+        if not candidates:
+            raise MlsynthConfigError(
+                "no candidate test region satisfies the design constraints "
+                "(e.g. treatment_size exceeds the number of clusters, or the "
+                "forced-in markets interfere). Relax the constraint or the "
+                "treatment_size."
+            )
+
     cube = run_simulations(
         Ywide, candidates, config.durations, config.lookback_window, config.effect_sizes,
         how=config.how, augment=config.augment, ns=config.ns, seed=config.seed,
         conformal_type=config.conformal_type, fixed_effects=config.fixed_effects,
-        cpic=config.cpic,
+        cpic=config.cpic, conflict=conflict,
     )
     power_table = compute_power(cube, alpha=config.alpha)
     shortlist = compute_rank(power_table, power_threshold=config.power_threshold,
                              budget=config.budget)
 
-    # Per-candidate deployable design fit (full pre-period).
+    # Per-candidate deployable design fit (full pre-period), with the same
+    # spillover donor exclusion the scoring stage used.
     designs = {
-        candidate: design_fit(Ywide, candidate, how=config.how, augment=config.augment,
-                               fixed_effects=config.fixed_effects)
+        candidate: design_fit(
+            Ywide, candidate, how=config.how, augment=config.augment,
+            fixed_effects=config.fixed_effects,
+            exclude=(conflict_neighbors(candidate, conflict) if conflict else None),
+        )
         for candidate in candidates
     }
 

--- a/mlsynth/utils/geolift_helpers/marketselect/orchestration.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/orchestration.py
@@ -25,6 +25,7 @@ from .helpers.constraints import (
     admissible_candidates,
     build_conflict_graph,
     conflict_neighbors,
+    eligible_by_size,
     unit_attribute_map,
 )
 from .helpers.design import design_fit, CandidateDesign
@@ -74,20 +75,49 @@ def run_design(config: GeoLiftConfig) -> GEOLIFTResults:
     Ywide = prep["Ywide"]
 
     ranked = rank_markets_by_correlation(Ywide)
+    units = list(Ywide.columns)
+
+    # === Design constraints (geography / coverage / size) ===
+    # All optional and purely subtractive: with none set, the design is identical
+    # to the unconstrained run. Treatment criteria restrict which candidate
+    # regions are admissible (size band on the nomination pool, cluster
+    # independent-set + stratum quota on the nominated regions); the lone control
+    # criterion is the spillover donor exclusion driven by the conflict graph.
+    not_treated = set(config.not_to_be_treated or ())
+
+    # Size band -- a treated-unit eligibility filter on the *nomination* pool
+    # (out-of-band markets stay available as donors).
+    size_ineligible: set = set()
+    if config.size_col is not None and (
+        config.min_size is not None or config.max_size is not None
+    ):
+        size_map = unit_attribute_map(config.df, config.unitid, config.size_col)
+        eligible = eligible_by_size(
+            units, size_map, min_size=config.min_size, max_size=config.max_size
+        )
+        size_ineligible = set(units) - set(eligible)
+
+    eligible_for_treatment = [u for u in units
+                              if u not in (not_treated | size_ineligible)]
+    if size_ineligible and len(eligible_for_treatment) < config.treatment_size:
+        raise MlsynthConfigError(
+            f"the size band leaves only {len(eligible_for_treatment)} market(s) "
+            f"eligible for treatment, fewer than treatment_size "
+            f"({config.treatment_size}). Widen the size band."
+        )
+
     candidates = generate_candidate_markets(
         ranked,
         config.treatment_size,
         to_be_treated=config.to_be_treated,
-        not_to_be_treated=config.not_to_be_treated,
+        not_to_be_treated=(sorted(not_treated | size_ineligible) or None),
         run_stochastic=config.run_stochastic,
         stochastic_mode=config.stochastic_mode,
         rng=config.seed,
     )
 
-    # Design constraints (geography / interference). The conflict graph drives
-    # both the Stage-1 no-interference filter on candidates (treatment criterion)
-    # and the Stage-2 spillover donor exclusion (control criterion). Absent any
-    # constraint config the graph is empty and nothing changes.
+    # Conflict graph (cluster_col + adjacency) -> independent-set filter + the
+    # Stage-2 spillover donor exclusion.
     conflict = None
     if config.cluster_col is not None or config.adjacency is not None:
         cluster_map = (
@@ -95,16 +125,32 @@ def run_design(config: GeoLiftConfig) -> GEOLIFTResults:
             if config.cluster_col is not None else None
         )
         conflict = build_conflict_graph(
-            Ywide.columns, cluster_map=cluster_map, adjacency=config.adjacency,
+            units, cluster_map=cluster_map, adjacency=config.adjacency,
             spillover_threshold=config.spillover_threshold,
         )
-        candidates = admissible_candidates(candidates, conflict=conflict)
+
+    # Stratum quotas -> coverage filter on the nominated regions.
+    stratum_map = None
+    required_strata = None
+    has_quota = config.min_per_stratum is not None or config.max_per_stratum is not None
+    if config.stratum_col is not None and has_quota:
+        stratum_map = unit_attribute_map(config.df, config.unitid, config.stratum_col)
+        if config.min_per_stratum is not None:
+            required_strata = {stratum_map[u] for u in eligible_for_treatment
+                               if u in stratum_map}
+
+    if conflict is not None or (stratum_map is not None and has_quota):
+        candidates = admissible_candidates(
+            candidates, conflict=conflict, stratum_map=stratum_map,
+            min_per_stratum=config.min_per_stratum,
+            max_per_stratum=config.max_per_stratum, required_strata=required_strata,
+        )
         if not candidates:
             raise MlsynthConfigError(
                 "no candidate test region satisfies the design constraints "
-                "(e.g. treatment_size exceeds the number of clusters, or the "
-                "forced-in markets interfere). Relax the constraint or the "
-                "treatment_size."
+                "(e.g. treatment_size exceeds the number of clusters/strata to "
+                "cover, or the forced-in markets interfere). Relax the constraint "
+                "or the treatment_size."
             )
 
     cube = run_simulations(


### PR DESCRIPTION
Makes mlsynth's GeoLift strictly more expressive than the upstream R package by adding a **rule-based design-constraint layer**, brings the whole GeoLift package to **100% coverage**, and fixes a latent multi-cell plotter crash. LEXSCM is **not modified** — it is reference-only.

## 1. Coverage → true 100%
Backfilled the multi-cell + aggregate gaps so the entire GeoLift package (marketselect + multicell + both estimators) is 100% covered: config-validation failures, the symmetric cross-cell winner branches, dataprep edges, the empty-cells plot guard, the budget-excludes-everyone edge, and `fit()` re-raising a dataprep error.

Also fixes a real bug it surfaced: `plot_multicell` fed `mlsynth_style()` (already a context manager) into `plt.style.context(...)`, crashing the default `display_graphs=True` path — every multi-cell `.fit()` would throw. Fixed to `with mlsynth_style(theme):`, with regression tests.

## 2. Design constraints (the feature)
A self-contained, label-based constraint layer GeoLift owns (`geolift_helpers/marketselect/helpers/constraints.py`), wired into the pipeline:

- **`cluster_col` / `adjacency` / `spillover_threshold`** — market interference graph. Treatment criterion: treated regions must be an independent set (≤1 per cluster). Control criterion: a treated market's conflict-neighbours `A(S)` are dropped from its donor pool.
- **`stratum_col` + `min_per_stratum` / `max_per_stratum`** — coverage quotas (cover every region / cap per region).
- **`size_col` + `min_size` / `max_size`** — treated-unit size band (out-of-band markets stay donors); `max_size` is the a-priori analogue of the scaled-L2 imbalance κ→1.

Infeasible constraints raise `MlsynthConfigError` rather than returning a degenerate design. **Purely additive**: with no constraint fields the design is byte-identical — the augsynth replication walkthrough is unchanged.

## 3. Real geography
GeoLift now consumes the bundled **Nielsen DMA contiguity** map (`basedata/markets/`, the same artifact LEXSCM uses). Added durable tests validating the spillover guarantees on **real US borders** (no two treated DMAs border each other; no donor borders a treated DMA; a known Atlanta–Macon border is never co-treated; `cluster_col` on real states caps one per state).

## 4. Docs
New "Design constraints (geography, coverage, size)" section in `geolift.rst` (treatment-vs-control framing, the κ connection, infeasibility contract), formal **Stage 1b — Design constraints** notation in the Mathematical Formulation, and **fully runnable MREs** — including one that simulates a grouped linear factor model of seasonal sales (latent groups = census divisions, in the spirit of Liao–Shi–Zheng 2025) over a real DMA footprint and designs a non-adjacent, region-spread geo test.

## Verification
- Whole GeoLift package at **100%** (896 statements); **242 + constraint + DMA-border tests** green.
- Replication walkthrough (augsynth parity) unchanged.
- LEXSCM untouched (cross-family consolidation into a shared module deliberately deferred — see `agents/future_integrations.md` §4).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_