### PR TITLE
SYNDES: solution pool (top_K menu) + annealed weight-QP robustness fix

### DIFF
--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -442,6 +442,31 @@ A budget constraint (``costs`` + ``budget``) adds
 :math:`\sum_i \mathrm{cost}_i D_i \le B` to the MIP; ``mode="two_way_global"``
 also accepts ``K=None`` to let the program choose the number of treated units.
 
+Solution pool (``top_K``): a menu, not one answer
+-------------------------------------------------
+
+The MIP returns the single MSE-optimal design, but that is optimal for *fit
+alone* -- it discards every other feasible design, some of which may be cheaper,
+more detectable, or operationally preferable at a negligible fit cost. Setting
+``top_K > 1`` returns a ranked pool of the best ``top_K`` distinct designs,
+obtained by *no-good cuts*: after each solve the chosen treated set
+:math:`S` is forbidden (:math:`\sum_{i \in S} D_i \le |S|-1`) and the MIP is
+re-solved for the next-best design. The pool is attached as ``results.pool`` --
+a list of dicts ranked by MSE, each with its ``markets``, ``objective`` (MSE),
+``pre_fit_rmse``, ``mde_pct`` (the same permutation-null MDE
+:func:`~mlsynth.power_analysis` uses), and ``cost`` (when ``costs`` is given).
+Because the objective only ranks fit, the value is precisely the re-scoring on
+the dimensions it ignored: a manager can trade a small fit increase for lower
+cost or higher power. ``top_K=1`` (default) is unchanged -- only the optimum is
+returned and ``results.pool`` is ``None``.
+
+.. code-block:: python
+
+   res = SYNDES({"df": df, "outcome": "y", "unitid": "unit", "time": "time",
+                 "K": 3, "mode": "two_way_global", "top_K": 5}).fit()
+   for d in res.pool:                        # ranked menu, best fit first
+       print(d["markets"], round(d["objective"], 1), round(d["mde_pct"], 2), d["cost"])
+
 Verification
 ------------
 

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -63,7 +63,10 @@ from ..utils.syndes_helpers.inference import (
     permutation_test_global,
     permutation_test_relaxed_global,
 )
-from ..utils.syndes_helpers.optimization import solve_synthetic_design
+from ..utils.syndes_helpers.optimization import (
+    solve_synthetic_design,
+    solve_synthetic_design_pool,
+)
 from ..utils.syndes_helpers.plotter import plot_syndes_design
 from ..utils.syndes_helpers.relaxed_solver import solve_two_way_relaxed
 from ..utils.syndes_helpers.relaxed_structures import RelaxedSolverResults
@@ -155,6 +158,41 @@ def _syndes_post_fit(inputs, design, inference, alpha):
     return pf
 
 
