### PR TITLE
docs phase 1: conventions (no-bold, non-expert framing, benchmark links) + build fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,9 +99,23 @@ migration or refactor PR.
 - One `docs/<name>.rst` per estimator: When-to-use → Notation → Assumptions
   (numbered, each with a Remark) → Inference/diagnostics → runnable Example →
   Verification pointer → Core API autodoc. Follow `agents/agents_docs.md`
-  — the **binding** math-notation canon (symbols derived from the `qdocs`
+  — the binding math-notation canon (symbols derived from the `qdocs`
   blog; Shi–Huang for expository structure).
-- Section underlines must be **≥** the title length (RST requirement).
+- No bold in prose. Never use RST bold (`**...**`) on doc pages or in README
+  prose — the author does not write in bold. Bold is reserved for mathematics
+  (`\mathbf{}` in math). For emphasis use wording, not weight; for terms-of-art
+  use ``literal`` or *italic* sparingly. (Table content and section headings are
+  fine; the rule is about emphasis in prose.)
+- Write for a non-expert reader: assume the reader wants to learn what the
+  method is and does, not that they already know synthetic control. Define
+  jargon on first use.
+- Link every estimator page to its verification: the benchmark case
+  (`benchmarks/cases/<name>.py`, link the source on GitHub) and/or its
+  replication page, so readers can see it is validated and inspect the outputs.
+  Keep the benchmarks index page current as cases are added.
+- Keep the decision tree (`docs/choose.rst`) current as estimators are added or
+  change regime — it is the primary "which estimator do I use" navigation.
+- Section underlines must be ≥ the title length (RST requirement).
 
 ## Git
 

--- a/agents/agents_docs.md
+++ b/agents/agents_docs.md
@@ -48,6 +48,25 @@ Operators and symbols: norms `\|\cdot\|_1`, `\|\cdot\|_2`, squared
 `\mathbf{1}\{\cdot\}`; standard-normal CDF `\Phi(\cdot)`; expectation
 `\mathbb{E}[\cdot]`; Moore–Penrose pseudoinverse `(\cdot)^{+}`.
 
+### Prose emphasis — no bold
+
+**Bold is for mathematics only.** Outside of math (`\mathbf{}` vectors and
+matrices), never use RST bold (`**...**`) in the prose of a doc page or in
+README prose — the author does not write in bold, so a page full of `**…**`
+reads as not-them. This is binding for every page you touch: when migrating a
+page, strip non-math bold along with the symbol conversion.
+
+* For emphasis, choose the *word*, not the weight. If a sentence needs bold to
+  land, rewrite the sentence.
+* For a term of art or an API name use a ``literal`` (double-backtick) role;
+  use *italic* (single asterisk) only sparingly for genuine emphasis on first
+  definition.
+* Section headings, and the cells/headers of `list-table` / grid tables, are
+  fine — the rule is specifically about `**bold**` emphasis runs in sentences.
+
+(The heading above is itself bold only because this is an agent instruction
+file, not a rendered doc page; do not copy that style into `docs/`.)
+
 ### Units
 
 * `\mathcal{N} \coloneqq \{1,\dots,N\}` — all `N` units.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from sphinx_gallery.sorting import FileNameSortKey  # Import FileNameSortKey
 
 sys.path.insert(0, os.path.abspath("../"))
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -183,7 +183,6 @@ headline numbers.
    fscm
    masc
    msqrt
-   tascm
    sparse_sc
    pda
    rescm

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,8 @@
 # Sphinx dependencies
-# Pin to known-good ranges: Sphinx 9 currently breaks the build, and the
-# extensions below need a modern Sphinx (and a modern sphinxcontrib-bibtex).
+# Pin to known-good ranges: Sphinx 9 currently breaks the build.
 sphinx>=7,<9
 sphinx-book-theme>=1.1
-sphinxcontrib-bibtex>=2.5
 sphinx-copybutton>=0.5
-sphinx-gallery>=0.15
 
 pandas
 numpy


### PR DESCRIPTION
First of a phased docs-polish series. This one is mechanical and low-risk.

## Conventions (CLAUDE.md, agents/agents_docs.md)
- No bold in prose on doc pages or in README prose — bold is reserved for mathematics (`\mathbf{}`). The author doesn't write in bold; a page of `**…**` reads as not-them.
- Write for a non-expert reader (explain what the method is and does; define jargon on first use).
- Link every estimator page to its verification (benchmark case source on GitHub and/or replication page); keep a benchmarks index and the `docs/choose.rst` decision tree current.

## Build fixes
- Remove the dead `from sphinx_gallery.sorting import FileNameSortKey` in `docs/conf.py` — an unused import that would crash the whole build if `sphinx-gallery` were absent.
- Drop the unused `sphinx-gallery` / `sphinxcontrib-bibtex` from `docs/requirements.txt` (neither is wired into `extensions`; no `.. bibliography::` / `:cite:` anywhere).
- Remove the ghost `tascm` toctree entry in `docs/index.rst` (no such file — the page is `tasc.rst`), fixing a Sphinx "nonexisting document" warning.

Follow-up phases: README + navigation (estimator table, decision tree, reconcile the estimator count to the canonical 46), a per-page sweep (de-bold, add Notation/Remarks/Verification, accessible framing), and a benchmarks index page with verified numbers.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_