### PR TITLE
GEOLIFT ridge + conformal: exact speedups (eigendecomposition CV + linear solve + warm-started folds + vectorized permutation reference)

### DIFF
--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -333,8 +333,14 @@ and an effect is *detected* when :math:`p < \alpha`. The permutation set
 :math:`\Pi` follows ``conformal_type``: ``"iid"`` (the augsynth/GeoLift default —
 :math:`n_s` independent draws) or ``"block"`` (the :math:`T` moving-block cyclic
 shifts :math:`\Pi_k(t) = ((t + k) \bmod T)`, which preserve serial dependence
-and are deterministic, ignoring :math:`n_s`). Power is the detection rate
-across the :math:`L` lookback placements,
+and are deterministic, ignoring :math:`n_s`). The :math:`n_s` reference
+statistics are evaluated in one broadcast over the whole permutation block
+rather than one Python call per permutation; the permutations and their random
+draws are unchanged, so the p-value is bit-identical to the per-permutation
+loop (at the default :math:`q=1`) — only faster, which matters because this
+reference is rebuilt for every candidate, duration, lookback, and effect size
+in the search. Power is the detection rate across the :math:`L` lookback
+placements,
 
 .. math::
 

--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -231,6 +231,30 @@ whose stationarity condition has the closed form (push-through identity)
 with the penalty :math:`\lambda` chosen by leave-one-period-out cross-validation
 (:math:`\lambda \to 0` recovers the plain simplex SCM; :math:`\lambda \to \infty`
 pulls back to :math:`\mathbf{w}^{\mathrm{scm}}`).
+
+How the cross-validation is solved (a faster route than the native method).
+The reference implementation (augsynth) selects :math:`\lambda` by, for every
+fold and every penalty on the grid, inverting
+:math:`\widetilde{\mathbf{Y}}_{0}\widetilde{\mathbf{Y}}_{0}^{\top} + \lambda\mathbf{I}`
+and cold-refitting the base simplex weights. ``mlsynth`` computes the identical
+quantity by a cheaper algebraic route. Within a fold the matrix
+:math:`\widetilde{\mathbf{Y}}_{0}\widetilde{\mathbf{Y}}_{0}^{\top}` and the
+anchor :math:`\mathbf{w}^{\mathrm{scm}}` do not depend on :math:`\lambda`, so a
+single symmetric eigendecomposition
+:math:`\widetilde{\mathbf{Y}}_{0}\widetilde{\mathbf{Y}}_{0}^{\top}=\mathbf{V}\operatorname{diag}(\mathbf{d})\mathbf{V}^{\top}`
+serves the whole grid via
+:math:`(\widetilde{\mathbf{Y}}_{0}\widetilde{\mathbf{Y}}_{0}^{\top}+\lambda\mathbf{I})^{-1}=\mathbf{V}\operatorname{diag}\!\bigl(1/(\mathbf{d}+\lambda)\bigr)\mathbf{V}^{\top}`,
+replacing one matrix inversion per penalty with one decomposition per fold; the
+single-penalty correction is taken with a linear solve rather than an explicit
+inverse; and the leave-one-out folds (tiny perturbations of one another) are
+warm-started from the previous fold's base weights. Because the base simplex
+objective is strictly convex under full column rank, the cross-validation curve,
+the selected :math:`\lambda`, and the fitted weights are unchanged to numerical
+tolerance — only the runtime differs. On a representative design this cuts the
+fit roughly five-fold relative to the per-penalty-inversion native method, which
+matters because the cross-validation is re-run across every candidate, duration,
+and lookback placement in the market-selection search.
+
 The counterfactual and gap follow the canon,
 
 .. math::

--- a/mlsynth/tests/test_ridge_eigh.py
+++ b/mlsynth/tests/test_ridge_eigh.py
@@ -36,6 +36,16 @@ from mlsynth.utils.bilevel.ridge_augment import (
     solve_ridge,
     solve_ridge_path,
 )
+from mlsynth.utils.bilevel.ridge_inference import _reference_stats, _stat
+
+
+def _naive_reference_stats(resids, post_slice, q, ns, seed):
+    """Frozen copy of the original per-permutation conformal reference loop."""
+    rng = np.random.default_rng(seed)
+    return np.fromiter(
+        (_stat(rng.permutation(resids)[post_slice], q) for _ in range(ns)),
+        dtype=float, count=ns,
+    )
 
 
 def _inv_solve_ridge(A, B, W, lam):