+def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8):
+    """Re-score a SYNDES solution pool into a manager-facing menu.
+
+    The MIP ranks designs by fit alone, so each pooled design is annotated with
+    the dimensions the objective ignored: its MDE% (same permutation-null formula
+    ``power_analysis`` uses -- ``sigma_perm / sqrt(n_post)`` on the design's
+    pre-period contrast, as a percent of the treated baseline) and its cost (when
+    ``costs`` is supplied). Returned as a list of dicts ranked by MSE.
+    """
+    from scipy.stats import norm
+
+    Y_pre = np.asarray(inputs.Y_pre, dtype=float)
+    n_post = int(inputs.Y_post.shape[0]) if inputs.Y_post is not None else 4
+    z = float(norm.ppf(1.0 - alpha / 2.0) + norm.ppf(power_target))
+    costs_arr = None if costs is None else np.asarray(costs, dtype=float).reshape(-1)
+    menu = []
+    for d in pool_designs:
+        contrast = np.asarray(d.contrast_weights, dtype=float).reshape(-1)
+        per_period = Y_pre @ contrast
+        sigma = (float(np.std(per_period, ddof=1)) if per_period.size > 1
+                 else float(np.std(per_period)))
+        mde_abs = z * sigma / np.sqrt(n_post)
+        idx = np.asarray(d.selected_unit_indices, dtype=int)
+        base = float(np.mean(Y_pre[:, idx])) if idx.size else float("nan")
+        mde_pct = 100.0 * mde_abs / abs(base) if abs(base) > 1e-9 else float("nan")
+        menu.append({
+            "markets": [x for x in np.asarray(d.selected_unit_labels).tolist()],
+            "objective": float(d.objective_value),
+            "pre_fit_rmse": (None if d.pre_fit_rmse is None else float(d.pre_fit_rmse)),
+            "mde_pct": float(mde_pct),
+            "cost": (None if costs_arr is None else float(costs_arr[idx].sum())),
+        })
+    return menu
+
+
 class SYNDES:
     """Synthetic Design (Doudchenko et al. 2021) estimator.
 
@@ -203,6 +241,7 @@ class SYNDES:
         self.verbose: bool = config.verbose
         self.costs = config.costs
         self.budget = config.budget
+        self.top_K: int = config.top_K
         self.arm: Optional[str] = config.arm
 
     # ------------------------------------------------------------------
@@ -278,19 +317,21 @@ class SYNDES:
     def _fit_mip(self, inputs) -> SYNDESResults:
         mode_internal = _MODE_TO_INTERNAL[self.mode_public]
 
-        design = solve_synthetic_design(
-            Y=inputs.Y_pre,
-            K=self.K,
-            mode=mode_internal,
-            lam=self.lam,
-            solver=self.solver,
-            verbose=self.verbose,
-            unit_index=inputs.unit_index,
-            costs=self.costs,
-            budget=self.budget,
-            gap_limit=self.gap_limit,
-            time_limit=self.time_limit,
+        solve_kw = dict(
+            Y=inputs.Y_pre, K=self.K, mode=mode_internal, lam=self.lam,
+            solver=self.solver, verbose=self.verbose,
+            unit_index=inputs.unit_index, costs=self.costs, budget=self.budget,
+            gap_limit=self.gap_limit, time_limit=self.time_limit,
         )
+        pool = None
+        if self.top_K and self.top_K > 1:
+            # Solution pool: top-K distinct designs by no-good cuts. The rank-1
+            # design IS the single-solve optimum, so reuse it (no double solve).
+            pool_designs = solve_synthetic_design_pool(top_K=self.top_K, **solve_kw)
+            design = pool_designs[0]
+            pool = _syndes_pool_menu(pool_designs, inputs, self.costs, self.alpha)
+        else:
+            design = solve_synthetic_design(**solve_kw)
 
         # Re-tag with the paper-aligned mode label so the design surface
         # the user sees uses SYNDES vocabulary.
@@ -312,7 +353,7 @@ class SYNDES:
 
         results = SYNDESResults(
             design=design, inputs=inputs, inference=inference,
-            post_fit=post_fit,
+            post_fit=post_fit, pool=pool,
         )
 
         if self.display_graph:

--- a/mlsynth/tests/test_syndes_pool.py
+++ b/mlsynth/tests/test_syndes_pool.py
@@ -1,0 +1,120 @@
+"""TDD for the SYNDES solution pool (no-good-cut enumeration of near-optimal designs).
+
+SYNDES's MIP returns a single MSE-optimal design, but managers want options. The
+pool re-solves with a "no-good cut" each round -- forbidding the previously
+chosen treated set (``sum_{i in S} D_i <= |S|-1``) -- so the next solve returns
+the next-best *distinct* design. The result is the top-K designs ranked by MSE
+(non-decreasing), the rank-1 being exactly the single-solve optimum.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.syndes_helpers.optimization import (
+    solve_synthetic_design,
+    solve_synthetic_design_pool,
+)
+
+
+def _Y(T=20, N=10, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.standard_normal((T, 3)); L = rng.standard_normal((3, N))
+    return 100.0 + F @ L + rng.standard_normal((T, N)) * 0.5
+
+
+class TestSolutionPool:
+    def test_top1_matches_single_solve(self):
+        Y = _Y()
+        single = solve_synthetic_design(Y, K=3, mode="global_2way")
+        pool = solve_synthetic_design_pool(Y, K=3, top_K=1, mode="global_2way")
+        assert len(pool) == 1
+        assert set(pool[0].selected_unit_indices) == set(single.selected_unit_indices)
+        assert pool[0].objective_value == pytest.approx(single.objective_value, rel=1e-6)
+
+    def test_pool_distinct_and_ranked(self):
+        Y = _Y(seed=1)
+        pool = solve_synthetic_design_pool(Y, K=3, top_K=4, mode="global_2way")
+        assert len(pool) == 4
+        sets = [frozenset(d.selected_unit_indices) for d in pool]
+        assert len(set(sets)) == 4                                   # all distinct
+        objs = [d.objective_value for d in pool]
+        assert all(objs[i] <= objs[i + 1] + 1e-6 for i in range(len(objs) - 1))
+        single = solve_synthetic_design(Y, K=3, mode="global_2way")
+        assert sets[0] == frozenset(single.selected_unit_indices)   # rank-1 == optimum
+
+    def test_pool_respects_budget(self):
+        Y = _Y(seed=2)
+        costs = np.arange(1.0, 11.0); budget = 12.0
+        pool = solve_synthetic_design_pool(Y, K=3, top_K=3, mode="global_2way",
+                                           costs=costs, budget=budget)
+        assert len(pool) >= 1
+        for d in pool:
+            assert costs[d.selected_unit_indices].sum() <= budget + 1e-6
+
+    def test_pool_early_stop_when_exhausted(self):
+        Y = _Y(N=5, seed=3)                       # C(5,3) = 10 distinct treated sets
+        pool = solve_synthetic_design_pool(Y, K=3, top_K=50, mode="global_2way")
+        assert 1 <= len(pool) <= 10
+        sets = [frozenset(d.selected_unit_indices) for d in pool]
+        assert len(set(sets)) == len(pool)        # no duplicates ever returned
+
+    def test_top_K_validated(self):
+        with pytest.raises(Exception):
+            solve_synthetic_design_pool(_Y(), K=3, top_K=0, mode="global_2way")
+
+
+# ----------------------------------------------------------------------
+# Estimator-level: SYNDES(top_K=...).fit() -> results.pool menu
+# ----------------------------------------------------------------------
+
+import pandas as pd  # noqa: E402
+
+from mlsynth import SYNDES  # noqa: E402
+
+
+def _panel(T=24, N=10, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.standard_normal((T, 3)); L = rng.standard_normal((3, N))
+    Y = 100.0 + F @ L + rng.standard_normal((T, N)) * 0.5
+    rows = []
+    for i in range(N):
+        for t in range(T):
+            rows.append({"unit": f"u{i:02d}", "time": t, "y": float(Y[t, i]),
+                         "post": int(t >= T - 4)})
+    return pd.DataFrame(rows)
+
+
+class TestEstimatorPool:
+    def _cfg(self, **over):
+        base = dict(df=_panel(), outcome="y", unitid="unit", time="time", K=3,
+                    mode="two_way_global", post_col="post", run_inference=False)
+        base.update(over)
+        return base
+
+    def test_top_K_default_no_pool(self):
+        res = SYNDES(self._cfg()).fit()
+        assert res.pool is None
+        assert res.design.selected_unit_indices.size == 3
+
+    def test_pool_menu_returned(self):
+        res = SYNDES(self._cfg(top_K=4)).fit()
+        assert res.pool is not None and len(res.pool) == 4
+        # ranked by MSE (the objective), non-decreasing
+        objs = [e["objective"] for e in res.pool]
+        assert all(objs[i] <= objs[i + 1] + 1e-6 for i in range(len(objs) - 1))
+        # rank-1 menu entry IS the returned optimal design
+        assert sorted(res.pool[0]["markets"]) == sorted(res.design.selected_unit_labels.tolist())
+        # distinct treated sets, each with the menu columns
+        mkts = [tuple(sorted(e["markets"])) for e in res.pool]
+        assert len(set(mkts)) == 4
+        for e in res.pool:
+            assert set(e) >= {"markets", "objective", "pre_fit_rmse", "mde_pct", "cost"}
+            assert len(e["markets"]) == 3 and np.isfinite(e["mde_pct"])
+
+    def test_pool_cost_column_with_costs(self):
+        N = 10
+        costs = list(np.arange(1.0, N + 1.0))
+        res = SYNDES(self._cfg(top_K=3, costs=costs, budget=20.0)).fit()
+        for e in res.pool:
+            assert e["cost"] is not None and e["cost"] <= 20.0 + 1e-6

--- a/mlsynth/tests/test_syndes_relaxed_weights.py
+++ b/mlsynth/tests/test_syndes_relaxed_weights.py
@@ -1,0 +1,59 @@
+"""TDD for robustness of the relaxed-SYNDES weight QP (annealed solver inner step).
+
+``solve_weights_global`` is a simplex-constrained least squares -- always feasible
+(uniform weights satisfy the constraints). But its OSQP (first-order ADMM) solve
+spuriously reports ``infeasible`` / inaccurate on large-magnitude, ill-scaled
+panels, which crashes the annealed solver mid-search (it evaluates many candidate
+assignments). The fix: fall back to the robust interior-point CLARABEL solver
+before giving up. These tests pin "never crash on a feasible QP; return
+simplex-feasible weights matching a direct robust solve."
+"""
+from __future__ import annotations
+
+import numpy as np
+import cvxpy as cp
+import pytest
+
+from mlsynth.utils.syndes_helpers.relaxed_formulation import solve_weights_global
+
+
+def _big_panel(T=40, N=16, seed=0):
+    # Large-magnitude, seasonal, partly-collinear panel (mimics real geo sales),
+    # the regime where OSQP mis-reports the simplex LSQ as infeasible.
+    rng = np.random.default_rng(seed)
+    t = np.arange(T)
+    season = 500.0 * np.sin(2 * np.pi * t / 12)[:, None]
+    levels = 3000.0 + rng.standard_normal(N) * 400.0
+    return levels[None, :] + season + rng.standard_normal((T, N)) * 50.0
+
+
+def _direct(Y, D):
+    tr = np.where(D == 1)[0]; co = np.where(D == 0)[0]
+    wT = cp.Variable(len(tr)); wC = cp.Variable(len(co))
+    p = cp.Problem(cp.Minimize(cp.sum_squares(Y[:, tr] @ wT - Y[:, co] @ wC)),
+                   [wT >= 0, wC >= 0, cp.sum(wT) == 1, cp.sum(wC) == 1])
+    p.solve(solver=cp.CLARABEL)
+    return float(p.value)
+
+
+class TestRelaxedWeightRobustness:
+    def test_never_crashes_on_feasible_qp(self):
+        # Across many random assignments on a large-magnitude panel, the weight
+        # QP must always return simplex-feasible weights (no MlsynthEstimationError).
+        Y = _big_panel(seed=1); N = Y.shape[1]; rng = np.random.default_rng(7)
+        for _ in range(40):
+            D = np.zeros(N, dtype=int); D[rng.choice(N, 3, replace=False)] = 1
+            w = solve_weights_global(Y, D, lam=0.0)
+            tr = np.where(D == 1)[0]; co = np.where(D == 0)[0]
+            assert np.all(w >= -1e-5)            # feasible to solver tolerance
+            assert w[tr].sum() == pytest.approx(1.0, abs=1e-4)
+            assert w[co].sum() == pytest.approx(1.0, abs=1e-4)
+
+    def test_matches_direct_robust_solve(self):
+        Y = _big_panel(seed=2); N = Y.shape[1]; rng = np.random.default_rng(3)
+        for _ in range(10):
+            D = np.zeros(N, dtype=int); D[rng.choice(N, 3, replace=False)] = 1
+            w = solve_weights_global(Y, D, lam=0.0)
+            tr = np.where(D == 1)[0]; co = np.where(D == 0)[0]
+            obj = float(np.sum((Y[:, tr] @ w[tr] - Y[:, co] @ w[co]) ** 2))
+            assert obj <= _direct(Y, D) * (1 + 1e-4) + 1e-6   # at the optimum

--- a/mlsynth/utils/syndes_helpers/config.py
+++ b/mlsynth/utils/syndes_helpers/config.py
@@ -173,6 +173,18 @@ class SYNDESConfig(BaseMAREXConfig):
             "Required when ``costs`` is supplied; ignored otherwise."
         ),
     )
