### PR TITLE
Fix include_markets candidate generation; pin the GeoLiftMarketSelection BestMarkets ranking

### DIFF
--- a/benchmarks/R/geolift_marketselection.R
+++ b/benchmarks/R/geolift_marketselection.R
@@ -1,0 +1,35 @@
+#!/usr/bin/env Rscript
+# Live GeoLiftMarketSelection on the walkthrough PreTest panel, for
+# benchmarks/cases/geolift_marketselection_ref.py. Install the reference once
+# with benchmarks/R/install_geolift.sh.
+#
+# Prints the full BestMarkets ranking as tab-separated ROW lines (markets joined
+# by '|', since the location field itself contains commas), for the Python case
+# to parse and compare against mlsynth's pooled N=2-5 selection.
+suppressMessages(library(GeoLift))
+
+args <- commandArgs(trailingOnly = TRUE)
+data_path <- args[1]                       # basedata/geolift_market_data.csv (PreTest)
+df <- read.csv(data_path)
+
+geodata <- GeoDataRead(data = df, date_id = "date", location_id = "location",
+                       Y_id = "Y", format = "yyyy-mm-dd", summary = FALSE)
+
+ms <- GeoLiftMarketSelection(
+  data = geodata, treatment_periods = c(10, 15), N = c(2, 3, 4, 5),
+  Y_id = "Y", location_id = "location", time_id = "time",
+  effect_size = seq(0, 0.2, 0.05), lookback_window = 1,
+  include_markets = c("chicago"), exclude_markets = c("honolulu"),
+  cpic = 7.50, budget = 100000, alpha = 0.1, Correlations = TRUE,
+  fixed_effects = TRUE, side_of_test = "two_sided"
+)
+
+bm <- ms$BestMarkets
+rank_col <- if ("rank" %in% colnames(bm)) "rank" else "Rank"
+for (i in seq_len(nrow(bm))) {
+  loc <- gsub(", ", "|", bm$location[i])
+  cat(sprintf("ROW\t%s\t%d\t%.4f\t%.4f\t%.4f\t%.2f\t%.3f\t%d\n",
+              loc, bm$duration[i], bm$EffectSize[i], bm$Power[i],
+              bm$AvgScaledL2Imbalance[i], bm$Investment[i],
+              bm$abs_lift_in_zero[i], bm[[rank_col]][i]))
+}

--- a/benchmarks/R/install_geolift.sh
+++ b/benchmarks/R/install_geolift.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install the GeoLift reference for benchmarks/cases/geolift_marketselection_ref.py.
+#
+# GeoLiftMarketSelection's power simulation is augsynth under the hood, but the
+# GeoLift package hard-imports the MarketMatching -> CausalImpact -> bsts -> Boom
+# chain plus gsynth (its NAMESPACE does import(gsynth) and uses MarketMatching),
+# so the whole package must be installed to call it. Verified on Ubuntu + R 4.3.x
+# where CRAN is blocked but apt and GitHub are open: apt for the prebuilt
+# majority, compile the non-apt leaves from the GitHub cran mirror (no CRAN call).
+#
+# Builds on install_augsynth.sh (augsynth is a GeoLift import). Every source
+# package is pinned to a CRAN version tag / commit so the cross-check runs the
+# SAME reference every time. The latest Boom requires R >= 4.5, so the chain is
+# frozen to the last R-4.3-compatible release set:
+#
+#   Boom           0.9.13     bsts           0.9.10    BoomSpikeSlab  1.2.6
+#   CausalImpact   1.4.1      MarketMatching 1.2.1     lfe            3.1.1
+#   gsynth         1.2.1      dtw            1.23-3     panelView      1.3.1
+#   directlabels   2026.4.23
+#   GeoLift        2.7.5  db34ea4299ff0e28515ebac502b78c076c93c905  (facebookincubator/GeoLift)
+set -euo pipefail
+export MAKEFLAGS="-j$(nproc)"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$HERE/install_augsynth.sh"   # augsynth + its deps (GeoLift imports augsynth)
+
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  r-cran-zoo r-cran-xts r-cran-assertthat r-cran-proxy r-cran-quadprog \
+  r-cran-xtable r-cran-sandwich r-cran-ggally r-cran-future r-cran-dorng \
+  r-cran-iterators r-cran-abind r-cran-mvtnorm r-cran-reshape2 r-cran-scales \
+  r-cran-knitr r-cran-progress r-cran-tibble r-cran-data.table r-cran-bh
+
+# inst <owner/repo> <ref> -- compile a GitHub tarball at a pinned tag/commit.
+inst() { cd /tmp; curl -sL "https://codeload.github.com/$1/tar.gz/$2" -o pkg.tgz
+         tar xzf pkg.tgz; R CMD INSTALL --no-docs --no-help "$(basename "$1")-${2##*/}"; }
+
+inst cran/dtw            1.23-3
+inst cran/directlabels   2026.4.23
+inst cran/panelView      1.3.1
+inst cran/Boom           0.9.13      # the big C++ compile
+inst cran/BoomSpikeSlab  1.2.6
+inst cran/bsts           0.9.10
+inst cran/CausalImpact   1.4.1
+inst cran/lfe            3.1.1
+inst cran/gsynth         1.2.1
+inst cran/MarketMatching 1.2.1
+inst facebookincubator/GeoLift db34ea4299ff0e28515ebac502b78c076c93c905
+
+Rscript -e 'suppressMessages(library(GeoLift)); cat("GeoLift", as.character(packageVersion("GeoLift")), "OK\n")'

