### PR TITLE
ci: skip suite for docs/benchmarks-only PRs, drop PR-gate coverage, fix daily badge job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read     # dorny/paths-filter reads the PR's changed files
 
 # Cancel superseded runs on the same ref instead of piling up.
 concurrency:
@@ -30,9 +31,26 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 25     # a hung suite shouldn't burn a full-length runner slot
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      # Decide whether this change can affect the test suite. Docs-only and
+      # benchmarks-only PRs skip the (slow) run -- the job still completes, so a
+      # required "build" check stays satisfiable. Workflow_dispatch always runs.
+      - name: Detect code changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - 'mlsynth/**'
+              - 'requirements.txt'
+              - 'setup.py'
+              - 'pyproject.toml'
+              - '.github/workflows/build.yml'
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -50,7 +68,11 @@ jobs:
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
 
       # A failing test FAILS the job (no continue-on-error). Parallel via -n auto.
+      # Runs on dispatch always; on a PR only when code (not just docs/benchmarks)
+      # changed. Coverage is produced out-of-band by coverage-badge.yml, so the
+      # gate runs pass/fail only -- no --cov overhead here.
       - name: Run tests
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         run: |
           # PRs run the full suite; dispatch honors the input target.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -63,11 +85,7 @@ jobs:
           if [ "$TARGET" = "smoke" ]; then
             pytest -n auto -k "smoke" --tb=short
           elif [ "$TARGET" = "all" ]; then
-            pytest -n auto \
-                   --cov=mlsynth \
-                   --cov-report=xml \
-                   --cov-report=term-missing \
-                   --tb=short
+            pytest -n auto --tb=short
           else
             MATCH=$(find . -name "$TARGET" | head -n 1)
             if [ -z "$MATCH" ]; then

--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-xdist coverage coverage-badge
+          pip install pytest pytest-cov pytest-xdist coverage coverage-badge
 
       - name: Run tests with coverage
         if: steps.guard.outputs.run == 'true'


### PR DESCRIPTION
CI tuning, separate from any estimator/benchmark work.

## `build.yml` (the PR gate)

1. Skip the suite for docs/benchmarks-only PRs. A `dorny/paths-filter` step computes whether the change touches `mlsynth/**`, `requirements.txt`, `setup.py`, `pyproject.toml`, or `build.yml` itself; the test step is gated on it. Docs-only and `benchmarks/**`-only PRs skip the (slow) run. Done as a *step* `if:`, not a workflow-level `paths` filter, so the `build` job still completes and a required check stays satisfiable. `workflow_dispatch` always runs.
2. Drop `--cov` from the PR gate. Coverage is produced out-of-band by `coverage-badge.yml`, so the gate only needs pass/fail — this removes the `pytest-xdist` coverage-instrument/merge overhead on every PR.
3. Add `timeout-minutes: 25` so a hung suite can't sit on a runner for the 6h default.

## `coverage-badge.yml` (the daily badge)

Install `pytest-cov`. The daily job ran `pytest --cov` but only installed `pytest pytest-xdist coverage coverage-badge` — so **every scheduled run has been failing** with:

```
pytest: error: unrecognized arguments: --cov=mlsynth --cov-report=term-missing
```

Adding `pytest-cov` fixes the daily coverage refresh (and is what makes dropping `--cov` from the PR gate safe — the daily job becomes the real source of coverage).

## Notes

- `pull-requests: read` added to `permissions` for `dorny/paths-filter` to read the PR's changed files.
- The path filter is deliberately conservative; if a future workflow adds a merge queue, run the full suite there as a backstop.

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_