### PR TITLE
docs: cite Pouliot-Xie-Liu (IC) and Liao-Shi-Zheng (grouped factor)

### DIFF
--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -767,7 +767,7 @@ Gallery: every constraint on real geography. The block below is a single
 self-contained gallery, mirroring the SYNDES one (:doc:`syndes`): it pulls the
 real DMA contiguity map and metadata, simulates a grouped linear factor model of
 seasonal weekly sales — latent group structure in the loadings (groups = census
-divisions), in the spirit of Liao, Shi & Zheng (2025) — over a real Southeast /
+divisions), in the spirit of Liao, Shi & Zheng [RelaxSC]_ — over a real Southeast /
 Mid-South footprint, and then shows each geographic constraint GEOLIFT supports
 as a compact call. The geography is real; the sales outcome is reproducible and
 exists only so the snippets run end to end (a few seconds each). Every block

--- a/docs/lexscm.rst
+++ b/docs/lexscm.rst
@@ -1268,8 +1268,9 @@ Example: South & Midwest design with grouped factors
 This example exercises every selection constraint at once on real geography. We
 take the South and Midwest DMAs from the bundled map, group them by census
 division (South Atlantic, East/West South Central, East/West North Central),
-and draw outcomes from a grouped linear factor model: markets in the same
-division share factor loadings, so they co-move -- the latent-group structure the
+and draw outcomes from a grouped linear factor model (after the grouped factor
+structure of Liao, Shi & Zheng [RelaxSC]_): markets in the same division share
+factor loadings, so they co-move -- the latent-group structure the
 constraints are designed for. Each division is both a *stratum* (for coverage /
 quota) and, through the DMA borders, a source of *spillover*.
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -373,6 +373,12 @@ References
     https://github.com/PanJi-0/scmrelax); the Brexit / UK real-GDP
     empirical application: https://github.com/YapengZheng/Relaxed_SC
 
+.. [SCInfoCrit]
+    Pouliot, Guillaume Allaire, Zhen Xie, and Ziyi Liu.
+    *"Degrees of Freedom and Information Criteria for the Synthetic Control Method."*
+    Working Paper, 2022 (revised 2026).
+    arXiv: https://arxiv.org/abs/2207.02943.
+
 .. [BVSS]
     Xu, Yihong and Zhou, Quan.
     "Bayesian Synthetic Control with a Soft Simplex Constraint."

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -753,8 +753,9 @@ contiguity matrix and metadata (`basedata/markets/
 into the four `Census regions
 <https://www.cdc.gov/nchs/hus/sources-definitions/geographic-region.htm>`_. The
 geography is real; the sales outcome is a reproducible region-grouped factor
-model (same-region markets co-move), generated only so the snippets run end to
-end. Each block below assumes this setup has run, and each needs a MIP solver
+model (same-region markets co-move, after the grouped factor structure of Liao,
+Shi & Zheng [RelaxSC]_), generated only so the snippets run end to end. Each
+block below assumes this setup has run, and each needs a MIP solver
 (SCIP).
 
 .. code-block:: python
@@ -1015,8 +1016,8 @@ The holdout split spends part of the pre-period on validation, which is noisy
 exactly when the pre-period is short -- the regime SYNDES is built for. An
 information criterion avoids the split: it scores every candidate on the *whole*
 pre-window and penalises the model-selection flexibility directly. Pouliot, Xie
-& Liu (2024) show that in short-:math:`T_0` synthetic-control settings such a
-criterion outperforms cross-validation / holdout. Setting ``selection="ic"``
+& Liu [SCInfoCrit]_ show that in short-:math:`T_0` synthetic-control settings
+such a criterion outperforms cross-validation / holdout. Setting ``selection="ic"``
 ranks the ``top_K`` pool (solved on the full pre-period) by
 
 .. math::


### PR DESCRIPTION
## Summary

Two references were used in the docs but never linked:

- **Pouliot, Xie & Liu** — the SYNDES information-criterion selection invokes their degrees-of-freedom / information-criteria result, but the paper had no entry in `references.rst` and no link anywhere. Adds a `[SCInfoCrit]` reference (arXiv:2207.02943) and cites it from the SYNDES IC section.
- **Liao, Shi & Zheng** — the SYNDES / GEOLIFT / LEXSCM galleries simulate a grouped linear factor model "in the spirit of Liao, Shi & Zheng" but never linked the source. That paper is already in `references.rst` as `[RelaxSC]` (arXiv:2508.01793); now cited from each gallery's grouped-factor description.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_