### PR TITLE
SYNDES: align annealed default lambda + make all doc code blocks runnable MWEs

### DIFF
--- a/agents/agents_docs.md
+++ b/agents/agents_docs.md
@@ -254,6 +254,30 @@ Every estimator page carries, in this order near the top:
    (a)/(b)/(c), **each immediately followed by a Remark** giving the intuition.
    Do not bury assumptions in prose.
 
+### Code blocks are runnable MWEs
+
+Every ``.. code-block:: python`` on a doc page is a minimal worked example: a
+reader must be able to copy it, paste it, and run it as-is. That means each
+block, on its own, must
+
+* **obtain its data** — either simulate a panel (a few lines of numpy/pandas,
+  seeded with ``np.random.default_rng``) or import a real one (the
+  ``raw.githubusercontent.com/jgreathouse9/mlsynth/.../basedata/<file>.csv``
+  convention other pages use), never reference an undefined ``df``;
+* **call the public API** with real, existing column names and arguments —
+  no ``SYNDES({...})`` placeholders, no ``outcome="y"`` when the frame's column
+  is ``"Y"``;
+* **run and show the feature** — fit, then print/inspect the specific outputs
+  the surrounding prose is describing, so the block demonstrates the thing it
+  documents.
+
+Snippets that merely list a result object's attribute surface still count: give
+them a one-line data load + ``fit()`` so the variable they reference exists. If
+a block cannot be made to run, it does not belong on the page. Prefer a small,
+fast dataset; when an example is unavoidably slow (e.g. several sequential MIP
+solves), say so in a comment rather than shrinking it into something that no
+longer runs.
+
 ## Scope reminder
 
 This is a notation/style contract, not a license to revise mathematics. When

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -214,11 +214,30 @@ produced the design:
 
 .. code-block:: python
 
-   pf = res.post_fit                          # SyntheticControlPostFit
-   pf.ate, pf.ate_percent, pf.total_effect    # treatment-effect scalars
-   pf.rmse_fit, pf.rmse_post                  # pre / post fit quality
-   pf.p_value, pf.ci_lower, pf.ci_upper       # permutation inference
-   pf.power                                   # PowerAnalysis (see below)
+   import numpy as np
+   import pandas as pd
+   from mlsynth import SYNDES
+
+   rng = np.random.default_rng(0)
+   n_units, n_periods, n_post = 8, 20, 6
+   factors = rng.normal(size=(n_periods, 2))
+   loadings = rng.uniform(0.3, 1.0, size=(n_units, 2))
+   level = rng.uniform(8.0, 12.0, size=n_units)
+   Y = level + factors @ loadings.T + rng.normal(scale=0.3, size=(n_periods, n_units))
+   df = pd.DataFrame(
+       [{"unit": j, "time": t, "Y": float(Y[t, j]),
+         "post": int(t >= n_periods - n_post)}
+        for j in range(n_units) for t in range(n_periods)]
+   )
+   res = SYNDES({"df": df, "outcome": "Y", "unitid": "unit", "time": "time",
+                 "K": 3, "mode": "two_way_global", "post_col": "post",
+                 "run_inference": True}).fit()
+
+   pf = res.post_fit                            # SyntheticControlPostFit
+   print(pf.ate, pf.ate_percent, pf.total_effect)   # treatment-effect scalars
+   print(pf.rmse_fit, pf.rmse_post)                 # pre / post fit quality
+   print(pf.p_value, pf.ci_lower, pf.ci_upper)      # permutation inference
+   print(pf.power)                                  # PowerAnalysis (see below)
 
 The synthetic treated / control trajectories used to populate ``post_fit`` are
 the per-unit weighted aggregates ``Y[:, j] @ treated_weights`` and
@@ -244,11 +263,30 @@ the same module powers all three estimators.
 
 .. code-block:: python
 
