### PR TITLE
SYNDES menu: per-entry power curve; reconcile mde_pct to the curve

### DIFF
--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -662,11 +662,16 @@ kept on ``results.design``. Its keys are:
   weight (the synthetic-control pool backing the treated arms).
 * ``objective`` -- the MIP objective (fit) the design was ranked by.
 * ``pre_fit_rmse`` -- root-mean-square pre-period contrast.
-* ``mde_pct`` -- minimum detectable effect, as a percent of the treated
-  baseline (the same permutation-null MDE :func:`~mlsynth.power_analysis` uses).
+* ``mde_pct`` -- minimum detectable effect at the realised post horizon, as a
+  percent of the treated baseline. This is the entry's ``power_curve`` value at
+  that horizon (the Newey-West HAC MDE), so the headline number and the curve
+  always agree.
 * ``cost`` -- summed cost of the treated units (``None`` when no ``costs`` given).
 * ``design`` -- the full :class:`~mlsynth.utils.syndes_helpers.structures.SYNDESDesign`
   for the entry, with its treated, control, and contrast weights.
+* ``power_curve`` -- the entry's own :class:`~mlsynth.SYNDESPower` over horizons
+  ``1..12`` (``None`` if the computation is degenerate), so every candidate is
+  comparable on power, not just the rank-1 winner on ``results.power_curve``.
 
 Because the objective only ranks fit, the value is precisely the re-scoring on
 the dimensions it ignored: a manager can trade a small fit increase for lower
@@ -719,20 +724,20 @@ the optimiser happens to minimise.
 Ranking the menu by power
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Each menu entry carries its full ``design``, so the per-horizon MDE machinery of
-the previous section applies to every candidate, not just the rank-1 winner:
-wrap an entry's design with the shared ``inputs`` and call
-:func:`~mlsynth.power_analysis` at the horizon you plan to run. The example below
-takes a 20-market GeoLift subset, scores every menu design's MDE at horizon
-:math:`h = 3`, and plots them sorted most-detectable first -- turning the menu
-into a power ranking the MSE objective never sees:
+Each menu entry carries its own per-horizon ``power_curve`` (a
+:class:`~mlsynth.SYNDESPower` over horizons ``1..12``), computed with the same
+Newey-West machinery as the previous section, so the whole pool is comparable on
+power -- not just the rank-1 winner on ``res.power_curve``. Reading an entry's
+MDE at the horizon you plan to run is a single array lookup. The example below
+takes a 20-market GeoLift subset and plots every menu design's MDE at horizon
+:math:`h = 3`, sorted most-detectable first -- turning the menu into a power
+ranking the MSE objective never sees:
 
 .. code-block:: python
 
    import matplotlib.pyplot as plt
    import pandas as pd
-   from mlsynth import SYNDES, power_analysis
-   from mlsynth.utils.syndes_helpers.structures import SYNDESResults
+   from mlsynth import SYNDES
 
    df = pd.read_csv(                                      # GeoLift_PreTest panel
        "https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
@@ -751,12 +756,9 @@ into a power ranking the MSE objective never sees:
    }).fit()
 
    H = 3                                                  # horizon to plan for
-   scored = []
-   for d in res.pool:
-       p = power_analysis(SYNDESResults(design=d["design"], inputs=res.inputs),
-                          n_post_periods=[H])
-       scored.append(("+".join(map(str, sorted(d["markets"]))),
-                      float(p.mde_percent[0])))
+   scored = [("+".join(map(str, sorted(d["markets"]))),
+              float(d["power_curve"].mde_percent[H - 1]))   # 1-indexed horizon
+             for d in res.pool]
    scored.sort(key=lambda r: r[1])                        # smallest MDE -> left
 
    labels = [s[0] for s in scored]

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -177,17 +177,18 @@ def _design_control_weights(design, n_units):
     return np.zeros(n_units)
 
 
-def _syndes_power_curve(results, alpha):
-    """Per-horizon MDE table (horizons 1..12) attached to every SYNDES fit.
+def _syndes_power_curve(results, alpha, horizons=range(1, 13)):
+    """Per-horizon MDE table (horizons 1..12 by default) for a SYNDES design.
 
