### PR TITLE
bench(si): durable cross-validation vs the Agarwal-Shah-Shen 2026 authors' code

### DIFF
--- a/benchmarks/cases/si_prop99.py
+++ b/benchmarks/cases/si_prop99.py
@@ -1,0 +1,118 @@
+"""Cross-validation benchmark: SI vs the authors' code (Agarwal-Shah-Shen 2026).
+
+Cross-validation against the reference implementation. ``SI`` is mlsynth's port of
+Synthetic Interventions (Agarwal, Shah & Shen 2026, *Synthetic Interventions:
+Extending Synthetic Controls to Multiple Treatments*, Oper. Res. 74(2)). This case
+runs the **authors' own** estimation code -- vendored verbatim under
+:mod:`benchmarks.reference.synth_iv_OR25` from the INFORMS supplement
+``opre.2025.1590.cd`` -- side by side with mlsynth's public :class:`mlsynth.SI`
+API, and checks they agree to machine precision.
+
+It reproduces the Section 6 case study (Table, ``case_study.ipynb`` "Counterfactual
+Estimates"): for each of the five anti-tobacco *program* states, California's and
+its peers' 1999-2002 cigarette-consumption counterfactual **under the control and
+tax interventions**, with the bias-corrected SI-PCR prediction interval. Fit window
+1970-1988, prediction window 1999-2002, donor pool = the units assigned each
+intervention (target excluded), Gavish-Donoho rank, ``variance="double"``.
+
+Provenance
+----------
+* Data: ``basedata/prop99_packsales.csv`` -- the per-capita pack-sales panel (50
+  states, 1970-2015) the authors pivot from ``prop99_raw_data.csv``.
+* Reference: the authors' ``HSVT`` -> ``qr_column_pivoting_selection`` -> ``OLS``
+  with ``variance_estimation`` + ``predictionInterval`` (run live).
+* Published anchors (notebook): California under control ``[70.93, 80.63]`` and
+  under taxes ``[47.99, 67.06]`` packs/capita.
+"""
+from __future__ import annotations
+
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_BASE = Path(__file__).resolve().parents[2] / "basedata"
+_REF = Path(__file__).resolve().parents[1] / "reference" / "synth_iv_OR25"
+
+TAX = ["Alaska", "Hawaii", "Maryland", "Michigan", "New Jersey", "New York", "Washington"]
+PROGRAM = ["California", "Arizona", "Massachusetts", "Oregon", "Florida"]
+FIT_YEARS = list(range(1970, 1989))
+PRED_YEARS = list(range(1999, 2003))            # T1 = 4, the case study's window
+
+
+def _reference_ci(wide, state, donors):
+    """The authors' bias-corrected SI-PCR prediction interval (their code)."""
+    if str(_REF) not in sys.path:
+        sys.path.insert(0, str(_REF))
+    from estimation import HSVT, OLS, qr_column_pivoting_selection
+    from inference import variance_estimation, predictionInterval
+
+    y_pre_target = wide.loc[state, FIT_YEARS].to_numpy(dtype=float)
+    y_pre_donors = wide.loc[donors, FIT_YEARS].to_numpy(dtype=float).T
+    y_post_donors = wide.loc[donors, PRED_YEARS].to_numpy(dtype=float).T
+    H, U, V = HSVT(y_pre_donors)
+    k = U.shape[1]
+    omega = qr_column_pivoting_selection(H, k)
+    w = OLS(H[:, omega], y_pre_target)
+    theta = float(np.mean(y_post_donors[:, omega] @ w))
+    sigma = variance_estimation(U, V, y_pre_target, y_post_donors)[0]
+    lb, ub = predictionInterval(theta, w, sigma, len(PRED_YEARS), 0.05)
+    return float(lb), float(ub)
+
+
+def run() -> dict:
+    from mlsynth import SI
+
+    panel = pd.read_csv(_BASE / "prop99_packsales.csv")
+    wide = panel.pivot_table(index="state", columns="year", values="cigsale")
+    states = list(wide.index)
+    iv_states = {
+        "control": [s for s in states if s not in set(TAX) | set(PROGRAM)],
+        "taxes": TAX,
+        "program": PROGRAM,
+    }
+
+    # restrict to the fit + prediction windows (drops 1989-1998, as the paper does)
+    d = panel[panel.year.isin(FIT_YEARS + PRED_YEARS)].copy()
+    for iv, members in iv_states.items():
+        d[iv] = d.state.isin(members).astype(int)
+
+    max_diff = 0.0
+    ca = {}
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for target in PROGRAM:
+            dd = d.copy()
+            dd["treat"] = ((dd.state == target) & (dd.year >= 1999)).astype(int)
+            res = SI({
+                "df": dd, "outcome": "cigsale", "treat": "treat", "unitid": "state",
+                "time": "year", "inters": ["control", "taxes", "program"],
+                "bias_correct": True, "variance": "double", "interval": "prediction",
+                "rank_method": "donoho", "display_graphs": False,
+            }).fit()
+            for iv in ("control", "taxes"):
+                donors = [s for s in iv_states[iv] if s != target]
+                ref_lo, ref_hi = _reference_ci(wide, target, donors)
+                mls_lo, mls_hi = res.arms[iv].cf_mean_ci
+                max_diff = max(max_diff, abs(mls_lo - ref_lo), abs(mls_hi - ref_hi))
+                if target == "California":
+                    ca[iv] = (mls_lo, mls_hi)
+
+    return {
+        "si_vs_reference_max_abs_diff": float(max_diff),
+        "ca_control_lb": ca["control"][0], "ca_control_ub": ca["control"][1],
+        "ca_taxes_lb": ca["taxes"][0], "ca_taxes_ub": ca["taxes"][1],
+    }
+
+
+# mlsynth's public SI API matches the authors' own code to machine precision; the
+# California interval anchors are the published Section 6 values.
+EXPECTED = {
+    "si_vs_reference_max_abs_diff": (0.0, 1e-8),
+    "ca_control_lb": (70.93, 1e-2),
+    "ca_control_ub": (80.63, 1e-2),
+    "ca_taxes_lb": (47.99, 1e-2),
+    "ca_taxes_ub": (67.06, 1e-2),
+}

