### PR TITLE
refactor(sdid): native active-set simplex QP for unit/time weights

### DIFF
--- a/docs/sdid.rst
+++ b/docs/sdid.rst
@@ -135,11 +135,15 @@ The estimand is the average treatment effect on the treated, :math:`\tau`
 .. admonition:: Notation bridge
 
    The mlsynth implementation generalizes the single-treated block design
-   to cohorts: cohort :math:`a` is the set :math:`I^a` of units first
-   treated in period :math:`a`, with size :math:`N_{tr}^a` and
-   :math:`T_{tr}^a = T - a + 1` post-periods. The classical
+   to cohorts: cohort :math:`a` is the set :math:`I^a \subseteq \{N_{co} +
+   1, \dots, N\}` of units first treated in period :math:`a`, with size
+   :math:`N_{tr}^a = |I^a|` and :math:`T_{tr}^a = T - a + 1` post-periods;
+   :math:`A = \{a_1, \dots, a_K\}` collects the distinct adoption periods,
+   and :math:`T_{post} = \sum_{a \in A} N_{tr}^a T_{tr}^a` is the aggregate
+   post-treatment exposure (Clarke et al., 2023). The classical
    single-treated case (California) is the one-cohort special case, where
-   the cohort ATT and the overall ATT coincide.
+   the cohort ATT and the overall ATT coincide (and this aggregate exposure
+   reduces to the post-period count :math:`T_{post}` above).
 
 Assumptions
 -----------
@@ -232,23 +236,13 @@ Mathematical Formulation
 Setup
 ^^^^^
 
-Let :math:`y_{it}` denote the outcome of unit :math:`i` in period
-:math:`t`, with :math:`i \in \mathcal{N} \coloneqq \{1, \dots, N\}` and
-:math:`t \in \mathcal{T} \coloneqq \{1, \dots, T\}`. There are :math:`N_{co}` never-treated
-control units, and the treated units are partitioned into cohorts by
-their adoption period: cohort :math:`a` is the set
-:math:`I^a \subseteq \{N_{co} + 1, \dots, N\}` of units that first
-receive treatment in period :math:`a`. Let
-:math:`A = \{a_1, \dots, a_K\}` denote the set of distinct adoption
-periods, :math:`N_{tr}^a = |I^a|` the cohort size, and
-:math:`T_{tr}^a = T - a + 1` the number of post-treatment periods in
-cohort :math:`a`. Aggregate post-treatment exposure (Clarke et al.,
-2023) is :math:`T_{post} = \sum_{a \in A} N_{tr}^a T_{tr}^a`.
-
-The classical Arkhangelsky et al. (2021) SDID estimator targets a
-single cohort. The mlsynth implementation runs that estimator
-*per cohort*, accumulates the cohort-specific effects, and then
-aggregates them in two complementary ways (Ciccia, 2024).
+Using the cohort notation introduced above (:math:`I^a`,
+:math:`N_{tr}^a`, :math:`T_{tr}^a`, the adoption-period set :math:`A`, and
+the aggregate exposure :math:`T_{post}`), recall that the classical
+Arkhangelsky et al. (2021) SDID estimator targets a single cohort. The
+mlsynth implementation runs that estimator *per cohort*, accumulates the
+cohort-specific effects, and then aggregates them in two complementary
+ways (Ciccia, 2024).
 
 Cohort-Specific SDID (Equation 2)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mlsynth/tests/test_sdid_weights_native.py
+++ b/mlsynth/tests/test_sdid_weights_native.py
@@ -211,3 +211,71 @@ class TestValidationPreserved:
     def test_time_weights_rejects_1d_donor_matrix(self):
         with pytest.raises(MlsynthDataError):
             fit_time_weights(np.zeros(3), np.zeros(3))
