### PR TITLE
refactor(pcr): unify the PCR rank + weight kernel across ClusterSC, SI, SNN

### DIFF
--- a/mlsynth/utils/clustersc_helpers/pcr/hsvt.py
+++ b/mlsynth/utils/clustersc_helpers/pcr/hsvt.py
@@ -1,151 +1,18 @@
-"""HSVT (Hard Singular Value Thresholding) primitives for PCR-SC.
+"""HSVT primitives for PCR-SC — back-compat re-export of the shared kernel.
 
-Implements rank selection and the rank-:math:`r` truncation step
-:math:`\\widetilde{M} = HSVT_r(X)` from Rho, Tang, Bergam, Cummings &
-Misra (2025), *ClusterSC: Advancing Synthetic Control with Donor
-Selection*, Algorithm 2.
+The implementations now live in :mod:`mlsynth.utils.pcr` (the single source of
+truth shared by ClusterSC, SI, and SNN). This module is preserved so existing
+imports (``mlsynth.utils.clustersc_helpers.pcr.hsvt``) keep working unchanged;
+``hsvt`` and ``select_rank`` are byte-for-byte the same objects.
 
-Three rank-selection modes are exposed:
-
-* ``"cumvar"`` -- smallest :math:`r` whose cumulative spectral energy
-  reaches a user threshold (paper's empirical default of 95%, Section 6.1).
-* ``"fixed"`` -- caller supplies the explicit rank :math:`r`.
-* ``"usvt"`` -- Universal Singular Value Thresholding (Chatterjee 2015;
-  Donoho & Gavish 2014). Preserved for back-compat with the legacy
-  Amjad-Shah-Shen 2018 path.
+See Rho, Tang, Bergam, Cummings & Misra (2025), *ClusterSC*, Algorithm 2 for the
+HSVT step and the three rank-selection modes (``"cumvar"``, ``"fixed"``,
+``"usvt"``).
 """
 
 from __future__ import annotations
 
-from typing import Optional, Tuple
+from ...pcr.core import hsvt
+from ...pcr.rank import _standardise, select_rank
 
-import numpy as np
-
-from ....exceptions import MlsynthConfigError, MlsynthEstimationError
-
-
-def _standardise(X: np.ndarray) -> np.ndarray:
-    """Per-column z-score with zero-variance columns left at zero.
-
-    Used inside :func:`select_rank` for data-driven rules
-    (``"cumvar"``, ``"usvt"``) so the spectral-energy comparison is
-    not dominated by uncentered level information. The standardised
-    matrix is *only* used for rank picking -- the HSVT step itself
-    still consumes the raw matrix.
-    """
-    means = X.mean(axis=0)
-    stds = X.std(axis=0)
-    safe = np.where(stds == 0, 1.0, stds)
-    out = (X - means) / safe
-    out[:, stds == 0] = 0.0
-    return out
-
-
-def select_rank(
-    X: np.ndarray,
-    method: str = "cumvar",
-    cumvar_threshold: float = 0.95,
-    r: Optional[int] = None,
-    standardize: bool = True,
-) -> int:
-    """Pick a truncation rank for ``X`` under the chosen rule.
-
-    Parameters
-    ----------
-    X : np.ndarray
-        Matrix to decompose, shape ``(m, n)``.
-    method : {"cumvar", "fixed", "usvt"}
-        Rank-selection rule.
-    cumvar_threshold : float
-        Cumulative-variance target in ``(0, 1]`` for ``method="cumvar"``.
-    r : int, optional
-        Explicit rank for ``method="fixed"``.
-    standardize : bool
-        When True (default), the data-driven rules (``"cumvar"`` /
-        ``"usvt"``) operate on the column-standardised version of
-        ``X``. This prevents the leading singular value from being
-        dominated by uncentered level information (e.g. cigarette
-        sales numbers, GDP per capita) so that ``cumvar_threshold``
-        actually discriminates over the panel's *factor structure*
-        rather than the overall scale. Ignored for ``method="fixed"``.
-
-    Returns
-    -------
-    int
-        Selected rank :math:`r \\in [1, \\min(m, n)]`.
-    """
-    if X.ndim != 2:
-        raise MlsynthEstimationError("HSVT input must be a 2D matrix.")
-    m, n = X.shape
-    rank_cap = max(1, min(m, n))
-
-    if method == "fixed":
-        if r is None or r < 1:
-            raise MlsynthConfigError(
-                "rank_method='fixed' requires a positive integer `rank`."
-            )
-        return int(min(r, rank_cap))
-
-    X_for_rank = _standardise(X) if standardize else X
-
-    if method == "cumvar":
-        if not (0.0 < cumvar_threshold <= 1.0):
-            raise MlsynthConfigError(
-                "cumvar_threshold must lie in (0, 1]."
-            )
-        s = np.linalg.svd(X_for_rank, compute_uv=False)
-        energy = s ** 2
-        total = float(energy.sum())
-        if total <= 0.0:
-            return 1
-        cum = np.cumsum(energy) / total
-        # smallest r with cum[r-1] >= threshold
-        idx = int(np.searchsorted(cum, cumvar_threshold) + 1)
-        return max(1, min(idx, rank_cap))
-
-    if method == "usvt":
-        # Universal SVT threshold (Chatterjee 2015; Donoho-Gavish 2014):
-        # keep singular values exceeding 2.858 * median when the matrix
-        # is square-ish, with the well-known (m/n)-dependent constant.
-        s = np.linalg.svd(X_for_rank, compute_uv=False)
-        beta = min(m, n) / max(m, n)
-        omega = 0.56 * beta ** 3 - 0.95 * beta ** 2 + 1.43 + 1.82 * beta
-        threshold = omega * np.median(s)
-        r_usvt = int(np.sum(s > threshold))
-        return max(1, min(r_usvt, rank_cap))
-
-    raise MlsynthConfigError(
-        f"Unknown rank_method {method!r}; expected 'cumvar', 'fixed', or 'usvt'."
-    )
-
-
-
-def hsvt(
-    X: np.ndarray,
-    rank: int,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Apply hard rank-``rank`` truncation to ``X``.
-
-    Computes :math:`\\widetilde{M} = \\sum_{i=1}^{r} \\sigma_i u_i v_i^\\top`
-    (Algorithm 2 step 2 of Rho et al. 2025).
-
-    Returns
-    -------
-    M_hat : np.ndarray
-        Rank-``rank`` reconstruction, shape ``(m, n)``.
-    U_r : np.ndarray
-        Truncated left singular vectors, shape ``(m, rank)``.
-    s_r : np.ndarray
-        Truncated singular values, shape ``(rank,)``.
-    Vt_r : np.ndarray
-        Truncated right singular vectors (transposed), shape ``(rank, n)``.
-    """
-    if X.ndim != 2:
-        raise MlsynthEstimationError("HSVT input must be a 2D matrix.")
-    U, s, Vt = np.linalg.svd(X, full_matrices=False)
-    r = max(1, min(int(rank), s.size))
-    U_r = U[:, :r]
-    s_r = s[:r]
-    Vt_r = Vt[:r, :]
-    M_hat = (U_r * s_r) @ Vt_r
-    return M_hat, U_r, s_r, Vt_r
+__all__ = ["hsvt", "select_rank", "_standardise"]

--- a/mlsynth/utils/pcr/__init__.py
+++ b/mlsynth/utils/pcr/__init__.py
@@ -1,0 +1,27 @@
+"""Shared principal-component-regression kernel.
+
+The single home for the spectral rank-selection rules and the PCR linear algebra
+used across mlsynth's PCR-based estimators (ClusterSC, Synthetic Interventions,
+Synthetic Nearest Neighbors). Centralising these primitives keeps the
+Donoho-Gavish threshold and the truncated-SVD weights from drifting between
+estimators.
+"""
+
+from __future__ import annotations
+
+from .core import hsvt, pcr_weights
+from .rank import (
+    donoho_gavish_omega,
+    select_rank,
+    spectral_rank,
+    usvt_rank,
+)
+
+__all__ = [
+    "donoho_gavish_omega",
+    "hsvt",
+    "pcr_weights",
+    "select_rank",
+    "spectral_rank",
+    "usvt_rank",
+]

--- a/mlsynth/utils/pcr/core.py
+++ b/mlsynth/utils/pcr/core.py
@@ -1,0 +1,78 @@
+"""Hard singular-value truncation and principal-component-regression weights —
+the linear-algebra kernel shared by ClusterSC, SI, and SNN.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from ...exceptions import MlsynthEstimationError
+
+
+def hsvt(
+    X: np.ndarray,
+    rank: int,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Apply hard rank-``rank`` truncation to ``X``.
+
+    Computes :math:`\\widetilde{M} = \\sum_{i=1}^{r} \\sigma_i u_i v_i^\\top`
+    (Algorithm 2 step 2 of Rho et al. 2025).
+
+    Returns
+    -------
+    M_hat : np.ndarray
+        Rank-``rank`` reconstruction, shape ``(m, n)``.
+    U_r : np.ndarray
+        Truncated left singular vectors, shape ``(m, rank)``.
+    s_r : np.ndarray
+        Truncated singular values, shape ``(rank,)``.
+    Vt_r : np.ndarray
+        Truncated right singular vectors (transposed), shape ``(rank, n)``.
+    """
+    if X.ndim != 2:
+        raise MlsynthEstimationError("HSVT input must be a 2D matrix.")
+    U, s, Vt = np.linalg.svd(X, full_matrices=False)
+    r = max(1, min(int(rank), s.size))
+    U_r = U[:, :r]
+    s_r = s[:r]
+    Vt_r = Vt[:r, :]
+    M_hat = (U_r * s_r) @ Vt_r
+    return M_hat, U_r, s_r, Vt_r
+
+
+def pcr_weights(
+    design: np.ndarray,
+    target: np.ndarray,
+    rank: int,
+) -> np.ndarray:
+    """Principal-component-regression weights over the columns of ``design``.
+
+    Regresses ``target`` onto the top-``rank`` principal subspace of ``design``
+    and returns the closed-form weight vector
+
+    .. math:: \\widehat w = V_r \\, \\mathrm{diag}(1/s_r) \\, U_r^\\top \\, y,
+
+    i.e. :func:`hsvt`-truncate ``design`` and apply the pseudo-inverse. This is
+    SI-PCR eq. 10 with ``design = Y_{pre, donors}``; SNN's per-entry PCR is the
+    same kernel with ``design`` the *transposed* anchor block (weights over
+    anchor rows).
+
+    Parameters
+    ----------
+    design : np.ndarray
+        Design matrix, shape ``(m, p)``; weights are over its ``p`` columns.
+    target : np.ndarray
+        Response vector, shape ``(m,)``.
+    rank : int
+        Spectral truncation rank.
+
+    Returns
+    -------
+    np.ndarray
+        Weight vector, shape ``(p,)``.
+    """
+    target = np.ravel(target)
+    _, U_r, s_r, Vt_r = hsvt(design, rank)
+    return Vt_r.T @ ((U_r.T @ target) / s_r)

--- a/mlsynth/utils/pcr/rank.py
+++ b/mlsynth/utils/pcr/rank.py
@@ -1,0 +1,137 @@
+"""Spectral rank-selection — the single source of truth shared by every
+PCR-based estimator in mlsynth (ClusterSC, SI, SNN).
+
+Historically the Donoho-Gavish (2014) universal threshold was reimplemented in
+three places, and they drifted: SNN's copy had the ``omega`` coefficients
+swapped (``1.43 b + 1.82`` instead of the published ``1.82 b + 1.43``), which
+mis-selected the rank. Centralising the formula here removes that drift class.
+
+Three rules are exposed:
+
+* :func:`usvt_rank` -- Universal Singular Value Thresholding
+  (Chatterjee 2015; Donoho & Gavish 2014): keep singular values above
+  ``omega(ratio) * median``.
+* :func:`spectral_rank` -- smallest rank whose cumulative spectral *energy*
+  reaches a threshold (operates on raw singular values).
+* :func:`select_rank` -- the ClusterSC entry point that consumes a *matrix*
+  and dispatches over ``{"cumvar", "fixed", "usvt"}`` (standardising the matrix
+  for the data-driven rules).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError, MlsynthEstimationError
+
+
+def donoho_gavish_omega(ratio: float) -> float:
+    """Donoho & Gavish (2014) optimal-hard-threshold coefficient ``omega(beta)``.
+
+    ``omega(beta) = 0.56 beta^3 - 0.95 beta^2 + 1.82 beta + 1.43`` (their
+    median-based approximation; ``omega(1) = 2.86``). ``ratio`` is the aspect
+    ratio at which the approximation is evaluated -- the canonical choice is
+    ``min(m, n) / max(m, n)``, though Agarwal-Shah-Shen evaluate it at ``m / n``.
+    """
+    return 0.56 * ratio ** 3 - 0.95 * ratio ** 2 + 1.82 * ratio + 1.43
+
+
+def usvt_rank(singular_values: np.ndarray, ratio: float) -> int:
+    """USVT rank: count singular values exceeding ``omega(ratio) * median``.
+
+    Returns at least 1. Callers that need an upper cap (``min(m, n)``) apply it.
+    """
+    s = np.asarray(singular_values, dtype=float)
+    if s.size == 0:
+        return 1
+    threshold = donoho_gavish_omega(ratio) * np.median(s)
+    return max(1, int(np.sum(s > threshold)))
+
+
+def spectral_rank(singular_values: np.ndarray, energy: float = 0.95) -> int:
+    """Smallest rank whose singular values capture ``energy`` of the spectrum."""
+    s = np.asarray(singular_values, dtype=float)
+    if s.size == 0:
+        return 0
+    total = float(np.sum(s ** 2))
+    if total <= 0.0:
+        return 1
+    cum = np.cumsum(s ** 2) / total
+    return int(np.searchsorted(cum, energy) + 1)
+
+
+def _standardise(X: np.ndarray) -> np.ndarray:
+    """Per-column z-score with zero-variance columns left at zero.
+
+    Used inside :func:`select_rank` for data-driven rules (``"cumvar"``,
+    ``"usvt"``) so the spectral-energy comparison is not dominated by uncentered
+    level information. The standardised matrix is *only* used for rank picking --
+    the HSVT step itself still consumes the raw matrix.
+    """
+    means = X.mean(axis=0)
+    stds = X.std(axis=0)
+    safe = np.where(stds == 0, 1.0, stds)
+    out = (X - means) / safe
+    out[:, stds == 0] = 0.0
+    return out
+
+
+def select_rank(
+    X: np.ndarray,
+    method: str = "cumvar",
+    cumvar_threshold: float = 0.95,
+    r: Optional[int] = None,
+    standardize: bool = True,
+) -> int:
+    """Pick a truncation rank for matrix ``X`` under the chosen rule.
+
+    Parameters
+    ----------
+    X : np.ndarray
+        Matrix to decompose, shape ``(m, n)``.
+    method : {"cumvar", "fixed", "usvt"}
+        Rank-selection rule.
+    cumvar_threshold : float
+        Cumulative-variance target in ``(0, 1]`` for ``method="cumvar"``.
+    r : int, optional
+        Explicit rank for ``method="fixed"``.
+    standardize : bool
+        When True (default), the data-driven rules (``"cumvar"`` / ``"usvt"``)
+        operate on the column-standardised version of ``X`` so the leading
+        singular value is not dominated by uncentered level information.
+        Ignored for ``method="fixed"``.
+
+    Returns
+    -------
+    int
+        Selected rank :math:`r \\in [1, \\min(m, n)]`.
+    """
+    if X.ndim != 2:
+        raise MlsynthEstimationError("HSVT input must be a 2D matrix.")
+    m, n = X.shape
+    rank_cap = max(1, min(m, n))
+
+    if method == "fixed":
+        if r is None or r < 1:
+            raise MlsynthConfigError(
+                "rank_method='fixed' requires a positive integer `rank`."
+            )
+        return int(min(r, rank_cap))
+
+    X_for_rank = _standardise(X) if standardize else X
+
+    if method == "cumvar":
+        if not (0.0 < cumvar_threshold <= 1.0):
+            raise MlsynthConfigError("cumvar_threshold must lie in (0, 1].")
+        s = np.linalg.svd(X_for_rank, compute_uv=False)
+        return min(spectral_rank(s, cumvar_threshold), rank_cap)
+
+    if method == "usvt":
+        s = np.linalg.svd(X_for_rank, compute_uv=False)
+        return min(usvt_rank(s, min(m, n) / max(m, n)), rank_cap)
+
+    raise MlsynthConfigError(
+        f"Unknown rank_method {method!r}; expected 'cumvar', 'fixed', or 'usvt'."
+    )

--- a/mlsynth/utils/si_helpers/estimation.py
+++ b/mlsynth/utils/si_helpers/estimation.py
@@ -23,7 +23,7 @@ from typing import List, Tuple
 import numpy as np
 from scipy.linalg import qr
 
-from ..clustersc_helpers.pcr.hsvt import hsvt, select_rank
+from ..pcr import hsvt, pcr_weights, select_rank, usvt_rank
 
 
 def donoho_rank(s: np.ndarray, ratio: float) -> int:
@@ -32,12 +32,10 @@ def donoho_rank(s: np.ndarray, ratio: float) -> int:
     The authors evaluate the :math:`\\omega(\\beta)` approximation at
     ``ratio = m / n`` -- the donor pre-matrix's rows-over-columns
     (:math:`T_0 / N_d`) -- rather than the canonical ``min/max`` aspect ratio.
-    Reproduced here verbatim so SI matches the paper's reported ranks; see
-    ``rank_method="donoho"``.
+    Delegates to the shared kernel (:func:`mlsynth.utils.pcr.usvt_rank`) so the
+    threshold cannot drift from ClusterSC's and SNN's; see ``rank_method="donoho"``.
     """
-    omega = 0.56 * ratio ** 3 - 0.95 * ratio ** 2 + 1.43 + 1.82 * ratio
-    t = omega * np.median(s)
-    return max(int(np.sum(s > t)), 1)
+    return usvt_rank(s, ratio)
 
 
 def si_pcr_weights(
@@ -65,10 +63,8 @@ def si_pcr_weights(
     np.ndarray
         Donor weight vector, shape ``(Nd,)``.
     """
-    target_pre = np.ravel(target_pre)
-    _, U_r, s_r, Vt_r = hsvt(donor_pre, rank)
-    # w = V_k diag(1/s) U_k^T y
-    return Vt_r.T @ ((U_r.T @ target_pre) / s_r)
+    # w = V_k diag(1/s) U_k^T y  (shared PCR kernel; SI-PCR eq. 10)
+    return pcr_weights(donor_pre, target_pre, rank)
 
 
 def select_omega(donor_pre: np.ndarray, rank: int) -> List[int]:

--- a/mlsynth/utils/snn_helpers/completion.py
+++ b/mlsynth/utils/snn_helpers/completion.py
@@ -27,27 +27,29 @@ from typing import Optional, Tuple
 
 import numpy as np
 
+from ..pcr import pcr_weights, spectral_rank, usvt_rank
+
 _EPS = 1e-12
 
 
 def _spectral_rank(s: np.ndarray, energy: float = 0.95) -> int:
-    """Smallest rank whose singular values capture ``energy`` of the spectrum."""
-    if s.size == 0:
-        return 0
-    cum = np.cumsum(s ** 2) / np.sum(s ** 2)
-    return int(np.searchsorted(cum, energy) + 1)
+    """Smallest rank whose singular values capture ``energy`` of the spectrum.
+
+    Thin wrapper over the shared kernel (:func:`mlsynth.utils.pcr.spectral_rank`).
+    """
+    return spectral_rank(s, energy)
 
 
 def _universal_rank(s: np.ndarray, shape: Tuple[int, int]) -> int:
-    """Donoho & Gavish (2014) optimal hard-threshold rank for square-ish noise."""
+    """Donoho & Gavish (2014) optimal hard-threshold rank for square-ish noise.
+
+    Thin wrapper over the shared kernel (:func:`mlsynth.utils.pcr.usvt_rank`),
+    evaluated at the canonical ``min/max`` aspect ratio.
+    """
     m, n = shape
     if min(m, n) == 0:
         return 0
-    beta = min(m, n) / max(m, n)
-    omega = 0.56 * beta ** 3 - 0.95 * beta ** 2 + 1.82 * beta + 1.43
-    thresh = omega * np.median(s) if s.size else 0.0
-    r = int((s > thresh).sum())
-    return max(r, 1)
+    return usvt_rank(s, min(m, n) / max(m, n))
 
 
 def _pcr(
@@ -76,7 +78,7 @@ def _pcr(
     train_error : float
         Mean squared reconstruction error of ``q`` on the anchor columns.
     """
-    U, sv, Vt = np.linalg.svd(S, full_matrices=False)
+    sv = np.linalg.svd(S, compute_uv=False)
     if max_rank is not None:
         r = min(max_rank, sv.size)
     elif universal:
@@ -84,9 +86,9 @@ def _pcr(
     else:
         r = _spectral_rank(sv, spectral_energy)
     r = max(r, 1)
-    Ur, svr, Vtr = U[:, :r], sv[:r], Vt[:r]
-    # beta = U_r diag(1/sv_r) V_r^T q  (weights over anchor rows)
-    beta = Ur @ ((Vtr @ q) / np.maximum(svr, _EPS))
+    # beta = U_r diag(1/sv_r) V_r^T q  (weights over anchor rows): the shared
+    # PCR kernel applied to S^T regresses q onto the anchor-row subspace.
+    beta = pcr_weights(S.T, q, r)
     prediction = float(x @ beta)
     train_error = float(np.mean((S.T @ beta - q) ** 2))
     return prediction, beta, train_error


### PR DESCRIPTION
## Why
The Donoho-Gavish universal threshold and the truncated-SVD PCR weights were implemented in **three** places — ClusterSC (`hsvt.select_rank`), SI (`donoho_rank`/`si_pcr_weights`), SNN (`completion._pcr`/`_universal_rank`). They **drifted**: SNN's `omega` had its coefficients swapped (the bug fixed in #80). This extracts a single source of truth so they can't diverge again.

This is the consolidation recommended after the SNN/SI paper review: the two estimators stay distinct (SNN ⊋ SI in missingness generality; SI ⊋ SNN in multi-intervention estimand + bias-corrected inference) but stop duplicating the shared kernel.

## What
- **New `mlsynth/utils/pcr/`** — the canonical kernel: `donoho_gavish_omega`, `usvt_rank`, `spectral_rank`, `select_rank` (`rank.py`) + `hsvt`, `pcr_weights` (`core.py`).
- **`clustersc_helpers/pcr/hsvt.py` → back-compat re-export shim.** `hsvt` and `select_rank` are the *same objects* (`hsvt is h2` verified), so every existing import path and **ClusterSC's numerics are byte-for-byte unchanged**.
- **SI:** `donoho_rank` delegates to `usvt_rank`; `si_pcr_weights` delegates to `pcr_weights` (names preserved for the SI tests).
- **SNN:** `_universal_rank`/`_spectral_rank` are thin wrappers over the shared kernel; `_pcr`'s `beta` is `pcr_weights(S.T, q, r)` — algebraically identical to its inline truncated-SVD weights (derived: `U_r diag(1/s_r) V_rᵀ q`).

## Acceptance gate (your condition: ClusterSC unchanged)
- **ClusterSC tests pass unchanged** — `test_clustersc`, `test_bayesutils`, `test_si_replication`: 39 passed.
- **All three ClusterSC benchmarks pass unchanged** — `clustersc_subgroups`, `clustersc_rpca_germany`, `rsc_shen_coverage`.
- SI + SNN suites: 67 passed; SNN benchmark unchanged.

No new benchmark cases bundled (kept separate per CLAUDE.md). This unblocks doing the SI + SNN benchmarks on a shared, validated kernel next.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_