--- a/benchmarks/reference/synth_iv_OR25/NOTICE.md
+++ b/benchmarks/reference/synth_iv_OR25/NOTICE.md
@@ -1,0 +1,14 @@
+# Vendored reference: Synthetic Interventions (Agarwal, Shah & Shen 2026)
+
+`estimation.py` and `inference.py` are **verbatim** from the authors' replication
+package for
+
+> Agarwal, Shah & Shen (2026). "Synthetic Interventions: Extending Synthetic
+> Controls to Multiple Treatments." *Operations Research* 74(2):840-859.
+> INFORMS supplemental code `opre.2025.1590.cd` (`synth-iv-OR25/`).
+
+They are imported, not modified, so the benchmark cross-validates mlsynth's public
+`SI` API against the authors' own code (the SI-PCR + bias-corrected estimator:
+`HSVT` -> `qr_column_pivoting_selection` -> `OLS`, with `variance_estimation` +
+`predictionInterval`). Only the functions exercised by the Section 6 case study
+are used; the simulation/DGP helpers are omitted.

--- a/benchmarks/reference/synth_iv_OR25/estimation.py
+++ b/benchmarks/reference/synth_iv_OR25/estimation.py
@@ -1,0 +1,440 @@
+import random
+import numpy as np 
+import scipy 
+import cvxpy as cp
+
+#===================
+# Matrix operations
+#===================
+
+def donoho_rank(s, ratio): 
+    """
+    Retain all singular values above optimal threshold as per Donoho & Gavin '14:
+    https://arxiv.org/pdf/1305.5870.pdf
+    """ 
+    omega = 0.56*ratio**3 - 0.95*ratio**2 + 1.43 + 1.82*ratio
+    t = omega * np.median(s) 
+    rank = max(len(s[s>t]), 1)
+    return rank 
+
+def spectral_rank(s, thresh=None):
+    if thresh==1.0: 
+        rank = len(s)
+    else: 
+        total_energy = (s**2).cumsum() / (s**2).sum()
+        rank = list((total_energy>thresh)).index(True) + 1
+    return rank
+
+def HSVT(Z, max_rank=None, thresh=None):
+    """
+    Perform Hard Singular Value Thresholding (HSVT).
+
+    Parameters:
+        Z (np.ndarray): Input matrix of shape (n_samples, n_features).
+        max_rank (int, optional): Number of principal components to retain.
+        thresh (float, optional): Threshold for spectral decay to determine rank.
+
+    Returns:
+        X_hat (np.ndarray): Low-rank approximation of Z.
+        rank: rank of X_hat.
+    """
+    (u, s, v) = np.linalg.svd(Z, full_matrices=False)
+    if max_rank is not None: 
+        rank = max_rank 
+    elif thresh is not None: 
+        rank = spectral_rank(s, thresh=thresh)
+    else: 
+        (m, n) = Z.shape 
+        rank = donoho_rank(s, ratio=m/n)
+    s_rank = s[:rank]
+    u_rank = u[:, :rank]
+    v_rank = v[:rank, :] 
+    X_hat = (u_rank * s_rank) @ v_rank
+    return (X_hat, u_rank, v_rank.T)
+
+# PCR
+def PCR(Z, y, max_rank=None, thresh=None):
+    # de-noise X
+    (u, s, v) = np.linalg.svd(Z, full_matrices=False)
+    if max_rank is not None: 
+        rank = max_rank 
+    if thresh is not None: 
+        rank = spectral_rank(s, thresh=thresh)
+    else: 
+        (n, p) = Z.shape 
+        rank = donoho_rank(s, ratio=n/p)
+    s_rank = s[:rank]
+    u_rank = u[:, :rank]
+    v_rank = v[:rank, :] 
+    beta = ((v_rank.T/s_rank) @ u_rank.T) @ y
+    return (beta, rank)  
+
+# OLS
+def OLS(X, y):
+    return np.linalg.pinv(X) @ y 
+
+#=================
+# SELECTING OMEGA
+#=================
+
+#------------------
+# Random selection
+#------------------
+
+def random_selection(N, k, seed=None):
+    """
+    Randomly select k column indices (donor units) from Y_pre without modifying the original matrix.
+
+    Parameters:
+    - Y_pre (np.ndarray): Pre-treatment outcome matrix of shape (T_pre, N)
+    - k (int): Number of columns to select for Omega
+    - seed (int or None): Seed for reproducibility
+
+    Returns:
+    - omega_indices (list): List of selected column indices
+    """
+    np.random.seed(seed)
+
+    if k > N:
+        raise ValueError(f"Cannot select {k} columns from a matrix with only {N} columns.")
+
+    omega_indices = np.random.choice(N, size=k, replace=False).tolist()
+    return omega_indices
+
+#-----------------
+# Greedy strategy
+#-----------------
+
+def greedy_rank_preserving_selection(Y, k, seed=None):
+    """
+    Greedy selection of k columns from Y such that each newly added column
+    increases the matrix rank, starting from a randomized column order.
+
+    Parameters:
+    - Y (np.ndarray): Input matrix of shape (T, N)
+    - k (int): Number of columns to select
+    - seed (int, optional): Random seed for reproducibility
+
+    Returns:
+    - selected_indices (list): Indices of selected columns
+    """
+    T, N = Y.shape
+    selected_indices = []
+
+    # Set random seed
+    rng = np.random.default_rng(seed)
+    permuted_indices = rng.permutation(N)
+
+    # Initialize with the first non-zero column in the randomized order
+    for j in permuted_indices:
+        if np.linalg.norm(Y[:, j]) > 1e-10:
+            selected_indices.append(j)
+            current_matrix = Y[:, [j]]
+            break
+    else:
+        raise ValueError("All columns in the matrix are zero.")
+
+    # Continue greedy selection
+    while len(selected_indices) < k:
+        for j in permuted_indices:
+            if j in selected_indices:
+                continue
+            candidate_matrix = np.hstack((current_matrix, Y[:, [j]]))
+            if np.linalg.matrix_rank(candidate_matrix) > np.linalg.matrix_rank(current_matrix):
+                selected_indices.append(j)
+                current_matrix = candidate_matrix
+                break  # Greedily add the first one that increases rank
+        else:
+            break  # No further improvement possible
+
+    return selected_indices
+
+
+def hybrid_qr_leverage_selection(Y, k_total, qr_fraction=0.5, rank=None, seed=None):
+    """
+    Hybrid selection using QR with column pivoting + leverage score sampling.
+
+    Args:
+        Y (np.ndarray): Pre-treatment outcome matrix (T, N).
+        k_total (int): Total number of donor units to select.
+        qr_fraction (float): Fraction of k_total to select via QR pivoting.
+        rank (int or None): Truncation rank for leverage scores (defaults to k_total if None).
+        seed (int or None): Random seed for reproducibility.
+
+    Returns:
+        selected_indices (List[int]): Combined indices from QR and leverage sampling.
+    """
+    np.random.seed(seed)
+    T, N = Y.shape
+    k_qr = int(np.floor(qr_fraction * k_total))
+    k_lev = k_total - k_qr
+
+    # --- Step 1: QR pivoting ---
+    _, _, pivot_indices = scipy.linalg.qr(Y, pivoting=True)
+    qr_selected = list(pivot_indices[:k_qr])
+
+    # --- Step 2: Leverage score sampling ---
+    if rank is None:
+        rank = k_total
+    Yt = Y.T  # shape (N, T)
+    Uc, _, _ = scipy.linalg.svd(Yt, full_matrices=False)
+    Uc_k = Uc[:, :rank]
+    col_leverage_scores = np.sum(Uc_k**2, axis=1)
+    col_leverage_scores /= np.sum(col_leverage_scores)
+
+    # Avoid resampling columns already picked by QR
+    remaining_indices = list(set(range(N)) - set(qr_selected))
+    remaining_probs = col_leverage_scores[remaining_indices]
+    remaining_probs /= remaining_probs.sum()
+
+    leverage_selected = np.random.choice(remaining_indices, size=k_lev, replace=False, p=remaining_probs)
+
+    # --- Combine and return sorted list ---
+    combined_indices = sorted(qr_selected + list(leverage_selected))
+    return combined_indices
+
+
+
+# def greedy_rank_preserving_selection(Y, k):
+#     """
+#     Greedy selection of k columns from Y such that each newly added column
+#     increases the matrix rank.
+
+#     Parameters:
+#     - Y (np.ndarray): Input matrix of shape (T, N)
+#     - k (int): Number of columns to select
+
+#     Returns:
+#     - selected_indices (list): Indices of selected columns
+#     """
+#     T, N = Y.shape
+#     selected_indices = []
+
+#     # Initialize with the first non-zero column
+#     for j in range(N):
+#         if np.linalg.norm(Y[:, j]) > 1e-10:
+#             selected_indices.append(j)
+#             current_matrix = Y[:, [j]]
+#             break
+#     else:
+#         raise ValueError("All columns in the matrix are zero.")
+
+#     while len(selected_indices) < k:
+#         best_col = None
+#         for j in range(N):
+#             if j in selected_indices:
+#                 continue
+#             candidate_matrix = np.hstack((current_matrix, Y[:, [j]]))
+#             if np.linalg.matrix_rank(candidate_matrix) > np.linalg.matrix_rank(current_matrix):
+#                 best_col = j
+#                 current_matrix = candidate_matrix
+#                 break  # Greedily add the first one that increases rank
+#         if best_col is None:
+#             break  # No further improvement possible
+#         selected_indices.append(best_col)
+
+#     return selected_indices
+
+#-----------------------------------------
+# QR Decomposition with leverage sampling
+#-----------------------------------------
+def leverage_score_selection(Y, k, n_select, seed=None):
+    """
+    Select columns using QR decomposition and leverage score sampling.
+
+    Args:
+        Y (np.ndarray): Pre-treatment outcome matrix of shape (T, N).
+        k (int): Truncation rank for QR/SVD decomposition.
+        n_select (int): Number of columns to select into Ω.
+        seed (int or None): Seed for reproducibility
+
+    Returns:
+        selected_indices (List[int]): Indices of selected donor units (columns of Y).
+    """
+    np.random.seed(seed)
+    
+    T, N = Y.shape
+
+    # Step 1: Truncated SVD (used to compute leverage scores)
+    U, S, Vt = scipy.linalg.svd(Y, full_matrices=False)
+    U_k = U[:, :k]  # Top-k left singular vectors
+
+    # Step 2: Compute leverage scores for columns
+    leverage_scores = np.sum(U_k**2, axis=1)  # Leverage scores per row (time)
+    leverage_scores = leverage_scores / np.sum(leverage_scores)
+
+    # Transpose Y to compute leverage scores for columns
+    Yt = Y.T  # Now shape is (N, T)
+    Uc, _, _ = scipy.linalg.svd(Yt, full_matrices=False)
+    Uc_k = Uc[:, :k]
+    col_leverage_scores = np.sum(Uc_k**2, axis=1)
+    col_leverage_scores = col_leverage_scores / np.sum(col_leverage_scores)
+
+    # Step 3: Sample columns with probability ∝ leverage scores
+    selected_indices = np.random.choice(N, size=n_select, replace=False, p=col_leverage_scores)
+
+    return sorted(selected_indices)
+
+#---------------------------------------
+# QR Decomposition with column pivoting
+#---------------------------------------
+def qr_column_pivoting_selection(Y, k):
+    """
+    Select donor units using QR decomposition with column pivoting.
+
+    Args:
+        Y (np.ndarray): Pre-treatment outcome matrix of shape (T, N).
+        k (int): Number of columns to select.
+
+    Returns:
+        selected_indices (List[int]): Indices of selected donor units (columns of Y).
+    """
+    # QR with column pivoting
+    Q, R, pivot_indices = scipy.linalg.qr(Y, pivoting=True)
+    
+    # Select first k pivoted columns
+    selected_indices = sorted(pivot_indices[:k])
+    
+    return selected_indices
+
+#-------
+# Lasso 
+#-------
+from sklearn.linear_model import LassoCV
+
+def lasso_selection(X, y, alpha=None, cv=5):
+    """
+    Select donor columns using Lasso regression.
+
+    Args:
+        Y (np.ndarray): Matrix of shape (T, N), columns are units (including treated).
+        target_idx (int): Index of treated unit (whose outcomes we try to reconstruct).
+        alpha (float or None): Regularization parameter. If None, selected by CV.
+        cv (int): Number of folds for cross-validation (if alpha is None).
+
+    Returns:
+        selected_indices (List[int]): Indices of donor units selected by Lasso.
+    """
+    (T, N) = X.shape
+    donor_indices = [i for i in range(N)]
+
+    if alpha is None:
+        lasso = LassoCV(cv=cv, fit_intercept=False).fit(X, y)
+    else:
+        from sklearn.linear_model import Lasso
+        lasso = Lasso(alpha=alpha, fit_intercept=False).fit(X, y)
+
+    # Get non-zero coefficients
+    selected_mask = np.abs(lasso.coef_) > 1e-8
+    selected_indices = [donor_indices[i] for i, sel in enumerate(selected_mask) if sel]
+    print(len(selected_indices))
+
+    return selected_indices
+
+#-------------
+# Group Lasso 
+#-------------
+from sklearn.model_selection import KFold
+
+def group_lasso_selection(Y_donors, Y_target, lambdas=None, K=5, tol=1e-6, verbose=False):
+    """
+    Select Omega using group lasso with K-fold cross-validation to choose lambda.
+
+    Args:
+        Y_target: np.array of shape (T,), target pre-treatment outcomes.
+        Y_donors: np.array of shape (T, N), each column is a donor unit's outcomes.
+        lambdas: list or np.array of lambda values to try. If None, uses logspace.
+        K: int, number of folds.
+        tol: float, threshold to select non-zero weights.
+        verbose: bool, whether to print CV progress.
+
+    Returns:
+        selected_indices: list of selected donor indices.
+    """
+    T, N = Y_donors.shape
+    if lambdas is None:
+        lambdas = np.logspace(-4, 1, 20)  # adjust range as needed
+
+    kf = KFold(n_splits=K, shuffle=True, random_state=42)
+    cv_errors = []
+
+    for lam in lambdas:
+        errors = []
+
+        for train_idx, test_idx in kf.split(np.arange(T)):
+            Y_train = Y_target[train_idx]
+            X_train = Y_donors[train_idx, :]
+
+            Y_test = Y_target[test_idx]
+            X_test = Y_donors[test_idx, :]
+
+            W = cp.Variable(N)
+            residual = X_train @ W - Y_train
+            objective = cp.Minimize(0.5 * cp.sum_squares(residual) + lam * cp.norm1(W))
+            prob = cp.Problem(objective)
+            prob.solve()
+
+            if W.value is not None:
+                pred = X_test @ W.value
+                error = np.mean((Y_test - pred)**2)
+            else:
+                error = np.inf
+
+            errors.append(error)
+
+        mean_cv_error = np.mean(errors)
+        cv_errors.append(mean_cv_error)
+        if verbose:
+            print(f"Lambda: {lam:.5f}, CV Error: {mean_cv_error:.5f}")
+
+    # Choose best lambda
+    best_idx = np.argmin(cv_errors)
+    best_lambda = lambdas[best_idx]
+
+    # Fit final model on full data using best lambda
+    W_final = cp.Variable(N)
+    residual_final = Y_donors @ W_final - Y_target
+    final_obj = cp.Minimize(0.5 * cp.sum_squares(residual_final) + best_lambda * cp.norm1(W_final))
+    final_prob = cp.Problem(final_obj)
+    final_prob.solve()
+
+    weights = W_final.value
+    selected_indices = [j for j in range(N) if np.abs(weights[j]) > tol]
+    print(len(selected_indices))
+
+    return selected_indices
+
+
+# def select_omega_group_lasso(Y_target, Y_donors, lambda_reg=0.1, tol=1e-6):
+#     """
+#     Selects donor units (columns of Y_donors) using group lasso.
+    
+#     Args:
+#         Y_target: np.array of shape (T,), the pre-treatment outcomes for unit i.
+#         Y_donors: np.array of shape (T, N), each column is a donor's pre-treatment outcomes.
+#         lambda_reg: float, regularization strength for group lasso.
+#         tol: float, threshold for selecting nonzero groups.
+    
+#     Returns:
+#         omega: list of indices corresponding to selected donor units.
+#     """
+#     T, N = Y_donors.shape
+
+#     # Create N vector variables (one per unit)
+#     W = cp.Variable((N,))  # single coefficient per unit (or use blocks for richer models)
+
+#     # Define objective with group L1 penalty (just L1 since each group is scalar here)
+#     residual = Y_donors @ W - Y_target
+#     obj = cp.Minimize(0.5 * cp.sum_squares(residual) + lambda_reg * cp.norm1(W))
+
+#     # Solve problem
+#     problem = cp.Problem(obj)
+#     problem.solve()
+
+#     # Get selected unit indices
+#     w_value = W.value
+#     omega = [j for j in range(N) if np.abs(w_value[j]) > tol]
+
+#     return omega, w_value
+
+    

