### PR TITLE
SYNDES: experimental-design customization suite (selection rules + treated/donor restrictions) + Prop 99 pensynth benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,20 @@ now returns and the back-compat guarantee.
 
 ## [Unreleased]
 
+### Fixed
+- **SYNDES no longer leaks an `IndexError` when restrictions make the candidate
+  pool empty.** Over-constrained `top_K > 1` designs (in-sample, holdout, or ic
+  selection) whose every MIP solve is infeasible now raise a translated
+  `MlsynthEstimationError` naming the restrictions, instead of a bare "list
+  index out of range". Surfaced while building the docs gallery.
+
 ### Added
+- **SYNDES docs gallery** showcasing every design-customisation knob
+  (cardinality, force in/out, no-two-treated conflict, stratum quotas, size
+  bands, region-matched and non-bordering donor pools, per-unit multi-region
+  designs, and the restriction-aware `top_K` menu) as runnable MWEs on the
+  bundled real US DMA geography + Census regions, with a region-grouped linear
+  factor sales model.
 - **SYNDES donor-side restrictions (region-matched / non-bordering donors).**
   Beyond constraining *who is treated*, SYNDES can now constrain *who may serve
   as a treated unit's donor*. The primitive is a donor-exclusion relation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Added
+- **SYNDES donor-side restrictions (region-matched / non-bordering donors).**
+  Beyond constraining *who is treated*, SYNDES can now constrain *who may serve
+  as a treated unit's donor*. The primitive is a donor-exclusion relation
+  `B[i,j]` ("if `i` is treated, `j` may not be its donor"), enforced by coupling
+  the assignment `D` to the mode's control weights, so it works in every mode
+  (one-way global `c[j] ≤ 1−D[i]`, two-way global `w[j]−q[j] ≤ 1−D[i]`, per-unit
+  `w[i,j] = 0`). Filled by `donor_region_col` (a donor must share the treated
+  unit's region), `exclude_bordering_donors` (drop a treated unit's spillover
+  neighbours from its donor pool — the Vives-i-Bastida exclusion restriction,
+  reusing the conflict graph), or an explicit `donor_exclusion` matrix (escape
+  hatch), combined by union. In the global modes a region rule forces the treated
+  set into one region; `per_unit` supports a multi-region design (each treated
+  unit draws its own same-region donors). Validated on the bundled DMA borders +
+  CDC Census regions. Helpers `build_restrictions` / `donor_constraints` in
+  `utils/syndes_helpers/restrictions.py`.
 - **SYNDES design restrictions (geography / clustering / size / forcing).**
   SYNDES now accepts the same restriction vocabulary as GEOLIFT and LEXSCM,
   enforced exactly as linear constraints on the MIP assignment vector `D`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ now returns and the back-compat guarantee.
 
 ## [Unreleased]
 
+### Added
+- **SYNDES holdout (train/validate) design selection.** A new optional
+  `holdout_frac` config field switches SYNDES from in-sample MIP selection to
+  out-of-sample selection: the `top_K` candidate pool is learned on the leading
+  `1 - holdout_frac` of the pre-period and the winning design is the one whose
+  *held-out* contrast error on the trailing `holdout_frac` is smallest (e.g.
+  `0.3` for a 70/30 split) — a guard against overfitting transient pre-period
+  co-movement. The returned `results.pool` is ranked by OOS error and each entry
+  carries an `oos_rmse`. Requires `top_K >= 2` and a MIP mode; power and
+  inference are unchanged. `holdout_frac=None` (default) preserves the
+  Doudchenko et al. (2021) in-sample behaviour exactly. `compare_methods` now
+  defaults to holdout selection for SYNDES (`syndes_holdout_frac=0.3`), exposes
+  an `oos_rmse` column, and ranks the SYNDES rows by it; pass
+  `syndes_holdout_frac=None` to revert. New helper module
+  `utils/syndes_helpers/holdout.py` (`split_pre`, `oos_contrast_rmse`,
+  `select_by_holdout`).
+
 ### Changed
 - **SpSyDiD migrated onto the two-family result contract** (final estimator of
   the 9-estimator migration). `SpSyDiD.fit()` now returns `SpSyDiDResults` as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Added
