### PR TITLE
refactor(mlsc): native active-set simplex QP for weights + cross-validation

### DIFF
--- a/mlsynth/tests/test_mlsc_native_weights.py
+++ b/mlsynth/tests/test_mlsc_native_weights.py
@@ -1,0 +1,254 @@
+"""Native (active-set) MLSC weight solvers: parity + independence tests.
+
+The MLSC program is a penalized simplex least squares,
+
+    min_omega ||Y - X omega||^2 + lambda * sigma_y^2 * omega^T Q omega
+    s.t. sum(omega) = 1, omega >= 0,
+
+with the block penalty ``Q = R^T R`` (``R_s = I - v_s 1^T`` per block). It is
+strictly convex for any lambda > 0 whenever the aggregate control matrix has full
+column rank (the penalty fills exactly the part of X's null space the aggregate
+directions do not), so the optimum is unique. That lets us solve it with the
+library's active-set simplex QP after folding the penalty into the design as a
+``sqrt(lambda sigma_y^2) R`` augmentation -- no cvxpy on the default path.
+
+These tests pin, TDD-first:
+
+1. ``R^T R == Q`` (the square-root factor),
+2. parity with a cvxpy/CLARABEL oracle on strictly-convex instances
+   (lambda > 0 and the lambda = 0 ridge branch),
+3. simplex feasibility,
+4. cross-validation selecting the same grid penalty as a cvxpy oracle,
+5. independence from cvxpy on the default (solver=None) path,
+6. the explicit-solver escape hatch still routing through cvxpy.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.mlsc_helpers.crossval import _DEFAULT_GRID, select_lambda_cv
+from mlsynth.utils.mlsc_helpers.optimization import solve_mlsc
+from mlsynth.utils.mlsc_helpers.penalty import (
+    build_penalty_matrix,
+    build_sqrt_factor,
+)
+from mlsynth.utils.mlsc_helpers.setup import prepare_mlsc_inputs
+from mlsynth.utils.mlsc_helpers.simulation import simulate_mlsc_sample
+from mlsynth.utils.mlsc_helpers.variance import estimate_variance_components
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _inputs(seed: int = 0):
+    s = simulate_mlsc_sample(rng=np.random.default_rng(seed))
+    return prepare_mlsc_inputs(
+        s.df_agg, s.df_disagg, outcome="y", time="time", treat="treated",
+        unitid_agg="state", unitid_disagg="county", agg_id="state",
+        weight_col=None,
+    )
+
+
+def _problem(seed: int = 0):
+    inputs = _inputs(seed)
+    Q = build_penalty_matrix(inputs.v_population, inputs.disagg_to_agg)
+    _, sigma_y2 = estimate_variance_components(inputs)
+    return inputs, Q, float(sigma_y2)
+
+
+def _solve_cvxpy_oracle(inputs, Q, lambda_val, sigma_y2):
+    """CLARABEL oracle for the penalized simplex program (lambda=0 -> 1e-8 ridge)."""
+    import cvxpy as cp
+
+    T0 = inputs.T0
+    Y = inputs.Y_agg_treated[:T0]
+    X = inputs.X_disagg[:T0, :]
+    M = inputs.M
+    w = cp.Variable(M)
+    ps = float(lambda_val) * float(sigma_y2)
+    terms = [cp.sum_squares(Y - X @ w)]
+    if ps > 0:
+        terms.append(ps * cp.quad_form(w, cp.psd_wrap(Q)))
+    else:
+        terms.append(1e-8 * cp.sum_squares(w))
+    cp.Problem(cp.Minimize(sum(terms)), [cp.sum(w) == 1, w >= 0]).solve(solver=cp.CLARABEL)
+    wv = np.clip(np.asarray(w.value, dtype=float), 0.0, None)
+    return wv / wv.sum()
+
+
+# ---------------------------------------------------------------------------
+# Square-root factor
+# ---------------------------------------------------------------------------
+
+class TestSqrtFactor:
+    def test_reconstructs_Q(self):
+        inputs = _inputs(0)
+        Q = build_penalty_matrix(inputs.v_population, inputs.disagg_to_agg)
+        R = build_sqrt_factor(inputs.v_population, inputs.disagg_to_agg)
+        np.testing.assert_allclose(R.T @ R, Q, atol=1e-10)
+
+    def test_shape(self):
+        inputs = _inputs(0)
+        R = build_sqrt_factor(inputs.v_population, inputs.disagg_to_agg)
+        assert R.shape == (inputs.M, inputs.M)
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            build_sqrt_factor(np.array([0.5, 0.5]), np.array([0]))
+
+    def test_penalty_matrix_length_mismatch_raises(self):
+        from mlsynth.utils.mlsc_helpers.penalty import build_penalty_matrix
+
+        with pytest.raises(ValueError):
+            build_penalty_matrix(np.array([0.5, 0.5]), np.array([0]))
+
+
+# ---------------------------------------------------------------------------
+# Parity with cvxpy (strictly convex -> unique)
+# ---------------------------------------------------------------------------
+
+class TestSolveParity:
+    def test_lambda_positive_matches_oracle(self):
+        inputs, Q, sigma_y2 = _problem(0)
+        lam = 5.0
+        omega, agg, status = solve_mlsc(inputs, Q, lam, sigma_y2)
+        ref = _solve_cvxpy_oracle(inputs, Q, lam, sigma_y2)
+        np.testing.assert_allclose(omega, ref, atol=1e-5)
+
+    def test_lambda_positive_aggregate_weights(self):
+        inputs, Q, sigma_y2 = _problem(1)
+        omega, agg, _ = solve_mlsc(inputs, Q, 2.0, sigma_y2)
+        S = int(inputs.disagg_to_agg.max() + 1)
+        expect = np.array([omega[inputs.disagg_to_agg == s].sum() for s in range(S)])
+        np.testing.assert_allclose(agg, expect, atol=1e-10)
+        assert agg.sum() == pytest.approx(1.0, abs=1e-6)
+
+    def test_lambda_zero_ridge_matches_oracle(self):
+        inputs, Q, sigma_y2 = _problem(2)
+        omega, _, _ = solve_mlsc(inputs, Q, 0.0, sigma_y2)
+        ref = _solve_cvxpy_oracle(inputs, Q, 0.0, sigma_y2)
+        np.testing.assert_allclose(omega, ref, atol=1e-4)
+
+
+class TestFeasibility:
+    @pytest.mark.parametrize("lam", [0.0, 1e-3, 1.0, 100.0])
+    def test_simplex(self, lam):
+        inputs, Q, sigma_y2 = _problem(3)
+        omega, agg, _ = solve_mlsc(inputs, Q, lam, sigma_y2)
+        assert omega.shape == (inputs.M,)
+        assert omega.sum() == pytest.approx(1.0, abs=1e-6)
+        assert (omega >= -1e-8).all()
+
+
+# ---------------------------------------------------------------------------
+# Cross-validation parity
+# ---------------------------------------------------------------------------
+
+class TestCrossValidation:
+    def _cv_cvxpy_oracle(self, inputs, Q, sigma_y2, grid):
+        import cvxpy as cp
+
+        T0 = inputs.T0
+        t_cv = T0 - 1
+        Y = inputs.Y_agg_treated[:T0]
+        X = inputs.X_disagg[:T0, :]
+        Xtr, Ytr = X[:t_cv], Y[:t_cv]
+        Xte, Yte = X[t_cv:T0], Y[t_cv:T0]
+        M = Xtr.shape[1]
+        err = np.full(len(grid), np.inf)
+        for i, v in enumerate(grid):
+            w = cp.Variable(M)
+            if v == 0.0:
+                obj = cp.sum_squares(Ytr - Xtr @ w) + 1e-8 * cp.sum_squares(w)
+            else:
+                obj = (cp.sum_squares(Ytr - Xtr @ w)
+                       + v * sigma_y2 * cp.quad_form(w, cp.psd_wrap(Q)))
+            cp.Problem(cp.Minimize(obj), [cp.sum(w) == 1, w >= 0]).solve(solver=cp.CLARABEL)
+            if w.value is not None:
+                err[i] = float(np.mean((Yte - Xte @ np.asarray(w.value)) ** 2))
+        return float(grid[int(np.argmin(err))])
+
+    def test_selects_same_grid_penalty_as_oracle(self):
+        inputs, Q, sigma_y2 = _problem(0)
+        grid = np.asarray(_DEFAULT_GRID, dtype=float)
+        lam = select_lambda_cv(inputs, Q, sigma_y2)
+        lam_ref = self._cv_cvxpy_oracle(inputs, Q, sigma_y2, grid)
+        # Same grid step, or within one neighbouring step (CV curve can be flat).
+        idx = int(np.argmin(np.abs(grid - lam)))
+        idx_ref = int(np.argmin(np.abs(grid - lam_ref)))
+        assert abs(idx - idx_ref) <= 1
+
+    def test_returns_grid_member(self):
+        inputs, Q, sigma_y2 = _problem(1)
+        lam = select_lambda_cv(inputs, Q, sigma_y2)
+        assert np.isclose(np.asarray(_DEFAULT_GRID, dtype=float), lam).any()
+
+    def test_too_few_periods_raises(self):
+        inputs, Q, sigma_y2 = _problem(0)
+        with pytest.raises(ValueError):
+            select_lambda_cv(inputs, Q, sigma_y2, cv_holdout_periods=inputs.T0)
+
+
+# ---------------------------------------------------------------------------
+# Independence from cvxpy (default path)
+# ---------------------------------------------------------------------------
+
+class TestNoCvxpyDefaultPath:
+    def test_solve_without_cvxpy(self, monkeypatch):
+        import cvxpy
+
+        def boom(*a, **k):  # pragma: no cover - must never be called
+            raise AssertionError("native solve_mlsc must not call cvxpy")
+
+        monkeypatch.setattr(cvxpy, "Problem", boom)
+        inputs, Q, sigma_y2 = _problem(0)
+        omega, _, _ = solve_mlsc(inputs, Q, 3.0, sigma_y2)
+        assert omega.sum() == pytest.approx(1.0, abs=1e-6)
+
+    def test_cv_without_cvxpy(self, monkeypatch):
+        import cvxpy
+
+        def boom(*a, **k):  # pragma: no cover - must never be called
+            raise AssertionError("native select_lambda_cv must not call cvxpy")
+
+        monkeypatch.setattr(cvxpy, "Problem", boom)
+        inputs, Q, sigma_y2 = _problem(0)
+        lam = select_lambda_cv(inputs, Q, sigma_y2)
+        assert np.isfinite(lam)
+
+    def test_modules_do_not_import_cvxpy(self):
+        import mlsynth.utils.mlsc_helpers.crossval as cv
+        import mlsynth.utils.mlsc_helpers.optimization as op
+
+        assert not hasattr(op, "cp")
+        assert not hasattr(cv, "cp")
+
+
+# ---------------------------------------------------------------------------
+# Explicit-solver escape hatch
+# ---------------------------------------------------------------------------
+
+class TestExplicitSolverEscapeHatch:
+    def test_explicit_solver_matches_native(self):
+        import cvxpy as cp
+
+        inputs, Q, sigma_y2 = _problem(0)
+        omega_native, _, _ = solve_mlsc(inputs, Q, 5.0, sigma_y2)
+        omega_cvxpy, _, _ = solve_mlsc(inputs, Q, 5.0, sigma_y2, solver=cp.CLARABEL)
+        np.testing.assert_allclose(omega_native, omega_cvxpy, atol=1e-5)
+
+    def test_explicit_solver_cv_matches_native(self):
+        # Routes select_lambda_cv through the cvxpy grid sweep (incl. the
+        # lambda=0 county-SC branch); should pick the same grid penalty.
+        import cvxpy as cp
+
+        inputs, Q, sigma_y2 = _problem(0)
+        grid = np.asarray(_DEFAULT_GRID, dtype=float)
+        lam_native = select_lambda_cv(inputs, Q, sigma_y2)
+        lam_cvxpy = select_lambda_cv(inputs, Q, sigma_y2, solver=cp.CLARABEL)
+        idx = int(np.argmin(np.abs(grid - lam_native)))
+        idx_cvxpy = int(np.argmin(np.abs(grid - lam_cvxpy)))
+        assert abs(idx - idx_cvxpy) <= 1

--- a/mlsynth/utils/mlsc_helpers/crossval.py
+++ b/mlsynth/utils/mlsc_helpers/crossval.py
@@ -11,14 +11,22 @@ implementation (``multi_level_sc_estimator.mlSC``): the same train/test split
 ``||Y - X omega||^2 + lambda * sigma_y^2 * omega^T Q omega`` on the simplex, and
 the same default grid (with a ``0`` candidate that drops the penalty to recover
 fully-disaggregated SC, regularized by a tiny ridge for a unique solution).
+
+Each grid penalty is solved by the native active-set simplex QP after folding the
+penalty into the design as a ``sqrt(lambda sigma_y^2) R`` augmentation (``R^T R ==
+Q``); since every grid point is strictly convex (the ``lambda = 0`` point via the
+ridge floor), the optimum is unique and matches cvxpy to solver tolerance with no
+canonicalisation overhead in the loop. An explicit ``solver`` routes through
+cvxpy instead.
 """
 from __future__ import annotations
 
 from typing import Any, Optional, Sequence
 
