### PR TITLE
fix(snn): correct Donoho-Gavish rank threshold + cross-validation vs deshen24/syntheticNN

### DIFF
--- a/benchmarks/cases/snn_prop99.py
+++ b/benchmarks/cases/snn_prop99.py
@@ -1,0 +1,79 @@
+"""Cross-validation benchmark: SNN vs ``deshen24/syntheticNN`` (Prop 99).
+
+Cross-validation against the reference implementation. ``SNN`` is mlsynth's port
+of Synthetic Nearest Neighbors (Agarwal, Dahleh, Shah & Shen 2021, *Causal
+Matrix Completion*), whose canonical implementation is
+`deshen24/syntheticNN <https://github.com/deshen24/syntheticNN>`_. On block
+missingness -- the synthetic-control setting, where the treated unit's
+post-period is the only missing block -- the reference's NetworkX maximum-
+biclique anchor search and mlsynth's dependency-free greedy search both return
+the full *control x pre-period* block. With the same Donoho-Gavish (2014) rank
+and principal-component regression, the two implementations therefore impute the
+**same** counterfactual.
+
+Provenance
+----------
+* Data: ``basedata/smoking_data.csv`` -- the Abadie, Diamond & Hainmueller (2010)
+  Prop 99 panel (39 states, 1970-2000; California treated from 1989). Outcome
+  ``cigsale`` (per-capita cigarette packs).
+* ``REF_CF`` is California's imputed untreated counterfactual from a live run of
+  ``deshen24/syntheticNN`` (``SyntheticNearestNeighbors(n_neighbors=1)``,
+  universal/Donoho-Gavish rank), with California's 1989-2000 entries set to
+  ``NaN``. mlsynth reproduces it to machine precision (``< 1e-6`` here).
+
+This case also guards the Donoho-Gavish ``omega`` coefficients: an earlier
+mlsynth bug had ``1.43`` and ``1.82`` swapped, which mis-selected the rank and
+shifted the ATT by ~1 pack/capita. Matched to the reference formula, the gap
+vanishes.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_BASE = Path(__file__).resolve().parents[2] / "basedata"
+
+# California untreated counterfactual (cigsale) from deshen24/syntheticNN.
+REF_CF = {
+    1989: 89.236371, 1990: 82.673847, 1991: 79.485312, 1992: 78.230661,
+    1993: 78.142375, 1994: 77.473927, 1995: 78.417803, 1996: 77.388595,
+    1997: 77.785353, 1998: 77.896060, 1999: 77.752842, 2000: 70.925823,
+}
+REF_ATT = -18.434081
+
+
+def run() -> dict:
+    from mlsynth import SNN
+
+    df = pd.read_csv(_BASE / "smoking_data.csv")
+    obs = df.pivot(index="state", columns="year", values="cigsale").loc["California"]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = SNN({"df": df, "outcome": "cigsale", "treat": "Proposition 99",
+                   "unitid": "state", "time": "year", "display_graphs": False}).fit()
+
+    years = sorted(REF_CF)
+    cf_mls = np.array([float(obs[y]) - res.att_by_period[y] for y in years])
+    cf_ref = np.array([REF_CF[y] for y in years])
+
+    return {
+        "snn_att": float(res.att),
+        "snn_counterfactual_max_abs_diff": float(np.max(np.abs(cf_mls - cf_ref))),
+        "snn_gap_2000": float(res.att_by_period[2000]),
+        "n_states": int(df.state.nunique()),
+        "n_pre_periods": int((df[df.state == "California"].year < 1989).sum()),
+    }
+
+
+# mlsynth reproduces the reference to ~1e-6 (residual is the printed-digit
+# rounding of REF_CF); the structural agreement is exact.
+EXPECTED = {
+    "snn_att": (REF_ATT, 1e-3),
+    "snn_counterfactual_max_abs_diff": (0.0, 1e-5),
+    "snn_gap_2000": (-29.3258, 1e-2),                # reference gap by 2000
+    "n_states": (39, 0),
+    "n_pre_periods": (19, 0),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -5,6 +5,7 @@ import importlib
 
 # name -> "benchmarks.cases.<module>"  (pure-Python unless noted needs_reference)
 CASES = {
+    "snn_prop99": "benchmarks.cases.snn_prop99",        # cross-val vs deshen24/syntheticNN (Prop 99)
     "ppscm_paglayan": "benchmarks.cases.ppscm_paglayan",  # cross-val vs augsynth::multisynth (jackknife + bootstrap SEs)
     "rolldid_lw": "benchmarks.cases.rolldid_lw",        # Path A: Lee-Wooldridge Prop99 + castle
     "fdid_table5": "benchmarks.cases.fdid_table5",      # Path B: simulation

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -64,6 +64,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    replications/geolift
    replications/rolldid
    replications/ppscm
+   replications/snn
 
 .. _replications-canonical:
 

--- a/docs/replications/snn.rst
+++ b/docs/replications/snn.rst
@@ -1,0 +1,64 @@
+SNN — ``deshen24/syntheticNN`` (Prop 99)
+========================================
+
+.. currentmodule:: mlsynth
+
+Cross-validation against the reference implementation. ``SNN`` is mlsynth's port
+of Synthetic Nearest Neighbors (Agarwal, Dahleh, Shah & Shen 2021, *Causal
+Matrix Completion*); the canonical implementation is
+`deshen24/syntheticNN <https://github.com/deshen24/syntheticNN>`_.
+
+Why the two agree exactly
+-------------------------
+
+The reference finds each entry's anchor submatrix with a NetworkX **maximum
+biclique** search; mlsynth uses a dependency-free **greedy** largest-fully-
+observed-submatrix search. These are different algorithms in general — but under
+**block missingness** (the synthetic-control setting, where the treated unit's
+post-treatment cells are the *only* missing block) both return the same answer:
+the full *control × pre-period* block. With the same Donoho-Gavish (2014)
+universal rank and the same principal-component regression, the imputed
+counterfactual is then identical.
+
+Data
+----
+
+``basedata/smoking_data.csv`` — the Abadie, Diamond & Hainmueller (2010) Prop 99
+panel: 39 states, 1970–2000, California treated from 1989, outcome ``cigsale``
+(per-capita cigarette packs). 19 pre-periods.
+
+Result
+------
+
+Masking California's 1989–2000 outcomes and imputing them with
+``SyntheticNearestNeighbors(n_neighbors=1)`` (universal rank) gives a
+counterfactual that mlsynth's :class:`SNN` reproduces to **< 1e-6**:
+
+==========================  =====================  ===========================
+Quantity                    SNN (mlsynth)          ``deshen24/syntheticNN``
+==========================  =====================  ===========================
+Average ATT (1989–2000)     −18.43 packs           −18.43 packs
+Gap by 2000                 −29.33 packs           −29.33 packs
+Counterfactual path         match to ``< 1e-6``    (reference)
+==========================  =====================  ===========================
+
+.. note::
+
+   This case caught a real bug. mlsynth's Donoho-Gavish ``omega`` had its last
+   two coefficients swapped (``1.43 β + 1.82`` instead of the published
+   ``1.82 β + 1.43``), mis-selecting the rank and shifting the ATT by ~1
+   pack/capita. The corrected formula matches the reference's rank — and hence
+   its counterfactual — exactly.
+
+Reproduce
+---------
+
+.. code-block:: bash
+
+   python benchmarks/run_benchmarks.py snn_prop99
+
+The durable case is ``benchmarks/cases/snn_prop99.py`` (the reference
+counterfactual is embedded from a live run, so no ``networkx``/``sklearn`` is
+needed at benchmark time); unit regressions are in
+``mlsynth/tests/test_snn.py`` (``TestReferenceProp99`` and the Donoho-Gavish
+``omega`` guard ``test_universal_rank_matches_gavish_donoho``).

--- a/docs/snn.rst
+++ b/docs/snn.rst
@@ -203,8 +203,16 @@ counterfactual by matrix completion, and reports the ATT. With
 
 The default ``universal_rank=True`` (Donoho-Gavish hard threshold) keeps
 the rank well-calibrated for this small (39 x 31) low-rank panel; it
-returns an average ATT of about ``-19`` packs/capita, widening to roughly
-``-31`` by 2000 -- consistent with Abadie, Diamond & Hainmueller (2010).
+returns an average ATT of about ``-18`` packs/capita, widening to roughly
+``-29`` by 2000 -- consistent with Abadie, Diamond & Hainmueller (2010).
+
+Verification
+------------
+
+Cross-validated against the reference implementation
+(`deshen24/syntheticNN <https://github.com/deshen24/syntheticNN>`_): on the
+Prop 99 block-missingness pattern mlsynth reproduces the reference's imputed
+counterfactual to machine precision. See :doc:`replications/snn`.
 
 The same SNN engine performs general (non-causal) matrix completion on
 any matrix with ``NaN`` for the missing entries:

--- a/mlsynth/tests/test_snn.py
+++ b/mlsynth/tests/test_snn.py
@@ -13,6 +13,8 @@ Layered per agents/agents_tests.md:
 
 from __future__ import annotations
 
+import os
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -78,6 +80,20 @@ class TestEngine:
         completed, feasible = snn_complete(X)
         # Almost everything is infeasible (no observed anchor block).
         assert feasible.sum() < X.size
+
+    def test_universal_rank_matches_gavish_donoho(self):
+        """The Donoho-Gavish (2014) omega is 0.56b^3 - 0.95b^2 + 1.82b + 1.43
+        (linear coeff 1.82, constant 1.43 -- not swapped). This spectrum +
+        non-square shape picks a different rank under the swapped coefficients,
+        so it pins the correct formula (and matches deshen24/syntheticNN)."""
+        from mlsynth.utils.snn_helpers.completion import _universal_rank
+        s = np.array([10.0, 1.8, 1.0, 0.5, 0.1])
+        shape = (5, 50)                      # beta = 0.1, strongly non-square
+        beta = 0.1
+        omega = 0.56 * beta ** 3 - 0.95 * beta ** 2 + 1.82 * beta + 1.43
+        expected = max(int((s > omega * np.median(s)).sum()), 1)
+        assert expected == 2                 # guards the discriminator itself
+        assert _universal_rank(s, shape) == expected
 
 
 # ----------------------------------------------------------------------
@@ -157,6 +173,37 @@ class TestEstimator:
 # ----------------------------------------------------------------------
 # Layer 4: public API contracts
 # ----------------------------------------------------------------------
+
+_PROP99 = os.path.join(os.path.dirname(__file__), "..", "..", "basedata", "smoking_data.csv")
+
+
+@pytest.mark.skipif(not os.path.exists(_PROP99), reason="Prop99 data not present")
+class TestReferenceProp99:
+    """Cross-validation against deshen24/syntheticNN on the Prop 99 panel.
+
+    On block missingness (California's post-period the only NaN block) the
+    reference's NetworkX max-biclique and mlsynth's greedy anchor search both
+    return the full control x pre-period block, so -- with the corrected
+    Donoho-Gavish rank -- the imputed counterfactual matches the reference to
+    machine precision. Values below come from a live run of the reference
+    implementation (n_neighbors=1, universal rank)."""
+
+    REF_ATT = -18.4341
+    REF_GAP_2000 = -29.3258
+
+    def _fit(self):
+        df = pd.read_csv(_PROP99)
+        return SNN({"df": df, "outcome": "cigsale", "treat": "Proposition 99",
+                    "unitid": "state", "time": "year", "display_graphs": False}).fit()
+
+    def test_matches_reference_att(self):
+        res = self._fit()
+        assert res.att == pytest.approx(self.REF_ATT, abs=1e-3)
+
+    def test_matches_reference_gap_2000(self):
+        res = self._fit()
+        assert res.att_by_period[2000] == pytest.approx(self.REF_GAP_2000, abs=1e-3)
+
 
 class TestPublicAPI:
     def test_top_level_import(self):

--- a/mlsynth/utils/snn_helpers/completion.py
+++ b/mlsynth/utils/snn_helpers/completion.py
@@ -44,7 +44,7 @@ def _universal_rank(s: np.ndarray, shape: Tuple[int, int]) -> int:
     if min(m, n) == 0:
         return 0
     beta = min(m, n) / max(m, n)
-    omega = 0.56 * beta ** 3 - 0.95 * beta ** 2 + 1.43 * beta + 1.82
+    omega = 0.56 * beta ** 3 - 0.95 * beta ** 2 + 1.82 * beta + 1.43
     thresh = omega * np.median(s) if s.size else 0.0
     r = int((s > thresh).sum())
     return max(r, 1)


### PR DESCRIPTION
## What this does
Benchmarks **SNN** against the reference implementation [`deshen24/syntheticNN`](https://github.com/deshen24/syntheticNN) on Prop 99 — and in doing so **found and fixed a real bug**.

## The bug
mlsynth's Donoho-Gavish (2014) universal-rank `omega` had its last two coefficients **swapped**:
- published / reference: `0.56β³ − 0.95β² + 1.82β + 1.43`
- mlsynth (`completion.py:47`): `0.56β³ − 0.95β² + 1.43β + 1.82` ←

That mis-selected the PCR truncation rank, shifting the Prop 99 ATT to −19.4 vs the reference's −18.4. After the one-line fix, mlsynth's imputed counterfactual matches the reference **to machine precision** (max abs diff ~4e-7, i.e. just the printed-digit rounding of the embedded reference values).

Why an exact match is even possible: on **block missingness** (the SCM setting — the treated unit's post-period is the only missing block), the reference's NetworkX max-biclique anchor search and mlsynth's dependency-free greedy search both return the full *control × pre-period* block; same rank + same PCR ⇒ same counterfactual.

## Changes
- **Fix** the omega coefficients in `snn_helpers/completion.py`.
- **Tests** (TDD, red→green): a data-free Donoho-Gavish `omega` guard (`test_universal_rank_matches_gavish_donoho`) and a Prop 99 reference cross-validation (`TestReferenceProp99`).
- **Durable benchmark** `benchmarks/cases/snn_prop99.py` — embeds the reference counterfactual from a live run, so no `networkx`/`sklearn` at benchmark time.
- **Docs** — replication page `docs/replications/snn.rst` (+ toctree); corrected the Prop 99 numbers in `docs/snn.rst` (ATT ≈ −18, gap by 2000 ≈ −29).

## Validation
- `test_snn.py`: 15 passed (3 new + the pre-existing synthetic-recovery tests still pass under the corrected rank).
- SNN `result_contract`: green. Benchmark: 5/5 checks pass.

## Note on SI vs SNN
SI (Synthetic Interventions) is essentially the block-missingness special case of SNN's per-entry anchor+PCR machinery. There's a real consolidation question here — I've left a recommendation in the chat rather than acting on it in this PR.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_