### PR TITLE
feat(ppscm): port augsynth's wild bootstrap inference + multisynth cross-validation benchmark

### DIFF
--- a/benchmarks/cases/ppscm_paglayan.py
+++ b/benchmarks/cases/ppscm_paglayan.py
@@ -1,0 +1,116 @@
+"""Cross-validation benchmark: PPSCM vs ``augsynth::multisynth`` (Paglayan 2018).
+
+Path A / cross-validation against the reference implementation. ``PPSCM`` is
+mlsynth's port of partially-pooled SCM (Ben-Michael, Feller & Rothstein 2021,
+``augsynth::multisynth``); this case reproduces the package's own `multisynth
+vignette
+<https://github.com/ebenmichael/augsynth/blob/master/vignettes/multisynth-vignette.md>`_
+cell-for-cell: the partial-pooling ``nu``, the average ATT, the **event-study
+path**, and -- crucially -- the standard errors of **both** of augsynth's
+inference procedures.
+
+Provenance
+----------
+* Data: ``basedata/Teachingaugsynth.scv`` -- the Paglayan (2018) public-sector
+  collective-bargaining panel (log per-pupil expenditure ``lnppexpend``,
+  treatment ``cbr`` from ``YearCBrequired``), restricted as the vignette does:
+  drop DC and WI, years 1959-1997, leaving 32 staggered-treated and 17
+  never-treated states.
+* Reference values are augsynth's documented output. Point estimates: basic
+  ``nu = 0.2607``, ATT ``-0.011``, Global L2 ``0.003``; ``time_cohort``
+  ``nu = 0.3939``, ATT ``-0.018``. Standard errors come in two flavours, both
+  cross-checked here against a live R run of augsynth:
+
+  - ``AUG_JACK_SE`` -- ``inf_type="jackknife"`` (delete-one), which mlsynth's
+    jackknife reproduces to ``< 1.5e-3``;
+  - ``AUG_BOOT_SE`` -- ``inf_type="bootstrap"`` (the **default**, Mammen wild
+    multiplier bootstrap), which is what the vignette prints, reproduced by
+    mlsynth's ported bootstrap.
+
+The earlier "~10% SE gap" was an artefact of comparing mlsynth's jackknife to
+augsynth's *bootstrap* default; matched method-for-method they agree.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_BASE = Path(__file__).resolve().parents[2] / "basedata"
+
+AUG_TAU = np.array([-0.004281754, -0.010856856, 0.004378813, 0.001155346,
+                    -0.009305005, -0.016942988, -0.018505173, -0.003866657,
+                    -0.015835730, -0.031751350, -0.017839047])
+AUG_TAU_TC = np.array([-0.0007756959, -0.0160616979, -0.0028471499, -0.0026721191,
+                       -0.0181312843, -0.0284898474, -0.0228343778, -0.0140789250,
+                       -0.0245472682, -0.0476922268, -0.0216121159])
+AUG_JACK_SE = np.array([0.01857, 0.01553, 0.01577, 0.02042, 0.02236, 0.02538,
+                        0.02683, 0.03015, 0.03494, 0.03187, 0.03495])
+AUG_BOOT_SE = np.array([0.02247, 0.02139, 0.02404, 0.02461, 0.02561, 0.02445,
+                        0.02491, 0.02811, 0.03171, 0.02916, 0.03245])
+
+
+def _analysis_df() -> pd.DataFrame:
+    d = pd.read_csv(_BASE / "Teachingaugsynth.scv")
+    d = d[~d.State.isin(["DC", "WI"])].copy()
+    d = d[(d.year >= 1959) & (d.year <= 1997)].copy()
+    d["cbr"] = (d["year"] >= d["YearCBrequired"].fillna(np.inf)).astype(int)
+    return d
+
+
+def run() -> dict:
+    from mlsynth import PPSCM
+
+    d = _analysis_df()
+    common = dict(df=d, outcome="lnppexpend", treat="cbr", unitid="State",
+                  time="year", display_graphs=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        jack = PPSCM({**common, "run_inference": True,
+                      "inference_method": "jackknife"}).fit()
+        cohort = PPSCM({**common, "run_inference": False,
+                        "time_cohort": True}).fit()
+        boot = PPSCM({**common, "run_inference": True,
+                      "inference_method": "bootstrap", "n_boot": 2000,
+                      "seed": 0}).fit()
+
+    jse = np.asarray(jack.event_study.se, dtype=float)
+    bse = np.asarray(boot.event_study.se, dtype=float)
+    tau = np.asarray(jack.event_study.tau, dtype=float)
+    tau_tc = np.asarray(cohort.event_study.tau, dtype=float)
+
+    return {
+        "ppscm_nu": float(jack.design.nu_used),
+        "ppscm_att": float(jack.att),
+        "ppscm_global_l2": float(jack.design.global_l2),
+        "ppscm_event_study_max_abs_diff": float(np.max(np.abs(tau - AUG_TAU))),
+        "ppscm_time_cohort_nu": float(cohort.design.nu_used),
+        "ppscm_time_cohort_att": float(cohort.att),
+        "ppscm_tc_event_study_max_abs_diff": float(np.max(np.abs(tau_tc - AUG_TAU_TC))),
+        "ppscm_jackknife_se_max_abs_diff": float(np.max(np.abs(jse - AUG_JACK_SE))),
+        "ppscm_bootstrap_att_se": float(boot.inference.se),
+        "ppscm_bootstrap_se_max_abs_diff": float(np.max(np.abs(bse - AUG_BOOT_SE))),
+        "n_treated": int(d[d.cbr == 1].State.nunique()),
+        "n_control": int(d.State.nunique() - d[d.cbr == 1].State.nunique()),
+    }
+
+
+# All values cross-validate augsynth method-for-method; tolerances bracket the
+# OSQP solver residual (point estimates) and the bootstrap's Monte-Carlo error
+# (R RNG vs numpy RNG at n_boot=2000).
+EXPECTED = {
+    "ppscm_nu": (0.2607, 2e-3),
+    "ppscm_att": (-0.011, 1.5e-3),
+    "ppscm_global_l2": (0.003, 5e-4),
+    "ppscm_event_study_max_abs_diff": (0.0, 7e-4),
+    "ppscm_time_cohort_nu": (0.3939, 2e-3),
+    "ppscm_time_cohort_att": (-0.018, 2e-3),
+    "ppscm_tc_event_study_max_abs_diff": (0.0, 3e-3),
+    "ppscm_jackknife_se_max_abs_diff": (0.0, 1.5e-3),     # vs augsynth jackknife
+    "ppscm_bootstrap_att_se": (0.022, 2e-3),              # vs augsynth bootstrap (vignette)
+    "ppscm_bootstrap_se_max_abs_diff": (0.0, 4e-3),       # vs augsynth bootstrap path
+    "n_treated": (32, 0),
+    "n_control": (17, 0),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -5,6 +5,7 @@ import importlib
 
 # name -> "benchmarks.cases.<module>"  (pure-Python unless noted needs_reference)
 CASES = {
+    "ppscm_paglayan": "benchmarks.cases.ppscm_paglayan",  # cross-val vs augsynth::multisynth (jackknife + bootstrap SEs)
     "rolldid_lw": "benchmarks.cases.rolldid_lw",        # Path A: Lee-Wooldridge Prop99 + castle
     "fdid_table5": "benchmarks.cases.fdid_table5",      # Path B: simulation
     "fdid_hongkong": "benchmarks.cases.fdid_hongkong",  # Path A: HK GDP empirical

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -63,6 +63,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    replications/linf
    replications/geolift
    replications/rolldid
+   replications/ppscm
 
 .. _replications-canonical:
 

--- a/docs/replications/ppscm.rst
+++ b/docs/replications/ppscm.rst
@@ -1,0 +1,84 @@
+PPSCM — augsynth ``multisynth`` (Paglayan collective bargaining)
+================================================================
+
+.. currentmodule:: mlsynth
+
+Cross-validation against the reference implementation. ``PPSCM`` is mlsynth's
+port of partially-pooled SCM (Ben-Michael, Feller & Rothstein 2021), whose
+canonical implementation is ``augsynth::multisynth`` in R. This page reproduces
+the package's own `multisynth vignette
+<https://github.com/ebenmichael/augsynth/blob/master/vignettes/multisynth-vignette.md>`_
+cell-for-cell — point estimates, the event study, **and** standard errors, the
+last cross-checked against a live R run of augsynth for *both* of its inference
+procedures.
+
+Data
+----
+
+The Paglayan (2018) public-sector collective-bargaining panel shipped at
+``basedata/Teachingaugsynth.scv``: log per-pupil expenditure (``lnppexpend``) by
+``State`` and ``year``, treatment ``cbr`` derived from ``YearCBrequired``.
+Restricted exactly as the vignette does — drop DC and WI, keep 1959–1997 —
+leaving **32 staggered-treated and 17 never-treated** states.
+
+Point estimates
+---------------
+
+================================  =========================  ===========================
+Quantity                          PPSCM (mlsynth)            ``augsynth::multisynth``
+================================  =========================  ===========================
+Partial-pooling :math:`\nu`       0.2607                     0.2607
+Average ATT                       −0.011                     −0.011
+Global L2 imbalance               0.0026                     0.003
+:math:`\nu` (``time_cohort``)     0.3939                     0.3939
+Average ATT (``time_cohort``)     −0.017                     −0.018
+Event-study path                  match to ``< 5e-4``        (reference)
+================================  =========================  ===========================
+
+The OSQP solver (the same one augsynth uses) and the heuristic :math:`\nu`
+reproduce the reference to display precision; the per-horizon point estimates
+match to ``< 5e-4`` (unit cohorts) and ``< 2.2e-3`` (time cohorts).
+
+Inference — both of augsynth's procedures
+-----------------------------------------
+
+augsynth offers two inference types; ``PPSCM`` reproduces **each**, method for
+method, and exposes them via ``inference_method``:
+
+* ``inference_method="jackknife"`` — the delete-one jackknife
+  (``inf_type="jackknife"``). mlsynth's per-horizon SEs match augsynth's to
+  ``< 1.5e-3``.
+* ``inference_method="bootstrap"`` — the Mammen wild/multiplier bootstrap
+  (``inf_type="bootstrap"``), which is augsynth's **default** and the SE the
+  vignette prints. The ported bootstrap reproduces the overall ATT SE
+  (``0.022``) and the per-horizon path to ``< 4e-3`` (the residual is Monte-Carlo
+  noise — R's RNG vs numpy's at ``n_boot``).
+
+================================  ====================  ====================
+Per-horizon SE (rel. time)        jackknife             bootstrap (default)
+================================  ====================  ====================
+augsynth                          0.0186 … 0.0350       0.0225 … 0.0325
+PPSCM                             0.0185 … 0.0354       0.0224 … 0.0325
+================================  ====================  ====================
+
+.. note::
+
+   The two procedures legitimately differ by ~10% (the bootstrap is wider early
+   on). An earlier apparent "SE gap" was simply comparing mlsynth's *jackknife*
+   to augsynth's *bootstrap* default — different methods. Matched
+   method-for-method (verified against augsynth's R source and a live run), they
+   agree.
+
+Reproduce
+---------
+
+.. code-block:: bash
+
+   python benchmarks/run_benchmarks.py ppscm_paglayan
+
+The durable case is ``benchmarks/cases/ppscm_paglayan.py`` (it cross-checks the
+point estimates, the event study, and both SE methods); the unit-level
+regressions are pinned in ``mlsynth/tests/test_ppscm.py``
+(``test_matches_augsynth_vignette``, ``test_jackknife_se_matches_augsynth_vignette``,
+``test_bootstrap_se_matches_augsynth_vignette``). All run on the in-repo data,
+so no R or network access is required.

--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -29,7 +29,7 @@ from ..exceptions import (
     MlsynthPlottingError,
 )
 from ..utils.ppscm_helpers.engine import run_multisynth
-from ..utils.ppscm_helpers.inference import jackknife_inference
+from ..utils.ppscm_helpers.inference import jackknife_inference, bootstrap_inference
 from ..utils.ppscm_helpers.plotter import plot_ppscm
 from ..utils.ppscm_helpers.setup import prepare_ppscm_inputs
 from ..utils.ppscm_helpers.structures import (
@@ -79,6 +79,9 @@ class PPSCM:
         self.lam: float = config.lam
         self.solver: Any = config.solver
         self.run_inference: bool = config.run_inference
+        self.inference_method: str = config.inference_method
+        self.n_boot: int = config.n_boot
+        self.seed: int = config.seed
         self.alpha: float = config.alpha
 
         self.display_graphs: bool = config.display_graphs
@@ -121,7 +124,13 @@ class PPSCM:
 
             per_time = fit["per_time"]
             att = fit["att"]
-            if self.run_inference:
+            if self.run_inference and self.inference_method == "bootstrap":
+                att, se, ci, pt_se, pt_ci = bootstrap_inference(
+                    fit, alpha=self.alpha, n_boot=self.n_boot, seed=self.seed,
+                    per_time_full=per_time, att_full=att,
+                )
+                method = "bootstrap"
+            elif self.run_inference:
                 att, se, ci, pt_se, pt_ci = jackknife_inference(
                     Xy, trt, d, n_leads, n_lags,
                     fixedeff=self.fixedeff, time_cohort=self.time_cohort,

--- a/mlsynth/tests/test_ppscm.py
+++ b/mlsynth/tests/test_ppscm.py
@@ -133,6 +133,37 @@ def test_jackknife_inference_runs(panel):
     assert lo < res.att < hi
 
 
+def test_bootstrap_inference_runs(panel):
+    res = PPSCM(_cfg(panel, run_inference=True, inference_method="bootstrap",
+                     n_boot=200, seed=0)).fit()
+    assert res.inference.method == "bootstrap"
+    assert np.isfinite(res.inference.se) and res.inference.se > 0
+    lo, hi = res.inference.ci
+    assert lo < res.att < hi
+    assert np.all(np.isfinite(res.event_study.se))
+
+
+def test_invalid_inference_method_raises(panel):
+    from mlsynth.exceptions import MlsynthConfigError
+    with pytest.raises(MlsynthConfigError, match="inference_method"):
+        PPSCM(_cfg(panel, inference_method="bogus"))
+
+
+def test_predict_tau_unit_weights_match_point_estimate(panel):
+    """predict_tau with all-ones bs_weight reproduces run_multisynth's per_time
+    (guards the refactor that the bootstrap shares)."""
+    from mlsynth.utils.ppscm_helpers.engine import predict_tau
+    inp = prepare_ppscm_inputs(panel, outcome="y", treat="tr", unitid="unit", time="year")
+    H = inp.Xy.shape[1] - inp.n_pre
+    fit = run_multisynth(inp.Xy, inp.trt, inp.n_pre, H, inp.n_pre,
+                         fixedeff=True, time_cohort=False, nu=None)
+    _, per_time, att = predict_tau(fit["res"], fit["groups"], fit["adopt_of"],
+                                   fit["members"], fit["donors"], fit["weights"],
+                                   fit["n1"], H, fit["n"])
+    np.testing.assert_allclose(per_time, fit["per_time"], atol=1e-12)
+    assert att == pytest.approx(fit["att"], abs=1e-12)
+
+
 def test_requires_treated_unit(panel):
     df = panel.copy(); df["tr"] = 0
     with pytest.raises(MlsynthDataError):
@@ -161,3 +192,40 @@ def test_matches_augsynth_vignette():
     rt = PPSCM({**common, "time_cohort": True}).fit()
     assert rt.design.nu_used == pytest.approx(0.3939, abs=2e-3)
     assert rt.att == pytest.approx(-0.018, abs=2e-3)
+
+
+# augsynth jackknife per-horizon SE (inf_type="jackknife"), relative time 0..10
+_AUG_JACK_SE = np.array([0.01857, 0.01553, 0.01577, 0.02042, 0.02236, 0.02538,
+                         0.02683, 0.03015, 0.03494, 0.03187, 0.03495])
+# augsynth DEFAULT bootstrap per-horizon SE (inf_type="bootstrap"), relative time 0..10
+_AUG_BOOT_SE = np.array([0.02247, 0.02139, 0.02404, 0.02461, 0.02561, 0.02445,
+                         0.02491, 0.02811, 0.03171, 0.02916, 0.03245])
+
+
+def _vignette_cfg(**kw):
+    df = pd.read_csv(_DATA)
+    d = df[~df.State.isin(["DC", "WI"])].copy()
+    d = d[(d.year >= 1959) & (d.year <= 1997)].copy()
+    d["cbr"] = (d["year"] >= d["YearCBrequired"].fillna(np.inf)).astype(int)
+    base = dict(df=d, outcome="lnppexpend", treat="cbr", unitid="State",
+                time="year", display_graphs=False, run_inference=True)
+    base.update(kw)
+    return base
+
+
+@pytest.mark.skipif(not os.path.exists(_DATA), reason="Paglayan data not present")
+def test_jackknife_se_matches_augsynth_vignette():
+    """mlsynth's delete-one jackknife reproduces augsynth's inf_type='jackknife'."""
+    r = PPSCM(_vignette_cfg(inference_method="jackknife")).fit()
+    assert r.inference.method == "jackknife"
+    assert np.max(np.abs(np.asarray(r.event_study.se, float) - _AUG_JACK_SE)) < 1.5e-3
+
+
+@pytest.mark.skipif(not os.path.exists(_DATA), reason="Paglayan data not present")
+def test_bootstrap_se_matches_augsynth_vignette():
+    """The ported Mammen wild/multiplier bootstrap reproduces augsynth's default
+    inf_type='bootstrap' (the vignette's printed SEs)."""
+    r = PPSCM(_vignette_cfg(inference_method="bootstrap", n_boot=2000, seed=0)).fit()
+    assert r.inference.method == "bootstrap"
+    assert r.inference.se == pytest.approx(0.022, abs=2e-3)
+    assert np.max(np.abs(np.asarray(r.event_study.se, float) - _AUG_BOOT_SE)) < 4e-3

--- a/mlsynth/utils/ppscm_helpers/config.py
+++ b/mlsynth/utils/ppscm_helpers/config.py
@@ -7,8 +7,9 @@ Co-located with the helper package; re-exported from
 from __future__ import annotations
 
 from typing import Any, Literal, Optional, Union
-from pydantic import Field
+from pydantic import Field, model_validator
 from ...config_models import BaseEstimatorConfig
+from ...exceptions import MlsynthConfigError
 
 
 class PPSCMConfig(BaseEstimatorConfig):
@@ -75,9 +76,25 @@ class PPSCMConfig(BaseEstimatorConfig):
     run_inference: bool = Field(
         default=True,
         description=(
-            "Whether to run the paper's delete-one jackknife inference "
-            "(refits the estimator dropping each unit; can be slow)."
+            "Whether to run inference (see ``inference_method``); refits or "
+            "reweights the estimator, can be slow for the jackknife."
         ),
+    )
+    inference_method: str = Field(
+        default="jackknife",
+        description=(
+            "Inference procedure: 'jackknife' (delete-one, refit per unit) or "
+            "'bootstrap' (augsynth's default Mammen wild/multiplier bootstrap; "
+            "reweights the single fit, no refit). The augsynth multisynth "
+            "vignette prints the bootstrap SEs."
+        ),
+    )
+    n_boot: int = Field(
+        default=1000, ge=1,
+        description="Bootstrap replications when ``inference_method='bootstrap'``.",
+    )
+    seed: int = Field(
+        default=0, description="RNG seed for the bootstrap multipliers.",
     )
     alpha: float = Field(
         default=0.05,
@@ -85,3 +102,11 @@ class PPSCMConfig(BaseEstimatorConfig):
         lt=1.0,
         description="Significance level for the Wald confidence band.",
     )
+
+    @model_validator(mode="after")
+    def _check_inference_method(self):
+        if self.inference_method not in ("jackknife", "bootstrap"):
+            raise MlsynthConfigError(
+                "inference_method must be 'jackknife' or 'bootstrap'; got "
+                f"{self.inference_method!r}.")
+        return self

--- a/mlsynth/utils/ppscm_helpers/engine.py
+++ b/mlsynth/utils/ppscm_helpers/engine.py
@@ -96,6 +96,36 @@ def solve_cohort_qp(res, groups, adopt_of, members, donors, n1, d, n, n_lags,
     return W
 
 
+def predict_tau(res, groups, adopt_of, members, donors, W, n1, H, n, bs_weight=None):
+    """Relative-time ``tau`` per cohort, plus the n1-weighted event study and ATT.
+
+    With ``bs_weight`` (per-unit multipliers, default all ones) this is augsynth's
+    ``predict.multisynth(bs_weight=...)`` written in residual space: the
+    fixed-effect terms cancel between the treated mean and the synthetic, leaving
+    the treated residuals (scaled by ``bs_weight``, averaged over the cohort) minus
+    the donor residuals weighted by ``W[g] * bs_weight``. ``bs_weight = ones``
+    reproduces the point estimate exactly.
+    """
+    if bs_weight is None:
+        bs_weight = np.ones(n)
+    J = len(groups)
+    tau_rel = np.full((J, H), np.nan)
+    for k, g in enumerate(groups):
+        tj = adopt_of[g]
+        resid = res[tj]
+        mem = members[g]
+        mu1 = (bs_weight[mem, None] * resid[mem]).sum(axis=0) / n1[k]
+        mu0 = (W[g] * bs_weight) @ resid
+        tt = mu1 - mu0
+        hi = min(tj + H, resid.shape[1])
+        tau_rel[k, : hi - tj] = tt[tj:hi]
+    denom = np.array([np.nansum(n1 * ~np.isnan(tau_rel[:, h])) for h in range(H)])
+    per_time = np.array([np.nansum(n1 * tau_rel[:, h]) / denom[h] if denom[h] > 0 else np.nan
+                         for h in range(H)])
+    att = float(np.nanmean(per_time))
+    return tau_rel, per_time, att
+
+
 def run_multisynth(
     Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
     *, fixedeff: bool = True, time_cohort: bool = False,
@@ -144,21 +174,13 @@ def run_multisynth(
 
     # predict: relative-time tau per cohort, n1-weighted per-horizon average
     H = n_leads
-    tau_rel = np.full((J, H), np.nan)
-    for k, g in enumerate(groups):
-        tj = adopt_of[g]; resid = res[tj]
-        treated_resid = resid[members[g]].mean(axis=0)
-        tt = treated_resid - W[g] @ resid
-        hi = min(tj + H, Xy.shape[1])
-        tau_rel[k, : hi - tj] = tt[tj:hi]
-    denom = np.array([np.nansum(n1 * ~np.isnan(tau_rel[:, h])) for h in range(H)])
-    per_time = np.array([np.nansum(n1 * tau_rel[:, h]) / denom[h] if denom[h] > 0 else np.nan
-                         for h in range(H)])
-    att = float(np.nanmean(per_time))
+    tau_rel, per_time, att = predict_tau(
+        res, groups, adopt_of, members, donors, W, n1, H, n)
 
     return {
         "groups": groups, "members": members, "adopt_of": adopt_of, "donors": donors,
         "weights": W, "n1": n1, "tau_rel": tau_rel, "per_time": per_time, "att": att,
         "nu_used": nu_used, "global_l2": fin_global, "ind_l2": fin_ind,
         "scaled_global_l2": fin_global / unif_global, "scaled_ind_l2": fin_ind / unif_ind,
+        "res": res, "n": n, "n_leads": n_leads,
     }

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -17,7 +17,50 @@ from typing import Any, Tuple
 import numpy as np
 from scipy.stats import norm
 
-from .engine import run_multisynth
+from .engine import run_multisynth, predict_tau
+
+# Mammen (1993) two-point wild-bootstrap multipliers (mean 0, variance 1) --
+# augsynth's default ``rwild_b``.
+_PHI = np.sqrt(5.0)
+_WILD_VALUES = np.array([-(_PHI - 1.0) / 2.0, (_PHI + 1.0) / 2.0])
+_WILD_PROBS = np.array([(_PHI + 1.0) / (2.0 * _PHI), (_PHI - 1.0) / (2.0 * _PHI)])
+
+
+def bootstrap_inference(
+    fit: dict, *, alpha: float, n_boot: int, seed: int,
+    per_time_full: np.ndarray, att_full: float,
+):
+    """augsynth's default Mammen wild/multiplier bootstrap (``weighted_bootstrap_multi``).
+
+    Reweights the *single* fit by per-unit multipliers ``Z`` (no refit): for each
+    draw, ``predict_tau(bs_weight=Z) - (sum(Z)/n_treated) * point_estimate``; the
+    bootstrap SE is the root-mean-square of the centered draws. Returns
+    ``(att, se, ci, per_time_se, per_time_ci)`` matching ``jackknife_inference``.
+    """
+    res = fit["res"]
+    groups, adopt_of, members = fit["groups"], fit["adopt_of"], fit["members"]
+    donors, W, n1 = fit["donors"], fit["weights"], fit["n1"]
+    n, H = fit["n"], fit["n_leads"]
+    n_treated = float(np.sum(n1))
+    rng = np.random.default_rng(seed)
+
+    att_b = np.empty(n_boot)
+    pt_b = np.full((n_boot, H), np.nan)
+    for b in range(n_boot):
+        Z = rng.choice(_WILD_VALUES, size=n, p=_WILD_PROBS)
+        _, pt, a = predict_tau(res, groups, adopt_of, members, donors, W, n1, H, n,
+                               bs_weight=Z)
+        shift = Z.sum() / n_treated
+        att_b[b] = a - shift * att_full
+        pt_b[b] = pt - shift * per_time_full
+
+    se = float(np.sqrt(np.mean((att_b - att_b.mean()) ** 2)))
+    per_time_se = np.sqrt(np.nanmean((pt_b - np.nanmean(pt_b, axis=0)) ** 2, axis=0))
+    z = float(norm.ppf(1.0 - alpha / 2.0))
+    ci = (att_full - z * se, att_full + z * se)
+    per_time_ci = np.column_stack([per_time_full - z * per_time_se,
+                                   per_time_full + z * per_time_se])
+    return float(att_full), se, ci, per_time_se, per_time_ci
 
 
 def jackknife_inference(


### PR DESCRIPTION
## The investigation
The PPSCM benchmark task surfaced an apparent ~10% SE difference vs `augsynth::multisynth`. Tracking it down (clone + read augsynth's R source + a live R run) gave a clean, surprising root cause:

- **augsynth's `summary.multisynth` defaults to `inf_type="bootstrap"`** — a Mammen wild/multiplier bootstrap (`weighted_bootstrap_multi`). That's what the vignette prints.
- mlsynth's PPSCM implemented only the **delete-one jackknife** — which is **identical** to augsynth's `inf_type="jackknife"` (same drop-one refit, same `(n−1)/n` formula). Confirmed cell-by-cell against a live augsynth run (≤ 1.5e-3).
- So the "gap" was **jackknife vs bootstrap** — two different procedures augsynth offers — not a bug.
- Bonus finding: augsynth's QP solver is **OSQP** (same as mlsynth). An earlier FISTA-swap hypothesis was disproven and abandoned; no solver change.

## What this PR does
- Adds augsynth's **wild/multiplier bootstrap** as a PPSCM inference option (`inference_method="bootstrap"`, `n_boot`, `seed`). It reweights the *single* fit by Mammen two-point multipliers (no refit) via a new shared `predict_tau(bs_weight=...)` that expresses augsynth's `bs_weight` predict in residual space (the fixed-effect terms cancel). Reproduces the vignette SEs: overall ATT SE **0.022**, per-horizon path to **< 4e-3** (residual = R-vs-numpy bootstrap Monte-Carlo noise).
- Keeps **jackknife the default** (backward compatible); confirmed to match augsynth's `inf_type="jackknife"` to **< 1.5e-3**.
- Durable benchmark **`benchmarks/cases/ppscm_paglayan.py`** cross-validating point estimates, the event study, and **both** SE methods; replication page `docs/replications/ppscm.rst` (+ toctree).

## Validation
- `test_ppscm.py`: 15 passed — jackknife-SE and bootstrap-SE vignette regressions, bootstrap smoke, config validation, and a `predict_tau(ones) == point-estimate` refactor guard. New bootstrap code fully covered.
- **No regressions:** GeoLift + bilevel + SC-family + `result_contract` = **211 passed, 1 skipped**.
- Benchmark: 12/12 checks pass.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_