@@ -191,3 +201,54 @@ class TestWarmStartBase:
         _, en, sn = _naive_cross_validate(simplex_qp, X0, X1, lambdas)
         np.testing.assert_allclose(ec, en, rtol=1e-7, atol=1e-9)
         np.testing.assert_allclose(sc, sn, rtol=1e-7, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Conformal permutation reference: vectorized statistic must be BIT-IDENTICAL
+# to the per-permutation loop (the exact hybrid -- same permutations, same
+# draws, only the statistic is broadcast). No re-pinning of the conformal /
+# augsynth replications.
+# ---------------------------------------------------------------------------
+
+class TestReferenceStatsVectorized:
+    @pytest.mark.parametrize("T,post,ns,seed", [
+        (45, slice(39, 45), 1000, 0),
+        (90, slice(80, 90), 500, 3),
+        (30, slice(20, 30), 200, 7),
+    ])
+    def test_iid_bit_identical_q1(self, T, post, ns, seed):
+        # q = 1 is the augsynth default (the only value used in practice): the
+        # vectorized statistic is BIT-identical to the per-permutation loop.
+        rng = _rng(T + ns + seed)
+        resids = rng.standard_normal(T)
+        ref = _naive_reference_stats(resids, post, 1.0, ns, seed)
+        got = _reference_stats(resids, post, 1.0, conformal_type="iid", ns=ns, seed=seed)
+        np.testing.assert_array_equal(got, ref)          # exact, not just close
+
+    def test_iid_general_q_matches_to_tol(self):
+        # For q != 1 the 2D axis-reduction sums in a different order than the 1D
+        # per-row sum, so the match is to floating-point tolerance (~1e-15), not
+        # bitwise -- the permutations and draws are still identical.
+        rng = _rng(7)
+        resids = rng.standard_normal(30)
+        post = slice(20, 30)
+        ref = _naive_reference_stats(resids, post, 2.0, 200, 7)
+        got = _reference_stats(resids, post, 2.0, conformal_type="iid", ns=200, seed=7)
+        np.testing.assert_allclose(got, ref, rtol=1e-12, atol=1e-12)
+
+    def test_iid_array_post_indices(self):
+        rng = _rng(11)
+        resids = rng.standard_normal(40)
+        post = np.array([35, 36, 37, 38, 39])
+        ref = _naive_reference_stats(resids, post, 1.0, 300, 2)
+        got = _reference_stats(resids, post, 1.0, conformal_type="iid", ns=300, seed=2)
+        np.testing.assert_array_equal(got, ref)
+
+    def test_block_unchanged(self):
+        # Block conformal is deterministic cyclic shifts; must equal manual roll.
+        rng = _rng(2)
+        resids = rng.standard_normal(24)
+        got = _reference_stats(resids, slice(18, 24), 1.0,
+                               conformal_type="block", ns=999, seed=0)
+        man = np.array([_stat(np.roll(resids, s)[18:24], 1.0) for s in range(24)])
+        np.testing.assert_array_equal(got, man)

--- a/mlsynth/tests/test_ridge_eigh.py
+++ b/mlsynth/tests/test_ridge_eigh.py
@@ -32,9 +32,19 @@ import pytest
 from mlsynth.utils.bilevel.ridge_augment import (
     _HoldoutSplitter,
     cross_validate,
+    simplex_qp,
     solve_ridge,
     solve_ridge_path,
 )
+
+
+def _inv_solve_ridge(A, B, W, lam):
+    """Reference: the original inv()-based single-lambda ridge correction."""
+    A = np.asarray(A, float).ravel(); B = np.asarray(B, float)
+    W = np.asarray(W, float).ravel()
+    M = A - B @ W
+    N = np.linalg.inv(B @ B.T + lam * np.identity(B.shape[0]))
+    return M @ N @ B
 
 
 def _rng(seed=0):
@@ -128,3 +138,56 @@ class TestCrossValidateParity:
         _, eo, _ = _naive_cross_validate(_simplex_base, X0, X1, lambdas)
         _, en, _ = cross_validate(_simplex_base, X0, X1, lambdas)
         assert int(np.argmin(en)) == int(np.argmin(eo))
+
+
+# ---------------------------------------------------------------------------
+# solve_ridge: np.linalg.solve replaces np.linalg.inv (single-lambda callers)
+# ---------------------------------------------------------------------------
+
+class TestSolveRidgeUsesSolve:
+    @pytest.mark.parametrize("m,J", [(20, 5), (8, 12), (15, 15), (30, 4)])
+    def test_matches_inv_reference(self, m, J):
+        rng = _rng(m * 7 + J)
+        B = rng.standard_normal((m, J)); A = rng.standard_normal(m)
+        W = np.clip(rng.standard_normal(J), 0, None)
+        for lam in (1e-5, 0.3, 12.0, 200.0):
+            np.testing.assert_allclose(
+                solve_ridge(A=A, B=B, W=W, lambda_=lam),
+                _inv_solve_ridge(A, B, W, lam), rtol=1e-8, atol=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# cross_validate: warm-starting the per-fold base QP must not change results
+# (the base simplex objective is strictly convex under full column rank, so the
+# optimum -- and thus the CV curve -- is identical with or without a warm start)
+# ---------------------------------------------------------------------------
+
+class TestWarmStartBase:
+    def test_warm_vs_cold_parity(self):
+        rng = _rng(5)
+        X0 = rng.standard_normal((40, 8)); X1 = rng.standard_normal(40)
+        lambdas = np.geomspace(1e-6, 1e3, 21)
+        _, ew, sw = cross_validate(simplex_qp, X0, X1, lambdas, warm_start_base=True)
+        _, ec, sc = cross_validate(simplex_qp, X0, X1, lambdas, warm_start_base=False)
+        np.testing.assert_allclose(ew, ec, rtol=1e-7, atol=1e-9)
+        np.testing.assert_allclose(sw, sc, rtol=1e-7, atol=1e-9)
+
+    def test_warm_vs_cold_collinear(self):
+        # Adversarial: collinear donors -> the base objective is only weakly
+        # convex; warm-start must still land the same CV curve.
+        rng = _rng(8)
+        base = rng.standard_normal((30, 4))
+        X0 = np.hstack([base, base[:, :2]]); X1 = rng.standard_normal(30)
+        lambdas = np.geomspace(1e-5, 1e2, 15)
+        _, ew, _ = cross_validate(simplex_qp, X0, X1, lambdas, warm_start_base=True)
+        _, ec, _ = cross_validate(simplex_qp, X0, X1, lambdas, warm_start_base=False)
+        np.testing.assert_allclose(ew, ec, rtol=1e-6, atol=1e-8)
+
+    def test_cold_matches_naive_with_simplex(self):
+        rng = _rng(2)
+        X0 = rng.standard_normal((24, 6)); X1 = rng.standard_normal(24)
+        lambdas = np.geomspace(1e-5, 1e2, 12)
+        _, ec, sc = cross_validate(simplex_qp, X0, X1, lambdas, warm_start_base=False)
+        _, en, sn = _naive_cross_validate(simplex_qp, X0, X1, lambdas)
+        np.testing.assert_allclose(ec, en, rtol=1e-7, atol=1e-9)
+        np.testing.assert_allclose(sc, sn, rtol=1e-7, atol=1e-9)

--- a/mlsynth/tests/test_ridge_eigh.py
+++ b/mlsynth/tests/test_ridge_eigh.py
@@ -1,0 +1,130 @@
+"""TDD for the eigendecomposition-based ridge path used in GEOLIFT's ridge CV.
+
+Background
+----------
+``ridge_augment.solve_ridge`` computes the additive ridge correction
+
+    W_ridge(lambda) = M @ inv(B B^T + lambda I) @ B,   M = A - B W,
+
+inverting an ``m x m`` matrix for *every* lambda. In ``cross_validate`` this is
+called once per (fold, lambda), so the inversion dominates the GEOLIFT design
+(profiling: ``numpy.linalg.inv`` is the top self-time line, one call per
+``solve_ridge``).
+
+Because ``B B^T``, ``M``, and the eigenbasis are fixed across the lambda grid
+within a fold, the whole grid can be evaluated from a single eigendecomposition
+``B B^T = V diag(d) V^T``:
+
+    inv(B B^T + lambda I) = V diag(1/(d+lambda)) V^T
+    W_ridge(lambda)       = (p / (d + lambda)) @ Q,   p = M V,  Q = V^T B.
+
+This is the *same quantity*, algebraically refactored, so it must match the
+inversion path to numerical tolerance. These tests pin that parity (the
+DSCAR rule: only swap numerics where the result is provably identical) for the
+new ``solve_ridge_path`` and for the refactored ``cross_validate``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.ridge_augment import (
+    _HoldoutSplitter,
+    cross_validate,
+    solve_ridge,
+    solve_ridge_path,
+)
+
+
+def _rng(seed=0):
+    return np.random.default_rng(seed)
+
+
+def _simplex_base(B, A):
+    """A cheap, deterministic base-weight solver for CV parity tests (the
+    parity holds for ANY base_weights_fn since both paths share it)."""
+    w = np.linalg.lstsq(B, A, rcond=None)[0]
+    w = np.clip(w, 0.0, None)
+    s = w.sum()
+    return w / s if s > 1e-12 else w
+
+
+def _naive_cross_validate(base_weights_fn, X0, X1, lambdas, holdout_len=1):
+    """Reference implementation: the original per-lambda inv() loop."""
+    X0 = np.asarray(X0, float); X1 = np.asarray(X1, float).ravel()
+    lambdas = np.asarray(lambdas, float)
+    res = []
+    for B_t, B_v, A_t, A_v in _HoldoutSplitter(X0, X1, holdout_len=holdout_len):
+        W = base_weights_fn(B_t, A_t)
+        fold = [float(np.sum((A_v - B_v @ (W + solve_ridge(A_t, B_t, W, lam))) ** 2))
+                for lam in lambdas]
+        res.append(fold)
+    arr = np.asarray(res, float)
+    return (lambdas, arr.mean(axis=0), arr.std(axis=0) / np.sqrt(arr.shape[0]))
+
+
+# ---------------------------------------------------------------------------
+# solve_ridge_path parity with the per-lambda inv solve_ridge
+# ---------------------------------------------------------------------------
+
+class TestRidgePathParity:
+    @pytest.mark.parametrize("m,J", [(20, 5), (8, 12), (30, 30), (5, 1)])
+    def test_path_matches_solve_ridge(self, m, J):
+        rng = _rng(m * 100 + J)
+        B = rng.standard_normal((m, J))
+        A = rng.standard_normal(m)
+        W = np.clip(rng.standard_normal(J), 0, None)
+        lambdas = np.array([1e-6, 1e-3, 0.1, 1.0, 10.0, 100.0])
+        path = solve_ridge_path(A, B, W, lambdas)            # (n_lambda, J)
+        assert path.shape == (len(lambdas), J)
+        for i, lam in enumerate(lambdas):
+            ref = solve_ridge(A=A, B=B, W=W, lambda_=lam)
+            np.testing.assert_allclose(path[i], ref, rtol=1e-8, atol=1e-9)
+
+    def test_single_lambda(self):
+        rng = _rng(7)
+        B = rng.standard_normal((15, 6)); A = rng.standard_normal(15)
+        W = np.clip(rng.standard_normal(6), 0, None)
+        path = solve_ridge_path(A, B, W, [2.5])
+        np.testing.assert_allclose(path[0], solve_ridge(A=A, B=B, W=W, lambda_=2.5),
+                                   rtol=1e-8, atol=1e-9)
+
+    def test_rank_deficient_b(self):
+        # B with linearly dependent columns -> B B^T rank-deficient; +lambda I
+        # keeps the solve well-posed and the eigh path must still match.
+        rng = _rng(3)
+        base = rng.standard_normal((18, 3))
+        B = np.hstack([base, base[:, :1] * 2.0])             # rank 3, 4 columns
+        A = rng.standard_normal(18); W = np.clip(rng.standard_normal(4), 0, None)
+        for lam in (1e-4, 1.0, 50.0):
+            np.testing.assert_allclose(
+                solve_ridge_path(A, B, W, [lam])[0],
+                solve_ridge(A=A, B=B, W=W, lambda_=lam), rtol=1e-7, atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# cross_validate parity with the naive inv reference
+# ---------------------------------------------------------------------------
+
+class TestCrossValidateParity:
+    @pytest.mark.parametrize("m,J,holdout", [(24, 6, 1), (24, 6, 3), (12, 20, 1)])
+    def test_matches_naive(self, m, J, holdout):
+        rng = _rng(m + J + holdout)
+        X0 = rng.standard_normal((m, J))
+        X1 = rng.standard_normal(m)
+        lambdas = np.array([1e-5, 1e-2, 0.5, 5.0, 50.0])
+        lo, eo, so = _naive_cross_validate(_simplex_base, X0, X1, lambdas, holdout)
+        ln, en, sn = cross_validate(_simplex_base, X0, X1, lambdas, holdout)
+        np.testing.assert_allclose(ln, lo)
+        np.testing.assert_allclose(en, eo, rtol=1e-8, atol=1e-9)
+        np.testing.assert_allclose(sn, so, rtol=1e-8, atol=1e-9)
+
+    def test_selected_lambda_unchanged(self):
+        # The argmin (and hence the selected penalty) must be identical.
+        rng = _rng(99)
+        X0 = rng.standard_normal((40, 8)); X1 = rng.standard_normal(40)
+        lambdas = np.geomspace(1e-6, 1e3, 21)
+        _, eo, _ = _naive_cross_validate(_simplex_base, X0, X1, lambdas)
+        _, en, _ = cross_validate(_simplex_base, X0, X1, lambdas)
+        assert int(np.argmin(en)) == int(np.argmin(eo))

--- a/mlsynth/utils/bilevel/ridge_augment.py
+++ b/mlsynth/utils/bilevel/ridge_augment.py
@@ -37,6 +37,7 @@ weights ``W``,
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Tuple
 
@@ -129,8 +130,10 @@ def solve_ridge(
     B = np.asarray(B, dtype=float)
     W = np.asarray(W, dtype=float).ravel()
     M = A - B @ W
-    N = np.linalg.inv(B @ B.T + lambda_ * np.identity(B.shape[0]))
-    return M @ N @ B
+    # Solve (B B^T + lambda I) X = B instead of forming the inverse: same result,
+    # one LAPACK solve rather than a full inversion plus a matmul.
+    X = np.linalg.solve(B @ B.T + lambda_ * np.identity(B.shape[0]), B)
+    return M @ X
 
 
 def solve_ridge_path(
@@ -226,6 +229,7 @@ def cross_validate(
     X1: np.ndarray,
     lambdas: np.ndarray,
     holdout_len: int = 1,
+    warm_start_base: bool = True,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Leave-one-period-out CV of the ridge penalty (augsynth ``get_lambda_errors``).
 
@@ -246,6 +250,13 @@ def cross_validate(
         Candidate ridge penalties.
     holdout_len : int, optional
         Block length held out each fold, by default ``1``.
+    warm_start_base : bool, optional
+        Seed each fold's base solve with the previous fold's weights when the
+        base solver accepts a ``warm_start`` keyword (default ``True``). The
+        leave-one-out folds are tiny perturbations of one another, so this
+        roughly halves the active-set work; the base simplex objective is
+        strictly convex under full column rank, so the optimum -- and thus the
+        CV curve -- is unchanged. Set ``False`` for a cold refit each fold.
 
     Returns
     -------
@@ -256,12 +267,23 @@ def cross_validate(
     X0 = np.asarray(X0, dtype=float)
     X1 = np.asarray(X1, dtype=float).ravel()
     lambdas = np.asarray(lambdas, dtype=float)
+    accepts_ws = False
+    if warm_start_base:
+        try:
+            accepts_ws = "warm_start" in inspect.signature(base_weights_fn).parameters
+        except (TypeError, ValueError):       # builtins / un-inspectable callables
+            accepts_ws = False
     res = []
+    prev_W = None
     for B_t, B_v, A_t, A_v in _HoldoutSplitter(X0, X1, holdout_len=holdout_len):
-        W = base_weights_fn(B_t, A_t)
+        if accepts_ws and prev_W is not None and prev_W.shape[0] == B_t.shape[1]:
+            W = base_weights_fn(B_t, A_t, warm_start=prev_W)
+        else:
+            W = base_weights_fn(B_t, A_t)
+        prev_W = np.asarray(W, dtype=float).ravel()
         # All lambdas at once: one eigendecomposition of B_t B_t^T instead of
         # one matrix inversion per lambda (see solve_ridge_path).
-        W_aug = W[None, :] + solve_ridge_path(A_t, B_t, W, lambdas)   # (L, J)
+        W_aug = prev_W[None, :] + solve_ridge_path(A_t, B_t, prev_W, lambdas)  # (L, J)
         resid = A_v[None, :] - W_aug @ B_v.T                          # (L, h)
         res.append(np.sum(resid ** 2, axis=1))                        # (L,)
     arr = np.asarray(res, dtype=float)

--- a/mlsynth/utils/bilevel/ridge_augment.py
+++ b/mlsynth/utils/bilevel/ridge_augment.py
@@ -133,6 +133,51 @@ def solve_ridge(
     return M @ N @ B
 
 
+def solve_ridge_path(
+    A: np.ndarray, B: np.ndarray, W: np.ndarray, lambdas: np.ndarray
+) -> np.ndarray:
+    """Ridge corrections for a whole lambda grid from one eigendecomposition.
+
+    Equivalent to ``np.vstack([solve_ridge(A, B, W, lam) for lam in lambdas])``
+    but evaluates the entire grid from a single symmetric eigendecomposition of
+    ``B B^T`` instead of inverting ``B B^T + lambda I`` once per lambda. With
+
+        B B^T = V diag(d) V^T,    inv(B B^T + lambda I) = V diag(1/(d+lambda)) V^T,
+
+    the correction ``M @ inv(...) @ B`` becomes ``(p / (d + lambda)) @ Q`` where
+    ``M = A - B W``, ``p = M V`` and ``Q = V^T B`` are computed once. The
+    ``+ lambda I`` keeps every shifted system positive-definite, so the result
+    matches :func:`solve_ridge` to numerical tolerance even when ``B B^T`` is
+    rank-deficient (``J < m`` periods, or collinear donors).
+
+    Parameters
+    ----------
+    A : numpy.ndarray, shape (m,)
+        Treated unit's (centered) matching vector.
+    B : numpy.ndarray, shape (m, J)
+        Donor (centered) matching matrix.
+    W : numpy.ndarray, shape (J,)
+        Base (simplex) SCM weights.
+    lambdas : numpy.ndarray, shape (L,)
+        Candidate ridge penalties.
+
+    Returns
+    -------
+    numpy.ndarray, shape (L, J)
+        Row ``i`` is the additive ridge correction for ``lambdas[i]``.
+    """
+    A = np.asarray(A, dtype=float).ravel()
+    B = np.asarray(B, dtype=float)
+    W = np.asarray(W, dtype=float).ravel()
+    lambdas = np.asarray(lambdas, dtype=float).ravel()
+    M = A - B @ W                                   # (m,)
+    d, V = np.linalg.eigh(B @ B.T)                  # (m,), (m, m) symmetric PSD
+    p = M @ V                                       # (m,)
+    Q = V.T @ B                                     # (m, J)
+    scale = p[None, :] / (d[None, :] + lambdas[:, None])   # (L, m)
+    return scale @ Q                                # (L, J)
+
+
 def generate_lambdas(
     X: np.ndarray, lambda_min_ratio: float = 1e-8, n_lambda: int = 20
 ) -> np.ndarray:
@@ -214,11 +259,11 @@ def cross_validate(
     res = []
     for B_t, B_v, A_t, A_v in _HoldoutSplitter(X0, X1, holdout_len=holdout_len):
         W = base_weights_fn(B_t, A_t)
-        fold = []
-        for lam in lambdas:
-            W_aug = W + solve_ridge(A=A_t, B=B_t, W=W, lambda_=lam)
-            fold.append(float(np.sum((A_v - B_v @ W_aug) ** 2)))
-        res.append(fold)
+        # All lambdas at once: one eigendecomposition of B_t B_t^T instead of
+        # one matrix inversion per lambda (see solve_ridge_path).
+        W_aug = W[None, :] + solve_ridge_path(A_t, B_t, W, lambdas)   # (L, J)
+        resid = A_v[None, :] - W_aug @ B_v.T                          # (L, h)
+        res.append(np.sum(resid ** 2, axis=1))                        # (L,)
     arr = np.asarray(res, dtype=float)
     n_folds = arr.shape[0]
     errors_mean = arr.mean(axis=0)

--- a/mlsynth/utils/bilevel/ridge_inference.py
+++ b/mlsynth/utils/bilevel/ridge_inference.py
@@ -51,11 +51,19 @@ def _reference_stats(resids, post_slice, q, *, conformal_type, ns, seed):
             dtype=float,
         )
     if conformal_type == "iid":
+        # Same ns permutations and draws as the per-permutation loop
+        # ``[_stat(rng.permutation(resids)[post_slice], q) for _ in range(ns)]``,
+        # but the statistic is computed once over the whole (ns, |post|) block
+        # instead of ns times. Bit-identical to the loop (pinned in the tests);
+        # only the per-call Python/ufunc overhead is removed.
+        resids = np.asarray(resids, dtype=float)
         rng = np.random.default_rng(seed)
-        return np.fromiter(
-            (_stat(rng.permutation(resids)[post_slice], q) for _ in range(ns)),
-            dtype=float, count=ns,
-        )
+        idx = np.arange(resids.shape[0])[post_slice]      # slice or fancy index
+        m = idx.size
+        P = np.empty((ns, m), dtype=float)
+        for i in range(ns):
+            P[i] = rng.permutation(resids)[idx]
+        return (np.sum(np.abs(P) ** q, axis=1) / np.sqrt(m)) ** (1.0 / q)
     raise ValueError(f"conformal_type must be 'iid' or 'block'; got {conformal_type!r}.")
 
 


### PR DESCRIPTION
## Summary

Four exact speedups to the ridge cross-validation and conformal inference that dominate GEOLIFT's market-selection design. Every change is an algebraic/vectorization refactor of the same computation — results are unchanged (bit-identical at the augsynth default), so all are on by default.

Method: profile → optimize the hotspot → re-profile (the hotspot moves) → repeat.

## Changes

1. Eigendecomposition ridge path (`solve_ridge_path`). Within a CV fold, one symmetric eigendecomposition `B Bᵀ = V diag(d) Vᵀ` serves the whole λ grid via `(B Bᵀ + λI)⁻¹ = V diag(1/(d+λ)) Vᵀ`, replacing ~21 m×m inversions per fold with one eigh.
2. Linear solve for the single-λ correction. `solve_ridge` uses `np.linalg.solve(B Bᵀ + λI, B)` instead of forming the inverse — the path of the final fit and every conformal null.
3. Warm-started CV folds. Each leave-one-out fold's base simplex QP is seeded from the previous fold's weights (`warm_start_base`, default True). Strictly convex under full column rank ⇒ same optimum.
4. Vectorized conformal permutation reference. The `ns` (default 1000) reference statistics are evaluated in one broadcast over the `(ns, |post|)` permutation block instead of one `_stat` call per permutation. Same sequential permutations / draws ⇒ bit-identical p-value at the default `q=1` (chosen over a faster full `rng.permuted` broadcast, which was only ~6% faster end-to-end but reseeds the Monte-Carlo draw).

## Correctness (the DSCAR rule — only swap numerics where the result is provably identical)

TDD in `test_ridge_eigh.py`:
- `solve_ridge_path` == per-λ `solve_ridge` (incl. rank-deficient `B Bᵀ`).
- refactored `cross_validate` == naive per-λ `inv` reference; identical argmin λ.
- `solve_ridge` (solve-based) == an explicit `inv` reference.
- warm-vs-cold CV parity on random AND collinear donors.
- vectorized `_reference_stats` bit-identical to the per-permutation loop at `q=1` (tol for general `q`); block branch unchanged.

The augsynth ridge replication (`test_bilevel_ridge.py`, pinned Kansas ATT), the full GEOLIFT suite, and the marketselect suites are green — nothing re-pinned.

## Speed (empirically verified)

End-to-end GEOLIFT fit (20 units × T=50, synthetic) vs `main`: 12.96s → 2.55s (≈5×) from changes 1–3.

The real GeoLift_PreTest workload (40 markets, treatment_size 2→5, `ns=1000`): 60.4s → 51.8s with the conformal vectorization (change 4) on top.

## Docs

`docs/geolift.rst` now states plainly that the ridge CV is solved by a faster exact route (eigendecomposition per fold + linear solve + warm-started folds) and that the conformal reference is vectorized — both exact — over the native per-penalty-inversion / per-permutation methods.

Note: parallelism across the candidate search (joblib) is deferred to a follow-up PR.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX