### PR TITLE
LEXSCM: weakly-targeted treated-tuple selection (targeting_penalty)

### DIFF
--- a/docs/lexscm.rst
+++ b/docs/lexscm.rst
@@ -232,6 +232,38 @@ to the convex hull of the selected donors, and :math:`\sqrt{L(\mathcal{S})}`
 is the achieved imbalance of Assumption 1. Stage 1 returns the ``top_K`` sets of
 smallest :math:`L(\mathcal{S})`, subject to the budget below.
 
+Weakly targeted designs (``targeting_penalty``)
+"""""""""""""""""""""""""""""""""""""""""""""""
+
+By default Stage 1 is *fully targeted*: the weights :math:`\mathbf{w}` are free
+to contort onto the population mean (Abadie & Zhao's representative-experiment
+goal, so the estimand is the population ATE :math:`\tau_t = \sum_j f_j(Y^I_{jt}
+- Y^N_{jt})`). In practice you often treat the chosen markets as a group --
+equal- or population-weighted -- not with bespoke fractional weights, and you
+may prefer the treated group to look like *itself* rather than the population.
+``targeting_penalty`` :math:`= \gamma \ge 0` adds an anchor toward the group's
+own equal-weight aggregate,
+
+.. math::
+
+   \min_{\mathbf{w} \in \Delta(\mathcal{S})}\ \mathbf{w}^\top
+   \mathbf{G}_{\mathcal{S}\mathcal{S}}\, \mathbf{w}
+   \;+\; \gamma\,\bigl\lVert \mathbf{w} - \tfrac{1}{m}\mathbf{1} \bigr\rVert_2^2 .
+
+On the simplex :math:`\mathbf{1}^\top\mathbf{w}=1`, so :math:`\lVert \mathbf{w}
+- \tfrac1m\mathbf{1}\rVert_2^2 = \mathbf{w}^\top\mathbf{w} - \tfrac1m` and the
+penalty is exactly a diagonal ridge, :math:`\min_{\mathbf{w}\in\Delta}
+\mathbf{w}^\top(\mathbf{G}_{\mathcal{S}\mathcal{S}} + \gamma\mathbf{I})\mathbf{w}`.
+The reported imbalance stays the *true* targeting distance
+:math:`\sqrt{\mathbf{w}^\top\mathbf{G}_{\mathcal{S}\mathcal{S}}\mathbf{w}}` at the
+penalized weights. :math:`\gamma = 0` (default) is the fully targeted design;
+:math:`\gamma \to \infty` selects the best equal-weight :math:`m`-tuple; in
+between is *weakly targeted*, sliding the estimand from the population ATE toward
+the treated group's own ATT. This is also the mechanism that discourages
+idiosyncratic treated sets: free weights can hit the population mean even for an
+odd set, whereas the anchor favours sets that sit near the population naturally
+(with near-equal weights), which the donor pool can also reconstruct.
+
 How a single tuple is built: the inner simplex QP
 """""""""""""""""""""""""""""""""""""""""""""""""
 

--- a/mlsynth/estimators/lexscm.py
+++ b/mlsynth/estimators/lexscm.py
@@ -200,6 +200,7 @@ class LEXSCM:
         # =========================================================
         self.top_K: int = config.top_K
         self.top_P: int = config.top_P
+        self.targeting_penalty: float = config.targeting_penalty
 
         # =========================================================
         # INFERENCE / POWER
@@ -449,6 +450,7 @@ class LEXSCM:
             min_per_stratum=self.min_per_stratum,
             max_per_stratum=self.max_per_stratum,
             size_band=size_band,
+            targeting_penalty=self.targeting_penalty,
         )
         selection_results = {"top_tuples": search["top_designs"], "stats": search["stats"]}
 

--- a/mlsynth/tests/test_lexscm_weak_targeting.py
+++ b/mlsynth/tests/test_lexscm_weak_targeting.py
@@ -1,0 +1,134 @@
+"""TDD for the weakly-targeted treated-tuple selection in LEXSCM.
+
+LEXSCM's first QP (``lexsearch.select_treated_designs``) is the *fully targeted*
+design: it picks the treated m-tuple + simplex weights ``w`` that drive the
+weighted treated combination onto the population mean,
+
+    min_{w in simplex(S)}  || sum_j w_j Xtilde_j ||^2 = w' G_SS w,
+
+with ``Xtilde`` f-centred on the population (so the origin is the population
+mean). This is Abadie & Zhao's "representative experiment" goal (eq. 3) and
+Vives-i-Bastida's eq. (1) term 1, solved lexicographically (xi -> 0).
+
+A *weakly targeted* design relaxes that: add a penalty pulling ``w`` toward the
+group's own equal-weight aggregate, so the treated group looks more like itself
+than like the population, trading population-representativeness (the ATE) for a
+deployable equal-weight group (closer to its own ATT):
+
+    min_{w in simplex(S)}  w' G_SS w + gamma || w - (1/m) 1 ||^2 .
+
+On the simplex ``1'w = 1`` so ``||w - 1/m 1||^2 = w'w - 1/m``; the penalty is
+therefore a plain diagonal ridge and the program is exactly
+
+    min_{w in simplex(S)}  w' (G_SS + gamma I) w   (up to the constant gamma/m).
+
+So ``targeting_penalty=gamma`` ridges the Gram diagonal for the treated search,
+and the reported imbalance is the *true* targeting distance ``sqrt(w' G w)`` at
+the penalized ``w`` (the Abadie-Zhao validity quantity), not the penalized
+objective. ``gamma=0`` must be bit-identical to today's design.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.fast_scm_helpers.lexsearch import (
+    _afw_single,
+    select_treated_designs,
+)
+
+
+def _gram(n=12, T=20, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((T, n))
+    X = X - X.mean(axis=1, keepdims=True)          # f-centred (uniform f)
+    return X.T @ X
+
+
+class TestWeakTargeting:
+    def test_gamma_zero_bit_identical(self):
+        G = _gram(seed=0); cand = list(range(G.shape[0]))
+        base = select_treated_designs(G, cand, m=3, top_K=5, method="enumerate")
+        pen0 = select_treated_designs(G, cand, m=3, top_K=5, method="enumerate",
+                                      targeting_penalty=0.0)
+        assert [d.indices for d in base["top_designs"]] == \
+               [d.indices for d in pen0["top_designs"]]
+        for a, b in zip(base["top_designs"], pen0["top_designs"]):
+            np.testing.assert_array_equal(a.weights, b.weights)
+            assert a.loss == b.loss
+            assert a.imbalance == b.imbalance
+
+    def test_high_gamma_pulls_weights_to_uniform(self):
+        G = _gram(seed=1); cand = list(range(G.shape[0]))
+        m = 3
+        lo = select_treated_designs(G, cand, m=m, top_K=1, method="enumerate",
+                                    targeting_penalty=0.0)["top_designs"][0]
+        hi = select_treated_designs(G, cand, m=m, top_K=1, method="enumerate",
+                                    targeting_penalty=1e4)["top_designs"][0]
+        u = np.full(m, 1.0 / m)
+        np.testing.assert_allclose(hi.weights, u, atol=1e-2)
+        # weakly-targeted weights are at least as uniform as fully-targeted
+        assert np.sum((hi.weights - u) ** 2) <= np.sum((lo.weights - u) ** 2) + 1e-9
+
+    def test_reported_imbalance_is_true_not_penalized(self):
+        G = _gram(n=10, T=18, seed=2); cand = list(range(10))
+        d = select_treated_designs(G, cand, m=3, top_K=1, method="enumerate",
+                                   targeting_penalty=5.0)["top_designs"][0]
+        S = d.indices; w = np.asarray(d.weights)
+        true_imb = float(np.sqrt(max(w @ G[np.ix_(S, S)] @ w, 0.0)))
+        np.testing.assert_allclose(d.imbalance, true_imb, rtol=1e-6, atol=1e-9)
+        # penalized objective (loss) >= true imbalance^2
+        assert d.loss >= true_imb ** 2 - 1e-9
+
+    def test_ridge_equals_uniform_anchor_penalty(self):
+        # min w'(G+gamma I)w == min w'Gw + gamma||w - 1/m 1||^2  (differ by gamma/m).
+        G = _gram(n=5, T=12, seed=3); m = 5; gamma = 2.0
+        loss_ridge, w, _ = _afw_single(G + gamma * np.eye(m), iters=600, tol=1e-14)
+        u = np.full(m, 1.0 / m)
+        explicit = float(w @ G @ w + gamma * np.sum((w - u) ** 2))
+        assert loss_ridge == pytest.approx(explicit + gamma / m, abs=1e-9)
+
+    def test_negative_gamma_rejected(self):
+        G = _gram(seed=4); cand = list(range(G.shape[0]))
+        with pytest.raises(Exception):
+            select_treated_designs(G, cand, m=3, targeting_penalty=-1.0)
+
+
+# ---------------------------------------------------------------------------
+# Estimator wiring: targeting_penalty flows from config through LEXSCM.fit
+# ---------------------------------------------------------------------------
+
+import pandas as pd  # noqa: E402
+
+from mlsynth import LEXSCM  # noqa: E402
+from mlsynth.utils.fast_scm_helpers.config import LEXSCMConfig  # noqa: E402
+
+
+def _panel(n_units=12, T=40, T_post=10, n_candidates=8, L=2, sigma=0.1,
+           seed=0, baseline=100.0):
+    rng = np.random.default_rng(seed)
+    g = rng.standard_normal((n_units, L)); nu = rng.standard_normal((T, L))
+    Y = baseline + nu @ g.T + sigma * rng.standard_normal((T, n_units))
+    rows = []
+    for i in range(n_units):
+        for t in range(T):
+            rows.append({"unitid": f"u{i:02d}", "time": t, "y": Y[t, i],
+                         "post": int(t >= T - T_post),
+                         "candidate": int(i < n_candidates)})
+    return pd.DataFrame(rows)
+
+
+class TestEstimatorWiring:
+    def test_config_default_is_zero(self):
+        cfg = LEXSCMConfig(df=_panel(), outcome="y", unitid="unitid", time="time",
+                           candidate_col="candidate", m=3)
+        assert cfg.targeting_penalty == 0.0
+
+    def test_fit_weakly_targeted_weights_near_uniform(self):
+        base = dict(df=_panel(), outcome="y", unitid="unitid", time="time",
+                    candidate_col="candidate", m=3, post_col="post",
+                    display_graph=False, verbose=False)
+        rg = LEXSCM({**base, "targeting_penalty": 1e4}).fit()
+        wg = np.array(list(rg.search.candidates[0].treated_weight_dict.values()))
+        np.testing.assert_allclose(wg, np.full(len(wg), 1.0 / len(wg)), atol=1e-2)

--- a/mlsynth/utils/fast_scm_helpers/config.py
+++ b/mlsynth/utils/fast_scm_helpers/config.py
@@ -53,6 +53,19 @@ class LEXSCMConfig(BaseMAREXConfig):
                     "selected treated units."
     )
 
+    targeting_penalty: float = Field(
+        default=0.0, ge=0.0,
+        description="Weak-targeting penalty (gamma >= 0) on the treated-tuple QP. "
+                    "0 (default) is the fully targeted design: the treated weighted "
+                    "combination is driven onto the population mean (the ATE goal, "
+                    "Abadie-Zhao). gamma > 0 adds gamma||w - 1/m||^2, pulling the "
+                    "treatment weights toward the group's own equal-weight aggregate "
+                    "so the treated group looks more like itself than the population "
+                    "-- a weakly targeted design whose estimand slides from the "
+                    "population ATE toward the treated group's ATT. Large gamma "
+                    "selects the best equal-weight m-tuple."
+    )
+
     # =========================================================
     # SPILLOVER / INTERFERENCE EXCLUSIONS (Vives-i-Bastida 2022)
     # =========================================================

--- a/mlsynth/utils/fast_scm_helpers/lexsearch.py
+++ b/mlsynth/utils/fast_scm_helpers/lexsearch.py
@@ -364,8 +364,19 @@ def select_treated_designs(
     min_per_stratum: Optional[int] = None,
     max_per_stratum: Optional[int] = None,
     size_band: Optional[Any] = None,
+    targeting_penalty: float = 0.0,
 ) -> Dict[str, Any]:
     """Select the ``top_K`` treated m-tuples with smallest imbalance.
+
+    ``targeting_penalty`` (gamma >= 0) makes the design *weakly targeted*: it
+    adds ``gamma || w - (1/m) 1 ||^2`` to the treated QP, pulling the weights
+    toward the group's own equal-weight aggregate so the treated group looks more
+    like itself than like the population mean (trading some population
+    representativeness -- the ATE -- for a deployable equal-weight group closer
+    to its own ATT). On the simplex this is exactly a diagonal ridge,
+    ``min_w w'(G_SS + gamma I) w``; the reported ``imbalance`` remains the true
+    targeting distance ``sqrt(w' G w)`` at the penalized ``w``. ``gamma=0`` (the
+    default) is the fully targeted design, unchanged.
 
     Parameters
     ----------
@@ -388,6 +399,13 @@ def select_treated_designs(
     """
     t0 = time.time()
     G = np.asarray(G, dtype=float)
+    if targeting_penalty < 0:
+        raise MlsynthConfigError(
+            f"targeting_penalty (gamma) must be >= 0; got {targeting_penalty}."
+        )
+    # Weakly-targeted ridge: search and weight-solve on G + gamma I; the true
+    # targeting imbalance is read off the original G at the penalized weights.
+    Gsearch = G + targeting_penalty * np.eye(G.shape[0]) if targeting_penalty > 0 else G
     rng = np.random.default_rng(random_state)
 
     # Up-front feasibility audit: one itemised error naming EVERY binding
@@ -413,13 +431,13 @@ def select_treated_designs(
 
     consensus = None
     if method == "enumerate":
-        raw, n_eval = _enumerate(G, cand, m, top_K, unit_costs, budget, iters,
+        raw, n_eval = _enumerate(Gsearch, cand, m, top_K, unit_costs, budget, iters,
                                  conflict=conflict, strata=strata,
                                  min_per=min_per_stratum, max_per=max_per_stratum,
                                  required=required)
         exact = True
     elif method == "heuristic":
-        raw, n_eval, consensus = _local_search(G, cand, m, top_K, unit_costs,
+        raw, n_eval, consensus = _local_search(Gsearch, cand, m, top_K, unit_costs,
                                                budget, n_starts, rng, iters,
                                                conflict=conflict, strata=strata,
                                                min_per=min_per_stratum,
@@ -460,10 +478,12 @@ def select_treated_designs(
     designs: List[TreatedDesign] = []
     for rank, (S, _approx) in enumerate(raw, start=1):
         S = [int(x) for x in S]
-        loss, w, _ = _afw_single(G[np.ix_(S, S)], iters=600, tol=1e-14)
+        # Penalized weights/loss on G + gamma I; true targeting imbalance on G.
+        loss, w, _ = _afw_single(Gsearch[np.ix_(S, S)], iters=600, tol=1e-14)
+        imb2 = float(w @ G[np.ix_(S, S)] @ w)
         tc = float(unit_costs[S].sum()) if unit_costs is not None else 0.0
         d = TreatedDesign(
-            indices=S, weights=w, loss=loss, imbalance=float(np.sqrt(max(loss, 0.0))),
+            indices=S, weights=w, loss=loss, imbalance=float(np.sqrt(max(imb2, 0.0))),
             total_cost=tc, label=f"Design {rank}",
         )
         if unit_index is not None:


### PR DESCRIPTION
## Summary

Adds a weak-targeting knob to LEXSCM's Stage-1 treated-tuple selection, so the design spans the full targeted↔untargeted spectrum of Abadie–Zhao (2026) / Vives-i-Bastida.

Today LEXSCM's first QP is the fully targeted design: `min_w ‖Σ wⱼ X̃ⱼ‖² = w'G_SS w`, which drives the treated weighted combination onto the population mean (the representative-experiment goal; estimand = population ATE), with the weights free to contort to get there. `targeting_penalty = γ ≥ 0` adds an anchor toward the group's own equal-weight aggregate:

```
min_{w∈Δ(S)}  w'G_SS w + γ‖w − (1/m)𝟙‖²
```

so the treated group looks more like itself than the population — sliding the estimand from the population ATE toward the treated group's ATT, and discouraging idiosyncratic treated sets (free weights can hit the population mean even for an odd set; the anchor favours sets that sit near the population naturally and that donors can reconstruct).

## Implementation (exact, no solver change)

On the simplex `𝟙'w = 1`, so `‖w − (1/m)𝟙‖² = w'w − 1/m` and the penalty is exactly a diagonal ridge:

```
min_{w∈Δ(S)}  w'(G_SS + γI) w
```

So the treated search and weight-solve run on `G + γI`; the reported `imbalance` stays the true targeting distance `√(w'Gw)` at the penalized weights (the Abadie–Zhao validity quantity). `γ=0` (default) is bit-identical to today. Threaded through `LEXSCMConfig.targeting_penalty` (default `0.0`) and the estimator.

## Correctness (TDD)

`test_lexscm_weak_targeting.py`:
- `γ=0` bit-identical to current (designs, weights, losses, imbalance).
- high `γ` → weights → uniform `1/m`.
- ridge ≡ uniform-anchor penalty (differ by the constant `γ/m`).
- reported imbalance is the true `√(w'Gw)`, not the penalized objective.
- negative `γ` rejected; estimator wiring (config default 0.0; high-γ fit → uniform treated weights).

7 new tests + the full existing LEXSCM suite (143: `test_lexscm`, `test_lexsearch`, `test_lexscm_pipeline`, `test_simplex_active_set`) green — `γ=0` default path unregressed.

## Docs

`docs/lexscm.rst` gains a "Weakly targeted designs" subsection: the knob, the ridge identity, and the ATE→ATT estimand slide.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_