-import cvxpy as cp
 import numpy as np
 
+from .optimization import _RIDGE_FLOOR, _augmented_design
+from .penalty import build_sqrt_factor
 from .structures import MLSCInputs
 
 # Reference default grid (``mlSC_estimator``'s ``lambda_grid`` argument).
@@ -29,25 +37,65 @@ _DEFAULT_GRID = np.concatenate((
 ))
 
 
+def _holdout_mse_native(
+    inputs: MLSCInputs, X_train: np.ndarray, Y_train: np.ndarray,
+    X_test: np.ndarray, Y_test: np.ndarray, penalty_scale: float,
+) -> float:
+    """One grid point's held-out forecast MSE via the active-set simplex QP."""
+    from ..bilevel.active_set import solve_simplex_qp
+
+    B, A = _augmented_design(X_train, Y_train, inputs, penalty_scale)
+    omega = solve_simplex_qp(B, A)
+    return float(np.mean((Y_test - X_test @ omega) ** 2))
+
+
 def _county_sc_holdout_mse(
     X_train: np.ndarray, Y_train: np.ndarray,
     X_test: np.ndarray, Y_test: np.ndarray, solver: Any,
 ) -> float:
-    """``lambda = 0`` branch: fully-disaggregated SC with a tiny ridge.
+    """``lambda = 0`` branch via cvxpy (escape hatch): tiny-ridge disaggregate SC."""
+    import cvxpy as cp
 
-    Matches the reference ``synthetic_control_counties`` (a small ``1e-8``
-    L2 term keeps the simplex solution unique on a flat objective).
-    """
     M = X_train.shape[1]
     w = cp.Variable(M)
