### PR TITLE
docs: lead SYNDES/GEOLIFT constraint galleries with when-to-use scenarios

### DIFF
--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -815,7 +815,9 @@ below assumes this setup has run.
                how="mean", ns=40, seed=0, display_graphs=False)
 
 Plain cardinality -- nominate the 3-market test region with the best detectable
-effect; and force one market in, another out (the latter stays a donor):
+effect; and force one market in, another out (the latter stays a donor) -- when
+the business has already committed to running the test in a given market, or
+must keep one out (a regulated market, a market already running another test):
 
 .. code-block:: python
 
@@ -824,11 +826,14 @@ effect; and force one market in, another out (the latter stays a donor):
             "not_to_be_treated": ["Miami-Fort Lauderdale, FL"]}).fit()
 
 Spillover non-interference. No two test markets in the same state (a
-``cluster_col``), or no two sharing a real border (the contiguity matrix). Both
-do double duty: the treated markets are forced apart, and -- the control
-criterion -- each treated market's same-cluster / bordering neighbours are
-dropped from its donor pool, so a spilling-over market never sits in the
-synthetic control:
+``cluster_col``), or no two sharing a real border (the contiguity matrix) --
+reach for this when treating two nearby markets would let one's campaign bleed
+into the other (overlapping DMAs/media, cross-border shopping), which biases the
+lift. Both do double duty: the treated markets are forced apart, and -- the
+control criterion -- each treated market's same-cluster / bordering neighbours
+are dropped from its donor pool, so a spilling-over market never sits in the
+synthetic control (a contaminated donor would drag the counterfactual toward the
+treated trend):
 
 .. code-block:: python
 
@@ -843,7 +848,10 @@ synthetic control:
    assert all(str(d) not in nbr for d in cd.weights.donor_weights)
 
 Coverage quotas. Require at least one treated market in every region ("test
-everywhere"), or cap the count per region:
+everywhere"), or cap the count per region -- use ``min_per_stratum`` when
+stakeholders need a read in every region, not just the ones the optimizer finds
+easiest to fit, and ``max_per_stratum`` to keep the test from concentrating in a
+single area:
 
 .. code-block:: python
 
@@ -853,7 +861,9 @@ everywhere"), or cap the count per region:
             "max_per_stratum": 1}).fit()                # <= 1 test market per division
 
 Size band -- only mid-sized markets are eligible for treatment (the rest stay
-donors); the floor is a power minimum and the ceiling encodes synthesizability:
+donors); the floor is a power minimum (a too-small market cannot detect the
+effect) and the ceiling encodes synthesizability (a market far larger than the
+donors cannot sit inside their convex hull):
 
 .. code-block:: python
 

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -812,7 +812,9 @@ Plain cardinality -- pick the 3 markets whose synthetic design fits best:
 
    SYNDES({**BASE, "K": 3}).fit()
 
-Force one market in and another out (it stays a donor):
+Force one market in and another out (it stays a donor) -- reach for this when
+leadership has already committed to launching in a particular market, or when
+you are contractually, legally, or operationally barred from treating one:
 
 .. code-block:: python
 
@@ -820,15 +822,20 @@ Force one market in and another out (it stays a donor):
            "not_to_be_treated": ["Cincinnati, OH"]}).fit()
 
 No two treated markets in the same state (a ``cluster_col`` clique), or no two
-sharing a border (the contiguity matrix):
+sharing a border (the contiguity matrix) -- use this when treating two nearby
+markets would let one contaminate the other's read (overlapping media buys,
+cross-border shopping, commuting), which would bias the measured lift:
 
 .. code-block:: python
 
    SYNDES({**BASE, "K": 3, "cluster_col": "state"}).fit()
    SYNDES({**BASE, "K": 3, "adjacency": adj, "spillover_threshold": 0.5}).fit()
 
-Coverage quota -- at least one treated market in every region; and a size band
--- only mid-sized markets are treatable (others remain donors):
+Coverage quota -- at least one treated market in every region, for when
+stakeholders need a read *everywhere* (not just the regions the optimizer finds
+easiest to fit); and a size band -- only mid-sized markets are treatable (others
+remain donors), because a market far larger than the donor pool cannot be
+synthesized (its imbalance blows up) and a too-small one cannot power the test:
 
 .. code-block:: python
 
@@ -838,7 +845,10 @@ Coverage quota -- at least one treated market in every region; and a size band
 
 Donor-pool rules. A treated market may borrow only from its own region; or only
 from markets that do not border it; or -- the motivating case -- only from
-non-bordering markets in its own region:
+non-bordering markets in its own region. Reach for these when you only trust
+within-region comparisons (a national donor would compare apples to oranges) and
+when a bordering market is itself partly treated by the very spillover you are
+trying to measure, so it cannot serve as a clean counterfactual:
 
 .. code-block:: python
 


### PR DESCRIPTION
## Summary

Closes the motivation gap the previous galleries had: they showed *how* to call each design constraint but were thin on *when a practitioner would reach for it*. Each gallery lead-in (SYNDES and GEOLIFT) now opens with a concrete scenario.

- **force in/out** — a market leadership has already committed to launching in, or one you're contractually/legally barred from treating (regulated, already under another test).
- **spillover non-interference** (`cluster_col` / `adjacency`) — two nearby markets where one's campaign bleeds into the other (overlapping DMAs/media, cross-border shopping), which biases the lift; and the matching donor exclusion keeps a contaminated market out of the synthetic control.
- **coverage quotas** — `min_per_stratum` when stakeholders need a read in *every* region (not just the regions the optimizer finds easiest to fit); `max_per_stratum` to avoid concentrating the test in one area.
- **size band** — floor is a power minimum (too-small markets can't detect the effect), ceiling is synthesizability (a market far larger than the donors can't sit in their convex hull).
- **donor-pool rules** (SYNDES) — when you only trust within-region comparisons and a bordering donor is itself partly treated by the spillover you're trying to measure.

Docs-only; no behaviour change, no code touched (code-block counts unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_