-   p = res.post_fit.power                      # PowerAnalysis
-   p.headline.mde_absolute                     # MDE at the realised T_post
-   p.headline.mde_pct                          # ... as % of post-period baseline
-   p.headline.power_at_observed                # power to detect res.post_fit.ate
-   p.curve                                     # tuple of MDEPoint per horizon
+   import numpy as np
+   import pandas as pd
+   from mlsynth import SYNDES
+
+   rng = np.random.default_rng(0)
+   n_units, n_periods, n_post = 8, 20, 6
+   factors = rng.normal(size=(n_periods, 2))
+   loadings = rng.uniform(0.3, 1.0, size=(n_units, 2))
+   level = rng.uniform(8.0, 12.0, size=n_units)
+   Y = level + factors @ loadings.T + rng.normal(scale=0.3, size=(n_periods, n_units))
+   df = pd.DataFrame(
+       [{"unit": j, "time": t, "Y": float(Y[t, j]),
+         "post": int(t >= n_periods - n_post)}
+        for j in range(n_units) for t in range(n_periods)]
+   )
+   res = SYNDES({"df": df, "outcome": "Y", "unitid": "unit", "time": "time",
+                 "K": 3, "mode": "two_way_global", "post_col": "post",
+                 "run_inference": True}).fit()
+
+   p = res.post_fit.power                        # PowerAnalysis
+   print(p.headline.mde_absolute)                # MDE at the realised T_post
+   print(p.headline.mde_pct)                     # ... as % of post-period baseline
+   print(p.headline.power_at_observed)           # power to detect res.post_fit.ate
+   print(p.curve)                                # tuple of MDEPoint per horizon
 
 Power-analysis failures (e.g. degenerate pre-period contrast) never break a
 fit; ``res.post_fit.power`` is simply left as ``None`` in that case. To
@@ -335,23 +373,36 @@ optimality:
 
 .. code-block:: python
 
+   import numpy as np
+   import pandas as pd
+   from mlsynth import SYNDES
+
+   # A small balanced panel: 8 units, 20 periods (last 6 are post-treatment).
+   rng = np.random.default_rng(0)
+   n_units, n_periods, n_post = 8, 20, 6
+   factors = rng.normal(size=(n_periods, 2))
+   loadings = rng.uniform(0.3, 1.0, size=(n_units, 2))
+   level = rng.uniform(8.0, 12.0, size=n_units)
+   Y = level + factors @ loadings.T + rng.normal(scale=0.3, size=(n_periods, n_units))
+   df = pd.DataFrame(
+       [{"unit": j, "time": t, "Y": float(Y[t, j]),
+         "post": int(t >= n_periods - n_post)}
+        for j in range(n_units) for t in range(n_periods)]
+   )
+
+   base = {"df": df, "outcome": "Y", "unitid": "unit", "time": "time",
+           "K": 3, "mode": "two_way_global", "post_col": "post"}
+
    # Default: 5% gap, 60s wall-clock — production-suitable.
-   SYNDES({
-       "df": df, "outcome": "y", "unitid": "unit", "time": "time",
-       "K": 3, "mode": "two_way_global", "post_col": "post",
-   }).fit()
+   SYNDES(base).fit()
 
    # Loosen the gap to return in seconds when you just need a
    # plausible design for prototyping.
-   SYNDES({...,
-           "gap_limit": 0.25, "time_limit": 5.0,
-   }).fit()
+   SYNDES({**base, "gap_limit": 0.25, "time_limit": 5.0}).fit()
 
    # Disable both limits for an asymptotic-optimality run. Be
    # prepared for hours-long solves on long panels.
-   SYNDES({...,
-           "gap_limit": None, "time_limit": None,
-   }).fit()
+   SYNDES({**base, "gap_limit": None, "time_limit": None}).fit()
 
 The MIP status codes ``user_limit`` and ``user_limit_inaccurate``
 (SCIP's "stopped early with a valid incumbent") are accepted as
@@ -381,6 +432,25 @@ per arm (so it must be smaller than the smallest arm's unit count).
 
 .. code-block:: python
 
+   import numpy as np
+   import pandas as pd
+   from mlsynth import SYNDES
+
+   # Two arms (A, B), each with 6 markets over 20 periods (last 6 post).
+   rng = np.random.default_rng(0)
+   n_per_arm, n_periods, n_post = 6, 20, 6
+   rows = []
+   for arm in ("A", "B"):
+       factors = rng.normal(size=(n_periods, 2))
+       for j in range(n_per_arm):
+           loading = rng.uniform(0.3, 1.0, size=2)
+           level = rng.uniform(8.0, 12.0)
+           series = level + factors @ loading + rng.normal(scale=0.3, size=n_periods)
+           for t in range(n_periods):
+               rows.append({"DMA": f"{arm}{j}", "week": t, "sales": float(series[t]),
+                            "treat": arm, "post": int(t >= n_periods - n_post)})
+   df = pd.DataFrame(rows)
+
    res = SYNDES({
        "df": df, "outcome": "sales", "unitid": "DMA", "time": "week",
        "arm": "treat",                 # categorical arm label per unit
@@ -388,9 +458,9 @@ per arm (so it must be smaller than the smallest arm's unit count).
        "run_inference": True,
    }).fit()
 
-   res.arm_designs["A"]                 # full SYNDESResults for arm A
-   res.atet_by_arm()                    # {arm: ATET}
-   res.selected_unit_labels_by_arm()    # {arm: treated units}
+   print(res.arm_designs["A"])              # full SYNDESResults for arm A
+   print(res.atet_by_arm())                 # {arm: ATET}
+   print(res.selected_unit_labels_by_arm()) # {arm: treated units}
 
 The arm column must be constant within each unit over time. ``arm`` is not
 compatible with the global ``costs``/``budget`` constraint (the cost vector is
@@ -460,12 +530,42 @@ the dimensions it ignored: a manager can trade a small fit increase for lower
 cost or higher power. ``top_K=1`` (default) is unchanged -- only the optimum is
 returned and ``results.pool`` is ``None``.
 
+The example below imports a subset of the GeoLift pre-test panel (the same
+40-market data the :doc:`geolift` page uses) and returns a five-design menu:
+
 .. code-block:: python
 
-   res = SYNDES({"df": df, "outcome": "y", "unitid": "unit", "time": "time",
-                 "K": 3, "mode": "two_way_global", "top_K": 5}).fit()
-   for d in res.pool:                        # ranked menu, best fit first
-       print(d["markets"], round(d["objective"], 1), round(d["mde_pct"], 2), d["cost"])
+   import pandas as pd
+   from mlsynth import SYNDES
+
+   df = pd.read_csv(                                      # GeoLift_PreTest, 40 mkts x 90d
+       "https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
+       "refs/heads/main/basedata/geolift_market_data.csv"
+   )
+   markets = sorted(df["location"].unique())[:8]         # 8-market subset keeps the MIP small
+   df = df[df["location"].isin(markets)].copy()
+   cut = sorted(df["date"].unique())[-14]                # last 14 days = post window
+   df["post"] = (df["date"] >= cut).astype(int)
+
+   # top_K=5 runs five MIPs (one per no-good cut), so expect ~a minute on SCIP.
+   res = SYNDES({
+       "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+       "K": 3, "mode": "two_way_global", "post_col": "post", "top_K": 5,
+       "gap_limit": 0.2, "time_limit": 10.0,
+   }).fit()
+
+   print(sorted(res.design.selected_unit_labels.tolist()))   # the MSE-optimal design
+   for d in res.pool:                                         # ranked menu, best fit first
+       print(sorted(d["markets"]), round(d["objective"], 1),
+             round(d["mde_pct"], 3), d["cost"])
+
+The lesson is the whole point of the menu: the rank-1 design minimises MSE, but
+fit is not power. On this subset the best-fitting design is not the most
+detectable — a design ranked further down the pool, with an essentially
+identical objective, can carry a materially smaller minimum detectable effect
+(or a lower ``cost`` once ``costs`` is supplied). The menu lets you choose the
+design that agrees with what you will actually deploy, instead of the one number
+the optimiser happens to minimise.
 
 Verification
 ------------

--- a/mlsynth/tests/test_syndes.py
+++ b/mlsynth/tests/test_syndes.py
@@ -728,6 +728,44 @@ class TestRelaxedInitialization:
         Y2 = np.array([[0.0, 0.0], [1.0, 3.0]])
         assert default_lambda(Y2) > 0.0
 
+    def test_default_lambda_matches_estimate_lambda(self):
+        # The annealed solver's default penalty MUST equal the exact solver's
+        # (``estimate_lambda``), so the two modes minimise the *same* objective
+        # and their objective values are directly comparable -- i.e. a feasible
+        # annealed point is a valid upper bound on the exact MIP optimum. They
+        # previously diverged (ddof=0 vs ddof=1).
+        from mlsynth.utils.syndes_helpers.relaxed_initialization import (
+            default_lambda,
+        )
+        from mlsynth.utils.syndes_helpers.optimization import estimate_lambda
+        rng = np.random.default_rng(0)
+        for seed in range(5):
+            Y = 1000.0 + rng.standard_normal((30, 12)) * 50.0
+            assert default_lambda(Y) == pytest.approx(estimate_lambda(Y), rel=1e-12)
+
+    def test_annealed_default_lambda_agrees_with_exact(self):
+        # Integration: with lam=None the annealed mode reports the same
+        # lambda_value as the exact solver would estimate, so objectives are
+        # on the same scale across modes.
+        from mlsynth.utils.syndes_helpers.optimization import estimate_lambda
+        rng = np.random.default_rng(3)
+        N, T = 8, 20
+        F = rng.standard_normal((T, 2)); L = rng.standard_normal((2, N))
+        Ymat = 1000.0 + F @ L * 10.0 + rng.standard_normal((T, N))
+        rows = []
+        for i in range(N):
+            for t in range(T):
+                rows.append({"unit": f"u{i}", "time": t, "y": float(Ymat[t, i]),
+                             "post": int(t >= T - 4)})
+        panel = pd.DataFrame(rows)
+        res = SYNDES({"df": panel, "outcome": "y", "unitid": "unit",
+                      "time": "time", "K": 3,
+                      "mode": "two_way_global_annealed",
+                      "relaxed_max_iter": 4, "post_col": "post",
+                      "lam": None, "run_inference": False}).fit()
+        Y_pre = Ymat[:T - 4]
+        assert res.design.lambda_value == pytest.approx(estimate_lambda(Y_pre), rel=1e-12)
+
     def test_init_assignment_picks_K_units(self):
         from mlsynth.utils.syndes_helpers.relaxed_initialization import (
             init_assignment,

--- a/mlsynth/utils/syndes_helpers/relaxed_initialization.py
+++ b/mlsynth/utils/syndes_helpers/relaxed_initialization.py
@@ -37,7 +37,7 @@ def validate_relaxed_inputs(Y: np.ndarray, K: int) -> None:
 
 
 def default_lambda(Y: np.ndarray) -> float:
-    """Default ridge parameter: average cross-sectional variance of ``Y``.
+    """Default ridge parameter: average within-unit (over-time) variance of ``Y``.
 
     Parameters
     ----------
@@ -51,11 +51,20 @@ def default_lambda(Y: np.ndarray) -> float:
 
     Notes
     -----
-    Uses ``ddof=0`` to preserve numerical compatibility with the original
-    inline default of the relaxed solver.
+    Delegates to :func:`mlsynth.utils.syndes_helpers.optimization.estimate_lambda`
+    so the annealed solver and the exact MIP share a single default penalty
+    (both ``var(..., ddof=1)``). Keeping them identical means the two modes
+    minimise the *same* objective, so an annealed feasible point is a valid
+    upper bound on the exact MIP optimum and the modes' objectives are directly
+    comparable. The previous ddof=0 default silently put the annealed objective
+    on a slightly different scale.
     """
 
-    return float(np.mean(np.var(Y, axis=0)))
+    # Local import avoids a module-level cycle (optimization imports from the
+    # syndes_helpers package); the dependency is one-way and safe at call time.
+    from .optimization import estimate_lambda
+
+    return estimate_lambda(Y)
 
 
 def _reconstruction_error(Yc: np.ndarray, cols: list[int]) -> float:


### PR DESCRIPTION
## Summary

Two related SYNDES improvements that came out of the warm-start / valid-bound investigation.

### 1. Align the annealed solver's default lambda with the exact solver

The annealed relaxation (`mode="two_way_global_annealed"`) defaulted its ridge penalty via `default_lambda` (`var ddof=0`) while the exact MIP defaults via `estimate_lambda` (`ddof=1`). With `lam=None` the two modes therefore minimised slightly different objectives, so their objective values were not on the same scale — which quietly distorts any cross-mode comparison (e.g. a bake-off) and means an annealed feasible point is not a guaranteed upper bound on the exact MIP optimum.

`default_lambda` now delegates to `estimate_lambda` (single source of truth), so both paths share one default penalty. A feasible annealed point is then a valid upper bound on the exact optimum, and annealed/exact objectives are directly comparable.

TDD: `default_lambda == estimate_lambda` across random panels; the annealed mode reports the same `lambda_value` the exact solver would estimate. Full SYNDES suite (182) green.

### 2. Make every SYNDES doc code block a runnable MWE

Every `.. code-block:: python` on the SYNDES page now obtains its own data (simulates a panel or imports the GeoLift subset from `raw.githubusercontent`), calls the public API with real column names, and runs — so a reader can copy, paste, and run each one. Fixes the previously un-runnable blocks:

- the `top_K` menu (referenced an undefined `df` and `outcome="y"`) — now imports an 8-market GeoLift subset and prints the five-design pool, illustrating the headline point that fit is not power;
- the multi-arm example (undefined `df` / `sales` / `DMA` / `week` columns) — now a simulated two-arm panel;
- the `gap_limit` examples (`SYNDES({...})` placeholders) — now a real `df` + a `base` dict spread across the three calls;
- the `post_fit` / `power` attribute snippets gain a compact load + `fit()` so their variables exist.

All six blocks were executed end-to-end (exit 0) before commit.

`agents/agents_docs.md` gains a binding "Code blocks are runnable MWEs" rule under Page requirements. The other estimator pages migrate incrementally as they are touched, per the existing agents_docs convention.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_