+
+    def test_time_weights_rejects_non_array_donor(self):
+        with pytest.raises(MlsynthDataError):
+            fit_time_weights([[1.0, 2.0]], np.zeros(2))
+
+    def test_time_weights_rejects_non_array_post_mean(self):
+        with pytest.raises(MlsynthDataError):
+            fit_time_weights(np.zeros((3, 2)), [0.0, 0.0])
+
+    def test_time_weights_rejects_2d_post_mean(self):
+        with pytest.raises(MlsynthDataError):
+            fit_time_weights(np.zeros((3, 2)), np.zeros((2, 1)))
+
+    def test_time_weights_rejects_zero_pre_periods(self):
+        with pytest.raises(MlsynthDataError):
+            fit_time_weights(np.zeros((0, 2)), np.zeros(2))
+
+    def test_time_weights_rejects_zero_donors(self):
+        with pytest.raises(MlsynthDataError):
+            fit_time_weights(np.zeros((3, 0)), np.zeros(0))
+
+    def test_unit_weights_rejects_non_array_target(self):
+        with pytest.raises(MlsynthDataError):
+            unit_weights(np.zeros((3, 2)), [0.0, 0.0, 0.0], 0.1)
+
+    def test_unit_weights_rejects_2d_target(self):
+        with pytest.raises(MlsynthDataError):
+            unit_weights(np.zeros((3, 2)), np.zeros((3, 1)), 0.1)
+
+    def test_unit_weights_rejects_zero_pre_periods(self):
+        with pytest.raises(MlsynthDataError):
+            unit_weights(np.zeros((0, 2)), np.zeros(0), 0.1)
+
+    def test_unit_weights_rejects_zero_donors(self):
+        with pytest.raises(MlsynthDataError):
+            unit_weights(np.zeros((3, 0)), np.zeros(3), 0.1)
+
+    def test_unit_weights_rejects_1d_donor_matrix(self):
+        with pytest.raises(MlsynthDataError):
+            unit_weights(np.zeros(3), np.zeros(3), 0.1)
+
+
+class TestRegularizationBranches:
+    def test_rejects_non_array(self):
+        with pytest.raises(MlsynthDataError):
+            compute_regularization([[1.0]], 5)
+
+    def test_rejects_1d(self):
+        with pytest.raises(MlsynthDataError):
+            compute_regularization(np.zeros(5), 5)
+
+    def test_rejects_negative_post_periods(self):
+        with pytest.raises(MlsynthConfigError):
+            compute_regularization(np.zeros((5, 3)), -1)
+
+    def test_single_pre_period_fallback(self):
+        # < 2 pre-periods -> std fallback of 1.0 -> zeta = post^0.25.
+        zeta = compute_regularization(np.zeros((1, 3)), 16)
+        assert zeta == pytest.approx(16 ** 0.25, abs=1e-9)
+
+    def test_no_donors_fallback(self):
+        zeta = compute_regularization(np.zeros((5, 0)), 16)
+        assert zeta == pytest.approx(16 ** 0.25, abs=1e-9)
+
+    def test_nan_std_fallback(self):
+        # All-NaN diffs -> NaN std -> fallback of 1.0 -> zeta = post^0.25.
+        zeta = compute_regularization(np.full((5, 3), np.nan), 16)
+        assert zeta == pytest.approx(16 ** 0.25, abs=1e-9)