--- a/benchmarks/reference/synth_iv_OR25/inference.py
+++ b/benchmarks/reference/synth_iv_OR25/inference.py
@@ -1,0 +1,47 @@
+import numpy as np
+from scipy.stats import norm
+
+#=====================
+# Variance estimation
+#=====================
+def variance_estimation(U, V, Y_pre_target, Y_post_donors): 
+    
+    # get dimensions
+    T0 = len(Y_pre_target)
+    (T1, N) = Y_post_donors.shape 
+    k = U.shape[1] 
+
+    # estimator 1 
+    df1 = T0 - k 
+    residual = (np.eye(T0) - U@U.T) @ Y_pre_target 
+    var_hat1 = np.linalg.norm(residual, 2)**2 / df1
+    sigma_hat1 = np.sqrt(var_hat1)
+
+    # estimator 2
+    df2 = T1 * (N - k) 
+    residual = (np.eye(N) - V@V.T) @ Y_post_donors.T 
+    var_hat2 = np.linalg.norm(residual, 'fro')**2 / df2 
+    sigma_hat2 = np.sqrt(var_hat2)
+
+    # weighted estimator
+    df = df1 + df2 
+    var_hat = (df2/df)*var_hat1 + (df1/df)*var_hat2
+    sigma_hat = np.sqrt(var_hat)
+
+    return (sigma_hat, sigma_hat1, sigma_hat2)
+
+#=====================
+# Confidence interval
+#=====================
+def confidenceInterval(theta_hat, w_hat, sigma_hat, T1, alpha):
+    z_critical = norm.ppf(1 - alpha / 2) 
+    delta = (z_critical*sigma_hat*np.linalg.norm(w_hat,2)) / np.sqrt(T1)
+    return (theta_hat-delta, theta_hat+delta) 
+
+#=====================
+# Confidence interval
+#=====================
+def predictionInterval(theta_hat, w_hat, sigma_hat, T1, alpha):
+    z_critical = norm.ppf(1 - alpha / 2) 
+    delta = z_critical * sigma_hat * np.sqrt(1 + np.linalg.norm(w_hat,2)**2) / np.sqrt(T1)
+    return (theta_hat-delta, theta_hat+delta) 

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -5,6 +5,7 @@ import importlib
 
 # name -> "benchmarks.cases.<module>"  (pure-Python unless noted needs_reference)
 CASES = {
+    "si_prop99": "benchmarks.cases.si_prop99",          # cross-val vs Agarwal-Shah-Shen 2026 authors' code (Prop 99)
     "snn_prop99": "benchmarks.cases.snn_prop99",        # cross-val vs deshen24/syntheticNN (Prop 99)
     "ppscm_paglayan": "benchmarks.cases.ppscm_paglayan",  # cross-val vs augsynth::multisynth (jackknife + bootstrap SEs)
     "rolldid_lw": "benchmarks.cases.rolldid_lw",        # Path A: Lee-Wooldridge Prop99 + castle

--- a/docs/si.rst
+++ b/docs/si.rst
@@ -663,8 +663,15 @@ The bridge is design rather than luck: ``mlsynth`` reuses the same HSVT
 truncation, the authors' exact Gavish-Donoho rank rule
 (``rank_method="donoho"``, :math:`\beta = T_0/N_d`), QR-pivot subset selection,
 pseudo-inverse fit, and degrees-of-freedom-weighted variance
-(``variance="double"``). The one-time side-by-side harness above ran against the
-authors' replication package (``opre.2025.1590.cd``).
+(``variance="double"``).
+
+This side-by-side harness is now a **durable benchmark**, not a one-time check:
+``benchmarks/cases/si_prop99.py`` runs the authors' own code -- vendored verbatim
+under ``benchmarks/reference/synth_iv_OR25`` from ``opre.2025.1590.cd`` -- against
+mlsynth's public :class:`~mlsynth.SI` API for all five program states under the
+control and tax interventions, and confirms agreement to **machine precision**
+(max\|diff\| ``1.4e-14``). Run it with
+``python benchmarks/run_benchmarks.py si_prop99``.
 
 The **durable replication does not depend on the authors' code**. Both paths are
 reproduced from public data and mlsynth's own DGPs, and locked in as a test


### PR DESCRIPTION
## What
SI had a thorough replication **test** against the paper's *published numbers*, but the machine-precision check against the **authors' actual code** was described as a one-time harness. Now that we have their replication package (INFORMS `opre.2025.1590.cd`), this makes it a **durable benchmark** — per the contract: *maintain the original authors' code against the module's public API when we have it.*

## Changes
- **Vendored the authors' code verbatim** under `benchmarks/reference/synth_iv_OR25/` (`estimation.py`, `inference.py`, `NOTICE.md` with provenance) — imported, not modified.
- **`benchmarks/cases/si_prop99.py`** reproduces the Section 6 case study: for all five anti-tobacco *program* states, the 1999–2002 counterfactual **under the control and tax interventions** (bias-corrected SI-PCR prediction interval; fit 1970–1988; Gavish-Donoho rank; `variance="double"`). It runs the authors' `HSVT → qr_column_pivoting_selection → OLS` + `variance_estimation`/`predictionInterval` side-by-side with mlsynth's **public `SI` API**.
- Updated `docs/si.rst` (the authors'-code check is now durable).

## Result
- mlsynth's public SI matches the authors' own code to **1.4e-14** across all 5 states × 2 interventions.
- California's intervals equal the published values: control **[70.93, 80.63]**, taxes **[47.99, 67.06]**.

Uses the in-repo `basedata/prop99_packsales.csv` (identical to the authors' pivot of `prop99_raw_data.csv`). Benchmark-only; no test or estimator changes — independent of the in-flight #81 refactor.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_