-    Computed by default so the minimum-detectable-effect curve comes back from
-    :meth:`SYNDES.fit` without a separate :func:`mlsynth.power_analysis` call.
+    Attached to every SYNDES fit so the minimum-detectable-effect curve comes
+    back from :meth:`SYNDES.fit` without a separate :func:`mlsynth.power_analysis`
+    call, and reused per pool entry so the whole menu is comparable on power.
     Custom horizon grids, significance levels, or baselines still go through
     :func:`mlsynth.power_analysis`. Never breaks a fit: returns ``None`` on any
     degeneracy (e.g. a too-short pre-period), mirroring ``post_fit.power``.
     """
     try:
-        return power_analysis(results, n_post_periods=range(1, 13), alpha=alpha)
+        return power_analysis(results, n_post_periods=horizons, alpha=alpha)
     except Exception:                # never let power analysis break a fit
         return None
 
@@ -196,28 +197,33 @@ def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8):
     """Re-score a SYNDES solution pool into a manager-facing menu.
 
     The MIP ranks designs by fit alone, so each pooled design is annotated with
-    the dimensions the objective ignored: its MDE% (same permutation-null formula
-    ``power_analysis`` uses -- ``sigma_perm / sqrt(n_post)`` on the design's
-    pre-period contrast, as a percent of the treated baseline) and its cost (when
-    ``costs`` is supplied). Returned as a list of dicts ranked by MSE.
+    the dimensions the objective ignored: its full power curve, the headline MDE%
+    at the realised post horizon, and its cost (when ``costs`` is supplied).
+    Returned as a list of dicts ranked by MSE.
 
     Crucially, every entry is *actionable*, not just rankable: it carries the
     full :class:`SYNDESDesign` under ``"design"`` (treated/control weights and
-    all) and the names of the donor units that form its synthetic control under
-    ``"control_group"`` -- so a manager can pick any entry, not only the rank-1
-    winner kept on ``results.design``, and have everything needed to deploy it.
-    Each entry's keys are:
+    all), the names of the donor units that form its synthetic control under
+    ``"control_group"``, and its own per-horizon power curve under
+    ``"power_curve"`` -- so a manager can pick any entry, not only the rank-1
+    winner kept on ``results.design``, and have everything needed to deploy it
+    and to compare the whole pool on power. Each entry's keys are:
 
     * ``"markets"``       -- labels of the treated units (the design's arms).
     * ``"control_group"`` -- labels of the donor units carrying nonzero control
       weight (the synthetic-control pool backing the treated arms).
     * ``"objective"``     -- the MIP objective (fit) the design was ranked by.
     * ``"pre_fit_rmse"``  -- root-mean-square pre-period contrast.
-    * ``"mde_pct"``       -- minimum detectable effect, % of treated baseline.
+    * ``"mde_pct"``       -- minimum detectable effect at the realised post
+      horizon, % of treated baseline. This is the design's ``power_curve``
+      value at that horizon (the Newey-West HAC MDE), so the headline number and
+      the curve always agree.
     * ``"cost"``          -- summed cost of the treated units (``None`` if no
       ``costs`` supplied).
     * ``"design"``        -- the full :class:`SYNDESDesign` (treated/control/
       contrast weights) for this entry.
+    * ``"power_curve"``   -- the entry's own :class:`SYNDESPower` over horizons
+      ``1..12`` (``None`` if the computation is degenerate).
     """
     from scipy.stats import norm
 
@@ -229,14 +235,32 @@ def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8):
     costs_arr = None if costs is None else np.asarray(costs, dtype=float).reshape(-1)
     menu = []
     for d in pool_designs:
-        contrast = np.asarray(d.contrast_weights, dtype=float).reshape(-1)
-        per_period = Y_pre @ contrast
-        sigma = (float(np.std(per_period, ddof=1)) if per_period.size > 1
-                 else float(np.std(per_period)))
-        mde_abs = z * sigma / np.sqrt(n_post)
         idx = np.asarray(d.selected_unit_indices, dtype=int)
         base = float(np.mean(Y_pre[:, idx])) if idx.size else float("nan")
-        mde_pct = 100.0 * mde_abs / abs(base) if abs(base) > 1e-9 else float("nan")
+
+        # Per-entry power curve (Newey-West, horizons 1..12) so the whole pool is
+        # comparable on power, not just the rank-1 winner on results.power_curve.
+        power_curve = _syndes_power_curve(SYNDESResults(design=d, inputs=inputs),
+                                          alpha)
+        # Headline MDE% is that curve's value at the realised post horizon, so
+        # the menu's summary number and its curve always agree.
+        if power_curve is not None and 1 <= n_post <= 12:
+            mde_pct = float(power_curve.mde_percent[n_post - 1])
+        else:
+            pc_h = _syndes_power_curve(SYNDESResults(design=d, inputs=inputs),
+                                       alpha, horizons=[n_post])
+            mde_pct = (float(pc_h.mde_percent[0]) if pc_h is not None
+                       else float("nan"))
+        if not np.isfinite(mde_pct):
+            # Degenerate curve -> fall back to the i.i.d. realised-window MDE.
+            contrast = np.asarray(d.contrast_weights, dtype=float).reshape(-1)
+            per_period = Y_pre @ contrast
+            sigma = (float(np.std(per_period, ddof=1)) if per_period.size > 1
+                     else float(np.std(per_period)))
+            mde_abs = z * sigma / np.sqrt(n_post)
+            mde_pct = (100.0 * mde_abs / abs(base)
+                       if abs(base) > 1e-9 else float("nan"))
+
         # Donor units backing the synthetic control: nonzero control weight.
         control_w = _design_control_weights(d, n_units)
         control_idx = np.flatnonzero(np.abs(control_w) > 1e-8)
@@ -249,6 +273,7 @@ def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8):
             "mde_pct": float(mde_pct),
             "cost": (None if costs_arr is None else float(costs_arr[idx].sum())),
             "design": d,
+            "power_curve": power_curve,
         })
     return menu
 

--- a/mlsynth/tests/test_syndes_pool.py
+++ b/mlsynth/tests/test_syndes_pool.py
@@ -168,3 +168,37 @@ class TestEstimatorPool:
             ctrl = e["control_group"]
             assert isinstance(ctrl, list) and len(ctrl) > 0
             assert set(ctrl).isdisjoint(set(e["markets"]))
+
+    # ------------------------------------------------------------------
+    # Each menu entry should carry its own per-horizon power curve, so the
+    # whole pool can be compared on power -- not just the rank-1 winner --
+    # and the entry's headline mde_pct should agree with that curve.
+    # ------------------------------------------------------------------
+
+    def test_pool_entry_exposes_power_curve(self):
+        from mlsynth.utils.syndes_helpers.power import SYNDESPower
+
+        res = SYNDES(self._cfg(top_K=4)).fit()
+        for e in res.pool:
+            assert "power_curve" in e
+            pc = e["power_curve"]
+            assert isinstance(pc, SYNDESPower)
+            assert pc.n_post_periods.tolist() == list(range(1, 13))
+
+    def test_pool_mde_pct_matches_power_curve_at_realised_horizon(self):
+        # Realised post window in _panel() is 4 periods -> mde_pct must equal
+        # the curve's value at horizon 4 (index 3), not an i.i.d. number.
+        res = SYNDES(self._cfg(top_K=4)).fit()
+        for e in res.pool:
+            assert e["mde_pct"] == pytest.approx(
+                float(e["power_curve"].mde_percent[3])
+            )
+
+    def test_pool_rank1_power_curve_matches_results_power_curve(self):
+        # The rank-1 menu entry is res.design, so its per-entry curve must
+        # coincide with the top-level res.power_curve.
+        res = SYNDES(self._cfg(top_K=4)).fit()
+        np.testing.assert_allclose(
+            res.pool[0]["power_curve"].mde_absolute,
+            res.power_curve.mde_absolute,
+        )


### PR DESCRIPTION
## Summary

Follow-up to the menu work: previously only the rank-1 design's power curve was available (`res.power_curve`); the other `top_K` menu entries carried no power surface, and the menu's `mde_pct` used an i.i.d. `σ/√n_post` at the realised horizon — inconsistent with the Newey-West HAC curve used everywhere else. So comparing the pool on power required reconstructing a `SYNDESResults` per entry and calling `power_analysis` by hand.

### What changed

Each pool entry now carries:

- `power_curve` — its own `SYNDESPower` over horizons 1–12 (`None` if degenerate), so the whole pool is comparable on power, not just the rank-1 winner.
- `mde_pct` — redefined as that curve's value at the realised post horizon (the Newey-West HAC MDE), so the headline number and the curve always agree. Falls back to the i.i.d. realised-window MDE only if the curve is degenerate.

`_syndes_power_curve` gains a `horizons` argument so the one helper serves both the fit-level default (1–12) and per-horizon lookups.

### Docs

The menu key list now documents `power_curve` and the reconciled `mde_pct`. The horizon-3 plotting MWE collapses to reading `d["power_curve"].mde_percent[H-1]` — no `power_analysis` import or `SYNDESResults` reconstruction — re-verified end-to-end.

### TDD

Tests written first (red → green): each entry exposes a 1–12 `SYNDESPower`, `mde_pct` equals the curve at the realised horizon, and the rank-1 entry's curve matches `res.power_curve`. Full SYNDES suite (195) green.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_