--- a/benchmarks/cases/geolift_marketselection.py
+++ b/benchmarks/cases/geolift_marketselection.py
@@ -1,0 +1,133 @@
+"""GEOLIFT market-selection cross-validation vs GeoLift's BestMarkets ranking.
+
+Cross-validation against the reference. The GeoLift_Walkthrough runs
+
+    GeoLiftMarketSelection(data = GeoTestData_PreTest, treatment_periods = c(10,15),
+        N = c(2,3,4,5), effect_size = seq(0, 0.2, 0.05), include_markets = "chicago",
+        exclude_markets = "honolulu", cpic = 7.50, budget = 1e5, fixed_effects = TRUE,
+        side_of_test = "two_sided")
+
+and prints a ranked ``BestMarkets`` table whose top five designs are:
+
+    rank  candidate                                  dur  es    investment   abs_lift0
+    1     chicago, cincinnati, houston, portland     15   0.05  $74,118.38   0.002
+    1     chicago, portland                          15   0.10  $64,563.75   0.001
+    3     chicago, cincinnati, houston, portland     10   0.10  $99,027.75   0.004
+    3     chicago, portland                          10   0.10  $43,646.25   0.004
+    5     chicago, houston, portland                 10   0.10  $75,389.25   0.005
+
+mlsynth's ``GEOLIFT`` design takes a single ``treatment_size``, so this case runs
+it for N = 2, 3, 4, 5 (chicago forced in, honolulu out, the same duration/effect
+grid) and pools the per-(candidate, duration) MDE rows, then re-applies GeoLift's
+composite rank (the mean of the three ``dense_rank``s over |MDE|, power, and
+abs_lift_in_zero, ties = min) across the pool -- exactly as
+``GeoLiftMarketSelection`` ranks its single ``resultsM`` table. It pins, for each
+of the five published designs, the rank, the CPIC investment (a deterministic
+data transform, exact to the cent), the MDE, and the rounded abs_lift_in_zero.
+
+This depends on the ``include_markets`` candidate generation being faithful to
+GeoLift's generate-then-filter (``pre_test_power.R``): candidates are generated
+ignoring the forced units, then filtered to those that already contain them, so
+only correlation-natural sets survive. (The per-candidate fit/conformal scoring
+that produces the MDE / investment is pinned by ``geolift_walkthrough`` /
+``geolift_cpic`` / ``geolift_augsynth_ref``.) The marginal rank-6 design differs
+from the vignette (augsynth-version scoring at the tail), so only the stable
+top-five are pinned.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import pandas as pd
+
+from mlsynth import GEOLIFT
+
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..",
+                     "basedata", "geolift_market_data.csv")  # 90-period PreTest
+
+_CP = frozenset({"chicago", "portland"})
+_CCHP = frozenset({"chicago", "cincinnati", "houston", "portland"})
+_CHP = frozenset({"chicago", "houston", "portland"})
+
+
+def _fit_power(N: int) -> pd.DataFrame:
+    df = pd.read_csv(os.path.abspath(_DATA))
+    config = {
+        "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+        "treatment_size": N, "to_be_treated": ["chicago"],
+        "not_to_be_treated": ["honolulu"], "durations": [10, 15],
+        "effect_sizes": [0.0, 0.05, 0.10, 0.15, 0.20], "lookback_window": 1,
+        "how": "sum", "augment": "ridge", "fixed_effects": True, "alpha": 0.1,
+        "power_threshold": 0.8, "cpic": 7.5, "budget": 1e5, "ns": 1000,
+        "seed": 0, "conformal_type": "iid", "display_graphs": False, "n_jobs": -1,
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return GEOLIFT(config).fit().power
+
+
+def run() -> dict:
+    pool = pd.concat([_fit_power(N) for N in (2, 3, 4, 5)], ignore_index=True)
+    pool["cand"] = pool["candidate"].apply(frozenset)
+
+    # GeoLift composite rank across the pooled MDE table (pre_test_power.R):
+    # mean of the three dense_ranks over |MDE|, power, abs_lift_in_zero; ties min.
+    pool["rank_mde"] = pool["mde"].abs().rank(method="dense")
+    pool["rank_pvalue"] = pool["power"].rank(method="dense")
+    pool["rank_abszero"] = pool["abs_lift_in_zero"].rank(method="dense")
+    pool["rank"] = pool[["rank_mde", "rank_pvalue", "rank_abszero"]].mean(
+        axis=1).rank(method="min")
+
+    def row(cand: frozenset, duration: int) -> pd.Series:
+        hit = pool[(pool["cand"] == cand) & (pool["duration"] == duration)]
+        return hit.iloc[0]
+
+    cp15, cchp15 = row(_CP, 15), row(_CCHP, 15)
+    cp10, cchp10 = row(_CP, 10), row(_CCHP, 10)
+    chp10 = row(_CHP, 10)
+
+    # the two rank-1 designs are exactly {chicago, portland}@15 and
+    # {chicago, cincinnati, houston, portland}@15
+    rank1 = {(r["cand"], int(r["duration"]))
+             for _, r in pool[pool["rank"] == 1.0].iterrows()}
+
+    return {
+        "cp15_rank": float(cp15["rank"]),
+        "cp15_inv": float(cp15["investment"]),
+        "cp15_mde": float(cp15["mde"]),
+        "cp15_az": float(cp15["abs_lift_in_zero"]),
+        "cchp15_rank": float(cchp15["rank"]),
+        "cchp15_inv": float(cchp15["investment"]),
+        "cchp15_mde": float(cchp15["mde"]),
+        "cchp15_az": float(cchp15["abs_lift_in_zero"]),
+        "cp10_rank": float(cp10["rank"]),
+        "cp10_inv": float(cp10["investment"]),
+        "cchp10_rank": float(cchp10["rank"]),
+        "cchp10_inv": float(cchp10["investment"]),
+        "chp10_rank": float(chp10["rank"]),
+        "chp10_inv": float(chp10["investment"]),
+        "top1_designs_match": float(
+            rank1 == {(_CP, 15), (_CCHP, 15)}),
+    }
+
+
+# Targets are GeoLift's printed BestMarkets top five; investments are exact to
+# the cent, ranks/MDEs/abs_lift_in_zero to the published rounding.
+EXPECTED = {
+    "cp15_rank": (1.0, 0.5),
+    "cp15_inv": (64563.75, 1.0),
+    "cp15_mde": (0.10, 0.001),
+    "cp15_az": (0.001, 0.0015),
+    "cchp15_rank": (1.0, 0.5),
+    "cchp15_inv": (74118.38, 1.0),
+    "cchp15_mde": (0.05, 0.001),
+    "cchp15_az": (0.002, 0.0015),
+    "cp10_rank": (3.0, 0.5),
+    "cp10_inv": (43646.25, 1.0),
+    "cchp10_rank": (3.0, 0.5),
+    "cchp10_inv": (99027.75, 1.0),
+    "chp10_rank": (5.0, 0.5),
+    "chp10_inv": (75389.25, 1.0),
+    "top1_designs_match": (1.0, 0.5),
+}

--- a/benchmarks/cases/geolift_marketselection_ref.py
+++ b/benchmarks/cases/geolift_marketselection_ref.py
@@ -1,0 +1,133 @@
+"""GEOLIFT live cross-check vs GeoLiftMarketSelection: the BestMarkets ranking.
+
+Cross-validation against the *running* reference. ``geolift_marketselection`` pins
+the public ``GEOLIFT`` selection against GeoLift's *published* BestMarkets table;
+this case goes further and checks it against **live GeoLift** -- the real
+``GeoLiftMarketSelection`` (``facebookincubator/GeoLift``) on the identical
+PreTest panel, the gold-standard cross-validation.
+
+It shells out to ``benchmarks/R/geolift_marketselection.R`` (install the
+reference once with ``benchmarks/R/install_geolift.sh``) and compares GeoLift's
+ranked BestMarkets table to mlsynth's pooled N=2-5 selection. On the stable
+top-five designs mlsynth matches live GeoLift exactly: same candidate sets, same
+rank, the CPIC investment to the cent, and the MDE. (This is what licensed the
+``include_markets`` generate-then-filter fix: live GeoLift surfaces the same
+candidate sets -- including the low-correlation ones like
+``{atlanta, chicago, cleveland, las vegas}`` -- that mlsynth now generates.)
+
+The marginal rank-six design (an N=5 set at the es=0.05 / budget boundary) is
+*not* pinned: with ``lookback_window=1`` the power is a single-placement binary,
+and that design's flush-placement conformal p sits right at ``alpha`` (mlsynth
+0.123 vs GeoLift just under), so it tips one way for GeoLift and the other for
+mlsynth -- a known small-effect power-methodology difference, not a selection
+discrepancy (its true power over placements is ~0.8).
+
+The reference is version-pinned (the install script freezes every source package
+to a CRAN tag / commit). Skips itself (``BenchmarkSkipped``) when ``Rscript`` or
+the GeoLift package is absent, so it is a no-op in CI and runs only where the
+reference is installed.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import warnings
+
+import pandas as pd
+
+from benchmarks.compare import BenchmarkSkipped
+from mlsynth import GEOLIFT
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_DATA = os.path.join(_ROOT, "basedata", "geolift_market_data.csv")  # 90-period PreTest
+_RSCRIPT_REF = os.path.join(_ROOT, "benchmarks", "R", "geolift_marketselection.R")
+
+
+def _geolift_reference() -> pd.DataFrame:
+    """Run GeoLiftMarketSelection via Rscript and parse its BestMarkets ROWs."""
+    rscript = shutil.which("Rscript")
+    if rscript is None:
+        raise BenchmarkSkipped("Rscript not on PATH (run benchmarks/R/install_geolift.sh)")
+    probe = subprocess.run([rscript, "-e", "suppressMessages(library(GeoLift))"],
+                           capture_output=True, text=True)
+    if probe.returncode != 0:
+        raise BenchmarkSkipped("R package 'GeoLift' not installed")
+    out = subprocess.run([rscript, _RSCRIPT_REF, _DATA], capture_output=True, text=True)
+    if out.returncode != 0:
+        raise BenchmarkSkipped(f"GeoLift reference failed: {out.stderr.strip()[-200:]}")
+
+    rows = []
+    for line in out.stdout.splitlines():
+        parts = line.split("\t")
+        if parts[0] != "ROW":
+            continue
+        _, loc, dur, es, power, sl2, inv, az, rank = parts
+        rows.append({
+            "cand": frozenset(loc.split("|")), "duration": int(dur),
+            "EffectSize": float(es), "investment": float(inv), "rank": int(rank),
+        })
+    if not rows:
+        raise BenchmarkSkipped("could not parse GeoLift BestMarkets output")
+    return pd.DataFrame(rows)
+
+
+def _mlsynth_pool() -> pd.DataFrame:
+    """mlsynth's pooled N=2-5 selection with GeoLift's composite rank."""
+    df = pd.read_csv(_DATA)
+
+    def fit(N):
+        cfg = dict(df=df, outcome="Y", unitid="location", time="date",
+                   treatment_size=N, to_be_treated=["chicago"],
+                   not_to_be_treated=["honolulu"], durations=[10, 15],
+                   effect_sizes=[0.0, 0.05, 0.10, 0.15, 0.20], lookback_window=1,
+                   how="sum", augment="ridge", fixed_effects=True, alpha=0.1,
+                   power_threshold=0.8, cpic=7.5, budget=1e5, ns=1000, seed=0,
+                   conformal_type="iid", display_graphs=False, n_jobs=-1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return GEOLIFT(cfg).fit().power
+
+    pool = pd.concat([fit(N) for N in (2, 3, 4, 5)], ignore_index=True)
+    pool["cand"] = pool["candidate"].apply(frozenset)
+    pool["rank_mde"] = pool["mde"].abs().rank(method="dense")
+    pool["rank_pvalue"] = pool["power"].rank(method="dense")
+    pool["rank_abszero"] = pool["abs_lift_in_zero"].rank(method="dense")
+    pool["rank"] = pool[["rank_mde", "rank_pvalue", "rank_abszero"]].mean(
+        axis=1).rank(method="min")
+    return pool
+
+
+def run() -> dict:
+    ref = _geolift_reference()
+    pool = _mlsynth_pool()
+
+    top5 = ref[ref["rank"] <= 5]
+    inv_diffs, rank_diffs, mde_diffs = [], [], []
+    n_present = 0
+    for _, g in top5.iterrows():
+        m = pool[(pool["cand"] == g["cand"]) & (pool["duration"] == g["duration"])]
+        if m.empty:
+            continue
+        n_present += 1
+        m = m.iloc[0]
+        inv_diffs.append(abs(m["investment"] - g["investment"]))
+        rank_diffs.append(abs(m["rank"] - g["rank"]))
+        mde_diffs.append(abs(m["mde"] - g["EffectSize"]))
+
+    return {
+        "top5_designs_present": float(n_present == len(top5)),
+        "top5_investment_max_abs_diff": float(max(inv_diffs)) if inv_diffs else float("inf"),
+        "top5_rank_max_abs_diff": float(max(rank_diffs)) if rank_diffs else float("inf"),
+        "top5_mde_max_abs_diff": float(max(mde_diffs)) if mde_diffs else float("inf"),
+    }
+
+
+# mlsynth reproduces live GeoLift's BestMarkets top-five exactly: every design
+# present, investment to the cent, identical rank, identical MDE.
+EXPECTED = {
+    "top5_designs_present": (1.0, 0.5),
+    "top5_investment_max_abs_diff": (0.0, 1.0),
+    "top5_rank_max_abs_diff": (0.0, 0.5),
+    "top5_mde_max_abs_diff": (0.0, 0.001),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -85,6 +85,7 @@ CASES = {
     "geolift_augsynth_ref": "benchmarks.cases.geolift_augsynth_ref",  # cross-val vs LIVE augsynth (Rscript): lambda/weights/ATT (skips if absent)
     "geolift_cpic": "benchmarks.cases.geolift_cpic",  # cross-val vs GeoLiftMarketSelection: CPIC investment value-for-value
     "geolift_marketselection": "benchmarks.cases.geolift_marketselection",  # cross-val vs GeoLiftMarketSelection: pooled N=2-5 BestMarkets top-5 ranking (rank/investment/MDE/abs_lift_in_zero)
+    "geolift_marketselection_ref": "benchmarks.cases.geolift_marketselection_ref",  # cross-val vs LIVE GeoLiftMarketSelection (Rscript): BestMarkets top-5 (skips if absent)
     "geolift_multicell": "benchmarks.cases.geolift_multicell",  # cross-val vs augsynth: multi-cell per-cell ATT + donor exclusion
     "microsynth_seattle": "benchmarks.cases.microsynth_seattle",  # cross-val vs R microsynth panel method (Seattle DMI)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -84,6 +84,7 @@ CASES = {
     "geolift_walkthrough": "benchmarks.cases.geolift",  # cross-val vs GeoLift/augsynth: GeoLift_Walkthrough full summary, base + ridge-augmented (ATT/lift/incremental/L2/scaled-L2/%improve/bias/weights/conformal)
     "geolift_augsynth_ref": "benchmarks.cases.geolift_augsynth_ref",  # cross-val vs LIVE augsynth (Rscript): lambda/weights/ATT (skips if absent)
     "geolift_cpic": "benchmarks.cases.geolift_cpic",  # cross-val vs GeoLiftMarketSelection: CPIC investment value-for-value
+    "geolift_marketselection": "benchmarks.cases.geolift_marketselection",  # cross-val vs GeoLiftMarketSelection: pooled N=2-5 BestMarkets top-5 ranking (rank/investment/MDE/abs_lift_in_zero)
     "geolift_multicell": "benchmarks.cases.geolift_multicell",  # cross-val vs augsynth: multi-cell per-cell ATT + donor exclusion
     "microsynth_seattle": "benchmarks.cases.microsynth_seattle",  # cross-val vs R microsynth panel method (Seattle DMI)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)

--- a/docs/replications/geolift.rst
+++ b/docs/replications/geolift.rst
@@ -18,9 +18,10 @@ GEOLIFT — Meta's GeoLift walkthrough (augsynth cross-validation)
    donor weights.
 :Durable check: ``benchmarks/cases/geolift.py`` (``geolift_walkthrough``, vs the
    published vignette), ``benchmarks/cases/geolift_marketselection.py``
-   (``geolift_marketselection``, vs the BestMarkets ranking), and
-   ``benchmarks/cases/geolift_augsynth_ref.py`` (``geolift_augsynth_ref``, vs
-   **live** augsynth via Rscript); plus ``mlsynth/tests/test_geolift_walkthrough.py``.
+   (``geolift_marketselection``, vs the BestMarkets ranking), and the live-Rscript
+   cross-checks ``geolift_augsynth_ref`` (vs **live** augsynth) and
+   ``geolift_marketselection_ref`` (vs **live** ``GeoLiftMarketSelection``); plus
+   ``mlsynth/tests/test_geolift_walkthrough.py``.
 
 Why this is the replication target
 ----------------------------------
@@ -196,22 +197,52 @@ composite rank (the mean of three ``dense_rank``s over |MDE|, power, and
    with. The earlier *remove-and-reattach* approach manufactured low-correlation
    candidates (e.g. ``{chicago, las vegas}``) that GeoLift never forms, which then
    polluted the ranking (the composite ranks on MDE/power, not fit). Only the
-   stable top-five are pinned; the marginal rank-six design differs by augsynth's
-   own version-to-version scoring at the tail.
+   stable top-five are pinned (see the live cross-check below for why).
+
+Live cross-check vs GeoLiftMarketSelection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Beyond the published table, ``benchmarks/cases/geolift_marketselection_ref.py``
+(``geolift_marketselection_ref``) runs the *real* ``GeoLiftMarketSelection`` via
+``Rscript`` and compares its ``BestMarkets`` to mlsynth's pooled selection. On
+the top-five designs mlsynth matches live GeoLift exactly — same candidate sets,
+same rank, investment to the cent, same MDE. Crucially it also reproduces the
+*low-correlation* candidates live GeoLift forms (e.g.
+``{atlanta, chicago, cleveland, las vegas}``), which is what licenses the
+generate-then-filter fix: the two libraries now build the same candidate pool.
+
+The one design that differs is a single N=5 set
+(``{chicago, cincinnati, houston, nashville, san diego}``) at GeoLift's rank six.
+The cause is not selection but the power metric: with ``lookback_window = 1`` the
+power is a *single*-placement binary (detected or not at one flush window), and
+that design's flush-placement conformal p sits right at ``alpha`` — mlsynth gets
+``0.123``, GeoLift just under ``0.10`` — so it falls on opposite sides of the
+threshold, and (its only within-budget effect size being ``0.05``) mlsynth drops
+it while GeoLift keeps it. The design's *true* power at ``0.05`` is ~0.8 (with
+``lookback_window = 5`` the p-values are ``0.123, 0.061, 0.054, 0.016, 0.046``),
+so it is a known small-effect / single-placement power-methodology difference,
+not a candidate-generation discrepancy — and it sits below the stable top-five.
+
+Install the reference once with ``benchmarks/R/install_geolift.sh`` (it builds on
+``install_augsynth.sh`` and compiles the ``MarketMatching`` → ``CausalImpact`` →
+``bsts`` → ``Boom`` chain plus ``gsynth`` from GitHub's CRAN mirrors, every
+package pinned to a CRAN tag / commit, so no CRAN call is needed — the latest
+``Boom`` requires R ≥ 4.5, so the set is frozen to the last R-4.3-compatible
+release). The case skips itself when ``Rscript`` / ``GeoLift`` is absent, so it
+is a no-op in CI.
 
 Pinned in ``benchmarks/cases/geolift_marketselection.py``
-(``geolift_marketselection``); the per-design investment is also pinned
-independently by ``geolift_cpic``.
+(``geolift_marketselection``, vs the published table) and
+``geolift_marketselection_ref`` (vs the live run); the per-design investment is
+also pinned independently by ``geolift_cpic``.
 
 .. note::
 
    The walkthrough's *power curve* (``GeoLiftPower`` over an effect-size grid) is
    published only as a plot, with no numeric table, so it has no value-for-value
    target. The quantities that build it — each design's per-effect-size power and
-   MDE — are the same ones validated by ``geolift_walkthrough`` and
-   ``geolift_marketselection``; a live numeric cross-check would require the full
-   GeoLift R package (the ``MarketMatching`` → ``Boom`` chain), which is heavier
-   than the ``augsynth``-only reference used here.
+   MDE — are the same ones validated by ``geolift_walkthrough``,
+   ``geolift_marketselection``, and the live ``geolift_marketselection_ref``.
 
 What it took to match — the four ingredients
 --------------------------------------------

--- a/docs/replications/geolift.rst
+++ b/docs/replications/geolift.rst
@@ -17,9 +17,10 @@ GEOLIFT — Meta's GeoLift walkthrough (augsynth cross-validation)
    p-value, L2 imbalance, scaled L2, percent improvement, bias removed, and the
    donor weights.
 :Durable check: ``benchmarks/cases/geolift.py`` (``geolift_walkthrough``, vs the
-   published vignette) and ``benchmarks/cases/geolift_augsynth_ref.py``
-   (``geolift_augsynth_ref``, vs **live** augsynth via Rscript); plus
-   ``mlsynth/tests/test_geolift_walkthrough.py``.
+   published vignette), ``benchmarks/cases/geolift_marketselection.py``
+   (``geolift_marketselection``, vs the BestMarkets ranking), and
+   ``benchmarks/cases/geolift_augsynth_ref.py`` (``geolift_augsynth_ref``, vs
+   **live** augsynth via Rscript); plus ``mlsynth/tests/test_geolift_walkthrough.py``.
 
 Why this is the replication target
 ----------------------------------
@@ -152,6 +153,65 @@ This is what licenses the strong claim above: ``mlsynth``'s ridge ASCM, its CV
 λ-selection (the 1-SE rule), and its fixed-effect conformal refit are not merely
 *close* to augsynth — they are the **same computation**, to ~7–11 significant
 figures.
+
+Market selection (the BestMarkets ranking)
+------------------------------------------
+
+The walkthrough's other half is the *search* for a test region, run on the
+90-period pre-test panel:
+
+.. code-block:: r
+
+   GeoLiftMarketSelection(data = GeoTestData_PreTest, treatment_periods = c(10, 15),
+       N = c(2, 3, 4, 5), effect_size = seq(0, 0.2, 0.05), include_markets = "chicago",
+       exclude_markets = "honolulu", cpic = 7.50, budget = 1e5, fixed_effects = TRUE,
+       side_of_test = "two_sided")
+
+GeoLift prints a ranked ``BestMarkets`` table; its top five designs are reproduced
+by ``mlsynth`` value-for-value — rank, CPIC investment (exact to the cent), MDE,
+and ``abs_lift_in_zero``:
+
+===========================================  ===  ====  =============  ====
+Design (chicago forced in)                   dur  rank  investment     |MDE
+===========================================  ===  ====  =============  ====
+chicago, portland                            15   1     ``$64,563.75``  0.10
+chicago, cincinnati, houston, portland       15   1     ``$74,118.38``  0.05
+chicago, portland                            10   3     ``$43,646.25``  0.10
+chicago, cincinnati, houston, portland       10   3     ``$99,027.75``  0.10
+chicago, houston, portland                   10   5     ``$75,389.25``  0.10
+===========================================  ===  ====  =============  ====
+
+``mlsynth``'s ``GEOLIFT`` design takes one ``treatment_size``, so the case runs it
+for ``N = 2, 3, 4, 5`` and pools the per-design MDE rows, then applies GeoLift's
+composite rank (the mean of three ``dense_rank``s over |MDE|, power, and
+``abs_lift_in_zero``, ties = ``min``) across the pool — exactly how
+``GeoLiftMarketSelection`` ranks its single results table.
+
+.. note::
+
+   Matching this top-five required fixing ``include_markets`` handling to GeoLift's
+   *generate-then-filter* semantics (``pre_test_power.R``): candidates are
+   generated ignoring the forced markets, then kept only if they already contain
+   them, so a forced market is never welded onto an anchor it is uncorrelated
+   with. The earlier *remove-and-reattach* approach manufactured low-correlation
+   candidates (e.g. ``{chicago, las vegas}``) that GeoLift never forms, which then
+   polluted the ranking (the composite ranks on MDE/power, not fit). Only the
+   stable top-five are pinned; the marginal rank-six design differs by augsynth's
+   own version-to-version scoring at the tail.
+
+Pinned in ``benchmarks/cases/geolift_marketselection.py``
+(``geolift_marketselection``); the per-design investment is also pinned
+independently by ``geolift_cpic``.
+
+.. note::
+
+   The walkthrough's *power curve* (``GeoLiftPower`` over an effect-size grid) is
+   published only as a plot, with no numeric table, so it has no value-for-value
+   target. The quantities that build it — each design's per-effect-size power and
+   MDE — are the same ones validated by ``geolift_walkthrough`` and
+   ``geolift_marketselection``; a live numeric cross-check would require the full
+   GeoLift R package (the ``MarketMatching`` → ``Boom`` chain), which is heavier
+   than the ``augsynth``-only reference used here.
 
 What it took to match — the four ingredients
 --------------------------------------------

--- a/docs/replications/geolift.rst
+++ b/docs/replications/geolift.rst
@@ -223,6 +223,11 @@ it while GeoLift keeps it. The design's *true* power at ``0.05`` is ~0.8 (with
 so it is a known small-effect / single-placement power-methodology difference,
 not a candidate-generation discrepancy — and it sits below the stable top-five.
 
+Set ``lookback_window > 1`` for a stable MDE/ranking: it is not the treatment
+length (that is ``durations``) but the number of staggered historical placements
+the power is averaged over, so a single placement (the walkthrough's default) is
+a high-variance estimate at borderline designs.
+
 Install the reference once with ``benchmarks/R/install_geolift.sh`` (it builds on
 ``install_augsynth.sh`` and compiles the ``MarketMatching`` → ``CausalImpact`` →
 ``bsts`` → ``Boom`` chain plus ``gsynth`` from GitHub's CRAN mirrors, every

--- a/mlsynth/tests/test_marketselect.py
+++ b/mlsynth/tests/test_marketselect.py
@@ -355,3 +355,70 @@ def test_candidates_free_pool_too_small_raises():
     ranked = rank_markets_by_correlation(planted_panel())   # A, B, C, D
     with pytest.raises(MlsynthConfigError, match="free pool"):
         generate_candidate_markets(ranked, 3, not_to_be_treated={"C", "D"})
+
+
+# === generate_candidate_markets: include_markets is generate-then-filter ===
+# GeoLift (pre_test_power.R) runs stochastic_market_selector ignoring
+# include_markets, then keeps only candidates that already contain the included
+# markets. So a forced unit is never welded onto an anchor it is uncorrelated
+# with: only correlation-natural sets survive.
+
+def _two_pair_panel():
+    """Two correlated pairs with ~zero cross-correlation: A~B and C~D.
+
+    A's nearest neighbour is therefore B (and vice-versa); C's is D. corr(A,C)
+    and corr(A,D) are ~0, so {A, C} / {A, D} are *not* correlation-natural sets.
+    """
+    t = np.arange(8, dtype=float)
+    a = np.sin(2 * np.pi * t / 8.0)
+    c = np.sin(2 * np.pi * 2 * t / 8.0)          # orthogonal to a over the period
+    Ywide = pd.DataFrame(
+        {"A": a, "B": 2.0 * a + 1.0, "C": c, "D": 2.0 * c + 1.0},
+        index=pd.Index(range(8), name="time"),
+    )
+    Ywide.columns.name = "unit"
+    return Ywide
+
+
+def test_candidates_include_filters_out_uncorrelated_pairings():
+    ranked = rank_markets_by_correlation(_two_pair_panel())
+    out = set(generate_candidate_markets(ranked, 2, to_be_treated={"A"}))
+    assert frozenset({"A", "B"}) in out          # A is B's nearest neighbour
+    assert frozenset({"A", "C"}) not in out       # C's nearest is D, not A
+    assert frozenset({"A", "D"}) not in out       # likewise D
+    assert all("A" in s and len(s) == 2 for s in out)
+
+
+def test_candidates_include_filter_yields_fewer_than_reattach():
+    # The old remove-and-reattach welded A onto every anchor (3 pairs here);
+    # generate-then-filter keeps only the correlation-natural one.
+    ranked = rank_markets_by_correlation(_two_pair_panel())
+    out = generate_candidate_markets(ranked, 2, to_be_treated={"A"})
+    assert set(out) == {frozenset({"A", "B"})}
+
+
+def _two_triple_panel():
+    """Two correlated triples (A,B,B2) and (C,D,D2), ~zero cross-correlation.
+
+    Each unit's two nearest neighbours are its own group-mates, so no generated
+    triple mixes the groups: A only ever co-occurs with B/B2, never with C.
+    """
+    t = np.arange(8, dtype=float)
+    a = np.sin(2 * np.pi * t / 8.0)
+    c = np.sin(2 * np.pi * 2 * t / 8.0)
+    Ywide = pd.DataFrame(
+        {"A": a, "B": 2.0 * a + 1.0, "B2": 0.5 * a - 2.0,
+         "C": c, "D": 2.0 * c + 1.0, "D2": 0.5 * c - 2.0},
+        index=pd.Index(range(8), name="time"),
+    )
+    Ywide.columns.name = "unit"
+    return Ywide
+
+
+def test_candidates_include_no_natural_set_raises():
+    # Force two units from different correlation groups (A and C), with a free
+    # slot (n=3) so the equals-size shortcut does not apply. A's two nearest are
+    # B/B2 and C's are D/D2, so no generated triple contains both A and C.
+    ranked = rank_markets_by_correlation(_two_triple_panel())
+    with pytest.raises(MlsynthConfigError, match="no correlation-natural candidate"):
+        generate_candidate_markets(ranked, 3, to_be_treated={"A", "C"})

--- a/mlsynth/utils/geolift_helpers/marketselect/helpers/candidates.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/helpers/candidates.py
@@ -177,44 +177,52 @@ def generate_candidate_markets(
             stochastic_mode=stochastic_mode, rng=rng,
         )
 
-    # Forced-in units join every candidate; the remaining "free" slots are
-    # generated from the pool with both forced-in and forced-out units removed.
-    free_size = n - len(forced_in)
-    if free_size == 0:
+    # Forced-in units fully specify the test set: use it directly.
+    if forced_in and len(forced_in) == n:
         return [frozenset(forced_in)]
 
-    excluded = forced_in | forced_out
-    free_pool = [u for u in ranked.index if u not in excluded]
-    if free_size > len(free_pool):
+    # GeoLift's generate-then-filter (``pre_test_power.R``): generate candidates
+    # from the full ranked table with only the *forbidden* (``not_to_be_treated``)
+    # units removed -- those stay donors -- then keep the candidates that already
+    # contain every forced-in (``include``) unit. GeoLift runs
+    # ``stochastic_market_selector`` ignoring ``include_markets`` and filters the
+    # result afterwards, so a forced unit is never welded onto an anchor it is
+    # uncorrelated with: only correlation-natural sets survive. (Re-attaching the
+    # forced unit to every anchor's neighbourhood -- the previous approach --
+    # manufactured low-correlation candidates GeoLift never forms.)
+    pool = [u for u in ranked.index if u not in forced_out]
+    if n > len(pool):
         raise MlsynthConfigError(
-            f"free pool ({len(free_pool)}) too small for {free_size} free "
-            f"market(s) (treatment_size {n} minus {len(forced_in)} forced-in)."
+            f"free pool ({len(pool)}) too small for {n} market(s) "
+            f"(treatment_size {n} after removing "
+            f"{len(forced_out)} not_to_be_treated)."
         )
 
-    # Restrict each anchor's neighbour list to the free pool (uniform length,
-    # since every unit appears in every original row), then generate + re-attach
-    # the forced-in units.
-    free_pool_set = set(free_pool)
+    # Restrict each anchor's neighbour list to the pool (uniform length, since
+    # every unit appears in every original row).
+    pool_set = set(pool)
     rows = [
         [neighbor for neighbor in ranked.loc[anchor].tolist()
-         if neighbor in free_pool_set]
-        for anchor in free_pool
+         if neighbor in pool_set]
+        for anchor in pool
     ]
     filtered_ranked = pd.DataFrame(
-        rows, index=pd.Index(free_pool, name=ranked.index.name)
+        rows, index=pd.Index(pool, name=ranked.index.name)
     )
     filtered_ranked.columns = range(1, filtered_ranked.shape[1] + 1)
 
-    free_candidates = _generate_from_ranked(
-        filtered_ranked, free_size, run_stochastic=run_stochastic,
+    generated = _generate_from_ranked(
+        filtered_ranked, n, run_stochastic=run_stochastic,
         stochastic_mode=stochastic_mode, rng=rng,
     )
+    if not forced_in:                       # only not_to_be_treated given
+        return generated
 
-    seen: set = set()
-    out: List[frozenset] = []
-    for free in free_candidates:
-        candidate = forced_in | free
-        if candidate not in seen:
-            seen.add(candidate)
-            out.append(candidate)
-    return out
+    kept = [c for c in generated if forced_in <= c]
+    if not kept:
+        raise MlsynthConfigError(
+            "no correlation-natural candidate contains all to_be_treated units "
+            f"{sorted(map(str, forced_in))} at treatment_size {n}; increase "
+            "treatment_size or reduce to_be_treated."
+        )
+    return kept


### PR DESCRIPTION
## Summary

Fixes `include_markets` candidate generation in `GEOLIFT` to match GeoLift's actual algorithm, then pins the `GeoLiftMarketSelection` BestMarkets ranking against both the published table and a live GeoLift R run.

### The bug

GeoLift (`pre_test_power.R`) does generate-then-filter: it runs `stochastic_market_selector` ignoring `include_markets`, then keeps only candidates that already contain the included markets. mlsynth instead did remove-and-reattach: it stripped the forced market from the pool, anchored a candidate at every remaining unit, and re-attached it — welding `chicago` onto every anchor and manufacturing low-correlation sets (`{chicago, las vegas}`) GeoLift never forms. Since the composite rank scores MDE/power/abs_lift_in_zero (not fit), those spurious candidates polluted the ranking.

### The fix (`marketselect/helpers/candidates.py`)

Switch the forced-in branch to generate-then-filter (test-first; 3 new tests, 42 marketselect tests green, no regressions).

### Durable pins

- `geolift_marketselection` — pooled N=2–5 selection vs the published BestMarkets top-5: rank, CPIC investment (exact to the cent), MDE, abs_lift_in_zero.
- `geolift_marketselection_ref` — vs a live `GeoLiftMarketSelection` Rscript run (skips if GeoLift absent). mlsynth matches live GeoLift on the top-5 exactly, including the low-correlation candidate sets it forms (e.g. `{atlanta, chicago, cleveland, las vegas}`) — confirming the fix is faithful, not just vignette-matching.
- `benchmarks/R/install_geolift.sh` — builds the full GeoLift R package with no CRAN call (apt for the prebuilt majority; the MarketMatching → CausalImpact → bsts → Boom chain + gsynth compiled from GitHub's CRAN mirrors), every package version-pinned, frozen to the last R-4.3-compatible release set (the latest Boom needs R ≥ 4.5).

### The one residual (investigated)

GeoLift ranks one N=5 set (`{chicago, cincinnati, houston, nashville, san diego}`) at #6 that mlsynth drops. Root cause is not selection: with `lookback_window=1` power is a single-placement binary, and that design's flush-placement conformal p sits at α (mlsynth 0.123, GeoLift just under 0.10), so it tips opposite ways. Its true power at es=0.05 is ~0.8 (with `lookback_window=5`: p = 0.123, 0.061, 0.054, 0.016, 0.046). A known small-effect/single-placement power-methodology difference, below the stable top-5 — not a candidate-generation discrepancy. No code change warranted.

### Docs

A "Market selection (the BestMarkets ranking)" section on the replication page: the reproduction, the fix, the live cross-check, and the precise power-methodology explanation of the residual. (The power curve `GeoLiftPower` is published only as a plot, so it's documented but not pinned.)

## Testing

- `pytest mlsynth/tests/test_marketselect.py` — 42 pass (3 new, test-first).
- `geolift_marketselection` — 15/15 pass; `geolift_marketselection_ref` (live GeoLift here) — 4/4 pass.
- `geolift_cpic`, `geolift_walkthrough`, `geolift_multicell`, `geolift_augsynth_ref` — still green.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX