### PR TITLE
SYNDES pool menu: expose each design's control group and full design

### DIFF
--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -522,13 +522,26 @@ more detectable, or operationally preferable at a negligible fit cost. Setting
 obtained by *no-good cuts*: after each solve the chosen treated set
 :math:`S` is forbidden (:math:`\sum_{i \in S} D_i \le |S|-1`) and the MIP is
 re-solved for the next-best design. The pool is attached as ``results.pool`` --
-a list of dicts ranked by MSE, each with its ``markets``, ``objective`` (MSE),
-``pre_fit_rmse``, ``mde_pct`` (the same permutation-null MDE
-:func:`~mlsynth.power_analysis` uses), and ``cost`` (when ``costs`` is given).
+a list of dicts ranked by MSE. Each entry is *actionable*, not merely rankable:
+it carries everything needed to deploy that design, not just the rank-1 winner
+kept on ``results.design``. Its keys are:
+
+* ``markets`` -- labels of the treated units (the design's arms).
+* ``control_group`` -- labels of the donor units carrying nonzero control
+  weight (the synthetic-control pool backing the treated arms).
+* ``objective`` -- the MIP objective (fit) the design was ranked by.
+* ``pre_fit_rmse`` -- root-mean-square pre-period contrast.
+* ``mde_pct`` -- minimum detectable effect, as a percent of the treated
+  baseline (the same permutation-null MDE :func:`~mlsynth.power_analysis` uses).
+* ``cost`` -- summed cost of the treated units (``None`` when no ``costs`` given).
+* ``design`` -- the full :class:`~mlsynth.utils.syndes_helpers.structures.SYNDESDesign`
+  for the entry, with its treated, control, and contrast weights.
+
 Because the objective only ranks fit, the value is precisely the re-scoring on
 the dimensions it ignored: a manager can trade a small fit increase for lower
-cost or higher power. ``top_K=1`` (default) is unchanged -- only the optimum is
-returned and ``results.pool`` is ``None``.
+cost or higher power, then read the chosen entry's ``control_group`` and
+``design`` weights to deploy it. ``top_K=1`` (default) is unchanged -- only the
+optimum is returned and ``results.pool`` is ``None``.
 
 The example below imports a subset of the GeoLift pre-test panel (the same
 40-market data the :doc:`geolift` page uses) and returns a five-design menu:
@@ -556,8 +569,13 @@ The example below imports a subset of the GeoLift pre-test panel (the same
 
    print(sorted(res.design.selected_unit_labels.tolist()))   # the MSE-optimal design
    for d in res.pool:                                         # ranked menu, best fit first
-       print(sorted(d["markets"]), round(d["objective"], 1),
-             round(d["mde_pct"], 3), d["cost"])
+       print("treated:", sorted(d["markets"]),
+             "| control:", sorted(d["control_group"]),        # donors backing the SC
+             "| obj:", round(d["objective"], 1),
+             "| mde%:", round(d["mde_pct"], 3))
+   # any entry is deployable: read its control group and weights, not just rank-1
+   chosen = res.pool[1]
+   print(chosen["control_group"], chosen["design"].control_weights)
 
 The lesson is the whole point of the menu: the rank-1 design minimises MSE, but
 fit is not power. On this subset the best-fitting design is not the most

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -158,6 +158,24 @@ def _syndes_post_fit(inputs, design, inference, alpha):
     return pf
 
 
+def _design_control_weights(design, n_units):
+    """Return the (N,) control-side weight vector for any SYNDES mode.
+
+    Mirrors the contrast bookkeeping in :func:`_syndes_post_fit`: the two-way /
+    equal-weight / annealed modes store the control simplex in
+    ``control_weights`` directly, whereas ``per_unit`` leaves ``control_weights``
+    ``None`` and keeps the per-treated-unit synthetic controls in the ``(K, N)``
+    ``treated_weights`` matrix -- whose column sum is the aggregate control side.
+    """
+    tw_raw = getattr(design, "treated_weights", None)
+    cw_raw = getattr(design, "control_weights", None)
+    if tw_raw is not None and np.asarray(tw_raw).ndim == 2:
+        return np.asarray(tw_raw, dtype=float).sum(axis=0)
+    if cw_raw is not None:
+        return np.asarray(cw_raw, dtype=float).reshape(-1)
+    return np.zeros(n_units)
+
+
 def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8):
     """Re-score a SYNDES solution pool into a manager-facing menu.
 
@@ -166,10 +184,30 @@ def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8):
     ``power_analysis`` uses -- ``sigma_perm / sqrt(n_post)`` on the design's
     pre-period contrast, as a percent of the treated baseline) and its cost (when
     ``costs`` is supplied). Returned as a list of dicts ranked by MSE.
+
+    Crucially, every entry is *actionable*, not just rankable: it carries the
+    full :class:`SYNDESDesign` under ``"design"`` (treated/control weights and
+    all) and the names of the donor units that form its synthetic control under
+    ``"control_group"`` -- so a manager can pick any entry, not only the rank-1
+    winner kept on ``results.design``, and have everything needed to deploy it.
+    Each entry's keys are:
+
+    * ``"markets"``       -- labels of the treated units (the design's arms).
+    * ``"control_group"`` -- labels of the donor units carrying nonzero control
+      weight (the synthetic-control pool backing the treated arms).
+    * ``"objective"``     -- the MIP objective (fit) the design was ranked by.
+    * ``"pre_fit_rmse"``  -- root-mean-square pre-period contrast.
+    * ``"mde_pct"``       -- minimum detectable effect, % of treated baseline.
+    * ``"cost"``          -- summed cost of the treated units (``None`` if no
+      ``costs`` supplied).
+    * ``"design"``        -- the full :class:`SYNDESDesign` (treated/control/
+      contrast weights) for this entry.
     """
     from scipy.stats import norm
 
     Y_pre = np.asarray(inputs.Y_pre, dtype=float)
+    n_units = Y_pre.shape[1]
+    unit_labels = np.asarray(inputs.unit_index.labels)
     n_post = int(inputs.Y_post.shape[0]) if inputs.Y_post is not None else 4
     z = float(norm.ppf(1.0 - alpha / 2.0) + norm.ppf(power_target))
     costs_arr = None if costs is None else np.asarray(costs, dtype=float).reshape(-1)
@@ -183,12 +221,18 @@ def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8):
         idx = np.asarray(d.selected_unit_indices, dtype=int)
         base = float(np.mean(Y_pre[:, idx])) if idx.size else float("nan")
         mde_pct = 100.0 * mde_abs / abs(base) if abs(base) > 1e-9 else float("nan")