--- a/mlsynth/tests/test_sdid_weights_native.py
+++ b/mlsynth/tests/test_sdid_weights_native.py
@@ -1,0 +1,213 @@
+"""Native (cvxpy-free) SDID weight solvers: parity + independence tests.
+
+The SDID unit- and time-weight programs are simplex-constrained least squares
+with a free intercept (and, for unit weights, an L2 ridge). Both reduce to the
+library's active-set simplex QP (``bilevel.active_set.solve_simplex_qp``) once
+the intercept is profiled out by centering over the observation axis and the
+ridge is folded in by augmenting the design with a ``sqrt(lambda) * I`` block.
+
+These tests pin two things, TDD-first:
+
+1. **Parity** -- on strictly-convex (unique-optimum) instances the native
+   solvers reproduce the cvxpy/CLARABEL oracle (weights *and* intercept) to
+   high tolerance. Uniqueness is guaranteed by construction: the unit-weight
+   program carries a positive ridge; the time-weight instance is overdetermined
+   (more donors than pre-periods).
+2. **Independence** -- the native solvers never touch cvxpy. We monkeypatch
+   ``cvxpy.Problem`` to explode and assert the solvers still return correct
+   results.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.sdid_helpers.weights import (
+    compute_regularization,
+    fit_time_weights,
+    unit_weights,
+)
+
+
+# ---------------------------------------------------------------------------
+# cvxpy oracles (mirror the pre-refactor implementation exactly)
+# ---------------------------------------------------------------------------
+
+def _unit_weights_cvxpy(Y0_pre, y_treated_pre, zeta):
+    import cvxpy as cp
+
+    T0, N = Y0_pre.shape
+    a = cp.Variable()
+    w = cp.Variable(N, nonneg=True)
+    pred = a + Y0_pre @ w
+    penalty = T0 * (float(zeta) ** 2) * cp.sum_squares(w)
+    prob = cp.Problem(
+        cp.Minimize(cp.sum_squares(pred - y_treated_pre) + penalty),
+        [cp.sum(w) == 1],
+    )
+    prob.solve(solver=cp.CLARABEL)
+    return float(a.value), np.asarray(w.value).ravel()
+
+
+def _time_weights_cvxpy(Y0_pre, mean_post):
+    import cvxpy as cp
+
+    T0, N = Y0_pre.shape
+    a = cp.Variable()
+    lam = cp.Variable(T0, nonneg=True)
+    pred = a + (lam @ Y0_pre)
+    prob = cp.Problem(
+        cp.Minimize(cp.sum_squares(pred - mean_post)),
+        [cp.sum(lam) == 1],
+    )
+    prob.solve(solver=cp.CLARABEL)
+    return float(a.value), np.asarray(lam.value).ravel()
+
+
+# ---------------------------------------------------------------------------
+# Parity (strictly-convex / unique optimum)
+# ---------------------------------------------------------------------------
+
+class TestParityWithCvxpy:
+    def test_unit_weights_match_oracle(self):
+        rng = np.random.default_rng(11)
+        T0, N = 18, 6
+        Y0_pre = rng.standard_normal((T0, N)) * 3 + 10
+        y_pre = rng.standard_normal(T0) * 3 + 10
+        zeta = compute_regularization(Y0_pre, 12)
+        a_ref, w_ref = _unit_weights_cvxpy(Y0_pre, y_pre, zeta)
+
+        a, w = unit_weights(Y0_pre, y_pre, zeta)
+        assert w is not None
+        np.testing.assert_allclose(w, w_ref, atol=1e-6)
+        assert a == pytest.approx(a_ref, abs=1e-6)
+
+    def test_unit_weights_match_oracle_underdetermined_with_ridge(self):
+        # J > T0: the *unregularized* fit is non-unique, but the ridge makes
+        # the program strictly convex, so the optimum is unique and the native
+        # solver must still reproduce CLARABEL.
+        rng = np.random.default_rng(12)
+        T0, N = 8, 20
+        Y0_pre = rng.standard_normal((T0, N)) * 2 + 5
+        y_pre = rng.standard_normal(T0) * 2 + 5
+        zeta = compute_regularization(Y0_pre, 10)
+        a_ref, w_ref = _unit_weights_cvxpy(Y0_pre, y_pre, zeta)
+
+        a, w = unit_weights(Y0_pre, y_pre, zeta)
+        np.testing.assert_allclose(w, w_ref, atol=1e-6)
+        assert a == pytest.approx(a_ref, abs=1e-6)
+
+    def test_time_weights_match_oracle_overdetermined(self):
+        # More donors than pre-periods -> overdetermined -> unique optimum.
+        rng = np.random.default_rng(13)
+        T0, N = 10, 40
+        Y0_pre = rng.standard_normal((T0, N)) * 4 + 8
+        mean_post = rng.standard_normal(N) * 4 + 8
+        a_ref, lam_ref = _time_weights_cvxpy(Y0_pre, mean_post)
+
+        a, lam = fit_time_weights(Y0_pre, mean_post)
+        assert lam is not None
+        np.testing.assert_allclose(lam, lam_ref, atol=1e-6)
+        assert a == pytest.approx(a_ref, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Simplex feasibility + intercept optimality
+# ---------------------------------------------------------------------------
+
+class TestFeasibilityAndIntercept:
+    def test_unit_weights_simplex(self):
+        rng = np.random.default_rng(20)
+        Y0_pre = rng.standard_normal((12, 5))
+        y_pre = rng.standard_normal(12)
+        a, w = unit_weights(Y0_pre, y_pre, 0.1)
+        assert w.shape == (5,)
+        assert w.sum() == pytest.approx(1.0, abs=1e-9)
+        assert (w >= -1e-9).all()
+        assert np.isfinite(a)
+
+    def test_time_weights_simplex(self):
+        rng = np.random.default_rng(21)
+        Y0_pre = rng.standard_normal((10, 25))
+        mean_post = rng.standard_normal(25)
+        a, lam = fit_time_weights(Y0_pre, mean_post)
+        assert lam.shape == (10,)
+        assert lam.sum() == pytest.approx(1.0, abs=1e-9)
+        assert (lam >= -1e-9).all()
+        assert np.isfinite(a)
+
+    def test_unit_weights_intercept_is_profiled_optimum(self):
+        # For the returned weights, the optimal free intercept is the mean
+        # residual a* = mean(y - Y0 @ w); the solver must return exactly that.
+        rng = np.random.default_rng(22)
+        T0, N = 15, 6
+        Y0_pre = rng.standard_normal((T0, N)) * 2
+        y_pre = rng.standard_normal(T0) * 2
+        a, w = unit_weights(Y0_pre, y_pre, 0.2)
+        a_star = float(np.mean(y_pre - Y0_pre @ w))
+        assert a == pytest.approx(a_star, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Independence from cvxpy
+# ---------------------------------------------------------------------------
+
+class TestNoCvxpyDependence:
+    def test_unit_weights_without_cvxpy(self, monkeypatch):
+        import cvxpy
+
+        def boom(*a, **k):  # pragma: no cover - must never be called
+            raise AssertionError("native unit_weights must not call cvxpy")
+
+        monkeypatch.setattr(cvxpy, "Problem", boom)
+        rng = np.random.default_rng(30)
+        Y0_pre = rng.standard_normal((12, 5))
+        y_pre = rng.standard_normal(12)
+        a, w = unit_weights(Y0_pre, y_pre, 0.1)
+        assert w.sum() == pytest.approx(1.0, abs=1e-9)
+
+    def test_time_weights_without_cvxpy(self, monkeypatch):
+        import cvxpy
+
+        def boom(*a, **k):  # pragma: no cover - must never be called
+            raise AssertionError("native fit_time_weights must not call cvxpy")
+
+        monkeypatch.setattr(cvxpy, "Problem", boom)
+        rng = np.random.default_rng(31)
+        Y0_pre = rng.standard_normal((10, 20))
+        mean_post = rng.standard_normal(20)
+        a, lam = fit_time_weights(Y0_pre, mean_post)
+        assert lam.sum() == pytest.approx(1.0, abs=1e-9)
+
+    def test_module_does_not_import_cvxpy(self):
+        import mlsynth.utils.sdid_helpers.weights as wmod
+
+        assert not hasattr(wmod, "cp"), "weights.py should no longer import cvxpy as cp"
+
+
+# ---------------------------------------------------------------------------
+# Validation contract preserved
+# ---------------------------------------------------------------------------
+
+class TestValidationPreserved:
+    def test_unit_weights_rejects_non_array(self):
+        with pytest.raises(MlsynthDataError):
+            unit_weights([[1.0]], np.zeros(1), 0.1)
+
+    def test_unit_weights_rejects_negative_zeta(self):
+        with pytest.raises(MlsynthConfigError):
+            unit_weights(np.zeros((2, 2)), np.zeros(2), -1.0)
+
+    def test_unit_weights_rejects_shape_mismatch(self):
+        with pytest.raises(MlsynthDataError):
+            unit_weights(np.zeros((3, 2)), np.zeros(4), 0.1)
+
+    def test_time_weights_rejects_donor_mismatch(self):
+        with pytest.raises(MlsynthDataError):
+            fit_time_weights(np.zeros((3, 2)), np.zeros(5))
+
+    def test_time_weights_rejects_1d_donor_matrix(self):
+        with pytest.raises(MlsynthDataError):
+            fit_time_weights(np.zeros(3), np.zeros(3))

--- a/mlsynth/utils/sdid_helpers/weights.py
+++ b/mlsynth/utils/sdid_helpers/weights.py
@@ -239,7 +239,7 @@ def compute_regularization(
     else:
         # Calculate first differences of donor outcomes along the time axis (axis=0).
         diffs = np.diff(donor_outcomes_pre_treatment, axis=0)
-        if diffs.size == 0: # Can happen if T0=1 (already caught by shape[0]<2) or N_donors=0 (caught by shape[1]==0).
+        if diffs.size == 0: # pragma: no cover - unreachable: T0<2 and N_donors==0 are both caught above.
              std_dev_of_first_differenced_donor_outcomes = 1.0 # Fallback if differences result in an empty array.
         else:
              # Calculate standard deviation of these differences. ddof=1 for sample standard deviation.

--- a/mlsynth/utils/sdid_helpers/weights.py
+++ b/mlsynth/utils/sdid_helpers/weights.py
@@ -1,14 +1,83 @@
 """Unit-weight, time-weight, and regularization solvers for SDID.
 
