### PR TITLE
docs(orthsc): link the paper (arXiv:2510.22828) and reword the orthogonalization step

### DIFF
--- a/docs/orthsc.rst
+++ b/docs/orthsc.rst
@@ -142,11 +142,12 @@ with :math:`\lambda` itself the smallest achievable slack (an LP), inflated by
 a :math:`\log` factor in the sample size and dimensions.
 
 Step 2: Neyman orthogonalization. Choose moment weights
-:math:`\boldsymbol{\eta}` (normalized so the post-moment entry is one) that
-annihilate the derivative of the combined moment with respect to
-:math:`\mathbf{w}`, i.e. :math:`\partial_{\mathbf{w}}\,
-\boldsymbol{\eta}^\top \mathbf{g} = \mathbf{0}`. The ATT is then read off the
-orthogonalized moment,
+:math:`\boldsymbol{\eta}` (normalized so the post-moment entry is one) that make
+the combined moment insensitive to the control weights to first order -- that
+is, its derivative with respect to :math:`\mathbf{w}` vanishes,
+:math:`\partial_{\mathbf{w}}\,\boldsymbol{\eta}^\top \mathbf{g} = \mathbf{0}`.
+Intuitively, a small error in the estimated weights then does not move the
+equation we solve for the ATT. The ATT is read off the orthogonalized moment,
 
 .. math::
 
@@ -354,6 +355,12 @@ small convex solves, so it takes ~30s):
 
 See :doc:`replications/orthsc` for the live-R cross-check and the demonstrate-
 first port story.
+
+References
+----------
+
+.. [ORTHSC] Fry, J. (2026). Orthogonalized Synthetic Controls. arXiv:2510.22828.
+   https://arxiv.org/abs/2510.22828
 
 Core API
 --------

--- a/docs/replications/orthsc.rst
+++ b/docs/replications/orthsc.rst
@@ -4,7 +4,8 @@ ORTHSC -- Fry's Orthogonalized Synthetic Control (carbon tax + Monte Carlo)
 ===========================================================================
 
 :Estimator: :doc:`../orthsc` -- :class:`mlsynth.ORTHSC`
-:Source: Fry, J. (2026). "Orthogonalized Synthetic Controls," with the author's
+:Source: Fry, J. (2026). "Orthogonalized Synthetic Controls"
+   (`arXiv:2510.22828 <https://arxiv.org/abs/2510.22828>`_), with the author's
    R reference (``JosephPatrickFry/OrthogonalizedSyntheticControl``).
 :Replication type: Path A (the paper's empirical result on Andersson's data)
    and Path B (the paper's size/power simulation), plus a live cross-check


### PR DESCRIPTION
## Summary

Two small ORTHSC documentation fixes.

1. Link the paper. The `[ORTHSC]_` citation was used on the estimator page but never defined (a dangling reference). Adds the citation definition with the arXiv link — `arXiv:2510.22828` (https://arxiv.org/abs/2510.22828) — and also links it from the replication page's source line.

2. Reword the orthogonalization step. Step 2 said the weights "annihilate the derivative of the combined moment with respect to w," which read as jargon. Reworded to a plain statement: choose `η` so the combined moment is insensitive to the control weights to first order (its `w`-derivative vanishes), so a small error in the estimated weights doesn't move the equation solved for the ATT — same math, clearer prose.

Docs-only; no code or test changes.

https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFEcDVvBWKQwjc1u87fvFX)_