+    top_K: int = Field(
+        default=1, ge=1,
+        description=(
+            "Size of the returned solution pool. ``1`` (default) returns only "
+            "the MSE-optimal design. ``>1`` enumerates the top-K distinct "
+            "designs by no-good cuts (forbidding each chosen treated set and "
+            "re-solving for the next-best), ranked by MSE, and attaches them as "
+            "``results.pool`` -- a menu of near-optimal options re-scored on MDE "
+            "and cost, since the MIP optimises fit alone. Fewer than ``top_K`` "
+            "are returned if the feasible region is exhausted."
+        ),
+    )
     arm: Optional[str] = Field(
         default=None,
         description=(

--- a/mlsynth/utils/syndes_helpers/optimization.py
+++ b/mlsynth/utils/syndes_helpers/optimization.py
@@ -206,6 +206,7 @@ def solve_synthetic_design(
     budget: Optional[float] = None,
     gap_limit: Optional[float] = None,
     time_limit: Optional[float] = None,
+    forbidden_sets: Optional[list] = None,
 ) -> SYNDESDesign:
     """
     Solve the SYNDES synthetic design optimization problem.
@@ -272,7 +273,16 @@ def solve_synthetic_design(
             raise MlsynthConfigError("budget must be strictly positive.")
         components = components.with_constraints([cost_vec @ D <= float(budget)])
 
-    problem = cp.Problem(cp.Minimize(components.objective), components.constraints)
+    # No-good cuts (solution pool): forbid each previously-chosen treated set
+    # ``S`` via ``sum_{i in S} D_i <= |S|-1``, so re-solving returns the next-best
+    # *distinct* design. Empty by default -> the single-optimum solve, unchanged.
+    prob_constraints = list(components.constraints)
+    for _fs in (forbidden_sets or []):
+        _fs = np.asarray(_fs, dtype=int).reshape(-1)
+        if _fs.size:
+            prob_constraints.append(cp.sum(D[_fs]) <= int(_fs.size) - 1)
+
+    problem = cp.Problem(cp.Minimize(components.objective), prob_constraints)
 
     # Plumb the user-supplied SCIP limits (Abadie & Zhao 2026 p. 13:
     # "we do not strictly require optimality of {w*, v*}, provided
@@ -366,3 +376,58 @@ def solve_synthetic_design(
 
         raw_results=raw_results,
     )
+
+
+def solve_synthetic_design_pool(
+    Y: np.ndarray,
+    K: int,
+    top_K: int = 1,
+    *,
+    mode: str = "global_2way",
+    lam: Optional[float] = None,
+    solver: Any = "SCIP",
+    verbose: bool = False,
+    unit_index: Optional[IndexSet] = None,
+    costs: Optional[np.ndarray] = None,
+    budget: Optional[float] = None,
+    gap_limit: Optional[float] = None,
+    time_limit: Optional[float] = None,
+) -> list:
+    """Top-``top_K`` SYNDES designs, ranked by MSE, via no-good cuts.
+
+    Re-solves the SYNDES MIP ``top_K`` times; after each solve the chosen treated
+    set is forbidden (``sum_{i in S} D_i <= |S|-1``) so the next solve returns the
+    next-best *distinct* design. The returned list is ranked by objective value
+    (non-decreasing), and ``solve_synthetic_design_pool(..., top_K=1)`` returns
+    ``[solve_synthetic_design(...)]`` -- the single optimum unchanged. Stops early
+    (returning fewer than ``top_K``) once the feasible region is exhausted.
+
+    Parameters
+    ----------
+    top_K : int
+        Number of distinct designs to enumerate (``>= 1``).
+    (all other parameters as in :func:`solve_synthetic_design`).
+
+    Returns
+    -------
+    list of SYNDESDesign
+        Distinct designs ordered by ascending MSE; ``[0]`` is the global optimum.
+    """
+    if not isinstance(top_K, (int, np.integer)) or top_K < 1:
+        raise MlsynthConfigError(f"top_K must be a positive integer; got {top_K!r}.")
+
+    designs: list = []
+    forbidden: list = []
+    for _ in range(int(top_K)):
+        try:
+            d = solve_synthetic_design(
+                Y=Y, K=K, mode=mode, lam=lam, solver=solver, verbose=verbose,
+                unit_index=unit_index, costs=costs, budget=budget,
+                gap_limit=gap_limit, time_limit=time_limit,
+                forbidden_sets=forbidden,
+            )
+        except MlsynthEstimationError:
+            break  # feasible region exhausted (no further distinct design)
+        designs.append(d)
+        forbidden.append(np.asarray(d.selected_unit_indices, dtype=int))
+    return designs

--- a/mlsynth/utils/syndes_helpers/relaxed_formulation.py
+++ b/mlsynth/utils/syndes_helpers/relaxed_formulation.py
@@ -83,7 +83,15 @@ def solve_weights_global(
     problem = cp.Problem(objective, constraints)
     problem.solve(solver=cp.OSQP, warm_start=True, verbose=False)
 
-    if problem.status not in _OPTIMAL_STATUSES:
+    # This simplex-constrained LSQ is always feasible (uniform weights satisfy
+    # it), but OSQP (first-order ADMM) can spuriously report infeasible/inaccurate
+    # on large-magnitude, ill-scaled panels -- which would otherwise crash the
+    # annealed solver mid-search. Fall back to the robust interior-point CLARABEL
+    # solver before giving up.
+    if problem.status not in _OPTIMAL_STATUSES or w_T.value is None:
+        problem.solve(solver=cp.CLARABEL, verbose=False)
+
+    if problem.status not in _OPTIMAL_STATUSES or w_T.value is None:
         raise MlsynthEstimationError(
             f"Relaxed weight QP failed with status: {problem.status}"
         )

--- a/mlsynth/utils/syndes_helpers/structures.py
+++ b/mlsynth/utils/syndes_helpers/structures.py
@@ -258,6 +258,7 @@ class SYNDESResults:
     inputs: SYNDESInputs
     inference: Optional[SYNDESInference] = None
     post_fit: Optional[Any] = None    # SyntheticControlPostFit; Any to dodge import cycle
+    pool: Optional[Any] = None        # solution-pool menu (list of dicts) when top_K > 1
 
     @property
     def mode(self) -> str:


### PR DESCRIPTION
## Summary

Two SYNDES improvements: a solution-pool menu (the headline feature you asked for) and a robustness fix to the annealed solver discovered while bake-off-testing it.

## 1. Solution pool (`top_K`) — a menu, not one answer

SYNDES's MIP returns the single MSE-optimal design, but that's optimal for fit alone — it discards feasible designs that may be cheaper, more detectable, or operationally preferable at a tiny fit cost. `top_K > 1` enumerates the top-K distinct designs by no-good cuts (after each solve, forbid the chosen treated set via `Σ_{i∈S} D_i ≤ |S|−1` and re-solve for the next-best), ranked by MSE.

- `solve_synthetic_design` gains `forbidden_sets` (the no-good cuts); empty default = the single optimum, unchanged.
- `solve_synthetic_design_pool(top_K)` loops it: distinct designs ranked by non-decreasing MSE, rank-1 == the single-solve optimum, early-stopping when the feasible region is exhausted.
- `SYNDESConfig.top_K` (default 1); `SYNDESResults.pool` attaches a re-scored menu (`markets`, `objective`/MSE, `pre_fit_rmse`, `mde_pct` via the same permutation-null power formula `fit()` uses, `cost` when `costs` given) — so managers see options on the dimensions the MIP ignored.

## 2. Annealed solver robustness (OSQP false-infeasible)

The relaxed/annealed solver's inner weight step (`solve_weights_global`) is a simplex-constrained least squares — always feasible (uniform weights satisfy it). But OSQP (first-order ADMM) spuriously reports `infeasible`/inaccurate on large-magnitude, ill-scaled panels (confirmed: 8/40 random assignments on the GeoLift dummy data failed under OSQP vs 40/40 optimal under CLARABEL), which crashed `mode="two_way_global_annealed"` mid-search. Fixed with a CLARABEL fallback when OSQP returns a non-optimal status (mirrors the cvxpy fallbacks elsewhere in mlsynth).

## Correctness (TDD)

- `test_syndes_pool.py` (8): `top_K=1` ≡ single solve; pool distinct + non-decreasing MSE; budget respected; early-stop on exhaustion; estimator menu columns + cost.
- `test_syndes_relaxed_weights.py` (2): never crashes on a feasible QP across many large-magnitude assignments; matches a direct CLARABEL solve at the optimum.

Full SYNDES suite (170) green; `top_K=1` default path unchanged.

## Docs

`docs/syndes.rst` gains a "Solution pool (`top_K`)" section documenting the menu.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_