-Verbatim from the previous monolithic ``sdidutils.py``; kept untouched so the
-Prop 99 ATT remains numerically identical to the pre-refactor result.
+Both SDID weight programs are simplex-constrained least squares with a free
+intercept (and, for the unit weights, an L2 ridge):
+
+* unit weights ``omega`` minimise
+  ``||a + Y0_pre @ omega - y_treated_pre||^2 + T0 * zeta^2 * ||omega||^2``
+  subject to ``sum(omega) = 1, omega >= 0`` (Arkhangelsky et al. 2021 eq. 4 /
+  Clarke et al. 2024 eq. 4);
+* time weights ``lambda`` minimise
+  ``||a + lambda @ Y0_pre - mean_post||^2`` subject to ``sum(lambda) = 1,
+  lambda >= 0`` (eq. 6).
+
+Rather than canonicalise these through cvxpy on every call -- expensive in the
+placebo / jackknife loops, which re-solve them hundreds of times -- we solve
+them natively with the library's active-set simplex QP
+(:func:`mlsynth.utils.bilevel.active_set.solve_simplex_qp`). Two standard
+reductions make the active-set primitive applicable without changing the
+optimum:
+
+1. the free intercept ``a`` is *profiled out* by centering the design and
+   target over the observation axis (for fixed weights, the optimal intercept
+   is the mean residual, which is exactly what centering enforces); the
+   intercept is recovered afterwards as ``a* = mean(target) - colmean(X) @ w``;
+2. the unit-weight ridge ``lambda_r = T0 * zeta^2`` is folded in by stacking a
+   ``sqrt(lambda_r) * I`` block beneath the centered design with a zero target,
+   so ``||X_aug w - b_aug||^2 == ||X_c w - b_c||^2 + lambda_r ||w||^2``.
+
+Both reduced programs are strictly convex on SDID's panels (the unit program by
+the positive ridge; the time program because the donors outnumber the
+pre-periods), so the optimum is unique and the active-set solution coincides
+with CLARABEL's to solver tolerance -- the Prop 99 ATT is preserved bit-for-bit
+within the pinned benchmark tolerance. Parity is asserted in
+``tests/test_sdid_weights_native.py``.
 """
 
 import numpy as np
-import cvxpy as cp
 from typing import Optional, Tuple
 
-from mlsynth.exceptions import MlsynthDataError, MlsynthConfigError, MlsynthEstimationError
+from mlsynth.exceptions import MlsynthDataError, MlsynthConfigError
+from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+
+
+def _solve_intercept_simplex(
+    design: np.ndarray, target: np.ndarray, ridge: float = 0.0
+) -> Tuple[float, np.ndarray]:
+    """Simplex least squares with a free intercept and optional L2 ridge.
+
+    Solves ``min_{a, w} ||a + design @ w - target||^2 + ridge * ||w||^2`` over
+    ``sum(w) = 1, w >= 0`` and returns ``(a, w)``. The intercept is profiled out
+    by centering over the observation (row) axis; the ridge is folded in by
+    augmenting the centered design with a ``sqrt(ridge) * I`` block.
+
+    Parameters
+    ----------
+    design : np.ndarray, shape (m, J)
+        Design matrix (observations x weights).
+    target : np.ndarray, shape (m,)
+        Target vector.
+    ridge : float, optional
+        Non-negative L2 penalty coefficient on ``w`` (default ``0``).
+
+    Returns
+    -------
+    (intercept, weights) : tuple of (float, np.ndarray)
+        The optimal free intercept and the ``(J,)`` simplex weights.
+    """
+    col_mean = design.mean(axis=0)
+    target_mean = float(target.mean())
+    design_c = design - col_mean[None, :]
+    target_c = target - target_mean
+
+    if ridge > 0.0:
+        J = design_c.shape[1]
+        design_c = np.vstack([design_c, np.sqrt(ridge) * np.eye(J)])
+        target_c = np.concatenate([target_c, np.zeros(J)])
+
+    weights = solve_simplex_qp(design_c, target_c)
+    intercept = target_mean - float(col_mean @ weights)
+    return intercept, weights
 
 
 def fit_time_weights(
@@ -88,32 +157,18 @@ def fit_time_weights(
             f"but mean_donor_outcomes_post_treatment has {num_donors_post} donors."
         )
 
-    # Define CVXPY optimization variables.
-    intercept_variable = cp.Variable() # Intercept term (beta_0).
-    time_weights_variable = cp.Variable(num_pre_treatment_periods, nonneg=True) # Time weights (lambda_t), constrained to be non-negative.
-    
-    # Define the prediction model: intercept + time_weights @ donor_outcomes_pre_treatment.
-    # This reconstructs the mean post-treatment donor outcomes using weighted pre-treatment donor outcomes.
-    prediction = intercept_variable + (time_weights_variable @ donor_outcomes_pre_treatment)
-    # Define constraints: time weights must sum to 1.
-    constraints = [cp.sum(time_weights_variable) == 1]
-    # Define the objective: minimize sum of squared differences between actual and predicted mean post-treatment donor outcomes.
-    objective = cp.Minimize(cp.sum_squares(prediction - mean_donor_outcomes_post_treatment))
-    # Create and solve the CVXPY problem.
-    problem = cp.Problem(objective, constraints)
-    
-    try:
-        problem.solve(solver=cp.CLARABEL) # Using CLARABEL solver.
-    except cp.error.SolverError as e: # Catch solver errors.
-        raise MlsynthEstimationError(f"CVXPY solver failed in fit_time_weights: {e}") from e
-
-    # Check problem status and return results if optimal or optimal_inaccurate.
-    if problem.status in ["optimal", "optimal_inaccurate"]:
-        return intercept_variable.value, time_weights_variable.value
-    # If solver finishes but status is not optimal/optimal_inaccurate,
-    # it implies a failure to find a good solution. Returning None, None is current behavior.
-    # This indicates the optimization did not converge to a satisfactory solution.
-    return None, None
+    # Native simplex least squares with a free intercept. The time weights
+    # reconstruct the mean post-treatment donor outcomes (one per donor) as a
+    # weighted average over pre-treatment periods, so the *observations* are the
+    # donors and the *weights* are the time periods: the design is
+    # ``donor_outcomes_pre_treatment.T`` (N_donors x T0) and the target is
+    # ``mean_donor_outcomes_post_treatment`` (N_donors,). No ridge (eq. 6 uses
+    # only an infinitesimal tie-breaker, which the overdetermined Prop 99 system
+    # does not need).
+    intercept, time_weights = _solve_intercept_simplex(
+        donor_outcomes_pre_treatment.T, mean_donor_outcomes_post_treatment
+    )
+    return float(intercept), time_weights
 
 
 def compute_regularization(
@@ -279,35 +334,17 @@ def unit_weights(
             f"but mean_treated_outcome_pre_treatment has {mean_treated_outcome_pre_treatment.shape[0]}."
         )
 
-    # Define CVXPY optimization variables.
-    intercept_variable = cp.Variable() # Intercept term (beta_0).
-    unit_weights_variable = cp.Variable(num_donors, nonneg=True) # Unit (donor) weights (omega_j), constrained to be non-negative.
-    
-    # Define the prediction model: intercept + donor_outcomes_pre_treatment @ unit_weights.
-    # This reconstructs the mean pre-treatment treated outcome using weighted donor outcomes.
-    prediction = intercept_variable + donor_outcomes_pre_treatment @ unit_weights_variable
-    
-    # Define the L2 regularization penalty on unit weights.
-    # Penalty = T0 * zeta^2 * sum_squares(omega).
-    # Ensure penalty term is well-defined even if num_pre_treatment_periods is 0 (though caught above by validation).
-    penalty_coefficient = num_pre_treatment_periods * (float(regularization_parameter_zeta)**2)
-    penalty = penalty_coefficient * cp.sum_squares(unit_weights_variable)
-    
-    # Define the objective: minimize sum of squared differences between actual and predicted mean treated outcome, plus the L2 penalty.
-    objective = cp.Minimize(cp.sum_squares(prediction - mean_treated_outcome_pre_treatment) + penalty)
-    # Define constraints: unit weights must sum to 1.
-    constraints = [cp.sum(unit_weights_variable) == 1]
-    # Create and solve the CVXPY problem.
-    problem = cp.Problem(objective, constraints)
-    
-    try:
-        problem.solve(solver=cp.CLARABEL) # Using CLARABEL solver.
-    except cp.error.SolverError as e: # Catch solver errors.
-        raise MlsynthEstimationError(f"CVXPY solver failed in unit_weights: {e}") from e
-
-    # Check problem status and return results if optimal or optimal_inaccurate.
-    if problem.status in ["optimal", "optimal_inaccurate"]:
-        return intercept_variable.value, unit_weights_variable.value
-    # If solver finishes but status is not optimal/optimal_inaccurate,
-    # it implies a failure to find a good solution. Returning None, None indicates this.
-    return None, None
+    # Native simplex least squares with a free intercept and the SDID ridge.
+    # The unit weights reconstruct the mean pre-treatment treated trajectory
+    # from the donors, so the *observations* are the pre-periods and the
+    # *weights* are the donors: the design is ``donor_outcomes_pre_treatment``
+    # (T0 x N_donors) and the target is ``mean_treated_outcome_pre_treatment``
+    # (T0,). The ridge coefficient T0 * zeta^2 (eq. 4) makes the program
+    # strictly convex.
+    penalty_coefficient = num_pre_treatment_periods * (float(regularization_parameter_zeta) ** 2)
+    intercept, omega = _solve_intercept_simplex(
+        donor_outcomes_pre_treatment,
+        mean_treated_outcome_pre_treatment,
+        ridge=penalty_coefficient,
+    )
+    return float(intercept), omega


### PR DESCRIPTION
## Summary

Replaces the cvxpy/CLARABEL weight solvers in SDID with the library's native
active-set simplex QP (`bilevel.active_set.solve_simplex_qp`), removing cvxpy
from the SDID weight path. Both SDID weight programs reduce to the active-set
primitive without changing the optimum:

- the free intercept is profiled out by centering the design and target over the
  observation axis (recovering `a* = mean(target) - colmean(X) @ w` afterward);
- the unit-weight ridge `T0 * zeta^2` is folded in by augmenting the centered
  design with a `sqrt(ridge) * I` block.

Both reduced programs are strictly convex on SDID panels (the unit program by the
positive ridge; the time program because the donors outnumber the pre-periods),
so the optimum is unique and the active-set solution coincides with CLARABEL's to
solver tolerance. The active-set primitive is already the library's established
cvxpy-replacement; it solves this exact problem class exactly and avoids cvxpy's
per-call canonicalisation overhead in the placebo / jackknife loops.

Also deduplicates the SDID docs page, which defined notation twice (the
`Notation` section + bridge, then `Mathematical Formulation > Setup` re-declaring
it). The new symbols (`A`, the aggregate `T_post`) move into the bridge; `Setup`
now references the established notation, matching the `seq_sdid` convention.

## Verification

- New `tests/test_sdid_weights_native.py`: cvxpy parity on strictly-convex
  instances (weights + intercept to 1e-6), simplex feasibility, intercept
  optimality, and independence from cvxpy (monkeypatched `Problem`).
- `sdid_helpers/weights.py` at 100% line coverage.
- Full SDID suite green; SDID-family suites (seq_sdid, spsydid, iscm) green.
- Gate: `sdid_prop99` cross-validation benchmark passes — ATT -15.61
  (|Δ|=0.0014, tol 0.05) and causaltensor abs-diff 0.0031 (tol 0.005).

Blast radius is confined to the SDID estimator; no other estimator imports these
functions.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_