-    objective = cp.Minimize(
-        cp.sum_squares(Y_train - X_train @ w) + 1e-8 * cp.sum_squares(w)
+    problem = cp.Problem(
+        cp.Minimize(cp.sum_squares(Y_train - X_train @ w) + _RIDGE_FLOOR * cp.sum_squares(w)),
+        [cp.sum(w) == 1, w >= 0],
     )
-    problem = cp.Problem(objective, [cp.sum(w) == 1, w >= 0])
     problem.solve(solver=solver or cp.SCS)
-    if w.value is None:
+    if w.value is None:  # pragma: no cover - defensive: county-SC solve returned None
         return float("inf")
     return float(np.mean((Y_test - X_test @ np.asarray(w.value)) ** 2))
+
+
+def _select_lambda_cv_cvxpy(
+    inputs, Q, sigma_y2, grid, X_train, Y_train, X_test, Y_test, solver,
+):
+    """cvxpy escape hatch: the original Parameter-based grid sweep."""
+    import cvxpy as cp
+
+    M = X_train.shape[1]
+    omega = cp.Variable(M)
+    lambd = cp.Parameter(nonneg=True)
+    objective = cp.Minimize(
+        cp.sum_squares(Y_train - X_train @ omega)
+        + lambd * sigma_y2 * cp.quad_form(omega, cp.psd_wrap(Q))
+    )
+    problem = cp.Problem(objective, [cp.sum(omega) == 1, omega >= 0])
+    cv_error = np.full(grid.shape[0], np.inf)
+    for i, v in enumerate(grid):
+        if v == 0.0:
+            cv_error[i] = _county_sc_holdout_mse(X_train, Y_train, X_test, Y_test, solver)
+            continue
+        lambd.value = float(v)
+        try:
+            problem.solve(solver=solver or cp.SCS)
+        except cp.error.SolverError:  # pragma: no cover - solver hiccup on a grid point
+            continue
+        if omega.value is None:  # pragma: no cover - defensive
+            continue
+        cv_error[i] = float(np.mean((Y_test - X_test @ np.asarray(omega.value)) ** 2))
+    return cv_error
 
 
 def select_lambda_cv(
@@ -66,7 +114,8 @@ def select_lambda_cv(
     inputs : MLSCInputs
         Pre-processed two-level panel (uses the pre-period only).
     Q : np.ndarray
-        Block-diagonal penalty matrix, shape ``(M, M)``.
+        Block-diagonal penalty matrix, shape ``(M, M)`` (used only by the cvxpy
+        escape hatch; the native path rebuilds the square-root factor).
     sigma_y2 : float
         Outcome-variance scale on the penalty (as in :func:`solve_mlsc`).
     lambda_grid : sequence of float, optional
@@ -74,7 +123,8 @@ def select_lambda_cv(
     cv_holdout_periods : int
         Trailing pre-treatment periods held out as the forecast target.
     solver : Any
-        cvxpy solver; ``None`` -> ``cp.SCS``.
+        cvxpy solver. ``None`` (default) uses the native active-set simplex QP;
+        any explicit value routes through cvxpy with that solver.
 
     Returns
     -------
@@ -96,33 +146,16 @@ def select_lambda_cv(
 
     grid = np.asarray(_DEFAULT_GRID if lambda_grid is None else lambda_grid, dtype=float)
 
-    # Build the penalized problem once and re-solve per lambda via a Parameter
-    # (the reference reuses a single cvxpy Problem across the grid).
-    M = X_train.shape[1]
-    omega = cp.Variable(M)
-    lambd = cp.Parameter(nonneg=True)
-    constraints = [cp.sum(omega) == 1, omega >= 0]
-    objective = cp.Minimize(
-        cp.sum_squares(Y_train - X_train @ omega)
-        + lambd * sigma_y2 * cp.quad_form(omega, cp.psd_wrap(Q))
-    )
-    problem = cp.Problem(objective, constraints)
-
-    cv_error = np.full(grid.shape[0], np.inf)
-    for i, v in enumerate(grid):
-        if v == 0.0:
-            cv_error[i] = _county_sc_holdout_mse(
-                X_train, Y_train, X_test, Y_test, solver
-            )
-            continue
-        lambd.value = float(v)
-        try:
-            problem.solve(solver=solver or cp.SCS)
-        except cp.error.SolverError:  # pragma: no cover - solver hiccup on a grid point
-            continue
-        if omega.value is None:
-            continue
-        cv_error[i] = float(np.mean((Y_test - X_test @ np.asarray(omega.value)) ** 2))
+    if solver is not None:
+        cv_error = _select_lambda_cv_cvxpy(
+            inputs, Q, sigma_y2, grid, X_train, Y_train, X_test, Y_test, solver
+        )
+    else:
+        cv_error = np.array([
+            _holdout_mse_native(inputs, X_train, Y_train, X_test, Y_test,
+                                float(v) * sigma_y2)
+            for v in grid
+        ])
 
     if not np.isfinite(cv_error).any():  # pragma: no cover - defensive
         raise RuntimeError("mlSC cross-validation: no grid penalty was solvable.")

--- a/mlsynth/utils/mlsc_helpers/optimization.py
+++ b/mlsynth/utils/mlsc_helpers/optimization.py
@@ -7,22 +7,63 @@ Solves Equation 5.2 of Bottmer (2025)::
         + lambda * sigma_y^2 * omega^T Q omega
     s.t.  1^T omega = 1,   omega >= 0.
 
-The objective is a convex QP. We seed cvxpy with the warm-start trick the
-upstream package uses (Bottmer's reference implementation): solve the
-classical aggregate-level SC first, then expand each aggregate weight
-``w_s`` proportionally to the population shares ``v_s`` to produce a feasible
-disaggregate starting point. This typically takes the SCS solver a handful
-of iterations to reach optimality even on noisy panels.
+The penalty ``Q = R^T R`` factors in closed form (``R_s = I - v_s 1^T`` per
+block; see :func:`mlsynth.utils.mlsc_helpers.penalty.build_sqrt_factor`), so the
+penalized objective is an ordinary simplex least squares once the penalty is
+folded into the design as the augmentation ``[X; sqrt(lambda sigma_y^2) R]`` with
+a zero target. For any ``lambda > 0`` the program is strictly convex whenever the
+aggregate control matrix has full column rank (the penalty fills exactly the part
+of X's null space the aggregate directions do not pin down), so the optimum is
+unique. We solve it with the library's active-set simplex QP
+(:func:`mlsynth.utils.bilevel.active_set.solve_simplex_qp`) -- exact and free of
+cvxpy's per-call canonicalisation overhead in the cross-validation loop.
+
+The ``lambda = 0`` case is regularised by a tiny ridge (``_RIDGE_FLOOR``), the
+same device the reference uses to keep the fully-disaggregated fit unique on a
+flat objective. An explicit ``solver`` argument routes through cvxpy instead, an
+escape hatch that preserves the original behaviour for callers who request a
+particular cvxpy solver.
 """
 
 from __future__ import annotations
 
 from typing import Any, Tuple
 
-import cvxpy as cp
 import numpy as np
 
+from .penalty import build_sqrt_factor
 from .structures import MLSCInputs
+
+# Tiny ridge that keeps the unpenalised (lambda = 0) simplex fit unique on the
+# flat, under-determined objective (M disaggregate columns >> T0 periods). Mirrors
+# the reference ``synthetic_control_counties`` 1e-8 L2 term.
+_RIDGE_FLOOR = 1e-8
+
+
+def _augmented_design(
+    X: np.ndarray, Y: np.ndarray, inputs: MLSCInputs, penalty_scale: float
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Build the penalty-augmented design ``([X; sqrt(p) R], [Y; 0])``.
+
+    For ``penalty_scale > 0`` the augmentation uses the block square-root factor
+    ``R`` (``R^T R == Q``); for ``penalty_scale == 0`` it uses the uniqueness
+    ridge ``sqrt(_RIDGE_FLOOR) I``.
+    """
+    M = X.shape[1]
+    if penalty_scale > 0:
+        R = build_sqrt_factor(inputs.v_population, inputs.disagg_to_agg)
+        aug = np.sqrt(penalty_scale) * R
+    else:
+        aug = np.sqrt(_RIDGE_FLOOR) * np.eye(M)
+    B = np.vstack([X, aug])
+    A = np.concatenate([Y, np.zeros(M)])
+    return B, A
+
+
+def _aggregate(omega: np.ndarray, disagg_to_agg: np.ndarray) -> np.ndarray:
+    """Implied aggregate weights ``w_s = sum_c omega_sc``."""
+    S = int(disagg_to_agg.max() + 1)
+    return np.array([omega[disagg_to_agg == s].sum() for s in range(S)])
 
 
 def _classical_sc_warm_start(
@@ -32,14 +73,12 @@ def _classical_sc_warm_start(
     disagg_to_agg: np.ndarray,
     solver: Any,
 ) -> np.ndarray:
-    """Solve the aggregate-level classical SC and expand to disaggregate weights.
+    """Aggregate-level classical SC, expanded to a disaggregate warm start.
 
-    ``Y_pre`` is the pre-treatment aggregate treated series; ``X_disagg_pre``
-    is the pre-treatment disaggregate control matrix. We first build the
-    implied aggregate control matrix ``X_agg_pre`` by population-weighted
-    aggregation within each block, solve classical SC for state weights
-    ``w_s``, then return ``omega_sc = v_sc * w_s``.
+    Used only by the cvxpy escape hatch (:func:`_solve_mlsc_cvxpy`) to seed the
+    solver; the native active-set path needs no feasible warm start.
     """
+    import cvxpy as cp
 
     S = int(disagg_to_agg.max() + 1)
     T0 = Y_pre.shape[0]
@@ -49,26 +88,52 @@ def _classical_sc_warm_start(
         X_agg_pre[:, s] = X_disagg_pre[:, mask] @ v_population[mask]
 
     w = cp.Variable(S)
-    objective = cp.Minimize(cp.sum_squares(Y_pre - X_agg_pre @ w))
-    constraints = [cp.sum(w) == 1, w >= 0]
-    problem = cp.Problem(objective, constraints)
+    problem = cp.Problem(
+        cp.Minimize(cp.sum_squares(Y_pre - X_agg_pre @ w)),
+        [cp.sum(w) == 1, w >= 0],
+    )
     problem.solve(solver=solver or cp.SCS)
-    if w.value is None:
-        # Fallback: uniform aggregate weights.
+    if w.value is None:  # pragma: no cover - defensive: warm-start solve returned None
         return v_population / max(S, 1)
 
     w_val = np.asarray(w.value, dtype=float)
-    # omega_sc = v_sc * w_s, in disaggregate order.
     omega0 = np.zeros_like(v_population)
     for s in range(S):
         mask = disagg_to_agg == s
         omega0[mask] = v_population[mask] * w_val[s]
-    # Numerical clean-up.
     omega0 = np.clip(omega0, 0.0, None)
     total = omega0.sum()
-    if total > 0:
-        omega0 = omega0 / total
-    return omega0
+    return omega0 / total if total > 0 else omega0
+
+
+def _solve_mlsc_cvxpy(
+    inputs: MLSCInputs, Q: np.ndarray, penalty_scale: float, solver: Any,
+) -> Tuple[np.ndarray, str]:
+    """cvxpy escape hatch: the original SCS/CLARABEL solve (warm-started)."""
+    import cvxpy as cp
+
+    T0 = inputs.T0
+    Y_pre = inputs.Y_agg_treated[:T0]
+    X_pre = inputs.X_disagg[:T0, :]
+    omega = cp.Variable(inputs.M)
+    try:
+        omega.value = _classical_sc_warm_start(
+            Y_pre=Y_pre, X_disagg_pre=X_pre, v_population=inputs.v_population,
+            disagg_to_agg=inputs.disagg_to_agg, solver=solver,
+        )
+    except Exception:  # pragma: no cover - warm start is a numerical hint only
+        pass
+    objective_terms = [cp.sum_squares(Y_pre - X_pre @ omega)]
+    if penalty_scale > 0:
+        objective_terms.append(penalty_scale * cp.quad_form(omega, cp.psd_wrap(Q)))
+    problem = cp.Problem(cp.Minimize(sum(objective_terms)),
+                         [cp.sum(omega) == 1, omega >= 0])
+    problem.solve(solver=solver or cp.SCS, warm_start=True)
+    if omega.value is None:  # pragma: no cover - defensive: cvxpy returned no solution
+        raise RuntimeError(
+            f"cvxpy failed to solve the mlSC QP (status={problem.status})."
+        )
+    return np.asarray(omega.value, dtype=float), str(problem.status)
 
 
 def solve_mlsc(
@@ -85,14 +150,16 @@ def solve_mlsc(
     inputs : MLSCInputs
         Pre-processed two-level panel.
     Q : np.ndarray
-        Block-diagonal penalty matrix of shape ``(M, M)``.
+        Block-diagonal penalty matrix of shape ``(M, M)`` (used only by the
+        cvxpy escape hatch; the native path rebuilds the square-root factor).
     lambda_val : float
         Penalty value (already chosen via heuristic or fixed).
     sigma_y2 : float
-        Outcome variance, used as the penalty's scale factor so that
-        ``lambda`` is scale-invariant as in the paper.
+        Outcome variance, the penalty's scale factor so that ``lambda`` is
+        scale-invariant as in the paper.
     solver : Any
-        cvxpy solver. ``None`` -> ``cp.SCS``.
+        cvxpy solver. ``None`` (default) uses the native active-set simplex QP;
+        any explicit value routes through cvxpy with that solver.
 
     Returns
     -------
@@ -101,53 +168,28 @@ def solve_mlsc(
     aggregate_weights : np.ndarray
         Implied ``w_s = sum_c omega_sc``, length ``S``.
     status : str
-        cvxpy solver status string.
+        Solver status string.
     """
-
-    T0 = inputs.T0
-    Y_pre = inputs.Y_agg_treated[:T0]
-    X_pre = inputs.X_disagg[:T0, :]
-
-    M = inputs.M
-    omega = cp.Variable(M)
-
-    # Warm start (numerical only — cvxpy doesn't require feasibility here).
-    try:
-        omega.value = _classical_sc_warm_start(
-            Y_pre=Y_pre,
-            X_disagg_pre=X_pre,
-            v_population=inputs.v_population,
-            disagg_to_agg=inputs.disagg_to_agg,
-            solver=solver,
-        )
-    except Exception:
-        pass
-
     penalty_scale = float(lambda_val) * float(sigma_y2)
-    objective_terms = [cp.sum_squares(Y_pre - X_pre @ omega)]
-    if penalty_scale > 0:
-        objective_terms.append(penalty_scale * cp.quad_form(omega, cp.psd_wrap(Q)))
 
-    objective = cp.Minimize(sum(objective_terms))
-    constraints = [cp.sum(omega) == 1, omega >= 0]
-    problem = cp.Problem(objective, constraints)
-    problem.solve(solver=solver or cp.SCS, warm_start=True)
+    if solver is not None:
+        omega_val, status = _solve_mlsc_cvxpy(inputs, Q, penalty_scale, solver)
+    else:
+        T0 = inputs.T0
+        Y_pre = inputs.Y_agg_treated[:T0]
+        X_pre = inputs.X_disagg[:T0, :]
+        B, A = _augmented_design(X_pre, Y_pre, inputs, penalty_scale)
+        from ..bilevel.active_set import solve_simplex_qp
 
-    if omega.value is None:
-        raise RuntimeError(
-            f"cvxpy failed to solve the mlSC QP (status={problem.status})."
-        )
+        omega_val, info = solve_simplex_qp(B, A, return_info=True)
+        if info["converged"]:
+            status = "optimal"
+        else:  # pragma: no cover - degenerate fallback to cvxpy
+            omega_val, status = _solve_mlsc_cvxpy(inputs, Q, penalty_scale, None)
 
-    omega_val = np.asarray(omega.value, dtype=float)
-    # Numerical clean-up: kill small negatives, renormalize.
-    omega_val = np.clip(omega_val, 0.0, None)
+    omega_val = np.clip(np.asarray(omega_val, dtype=float), 0.0, None)
     total = omega_val.sum()
     if total > 0:
         omega_val = omega_val / total
 
-    S = int(inputs.disagg_to_agg.max() + 1)
-    aggregate_weights = np.zeros(S)
-    for s in range(S):
-        aggregate_weights[s] = omega_val[inputs.disagg_to_agg == s].sum()
-
-    return omega_val, aggregate_weights, str(problem.status)
+    return omega_val, _aggregate(omega_val, inputs.disagg_to_agg), status

--- a/mlsynth/utils/mlsc_helpers/penalty.py
+++ b/mlsynth/utils/mlsc_helpers/penalty.py
@@ -36,6 +36,44 @@ def build_block(v_s: np.ndarray) -> np.ndarray:
     )
 
 
+def build_sqrt_block(v_s: np.ndarray) -> np.ndarray:
+    """Return the single-block square-root factor ``R_s = I - v_s 1^T``.
+
+    By construction ``R_s^T R_s == Q_s`` (see :func:`build_block`), so stacking
+    ``sqrt(penalty) * R_s`` as extra rows of the design reproduces the quadratic
+    penalty ``omega_s^T Q_s omega_s`` as an ordinary least-squares term. This is
+    what lets the active-set simplex QP solve the penalized program without a
+    general quadratic-form solver.
+    """
+    v_s = np.asarray(v_s, dtype=float).reshape(-1)
+    C_s = v_s.shape[0]
+    return np.eye(C_s) - np.outer(v_s, np.ones(C_s))
+
+
+def build_sqrt_factor(
+    v_population: np.ndarray, disagg_to_agg: np.ndarray
+) -> np.ndarray:
+    """Assemble the block-diagonal square-root factor ``R`` with ``R^T R == Q``.
+
+    Parameters mirror :func:`build_penalty_matrix`.
+
+    Returns
+    -------
+    np.ndarray
+        Block-diagonal ``R`` of shape ``(M, M)`` whose blocks are
+        :func:`build_sqrt_block`.
+    """
+    v_population = np.asarray(v_population, dtype=float).reshape(-1)
+    disagg_to_agg = np.asarray(disagg_to_agg, dtype=int).reshape(-1)
+    if v_population.shape[0] != disagg_to_agg.shape[0]:
+        raise ValueError("v_population and disagg_to_agg must have equal length.")
+    blocks = [
+        build_sqrt_block(v_population[disagg_to_agg == s])
+        for s in sorted(set(disagg_to_agg.tolist()))
+    ]
+    return block_diag(*blocks)
+
+
 def build_penalty_matrix(
     v_population: np.ndarray, disagg_to_agg: np.ndarray
 ) -> np.ndarray:


### PR DESCRIPTION
## Summary

Replaces the cvxpy/SCS weight solver and cross-validation grid sweep in MLSC with
the library's native active-set simplex QP on the default (`solver=None`) path.

The block penalty `Q = R^T R` factors in closed form (`R_s = I - v_s 1^T`), so the
penalized objective `||Y - X omega||^2 + lambda*sigma_y^2*omega^T Q omega` folds
into an ordinary simplex least squares via the augmentation
`[X; sqrt(lambda*sigma_y^2) R]` with a zero target — no quadratic-form solver
needed. Every grid point is strictly convex (the penalty fills the part of X's
null space the aggregate directions don't pin down; the `lambda = 0` point uses a
1e-8 uniqueness ridge), so the optimum is unique and active-set matches cvxpy to
solver tolerance without cvxpy's per-call canonicalisation overhead in the CV
loop.

An explicit `solver` argument still routes through cvxpy (escape hatch; original
behaviour preserved). Adds `build_sqrt_factor`/`build_sqrt_block` to `penalty.py`.

## Why this is a safe target

- Hot loop: the CV grid sweep re-solves the program 56× per fit, so dropping
  cvxpy's canonicalisation is a real gain.
- Unique optimum: verified up front (PD Hessian for any `lambda > 0`), unlike SSC
  where short-pre panels gave non-unique optima.

## Verification

- New `tests/test_mlsc_native_weights.py`: `R^T R == Q`, cvxpy parity on
  strictly-convex instances (`lambda > 0` and the `lambda = 0` ridge branch),
  simplex feasibility, CV selecting the same grid penalty as a CLARABEL oracle,
  independence from cvxpy on the default path, and the escape hatch.
- `optimization.py`, `crossval.py`, `penalty.py` at 100% line coverage; full MLSC
  suite (57 tests) green.
- Benchmark `mlsc_bottmer` (cross-validation vs the author's reference) passes —
  agreement actually improves (`path_b_max_dtau` 5.76e-4 -> 8.28e-5), since
  active-set is exact where SCS was approximate.

Blast radius is confined to MLSC (only the estimator imports these modules).

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_