+        # Donor units backing the synthetic control: nonzero control weight.
+        control_w = _design_control_weights(d, n_units)
+        control_idx = np.flatnonzero(np.abs(control_w) > 1e-8)
+        control_group = [x for x in unit_labels[control_idx].tolist()]
         menu.append({
             "markets": [x for x in np.asarray(d.selected_unit_labels).tolist()],
+            "control_group": control_group,
             "objective": float(d.objective_value),
             "pre_fit_rmse": (None if d.pre_fit_rmse is None else float(d.pre_fit_rmse)),
             "mde_pct": float(mde_pct),
             "cost": (None if costs_arr is None else float(costs_arr[idx].sum())),
+            "design": d,
         })
     return menu
 

--- a/mlsynth/tests/test_syndes_pool.py
+++ b/mlsynth/tests/test_syndes_pool.py
@@ -118,3 +118,53 @@ class TestEstimatorPool:
         res = SYNDES(self._cfg(top_K=3, costs=costs, budget=20.0)).fit()
         for e in res.pool:
             assert e["cost"] is not None and e["cost"] <= 20.0 + 1e-6
+
+    # ------------------------------------------------------------------
+    # The menu must be *actionable*: each entry has to expose enough to
+    # deploy that design -- not just rank it. That means the full design
+    # (treated/control weights) and the control group, for every entry,
+    # not only the rank-1 winner kept on ``res.design``.
+    # ------------------------------------------------------------------
+
+    def test_pool_entry_exposes_full_design(self):
+        from mlsynth.utils.syndes_helpers.structures import SYNDESDesign
+
+        res = SYNDES(self._cfg(top_K=4)).fit()
+        for e in res.pool:
+            assert "design" in e, "each menu entry must carry its full design"
+            d = e["design"]
+            assert isinstance(d, SYNDESDesign)
+            # the design's treated set agrees with the entry's market labels
+            assert sorted(d.selected_unit_labels.tolist()) == sorted(e["markets"])
+            # deploy-critical weights are present (two_way_global carries both)
+            assert d.treated_weights is not None
+            assert d.control_weights is not None
+
+    def test_pool_rank1_design_is_the_returned_optimum(self):
+        res = SYNDES(self._cfg(top_K=4)).fit()
+        rank1 = res.pool[0]["design"]
+        assert set(rank1.selected_unit_indices) == set(res.design.selected_unit_indices)
+
+    def test_pool_entry_exposes_control_group(self):
+        res = SYNDES(self._cfg(top_K=4)).fit()
+        all_labels = {f"u{i:02d}" for i in range(10)}
+        for e in res.pool:
+            assert "control_group" in e, "each entry must name its control group"
+            ctrl = e["control_group"]
+            assert isinstance(ctrl, list) and len(ctrl) > 0
+            treated = set(e["markets"])
+            # control group is donors only -- disjoint from the treated set
+            assert set(ctrl).isdisjoint(treated)
+            # and every control label is a real unit in the panel
+            assert set(ctrl) <= all_labels
+
+    def test_pool_control_group_per_unit_mode(self):
+        # per_unit: control_weights is None and the control side lives in the
+        # (K, N) treated-weight matrix -- the menu must still recover it.
+        res = SYNDES(self._cfg(top_K=3, mode="per_unit", K=3)).fit()
+        for e in res.pool:
+            d = e["design"]
+            assert d.control_weights is None  # confirm we exercise the matrix branch
+            ctrl = e["control_group"]
+            assert isinstance(ctrl, list) and len(ctrl) > 0
+            assert set(ctrl).isdisjoint(set(e["markets"]))


