### PR TITLE
GeoLift: control-weight vector accessor, result dedup, optimization-problem docs

### DIFF
--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -73,17 +73,27 @@ Pearson correlation matrix :math:`\mathbf{P} = [\rho_{ij}] \in \mathbb{R}^{N \ti
          \sqrt{\sum_{t \in \mathcal{T}_1}(y_{jt} - \bar{y}_j)^2}},
    \qquad \bar{y}_i \coloneqq T_0^{-1}\!\!\sum_{t \in \mathcal{T}_1} y_{it}.
 
-For each **anchor** :math:`i`, let :math:`\pi_i` order the other markets by
-descending correlation,
-:math:`\rho_{i,\pi_i(1)} \ge \rho_{i,\pi_i(2)} \ge \dots \ge \rho_{i,\pi_i(N-1)}`.
-The **deterministic** nominee anchored at :math:`i` is that market plus its
-:math:`k-1` nearest neighbours,
+For each **anchor** :math:`i`, the :math:`k-1` **nearest neighbours** are the
+solution of a per-anchor selection problem — pick the :math:`k-1` other markets
+of greatest correlation to the anchor:
 
 .. math::
 
-   \mathcal{S}_i \coloneqq \{i\} \cup \bigl\{\pi_i(1), \dots, \pi_i(k-1)\bigr\},
+   \mathcal{S}_i \coloneqq \{i\} \cup
+   \operatorname*{arg\,max}_{\substack{\mathcal{T} \subseteq \mathcal{N}
+   \setminus \{i\} \\ |\mathcal{T}| = k-1}}
+   \sum_{j \in \mathcal{T}} \rho_{ij},
 
-and the shortlist is :math:`\{\mathcal{S}_i\}_{i \in \mathcal{N}}` deduplicated —
+which, because the objective is additively separable in :math:`j`, is solved
+exactly by ranking: with :math:`\pi_i` ordering the other markets by descending
+correlation
+(:math:`\rho_{i,\pi_i(1)} \ge \dots \ge \rho_{i,\pi_i(N-1)}`),
+:math:`\mathcal{S}_i = \{i\} \cup \{\pi_i(1), \dots, \pi_i(k-1)\}`. This is the
+``mlsynth`` substitute for the intractable global
+:math:`\operatorname{arg\,min}_{\mathcal{S}} L(\mathcal{S})` (Stage 2's imbalance
+:math:`L`) over all :math:`\binom{N}{k}` regions — :math:`N` anchored top-:math:`k`
+problems instead, each closed-form. The shortlist is
+:math:`\{\mathcal{S}_i\}_{i \in \mathcal{N}}` deduplicated —
 :math:`N` candidates instead of :math:`\binom{N}{k}`. The **stochastic**
 ("paired-jitter") variant replaces ranks :math:`1, \dots, k-1` by one draw from
 each adjacent pair :math:`\{1,2\}, \{3,4\}, \dots`, exploring near-rank neighbours
@@ -194,7 +204,20 @@ A base simplex SCM is solved on the pre-period,
    \Delta^{N_0} \coloneqq \{\mathbf{w} \in \mathbb{R}_{\ge 0}^{N_0} :
    \|\mathbf{w}\|_1 = 1\},
 
-then ridge-augmented to close the residual pre-period imbalance,
+then **ridge-augmented**. The augmented weights are themselves the solution of an
+optimization problem — a ridge-penalized balance objective *anchored* at the
+simplex fit, dropping the simplex constraint so the correction can debias
+(augsynth's ASCM, hence the possible small negative weights):
+
+.. math::
+
+   \mathbf{w}^\ast \;=\;
+   \operatorname*{arg\,min}_{\mathbf{w} \in \mathbb{R}^{N_0}}
+   \;\bigl\| \widetilde{\mathbf{y}}^{\mathcal{S}}_{\mathcal{T}_1}
+         - \widetilde{\mathbf{Y}}_{0,\mathcal{T}_1}\mathbf{w} \bigr\|_2^2
+   \;+\; \lambda\,\bigl\| \mathbf{w} - \mathbf{w}^{\mathrm{scm}} \bigr\|_2^2 ,
+
+whose stationarity condition has the closed form (push-through identity)
 
 .. math::
 
@@ -205,7 +228,9 @@ then ridge-augmented to close the residual pre-period imbalance,
    \bigl(\widetilde{\mathbf{y}}^{\mathcal{S}}_{\mathcal{T}_1}
    - \widetilde{\mathbf{Y}}_{0,\mathcal{T}_1}\mathbf{w}^{\mathrm{scm}}\bigr),
 
-with the penalty :math:`\lambda` chosen by leave-one-period-out cross-validation.
+with the penalty :math:`\lambda` chosen by leave-one-period-out cross-validation
+(:math:`\lambda \to 0` recovers the plain simplex SCM; :math:`\lambda \to \infty`
+pulls back to :math:`\mathbf{w}^{\mathrm{scm}}`).
 The counterfactual and gap follow the canon,
 
 .. math::

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -272,6 +272,20 @@ class WeightsResults(BaseModel):
     # For estimators returning multiple sets of weights (e.g. TSSC sub-methods), this might be part of a list or dict structure.
     # donor_names is removed as it's incorporated into donor_weights dict keys
 
+    @property
+    def weight_vector(self) -> Optional[np.ndarray]:
+        """The donor/control weights as a dense :class:`numpy.ndarray`.
+
+        A **computed view**, not a stored copy: the values of ``donor_weights``
+        in their existing key order (use ``list(donor_weights)`` for the aligned
+        labels). ``None`` when no donor weights are present. Lets callers do
+        vector math on the control weights without rebuilding the array from the
+        dict, while keeping ``donor_weights`` the single stored source.
+        """
+        if self.donor_weights is None:
+            return None
+        return np.asarray(list(self.donor_weights.values()), dtype=float)
+
     class Config:
         arbitrary_types_allowed = True
         extra = 'allow'
@@ -381,6 +395,12 @@ class BaseEstimatorResults(MlsynthResult):
     def donor_weights(self) -> Optional[Dict[str, float]]:
         """Donor weights ``{label: weight}``."""
         return self.weights.donor_weights if self.weights else None
+
+    @property
+    def weight_vector(self) -> Optional[np.ndarray]:
+        """Donor/control weights as a dense :class:`numpy.ndarray` (computed view;
+        see :attr:`WeightsResults.weight_vector`)."""
+        return self.weights.weight_vector if self.weights else None
 
     @property
     def pre_rmse(self) -> Optional[float]:

--- a/mlsynth/estimators/geolift.py
+++ b/mlsynth/estimators/geolift.py
@@ -83,6 +83,12 @@ class GEOLIFT:
                         fixed_effects=self.config.fixed_effects,
                         cpic=self.config.cpic,
                     )
+                    # The realized SC *is* the chosen design's SC, so point the
+                    # design-weights front door at the report's weights — one
+                    # object, not a second identical donor dict. (Pre-realization
+                    # design_weights remains the winner's design-fit weights, which
+                    # are themselves a reference to ``search.winner.weights``.)
+                    result.design_weights = result.report.weights
                 if self.config.display_graphs:
                     plot_design(result, report=result.report, show=True)
             self._result = result

--- a/mlsynth/tests/test_geolift_estimator.py
+++ b/mlsynth/tests/test_geolift_estimator.py
@@ -53,6 +53,29 @@ def test_geolift_fit_auto_realizes_with_post_col():
     assert res.report.time_series.intervention_time is not None
 
 
+def test_geolift_weight_vector_matches_donor_dict():
+    """The numpy control-weight vector is the donor_weights values, in order."""
+    res = GEOLIFT(_cfg(post_col="post")).fit()
+    if res.search.winner is None:
+        pytest.skip("no detectable design in this tiny synthetic")
+    w = res.report.weights
+    vec = w.weight_vector
+    assert isinstance(vec, np.ndarray)
+    assert vec.shape == (len(w.donor_weights),)
+    assert np.allclose(vec, list(w.donor_weights.values()))
+    # the flat accessor on the EffectResult agrees
+    assert np.allclose(res.report.weight_vector, vec)
+
+
+def test_geolift_design_weights_not_duplicated_after_realize():
+    """After realization the design-weights front door and the report share one
+    weights object (no second identical donor dict)."""
+    res = GEOLIFT(_cfg(post_col="post")).fit()
+    if res.search.winner is None:
+        pytest.skip("no detectable design in this tiny synthetic")
+    assert res.design_weights is res.report.weights
+
+
 def test_geolift_display_graphs_runs_without_error():
     # display_graphs=True plots under the hood during fit (Agg -> no-op show)
     res = GEOLIFT(_cfg(display_graphs=True)).fit()

--- a/mlsynth/tests/test_multicell.py
+++ b/mlsynth/tests/test_multicell.py
@@ -204,6 +204,25 @@ def test_estimator_display_graphs_does_not_raise():
     assert isinstance(res, MultiCellResults)
 
 
+def test_multicell_weight_vector_per_cell():
+    """Each cell's control weights are available as a dense numpy vector matching
+    its donor_weights, and the report aliases a cell (no duplicate object)."""
+    df, _ = _panel(effA=10.0, effB=0.0)
+    res = MULTICELLGEOLIFT({
+        "df": df, "outcome": "Y", "unitid": "location", "time": "time",
+        "cell_column_name": "cell", "post_col": "post", "ns": 200,
+        "display_graphs": False,
+    }).fit()
+    for label in ("A", "B"):
+        w = res.cells[label].weights
+        vec = w.weight_vector
+        assert isinstance(vec, np.ndarray)
+        assert vec.shape == (len(w.donor_weights),)
+        assert np.allclose(vec, list(w.donor_weights.values()))
+    # the representative report is the same object as a cell (a reference, not a copy)
+    assert any(res.report is res.cells[c] for c in res.cells)
+
+
 def test_plot_multicell_empty_cells_returns_none():
     """The empty-result guard: nothing to plot -> None, no figure."""
     import types


### PR DESCRIPTION
Three focused follow-ups on the GeoLift result surface and docs.

## 1. Optimization-problem docs
- **Nearest-neighbour nomination (Stage 1)** stated as `S_i = {i} ∪ argmax_{|T|=k−1} Σ ρ_ij` — solved exactly by ranking (additively separable), the tractable per-anchor substitute for the intractable global `argmin_S L(S)` over C(N,k) regions.
- **Augmented SCM (Stage 2)** stated as the ridge-penalized balance objective anchored at the simplex fit, `argmin_w ‖ỹ − Ỹ₀w‖² + λ‖w − w_scm‖²`, with the existing closed form shown as its push-through solution and the λ→0/∞ limits.

## 2. Numpy control-weight vector
`WeightsResults.weight_vector` + a flat `EffectResult.weight_vector` return the donor/control weights as a dense `np.ndarray` — a **computed view** over `donor_weights` (no stored copy), available for single GeoLift and per multi-cell.

## 3. Minimize duplication
- **Single GeoLift:** after realization `design_weights` now points at `report.weights` (one front-door object, not a second identical donor dict). `search.winner.weights` remains the per-candidate design-fit detail.
- **Multi-cell:** `report` aliases `cells[winner]` (a reference, not a copy; required by the two-family contract) — documented.

## Verification
137 tests green (result-contract + estimator + multicell), including new tests that `weight_vector` matches `donor_weights` (single + per cell) and that `design_weights is report.weights` after realize. Purely additive to the result surface.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_