+- **SYNDES design restrictions (geography / clustering / size / forcing).**
+  SYNDES now accepts the same restriction vocabulary as GEOLIFT and LEXSCM,
+  enforced exactly as linear constraints on the MIP assignment vector `D`:
+  `to_be_treated` (`D_i = 1`) / `not_to_be_treated` (`D_i = 0`, stays a donor);
+  `cluster_col` and/or `adjacency` + `spillover_threshold` → no two interfering
+  units both treated (`D_i + D_j ≤ 1`, via the shared conflict-graph helper
+  LEXSCM uses); `stratum_col` + `min_per_stratum` / `max_per_stratum` → coverage
+  quotas; `size_col` + `min_size` / `max_size` → a treated-unit size band.
+  Restrictions compose with `costs`/`budget` and flow through every selection
+  rule (in-sample, holdout, ic). Not supported with the annealed mode or an
+  `arm` column; infeasible combinations raise a translated `MlsynthConfigError`.
+  New helper module `utils/syndes_helpers/restrictions.py` (`build_restrictions`,
+  `apply_restrictions`, `DesignRestrictions`).
 - **SYNDES information-criterion (IC) design selection.** A new `selection`
   config field unifies the design-selection rule into `{"in_sample", "holdout",
   "ic"}` (default `None` infers `"holdout"` when `holdout_frac` is set, else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,15 @@ now returns and the back-compat guarantee.
   quotas; `size_col` + `min_size` / `max_size` → a treated-unit size band.
   Restrictions compose with `costs`/`budget` and flow through every selection
   rule (in-sample, holdout, ic). Not supported with the annealed mode or an
-  `arm` column; infeasible combinations raise a translated `MlsynthConfigError`.
-  New helper module `utils/syndes_helpers/restrictions.py` (`build_restrictions`,
+  `arm` column. Over-constrained designs return translated errors, never a
+  leaked solver status: config-detectable cases (unknown/overlapping forced
+  units, forcing more than `K`, too few treatable units) raise
+  `MlsynthConfigError`, and a solve-time infeasibility (e.g. asking for more
+  mutually non-adjacent treated markets than the conflict graph allows) raises
+  `MlsynthEstimationError` with a message naming the restrictions as the cause.
+  Validated against the bundled real DMA contiguity matrix
+  (`basedata/markets/`), restricting to Florida + Georgia. New helper module
+  `utils/syndes_helpers/restrictions.py` (`build_restrictions`,
   `apply_restrictions`, `DesignRestrictions`).
 - **SYNDES information-criterion (IC) design selection.** A new `selection`
   config field unifies the design-selection rule into `{"in_sample", "holdout",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Added
+- **SYNDES information-criterion (IC) design selection.** A new `selection`
+  config field unifies the design-selection rule into `{"in_sample", "holdout",
+  "ic"}` (default `None` infers `"holdout"` when `holdout_frac` is set, else
+  `"in_sample"`, so existing configs are unchanged). `selection="ic"` ranks the
+  `top_K` pool (solved on the whole pre-period — no data split) by an
+  information criterion `IC = SSR_pre + 2·sigma^2·df`, with `df = active control
+  donors − 1` (Pouliot-Xie-Liu's `df = |A| − 1` for the unpenalised SCM) and a
+  Mallows-Cp noise estimate, penalising designs that buy fit by activating more
+  donors. Preferable to holdout when the pre-period is short. Each `results.pool`
+  entry gains `ic` and `df`; requires `top_K >= 2` and a MIP mode. New helper
+  module `utils/syndes_helpers/infocriterion.py` (`design_df`, `select_by_ic`).
+  In `compare_methods`, pass `syndes_options={"selection": "ic"}` to use it
+  (overrides the default holdout).
 - **SYNDES holdout (train/validate) design selection.** A new optional
   `holdout_frac` config field switches SYNDES from in-sample MIP selection to
   out-of-sample selection: the `top_K` candidate pool is learned on the leading

--- a/benchmarks/R/install_pensynth.sh
+++ b/benchmarks/R/install_pensynth.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Install the pensynth reference for benchmarks/cases/pensynth_prop99.py.
+#
+# The cross-check needs two things:
+#   1. the authors' solver functions (wsoll1.R / TZero.R) -- cloned on demand at a
+#      pinned commit by benchmarks/reference/clone_pensynth.py, NOT installed here;
+#   2. LowRankQP, the low-rank QP solver wsoll1 calls.
+#
+# LowRankQP was archived from CRAN, so it is compiled from the CRAN GitHub mirror
+# at a pinned commit. Verified on Ubuntu + R 4.3.x in a sandbox where CRAN is
+# blocked but apt and GitHub are open: apt for r-base/r-base-dev, build the leaf
+# from source.
+#
+# COMMIT-PINNED so the byte-for-byte solver cross-check runs the SAME reference
+# every time. To refresh, bump the SHAs here (and _COMMIT in clone_pensynth.py)
+# and re-pin EXPECTED in benchmarks/cases/pensynth_prop99.py.
+#
+#   pensynth    master   3f2ad93a96acd558841275d07cd70576c78d451f  (jeremylhour/pensynth)
+#   LowRankQP   1.0.5    dfa675f0598950548985f97a7b45229f65aa39b5  (cran/LowRankQP)
+set -euo pipefail
+
+LOWRANKQP_SHA=dfa675f0598950548985f97a7b45229f65aa39b5
+
+DEBIAN_FRONTEND=noninteractive apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  r-base r-base-dev build-essential
+
+# Compile LowRankQP from the CRAN GitHub mirror at its pinned commit.
+cd /tmp
+curl -sL "https://codeload.github.com/cran/LowRankQP/tar.gz/${LOWRANKQP_SHA}" -o LowRankQP.tgz
+tar xzf LowRankQP.tgz
+R CMD INSTALL "LowRankQP-${LOWRANKQP_SHA}"
+
+Rscript -e 'suppressMessages(library(LowRankQP)); cat("LowRankQP", as.character(packageVersion("LowRankQP")), "OK\n")'

--- a/benchmarks/R/pensynth_prop99.R
+++ b/benchmarks/R/pensynth_prop99.R
@@ -1,0 +1,35 @@
+# Live pensynth reference: Abadie & L'Hour's penalized SC solver on Prop 99.
+#
+# Runs the authors' own ``wsoll1`` (penalized synthetic-control QP, solved with
+# LowRankQP) over a lambda grid on a predictor matrix supplied by the Python
+# benchmark, and writes the resulting donor-weight matrix back. The Python case
+# (benchmarks/cases/pensynth_prop99.py) builds X0/X1 from mlsynth's vendored
+# P99data.csv and cross-checks mlsynth's ``penalized_weights`` against this dump.
+#
+# The solver source (wsoll1.R, TZero.R) is sourced from a commit-pinned clone of
+# jeremylhour/pensynth (see benchmarks/reference/clone_pensynth.py); LowRankQP is
+# installed by benchmarks/R/install_pensynth.sh. Feeding both implementations the
+# identical X0/X1 makes this a byte-level solver cross-check: for lambda > 0 the
+# penalized QP is strictly convex (Theorem 1), so the optimum is unique.
+#
+# Usage: Rscript pensynth_prop99.R <funcdir> <X0.csv> <X1.csv> <grid.csv> <out.csv>
+suppressMessages(library(LowRankQP))
+
+args <- commandArgs(trailingOnly = TRUE)
+funcdir <- args[1]; X0path <- args[2]; X1path <- args[3]
+gridpath <- args[4]; outpath <- args[5]
+
+source(file.path(funcdir, "wsoll1.R"))
+source(file.path(funcdir, "TZero.R"))
+
+X0 <- as.matrix(read.csv(X0path, header = FALSE))             # p x n0
+X1 <- as.numeric(as.matrix(read.csv(X1path, header = FALSE))) # p
+grid <- as.numeric(as.matrix(read.csv(gridpath, header = FALSE)))
+V <- diag(nrow(X0))                                           # Gamma = I, as in EXA/EXB
+
+Wref <- t(sapply(grid, function(l) {
+  w <- wsoll1(X0, X1, V, l)
+  as.numeric(TZero(w, 1e-6))
+}))
+write.table(Wref, outpath, sep = ",", row.names = FALSE, col.names = FALSE)
+cat(sprintf("OK grid %d donors %d\n", length(grid), ncol(X0)))

--- a/benchmarks/cases/pensynth_prop99.py
+++ b/benchmarks/cases/pensynth_prop99.py
@@ -12,16 +12,22 @@ backend of ``VanillaSC``). This case feeds the *identical* predictor matrix to
 mlsynth's solver and to the authors' own ``wsoll1`` (their ``functions/wsoll1.R``,
 solved with LowRankQP) over a regularisation path, and checks they agree.
 
-The predictor matrix is the California-vs-38-states Prop 99 panel from mlsynth's
-vendored ``basedata/P99data.csv`` (Abadie's smoking dataset, 1970-2000), matched
-on the pre-treatment cigarette-sales path 1970-1988 with ``Gamma = I`` -- the
-lagged-outcome predictor block of the authors' California example
-(``EXA_CaliforniaTobacco.R``). The penalised QP is deterministic in
-``(X0, X1, lambda)`` and strictly convex for ``lambda > 0`` (their Theorem 1), so
-mlsynth's FISTA and the reference's interior-point LowRankQP land on the same
-unique optimum: weights agree to ~1e-4 and the implied ATT to ~1e-3 across the
-path. (The residual is convergence/threshold slack on sub-1e-6 weights, not a
-methodological difference.)
+The predictor matrix is the canonical Abadie-Diamond-Hainmueller (2010) Prop 99
+spec, built from mlsynth's vendored ``basedata/augmented_cali_long.csv`` through
+``mlsynth.utils.datautils.dataprep`` and the same covariate-mean / unit-variance
+machinery ``VanillaSC`` uses (no hand-pivoting): California vs 38 states matched
+on the *original covariate averages* -- ln(income), retail price and percent aged
+15-24 over 1980-1988, beer over 1984-1988 -- plus cigarette sales in 1975, 1980
+and 1988, each scaled to unit variance (``Gamma = I``).
+
+The penalised QP is deterministic in ``(X0, X1, lambda)`` and strictly convex for
+``lambda > 0`` (their Theorem 1), so mlsynth's FISTA and the reference's
+interior-point LowRankQP land on the same optimum: at ``lambda = 0.1`` the
+synthetic California loads ~0.65 on Colorado and the post-period ATT is -23.4
+packs, matched to 4 decimals. Across the path the largest weight gap is a
+sub-1% residual at one active-set transition, where LowRankQP stops with a tiny
+extra donor weight while mlsynth reaches the true (marginally lower-objective)
+vertex -- the reference solver's tolerance, not a methodological difference.
 
 The reference is **commit-pinned**: ``benchmarks/reference/clone_pensynth.py``
 clones ``jeremylhour/pensynth`` at a fixed SHA, and ``install_pensynth.sh``
@@ -37,6 +43,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -44,28 +51,52 @@ import pandas as pd
 from benchmarks.compare import BenchmarkSkipped
 from benchmarks.reference.clone_pensynth import functions_dir
 from mlsynth.utils.bilevel.penalized import penalized_weights
+from mlsynth.utils.datautils import dataprep
+from mlsynth.utils.vanillasc_helpers.pipeline import (
+    _covariate_means, _scale_unit_variance,
+)
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-_DATA = os.path.join(_ROOT, "basedata", "P99data.csv")
+_DATA = os.path.join(_ROOT, "basedata", "augmented_cali_long.csv")
 _RSCRIPT_REF = os.path.join(_ROOT, "benchmarks", "R", "pensynth_prop99.R")
 
 _TREATED = "California"
-_PRE = list(range(1970, 1989))          # pre-treatment matching window (predictors)
-_ALL = list(range(1970, 2001))
-_POST = list(range(1989, 2001))         # Prop 99 took effect in 1989
+_LAGS = (1975, 1980, 1988)
+# Abadie-Diamond-Hainmueller (2010) predictor spec: covariate averages over their
+# original windows plus the three special lagged outcomes.
+_COVS = ["loginc", "p_cig", "pct15-24", "pc_beer", "cig1975", "cig1980", "cig1988"]
+_WINDOWS = {
+    "loginc": (1980, 1988), "p_cig": (1980, 1988), "pct15-24": (1980, 1988),
+    "pc_beer": (1984, 1988),
+    "cig1975": (1975, 1975), "cig1980": (1980, 1980), "cig1988": (1988, 1988),
+}
 _GRID = [0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0]
 
 
 def _matrices():
-    """Build the California-vs-donors predictor and outcome matrices from P99data."""
+    """Build the ADH predictor matrix via dataprep + mlsynth's covariate machinery."""
     d = pd.read_csv(_DATA)
-    wide = d.pivot(index="state", columns="year", values="cigsale")
-    donors = [s for s in wide.index if s != _TREATED]
-    X1 = wide.loc[_TREATED, _PRE].to_numpy(float)             # (p,)
-    X0 = wide.loc[donors, _PRE].to_numpy(float).T             # (p, J) predictors x donors
-    y1_all = wide.loc[_TREATED, _ALL].to_numpy(float)         # (T,)
-    Y0_all = wide.loc[donors, _ALL].to_numpy(float)           # (J, T)
-    return X1, X0, y1_all, Y0_all, donors
+    d["treated"] = ((d["state"] == _TREATED) & (d["year"] >= 1989)).astype(int)
+    for L in _LAGS:                                   # special lagged-outcome predictors
+        m = d[d["year"] == L].set_index("state")["cigsale"]
+        d[f"cig{L}"] = d["state"].map(m)
+
+    prep = dataprep(
+        df=d, unit_id_column_name="state", time_period_column_name="year",
+        outcome_column_name="cigsale", treatment_indicator_column_name="treated")
+    pre = int(prep["pre_periods"])
+    time_labels = list(np.asarray(prep["time_labels"]))
+    pre_labels = time_labels[:pre]
+    donors = [str(x) for x in prep["donor_names"]]
+    units = [str(prep["treated_unit_name"])] + donors
+
+    Xraw = _covariate_means(d, units, _COVS, _WINDOWS, pre_labels, "state", "year")
+    Xs = _scale_unit_variance(Xraw)                   # unit-variance, Gamma = I
+    X1, X0 = Xs[:, 0], Xs[:, 1:]                       # (K,), (K, J)
+
+    y = np.asarray(prep["y"], dtype=float).ravel()    # treated outcome path
+    Y0 = np.asarray(prep["donor_matrix"], dtype=float)  # (T, J)
+    return X1, X0, y, Y0, pre, donors
 
 
 def _tzero(W, tol=1e-6):
@@ -102,7 +133,9 @@ def _reference_weights(X0, X1, funcs) -> np.ndarray:
 
 
 def run() -> dict:
-    X1, X0, y1_all, Y0_all, donors = _matrices()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        X1, X0, y, Y0, pre, donors = _matrices()
     funcs = functions_dir()                       # clones the pinned repo (skips if absent)
     Wref = _reference_weights(X0, X1, funcs)      # (len(grid), J)
 
@@ -114,29 +147,30 @@ def run() -> dict:
     weight_max_abs_diff = float(np.max(np.abs(Wml_t - Wref_t)))
 
     # ATT (post-period mean gap) at each lambda, both implementations.
-    post = np.array([_ALL.index(y) for y in _POST])
-    att_ml = np.array([float(np.mean((y1_all - w @ Y0_all)[post])) for w in Wml])
-    att_ref = np.array([float(np.mean((y1_all - w @ Y0_all)[post])) for w in Wref])
+    att_ml = np.array([float(np.mean((y - Y0 @ w)[pre:])) for w in Wml])
+    att_ref = np.array([float(np.mean((y - Y0 @ w)[pre:])) for w in Wref])
     att_max_abs_diff = float(np.max(np.abs(att_ml - att_ref)))
 
     i01 = _GRID.index(0.1)
-    w_montana = float(Wml_t[i01, donors.index("Montana")])
+    w_colorado = float(Wml_t[i01, donors.index("Colorado")])
 
     return {
         "weight_max_abs_diff": weight_max_abs_diff,
         "att_max_abs_diff": att_max_abs_diff,
         "att_lambda_0p1": float(att_ml[i01]),
-        "w_montana_lambda_0p1": w_montana,
+        "w_colorado_lambda_0p1": w_colorado,
     }
 
 
-# mlsynth reproduces the authors' wsoll1 to solver precision on the identical
-# matrices. The diff tolerances pin a genuine match (weights ~1e-4, ATT ~1e-3);
-# the two anchored cells fix the actual fit (California's synthetic at lambda=0.1
-# loads ~0.48 on Montana, giving a -23.5 packs post-period ATT).
+# mlsynth reproduces the authors' wsoll1 on the identical ADH predictor matrix.
+# The anchored cells fix the actual penalized fit (synthetic California loads
+# ~0.65 on Colorado at lambda=0.1, a -23.4 packs post-period ATT); the diff
+# tolerances pin a genuine match and absorb the reference's interior-point slack
+# (a sub-1% residual weight at one active-set transition, where mlsynth's FISTA
+# reaches the marginally lower-objective vertex).
 EXPECTED = {
-    "weight_max_abs_diff": (0.0, 2e-3),
-    "att_max_abs_diff": (0.0, 5e-3),
-    "att_lambda_0p1": (-23.478, 0.05),
-    "w_montana_lambda_0p1": (0.478, 0.01),
+    "weight_max_abs_diff": (0.0, 1.5e-2),
+    "att_max_abs_diff": (0.0, 0.1),
+    "att_lambda_0p1": (-23.433, 0.05),
+    "w_colorado_lambda_0p1": (0.653, 0.01),
 }

--- a/benchmarks/cases/pensynth_prop99.py
+++ b/benchmarks/cases/pensynth_prop99.py
@@ -12,25 +12,25 @@ backend of ``VanillaSC``). This case feeds the *identical* predictor matrix to
 mlsynth's solver and to the authors' own ``wsoll1`` (their ``functions/wsoll1.R``,
 solved with LowRankQP) over a regularisation path, and checks they agree.
 
-The predictor matrix is the specification in the authors' own California example
-(``examples/EXA_CaliforniaTobacco.R`` in ``jeremylhour/pensynth``): the four MLAB
-covariate averages -- income, retail price, percent aged 15-24 and beer
-consumption -- stacked with the full pre-treatment cigarette-sales path
-1970-1988, matched with ``V = I`` (raw, no rescaling), exactly as that script
-builds ``X`` and sets ``V = diag(ncol(X))``. It is constructed from mlsynth's
-vendored ``basedata/augmented_cali_long.csv`` through
+The predictor matrix is the canonical Abadie-Diamond-Hainmueller (2010) MLAB
+vector -- the four covariate averages (income, retail price, percent aged 15-24
+and beer consumption, over their original windows) plus the three special lagged
+outcomes, cigarette sales in 1975, 1980 and 1988 -- matched with ``V = I`` (raw,
+no rescaling), the ``V = diag(ncol(X))`` convention of the authors' California
+example (``examples/EXA_CaliforniaTobacco.R`` in ``jeremylhour/pensynth``). It is
+constructed from mlsynth's vendored ``basedata/augmented_cali_long.csv`` through
 :func:`mlsynth.utils.datautils.dataprep` and the covariate-mean helper
 ``VanillaSC`` uses -- no hand-pivoting. California is the treated unit and the
 remaining 38 states are the donors.
 
 The penalised QP is deterministic in ``(X0, X1, lambda)`` and strictly convex for
-``lambda > 0`` (their Theorem 1). Over the penalty path before the nearest-
-neighbour collapse (``lambda`` up to 0.25) mlsynth's FISTA and the reference's
-interior-point LowRankQP land on the same optimum: weights agree to ~2e-4 and the
-post-period ATT to ~1e-3 packs. At small ``lambda`` the fit recovers the canonical
-Abadie-Diamond-Hainmueller donor pool (Utah, Nevada, Montana, Colorado,
-Connecticut); as ``lambda`` grows the weights concentrate toward the nearest
-neighbour (Montana), reproducing the penalty's interpolation property.
+``lambda > 0`` (their Theorem 1), so mlsynth's FISTA and the reference's
+interior-point LowRankQP land on the same optimum across the whole path: weights
+agree to ~3e-4 and the post-period ATT to ~2e-3 packs. With ``V = I`` (no nested
+``V`` optimisation) the penalized fit is Idaho-led rather than ADH's Utah/Nevada
+pool -- expected, since the penalty, not a fitted ``V``, resolves the weights;
+as ``lambda`` grows they concentrate toward the nearest neighbour (Montana),
+reproducing the penalty's interpolation property.
 
 The reference is **commit-pinned**: ``benchmarks/reference/clone_pensynth.py``
 clones ``jeremylhour/pensynth`` at a fixed SHA, and ``install_pensynth.sh``
@@ -62,22 +62,25 @@ _DATA = os.path.join(_ROOT, "basedata", "augmented_cali_long.csv")
 _RSCRIPT_REF = os.path.join(_ROOT, "benchmarks", "R", "pensynth_prop99.R")
 
 _TREATED = "California"
-# EXA_CaliforniaTobacco.R predictors: four MLAB covariate averages over their
-# original windows + the full pre-treatment outcome path; V = diag (raw, no scaling).
-_COVS = ["loginc", "p_cig", "pct15-24", "pc_beer"]
+_LAGS = (1975, 1980, 1988)
+# Abadie-Diamond-Hainmueller (2010) MLAB predictors: four covariate averages over
+# their original windows + three special lagged outcomes; V = diag (raw, no scaling).
+_COVS = ["loginc", "p_cig", "pct15-24", "pc_beer", "cig1975", "cig1980", "cig1988"]
 _WINDOWS = {
     "loginc": (1980, 1988), "p_cig": (1980, 1988),
     "pct15-24": (1980, 1988), "pc_beer": (1984, 1988),
+    "cig1975": (1975, 1975), "cig1980": (1980, 1980), "cig1988": (1988, 1988),
 }
-# Penalty path up to the nearest-neighbour collapse (beyond ~0.25 the solution
-# jumps to a single donor; that discontinuity is not a solver-parity test).
-_GRID = [0.001, 0.01, 0.05, 0.1, 0.25]
+_GRID = [0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0]
 
 
 def _matrices():
-    """Build the EXA predictor matrix via dataprep + mlsynth's covariate helper."""
+    """Build the MLAB predictor matrix via dataprep + mlsynth's covariate helper."""
     d = pd.read_csv(_DATA)
     d["treated"] = ((d["state"] == _TREATED) & (d["year"] >= 1989)).astype(int)
+    for L in _LAGS:                                   # special lagged-outcome predictors
+        m = d[d["year"] == L].set_index("state")["cigsale"]
+        d[f"cig{L}"] = d["state"].map(m)
 
     prep = dataprep(
         df=d, unit_id_column_name="state", time_period_column_name="year",
@@ -91,11 +94,8 @@ def _matrices():
     y = np.asarray(prep["y"], dtype=float).ravel()        # treated outcome path
     Y0 = np.asarray(prep["donor_matrix"], dtype=float)    # (T, J)
 
-    # Covariate-average block (K_cov, N), then the pre-treatment outcome path
-    # (pre, N) with the treated unit first -- the EXA stack, raw (V = I).
-    Xcov = _covariate_means(d, units, _COVS, _WINDOWS, pre_labels, "state", "year")
-    path = np.column_stack([y[:pre], Y0[:pre]])           # (pre, N)
-    X = np.vstack([Xcov, path])                           # (K_cov + pre, N)
+    # MLAB predictor means (K, N), raw (V = I) -- treated first, then donors.
+    X = _covariate_means(d, units, _COVS, _WINDOWS, pre_labels, "state", "year")
     X1, X0 = X[:, 0], X[:, 1:]
     return X1, X0, y, Y0, pre, donors
 
@@ -153,23 +153,23 @@ def run() -> dict:
     att_max_abs_diff = float(np.max(np.abs(att_ml - att_ref)))
 
     i01 = _GRID.index(0.1)
-    w_montana = float(Wml_t[i01, donors.index("Montana")])
+    w_idaho = float(Wml_t[i01, donors.index("Idaho")])
 
     return {
         "weight_max_abs_diff": weight_max_abs_diff,
         "att_max_abs_diff": att_max_abs_diff,
         "att_lambda_0p1": float(att_ml[i01]),
-        "w_montana_lambda_0p1": w_montana,
+        "w_idaho_lambda_0p1": w_idaho,
     }
 
 
-# mlsynth reproduces the authors' wsoll1 on the identical EXA predictor matrix to
-# solver precision (weights ~2e-4, ATT ~1e-3 across the interpolation path). The
+# mlsynth reproduces the authors' wsoll1 on the identical MLAB predictor matrix to
+# solver precision across the whole grid (weights ~3e-4, ATT ~2e-3 packs). The
 # anchored cells fix the actual penalized fit: at lambda=0.1 the synthetic
-# California loads ~0.43 on Montana for a -23.3 packs post-period ATT.
+# California loads ~0.54 on Idaho for a -23.4 packs post-period ATT.
 EXPECTED = {
     "weight_max_abs_diff": (0.0, 2e-3),
     "att_max_abs_diff": (0.0, 5e-3),
-    "att_lambda_0p1": (-23.268, 0.05),
-    "w_montana_lambda_0p1": (0.434, 0.01),
+    "att_lambda_0p1": (-23.423, 0.05),
+    "w_idaho_lambda_0p1": (0.538, 0.01),
 }

--- a/benchmarks/cases/pensynth_prop99.py
+++ b/benchmarks/cases/pensynth_prop99.py
@@ -1,0 +1,142 @@
+"""pensynth live cross-check vs Abadie & L'Hour's wsoll1 on Prop 99.
+
+Cross-validation against the *running* reference. mlsynth implements the
+penalized synthetic-control estimator of Abadie & L'Hour (2021, JASA) -- the
+pairwise-penalised QP
+
+    min_W  || X1 - X0 W ||^2  +  lambda * sum_j W_j || X1 - X_j ||^2
+    s.t.   W >= 0,  sum_j W_j = 1
+
+-- as ``mlsynth.utils.bilevel.penalized.penalized_weights`` (the ``penalized``
+backend of ``VanillaSC``). This case feeds the *identical* predictor matrix to
+mlsynth's solver and to the authors' own ``wsoll1`` (their ``functions/wsoll1.R``,
+solved with LowRankQP) over a regularisation path, and checks they agree.
+
+The predictor matrix is the California-vs-38-states Prop 99 panel from mlsynth's
+vendored ``basedata/P99data.csv`` (Abadie's smoking dataset, 1970-2000), matched
+on the pre-treatment cigarette-sales path 1970-1988 with ``Gamma = I`` -- the
+lagged-outcome predictor block of the authors' California example
+(``EXA_CaliforniaTobacco.R``). The penalised QP is deterministic in
+``(X0, X1, lambda)`` and strictly convex for ``lambda > 0`` (their Theorem 1), so
+mlsynth's FISTA and the reference's interior-point LowRankQP land on the same
+unique optimum: weights agree to ~1e-4 and the implied ATT to ~1e-3 across the
+path. (The residual is convergence/threshold slack on sub-1e-6 weights, not a
+methodological difference.)
+
+The reference is **commit-pinned**: ``benchmarks/reference/clone_pensynth.py``
+clones ``jeremylhour/pensynth`` at a fixed SHA, and ``install_pensynth.sh``
+freezes LowRankQP, so the cross-check runs the same solver source every time.
+Refresh by re-pinning those and updating ``EXPECTED``.
+
+Skips itself (``BenchmarkSkipped``) when ``Rscript``, LowRankQP, or the clone is
+unavailable, so it is a no-op in CI and runs only where the reference is present.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+import numpy as np
+import pandas as pd
+
+from benchmarks.compare import BenchmarkSkipped
+from benchmarks.reference.clone_pensynth import functions_dir
+from mlsynth.utils.bilevel.penalized import penalized_weights
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_DATA = os.path.join(_ROOT, "basedata", "P99data.csv")
+_RSCRIPT_REF = os.path.join(_ROOT, "benchmarks", "R", "pensynth_prop99.R")
+
+_TREATED = "California"
+_PRE = list(range(1970, 1989))          # pre-treatment matching window (predictors)
+_ALL = list(range(1970, 2001))
+_POST = list(range(1989, 2001))         # Prop 99 took effect in 1989
+_GRID = [0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0]
+
+
+def _matrices():
+    """Build the California-vs-donors predictor and outcome matrices from P99data."""
+    d = pd.read_csv(_DATA)
+    wide = d.pivot(index="state", columns="year", values="cigsale")
+    donors = [s for s in wide.index if s != _TREATED]
+    X1 = wide.loc[_TREATED, _PRE].to_numpy(float)             # (p,)
+    X0 = wide.loc[donors, _PRE].to_numpy(float).T             # (p, J) predictors x donors
+    y1_all = wide.loc[_TREATED, _ALL].to_numpy(float)         # (T,)
+    Y0_all = wide.loc[donors, _ALL].to_numpy(float)           # (J, T)
+    return X1, X0, y1_all, Y0_all, donors
+
+
+def _tzero(W, tol=1e-6):
+    """Threshold tiny weights and renormalise (the reference's TZero convention)."""
+    Y = np.where(W < tol, 0.0, W)
+    return Y / Y.sum(axis=1, keepdims=True)
+
+
+def _reference_weights(X0, X1, funcs) -> np.ndarray:
+    """Run the authors' wsoll1 over the grid via Rscript; return the weight matrix."""
+    rscript = shutil.which("Rscript")
+    if rscript is None:
+        raise BenchmarkSkipped("Rscript not on PATH (run benchmarks/R/install_pensynth.sh)")
+    probe = subprocess.run(
+        [rscript, "-e", "suppressMessages(library(LowRankQP))"],
+        capture_output=True, text=True)
+    if probe.returncode != 0:
+        raise BenchmarkSkipped("R package 'LowRankQP' not installed")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        x0p = os.path.join(tmp, "X0.csv")
+        x1p = os.path.join(tmp, "X1.csv")
+        gp = os.path.join(tmp, "grid.csv")
+        outp = os.path.join(tmp, "Wref.csv")
+        np.savetxt(x0p, X0, delimiter=",")
+        np.savetxt(x1p, X1, delimiter=",")
+        np.savetxt(gp, np.asarray(_GRID), delimiter=",")
+        out = subprocess.run(
+            [rscript, _RSCRIPT_REF, str(funcs), x0p, x1p, gp, outp],
+            capture_output=True, text=True)
+        if out.returncode != 0 or not os.path.exists(outp):
+            raise BenchmarkSkipped(f"pensynth reference failed: {out.stderr.strip()[-200:]}")
+        return np.loadtxt(outp, delimiter=",")
+
+
+def run() -> dict:
+    X1, X0, y1_all, Y0_all, donors = _matrices()
+    funcs = functions_dir()                       # clones the pinned repo (skips if absent)
+    Wref = _reference_weights(X0, X1, funcs)      # (len(grid), J)
+
+    Wml = np.array([penalized_weights(X1, X0, lam, max_iter=50000, tol=1e-13)
+                    for lam in _GRID])
+    Wml_t, Wref_t = _tzero(Wml), _tzero(Wref)
+
+    # Largest donor-weight gap across the whole regularisation path.
+    weight_max_abs_diff = float(np.max(np.abs(Wml_t - Wref_t)))
+
+    # ATT (post-period mean gap) at each lambda, both implementations.
+    post = np.array([_ALL.index(y) for y in _POST])
+    att_ml = np.array([float(np.mean((y1_all - w @ Y0_all)[post])) for w in Wml])
+    att_ref = np.array([float(np.mean((y1_all - w @ Y0_all)[post])) for w in Wref])
+    att_max_abs_diff = float(np.max(np.abs(att_ml - att_ref)))
+
+    i01 = _GRID.index(0.1)
+    w_montana = float(Wml_t[i01, donors.index("Montana")])
+
+    return {
+        "weight_max_abs_diff": weight_max_abs_diff,
+        "att_max_abs_diff": att_max_abs_diff,
+        "att_lambda_0p1": float(att_ml[i01]),
+        "w_montana_lambda_0p1": w_montana,
+    }
+
+
+# mlsynth reproduces the authors' wsoll1 to solver precision on the identical
+# matrices. The diff tolerances pin a genuine match (weights ~1e-4, ATT ~1e-3);
+# the two anchored cells fix the actual fit (California's synthetic at lambda=0.1
+# loads ~0.48 on Montana, giving a -23.5 packs post-period ATT).
+EXPECTED = {
+    "weight_max_abs_diff": (0.0, 2e-3),
+    "att_max_abs_diff": (0.0, 5e-3),
+    "att_lambda_0p1": (-23.478, 0.05),
+    "w_montana_lambda_0p1": (0.478, 0.01),
+}

--- a/benchmarks/cases/pensynth_prop99.py
+++ b/benchmarks/cases/pensynth_prop99.py
@@ -12,22 +12,25 @@ backend of ``VanillaSC``). This case feeds the *identical* predictor matrix to
 mlsynth's solver and to the authors' own ``wsoll1`` (their ``functions/wsoll1.R``,
 solved with LowRankQP) over a regularisation path, and checks they agree.
 
-The predictor matrix is the canonical Abadie-Diamond-Hainmueller (2010) Prop 99
-spec, built from mlsynth's vendored ``basedata/augmented_cali_long.csv`` through
-``mlsynth.utils.datautils.dataprep`` and the same covariate-mean / unit-variance
-machinery ``VanillaSC`` uses (no hand-pivoting): California vs 38 states matched
-on the *original covariate averages* -- ln(income), retail price and percent aged
-15-24 over 1980-1988, beer over 1984-1988 -- plus cigarette sales in 1975, 1980
-and 1988, each scaled to unit variance (``Gamma = I``).
+The predictor matrix is the specification in the authors' own California example
+(``examples/EXA_CaliforniaTobacco.R`` in ``jeremylhour/pensynth``): the four MLAB
+covariate averages -- income, retail price, percent aged 15-24 and beer
+consumption -- stacked with the full pre-treatment cigarette-sales path
+1970-1988, matched with ``V = I`` (raw, no rescaling), exactly as that script
+builds ``X`` and sets ``V = diag(ncol(X))``. It is constructed from mlsynth's
+vendored ``basedata/augmented_cali_long.csv`` through
+:func:`mlsynth.utils.datautils.dataprep` and the covariate-mean helper
+``VanillaSC`` uses -- no hand-pivoting. California is the treated unit and the
+remaining 38 states are the donors.
 
 The penalised QP is deterministic in ``(X0, X1, lambda)`` and strictly convex for
-``lambda > 0`` (their Theorem 1), so mlsynth's FISTA and the reference's
-interior-point LowRankQP land on the same optimum: at ``lambda = 0.1`` the
-synthetic California loads ~0.65 on Colorado and the post-period ATT is -23.4
-packs, matched to 4 decimals. Across the path the largest weight gap is a
-sub-1% residual at one active-set transition, where LowRankQP stops with a tiny
-extra donor weight while mlsynth reaches the true (marginally lower-objective)
-vertex -- the reference solver's tolerance, not a methodological difference.
+``lambda > 0`` (their Theorem 1). Over the penalty path before the nearest-
+neighbour collapse (``lambda`` up to 0.25) mlsynth's FISTA and the reference's
+interior-point LowRankQP land on the same optimum: weights agree to ~2e-4 and the
+post-period ATT to ~1e-3 packs. At small ``lambda`` the fit recovers the canonical
+Abadie-Diamond-Hainmueller donor pool (Utah, Nevada, Montana, Colorado,
+Connecticut); as ``lambda`` grows the weights concentrate toward the nearest
+neighbour (Montana), reproducing the penalty's interpolation property.
 
 The reference is **commit-pinned**: ``benchmarks/reference/clone_pensynth.py``
 clones ``jeremylhour/pensynth`` at a fixed SHA, and ``install_pensynth.sh``
@@ -52,34 +55,29 @@ from benchmarks.compare import BenchmarkSkipped
 from benchmarks.reference.clone_pensynth import functions_dir
 from mlsynth.utils.bilevel.penalized import penalized_weights
 from mlsynth.utils.datautils import dataprep
-from mlsynth.utils.vanillasc_helpers.pipeline import (
-    _covariate_means, _scale_unit_variance,
-)
+from mlsynth.utils.vanillasc_helpers.pipeline import _covariate_means
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 _DATA = os.path.join(_ROOT, "basedata", "augmented_cali_long.csv")
 _RSCRIPT_REF = os.path.join(_ROOT, "benchmarks", "R", "pensynth_prop99.R")
 
 _TREATED = "California"
-_LAGS = (1975, 1980, 1988)
-# Abadie-Diamond-Hainmueller (2010) predictor spec: covariate averages over their
-# original windows plus the three special lagged outcomes.
-_COVS = ["loginc", "p_cig", "pct15-24", "pc_beer", "cig1975", "cig1980", "cig1988"]
+# EXA_CaliforniaTobacco.R predictors: four MLAB covariate averages over their
+# original windows + the full pre-treatment outcome path; V = diag (raw, no scaling).
+_COVS = ["loginc", "p_cig", "pct15-24", "pc_beer"]
 _WINDOWS = {
-    "loginc": (1980, 1988), "p_cig": (1980, 1988), "pct15-24": (1980, 1988),
-    "pc_beer": (1984, 1988),
-    "cig1975": (1975, 1975), "cig1980": (1980, 1980), "cig1988": (1988, 1988),
+    "loginc": (1980, 1988), "p_cig": (1980, 1988),
+    "pct15-24": (1980, 1988), "pc_beer": (1984, 1988),
 }
-_GRID = [0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0]
+# Penalty path up to the nearest-neighbour collapse (beyond ~0.25 the solution
+# jumps to a single donor; that discontinuity is not a solver-parity test).
+_GRID = [0.001, 0.01, 0.05, 0.1, 0.25]
 
 
 def _matrices():
-    """Build the ADH predictor matrix via dataprep + mlsynth's covariate machinery."""
+    """Build the EXA predictor matrix via dataprep + mlsynth's covariate helper."""
     d = pd.read_csv(_DATA)
     d["treated"] = ((d["state"] == _TREATED) & (d["year"] >= 1989)).astype(int)
-    for L in _LAGS:                                   # special lagged-outcome predictors
-        m = d[d["year"] == L].set_index("state")["cigsale"]
-        d[f"cig{L}"] = d["state"].map(m)
 
     prep = dataprep(
         df=d, unit_id_column_name="state", time_period_column_name="year",
@@ -90,12 +88,15 @@ def _matrices():
     donors = [str(x) for x in prep["donor_names"]]
     units = [str(prep["treated_unit_name"])] + donors
 
-    Xraw = _covariate_means(d, units, _COVS, _WINDOWS, pre_labels, "state", "year")
-    Xs = _scale_unit_variance(Xraw)                   # unit-variance, Gamma = I
-    X1, X0 = Xs[:, 0], Xs[:, 1:]                       # (K,), (K, J)
+    y = np.asarray(prep["y"], dtype=float).ravel()        # treated outcome path
+    Y0 = np.asarray(prep["donor_matrix"], dtype=float)    # (T, J)
 
-    y = np.asarray(prep["y"], dtype=float).ravel()    # treated outcome path
-    Y0 = np.asarray(prep["donor_matrix"], dtype=float)  # (T, J)
+    # Covariate-average block (K_cov, N), then the pre-treatment outcome path
+    # (pre, N) with the treated unit first -- the EXA stack, raw (V = I).
+    Xcov = _covariate_means(d, units, _COVS, _WINDOWS, pre_labels, "state", "year")
+    path = np.column_stack([y[:pre], Y0[:pre]])           # (pre, N)
+    X = np.vstack([Xcov, path])                           # (K_cov + pre, N)
+    X1, X0 = X[:, 0], X[:, 1:]
     return X1, X0, y, Y0, pre, donors
 
 
@@ -152,25 +153,23 @@ def run() -> dict:
     att_max_abs_diff = float(np.max(np.abs(att_ml - att_ref)))
 
     i01 = _GRID.index(0.1)
-    w_colorado = float(Wml_t[i01, donors.index("Colorado")])
+    w_montana = float(Wml_t[i01, donors.index("Montana")])
 
     return {
         "weight_max_abs_diff": weight_max_abs_diff,
         "att_max_abs_diff": att_max_abs_diff,
         "att_lambda_0p1": float(att_ml[i01]),
-        "w_colorado_lambda_0p1": w_colorado,
+        "w_montana_lambda_0p1": w_montana,
     }
 
 
-# mlsynth reproduces the authors' wsoll1 on the identical ADH predictor matrix.
-# The anchored cells fix the actual penalized fit (synthetic California loads
-# ~0.65 on Colorado at lambda=0.1, a -23.4 packs post-period ATT); the diff
-# tolerances pin a genuine match and absorb the reference's interior-point slack
-# (a sub-1% residual weight at one active-set transition, where mlsynth's FISTA
-# reaches the marginally lower-objective vertex).
+# mlsynth reproduces the authors' wsoll1 on the identical EXA predictor matrix to
+# solver precision (weights ~2e-4, ATT ~1e-3 across the interpolation path). The
+# anchored cells fix the actual penalized fit: at lambda=0.1 the synthetic
+# California loads ~0.43 on Montana for a -23.3 packs post-period ATT.
 EXPECTED = {
-    "weight_max_abs_diff": (0.0, 1.5e-2),
-    "att_max_abs_diff": (0.0, 0.1),
-    "att_lambda_0p1": (-23.433, 0.05),
-    "w_colorado_lambda_0p1": (0.653, 0.01),
+    "weight_max_abs_diff": (0.0, 2e-3),
+    "att_max_abs_diff": (0.0, 5e-3),
+    "att_lambda_0p1": (-23.268, 0.05),
+    "w_montana_lambda_0p1": (0.434, 0.01),
 }

--- a/benchmarks/reference/clone_pensynth.py
+++ b/benchmarks/reference/clone_pensynth.py
@@ -1,0 +1,55 @@
+"""On-demand clone of Abadie & L'Hour's ``pensynth`` reference repo.
+
+The authors' replication repository (https://github.com/jeremylhour/pensynth,
+MIT-licensed) carries the penalized synthetic-control solver ``wsoll1`` -- the
+exact QP of Abadie & L'Hour (2021, JASA) -- as loose R functions rather than a
+package. Rather than vendor them, the ``pensynth_prop99`` cross-validation
+benchmark clones the repo at a pinned commit into a local cache and points the
+reference R script (``benchmarks/R/pensynth_prop99.R``) at its ``functions``
+directory. If git or the network is unavailable the benchmark skips gracefully.
+
+The pinned commit (``_COMMIT``) freezes the reference so the cross-check runs the
+same ``wsoll1``/``TZero`` source every time; bump it deliberately, never silently.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from benchmarks.compare import BenchmarkSkipped
+
+_REPO = "https://github.com/jeremylhour/pensynth.git"
+# pensynth master @ 2024 (the EXB_Lalonde / EXA_California solver functions).
+_COMMIT = "3f2ad93a96acd558841275d07cd70576c78d451f"
+_CACHE = Path(__file__).resolve().parent / ".cache" / "pensynth"
+
+
+def ensure_clone() -> Path:
+    """Clone (or reuse) the reference repo pinned at ``_COMMIT``. Returns its path."""
+    wsoll1 = _CACHE / "functions" / "wsoll1.R"
+    if wsoll1.exists():
+        return _CACHE
+    _CACHE.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        subprocess.run(
+            ["git", "-c", "credential.helper=", "clone", "--quiet", _REPO, str(_CACHE)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(_CACHE), "checkout", "--quiet", _COMMIT],
+            check=True, capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:  # pragma: no cover - env-dependent
+        detail = getattr(exc, "stderr", b"")
+        msg = detail.decode(errors="ignore").strip() if detail else str(exc)
+        raise BenchmarkSkipped(
+            f"could not clone reference repo {_REPO} @ {_COMMIT[:7]}: {msg}"
+        ) from exc
+    if not wsoll1.exists():  # pragma: no cover - defensive
+        raise BenchmarkSkipped("reference clone missing functions/wsoll1.R")
+    return _CACHE
+
+
+def functions_dir() -> Path:
+    """Path to the pinned clone's ``functions`` directory (has wsoll1.R, TZero.R)."""
+    return ensure_clone() / "functions"

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -85,6 +85,7 @@ CASES = {
     "augsynth_calibrated": "benchmarks.cases.augsynth_calibrated",  # Path B: ASCM near-nominal coverage + bias reduction (BMR 2021 Sec 7)
     "geolift_walkthrough": "benchmarks.cases.geolift",  # cross-val vs GeoLift/augsynth: GeoLift_Walkthrough full summary, base + ridge-augmented (ATT/lift/incremental/L2/scaled-L2/%improve/bias/weights/conformal)
     "geolift_augsynth_ref": "benchmarks.cases.geolift_augsynth_ref",  # cross-val vs LIVE augsynth (Rscript): lambda/weights/ATT (skips if absent)
+    "pensynth_prop99": "benchmarks.cases.pensynth_prop99",  # cross-val vs LIVE pensynth wsoll1 (Rscript+LowRankQP) on Prop 99 penalized SC (skips if absent)
     "geolift_cpic": "benchmarks.cases.geolift_cpic",  # cross-val vs GeoLiftMarketSelection: CPIC investment value-for-value
     "geolift_marketselection": "benchmarks.cases.geolift_marketselection",  # cross-val vs GeoLiftMarketSelection: pooled N=2-5 BestMarkets top-5 ranking (rank/investment/MDE/abs_lift_in_zero)
     "geolift_marketselection_ref": "benchmarks.cases.geolift_marketselection_ref",  # cross-val vs LIVE GeoLiftMarketSelection (Rscript): BestMarkets top-5 (skips if absent)

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -195,6 +195,8 @@ Cross-validation against reference implementations
      - vs authors' repo
    * - ``geolift_augsynth_ref``
      - vs LIVE augsynth (Rscript): lambda/weights/ATT (skips if absent)
+   * - ``pensynth_prop99``
+     - vs LIVE pensynth wsoll1 (Rscript+LowRankQP): penalized SC weights/ATT on Prop 99 (skips if absent)
    * - ``geolift_cpic``
      - vs GeoLiftMarketSelection: CPIC investment value-for-value
    * - ``geolift_multicell``

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -54,6 +54,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    replications/tssc
    replications/vanillasc
    replications/ascm_kansas
+   replications/pensynth
    replications/sparse_sc
    replications/nsc
    replications/sdid

--- a/docs/replications/pensynth.rst
+++ b/docs/replications/pensynth.rst
@@ -1,0 +1,81 @@
+.. _replication-pensynth:
+
+Penalized Synthetic Control (Abadie & L'Hour 2021)
+==================================================
+
+:Estimator: :doc:`../vanillasc` — the ``penalized`` backend
+   (:func:`mlsynth.utils.bilevel.penalized.penalized_weights`).
+:Source: Abadie & L'Hour (2021), *"A Penalized Synthetic Control Estimator for
+   Disaggregated Data,"* JASA 116(536), 1817–1834; reference implementation: the
+   authors' ``pensynth`` repository (``jeremylhour/pensynth``), function
+   ``wsoll1``.
+:Replication type: **Cross-validation** — mlsynth's penalized solver matched to
+   the authors' own ``wsoll1`` on identical inputs.
+:Status: **Fully verified** — weights and ATT reproduced to solver precision.
+
+Validation strategy
+-------------------
+
+The penalized estimator adds a pairwise matching penalty to the synthetic-control
+objective. For treated predictors :math:`X_1`, donor predictors :math:`X_0` and
+penalty :math:`\lambda \ge 0` it solves (the paper's eq. 5)
+
+.. math::
+
+   \min_{W}\; \lVert X_1 - X_0 W \rVert^2
+     \;+\; \lambda \sum_j W_j \lVert X_1 - X_{0j} \rVert^2
+   \quad\text{s.t.}\quad W \ge 0,\; \textstyle\sum_j W_j = 1 .
+
+The penalty interpolates between the pure synthetic control (:math:`\lambda \to 0`)
+and nearest-neighbour matching (large :math:`\lambda`); by the paper's Theorem 1,
+for any :math:`\lambda > 0` the solution is unique and sparse. Because the program
+is a strictly convex quadratic program in :math:`W` for :math:`\lambda > 0`, it has
+a single optimum, which makes it an ideal target for a solver-level cross-check:
+feed the same :math:`(X_0, X_1, \lambda)` to two independent solvers and they must
+agree.
+
+That is exactly what the benchmark does. mlsynth's implementation
+(:func:`~mlsynth.utils.bilevel.penalized.penalized_weights`, the ``penalized``
+backend of :class:`~mlsynth.estimators.vanillasc.VanillaSC`) solves the program by
+projected-gradient FISTA; the reference ``wsoll1`` solves the identical program by
+the interior-point routine ``LowRankQP``. We feed both the same predictor matrix
+and compare across a regularisation path.
+
+Cross-validation — the Prop 99 path
+-----------------------------------
+
+The predictor matrix is built from mlsynth's vendored ``basedata/P99data.csv``
+(Abadie's California tobacco panel, 39 states, 1970–2000). California is the
+treated unit and the remaining 38 states are donors, matched on the pre-treatment
+cigarette-sales path 1970–1988 with :math:`\Gamma = I` — the lagged-outcome
+predictor block of the authors' California example (``EXA_CaliforniaTobacco.R``).
+The same :math:`X_0` (:math:`19 \times 38`) and :math:`X_1` (:math:`19`) are sent
+to ``wsoll1`` and to ``penalized_weights`` over the grid
+:math:`\lambda \in \{0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1\}`.
+
+Across the whole path the two implementations agree to solver precision: the
+largest donor-weight difference is :math:`\approx 1.3\times10^{-4}` and the largest
+post-period ATT difference is :math:`\approx 8.6\times10^{-4}` packs (the residual
+is convergence and thresholding slack on sub-:math:`10^{-6}` weights, not a
+methodological difference). At :math:`\lambda = 0.1` the synthetic California loads
+on Montana (:math:`0.478`), Idaho (:math:`0.254`), Colorado (:math:`0.194`) and
+Connecticut (:math:`0.074`), giving a post-1989 ATT of :math:`-23.48` packs per
+capita; as :math:`\lambda` grows the weights collapse toward the single nearest
+neighbour, reproducing the paper's interpolation property.
+
+Durable benchmark
+-----------------
+
+The runnable case is ``pensynth_prop99`` in the durable suite
+(``benchmarks/cases/pensynth_prop99.py``). It is a live cross-check: the reference
+``wsoll1``/``TZero`` source is taken from a commit-pinned clone of
+``jeremylhour/pensynth`` (``benchmarks/reference/clone_pensynth.py``) and
+``LowRankQP`` is frozen by ``benchmarks/R/install_pensynth.sh``, so the same solver
+runs every time. The case skips itself when ``Rscript``, ``LowRankQP`` or the clone
+is unavailable, so it is a no-op where the reference toolchain is absent. Run it
+with
+
+.. code-block:: bash
+
+   bash benchmarks/R/install_pensynth.sh        # one-time: R + LowRankQP
+   python -m benchmarks.run_benchmarks --case pensynth_prop99

--- a/docs/replications/pensynth.rst
+++ b/docs/replications/pensynth.rst
@@ -44,30 +44,32 @@ and compare across a regularisation path.
 Cross-validation — the Prop 99 path
 -----------------------------------
 
-The predictor matrix is the canonical Abadie-Diamond-Hainmueller (2010) Prop 99
-specification, built from mlsynth's vendored ``basedata/augmented_cali_long.csv``
-through :func:`mlsynth.utils.datautils.dataprep` and the same covariate-mean and
-unit-variance machinery :class:`~mlsynth.estimators.vanillasc.VanillaSC` uses — no
-hand-pivoting. California is the treated unit and the remaining 38 states are
-donors, matched on the authors' *original covariate averages* — ln(personal
-income), retail cigarette price and percent aged 15–24 over 1980–1988, beer
-consumption over 1984–1988 — plus cigarette sales in 1975, 1980 and 1988, each
-scaled to unit variance (:math:`\Gamma = I`). The same :math:`X_0`
-(:math:`7 \times 38`) and :math:`X_1` (:math:`7`) are sent to ``wsoll1`` and to
-``penalized_weights`` over the grid
-:math:`\lambda \in \{0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1\}`.
+The predictor matrix is the specification in the authors' own California example
+(``examples/EXA_CaliforniaTobacco.R``): the four MLAB covariate averages —
+ln(personal income), retail cigarette price and percent aged 15–24 over 1980–1988,
+beer consumption over 1984–1988 — stacked with the full pre-treatment
+cigarette-sales path 1970–1988, matched with :math:`V = I` (raw, no rescaling),
+exactly as that script builds :math:`X` and sets ``V = diag(ncol(X))``. It is
+constructed from mlsynth's vendored ``basedata/augmented_cali_long.csv`` through
+:func:`mlsynth.utils.datautils.dataprep` and the covariate-mean helper
+:class:`~mlsynth.estimators.vanillasc.VanillaSC` uses — no hand-pivoting.
+California is the treated unit and the remaining 38 states are donors. The same
+:math:`X_0` (:math:`23 \times 38`) and :math:`X_1` (:math:`23`) are sent to
+``wsoll1`` and to ``penalized_weights`` over the grid
+:math:`\lambda \in \{0.001, 0.01, 0.05, 0.1, 0.25\}` — the penalty path up to the
+nearest-neighbour collapse (beyond :math:`\lambda \approx 0.25` the solution jumps
+to a single donor, a discontinuity that is not a solver-parity test).
 
-At the clean grid points the two implementations agree to four or five decimals:
-at :math:`\lambda = 0.1` the synthetic California loads :math:`\approx 0.65` on
-Colorado, with a post-1989 ATT of :math:`-23.43` packs per capita that matches
-``wsoll1`` to :math:`6\times10^{-5}`. Across the whole path the largest donor-weight
-gap is :math:`\approx 5\times10^{-3}` and the largest ATT gap :math:`\approx
-4\times10^{-2}` packs, both at a single active-set transition where the reference's
-interior-point ``LowRankQP`` stops carrying a sub-1% residual donor weight while
-mlsynth's FISTA reaches the (marginally lower-objective) vertex — the reference
-solver's tolerance, not a methodological difference. As :math:`\lambda` grows the
-weights concentrate, reproducing the paper's penalty-driven interpolation toward
-nearest-neighbour matching.
+Across this path the two implementations agree to solver precision: the largest
+donor-weight difference is :math:`\approx 2\times10^{-4}` and the largest
+post-period ATT difference :math:`\approx 9\times10^{-4}` packs. At small
+:math:`\lambda` the penalized fit recovers the canonical
+Abadie-Diamond-Hainmueller donor pool — Utah, Nevada, Montana, Colorado and
+Connecticut — and at :math:`\lambda = 0.1` the synthetic California loads
+:math:`\approx 0.43` on Montana, with a post-1989 ATT of :math:`-23.3` packs per
+capita matched to :math:`\approx 4\times10^{-4}`. As :math:`\lambda` grows the
+weights concentrate toward the nearest neighbour, reproducing the penalty's
+interpolation property.
 
 Durable benchmark
 -----------------

--- a/docs/replications/pensynth.rst
+++ b/docs/replications/pensynth.rst
@@ -44,24 +44,30 @@ and compare across a regularisation path.
 Cross-validation — the Prop 99 path
 -----------------------------------
 
-The predictor matrix is built from mlsynth's vendored ``basedata/P99data.csv``
-(Abadie's California tobacco panel, 39 states, 1970–2000). California is the
-treated unit and the remaining 38 states are donors, matched on the pre-treatment
-cigarette-sales path 1970–1988 with :math:`\Gamma = I` — the lagged-outcome
-predictor block of the authors' California example (``EXA_CaliforniaTobacco.R``).
-The same :math:`X_0` (:math:`19 \times 38`) and :math:`X_1` (:math:`19`) are sent
-to ``wsoll1`` and to ``penalized_weights`` over the grid
+The predictor matrix is the canonical Abadie-Diamond-Hainmueller (2010) Prop 99
+specification, built from mlsynth's vendored ``basedata/augmented_cali_long.csv``
+through :func:`mlsynth.utils.datautils.dataprep` and the same covariate-mean and
+unit-variance machinery :class:`~mlsynth.estimators.vanillasc.VanillaSC` uses — no
+hand-pivoting. California is the treated unit and the remaining 38 states are
+donors, matched on the authors' *original covariate averages* — ln(personal
+income), retail cigarette price and percent aged 15–24 over 1980–1988, beer
+consumption over 1984–1988 — plus cigarette sales in 1975, 1980 and 1988, each
+scaled to unit variance (:math:`\Gamma = I`). The same :math:`X_0`
+(:math:`7 \times 38`) and :math:`X_1` (:math:`7`) are sent to ``wsoll1`` and to
+``penalized_weights`` over the grid
 :math:`\lambda \in \{0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1\}`.
 
-Across the whole path the two implementations agree to solver precision: the
-largest donor-weight difference is :math:`\approx 1.3\times10^{-4}` and the largest
-post-period ATT difference is :math:`\approx 8.6\times10^{-4}` packs (the residual
-is convergence and thresholding slack on sub-:math:`10^{-6}` weights, not a
-methodological difference). At :math:`\lambda = 0.1` the synthetic California loads
-on Montana (:math:`0.478`), Idaho (:math:`0.254`), Colorado (:math:`0.194`) and
-Connecticut (:math:`0.074`), giving a post-1989 ATT of :math:`-23.48` packs per
-capita; as :math:`\lambda` grows the weights collapse toward the single nearest
-neighbour, reproducing the paper's interpolation property.
+At the clean grid points the two implementations agree to four or five decimals:
+at :math:`\lambda = 0.1` the synthetic California loads :math:`\approx 0.65` on
+Colorado, with a post-1989 ATT of :math:`-23.43` packs per capita that matches
+``wsoll1`` to :math:`6\times10^{-5}`. Across the whole path the largest donor-weight
+gap is :math:`\approx 5\times10^{-3}` and the largest ATT gap :math:`\approx
+4\times10^{-2}` packs, both at a single active-set transition where the reference's
+interior-point ``LowRankQP`` stops carrying a sub-1% residual donor weight while
+mlsynth's FISTA reaches the (marginally lower-objective) vertex — the reference
+solver's tolerance, not a methodological difference. As :math:`\lambda` grows the
+weights concentrate, reproducing the paper's penalty-driven interpolation toward
+nearest-neighbour matching.
 
 Durable benchmark
 -----------------

--- a/docs/replications/pensynth.rst
+++ b/docs/replications/pensynth.rst
@@ -44,32 +44,31 @@ and compare across a regularisation path.
 Cross-validation — the Prop 99 path
 -----------------------------------
 
-The predictor matrix is the specification in the authors' own California example
-(``examples/EXA_CaliforniaTobacco.R``): the four MLAB covariate averages —
-ln(personal income), retail cigarette price and percent aged 15–24 over 1980–1988,
-beer consumption over 1984–1988 — stacked with the full pre-treatment
-cigarette-sales path 1970–1988, matched with :math:`V = I` (raw, no rescaling),
-exactly as that script builds :math:`X` and sets ``V = diag(ncol(X))``. It is
+The predictor matrix is the canonical Abadie-Diamond-Hainmueller (2010) MLAB
+vector: the four covariate averages — ln(personal income), retail cigarette price
+and percent aged 15–24 over 1980–1988, beer consumption over 1984–1988 — plus the
+three special lagged outcomes, cigarette sales in 1975, 1980 and 1988, matched
+with :math:`V = I` (raw, no rescaling), the ``V = diag(ncol(X))`` convention of the
+authors' California example (``examples/EXA_CaliforniaTobacco.R``). It is
 constructed from mlsynth's vendored ``basedata/augmented_cali_long.csv`` through
 :func:`mlsynth.utils.datautils.dataprep` and the covariate-mean helper
 :class:`~mlsynth.estimators.vanillasc.VanillaSC` uses — no hand-pivoting.
 California is the treated unit and the remaining 38 states are donors. The same
-:math:`X_0` (:math:`23 \times 38`) and :math:`X_1` (:math:`23`) are sent to
+:math:`X_0` (:math:`7 \times 38`) and :math:`X_1` (:math:`7`) are sent to
 ``wsoll1`` and to ``penalized_weights`` over the grid
-:math:`\lambda \in \{0.001, 0.01, 0.05, 0.1, 0.25\}` — the penalty path up to the
-nearest-neighbour collapse (beyond :math:`\lambda \approx 0.25` the solution jumps
-to a single donor, a discontinuity that is not a solver-parity test).
+:math:`\lambda \in \{0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1\}`.
 
-Across this path the two implementations agree to solver precision: the largest
-donor-weight difference is :math:`\approx 2\times10^{-4}` and the largest
-post-period ATT difference :math:`\approx 9\times10^{-4}` packs. At small
-:math:`\lambda` the penalized fit recovers the canonical
-Abadie-Diamond-Hainmueller donor pool — Utah, Nevada, Montana, Colorado and
-Connecticut — and at :math:`\lambda = 0.1` the synthetic California loads
-:math:`\approx 0.43` on Montana, with a post-1989 ATT of :math:`-23.3` packs per
-capita matched to :math:`\approx 4\times10^{-4}`. As :math:`\lambda` grows the
-weights concentrate toward the nearest neighbour, reproducing the penalty's
-interpolation property.
+Across the whole path the two implementations agree to solver precision: the
+largest donor-weight difference is :math:`\approx 3\times10^{-4}` and the largest
+post-period ATT difference :math:`\approx 2\times10^{-3}` packs. At
+:math:`\lambda = 0.1` the synthetic California loads :math:`\approx 0.54` on Idaho,
+with a post-1989 ATT of :math:`-23.4` packs per capita matched to
+:math:`\approx 4\times10^{-4}`. With :math:`V = I` (no nested :math:`V`
+optimisation) the penalized fit is Idaho-led rather than ADH's published
+Utah/Nevada pool — expected, since here the penalty, not a fitted :math:`V`,
+resolves the donor weights. As :math:`\lambda` grows the weights concentrate
+toward the nearest neighbour (Montana), reproducing the penalty's interpolation
+property.
 
 Durable benchmark
 -----------------

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -764,6 +764,55 @@ holdout selection for SYNDES (``syndes_holdout_frac=0.3``), adds an ``oos_rmse``
 column to the comparison table, and orders the SYNDES rows by it; pass
 ``syndes_holdout_frac=None`` to compare in-sample designs instead.
 
+Information-criterion selection (``selection="ic"``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The holdout split spends part of the pre-period on validation, which is noisy
+exactly when the pre-period is short -- the regime SYNDES is built for. An
+information criterion avoids the split: it scores every candidate on the *whole*
+pre-window and penalises the model-selection flexibility directly. Pouliot, Xie
+& Liu (2024) show that in short-:math:`T_0` synthetic-control settings such a
+criterion outperforms cross-validation / holdout. Setting ``selection="ic"``
+ranks the ``top_K`` pool (solved on the full pre-period) by
+
+.. math::
+
+   \mathrm{IC}(d) = \mathrm{SSR}^{\text{pre}}(d)
+                  + 2\,\hat{\sigma}^2\,\mathrm{df}(d),
+
+mirroring Pouliot et al.'s :math:`\mathbb{E}\lVert \mathbf{Y} - \hat{\mathbf{Y}}
+\rVert^2 + 2\sigma^2\,\mathrm{df}`. Here :math:`\mathrm{SSR}^{\text{pre}}` is the
+in-sample contrast sum of squares; :math:`\mathrm{df} = \lvert A\rvert - 1` with
+:math:`A` the active control donors (their closed form for the unpenalised SCM,
+in which searching over *which* donors to use is free); and
+:math:`\hat{\sigma}^2` is a Mallows-:math:`C_p`-style noise estimate -- the
+best-fitting candidate's per-period contrast variance. The candidate with the
+smallest IC wins, so a design that buys a tighter fit by activating more donors
+is penalised for it.
+
+The returned ``results.pool`` is ranked by IC (rank-1 is the winner on
+``results.design``), and each entry carries an ``ic`` value and its ``df``.
+Like holdout, IC selection needs ``top_K >= 2`` and a MIP mode; it does not use
+``holdout_frac``. The ``selection`` field unifies the three rules -- ``None``
+(default) infers ``"holdout"`` when ``holdout_frac`` is set and ``"in_sample"``
+otherwise, so existing configs are unchanged.
+
+.. code-block:: python
+
+   res = SYNDES({
+       "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+       "K": 3, "mode": "two_way_global", "post_col": "post",
+       "top_K": 5, "selection": "ic",              # IC over the whole pre-window
+       "gap_limit": 0.2, "time_limit": 10.0,
+   }).fit()
+
+   for d in res.pool:                              # ranked by information criterion
+       print("treated:", sorted(d["markets"]),
+             "| ic:", round(d["ic"], 1), "| df:", d["df"])
+
+Pass ``syndes_options={"selection": "ic"}`` to :func:`~mlsynth.compare_methods`
+to use IC selection there (it overrides the default holdout).
+
 Ranking the menu by power
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -741,6 +741,142 @@ very large panel prefer ``per_unit`` or scoping the panel to the region.)
        "exclude_bordering_donors": True,      # ...and never a bordering donor
    }).fit()
 
+Gallery: designing the experiment on real geography
+---------------------------------------------------
+
+Because you are designing the experiment rather than accepting an observed
+treatment, the choice of treated units and donors is a decision variable -- so
+geography, spillover, budget, regional donor pools and forced markets all fold
+straight into one optimisation. The examples below run on the bundled US DMA
+contiguity matrix and metadata (`basedata/markets/
+<https://github.com/jgreathouse9/mlsynth/tree/main/basedata/markets>`_), grouped
+into the four `Census regions
+<https://www.cdc.gov/nchs/hus/sources-definitions/geographic-region.htm>`_. The
+geography is real; the sales outcome is a reproducible region-grouped factor
+model (same-region markets co-move), generated only so the snippets run end to
+end. Each block below assumes this setup has run, and each needs a MIP solver
+(SCIP).
+
+.. code-block:: python
+
+   import numpy as np
+   import pandas as pd
+   from mlsynth import SYNDES
+
+   RAW = ("https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
+          "refs/heads/main/basedata/markets/")
+   meta = pd.read_csv(RAW + "dma_metadata.csv")
+   adj = pd.read_csv(RAW + "dma_adjacency.csv", index_col=0)   # 206x206 0/1 borders
+
+   CDC = {**{s: "Northeast" for s in
+             ["CT", "ME", "MA", "NH", "RI", "VT", "NJ", "NY", "PA"]},
+          **{s: "Midwest" for s in
+             ["IL", "IN", "MI", "OH", "WI", "IA", "KS", "MN", "MO", "NE", "ND", "SD"]},
+          **{s: "South" for s in
+             ["DE", "FL", "GA", "MD", "NC", "SC", "VA", "DC", "WV", "AL", "KY",
+              "MS", "TN", "AR", "LA", "OK", "TX"]},
+          **{s: "West" for s in
+             ["AZ", "CO", "ID", "MT", "NV", "NM", "UT", "WY", "AK", "CA", "HI",
+              "OR", "WA"]}}
+   meta["region"] = meta["state"].map(CDC)
+
+   # A Midwest/South border zone with real cross-region borders.
+   zone = meta[meta["state"].isin(["OH", "IN", "MI", "KY", "WV", "VA", "TN"])]
+   names = [n for n in zone["dma_name"] if n in adj.index]
+   zone = zone[zone["dma_name"].isin(names)].reset_index(drop=True)
+   adj = adj.loc[names, names]                          # contiguity over the zone
+
+   # Region-grouped linear factor model: same-region DMAs share loadings.
+   rng = np.random.default_rng(11)
+   T, T_post, r = 40, 8, 4
+   reg = zone["region"].values
+   Lam_g = {g: rng.normal(size=r) for g in sorted(set(reg))}
+   Lam = np.array([Lam_g[g] for g in reg]) + 0.15 * rng.normal(size=(len(names), r))
+   F = np.cumsum(rng.normal(size=(T, r)), axis=0)        # random-walk factors
+   pop = np.round(rng.lognormal(12.5, 0.8, len(names))).astype(int)
+   Y = 100 + rng.normal(0, 5, len(names)) + F @ Lam.T + rng.normal(0, 1, (T, len(names)))
+   df = pd.DataFrame([
+       {"dma": names[j], "week": t, "sales": float(Y[t, j]),
+        "post": int(t >= T - T_post), "region": reg[j],
+        "state": zone["state"][j], "population": int(pop[j])}
+       for j in range(len(names)) for t in range(T)])
+
+   # Shared keyword arguments for every design below.
+   BASE = dict(df=df, outcome="sales", unitid="dma", time="week",
+               post_col="post", mode="two_way_global", run_inference=False,
+               solver="SCIP", gap_limit=0.2, time_limit=10.0)
+
+Plain cardinality -- pick the 3 markets whose synthetic design fits best:
+
+.. code-block:: python
+
+   SYNDES({**BASE, "K": 3}).fit()
+
+Force one market in and another out (it stays a donor):
+
+.. code-block:: python
+
+   SYNDES({**BASE, "K": 3, "to_be_treated": ["Detroit, MI"],
+           "not_to_be_treated": ["Cincinnati, OH"]}).fit()
+
+No two treated markets in the same state (a ``cluster_col`` clique), or no two
+sharing a border (the contiguity matrix):
+
+.. code-block:: python
+
+   SYNDES({**BASE, "K": 3, "cluster_col": "state"}).fit()
+   SYNDES({**BASE, "K": 3, "adjacency": adj, "spillover_threshold": 0.5}).fit()
+
+Coverage quota -- at least one treated market in every region; and a size band
+-- only mid-sized markets are treatable (others remain donors):
+
+.. code-block:: python
+
+   SYNDES({**BASE, "K": 3, "stratum_col": "region", "min_per_stratum": 1}).fit()
+   SYNDES({**BASE, "K": 3, "size_col": "population",
+           "min_size": 200_000, "max_size": 2_000_000}).fit()
+
+Donor-pool rules. A treated market may borrow only from its own region; or only
+from markets that do not border it; or -- the motivating case -- only from
+non-bordering markets in its own region:
+
+.. code-block:: python
+
+   SYNDES({**BASE, "K": 3, "donor_region_col": "region"}).fit()
+   SYNDES({**BASE, "K": 3, "adjacency": adj, "spillover_threshold": 0.5,
+           "exclude_bordering_donors": True}).fit()
+   SYNDES({**BASE, "K": 3, "donor_region_col": "region", "adjacency": adj,
+           "spillover_threshold": 0.5, "exclude_bordering_donors": True}).fit()
+
+In the global modes one shared donor vector forces the treated set into a single
+region; switch to ``per_unit`` for a genuinely multi-region design, where each
+treated market draws its own same-region, non-bordering donors:
+
+.. code-block:: python
+
+   SYNDES({**BASE, "K": 3, "mode": "per_unit", "donor_region_col": "region",
+           "adjacency": adj, "spillover_threshold": 0.5,
+           "exclude_bordering_donors": True}).fit()
+
+Everything at once, returning a ranked menu. The restrictions constrain every
+rung of the pool, so each of the (up to) ``top_K`` designs is a full
+restriction-respecting solve with its own fit and power curve:
+
+.. code-block:: python
+
+   res = SYNDES({**BASE, "K": 4, "top_K": 12, "mode": "per_unit",
+                 "cluster_col": "state", "adjacency": adj,
+                 "spillover_threshold": 0.5, "donor_region_col": "region",
+                 "exclude_bordering_donors": True,
+                 "stratum_col": "region", "min_per_stratum": 1}).fit()
+   for e in res.pool:                              # ranked menu of feasible designs
+       print(sorted(e["markets"]), round(e["pre_fit_rmse"], 3), round(e["mde_pct"], 2))
+
+If a restriction set is jointly unsatisfiable for the requested ``K``, SYNDES
+raises a translated ``MlsynthEstimationError`` naming the restrictions rather
+than returning a broken design; if it is satisfiable but only by fewer than
+``top_K`` distinct designs, the menu simply returns however many are feasible.
+
 Solution pool (``top_K``): a menu, not one answer
 -------------------------------------------------
 

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -643,6 +643,57 @@ A budget constraint (``costs`` + ``budget``) adds
 :math:`\sum_i \mathrm{cost}_i D_i \le B` to the MIP; ``mode="two_way_global"``
 also accepts ``K=None`` to let the program choose the number of treated units.
 
+Design restrictions (geography, clustering, size, forcing)
+----------------------------------------------------------
+
+Because SYNDES selects the treated set by a MIP over a binary assignment vector
+:math:`D`, the geographic and clustering restrictions GEOLIFT and LEXSCM expose
+become linear constraints on :math:`D` -- the same vocabulary, enforced exactly
+rather than by filtering enumerated candidates:
+
+* ``to_be_treated`` -- units forced into the treated set
+  (:math:`D_i = 1`); ``not_to_be_treated`` -- units forbidden from treatment
+  (:math:`D_i = 0`), which stay available as control donors.
+* ``cluster_col`` and/or ``adjacency`` with ``spillover_threshold`` -- a
+  spillover/interference conflict graph (built by the same helper LEXSCM uses).
+  Two units that share a cluster, or whose adjacency entry exceeds the
+  threshold, may not both be treated (:math:`D_i + D_j \le 1`), so the design
+  never places treated units where they would interfere.
+* ``stratum_col`` with ``min_per_stratum`` / ``max_per_stratum`` -- coverage
+  quotas: at least ``min_per_stratum`` treated units in every stratum that
+  contains a treatable unit, and at most ``max_per_stratum`` in any stratum
+  (:math:`\min \le \sum_{i \in s} D_i \le \max`).
+* ``size_col`` with ``min_size`` / ``max_size`` -- a treated-unit size band;
+  units outside it lose treatment eligibility (:math:`D_i = 0`) but remain
+  donors.
+
+The ``cluster_col`` / ``stratum_col`` / ``size_col`` columns must be constant
+within each unit. Restrictions compose with each other and with ``costs`` /
+``budget``, and they flow through every selection rule (in-sample, ``holdout``,
+``ic``). They are not available with ``mode="two_way_global_annealed"`` (no MIP)
+or an ``arm`` column (restrictions are global, not per-arm). Infeasible
+combinations -- forcing more units than ``K``, or forbidding so many that fewer
+than ``K`` remain treatable -- raise a translated ``MlsynthConfigError`` rather
+than leaking a solver ``INFEASIBLE``.
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import SYNDES
+
+   res = SYNDES({
+       "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+       "K": 3, "mode": "two_way_global", "post_col": "post",
+       "to_be_treated": ["chicago"],          # force this market in
+       "cluster_col": "dma",                  # no two treated in one DMA
+       "stratum_col": "region",               # ...
+       "min_per_stratum": 1,                  # at least one treated per region
+       "size_col": "population",              # only mid-sized markets treatable
+       "min_size": 5e5, "max_size": 5e6,
+   }).fit()
+
+   print(sorted(res.design.selected_unit_labels.tolist()))
+
 Solution pool (``top_K``): a menu, not one answer
 -------------------------------------------------
 

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -694,6 +694,53 @@ than leaking a solver ``INFEASIBLE``.
 
    print(sorted(res.design.selected_unit_labels.tolist()))
 
+Restricting the donor pool (region-matched, non-bordering)
+----------------------------------------------------------
+
+The restrictions above constrain *who is treated*. A separate family constrains
+*who may be a treated unit's donor* -- the control side. The primitive is a
+donor-exclusion relation :math:`B_{ij}` ("if :math:`i` is treated, :math:`j` may
+not be its donor"), enforced by coupling the assignment :math:`D` to the mode's
+control weights, so it works in every mode:
+
+.. math::
+
+   \text{one-way global:}\quad & c_j \le 1 - D_i, \\
+   \text{two-way global:}\quad & w_j - q_j \le 1 - D_i, \\
+   \text{per-unit:}\quad       & w_{ij} = 0.
+
+Two convenience knobs (and one escape hatch) fill :math:`B`:
+
+* ``donor_region_col`` -- a donor must share the treated unit's value in this
+  column (e.g. a Census region). So a Midwest market can borrow from another
+  Midwest market but never from a Northeast one.
+* ``exclude_bordering_donors`` -- a treated unit's spillover neighbours (from
+  ``cluster_col`` / ``adjacency`` + ``spillover_threshold``) are dropped from its
+  donor pool, so a donor cannot sit right across the treated unit's border (the
+  Vives-i-Bastida exclusion restriction). Requires a conflict source.
+* ``donor_exclusion`` -- an explicit per-pair matrix (DataFrame keyed by unit
+  label, entry :math:`[i, j] > 0` forbids :math:`j` as a donor for :math:`i`),
+  combined with the above by union. The fully general form.
+
+A subtlety worth knowing: the global modes share *one* donor vector across all
+treated units, so ``donor_region_col`` there forces the treated set into a
+single region (one donor vector cannot be same-region as treated units from two
+regions). The ``per_unit`` mode gives each treated unit its own synthetic
+control, so it supports a genuinely multi-region design -- Detroit drawing from
+the Midwest and a Pennsylvania market drawing from the Northeast, in the same
+fit. (Region exclusion in a global mode emits :math:`O(N^2)` constraints; on a
+very large panel prefer ``per_unit`` or scoping the panel to the region.)
+
+.. code-block:: python
+
+   res = SYNDES({
+       "df": df, "outcome": "Y", "unitid": "dma", "time": "date",
+       "K": 3, "mode": "per_unit", "post_col": "post",
+       "donor_region_col": "census_region",   # donors share the treated region
+       "adjacency": dma_borders,              # contiguity matrix
+       "exclude_bordering_donors": True,      # ...and never a bordering donor
+   }).fit()
+
 Solution pool (``top_K``): a menu, not one answer
 -------------------------------------------------
 

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -721,6 +721,49 @@ identical objective, can carry a materially smaller minimum detectable effect
 design that agrees with what you will actually deploy, instead of the one number
 the optimiser happens to minimise.
 
+Out-of-sample selection (``holdout_frac``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MIP ranks designs by the *in-sample* pre-period contrast, so the winning
+treated set is the one that balances best over the periods it was fit on. When
+the treated unit moves with the donor pool only transiently, that tight balance
+need not persist, and the in-sample optimum can overfit. Setting ``holdout_frac``
+turns selection into a train/validate procedure, in the spirit of the holdout
+split LEXSCM and MAREX use: the ``top_K`` candidate pool is learned on the
+leading :math:`1 - \texttt{holdout\_frac}` of the pre-period, and the winner is
+the candidate whose *held-out* contrast error on the trailing
+``holdout_frac`` is smallest. For example, ``holdout_frac=0.3`` is a 70/30
+split; the out-of-sample error of a design with contrast weights
+:math:`\mathbf{c}` is :math:`\sqrt{\operatorname{mean}((\mathbf{Y}^{\text{val}}
+\mathbf{c})^2)}`, the validation-tail analogue of ``pre_fit_rmse``.
+
+The returned ``results.pool`` is then ranked by this out-of-sample error (rank-1
+is the holdout winner kept on ``results.design``), and each entry carries an
+``oos_rmse`` key alongside the in-sample ``pre_fit_rmse``. Holdout selection
+needs a candidate pool to choose among, so ``top_K >= 2`` is required, and it
+applies to the MIP modes only (not the annealed relaxation). Power and inference
+are computed exactly as in the in-sample path. ``holdout_frac=None`` (the
+default) leaves selection on the in-sample optimum, unchanged.
+
+.. code-block:: python
+
+   res = SYNDES({
+       "df": df, "outcome": "Y", "unitid": "location", "time": "date",
+       "K": 3, "mode": "two_way_global", "post_col": "post",
+       "top_K": 5, "holdout_frac": 0.3,            # 70/30 train/validate
+       "gap_limit": 0.2, "time_limit": 10.0,
+   }).fit()
+
+   for d in res.pool:                              # ranked by out-of-sample error
+       print("treated:", sorted(d["markets"]),
+             "| oos:", round(d["oos_rmse"], 3),
+             "| in-sample:", round(d["pre_fit_rmse"], 3))
+
+In the cross-method comparison, :func:`~mlsynth.compare_methods` defaults to this
+holdout selection for SYNDES (``syndes_holdout_frac=0.3``), adds an ``oos_rmse``
+column to the comparison table, and orders the SYNDES rows by it; pass
+``syndes_holdout_frac=None`` to compare in-sample designs instead.
+
 Ranking the menu by power
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -192,7 +192,9 @@ The covariate path exposes three reliable solvers via ``backend=``:
 ``"penalized"``
     Abadie & L'Hour (2021): a pairwise-penalized estimator with
     leave-one-out :math:`\lambda` selection, giving a unique, sparse
-    :math:`\mathbf{w}`. Works with or without covariates.
+    :math:`\mathbf{w}`. Works with or without covariates. The solver is
+    cross-validated against the authors' own ``wsoll1`` (durable case
+    ``pensynth_prop99``); see :doc:`replications/pensynth`.
 
 The identification diagnostic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -64,6 +64,7 @@ from ..utils.syndes_helpers.inference import (
     permutation_test_relaxed_global,
 )
 from ..utils.syndes_helpers.holdout import select_by_holdout
+from ..utils.syndes_helpers.infocriterion import select_by_ic
 from ..utils.syndes_helpers.optimization import (
     solve_synthetic_design,
     solve_synthetic_design_pool,
@@ -196,7 +197,7 @@ def _syndes_power_curve(results, alpha, horizons=range(1, 13)):
 
 
 def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8,
-                      oos_errors=None):
+                      oos_errors=None, ic_values=None, df_values=None):
     """Re-score a SYNDES solution pool into a manager-facing menu.
 
     The MIP ranks designs by fit alone, so each pooled design is annotated with
@@ -277,6 +278,8 @@ def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8,
             "cost": (None if costs_arr is None else float(costs_arr[idx].sum())),
             "oos_rmse": (None if oos_errors is None
                          else float(oos_errors[entry_i])),
+            "ic": (None if ic_values is None else float(ic_values[entry_i])),
+            "df": (None if df_values is None else int(df_values[entry_i])),
             "design": d,
             "power_curve": power_curve,
         })
@@ -337,6 +340,10 @@ class SYNDES:
         self.fit_weight: float = config.fit_weight
         self.max_shortlist: int = config.max_shortlist
         self.holdout_frac: Optional[float] = config.holdout_frac
+        # Resolve the design-selection rule (None infers from holdout_frac).
+        self.selection: str = config.selection or (
+            "holdout" if config.holdout_frac is not None else "in_sample"
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -418,7 +425,7 @@ class SYNDES:
             gap_limit=self.gap_limit, time_limit=self.time_limit,
         )
         pool = None
-        if self.holdout_frac is not None:
+        if self.selection == "holdout":
             # Holdout selection: learn the candidate pool on the leading
             # 1 - holdout_frac of the pre-period, then pick the design with the
             # smallest out-of-sample contrast error on the held-out tail. The
@@ -431,6 +438,17 @@ class SYNDES:
             design = ranked[0]
             pool = _syndes_pool_menu(ranked, inputs, self.costs, self.alpha,
                                      oos_errors=oos_errors)
+        elif self.selection == "ic":
+            # Information-criterion selection: solve the pool on the whole
+            # pre-period, then re-rank by IC = SSR_pre + 2 sigma^2 df (no data
+            # split). The returned pool is ranked by IC (rank-1 is the winner).
+            pool_designs = solve_synthetic_design_pool(top_K=self.top_K, **solve_kw)
+            ranked, ic_values, df_values, _sigma2 = select_by_ic(
+                pool_designs, inputs.Y_pre,
+            )
+            design = ranked[0]
+            pool = _syndes_pool_menu(ranked, inputs, self.costs, self.alpha,
+                                     ic_values=ic_values, df_values=df_values)
         elif self.top_K and self.top_K > 1:
             # Solution pool: top-K distinct designs by no-good cuts. The rank-1
             # design IS the single-solve optimum, so reuse it (no double solve).

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -357,6 +357,9 @@ class SYNDES:
         self.size_col = config.size_col
         self.min_size = config.min_size
         self.max_size = config.max_size
+        self.donor_region_col = config.donor_region_col
+        self.exclude_bordering_donors = config.exclude_bordering_donors
+        self.donor_exclusion = config.donor_exclusion
 
     # ------------------------------------------------------------------
     # Public API
@@ -441,6 +444,9 @@ class SYNDES:
             min_per_stratum=self.min_per_stratum,
             max_per_stratum=self.max_per_stratum,
             size_col=self.size_col, min_size=self.min_size, max_size=self.max_size,
+            donor_region_col=self.donor_region_col,
+            exclude_bordering_donors=self.exclude_bordering_donors,
+            donor_exclusion=self.donor_exclusion,
         )
         if restrictions.is_empty:
             return None

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -69,6 +69,7 @@ from ..utils.syndes_helpers.optimization import (
     solve_synthetic_design,
     solve_synthetic_design_pool,
 )
+from ..utils.syndes_helpers.restrictions import build_restrictions
 from ..utils.syndes_helpers.plotter import plot_syndes_design
 from ..utils.syndes_helpers.power import power_analysis
 from ..utils.syndes_helpers.select import recommend_syndes
@@ -344,6 +345,18 @@ class SYNDES:
         self.selection: str = config.selection or (
             "holdout" if config.holdout_frac is not None else "in_sample"
         )
+        # Design restrictions (geography / clustering / size / forcing).
+        self.to_be_treated = config.to_be_treated
+        self.not_to_be_treated = config.not_to_be_treated
+        self.cluster_col = config.cluster_col
+        self.adjacency = config.adjacency
+        self.spillover_threshold = config.spillover_threshold
+        self.stratum_col = config.stratum_col
+        self.min_per_stratum = config.min_per_stratum
+        self.max_per_stratum = config.max_per_stratum
+        self.size_col = config.size_col
+        self.min_size = config.min_size
+        self.max_size = config.max_size
 
     # ------------------------------------------------------------------
     # Public API
@@ -409,13 +422,44 @@ class SYNDES:
 
         if self.mode_public == "two_way_global_annealed":
             return self._fit_relaxed(inputs)
-        return self._fit_mip(inputs)
+        restrictions = self._build_restrictions(df, inputs)
+        return self._fit_mip(inputs, restrictions)
+
+    def _build_restrictions(self, df, inputs):
+        """Translate restriction config into an index-level bundle (or None).
+
+        Also runs the cheap feasibility checks that would otherwise surface as an
+        opaque solver ``INFEASIBLE``: forced count and treatable-pool size vs K.
+        """
+        restrictions = build_restrictions(
+            df, self.unitid, inputs.unit_index,
+            to_be_treated=self.to_be_treated,
+            not_to_be_treated=self.not_to_be_treated,
+            cluster_col=self.cluster_col, adjacency=self.adjacency,
+            spillover_threshold=self.spillover_threshold,
+            stratum_col=self.stratum_col,
+            min_per_stratum=self.min_per_stratum,
+            max_per_stratum=self.max_per_stratum,
+            size_col=self.size_col, min_size=self.min_size, max_size=self.max_size,
+        )
+        if restrictions.is_empty:
+            return None
+        if self.K is not None:
+            n_units = int(inputs.Y_pre.shape[1])
+            treatable = n_units - len(restrictions.forbidden)
+            if treatable < self.K:
+                raise MlsynthConfigError(
+                    f"design restrictions leave only {treatable} treatable "
+                    f"unit(s), fewer than K ({self.K}); relax not_to_be_treated "
+                    "or the size band."
+                )
+        return restrictions
 
     # ------------------------------------------------------------------
     # MIP path
     # ------------------------------------------------------------------
 
-    def _fit_mip(self, inputs) -> SYNDESResults:
+    def _fit_mip(self, inputs, restrictions=None) -> SYNDESResults:
         mode_internal = _MODE_TO_INTERNAL[self.mode_public]
 
         solve_kw = dict(
@@ -423,6 +467,7 @@ class SYNDES:
             solver=self.solver, verbose=self.verbose,
             unit_index=inputs.unit_index, costs=self.costs, budget=self.budget,
             gap_limit=self.gap_limit, time_limit=self.time_limit,
+            restrictions=restrictions,
         )
         pool = None
         if self.selection == "holdout":

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -63,6 +63,7 @@ from ..utils.syndes_helpers.inference import (
     permutation_test_global,
     permutation_test_relaxed_global,
 )
+from ..utils.syndes_helpers.holdout import select_by_holdout
 from ..utils.syndes_helpers.optimization import (
     solve_synthetic_design,
     solve_synthetic_design_pool,
@@ -194,7 +195,8 @@ def _syndes_power_curve(results, alpha, horizons=range(1, 13)):
         return None
 
 
-def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8):
+def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8,
+                      oos_errors=None):
     """Re-score a SYNDES solution pool into a manager-facing menu.
 
     The MIP ranks designs by fit alone, so each pooled design is annotated with
@@ -235,7 +237,7 @@ def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8):
     z = float(norm.ppf(1.0 - alpha / 2.0) + norm.ppf(power_target))
     costs_arr = None if costs is None else np.asarray(costs, dtype=float).reshape(-1)
     menu = []
-    for d in pool_designs:
+    for entry_i, d in enumerate(pool_designs):
         idx = np.asarray(d.selected_unit_indices, dtype=int)
         base = float(np.mean(Y_pre[:, idx])) if idx.size else float("nan")
 
@@ -273,6 +275,8 @@ def _syndes_pool_menu(pool_designs, inputs, costs, alpha, power_target=0.8):
             "pre_fit_rmse": (None if d.pre_fit_rmse is None else float(d.pre_fit_rmse)),
             "mde_pct": float(mde_pct),
             "cost": (None if costs_arr is None else float(costs_arr[idx].sum())),
+            "oos_rmse": (None if oos_errors is None
+                         else float(oos_errors[entry_i])),
             "design": d,
             "power_curve": power_curve,
         })
@@ -332,6 +336,7 @@ class SYNDES:
         self.power_weight: float = config.power_weight
         self.fit_weight: float = config.fit_weight
         self.max_shortlist: int = config.max_shortlist
+        self.holdout_frac: Optional[float] = config.holdout_frac
 
     # ------------------------------------------------------------------
     # Public API
@@ -413,7 +418,20 @@ class SYNDES:
             gap_limit=self.gap_limit, time_limit=self.time_limit,
         )
         pool = None
-        if self.top_K and self.top_K > 1:
+        if self.holdout_frac is not None:
+            # Holdout selection: learn the candidate pool on the leading
+            # 1 - holdout_frac of the pre-period, then pick the design with the
+            # smallest out-of-sample contrast error on the held-out tail. The
+            # returned pool is ranked by OOS error (rank-1 is the winner).
+            base_kw = {k: v for k, v in solve_kw.items() if k != "Y"}
+            ranked, oos_errors = select_by_holdout(
+                inputs.Y_pre, holdout_frac=self.holdout_frac,
+                top_K=self.top_K, **base_kw,
+            )
+            design = ranked[0]
+            pool = _syndes_pool_menu(ranked, inputs, self.costs, self.alpha,
+                                     oos_errors=oos_errors)
+        elif self.top_K and self.top_K > 1:
             # Solution pool: top-K distinct designs by no-good cuts. The rank-1
             # design IS the single-solve optimum, so reuse it (no double solve).
             pool_designs = solve_synthetic_design_pool(top_K=self.top_K, **solve_kw)

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -465,6 +465,23 @@ class SYNDES:
     # MIP path
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _require_feasible_pool(designs):
+        """Raise a translated error when the candidate pool is empty.
+
+        An empty pool means every MIP solve was infeasible -- almost always
+        because the active restrictions are jointly unsatisfiable for the
+        requested ``K``. Without this guard the downstream ``designs[0]`` would
+        leak a bare ``IndexError`` ("list index out of range").
+        """
+        if not designs:
+            raise MlsynthEstimationError(
+                "SYNDES found no feasible design: the active restrictions "
+                "(forced/forbidden units, spillover/adjacency conflict, stratum "
+                "quotas, donor-pool rules) are jointly unsatisfiable for the "
+                "requested K. Relax the restrictions or reduce K."
+            )
+
     def _fit_mip(self, inputs, restrictions=None) -> SYNDESResults:
         mode_internal = _MODE_TO_INTERNAL[self.mode_public]
 
@@ -486,6 +503,7 @@ class SYNDES:
                 inputs.Y_pre, holdout_frac=self.holdout_frac,
                 top_K=self.top_K, **base_kw,
             )
+            self._require_feasible_pool(ranked)
             design = ranked[0]
             pool = _syndes_pool_menu(ranked, inputs, self.costs, self.alpha,
                                      oos_errors=oos_errors)
@@ -494,6 +512,7 @@ class SYNDES:
             # pre-period, then re-rank by IC = SSR_pre + 2 sigma^2 df (no data
             # split). The returned pool is ranked by IC (rank-1 is the winner).
             pool_designs = solve_synthetic_design_pool(top_K=self.top_K, **solve_kw)
+            self._require_feasible_pool(pool_designs)
             ranked, ic_values, df_values, _sigma2 = select_by_ic(
                 pool_designs, inputs.Y_pre,
             )
@@ -504,6 +523,7 @@ class SYNDES:
             # Solution pool: top-K distinct designs by no-good cuts. The rank-1
             # design IS the single-solve optimum, so reuse it (no double solve).
             pool_designs = solve_synthetic_design_pool(top_K=self.top_K, **solve_kw)
+            self._require_feasible_pool(pool_designs)
             design = pool_designs[0]
             pool = _syndes_pool_menu(pool_designs, inputs, self.costs, self.alpha)
         else:

--- a/mlsynth/tests/test_design_compare.py
+++ b/mlsynth/tests/test_design_compare.py
@@ -352,3 +352,16 @@ class TestSyndesOOSRanking:
         # GEOLIFT rows have no OOS notion -> NaN; SYNDES rows are populated.
         gl = cmp.table[cmp.table["method"] == "GEOLIFT"]
         assert gl["oos_rmse"].isna().all()
+
+    def test_ic_selection_via_options_does_not_conflict(self):
+        # Requesting IC selection through syndes_options must suppress the
+        # default holdout injection (they are mutually exclusive) and run.
+        df, T, n_post = _shared_panel()
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, top_K=4, methods=("SYNDES",),
+            syndes_options={**self._SYN, "selection": "ic"},
+        )
+        assert set(cmp.table["method"]) == {"SYNDES"}
+        # IC is in-sample, so there is no holdout OOS error to report.
+        assert cmp.table["oos_rmse"].isna().all()

--- a/mlsynth/tests/test_design_compare.py
+++ b/mlsynth/tests/test_design_compare.py
@@ -299,3 +299,56 @@ class TestCompareMethods:
             compare_methods(df, outcome="Y", unitid="unit", time="time",
                             treated_size=2, n_post=n_post, methods=("GEOLIFT",),
                             geolift_options={"not_a_real_option": 123})
+
+
+# ----------------------------------------------------------------------
+# SYNDES is selected/ranked by out-of-sample (holdout) error
+# ----------------------------------------------------------------------
+
+class TestSyndesOOSRanking:
+    _SYN = {"time_limit": 3.0, "gap_limit": 0.2}
+
+    def test_table_exposes_oos_column(self):
+        df, T, n_post = _shared_panel()
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, top_K=4, methods=("SYNDES",),
+            syndes_options=self._SYN,
+        )
+        assert "oos_rmse" in cmp.table.columns
+        syn = cmp.table[cmp.table["method"] == "SYNDES"]
+        assert syn["oos_rmse"].notna().all()
+
+    def test_syndes_rows_sorted_by_oos_ascending(self):
+        df, T, n_post = _shared_panel()
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, top_K=5, methods=("SYNDES",),
+            syndes_options=self._SYN,
+        )
+        oos = cmp.table[cmp.table["method"] == "SYNDES"]["oos_rmse"].tolist()
+        assert oos == sorted(oos)
+
+    def test_disabling_holdout_yields_no_oos(self):
+        # syndes_options overrides the default holdout -> in-sample selection,
+        # so OOS error is undefined (None/NaN) and nothing crashes.
+        df, T, n_post = _shared_panel()
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, top_K=4, methods=("SYNDES",),
+            syndes_holdout_frac=None, syndes_options=self._SYN,
+        )
+        syn = cmp.table[cmp.table["method"] == "SYNDES"]
+        assert syn["oos_rmse"].isna().all()
+
+    def test_holdout_default_still_runs_both_methods(self):
+        df, T, n_post = _shared_panel()
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, top_K=4,
+            syndes_options=self._SYN, geolift_options={"ns": 120},
+        )
+        assert set(cmp.table["method"]) == {"SYNDES", "GEOLIFT"}
+        # GEOLIFT rows have no OOS notion -> NaN; SYNDES rows are populated.
+        gl = cmp.table[cmp.table["method"] == "GEOLIFT"]
+        assert gl["oos_rmse"].isna().all()

--- a/mlsynth/tests/test_syndes_donor_restrictions.py
+++ b/mlsynth/tests/test_syndes_donor_restrictions.py
@@ -1,0 +1,298 @@
+"""TDD for SYNDES donor-side restrictions (region-matched / non-bordering donors).
+
+The treated-side restrictions constrain *who is treated* (the assignment ``D``).
+This module's feature constrains *who may serve as a donor for a treated unit* --
+a coupling between ``D`` and the control weights. The flexible primitive is a
+donor-exclusion relation ``B[i, j]`` ("if ``i`` is treated, ``j`` may not be its
+donor"), enforced in every mode:
+
+* one_way_global  (control vector ``c``):    ``c[j]      <= 1 - D[i]``
+* two_way_global  (control ``w - q``):       ``w[j]-q[j] <= 1 - D[i]``
+* per_unit        (row ``i``):               ``w[i, j]   == 0``
+
+``B`` is filled by ``donor_region_col`` (a donor must share the treated unit's
+region), ``exclude_bordering_donors`` (a treated unit's spillover neighbours are
+dropped from its donor pool -- the same conflict graph the treated-side uses), or
+an explicit ``donor_exclusion`` matrix (the escape hatch).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SYNDES
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.fast_scm_helpers.structure import IndexSet
+from mlsynth.utils.syndes_helpers.restrictions import (
+    build_restrictions,
+    donor_constraints,
+)
+
+_MARKETS = Path(__file__).resolve().parents[2] / "basedata" / "markets"
+
+# CDC/NCHS Census-region grouping of US states
+# (https://www.cdc.gov/nchs/hus/sources-definitions/geographic-region.htm).
+_CDC = {
+    **{s: "Northeast" for s in
+       ["CT", "ME", "MA", "NH", "RI", "VT", "NJ", "NY", "PA"]},
+    **{s: "Midwest" for s in
+       ["IL", "IN", "MI", "OH", "WI", "IA", "KS", "MN", "MO", "NE", "ND", "SD"]},
+    **{s: "South" for s in
+       ["DE", "FL", "GA", "MD", "NC", "SC", "VA", "DC", "WV", "AL", "KY", "MS",
+        "TN", "AR", "LA", "OK", "TX"]},
+    **{s: "West" for s in
+       ["AZ", "CO", "ID", "MT", "NV", "NM", "UT", "WY", "AK", "CA", "HI", "OR",
+        "WA"]},
+}
+
+
+_REGION = {f"u{j}": ("A" if j < 4 else "B") for j in range(8)}
+
+
+def _panel(N=8, T=14, n_post=4, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2))
+    L = rng.uniform(0.3, 1.0, (N, 2))
+    lvl = rng.uniform(8.0, 12.0, N)
+    Y = lvl + F @ L.T + rng.normal(scale=0.3, size=(T, N))
+    rows = [{"unit": f"u{j}", "time": t, "Y": float(Y[t, j]),
+             "post": int(t >= T - n_post), "region": _REGION[f"u{j}"]}
+            for j in range(N) for t in range(T)]
+    return pd.DataFrame(rows)
+
+
+def _uindex(N=8):
+    return IndexSet.from_labels([f"u{j}" for j in range(N)])
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- build the donor-exclusion relation
+# ----------------------------------------------------------------------
+
+class TestBuildDonorExclusion:
+    def test_region_col_excludes_cross_region(self):
+        r = build_restrictions(_panel(), "unit", _uindex(),
+                               donor_region_col="region")
+        expected = {(i, j) for i in range(8) for j in range(8)
+                    if i != j and (i < 4) != (j < 4)}
+        assert set(r.donor_exclusion) == expected
+
+    def test_exclude_bordering_uses_conflict_both_directions(self):
+        labels = [f"u{j}" for j in range(8)]
+        A = pd.DataFrame(0.0, index=labels, columns=labels)
+        A.loc["u0", "u1"] = A.loc["u1", "u0"] = 1.0
+        r = build_restrictions(_panel(), "unit", _uindex(),
+                               adjacency=A, spillover_threshold=0.5,
+                               exclude_bordering_donors=True)
+        assert {(0, 1), (1, 0)} <= set(r.donor_exclusion)
+
+    def test_explicit_matrix(self):
+        labels = [f"u{j}" for j in range(8)]
+        M = pd.DataFrame(0.0, index=labels, columns=labels)
+        M.loc["u0", "u3"] = 1.0                       # u3 forbidden donor for u0
+        r = build_restrictions(_panel(), "unit", _uindex(), donor_exclusion=M)
+        assert (0, 3) in r.donor_exclusion
+        assert (3, 0) not in r.donor_exclusion        # direction matters
+
+    def test_explicit_ndarray_matrix(self):
+        M = np.zeros((8, 8))
+        M[0, 3] = 1.0
+        r = build_restrictions(_panel(), "unit", _uindex(), donor_exclusion=M)
+        assert (0, 3) in r.donor_exclusion
+
+    def test_explicit_ndarray_wrong_shape_raises(self):
+        with pytest.raises(MlsynthConfigError):
+            build_restrictions(_panel(), "unit", _uindex(),
+                               donor_exclusion=np.zeros((3, 3)))
+
+    def test_explicit_matrix_missing_unit_raises(self):
+        from mlsynth.exceptions import MlsynthDataError
+        M = pd.DataFrame(0.0, index=["u0", "u1"], columns=["u0", "u1"])
+        with pytest.raises(MlsynthDataError):
+            build_restrictions(_panel(), "unit", _uindex(), donor_exclusion=M)
+
+    def test_empty_without_donor_rules(self):
+        r = build_restrictions(_panel(), "unit", _uindex())
+        assert not r.donor_exclusion
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- per-mode constraint emission
+# ----------------------------------------------------------------------
+
+class TestDonorConstraints:
+    def _vars(self):
+        import cvxpy as cp
+        return cp.Variable(5, boolean=True), cp.Variable(5, nonneg=True)
+
+    def test_one_way_global(self):
+        D, c = self._vars()
+        cons = donor_constraints("global_equal_weights", {"c": c}, D,
+                                 [(0, 3), (1, 4)])
+        assert len(cons) == 2
+
+    def test_two_way_global(self):
+        import cvxpy as cp
+        D = cp.Variable(5, boolean=True)
+        cons = donor_constraints("global_2way",
+                                 {"w": cp.Variable(5), "q": cp.Variable(5)},
+                                 D, [(0, 3)])
+        assert len(cons) == 1
+
+    def test_per_unit(self):
+        import cvxpy as cp
+        D = cp.Variable(5, boolean=True)
+        cons = donor_constraints("per_unit",
+                                 {"w": cp.Variable((5, 5)),
+                                  "q": cp.Variable((5, 5))}, D, [(0, 3)])
+        assert len(cons) == 1
+
+    def test_empty_pairs_no_constraints(self):
+        D, c = self._vars()
+        assert donor_constraints("global_equal_weights", {"c": c}, D, []) == []
+
+
+# ----------------------------------------------------------------------
+# Layer 3 -- the solved design honours donor restrictions, every mode
+# ----------------------------------------------------------------------
+
+def _control_idx(res, n_units):
+    cw = getattr(res.design, "control_weights", None)
+    if cw is not None:
+        return np.flatnonzero(np.abs(np.asarray(cw, float).reshape(-1)) > 1e-6)
+    tw = np.asarray(res.design.treated_weights, float)   # per_unit (K, N)
+    return np.flatnonzero(np.abs(tw).sum(axis=0) > 1e-6)
+
+
+class TestSYNDESDonorRestrictionsEnforced:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", post_col="post",
+                 run_inference=False, solver="SCIP", gap_limit=0.2,
+                 time_limit=10.0)
+
+    @pytest.mark.parametrize("mode", ["one_way_global", "two_way_global",
+                                      "per_unit"])
+    def test_same_region_donors(self, mode):
+        # Core invariant (all modes): every donor used for treated unit i shares
+        # i's region. In the global modes one shared donor vector serves every
+        # treated unit, so this also forces the treated set into a single region;
+        # in per_unit each treated unit draws its own same-region donors, so the
+        # treated set may span regions.
+        res = SYNDES({"df": _panel(), **self._BASE, "mode": mode, "K": 2,
+                      "donor_region_col": "region"}).fit()
+        labels = [f"u{j}" for j in range(8)]
+        treated_idx = list(np.asarray(res.design.selected_unit_indices).tolist())
+        if mode == "per_unit":
+            q = np.asarray(res.design.treated_weights, float)        # (N, N)
+            for i in treated_idx:
+                donors = np.flatnonzero(q[i] > 1e-6)
+                assert all(_REGION[labels[d]] == _REGION[labels[i]]
+                           for d in donors)
+        else:
+            cw = np.asarray(res.design.control_weights, float).reshape(-1)
+            donors = np.flatnonzero(cw > 1e-6)
+            for i in treated_idx:
+                assert all(_REGION[labels[d]] == _REGION[labels[i]]
+                           for d in donors)
+            assert len({_REGION[labels[i]] for i in treated_idx}) == 1
+
+    def test_non_bordering_donors_one_way(self):
+        labels = [f"u{j}" for j in range(8)]
+        A = pd.DataFrame(0.0, index=labels, columns=labels)
+        # u0 borders u1,u2 ; u4 borders u5
+        for a, b in [("u0", "u1"), ("u0", "u2"), ("u4", "u5")]:
+            A.loc[a, b] = A.loc[b, a] = 1.0
+        res = SYNDES({"df": _panel(), **self._BASE, "mode": "one_way_global",
+                      "K": 2, "adjacency": A, "spillover_threshold": 0.5,
+                      "exclude_bordering_donors": True}).fit()
+        treated_idx = set(np.asarray(res.design.selected_unit_indices).tolist())
+        donor_idx = set(_control_idx(res, 8).tolist())
+        Ab = A.to_numpy()
+        # no donor borders any treated unit
+        for i in treated_idx:
+            assert not any(Ab[i, j] > 0 for j in donor_idx)
+
+
+# ----------------------------------------------------------------------
+# Config / failure semantics
+# ----------------------------------------------------------------------
+
+class TestSYNDESDonorRestrictionsConfig:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", post_col="post",
+                 mode="two_way_global", run_inference=False)
+
+    def _make(self, **over):
+        return SYNDES({"df": _panel(), **self._BASE, **over})
+
+    def test_region_col_must_exist(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, donor_region_col="nope")
+
+    def test_exclude_bordering_needs_conflict_source(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, exclude_bordering_donors=True)   # no cluster/adjacency
+
+    def test_donor_restriction_rejects_annealed(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, mode="two_way_global_annealed",
+                       donor_region_col="region")
+
+    def test_donor_restriction_rejects_arm(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, arm="region", donor_region_col="region")
+
+
+# ----------------------------------------------------------------------
+# Real geography: the user's literal scenario on bundled DMA borders +
+# CDC regions -- a Midwest treated unit may borrow from non-bordering
+# Midwest DMAs, but never from a bordering Northeast (e.g. PA) one.
+# ----------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def dma():
+    adj = pd.read_csv(_MARKETS / "dma_adjacency.csv", index_col=0)
+    meta = pd.read_csv(_MARKETS / "dma_metadata.csv")
+    meta = meta.assign(cdc=meta["state"].map(_CDC))
+    return adj, meta
+
+
+def _geo_panel(units, cdc_of, T=16, n_post=4, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2))
+    L = rng.uniform(0.3, 1.0, (len(units), 2))
+    lvl = rng.uniform(8.0, 12.0, len(units))
+    Y = lvl + F @ L.T + rng.normal(scale=0.3, size=(T, len(units)))
+    rows = [{"market": u, "t": t, "Y": float(Y[t, j]),
+             "post": int(t >= T - n_post), "cdc": cdc_of[u]}
+            for j, u in enumerate(units) for t in range(T)]
+    return pd.DataFrame(rows)
+
+
+class TestSYNDESDonorRestrictionsRealDMA:
+    _BASE = dict(outcome="Y", unitid="market", time="t", post_col="post",
+                 run_inference=False, solver="SCIP", gap_limit=0.2,
+                 time_limit=15.0)
+
+    def test_region_matched_non_bordering_donors_per_unit(self, dma):
+        adj, meta = dma
+        # A Midwest + Northeast border zone with real cross-region borders
+        # (e.g. Erie, PA <-> Youngstown, OH).
+        zone = meta[meta["state"].isin(["MI", "OH", "IL", "IN", "PA", "NY"])]
+        units = zone["dma_name"].tolist()
+        cdc_of = meta.set_index("dma_name")["cdc"].to_dict()
+        df = _geo_panel(units, cdc_of)
+        res = SYNDES({"df": df, **self._BASE, "mode": "per_unit", "K": 3,
+                      "adjacency": adj, "spillover_threshold": 0.5,
+                      "donor_region_col": "cdc",
+                      "exclude_bordering_donors": True}).fit()
+        labels = list(np.asarray(res.inputs.unit_index.labels))
+        A = adj.reindex(index=labels, columns=labels).to_numpy()
+        q = np.asarray(res.design.treated_weights, float)        # (N, N)
+        treated = list(np.asarray(res.design.selected_unit_indices).tolist())
+        assert treated, "expected a non-empty treated set"
+        for i in treated:
+            for d in np.flatnonzero(q[i] > 1e-6):
+                assert cdc_of[labels[d]] == cdc_of[labels[i]]     # same region
+                assert A[i, d] == 0                               # not bordering

--- a/mlsynth/tests/test_syndes_holdout.py
+++ b/mlsynth/tests/test_syndes_holdout.py
@@ -1,0 +1,224 @@
+"""TDD for SYNDES holdout (train/validate) design selection.
+
+The vanilla SYNDES MIP selects the treated set that minimises the *in-sample*
+pre-period contrast, which can overfit transient co-movement. The holdout
+selector instead learns each candidate design on the first ``1 - holdout_frac``
+of the pre-period and ranks the candidate pool by *out-of-sample* contrast error
+on the held-out tail; the candidate with the smallest OOS error wins. Power and
+inference are then computed exactly as in the in-sample path.
+
+These tests pin:
+
+* Layer 1 -- the pure split / OOS / ranking helpers in
+  :mod:`mlsynth.utils.syndes_helpers.holdout`;
+* Layer 3 -- the estimator wiring (``holdout_frac`` config -> OOS-ranked pool,
+  winner = min-OOS design, power curve still attached);
+* config / failure semantics (translated ``MlsynthConfigError``).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SYNDES
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.syndes_helpers.holdout import (
+    oos_contrast_rmse,
+    select_by_holdout,
+    split_pre,
+)
+
+
+def _panel(N=8, T=18, n_post=5, seed=0):
+    """Factor-model long panel with a 0/1 ``post`` column (last ``n_post``)."""
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2))
+    L = rng.uniform(0.3, 1.0, (N, 2))
+    lvl = rng.uniform(8.0, 12.0, N)
+    Y = lvl + F @ L.T + rng.normal(scale=0.3, size=(T, N))
+    rows = [
+        {"unit": f"u{j}", "time": t, "Y": float(Y[t, j]),
+         "post": int(t >= T - n_post)}
+        for j in range(N) for t in range(T)
+    ]
+    return pd.DataFrame(rows)
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- split_pre
+# ----------------------------------------------------------------------
+
+class TestSplitPre:
+    def test_basic_split_shapes(self):
+        Y = np.zeros((10, 3))
+        Y_tr, Y_va, n_train = split_pre(Y, 0.3)
+        assert n_train == 7
+        assert Y_tr.shape == (7, 3) and Y_va.shape == (3, 3)
+
+    def test_train_plus_val_equals_pre(self):
+        Y = np.arange(13 * 4, dtype=float).reshape(13, 4)
+        Y_tr, Y_va, n_train = split_pre(Y, 0.3)
+        assert Y_tr.shape[0] + Y_va.shape[0] == 13
+        # val is the contiguous tail
+        assert np.allclose(Y_va, Y[n_train:])
+
+    def test_clamps_to_at_least_one_each_side(self):
+        Y = np.zeros((2, 2))
+        Y_tr, Y_va, n_train = split_pre(Y, 0.9)      # would round to 2 val
+        assert Y_tr.shape[0] >= 1 and Y_va.shape[0] >= 1
+        assert n_train == 1
+
+    def test_raises_when_too_short(self):
+        with pytest.raises(MlsynthConfigError):
+            split_pre(np.zeros((1, 3)), 0.3)
+
+    @pytest.mark.parametrize("bad", [0.0, 1.0, -0.1, 1.5])
+    def test_raises_on_bad_frac(self, bad):
+        with pytest.raises(MlsynthConfigError):
+            split_pre(np.zeros((10, 3)), bad)
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- oos_contrast_rmse
+# ----------------------------------------------------------------------
+
+class TestOOSContrastRMSE:
+    def test_finite_nonnegative(self):
+        rng = np.random.default_rng(0)
+        Y_val = rng.normal(size=(4, 5))
+
+        class _D:
+            contrast_weights = np.array([1.0, -0.5, -0.5, 0.0, 0.0])
+
+        v = oos_contrast_rmse(_D(), Y_val)
+        assert np.isfinite(v) and v >= 0.0
+
+    def test_zero_contrast_is_zero(self):
+        Y_val = np.ones((3, 4))
+
+        class _D:
+            contrast_weights = np.zeros(4)
+
+        assert oos_contrast_rmse(_D(), Y_val) == pytest.approx(0.0)
+
+    def test_missing_contrast_returns_inf(self):
+        class _D:
+            contrast_weights = None
+
+        assert oos_contrast_rmse(_D(), np.ones((3, 2))) == float("inf")
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- select_by_holdout ranking
+# ----------------------------------------------------------------------
+
+class TestSelectByHoldout:
+    def _Ypre(self):
+        df = _panel()
+        Ywide = df[df["post"] == 0].pivot(index="time", columns="unit",
+                                          values="Y").sort_index()
+        return np.asarray(Ywide.values, dtype=float)
+
+    def test_pool_ranked_by_oos_ascending(self):
+        Y_pre = self._Ypre()
+        ranked, oos = select_by_holdout(
+            Y_pre, holdout_frac=0.3, top_K=4, K=2, mode="global_2way",
+            solver="SCIP", unit_index=None, gap_limit=0.2, time_limit=5.0,
+        )
+        assert len(ranked) == len(oos) >= 1
+        assert all(oos[i] <= oos[i + 1] + 1e-12 for i in range(len(oos) - 1))
+
+    def test_winner_is_argmin_oos(self):
+        Y_pre = self._Ypre()
+        ranked, oos = select_by_holdout(
+            Y_pre, holdout_frac=0.3, top_K=4, K=2, mode="global_2way",
+            solver="SCIP", unit_index=None, gap_limit=0.2, time_limit=5.0,
+        )
+        # Recompute OOS independently on the same split and confirm rank-1 is min.
+        _, Y_val, _ = split_pre(Y_pre, 0.3)
+        recomputed = [oos_contrast_rmse(d, Y_val) for d in ranked]
+        assert recomputed[0] == pytest.approx(min(recomputed))
+        assert recomputed == pytest.approx(sorted(recomputed))
+
+
+# ----------------------------------------------------------------------
+# Layer 3 -- estimator integration
+# ----------------------------------------------------------------------
+
+class TestSYNDESHoldoutIntegration:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", post_col="post",
+                 K=2, mode="two_way_global", run_inference=False,
+                 solver="SCIP", gap_limit=0.2, time_limit=5.0)
+
+    def _fit(self, **over):
+        df = _panel()
+        cfg = {"df": df, **self._BASE, **over}
+        return SYNDES(cfg).fit()
+
+    def test_smoke_runs_and_keeps_power_curve(self):
+        res = self._fit(holdout_frac=0.3, top_K=4)
+        assert res is not None
+        assert res.pool is not None and len(res.pool) >= 1
+        assert res.power_curve is not None
+
+    def test_pool_entries_carry_oos_rmse(self):
+        res = self._fit(holdout_frac=0.3, top_K=4)
+        assert all("oos_rmse" in e for e in res.pool)
+        assert all(e["oos_rmse"] is not None
+                   and np.isfinite(e["oos_rmse"]) for e in res.pool)
+
+    def test_pool_ordered_by_oos_and_winner_is_min(self):
+        res = self._fit(holdout_frac=0.3, top_K=4)
+        oos = [e["oos_rmse"] for e in res.pool]
+        assert oos == pytest.approx(sorted(oos))
+        # winner design == rank-1 pool entry
+        assert (list(np.asarray(res.selected_unit_labels))
+                == list(res.pool[0]["markets"]))
+
+    def test_reported_oos_matches_independent_recompute(self):
+        res = self._fit(holdout_frac=0.3, top_K=4)
+        Y_pre = np.asarray(res.inputs.Y_pre, dtype=float)
+        _, Y_val, _ = split_pre(Y_pre, 0.3)
+        for e in res.pool:
+            assert e["oos_rmse"] == pytest.approx(
+                oos_contrast_rmse(e["design"], Y_val))
+
+    def test_default_none_preserves_in_sample_pool(self):
+        # No holdout: pool ranked by the MIP objective and oos_rmse is absent/None.
+        res = self._fit(top_K=4)
+        assert res.pool is not None
+        assert all(e.get("oos_rmse") is None for e in res.pool)
+
+    def test_backward_compat_single_design(self):
+        res = self._fit()                 # top_K=1, no holdout
+        assert not getattr(res, "pool", None)
+        assert res.design is not None
+
+
+# ----------------------------------------------------------------------
+# Config / failure semantics
+# ----------------------------------------------------------------------
+
+class TestSYNDESHoldoutConfig:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", post_col="post",
+                 K=2, run_inference=False)
+
+    def test_requires_top_K_ge_2(self):
+        df = _panel()
+        with pytest.raises(MlsynthConfigError):
+            SYNDES({"df": df, **self._BASE, "mode": "two_way_global",
+                    "holdout_frac": 0.3, "top_K": 1})
+
+    def test_rejects_annealed_mode(self):
+        df = _panel()
+        with pytest.raises(MlsynthConfigError):
+            SYNDES({"df": df, **self._BASE, "mode": "two_way_global_annealed",
+                    "holdout_frac": 0.3, "top_K": 4})
+
+    @pytest.mark.parametrize("bad", [0.0, 1.0, 1.5, -0.2])
+    def test_rejects_out_of_range_frac(self, bad):
+        df = _panel()
+        with pytest.raises(MlsynthConfigError):
+            SYNDES({"df": df, **self._BASE, "mode": "two_way_global",
+                    "holdout_frac": bad, "top_K": 4})

--- a/mlsynth/tests/test_syndes_ic.py
+++ b/mlsynth/tests/test_syndes_ic.py
@@ -1,0 +1,215 @@
+"""TDD for SYNDES information-criterion (IC) design selection.
+
+The holdout selector spends data on a validation tail, which is noisy when the
+pre-period is short -- exactly the regime SYNDES targets (few aggregate units).
+The IC selector instead uses the *whole* pre-window: it ranks the candidate pool
+by an information criterion
+
+    IC(d) = SSR_pre(d) + 2 * sigma^2 * df(d),
+
+where ``SSR_pre`` is the in-sample contrast sum of squares, ``df`` is the
+synthetic-control degrees of freedom (active control donors minus one, after
+Pouliot-Xie-Liu's ``df = |A| - 1``), and ``sigma^2`` is a Mallows-style noise
+estimate (the best-fitting candidate's per-period contrast variance). The
+candidate with the smallest IC wins -- penalising designs that buy fit by
+activating more donors.
+
+These tests pin the pure IC helpers, the estimator wiring (the new ``selection``
+field and its back-compat inference from ``holdout_frac``), and config/failure
+semantics.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SYNDES
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.syndes_helpers.infocriterion import design_df, select_by_ic
+
+
+def _panel(N=8, T=18, n_post=5, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2))
+    L = rng.uniform(0.3, 1.0, (N, 2))
+    lvl = rng.uniform(8.0, 12.0, N)
+    Y = lvl + F @ L.T + rng.normal(scale=0.3, size=(T, N))
+    rows = [
+        {"unit": f"u{j}", "time": t, "Y": float(Y[t, j]),
+         "post": int(t >= T - n_post)}
+        for j in range(N) for t in range(T)
+    ]
+    return pd.DataFrame(rows)
+
+
+class _FakeDesign:
+    """Duck-typed stand-in for SYNDESDesign (only the fields the IC reads)."""
+
+    def __init__(self, contrast, control=None, treated2d=None):
+        self.contrast_weights = None if contrast is None else np.asarray(contrast, float)
+        self.control_weights = None if control is None else np.asarray(control, float)
+        self.treated_weights = None if treated2d is None else np.asarray(treated2d, float)
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- design_df
+# ----------------------------------------------------------------------
+
+class TestDesignDF:
+    def test_active_control_minus_one(self):
+        d = _FakeDesign([1, -.5, -.5, 0, 0], control=[0, .5, .5, 0, 0])
+        assert design_df(d) == 1                       # 2 active controls - 1
+
+    def test_denser_control_higher_df(self):
+        d = _FakeDesign([1, -.25, -.25, -.25, -.25],
+                        control=[0, .25, .25, .25, .25])
+        assert design_df(d) == 3                       # 4 active controls - 1
+
+    def test_floor_at_zero(self):
+        d = _FakeDesign([1, -1, 0], control=[0, 1, 0])
+        assert design_df(d) == 0                        # single active control
+
+    def test_per_unit_uses_column_sum(self):
+        # control_weights None, treated_weights is the (K, N) per-unit SC matrix
+        d = _FakeDesign(None, control=None,
+                        treated2d=[[0.5, 0, 0.5, 0, 0], [0, 0.5, 0.5, 0, 0]])
+        assert design_df(d) == 2                        # cols {0,1,2} active - 1
+
+    def test_no_control_is_zero(self):
+        d = _FakeDesign([1, -1], control=None, treated2d=None)
+        assert design_df(d) == 0
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- select_by_ic
+# ----------------------------------------------------------------------
+
+class TestSelectByIC:
+    def test_penalty_prefers_sparser_at_equal_fit(self):
+        # Same contrast (=> same SSR) but B activates more control donors,
+        # so its df is larger and the IC must rank the sparser A first.
+        rng = np.random.default_rng(0)
+        Y = rng.normal(size=(12, 5)) + 10.0
+        c = np.array([1.0, -0.5, -0.5, 0.0, 0.0])
+        A = _FakeDesign(c, control=[0, .5, .5, 0, 0])             # df 1
+        B = _FakeDesign(c.copy(), control=[0, .25, .25, .25, .25])  # df 3
+        ranked, ic, dfs, sigma2 = select_by_ic([B, A], Y)
+        assert dfs[0] < dfs[1]
+        assert ranked[0] is A
+        assert ic[0] <= ic[1] + 1e-12
+
+    def test_ranks_ascending_and_sigma2_is_min_mse(self):
+        rng = np.random.default_rng(1)
+        Y = rng.normal(size=(15, 6)) + 5.0
+        designs = [
+            _FakeDesign([1, -1, 0, 0, 0, 0], control=[0, 1, 0, 0, 0, 0]),
+            _FakeDesign([1, -.5, -.5, 0, 0, 0], control=[0, .5, .5, 0, 0, 0]),
+            _FakeDesign([1, -.34, -.33, -.33, 0, 0],
+                        control=[0, .34, .33, .33, 0, 0]),
+        ]
+        ranked, ic, dfs, sigma2 = select_by_ic(designs, Y)
+        assert ic == sorted(ic)
+        ssr = [float(np.sum((Y @ d.contrast_weights) ** 2)) for d in designs]
+        assert sigma2 == pytest.approx(min(ssr) / Y.shape[0])
+
+    def test_empty_pool(self):
+        ranked, ic, dfs, sigma2 = select_by_ic([], np.zeros((4, 3)))
+        assert ranked == [] and ic == [] and dfs == []
+
+    def test_missing_contrast_never_wins(self):
+        # A design with no contrast vector gets infinite SSR -> ranked last.
+        rng = np.random.default_rng(2)
+        Y = rng.normal(size=(10, 4)) + 7.0
+        good = _FakeDesign([1, -1, 0, 0], control=[0, 1, 0, 0])
+        bad = _FakeDesign(None, control=[0, .5, .5, 0])
+        ranked, ic, dfs, sigma2 = select_by_ic([bad, good], Y)
+        assert ranked[0] is good
+        assert ic[-1] == float("inf")
+
+
+# ----------------------------------------------------------------------
+# Layer 3 -- estimator integration
+# ----------------------------------------------------------------------
+
+class TestSYNDESICIntegration:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", post_col="post",
+                 K=2, mode="two_way_global", run_inference=False,
+                 solver="SCIP", gap_limit=0.2, time_limit=5.0)
+
+    def _fit(self, **over):
+        return SYNDES({"df": _panel(), **self._BASE, **over}).fit()
+
+    def test_smoke_runs_and_keeps_power_curve(self):
+        res = self._fit(selection="ic", top_K=4)
+        assert res is not None
+        assert res.pool is not None and len(res.pool) >= 1
+        assert res.power_curve is not None
+
+    def test_pool_entries_carry_ic_and_df(self):
+        res = self._fit(selection="ic", top_K=4)
+        assert all("ic" in e and "df" in e for e in res.pool)
+        assert all(e["ic"] is not None and np.isfinite(e["ic"]) for e in res.pool)
+        assert all(isinstance(e["df"], int) and e["df"] >= 0 for e in res.pool)
+
+    def test_pool_ordered_by_ic_and_winner_is_min(self):
+        res = self._fit(selection="ic", top_K=4)
+        ic = [e["ic"] for e in res.pool]
+        assert ic == sorted(ic)
+        assert (list(np.asarray(res.selected_unit_labels))
+                == list(res.pool[0]["markets"]))
+
+    def test_reported_df_matches_recompute(self):
+        res = self._fit(selection="ic", top_K=4)
+        for e in res.pool:
+            assert e["df"] == design_df(e["design"])
+
+    def test_default_none_is_in_sample(self):
+        res = self._fit(top_K=4)                # no selection, no holdout
+        assert res.pool is not None
+        assert all(e.get("ic") is None for e in res.pool)
+
+    def test_holdout_still_works_via_frac(self):
+        # back-compat: holdout_frac alone still routes to holdout selection.
+        res = self._fit(holdout_frac=0.3, top_K=4)
+        assert all(e.get("oos_rmse") is not None for e in res.pool)
+        assert all(e.get("ic") is None for e in res.pool)
+
+
+# ----------------------------------------------------------------------
+# Config / failure semantics
+# ----------------------------------------------------------------------
+
+class TestSYNDESICConfig:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", post_col="post",
+                 K=2, run_inference=False)
+
+    def _make(self, **over):
+        return SYNDES({"df": _panel(), **self._BASE, "mode": "two_way_global",
+                       **over})
+
+    def test_ic_requires_top_K_ge_2(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(selection="ic", top_K=1)
+
+    def test_ic_rejects_annealed(self):
+        with pytest.raises(MlsynthConfigError):
+            SYNDES({"df": _panel(), **self._BASE,
+                    "mode": "two_way_global_annealed",
+                    "selection": "ic", "top_K": 4})
+
+    def test_ic_conflicts_with_holdout_frac(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(selection="ic", holdout_frac=0.3, top_K=4)
+
+    def test_in_sample_conflicts_with_holdout_frac(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(selection="in_sample", holdout_frac=0.3, top_K=4)
+
+    def test_holdout_selection_requires_frac(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(selection="holdout", top_K=4)     # no holdout_frac
+
+    def test_invalid_selection_string(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(selection="bogus", top_K=4)

--- a/mlsynth/tests/test_syndes_restrictions.py
+++ b/mlsynth/tests/test_syndes_restrictions.py
@@ -17,18 +17,26 @@ config/failure semantics (translated ``MlsynthConfigError``).
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest
 
 from mlsynth import SYNDES
-from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.exceptions import (
+    MlsynthConfigError,
+    MlsynthDataError,
+    MlsynthEstimationError,
+)
 from mlsynth.utils.fast_scm_helpers.structure import IndexSet
 from mlsynth.utils.syndes_helpers.restrictions import (
     DesignRestrictions,
     build_restrictions,
     apply_restrictions,
 )
+
+_MARKETS = Path(__file__).resolve().parents[2] / "basedata" / "markets"
 
 
 _CLUSTER = {f"u{j}": f"c{j // 2}" for j in range(8)}      # u0,u1->c0 ; u2,u3->c1 ; ...
@@ -251,3 +259,104 @@ class TestSYNDESRestrictionsConfig:
     def test_forbidden_leaves_too_few_treatable(self):
         with pytest.raises(MlsynthConfigError):
             self._make(K=3, not_to_be_treated=[f"u{j}" for j in range(6)]).fit()
+
+
+# ----------------------------------------------------------------------
+# Infeasibility: over-constrained restrictions return a translated, informative
+# error (not a leaked solver INFEASIBLE).
+# ----------------------------------------------------------------------
+
+class TestSYNDESRestrictionsInfeasible:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", post_col="post",
+                 mode="two_way_global", run_inference=False, solver="SCIP",
+                 gap_limit=0.2, time_limit=8.0)
+
+    def test_adjacency_clique_is_infeasible_and_reported(self):
+        # u0..u3 form a conflict clique (all mutually adjacent); u4..u7 forbidden.
+        # Only the clique is treatable, but no two of its members can both be
+        # treated -> K=3 is infeasible. The error must be translated and name the
+        # restrictions, not leak a bare solver status.
+        labels = [f"u{j}" for j in range(8)]
+        A = pd.DataFrame(0.0, index=labels, columns=labels)
+        for a in range(4):
+            for b in range(a + 1, 4):
+                A.loc[labels[a], labels[b]] = A.loc[labels[b], labels[a]] = 1.0
+        with pytest.raises(MlsynthEstimationError) as ei:
+            SYNDES({"df": _panel(), **self._BASE, "K": 3,
+                    "adjacency": A, "spillover_threshold": 0.5,
+                    "not_to_be_treated": ["u4", "u5", "u6", "u7"]}).fit()
+        assert "restriction" in str(ei.value).lower()
+
+
+# ----------------------------------------------------------------------
+# Real geography: validate against the bundled DMA contiguity matrix
+# (basedata/markets/), restricting to Florida + Georgia.
+# ----------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def dma():
+    adj = pd.read_csv(_MARKETS / "dma_adjacency.csv", index_col=0)
+    meta = pd.read_csv(_MARKETS / "dma_metadata.csv")
+    return adj, meta
+
+
+def _flga(meta):
+    return meta[meta["state"].isin(["FL", "GA"])]["dma_name"].tolist()
+
+
+def _geo_panel(units, T=16, n_post=4, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2))
+    L = rng.uniform(0.3, 1.0, (len(units), 2))
+    lvl = rng.uniform(8.0, 12.0, len(units))
+    Y = lvl + F @ L.T + rng.normal(scale=0.3, size=(T, len(units)))
+    rows = [{"market": u, "t": t, "Y": float(Y[t, j]),
+             "post": int(t >= T - n_post)}
+            for j, u in enumerate(units) for t in range(T)]
+    return pd.DataFrame(rows)
+
+
+class TestSYNDESRealDMAGeography:
+    _BASE = dict(outcome="Y", unitid="market", time="t", post_col="post",
+                 mode="two_way_global", run_inference=False, solver="SCIP",
+                 gap_limit=0.2, time_limit=12.0)
+
+    def test_feasible_design_respects_real_borders(self, dma):
+        adj, meta = dma
+        units = _flga(meta)
+        res = SYNDES({"df": _geo_panel(units), **self._BASE, "K": 4,
+                      "adjacency": adj, "spillover_threshold": 0.5}).fit()
+        treated = [str(x) for x in np.asarray(res.selected_unit_labels).tolist()]
+        assert len(treated) == 4
+        sub = adj.reindex(index=treated, columns=treated).to_numpy()
+        assert int(np.triu(sub, 1).sum()) == 0          # no two share a border
+
+    def test_full_matrix_auto_subsets_to_panel(self, dma):
+        # Passing the full 206x206 matrix for a 16-unit panel must subset, not error.
+        adj, meta = dma
+        res = SYNDES({"df": _geo_panel(_flga(meta)), **self._BASE, "K": 3,
+                      "adjacency": adj, "spillover_threshold": 0.5}).fit()
+        assert len(np.asarray(res.selected_unit_labels)) == 3
+
+    def test_restricting_treatment_to_flga_too_few_for_K(self, dma):
+        adj, meta = dma
+        flga = _flga(meta)
+        donors = meta[meta["state"].isin(["AL", "SC"])]["dma_name"].tolist()[:6]
+        forbid = donors                                  # treat only FL+GA (16)
+        with pytest.raises(MlsynthConfigError):
+            SYNDES({"df": _geo_panel(flga + donors), **self._BASE, "K": 20,
+                    "not_to_be_treated": forbid}).fit()
+
+    def test_adjacency_missing_a_panel_unit(self, dma):
+        adj, meta = dma
+        units = _flga(meta)[:8] + ["Atlantis, XX"]       # fake DMA not in matrix
+        with pytest.raises(MlsynthDataError):
+            SYNDES({"df": _geo_panel(units), **self._BASE, "K": 3,
+                    "adjacency": adj, "spillover_threshold": 0.5}).fit()
+
+    def test_over_constrained_borders_infeasible(self, dma):
+        adj, meta = dma
+        units = _flga(meta)                              # 16 bordering DMAs
+        with pytest.raises(MlsynthEstimationError):      # K=14 > max independent set
+            SYNDES({"df": _geo_panel(units), **self._BASE, "K": 14,
+                    "adjacency": adj, "spillover_threshold": 0.5}).fit()

--- a/mlsynth/tests/test_syndes_restrictions.py
+++ b/mlsynth/tests/test_syndes_restrictions.py
@@ -287,6 +287,25 @@ class TestSYNDESRestrictionsInfeasible:
                     "not_to_be_treated": ["u4", "u5", "u6", "u7"]}).fit()
         assert "restriction" in str(ei.value).lower()
 
+    @pytest.mark.parametrize("extra", [{}, {"holdout_frac": 0.3},
+                                       {"selection": "ic"}])
+    def test_infeasible_pool_reports_cleanly(self, extra):
+        # Same clique infeasibility but via the top_K>1 pool paths (in-sample,
+        # holdout, ic): an empty pool must raise a translated error, never leak
+        # an IndexError ("list index out of range").
+        labels = [f"u{j}" for j in range(8)]
+        A = pd.DataFrame(0.0, index=labels, columns=labels)
+        for a in range(4):
+            for b in range(a + 1, 4):
+                A.loc[labels[a], labels[b]] = A.loc[labels[b], labels[a]] = 1.0
+        with pytest.raises(MlsynthEstimationError) as ei:
+            SYNDES({"df": _panel(), **self._BASE, "K": 3, "top_K": 4,
+                    "adjacency": A, "spillover_threshold": 0.5,
+                    "not_to_be_treated": ["u4", "u5", "u6", "u7"], **extra}).fit()
+        msg = str(ei.value).lower()
+        assert "list index" not in msg
+        assert "feasible" in msg or "restriction" in msg
+
 
 # ----------------------------------------------------------------------
 # Real geography: validate against the bundled DMA contiguity matrix

--- a/mlsynth/tests/test_syndes_restrictions.py
+++ b/mlsynth/tests/test_syndes_restrictions.py
@@ -1,0 +1,253 @@
+"""TDD for SYNDES design restrictions (geography / clustering / size / forcing).
+
+SYNDES selects the treated set by a MIP over a binary assignment vector ``D``.
+The GEOLIFT/LEXSCM restriction vocabulary maps to linear constraints on ``D``:
+
+* ``to_be_treated``      -> ``D_i = 1``      (force a unit in)
+* ``not_to_be_treated``  -> ``D_i = 0``      (forbid treatment; stays a donor)
+* ``size_col`` band      -> ``D_i = 0`` for out-of-band units
+* ``cluster_col`` /
+  ``adjacency`` /
+  ``spillover_threshold`` -> ``D_i + D_j <= 1`` for every conflicting pair
+* ``stratum_col`` quota  -> ``min <= sum_{i in stratum} D_i <= max``
+
+These tests pin the pure restriction builder/applier (Layer 1), the estimator
+enforcement that the solved design honours every restriction (Layer 3), and the
+config/failure semantics (translated ``MlsynthConfigError``).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SYNDES
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.fast_scm_helpers.structure import IndexSet
+from mlsynth.utils.syndes_helpers.restrictions import (
+    DesignRestrictions,
+    build_restrictions,
+    apply_restrictions,
+)
+
+
+_CLUSTER = {f"u{j}": f"c{j // 2}" for j in range(8)}      # u0,u1->c0 ; u2,u3->c1 ; ...
+_REGION = {f"u{j}": ("east" if j < 4 else "west") for j in range(8)}
+_SIZE = {f"u{j}": float(j + 1) for j in range(8)}          # 1..8
+
+
+def _panel(N=8, T=14, n_post=4, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2))
+    L = rng.uniform(0.3, 1.0, (N, 2))
+    lvl = rng.uniform(8.0, 12.0, N)
+    Y = lvl + F @ L.T + rng.normal(scale=0.3, size=(T, N))
+    rows = []
+    for j in range(N):
+        u = f"u{j}"
+        for t in range(T):
+            rows.append({"unit": u, "time": t, "Y": float(Y[t, j]),
+                         "post": int(t >= T - n_post),
+                         "cluster": _CLUSTER[u], "region": _REGION[u],
+                         "size": _SIZE[u]})
+    return pd.DataFrame(rows)
+
+
+def _uindex(N=8):
+    return IndexSet.from_labels([f"u{j}" for j in range(N)])
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- build_restrictions
+# ----------------------------------------------------------------------
+
+class TestBuildRestrictions:
+    def test_forced_and_forbidden_to_indices(self):
+        r = build_restrictions(_panel(), "unit", _uindex(),
+                               to_be_treated=["u1"], not_to_be_treated=["u5", "u7"])
+        assert r.forced_in == [1]
+        assert r.forbidden == [5, 7]
+
+    def test_size_band_forbids_out_of_band(self):
+        # sizes are 1..8; band [3, 6] keeps u2..u5 (sizes 3..6) treatable.
+        r = build_restrictions(_panel(), "unit", _uindex(),
+                               size_col="size", min_size=3.0, max_size=6.0)
+        assert r.forbidden == [0, 1, 6, 7]               # sizes 1,2,7,8 excluded
+
+    def test_cluster_conflict_pairs(self):
+        r = build_restrictions(_panel(), "unit", _uindex(), cluster_col="cluster")
+        # same-cluster pairs (i<j): (0,1),(2,3),(4,5),(6,7)
+        assert set(r.conflict_pairs) == {(0, 1), (2, 3), (4, 5), (6, 7)}
+
+    def test_adjacency_conflict_pairs(self):
+        labels = [f"u{j}" for j in range(8)]
+        A = pd.DataFrame(0.0, index=labels, columns=labels)
+        A.loc["u0", "u3"] = A.loc["u3", "u0"] = 0.9       # one spillover edge
+        r = build_restrictions(_panel(), "unit", _uindex(),
+                               adjacency=A, spillover_threshold=0.5)
+        assert set(r.conflict_pairs) == {(0, 3)}
+
+    def test_stratum_min_max_groups(self):
+        r = build_restrictions(_panel(), "unit", _uindex(),
+                               stratum_col="region", min_per_stratum=1,
+                               max_per_stratum=2)
+        groups = {tuple(sorted(m)): (lo, hi) for m, lo, hi in r.strata}
+        assert groups == {(0, 1, 2, 3): (1, 2), (4, 5, 6, 7): (1, 2)}
+
+    def test_forced_forbidden_overlap_raises(self):
+        with pytest.raises(MlsynthConfigError):
+            build_restrictions(_panel(), "unit", _uindex(),
+                               to_be_treated=["u1"], not_to_be_treated=["u1"])
+
+    def test_empty_when_no_restrictions(self):
+        r = build_restrictions(_panel(), "unit", _uindex())
+        assert r.is_empty
+
+    def test_unknown_label_raises(self):
+        with pytest.raises(MlsynthConfigError):
+            build_restrictions(_panel(), "unit", _uindex(),
+                               to_be_treated=["ghost"])
+
+    def test_missing_stratum_value_skipped(self):
+        df = _panel()
+        df.loc[df["unit"] == "u0", "region"] = np.nan      # u0 has no stratum
+        r = build_restrictions(df, "unit", _uindex(),
+                               stratum_col="region", max_per_stratum=1)
+        members = sorted(sum((list(m) for m, _, _ in r.strata), []))
+        assert 0 not in members                            # u0 excluded
+        assert set(members) == {1, 2, 3, 4, 5, 6, 7}
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- apply_restrictions (constraint count, exercised via a tiny solve)
+# ----------------------------------------------------------------------
+
+class TestApplyRestrictions:
+    def test_builds_one_constraint_per_rule(self):
+        import cvxpy as cp
+        D = cp.Variable(8, boolean=True)
+        r = DesignRestrictions(forced_in=[1], forbidden=[5],
+                               conflict_pairs=[(0, 2)],
+                               strata=[((0, 1, 2, 3), 1, 2)])
+        cons = apply_restrictions(D, r)
+        # 1 forced + 1 forbidden + 1 conflict + (1 lower + 1 upper) = 5
+        assert len(cons) == 5
+
+
+# ----------------------------------------------------------------------
+# Layer 3 -- the solved design honours every restriction
+# ----------------------------------------------------------------------
+
+class TestSYNDESRestrictionsEnforced:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", post_col="post",
+                 mode="two_way_global", run_inference=False, solver="SCIP",
+                 gap_limit=0.2, time_limit=8.0)
+
+    def _treated(self, **over):
+        res = SYNDES({"df": _panel(), **self._BASE, **over}).fit()
+        return set(map(str, np.asarray(res.selected_unit_labels).tolist()))
+
+    def test_not_to_be_treated_excluded(self):
+        treated = self._treated(K=2, not_to_be_treated=["u0", "u1", "u2"])
+        assert treated.isdisjoint({"u0", "u1", "u2"})
+
+    def test_to_be_treated_forced_in(self):
+        treated = self._treated(K=3, to_be_treated=["u6"])
+        assert "u6" in treated
+
+    def test_cluster_no_two_treated_same_cluster(self):
+        treated = self._treated(K=3, cluster_col="cluster")
+        clusters = [_CLUSTER[u] for u in treated]
+        assert len(clusters) == len(set(clusters))
+
+    def test_adjacency_no_conflicting_pair_treated(self):
+        labels = [f"u{j}" for j in range(8)]
+        A = pd.DataFrame(0.0, index=labels, columns=labels)
+        for a, b in [("u0", "u1"), ("u2", "u3")]:
+            A.loc[a, b] = A.loc[b, a] = 1.0
+        res = SYNDES({"df": _panel(), **self._BASE, "K": 2,
+                      "adjacency": A, "spillover_threshold": 0.5}).fit()
+        treated = set(map(str, np.asarray(res.selected_unit_labels).tolist()))
+        assert treated not in ({"u0", "u1"}, {"u2", "u3"})
+
+    def test_size_band_excludes_out_of_band(self):
+        treated = self._treated(K=2, size_col="size", min_size=3.0, max_size=6.0)
+        assert treated <= {"u2", "u3", "u4", "u5"}
+
+    def test_stratum_max_per_stratum(self):
+        treated = self._treated(K=2, stratum_col="region", max_per_stratum=1)
+        regions = [_REGION[u] for u in treated]
+        assert regions.count("east") <= 1 and regions.count("west") <= 1
+
+    def test_stratum_min_per_stratum(self):
+        treated = self._treated(K=2, stratum_col="region", min_per_stratum=1)
+        regions = {_REGION[u] for u in treated}
+        assert regions == {"east", "west"}              # at least one each
+
+    def test_restrictions_flow_through_holdout(self):
+        treated = self._treated(K=2, not_to_be_treated=["u0", "u1"],
+                                top_K=4, holdout_frac=0.3)
+        assert treated.isdisjoint({"u0", "u1"})
+
+    def test_restrictions_flow_through_ic(self):
+        treated = self._treated(K=2, not_to_be_treated=["u0", "u1"],
+                                top_K=4, selection="ic")
+        assert treated.isdisjoint({"u0", "u1"})
+
+
+# ----------------------------------------------------------------------
+# Config / failure semantics
+# ----------------------------------------------------------------------
+
+class TestSYNDESRestrictionsConfig:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", post_col="post",
+                 mode="two_way_global", run_inference=False)
+
+    def _make(self, **over):
+        return SYNDES({"df": _panel(), **self._BASE, **over})
+
+    def test_unknown_forced_unit(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, to_be_treated=["nope"]).fit()
+
+    def test_forced_forbidden_disjoint(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, to_be_treated=["u1"], not_to_be_treated=["u1"])
+
+    def test_too_many_forced(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, to_be_treated=["u1", "u2", "u3"])
+
+    def test_stratum_quota_requires_col(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, min_per_stratum=1)
+
+    def test_size_band_requires_col(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, min_size=2.0)
+
+    def test_cluster_col_must_be_in_df(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, cluster_col="not_a_column")
+
+    @pytest.mark.parametrize("field", ["min_per_stratum", "max_per_stratum"])
+    def test_stratum_bound_must_be_positive(self, field):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, stratum_col="region", **{field: 0})
+
+    def test_min_size_le_max_size(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, size_col="size", min_size=6.0, max_size=3.0)
+
+    def test_restrictions_reject_arm(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, arm="region", not_to_be_treated=["u0"])
+
+    def test_restrictions_reject_annealed(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=2, mode="two_way_global_annealed",
+                       not_to_be_treated=["u0"])
+
+    def test_forbidden_leaves_too_few_treatable(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(K=3, not_to_be_treated=[f"u{j}" for j in range(6)]).fit()

--- a/mlsynth/utils/design_compare.py
+++ b/mlsynth/utils/design_compare.py
@@ -376,12 +376,18 @@ def compare_methods(
 
     if "SYNDES" in methods:
         from ..estimators.syndes import SYNDES
+        syn_over = syndes_options or {}
         # Holdout selection needs a candidate pool (top_K >= 2); fall back to
-        # in-sample selection otherwise so a top_K=1 caller still works.
-        holdout = syndes_holdout_frac if (syndes_holdout_frac is not None
-                                          and top_K >= 2) else None
+        # in-sample otherwise so a top_K=1 caller still works. If the caller
+        # picks a selection rule (or holdout_frac) explicitly, defer to it and
+        # do not inject the default holdout (they are mutually exclusive).
+        explicit = "selection" in syn_over or "holdout_frac" in syn_over
+        holdout = (None if explicit
+                   else (syndes_holdout_frac
+                         if (syndes_holdout_frac is not None and top_K >= 2)
+                         else None))
         sk = {**_SYNDES_DEFAULTS, **common, "K": treated_size, "top_K": top_K,
-              "alpha": alpha, "holdout_frac": holdout, **(syndes_options or {})}
+              "alpha": alpha, "holdout_frac": holdout, **syn_over}
         syn = SYNDES(sk).fit()
         specs += from_syndes(syn)
 

--- a/mlsynth/utils/design_compare.py
+++ b/mlsynth/utils/design_compare.py
@@ -45,12 +45,17 @@ class DesignSpec:
         negative and sum to minus one.
     treated : list
         Treated-unit labels (used for the baseline and the label).
+    oos_rmse : float, optional
+        Out-of-sample (holdout) contrast RMSE of the design, when it was
+        selected by SYNDES's holdout selector. ``None`` for in-sample SYNDES
+        designs and for GEOLIFT (which has no holdout notion).
     """
 
     method: str
     label: str
     contrast: Dict[Any, float]
     treated: List[Any]
+    oos_rmse: Optional[float] = None
 
 
 def simulated_mde(
@@ -175,6 +180,8 @@ def compare_pareto(
         rows.append({
             "method": s.method, "label": s.label, "treated": list(s.treated),
             "fit_rmse": fit_rmse, "mde_pct": mde_pct,
+            "oos_rmse": (float(s.oos_rmse) if s.oos_rmse is not None
+                         else float("nan")),
         })
 
     df = pd.DataFrame(rows)
@@ -195,16 +202,17 @@ def from_syndes(res) -> List[DesignSpec]:
     """
     labels = list(np.asarray(res.inputs.unit_index.labels))
 
-    def _spec(design, markets, tag):
+    def _spec(design, markets, tag, oos=None):
         c = np.asarray(design.contrast_weights, dtype=float).reshape(-1)
         contrast = {labels[j]: float(c[j]) for j in range(len(labels))}
-        return DesignSpec("SYNDES", tag, contrast, list(markets))
+        return DesignSpec("SYNDES", tag, contrast, list(markets), oos_rmse=oos)
 
     pool = getattr(res, "pool", None)
     if pool:
         return [
             _spec(e["design"], e["markets"],
-                  f"S{i + 1}:{'+'.join(map(str, sorted(e['markets'])))}")
+                  f"S{i + 1}:{'+'.join(map(str, sorted(e['markets'])))}",
+                  e.get("oos_rmse"))
             for i, e in enumerate(pool)
         ]
     d = res.design
@@ -285,6 +293,7 @@ def compare_methods(
     power_target: float = 0.80,
     effects_pct: Optional[Sequence[float]] = None,
     methods: Sequence[str] = ("SYNDES", "GEOLIFT"),
+    syndes_holdout_frac: Optional[float] = 0.3,
     syndes_options: Optional[Dict[str, Any]] = None,
     geolift_options: Optional[Dict[str, Any]] = None,
 ) -> DesignComparison:
@@ -317,6 +326,14 @@ def compare_methods(
         Common effect grid (percent of baseline) for the MDE simulation.
     methods : sequence of str, default ``("SYNDES", "GEOLIFT")``
         Which methods to fit and compare.
+    syndes_holdout_frac : float or None, default 0.3
+        Holdout fraction for SYNDES design selection: SYNDES learns its pool on
+        the leading ``1 - syndes_holdout_frac`` of the pre-period and is ranked
+        by out-of-sample contrast error on the tail (column ``oos_rmse``; SYNDES
+        rows are ordered ascending by it). ``None`` reverts SYNDES to in-sample
+        selection (``oos_rmse`` is ``NaN``). Ignored when ``top_K < 2`` (a pool
+        is required to validate). An explicit ``holdout_frac`` in
+        ``syndes_options`` overrides this.
     syndes_options, geolift_options : dict, optional
         Per-method overrides merged over the defaults (e.g.
         ``{"time_limit": 20.0}`` to give SYNDES a larger budget).
@@ -359,8 +376,12 @@ def compare_methods(
 
     if "SYNDES" in methods:
         from ..estimators.syndes import SYNDES
+        # Holdout selection needs a candidate pool (top_K >= 2); fall back to
+        # in-sample selection otherwise so a top_K=1 caller still works.
+        holdout = syndes_holdout_frac if (syndes_holdout_frac is not None
+                                          and top_K >= 2) else None
         sk = {**_SYNDES_DEFAULTS, **common, "K": treated_size, "top_K": top_K,
-              "alpha": alpha, **(syndes_options or {})}
+              "alpha": alpha, "holdout_frac": holdout, **(syndes_options or {})}
         syn = SYNDES(sk).fit()
         specs += from_syndes(syn)
 
@@ -375,6 +396,14 @@ def compare_methods(
     table = compare_pareto(specs, Ywide, n_pre, horizon=horizon,
                            effects_pct=effects_pct, alpha=alpha,
                            power_target=power_target)
+
+    # Rank the SYNDES block by out-of-sample (holdout) error when it is defined,
+    # keeping every other method's rows in place. Stable sort -> deterministic.
+    syn_mask = table["method"] == "SYNDES"
+    if syn_mask.any() and table.loc[syn_mask, "oos_rmse"].notna().any():
+        syn_sorted = table[syn_mask].sort_values("oos_rmse", kind="stable")
+        table = pd.concat([syn_sorted, table[~syn_mask]], ignore_index=True)
+
     return DesignComparison(table=table, syndes=syn, geolift=gl, specs=specs,
                             horizon=horizon)
 

--- a/mlsynth/utils/syndes_helpers/config.py
+++ b/mlsynth/utils/syndes_helpers/config.py
@@ -271,6 +271,28 @@ class SYNDESConfig(BaseMAREXConfig):
     max_size: Optional[float] = Field(
         default=None, description="Upper size bound for treatment eligibility.",
     )
+    # ---- donor-side restrictions (which units may be a treated unit's donor) ----
+    donor_region_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit-constant column; a unit may serve as a donor for a "
+        "treated unit only if they share this column's value (e.g. region). "
+        "Couples to the assignment via the control weights, so it works in every "
+        "mode (in the global modes it forces the treated set into one region).",
+    )
+    exclude_bordering_donors: bool = Field(
+        default=False,
+        description="When True, a treated unit's spillover neighbours (from "
+        "`cluster_col` / `adjacency` + `spillover_threshold`) are dropped from "
+        "its donor pool (the Vives-i-Bastida exclusion restriction). Requires a "
+        "conflict source.",
+    )
+    donor_exclusion: Optional[pd.DataFrame] = Field(
+        default=None,
+        description="Explicit donor-exclusion matrix (DataFrame indexed/columned "
+        "by unit label); entry [i, j] > 0 forbids unit j as a donor for treated "
+        "unit i. Combined with `donor_region_col` / `exclude_bordering_donors` by "
+        "union. The most flexible escape hatch.",
+    )
     selection: Optional[Literal["in_sample", "holdout", "ic"]] = Field(
         default=None,
         description=(
@@ -350,6 +372,9 @@ class SYNDESConfig(BaseMAREXConfig):
             or values.stratum_col is not None or values.min_per_stratum is not None
             or values.max_per_stratum is not None or values.size_col is not None
             or values.min_size is not None or values.max_size is not None
+            or values.donor_region_col is not None
+            or values.exclude_bordering_donors
+            or values.donor_exclusion is not None
         )
         if _restr_set:
             if values.mode == "two_way_global_annealed":
@@ -382,10 +407,16 @@ class SYNDESConfig(BaseMAREXConfig):
             raise MlsynthConfigError(
                 f"to_be_treated ({len(forced)}) cannot exceed K ({values.K})."
             )
-        for col in ("cluster_col", "stratum_col", "size_col"):
+        for col in ("cluster_col", "stratum_col", "size_col", "donor_region_col"):
             name = getattr(values, col)
             if name is not None and name not in df.columns:
                 raise MlsynthConfigError(f"{col} '{name}' is not a column of df.")
+        if values.exclude_bordering_donors and values.cluster_col is None \
+                and values.adjacency is None:
+            raise MlsynthConfigError(
+                "exclude_bordering_donors requires a conflict source "
+                "(cluster_col and/or adjacency)."
+            )
         if values.min_per_stratum is not None and values.min_per_stratum < 1:
             raise MlsynthConfigError(
                 f"min_per_stratum must be >= 1; got {values.min_per_stratum}."

--- a/mlsynth/utils/syndes_helpers/config.py
+++ b/mlsynth/utils/syndes_helpers/config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import Any, List, Literal, Optional
 import warnings
+import pandas as pd
 from pydantic import Field, model_validator
 from ...exceptions import MlsynthConfigError
 from ...config_models import BaseMAREXConfig
@@ -215,6 +216,61 @@ class SYNDESConfig(BaseMAREXConfig):
         default=5, gt=0,
         description="Maximum number of designs in results.recommendation.shortlist.",
     )
+    # ---- design restrictions (geography / clustering / size / forcing) ----
+    # Same vocabulary as GEOLIFT/LEXSCM; translated to linear constraints on the
+    # MIP assignment vector D. Not supported with mode='two_way_global_annealed'
+    # (no MIP) or an 'arm' column (restrictions are global, not per-arm).
+    to_be_treated: Optional[List] = Field(
+        default=None,
+        description="Units forced into the treated set (D_i = 1). Must not "
+        "exceed K, and must be disjoint from not_to_be_treated.",
+    )
+    not_to_be_treated: Optional[List] = Field(
+        default=None,
+        description="Units forbidden from treatment (D_i = 0); they remain "
+        "available as control donors.",
+    )
+    cluster_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit-constant column; units sharing a cluster interfere "
+        "(treating both is forbidden), combined with `adjacency` by logical OR.",
+    )
+    adjacency: Optional[pd.DataFrame] = Field(
+        default=None,
+        description="Square spillover matrix (DataFrame indexed/columned by unit "
+        "label). Off-diagonal pairs strictly above `spillover_threshold` "
+        "interfere; combined with `cluster_col` by logical OR.",
+    )
+    spillover_threshold: float = Field(
+        default=0.0,
+        description="Off-diagonal `adjacency` entries strictly above this mark a "
+        "conflicting (spillover) pair.",
+    )
+    stratum_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit-constant column defining strata for coverage quotas "
+        "via `min_per_stratum` / `max_per_stratum`.",
+    )
+    min_per_stratum: Optional[int] = Field(
+        default=None,
+        description="Minimum treated units in every stratum that contains a "
+        "treatable unit. Requires stratum_col.",
+    )
+    max_per_stratum: Optional[int] = Field(
+        default=None,
+        description="Maximum treated units in any stratum. Requires stratum_col.",
+    )
+    size_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit-constant size column; units outside "
+        "[min_size, max_size] lose treatment eligibility (stay donors).",
+    )
+    min_size: Optional[float] = Field(
+        default=None, description="Lower size bound for treatment eligibility.",
+    )
+    max_size: Optional[float] = Field(
+        default=None, description="Upper size bound for treatment eligibility.",
+    )
     selection: Optional[Literal["in_sample", "holdout", "ic"]] = Field(
         default=None,
         description=(
@@ -286,6 +342,72 @@ class SYNDESConfig(BaseMAREXConfig):
                     f"selection={resolved!r} requires top_K >= 2 (a candidate "
                     f"pool to rank); got top_K={values.top_K!r}."
                 )
+
+        # ---- design restrictions ----
+        _restr_set = (
+            values.to_be_treated is not None or values.not_to_be_treated is not None
+            or values.cluster_col is not None or values.adjacency is not None
+            or values.stratum_col is not None or values.min_per_stratum is not None
+            or values.max_per_stratum is not None or values.size_col is not None
+            or values.min_size is not None or values.max_size is not None
+        )
+        if _restr_set:
+            if values.mode == "two_way_global_annealed":
+                raise MlsynthConfigError(
+                    "design restrictions are not supported for "
+                    "mode='two_way_global_annealed' (it has no MIP assignment "
+                    "vector); use a MIP mode."
+                )
+            if values.arm is not None:
+                raise MlsynthConfigError(
+                    "design restrictions are not supported together with an "
+                    "'arm' column (restrictions are global, not per-arm)."
+                )
+        units = set(df[values.unitid].unique())
+        forced = list(values.to_be_treated or [])
+        forbidden = list(values.not_to_be_treated or [])
+        unknown = [u for u in (forced + forbidden) if u not in units]
+        if unknown:
+            raise MlsynthConfigError(
+                "to_be_treated/not_to_be_treated contain units not in df: "
+                f"{sorted(map(str, set(unknown)))}."
+            )
+        clash = set(forced) & set(forbidden)
+        if clash:
+            raise MlsynthConfigError(
+                "units cannot be both to_be_treated and not_to_be_treated: "
+                f"{sorted(map(str, clash))}."
+            )
+        if values.K is not None and len(forced) > values.K:
+            raise MlsynthConfigError(
+                f"to_be_treated ({len(forced)}) cannot exceed K ({values.K})."
+            )
+        for col in ("cluster_col", "stratum_col", "size_col"):
+            name = getattr(values, col)
+            if name is not None and name not in df.columns:
+                raise MlsynthConfigError(f"{col} '{name}' is not a column of df.")
+        if values.min_per_stratum is not None and values.min_per_stratum < 1:
+            raise MlsynthConfigError(
+                f"min_per_stratum must be >= 1; got {values.min_per_stratum}."
+            )
+        if values.max_per_stratum is not None and values.max_per_stratum < 1:
+            raise MlsynthConfigError(
+                f"max_per_stratum must be >= 1; got {values.max_per_stratum}."
+            )
+        if (values.min_per_stratum is not None or values.max_per_stratum is not None) \
+                and values.stratum_col is None:
+            raise MlsynthConfigError(
+                "min_per_stratum / max_per_stratum require stratum_col."
+            )
+        if (values.min_size is not None or values.max_size is not None) \
+                and values.size_col is None:
+            raise MlsynthConfigError("min_size / max_size require size_col.")
+        if values.min_size is not None and values.max_size is not None \
+                and values.min_size > values.max_size:
+            raise MlsynthConfigError(
+                f"min_size ({values.min_size}) must be <= max_size "
+                f"({values.max_size})."
+            )
 
         if values.arm is not None and values.arm in df.columns:
             # K applies within each arm, so validate against the smallest arm.

--- a/mlsynth/utils/syndes_helpers/config.py
+++ b/mlsynth/utils/syndes_helpers/config.py
@@ -215,6 +215,22 @@ class SYNDESConfig(BaseMAREXConfig):
         default=5, gt=0,
         description="Maximum number of designs in results.recommendation.shortlist.",
     )
+    selection: Optional[Literal["in_sample", "holdout", "ic"]] = Field(
+        default=None,
+        description=(
+            "Design-selection rule applied to the ``top_K`` candidate pool. "
+            "``None`` (default) infers ``'holdout'`` when ``holdout_frac`` is "
+            "set, otherwise ``'in_sample'`` -- so existing configs are "
+            "unchanged. ``'in_sample'`` keeps the MIP fit optimum (Doudchenko "
+            "et al. 2021). ``'holdout'`` validates candidates on a held-out tail "
+            "and needs ``holdout_frac``. ``'ic'`` ranks candidates by an "
+            "information criterion (in-sample contrast SSR + ``2 sigma^2 df`` "
+            "with ``df = active control donors - 1``, after Pouliot-Xie-Liu) "
+            "over the whole pre-window -- no data split, preferable when the "
+            "pre-period is short. ``'holdout'`` and ``'ic'`` need ``top_K >= 2`` "
+            "and a MIP mode."
+        ),
+    )
     holdout_frac: Optional[float] = Field(
         default=None, gt=0.0, lt=1.0,
         description=(
@@ -238,17 +254,37 @@ class SYNDESConfig(BaseMAREXConfig):
         n_units = df[values.unitid].nunique()
         n_periods = df[values.time].nunique()
 
-        if values.holdout_frac is not None:
+        # Resolve the design-selection rule (None infers from holdout_frac).
+        resolved = values.selection or (
+            "holdout" if values.holdout_frac is not None else "in_sample"
+        )
+        # Mutual-exclusion / coherence between selection and holdout_frac.
+        if values.selection == "in_sample" and values.holdout_frac is not None:
+            raise MlsynthConfigError(
+                "selection='in_sample' conflicts with holdout_frac; clear "
+                "holdout_frac or set selection='holdout'."
+            )
+        if values.selection == "ic" and values.holdout_frac is not None:
+            raise MlsynthConfigError(
+                "selection='ic' does not use holdout_frac (it needs no data "
+                "split); clear holdout_frac."
+            )
+        if resolved == "holdout" and values.holdout_frac is None:
+            raise MlsynthConfigError(
+                "selection='holdout' requires holdout_frac in (0, 1)."
+            )
+        # Pool-based selectors need a candidate pool and a MIP mode.
+        if resolved in ("holdout", "ic"):
             if values.mode == "two_way_global_annealed":
                 raise MlsynthConfigError(
-                    "holdout_frac selection is not supported for "
+                    f"selection={resolved!r} is not supported for "
                     "mode='two_way_global_annealed' (it has no candidate pool); "
                     "use a MIP mode."
                 )
             if values.top_K is None or values.top_K < 2:
                 raise MlsynthConfigError(
-                    "holdout_frac selection requires top_K >= 2 (a candidate "
-                    f"pool to validate); got top_K={values.top_K!r}."
+                    f"selection={resolved!r} requires top_K >= 2 (a candidate "
+                    f"pool to rank); got top_K={values.top_K!r}."
                 )
 
         if values.arm is not None and values.arm in df.columns:

--- a/mlsynth/utils/syndes_helpers/config.py
+++ b/mlsynth/utils/syndes_helpers/config.py
@@ -215,12 +215,41 @@ class SYNDESConfig(BaseMAREXConfig):
         default=5, gt=0,
         description="Maximum number of designs in results.recommendation.shortlist.",
     )
+    holdout_frac: Optional[float] = Field(
+        default=None, gt=0.0, lt=1.0,
+        description=(
+            "Out-of-sample design selection. When ``None`` (default) the winning "
+            "design is the MIP's in-sample optimum (Doudchenko et al. 2021 "
+            "behaviour, unchanged). When set to a fraction in (0, 1), SYNDES "
+            "learns the ``top_K`` candidate pool on the leading ``1 - "
+            "holdout_frac`` of the pre-period and selects the candidate whose "
+            "*held-out* contrast error on the trailing ``holdout_frac`` is "
+            "smallest -- a train/validate guard against overfitting transient "
+            "pre-period co-movement (e.g. ``0.3`` for a 70/30 split). Requires "
+            "``top_K >= 2`` (a pool to validate) and a MIP mode (not the "
+            "annealed relaxation). Power and inference are computed exactly as in "
+            "the in-sample path."
+        ),
+    )
 
     @model_validator(mode="after")
     def _check_syndes_params(cls, values: Any) -> Any:
         df = values.df
         n_units = df[values.unitid].nunique()
         n_periods = df[values.time].nunique()
+
+        if values.holdout_frac is not None:
+            if values.mode == "two_way_global_annealed":
+                raise MlsynthConfigError(
+                    "holdout_frac selection is not supported for "
+                    "mode='two_way_global_annealed' (it has no candidate pool); "
+                    "use a MIP mode."
+                )
+            if values.top_K is None or values.top_K < 2:
+                raise MlsynthConfigError(
+                    "holdout_frac selection requires top_K >= 2 (a candidate "
+                    f"pool to validate); got top_K={values.top_K!r}."
+                )
 
         if values.arm is not None and values.arm in df.columns:
             # K applies within each arm, so validate against the smallest arm.

--- a/mlsynth/utils/syndes_helpers/holdout.py
+++ b/mlsynth/utils/syndes_helpers/holdout.py
@@ -1,0 +1,132 @@
+"""Holdout (train/validate) design selection for SYNDES.
+
+The vanilla SYNDES MIP ranks treated sets by the *in-sample* pre-period
+contrast, which can reward a set whose tight balance is transient co-movement
+that will not persist. The holdout selector guards against that overfitting:
+
+1. split the pre-period into a leading training block (``1 - holdout_frac`` of
+   the periods) and a held-out validation tail (``holdout_frac``);
+2. solve the SYNDES candidate pool on the training block only
+   (:func:`mlsynth.utils.syndes_helpers.optimization.solve_synthetic_design_pool`);
+3. score each candidate's *out-of-sample* contrast error on the validation tail
+   -- ``sqrt(mean((Y_val @ contrast_weights)**2))`` -- and rank ascending.
+
+The rank-1 (smallest OOS error) design is the winner; downstream power and
+inference are computed exactly as in the in-sample path. This mirrors the
+train/validate selection used by LEXSCM and the MAREX blank-period split, but on
+the SYNDES contrast vector.
+
+Note the OOS error uses the *training-learned* weights applied to the validation
+periods: it measures how well a design selected on the training block continues
+to balance out of sample, which is the quantity overfitting inflates.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Tuple
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError
+from .optimization import solve_synthetic_design_pool
+
+
+def split_pre(
+    Y_pre: np.ndarray, holdout_frac: float
+) -> Tuple[np.ndarray, np.ndarray, int]:
+    """Split the pre-period matrix into a training block and a validation tail.
+
+    Parameters
+    ----------
+    Y_pre : np.ndarray
+        Pre-treatment outcome matrix, shape ``(T_pre, N)`` (rows are periods).
+    holdout_frac : float
+        Fraction of the pre-period (the tail) held out for validation; must be
+        in the open interval ``(0, 1)``.
+
+    Returns
+    -------
+    (Y_train, Y_val, n_train) : tuple
+        The leading ``n_train`` rows, the trailing validation rows, and the
+        training-block length. Both blocks are guaranteed at least one row.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``holdout_frac`` is outside ``(0, 1)`` or fewer than two pre-periods
+        are available (nothing to split).
+    """
+    if not (0.0 < float(holdout_frac) < 1.0):
+        raise MlsynthConfigError(
+            f"holdout_frac must lie in the open interval (0, 1); got {holdout_frac!r}."
+        )
+    Y = np.asarray(Y_pre, dtype=float)
+    T = Y.shape[0]
+    if T < 2:
+        raise MlsynthConfigError(
+            "holdout selection needs at least 2 pre-treatment periods to split; "
+            f"got {T}."
+        )
+    n_val = int(round(float(holdout_frac) * T))
+    n_val = min(max(n_val, 1), T - 1)        # >=1 each side
+    n_train = T - n_val
+    return Y[:n_train], Y[n_train:], n_train
+
+
+def oos_contrast_rmse(design: Any, Y_val: np.ndarray) -> float:
+    """Out-of-sample contrast RMSE of a design on a validation block.
+
+    Applies the design's (training-learned) contrast weights to the validation
+    periods and returns ``sqrt(mean((Y_val @ contrast_weights)**2))`` -- the
+    held-out analogue of ``design.pre_fit_rmse``. Returns ``inf`` when the design
+    carries no contrast vector (so it never wins the argmin).
+    """
+    c = getattr(design, "contrast_weights", None)
+    if c is None:
+        return float("inf")
+    c = np.asarray(c, dtype=float).reshape(-1)
+    g = np.asarray(Y_val, dtype=float) @ c
+    return float(np.sqrt(np.mean(g ** 2)))
+
+
+def select_by_holdout(
+    Y_pre: np.ndarray,
+    *,
+    holdout_frac: float,
+    top_K: int,
+    **solve_kw: Any,
+) -> Tuple[List[Any], List[float]]:
+    """Rank the SYNDES candidate pool by out-of-sample (holdout) contrast error.
+
+    Solves the ``top_K`` candidate pool on the training block and re-ranks it by
+    validation-tail OOS error (ascending). The rank-1 design is the holdout
+    winner.
+
+    Parameters
+    ----------
+    Y_pre : np.ndarray
+        Pre-treatment outcome matrix, shape ``(T_pre, N)``.
+    holdout_frac : float
+        Validation-tail fraction in ``(0, 1)`` (see :func:`split_pre`).
+    top_K : int
+        Candidate-pool size handed to
+        :func:`~mlsynth.utils.syndes_helpers.optimization.solve_synthetic_design_pool`.
+    **solve_kw
+        Remaining solver arguments (``K``, ``mode``, ``lam``, ``solver``,
+        ``verbose``, ``unit_index``, ``costs``, ``budget``, ``gap_limit``,
+        ``time_limit``) forwarded to the pool solver. ``Y`` and ``top_K`` are
+        supplied here and must not appear in ``solve_kw``.
+
+    Returns
+    -------
+    (ranked_designs, oos_errors) : tuple
+        Designs ordered by ascending OOS error, and the matching OOS errors
+        (same order). Ties keep the solver's in-sample order (stable sort).
+    """
+    Y_train, Y_val, _ = split_pre(Y_pre, holdout_frac)
+    designs = solve_synthetic_design_pool(Y=Y_train, top_K=top_K, **solve_kw)
+    oos = [oos_contrast_rmse(d, Y_val) for d in designs]
+    order = sorted(range(len(designs)), key=lambda i: (oos[i], i))   # stable
+    ranked = [designs[i] for i in order]
+    oos_sorted = [oos[i] for i in order]
+    return ranked, oos_sorted

--- a/mlsynth/utils/syndes_helpers/infocriterion.py
+++ b/mlsynth/utils/syndes_helpers/infocriterion.py
@@ -1,0 +1,118 @@
+"""Information-criterion (IC) design selection for SYNDES.
+
+The holdout selector (:mod:`mlsynth.utils.syndes_helpers.holdout`) spends part of
+the pre-period on a validation tail. When the pre-period is short -- the regime
+SYNDES is built for -- that split is noisy, and an information criterion that
+uses the *whole* pre-window is the more reliable model-selection device
+(Pouliot, Xie & Liu 2024, who show cross-validation/holdout underperforms an IC
+in short-``T0`` synthetic-control settings).
+
+For a candidate design with pre-period contrast series ``g = Y_pre @ c`` the IC is
+
+    IC(d) = SSR_pre(d) + 2 * sigma^2 * df(d),
+
+mirroring Pouliot et al.'s ``E||Y - Yhat||^2 + 2 sigma^2 df``:
+
+* ``SSR_pre`` -- in-sample contrast sum of squares (the design's pre-period fit);
+* ``df`` -- the synthetic-control degrees of freedom. Pouliot et al.'s
+  closed form for the unpenalised SCM is ``df = |A| - 1`` where ``A`` is the set
+  of active donors (positive weight), and "model selection is free" -- the search
+  over which donors to use costs no extra df. We take ``A`` to be the active
+  *control* donors (the synthetic control that reconstructs the treated
+  aggregate), so ``df = max(|active control donors| - 1, 0)``;
+* ``sigma^2`` -- a Mallows-``Cp``-style noise estimate: the smallest per-period
+  contrast variance in the candidate pool (the best-fitting / least-biased
+  design's residual variance). This needs no data split, only the pool already
+  solved on the full pre-period.
+
+The candidate with the smallest IC wins: it penalises designs that buy a tighter
+in-sample fit by activating more donors. ``df`` is deliberately a single, simple,
+paper-aligned choice computed in one place (:func:`design_df`) so it can be
+refined without touching the ranking logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List, Optional, Tuple
+
+import numpy as np
+
+
+def _control_weights(design: Any) -> Optional[np.ndarray]:
+    """Aggregate ``(N,)`` control-side weights for any SYNDES design mode.
+
+    Mirrors the contrast bookkeeping in the estimator: the two-way / equal-weight
+    / annealed modes store the control simplex in ``control_weights`` directly,
+    whereas ``per_unit`` leaves it ``None`` and keeps the per-treated-unit
+    synthetic controls in the ``(K, N)`` ``treated_weights`` matrix, whose column
+    sum is the aggregate control side.
+    """
+    tw = getattr(design, "treated_weights", None)
+    cw = getattr(design, "control_weights", None)
+    if tw is not None and np.asarray(tw).ndim == 2:
+        return np.asarray(tw, dtype=float).sum(axis=0)
+    if cw is not None:
+        return np.asarray(cw, dtype=float).reshape(-1)
+    return None
+
+
+def design_df(design: Any, tol: float = 1e-8) -> int:
+    """Synthetic-control degrees of freedom of a design: active controls minus one.
+
+    ``df = max(|A| - 1, 0)`` with ``A`` the active control donors (Pouliot et al.
+    2024, ``df = |A| - 1`` for the unpenalised SCM; the ``-1`` is the simplex
+    sum-to-one constraint). Returns ``0`` when no control side is defined.
+    """
+    cw = _control_weights(design)
+    if cw is None:
+        return 0
+    n_active = int(np.sum(np.abs(cw) > tol))
+    return max(n_active - 1, 0)
+
+
+def select_by_ic(
+    designs: List[Any],
+    Y_pre: np.ndarray,
+    *,
+    df_fn: Callable[[Any], int] = design_df,
+) -> Tuple[List[Any], List[float], List[int], float]:
+    """Rank a SYNDES candidate pool by the information criterion.
+
+    Parameters
+    ----------
+    designs : list
+        Candidate designs (each exposing ``contrast_weights`` and the weight
+        fields :func:`design_df` reads). Typically the pool solved on the full
+        pre-period.
+    Y_pre : np.ndarray
+        Pre-treatment outcome matrix, shape ``(T_pre, N)``.
+    df_fn : callable, optional
+        Degrees-of-freedom function (defaults to :func:`design_df`); injected for
+        testability.
+
+    Returns
+    -------
+    (ranked_designs, ic_values, df_values, sigma2) : tuple
+        Designs ordered by ascending IC; the matching IC values and degrees of
+        freedom (same order); and the Mallows-``Cp`` noise estimate ``sigma^2``.
+        Ties keep the input order (stable sort).
+    """
+    if not designs:
+        return [], [], [], 0.0
+    Y = np.asarray(Y_pre, dtype=float)
+    T = Y.shape[0]
+    ssr: List[float] = []
+    for d in designs:
+        c = getattr(d, "contrast_weights", None)
+        if c is None:
+            ssr.append(float("inf"))
+            continue
+        g = Y @ np.asarray(c, dtype=float).reshape(-1)
+        ssr.append(float(np.sum(g ** 2)))
+    finite = [s for s in ssr if np.isfinite(s)]
+    sigma2 = (min(finite) / T) if (finite and T > 0) else 0.0
+    dfs = [int(df_fn(d)) for d in designs]
+    ic = [ssr[i] + 2.0 * sigma2 * dfs[i] for i in range(len(designs))]
+    order = sorted(range(len(designs)), key=lambda i: (ic[i], i))   # stable
+    ranked = [designs[i] for i in order]
+    return ranked, [ic[i] for i in order], [dfs[i] for i in order], sigma2

--- a/mlsynth/utils/syndes_helpers/optimization.py
+++ b/mlsynth/utils/syndes_helpers/optimization.py
@@ -284,10 +284,14 @@ def solve_synthetic_design(
             prob_constraints.append(cp.sum(D[_fs]) <= int(_fs.size) - 1)
 
     # Design restrictions (geography / clustering / size / forcing) as linear
-    # constraints on the assignment vector D.
+    # constraints on the assignment vector D, plus donor-side exclusions that
+    # couple D to the mode's control weights.
     if restrictions is not None and not restrictions.is_empty:
-        from .restrictions import apply_restrictions
+        from .restrictions import apply_restrictions, donor_constraints
         prob_constraints += apply_restrictions(D, restrictions)
+        prob_constraints += donor_constraints(
+            mode, components.variables, D, restrictions.donor_exclusion,
+        )
 
     problem = cp.Problem(cp.Minimize(components.objective), prob_constraints)
 

--- a/mlsynth/utils/syndes_helpers/optimization.py
+++ b/mlsynth/utils/syndes_helpers/optimization.py
@@ -313,7 +313,18 @@ def solve_synthetic_design(
         ) from exc
 
     if problem.status not in _OPTIMAL_STATUSES:
-        raise MlsynthEstimationError(f"SYNDES optimization failed: {problem.status}")
+        msg = f"SYNDES optimization failed: {problem.status}"
+        if (restrictions is not None and not restrictions.is_empty
+                and "infeasible" in str(problem.status).lower()):
+            # Point the user at the most likely cause rather than a bare status:
+            # the active design restrictions are jointly unsatisfiable for this K.
+            msg = (
+                "SYNDES optimization is infeasible under the active design "
+                "restrictions (spillover/adjacency conflict, stratum quotas, "
+                f"forced/forbidden units) for K={K}. No size-K treated set "
+                "satisfies them -- relax the restrictions or reduce K."
+            )
+        raise MlsynthEstimationError(msg)
 
     if D.value is None:
         raise MlsynthEstimationError("SYNDES optimization did not return an assignment.")

--- a/mlsynth/utils/syndes_helpers/optimization.py
+++ b/mlsynth/utils/syndes_helpers/optimization.py
@@ -207,6 +207,7 @@ def solve_synthetic_design(
     gap_limit: Optional[float] = None,
     time_limit: Optional[float] = None,
     forbidden_sets: Optional[list] = None,
+    restrictions: Optional[Any] = None,
 ) -> SYNDESDesign:
     """
     Solve the SYNDES synthetic design optimization problem.
@@ -281,6 +282,12 @@ def solve_synthetic_design(
         _fs = np.asarray(_fs, dtype=int).reshape(-1)
         if _fs.size:
             prob_constraints.append(cp.sum(D[_fs]) <= int(_fs.size) - 1)
+
+    # Design restrictions (geography / clustering / size / forcing) as linear
+    # constraints on the assignment vector D.
+    if restrictions is not None and not restrictions.is_empty:
+        from .restrictions import apply_restrictions
+        prob_constraints += apply_restrictions(D, restrictions)
 
     problem = cp.Problem(cp.Minimize(components.objective), prob_constraints)
 
@@ -392,6 +399,7 @@ def solve_synthetic_design_pool(
     budget: Optional[float] = None,
     gap_limit: Optional[float] = None,
     time_limit: Optional[float] = None,
+    restrictions: Optional[Any] = None,
 ) -> list:
     """Top-``top_K`` SYNDES designs, ranked by MSE, via no-good cuts.
 
@@ -424,7 +432,7 @@ def solve_synthetic_design_pool(
                 Y=Y, K=K, mode=mode, lam=lam, solver=solver, verbose=verbose,
                 unit_index=unit_index, costs=costs, budget=budget,
                 gap_limit=gap_limit, time_limit=time_limit,
-                forbidden_sets=forbidden,
+                forbidden_sets=forbidden, restrictions=restrictions,
             )
         except MlsynthEstimationError:
             break  # feasible region exhausted (no further distinct design)

--- a/mlsynth/utils/syndes_helpers/restrictions.py
+++ b/mlsynth/utils/syndes_helpers/restrictions.py
@@ -36,7 +36,7 @@ from typing import Any, List, Optional, Tuple
 
 import numpy as np
 
-from ...exceptions import MlsynthConfigError
+from ...exceptions import MlsynthConfigError, MlsynthDataError
 from ..fast_scm_helpers.conflict import build_conflict_matrix
 from ..geolift_helpers.marketselect.helpers.constraints import (
     eligible_by_size,
@@ -62,18 +62,23 @@ class DesignRestrictions:
         Index pairs ``(i, j)``, ``i < j``, that interfere (``D_i + D_j <= 1``).
     strata : list of (tuple of int, int or None, int or None)
         Per-stratum ``(members, lower, upper)`` coverage quotas.
+    donor_exclusion : list of (int, int)
+        Directed pairs ``(i, j)``: if treated unit ``i`` is selected, unit ``j``
+        may not serve as its donor (control). Couples ``D`` to the control
+        weights; see :func:`donor_constraints`.
     """
 
     forced_in: List[int] = field(default_factory=list)
     forbidden: List[int] = field(default_factory=list)
     conflict_pairs: List[Tuple[int, int]] = field(default_factory=list)
     strata: List[Stratum] = field(default_factory=list)
+    donor_exclusion: List[Tuple[int, int]] = field(default_factory=list)
 
     @property
     def is_empty(self) -> bool:
         """True when no restriction is present (the MIP is unconstrained by this)."""
-        return not (self.forced_in or self.forbidden
-                    or self.conflict_pairs or self.strata)
+        return not (self.forced_in or self.forbidden or self.conflict_pairs
+                    or self.strata or self.donor_exclusion)
 
 
 def build_restrictions(
@@ -92,6 +97,9 @@ def build_restrictions(
     size_col: Optional[str] = None,
     min_size: Optional[float] = None,
     max_size: Optional[float] = None,
+    donor_region_col: Optional[str] = None,
+    exclude_bordering_donors: bool = False,
+    donor_exclusion: Optional[Any] = None,
 ) -> DesignRestrictions:
     """Translate label-based design restrictions into an index-level bundle.
 
@@ -177,10 +185,53 @@ def build_restrictions(
             if lo is not None or hi is not None:
                 strata.append((members, lo, hi))
 
+    # ---- donor-side exclusion: (i, j) means "if i is treated, j is not its
+    # donor". Filled by region matching, spillover-neighbour exclusion, and/or
+    # an explicit matrix; combined by union.
+    donor_pairs: set = set()
+    if donor_region_col is not None:
+        region_of = unit_attribute_map(df, unitid, donor_region_col)
+        regions = [region_of.get(lab) for lab in labels]
+        for i in range(len(labels)):
+            for j in range(len(labels)):
+                if i != j and regions[i] != regions[j]:
+                    donor_pairs.add((i, j))
+    if exclude_bordering_donors and conflict is not None:
+        iu, ju = np.where(conflict)            # both directions (symmetric graph)
+        donor_pairs.update(zip(iu.tolist(), ju.tolist()))
+    if donor_exclusion is not None:
+        M = _align_square(donor_exclusion, labels, "donor_exclusion")
+        iu, ju = np.where(M > 0)
+        donor_pairs.update((int(i), int(j)) for i, j in zip(iu, ju) if i != j)
+
     return DesignRestrictions(
         forced_in=forced_in, forbidden=forbidden,
         conflict_pairs=conflict_pairs, strata=strata,
+        donor_exclusion=sorted(donor_pairs),
     )
+
+
+def _align_square(matrix: Any, labels: list, name: str) -> np.ndarray:
+    """Reindex a square label-keyed matrix to ``labels`` order, validating cover."""
+    import pandas as pd
+
+    if isinstance(matrix, pd.DataFrame):
+        missing = [l for l in labels
+                   if l not in matrix.index or l not in matrix.columns]
+        if missing:
+            raise MlsynthDataError(
+                f"{name} is missing rows/columns for units: {missing[:5]}"
+                + (" ..." if len(missing) > 5 else "")
+            )
+        return matrix.reindex(index=labels, columns=labels).to_numpy(dtype=float)
+    M = np.asarray(matrix, dtype=float)
+    if M.shape != (len(labels), len(labels)):
+        raise MlsynthConfigError(
+            f"{name} has shape {M.shape}, expected "
+            f"({len(labels)}, {len(labels)}); pass a DataFrame keyed by unit id "
+            "to avoid relying on ordering."
+        )
+    return M
 
 
 def apply_restrictions(D: Any, restrictions: DesignRestrictions) -> list:
@@ -214,4 +265,41 @@ def apply_restrictions(D: Any, restrictions: DesignRestrictions) -> list:
             cons.append(cp.sum(D[members]) >= lo)
         if hi is not None:
             cons.append(cp.sum(D[members]) <= hi)
+    return cons
+
+
+def donor_constraints(mode: str, variables: dict, D: Any,
+                      donor_exclusion: list) -> list:
+    """cvxpy constraints forbidding donor ``j`` for treated unit ``i``.
+
+    The control weight of ``j`` (toward ``i``) is forced to zero whenever ``i``
+    is treated, encoded per mode against that mode's control variables:
+
+    * ``global_equal_weights`` (one-way): ``c[j] <= 1 - D[i]``;
+    * ``global_2way``:                    ``w[j] - q[j] <= 1 - D[i]``
+      (``w - q`` is the control simplex);
+    * ``per_unit``:                       ``w[i, j] == 0`` (row ``i``'s weight on
+      donor ``j``; only binds when ``i`` is treated since ``w[i, j] <= D[i]``).
+
+    Returns an empty list when ``donor_exclusion`` is empty.
+    """
+    if not donor_exclusion:
+        return []
+    cons: list = []
+    if mode == "global_equal_weights":
+        c = variables["c"]
+        for i, j in donor_exclusion:
+            cons.append(c[j] <= 1 - D[i])
+    elif mode == "global_2way":
+        w, q = variables["w"], variables["q"]
+        for i, j in donor_exclusion:
+            cons.append(w[j] - q[j] <= 1 - D[i])
+    elif mode == "per_unit":
+        w = variables["w"]
+        for i, j in donor_exclusion:
+            cons.append(w[i, j] == 0)
+    else:                                          # pragma: no cover - guarded upstream
+        raise MlsynthConfigError(
+            f"donor restrictions are not supported for mode {mode!r}."
+        )
     return cons

--- a/mlsynth/utils/syndes_helpers/restrictions.py
+++ b/mlsynth/utils/syndes_helpers/restrictions.py
@@ -1,0 +1,217 @@
+"""Design restrictions for the SYNDES MIP (geography / clustering / size / forcing).
+
+SYNDES selects the treated set by a mixed-integer program over a binary
+assignment vector ``D`` (length ``N``, in ``unit_index`` order). The same
+restriction vocabulary GEOLIFT and LEXSCM expose by *filtering* enumerated
+candidate sets maps, for a MIP, to linear constraints on ``D``:
+
+* ``to_be_treated``      -> ``D_i = 1``         (force a unit into the treated set)
+* ``not_to_be_treated``  -> ``D_i = 0``         (forbid treatment; the unit stays
+                                                  available as a control donor)
+* ``size_col`` band      -> ``D_i = 0`` for units whose size falls outside
+                            ``[min_size, max_size]`` (they remain donors)
+* ``cluster_col`` /
+  ``adjacency`` /
+  ``spillover_threshold`` -> ``D_i + D_j <= 1`` for every conflicting (spillover)
+                            pair, so two interfering units are never both treated
+* ``stratum_col`` quota  -> ``min_per_stratum <= sum_{i in stratum} D_i`` (on the
+                            strata that contain a treatable unit) and
+                            ``sum_{i in stratum} D_i <= max_per_stratum``
+
+This module translates the label-based config into an index-level
+:class:`DesignRestrictions` bundle (:func:`build_restrictions`) and turns that
+bundle into cvxpy constraints (:func:`apply_restrictions`). The conflict graph is
+built by the shared :func:`mlsynth.utils.fast_scm_helpers.conflict.build_conflict_matrix`
+(the same one LEXSCM uses), aligned to the ``unit_index``; cluster / stratum /
+size attributes are read with GEOLIFT's
+:func:`~mlsynth.utils.geolift_helpers.marketselect.helpers.constraints.unit_attribute_map`
+and :func:`~...eligible_by_size`, so the vocabulary is identical across the
+three estimators.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError
+from ..fast_scm_helpers.conflict import build_conflict_matrix
+from ..geolift_helpers.marketselect.helpers.constraints import (
+    eligible_by_size,
+    unit_attribute_map,
+)
+
+# A stratum constraint: (member indices, lower bound or None, upper bound or None).
+Stratum = Tuple[Tuple[int, ...], Optional[int], Optional[int]]
+
+
+@dataclass(frozen=True)
+class DesignRestrictions:
+    """Index-level restrictions for the SYNDES assignment vector ``D``.
+
+    Attributes
+    ----------
+    forced_in : list of int
+        Unit indices fixed to treatment (``D_i = 1``).
+    forbidden : list of int
+        Unit indices forbidden from treatment (``D_i = 0``) -- the union of
+        ``not_to_be_treated`` and any size-ineligible units.
+    conflict_pairs : list of (int, int)
+        Index pairs ``(i, j)``, ``i < j``, that interfere (``D_i + D_j <= 1``).
+    strata : list of (tuple of int, int or None, int or None)
+        Per-stratum ``(members, lower, upper)`` coverage quotas.
+    """
+
+    forced_in: List[int] = field(default_factory=list)
+    forbidden: List[int] = field(default_factory=list)
+    conflict_pairs: List[Tuple[int, int]] = field(default_factory=list)
+    strata: List[Stratum] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        """True when no restriction is present (the MIP is unconstrained by this)."""
+        return not (self.forced_in or self.forbidden
+                    or self.conflict_pairs or self.strata)
+
+
+def build_restrictions(
+    df: Any,
+    unitid: str,
+    unit_index: Any,
+    *,
+    to_be_treated: Optional[List[Any]] = None,
+    not_to_be_treated: Optional[List[Any]] = None,
+    cluster_col: Optional[str] = None,
+    adjacency: Optional[Any] = None,
+    spillover_threshold: float = 0.0,
+    stratum_col: Optional[str] = None,
+    min_per_stratum: Optional[int] = None,
+    max_per_stratum: Optional[int] = None,
+    size_col: Optional[str] = None,
+    min_size: Optional[float] = None,
+    max_size: Optional[float] = None,
+) -> DesignRestrictions:
+    """Translate label-based design restrictions into an index-level bundle.
+
+    Returns an (empty) :class:`DesignRestrictions` when no restriction field is
+    set. Labels are resolved against ``unit_index`` (the single source of truth
+    for unit order), so the resulting indices line up with the MIP's ``D``.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If a forced/forbidden label is not a unit, or a unit is both forced in
+        and forbidden.
+    MlsynthDataError
+        If a cluster / stratum / size column varies within a unit (via
+        :func:`unit_attribute_map`) or an adjacency matrix is malformed.
+    """
+    labels = list(np.asarray(unit_index.labels).tolist())
+    pos = {lab: i for i, lab in enumerate(labels)}
+    units = set(labels)
+
+    def _to_idx(items, what):
+        bad = [u for u in items if u not in units]
+        if bad:
+            raise MlsynthConfigError(
+                f"{what} contains units not in the panel: {sorted(map(str, bad))}."
+            )
+        return [pos[u] for u in items]
+
+    forced_set = list(to_be_treated or [])
+    forbidden_labels = set(not_to_be_treated or [])
+
+    # Size band: units outside [min_size, max_size] lose treatment eligibility
+    # (they stay donors), i.e. they join the forbidden set.
+    if size_col is not None and (min_size is not None or max_size is not None):
+        size_map = unit_attribute_map(df, unitid, size_col)
+        eligible = eligible_by_size(labels, size_map,
+                                    min_size=min_size, max_size=max_size)
+        forbidden_labels |= (units - set(eligible))
+
+    forced_in = sorted(_to_idx(forced_set, "to_be_treated"))
+    forbidden = sorted(_to_idx(list(forbidden_labels), "not_to_be_treated"))
+
+    overlap = set(forced_in) & set(forbidden)
+    if overlap:
+        clash = sorted(labels[i] for i in overlap)
+        raise MlsynthConfigError(
+            "units cannot be both to_be_treated and forbidden "
+            f"(not_to_be_treated / size-ineligible): {list(map(str, clash))}."
+        )
+
+    # Spillover / interference conflict graph (shared with LEXSCM).
+    cluster_of = (unit_attribute_map(df, unitid, cluster_col)
+                  if cluster_col is not None else None)
+    conflict_pairs: List[Tuple[int, int]] = []
+    conflict = build_conflict_matrix(
+        unit_index, cluster_of=cluster_of, adjacency=adjacency,
+        spillover_threshold=spillover_threshold,
+    )
+    if conflict is not None:
+        iu, ju = np.where(np.triu(conflict, 1))
+        conflict_pairs = list(zip(iu.tolist(), ju.tolist()))
+
+    # Stratum coverage quotas.
+    strata: List[Stratum] = []
+    if stratum_col is not None and (min_per_stratum is not None
+                                    or max_per_stratum is not None):
+        stratum_map = unit_attribute_map(df, unitid, stratum_col)
+        treatable = set(range(len(labels))) - set(forbidden)
+        groups: dict = {}
+        for lab in labels:
+            s = stratum_map.get(lab)
+            if s is None or (isinstance(s, float) and np.isnan(s)):
+                continue
+            groups.setdefault(s, []).append(pos[lab])
+        for s in groups:
+            members = tuple(sorted(groups[s]))
+            hi = max_per_stratum
+            # A minimum applies only to strata that have a treatable member.
+            lo = (min_per_stratum
+                  if (min_per_stratum is not None
+                      and any(m in treatable for m in members))
+                  else None)
+            if lo is not None or hi is not None:
+                strata.append((members, lo, hi))
+
+    return DesignRestrictions(
+        forced_in=forced_in, forbidden=forbidden,
+        conflict_pairs=conflict_pairs, strata=strata,
+    )
+
+
+def apply_restrictions(D: Any, restrictions: DesignRestrictions) -> list:
+    """Build the cvxpy constraints encoding ``restrictions`` on assignment ``D``.
+
+    Parameters
+    ----------
+    D : cvxpy.Variable
+        The boolean assignment vector (length ``N``).
+    restrictions : DesignRestrictions
+        The index-level restriction bundle.
+
+    Returns
+    -------
+    list of cvxpy.Constraint
+        ``D_i == 1`` (forced), ``D_i == 0`` (forbidden), ``D_i + D_j <= 1``
+        (conflict), and ``sum`` bounds (stratum quotas).
+    """
+    import cvxpy as cp
+
+    cons: list = []
+    for i in restrictions.forced_in:
+        cons.append(D[i] == 1)
+    for i in restrictions.forbidden:
+        cons.append(D[i] == 0)
+    for i, j in restrictions.conflict_pairs:
+        cons.append(D[i] + D[j] <= 1)
+    for members, lo, hi in restrictions.strata:
+        members = list(members)
+        if lo is not None:
+            cons.append(cp.sum(D[members]) >= lo)
+        if hi is not None:
+            cons.append(cp.sum(D[members]) <= hi)
+    return cons


### PR DESCRIPTION
## Summary

Turns SYNDES (Abadie–Zhao / Doudchenko experimental design) into a fully customizable design optimizer, and adds a durable Prop 99 benchmark for the penalized SC. All work is test-first; every new module is at ~100% coverage and the full SYNDES suite is green.

### SYNDES selection rules
- **Holdout selection** (`holdout_frac`): learn the `top_K` pool on the leading `1−frac` of the pre-period, pick the design with the smallest *out-of-sample* contrast error on the tail. A train/validate guard against overfitting transient co-movement. `compare_methods` defaults to it for SYNDES and ranks the rows by `oos_rmse`.
- **Information-criterion selection** (`selection="ic"`): rank the pool by `IC = SSR_pre + 2σ²·df`, `df = active control donors − 1` (Pouliot–Xie–Liu), over the whole pre-window — no data split, preferable when `T0` is short. Unified `selection ∈ {in_sample, holdout, ic}` field (default `None` infers from `holdout_frac`, so existing configs are unchanged).

### Treated-side restrictions (geography / clustering / size / forcing)
The GEOLIFT/LEXSCM restriction vocabulary, enforced exactly as linear constraints on the MIP assignment `D`: `to_be_treated` / `not_to_be_treated`, `cluster_col` + `adjacency` + `spillover_threshold` (no two interfering units both treated), `stratum_col` + `min/max_per_stratum`, `size_col` + `min/max_size`. Reuses LEXSCM's conflict-graph helper and GEOLIFT's attribute/size helpers, so the vocabulary is identical across estimators. Validated against the bundled real DMA contiguity matrix (Florida + Georgia).

### Donor-side restrictions (region-matched / non-bordering donors)
A donor-exclusion relation `B[i,j]` ("if `i` is treated, `j` may not be its donor") coupling `D` to the control weights, enforced in **every** mode (one-way global, two-way global, per-unit). Filled by `donor_region_col`, `exclude_bordering_donors` (the Vives-i-Bastida exclusion restriction), or an explicit `donor_exclusion` matrix. The global modes share one donor vector (region rule ⇒ single-region design); `per_unit` supports a genuinely multi-region design. Validated on real DMA borders + CDC Census regions (a Midwest market borrows only from non-bordering Midwest markets, never a bordering PA one).

### Robustness, docs, benchmark
- Over-constrained designs return translated errors, never leaked solver/`IndexError` status: config-detectable cases raise `MlsynthConfigError`; solve-time infeasibility (incl. an empty `top_K` pool across all three selection paths) raises `MlsynthEstimationError` naming the restrictions.
- A docs gallery walks every customization knob as runnable MWEs on the real DMA geography + Census regions, with a region-grouped linear factor sales model.
- Prop 99 pensynth benchmark: cross-validates mlsynth's penalized SC against the live `jeremylhour/pensynth` `wsoll1` reference (ADH MLAB 7-predictor spec), with a dedicated replication docs page.

## Testing
New suites: `test_syndes_holdout`, `test_syndes_ic`, `test_syndes_restrictions`, `test_syndes_donor_restrictions`, plus `test_design_compare` additions. Red→green across smoke/unit/edge/failure levels; real-DMA-geography validation; new helper modules (`holdout`, `infocriterion`, `restrictions`) at 100% coverage. Backward-compatible: the in-sample path, the `arm` option, and every existing SYNDES test are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_