### PR DESCRIPTION
## Summary

Make the SYNDES `top_K` solution-pool menu actionable, not merely rankable.

Each pool entry previously surfaced only the treated `markets`, `objective`, `mde_pct`, and `cost`. The treated/control weights and the control group were dropped in `_syndes_pool_menu`, and the raw pool designs were discarded by `_fit_mip` (only the menu dicts and the rank-1 `results.design` survived). So a manager could rank candidate designs but could only actually deploy the rank-1 winner — picking any other entry required a re-fit, and the control side (which donors back the synthetic control) was never exposed at all.

### What changed

Each menu entry now also carries:

- `control_group` — labels of the donor units with nonzero control weight, derived mode-aware: `per_unit` reads the `(K, N)` treated-weight matrix column sum (its `control_weights` is `None`), matching the contrast bookkeeping in `_syndes_post_fit`; the two-way / equal-weight / annealed modes read `control_weights` directly.
- `design` — the full `SYNDESDesign` (treated/control/contrast weights) for that entry.

Existing keys (`markets`, `objective`, `pre_fit_rmse`, `mde_pct`, `cost`) are unchanged, so this is backward compatible.

### Docs

The SYNDES page now labels every menu key explicitly and shows reading a non-winner entry's `control_group` and `design.control_weights` to deploy it. The example was re-run end-to-end (exit 0) per the runnable-MWE rule — and it sharpens the page's own lesson: on the 8-market subset the rank-1 design fits best (obj 478070) but has the worst MDE (4.28%), while a near-tied design further down (obj 478428) lands at 2.745% — far more detectable, and now fully deployable straight from the menu.

### TDD

Tests written first (red → green). New tests assert each entry exposes a typed `SYNDESDesign`, the rank-1 entry's design matches `results.design`, the control group is non-empty and disjoint from the treated set with all labels real panel units, and the `per_unit` branch recovers the control group from the weight matrix. Full `test_syndes_pool.py` (12) green.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_