### PR TITLE
MAREX: geographic design restrictions on an IndexSet foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ now returns and the back-compat guarantee.
 
 ## [Unreleased]
 
+### Added
+- **MAREX geographic design restrictions.** MAREX gains the SYNDES/GEOLIFT
+  restriction vocabulary, on top of what it already had natively (region
+  clustering, `m_min`/`m_max` stratum quotas, cost/budget, same-region donors):
+  `to_be_treated` / `not_to_be_treated`, `adjacency` + `spillover_threshold`
+  (no two treated markets border each other), `size_col` + `min/max_size`, and
+  `exclude_bordering_donors` (drop a treated market's neighbours from its
+  within-cluster control pool). Enforced as constraints on the MIP's `z`/`v`,
+  reusing the shared estimator-agnostic `DesignRestrictions` / `build_restrictions`
+  (new `marex_helpers/restrictions.apply_restrictions_marex` for the applier).
+  MIQP-only (rejected with `relaxed=True`); infeasible combinations raise a
+  translated `MlsynthEstimationError`. Docs gallery on real DMA geography.
+
+### Changed
+- **MAREX routes unit/time identity through `IndexSet` + `geoex_dataprep`.**
+  `prepare_marex_panel` now ingests via the canonical `geoex_dataprep` (which
+  enforces a strongly balanced panel) and carries `unit_index` / `time_index`
+  IndexSets as the single source of truth, threaded through the optimizer and
+  orchestrator instead of being re-derived from the frame. Unit order is
+  preserved, so numerics are unchanged; the only behavioural change is that an
+  unbalanced panel now raises a translated `MlsynthDataError`.
+
 ### Fixed
 - **SYNDES no longer leaks an `IndexError` when restrictions make the candidate
   pool empty.** Over-constrained `top_K > 1` designs (in-sample, holdout, or ic

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -339,6 +339,23 @@ so the untreated markets form a clean control, often under a budget?
   level at once) -- :doc:`multicellgeolift` extends the selection to multiple
   cells simultaneously.
 
+Q3.5 · Designing across groups (regions / arms / strata)? Three mechanisms look
+similar but are distinct -- pick by what you want, not by the word "group":
+
+* A *separate experiment per group* -- its own estimand and donor pool:
+  :doc:`marex`'s ``cluster`` (baked into the per-cluster objective) or
+  :doc:`syndes`'s ``arm`` (separate solves). Use when each region/arm is its own
+  study.
+* *One* design representative of *every* group (coverage): the stratum quota
+  ``stratum_col`` + ``min_per_stratum`` / ``max_per_stratum`` -- one shared donor
+  pool, one estimand. In MAREX this quota is just the per-cluster cardinality.
+* *One* design with geographic / forcing limits: the restriction suite (force
+  in/out, border conflict, size band, donor rules) on SYNDES, MAREX, or GEOLIFT.
+
+A constraint cannot turn one design into K designs, so ``cluster`` / ``arm`` are
+not special cases of the quota; the quota is the lighter choice when you only
+need coverage in a single design.
+
 Failure-mode index
 ------------------
 

--- a/docs/marex.rst
+++ b/docs/marex.rst
@@ -239,6 +239,29 @@ Liao, Shi & Zheng [RelaxSC]_); the geography is real, the sales reproducible.
    MAREX({**B, "m_max": 1, "adjacency": adj, "spillover_threshold": 0.5,
           "exclude_bordering_donors": True}).fit()      # non-bordering donors
 
+Across groups: cluster vs. quotas vs. restrictions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Three mechanisms touch on grouping/geography; they are distinct, not
+interchangeable, and ``cluster`` is *not* made obsolete by the restrictions:
+
+* A *separate experiment per group* -- each group's own representativeness
+  target and donor pool: ``cluster``. This is the design's objective, not a
+  constraint: each cluster ``k`` reconstructs its own predictor mean
+  :math:`\overline{X}_k`. It is the SYNDES analog of that estimator's ``arm``
+  (:doc:`syndes`), but baked into the objective rather than run as separate
+  solves -- which is why, in MAREX, the restrictions compose *with* ``cluster``
+  (they apply within each cluster) and the per-cluster cardinality ``m_min`` /
+  ``m_max`` *is* the stratum quota.
+* *One* design with geographic / forcing limits within those clusters: the
+  restriction suite above (force in/out, border conflict, size band, donor
+  exclusion).
+
+So a stratum quota is not an alternative to ``cluster``; in MAREX it is a
+property *of* the clustering. Drop ``cluster`` (a single global cluster) and you
+recover one design against the whole-population mean -- a different estimand, not
+a constrained version of the clustered one.
+
 Inference
 ^^^^^^^^^
 

--- a/docs/marex.rst
+++ b/docs/marex.rst
@@ -163,6 +163,82 @@ predictor distribution and limits interpolation bias (paper OA.1). Per-unit
 ``costs`` and a ``budget`` (scalar or per-cluster) add a knapsack constraint
 :math:`\sum_j c_j w_j \le B`, so the chosen treatment group respects a spend cap.
 
+Geographic design restrictions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+MAREX already carries most geographic structure natively. Its ``cluster`` field
+*is* the paper's "region as a distinct experimental design" (p.13: weather
+patterns dependent across cities in the same region motivate treating each region
+separately); ``m_min`` / ``m_max`` per cluster is a stratum quota ("at least /
+at most this many treated per region"); ``costs`` / ``budget`` is the cost bound;
+and because each cluster's control synthetic :math:`v_{\cdot,k}` is built only
+from cluster-``k`` members, donors are automatically same-region. The same
+restriction vocabulary SYNDES and GEOLIFT expose then adds the rest, as
+constraints on the MIP:
+
+* ``to_be_treated`` / ``not_to_be_treated`` -- force a market in (one leadership
+  already committed to) or out (a regulated market, or one already under another
+  test); a forbidden market stays a donor.
+* ``adjacency`` + ``spillover_threshold`` -- no two treated markets may share a
+  border (:math:`\sum_k z_{ik} + \sum_k z_{jk} \le 1`), for when one test
+  market's campaign would bleed into a neighbouring one and bias the lift.
+* ``size_col`` + ``min_size`` / ``max_size`` -- a treated-unit size band (the
+  floor is a power minimum, the ceiling is synthesizability); out-of-band markets
+  stay donors.
+* ``exclude_bordering_donors`` -- drop a treated market's bordering neighbours
+  from its (within-cluster) control pool, so a market partly treated by spillover
+  never sits in its counterfactual. Requires ``adjacency``.
+
+These are supported in the exact MIQP only (not ``relaxed=True``, whose post-hoc
+rounding cannot guarantee them). An over-constrained design -- e.g. forbidding
+every market of a region, leaving its required treated synthetic with no member
+-- raises a translated :class:`~mlsynth.exceptions.MlsynthEstimationError` naming
+the restrictions. The example below runs on the bundled real US DMA contiguity
+map and Census regions, with a region-grouped linear factor sales model (after
+Liao, Shi & Zheng [RelaxSC]_); the geography is real, the sales reproducible.
+
+.. code-block:: python
+
+   import numpy as np
+   import pandas as pd
+   from mlsynth import MAREX
+
+   base = ("https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
+           "refs/heads/main/basedata/markets")
+   adj = pd.read_csv(f"{base}/dma_adjacency.csv", index_col=0)
+   meta = pd.read_csv(f"{base}/dma_metadata.csv")
+   CDC = {**{s: "Midwest" for s in ["OH", "IN", "MI", "KY"]},
+          **{s: "South" for s in ["WV", "VA", "TN", "GA", "FL", "SC"]}}
+   meta = meta[meta["state"].isin(CDC)].copy()
+   meta["region"] = meta["state"].map(CDC)
+   names = [n for n in meta["dma_name"] if n in adj.index]
+   meta = meta[meta["dma_name"].isin(names)].reset_index(drop=True)
+   adj = adj.loc[names, names]
+
+   rng = np.random.default_rng(7)
+   reg = meta["region"].to_numpy(); n, r, T, T0 = len(names), 3, 30, 24
+   Lam = (np.array([{g: rng.normal(size=r) for g in sorted(set(reg))}[g] for g in reg])
+          + 0.15 * rng.normal(size=(n, r)))
+   F = np.cumsum(rng.normal(size=(T, r)), axis=0)
+   pop = np.round(rng.lognormal(12.5, 0.7, n)).astype(int)
+   Y = 100 + rng.normal(0, 5, n) + F @ Lam.T + rng.normal(0, 1, (T, n))
+   df = pd.DataFrame([{"dma": names[j], "week": t, "sales": float(Y[t, j]),
+                       "region": reg[j], "population": int(pop[j])}
+                      for j in range(n) for t in range(T)])
+
+   B = dict(df=df, outcome="sales", unitid="dma", time="week",
+            cluster="region", T0=T0)                    # cluster = Census region
+
+   MAREX({**B, "m_max": 2}).fit()                       # native quota: <=2 per region
+   MAREX({**B, "m_max": 2, "to_be_treated": ["Atlanta, GA"],
+          "not_to_be_treated": ["Miami-Fort Lauderdale, FL"]}).fit()
+   MAREX({**B, "m_max": 2, "adjacency": adj,
+          "spillover_threshold": 0.5}).fit()            # no two treated border
+   MAREX({**B, "m_max": 2, "size_col": "population",
+          "min_size": 200_000, "max_size": 3_000_000}).fit()
+   MAREX({**B, "m_max": 1, "adjacency": adj, "spillover_threshold": 0.5,
+          "exclude_bordering_donors": True}).fit()      # non-bordering donors
+
 Inference
 ^^^^^^^^^
 

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -598,6 +598,30 @@ compatible with the global ``costs``/``budget`` constraint (the cost vector is
 defined over all units, not per arm). When ``arm`` is ``None`` (default), a
 single :class:`SYNDESResults` is returned, exactly as before.
 
+Across groups: arm vs. quotas vs. restrictions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Three mechanisms touch on grouping/geography; they are distinct, not
+interchangeable. Pick by what you actually want:
+
+* A *separate experiment per group* -- its own estimand, its own donor pool:
+  ``arm`` (above). This is the SYNDES analog of MAREX's ``cluster``
+  (:doc:`marex`), which bakes the same idea into a per-cluster objective.
+  ``arm`` partitions the units and solves an independent design in each.
+* *One* design representative of *every* group (coverage): ``stratum_col`` with
+  ``min_per_stratum`` / ``max_per_stratum`` -- one shared donor pool, one
+  estimand, with a quota of treated units per group.
+* *One* design with geographic / forcing limits: the restriction suite (force
+  in/out, border conflict, size band, donor rules).
+
+A constraint cannot split one design into ``K`` independent designs, so ``arm``
+is not a special case of the quota -- it is a different object (``K`` estimands
+and ``K`` disjoint donor pools). Note the asymmetry with MAREX: there the
+restrictions compose *with* ``cluster`` (they apply within each cluster), because
+``cluster`` lives in the objective; in SYNDES ``arm`` runs separate solves and
+does **not** combine with the restriction fields -- to get both, loop a
+restricted ``SYNDES`` over each arm's sub-panel.
+
 Example
 -------
 

--- a/mlsynth/estimators/scexp.py
+++ b/mlsynth/estimators/scexp.py
@@ -87,6 +87,15 @@ class MAREX:
         self.T_post = config.T_post
         self.relaxed: bool = getattr(config, "relaxed", False)
         self.display_graph: bool = config.display_graph
+        # geographic design restrictions
+        self.to_be_treated = config.to_be_treated
+        self.not_to_be_treated = config.not_to_be_treated
+        self.adjacency = config.adjacency
+        self.spillover_threshold = config.spillover_threshold
+        self.exclude_bordering_donors = config.exclude_bordering_donors
+        self.size_col = config.size_col
+        self.min_size = config.min_size
+        self.max_size = config.max_size
 
         if self.cluster and self.cluster not in self.df.columns:
             raise MlsynthDataError(f"Cluster column '{self.cluster}' not found in DataFrame.")
@@ -119,6 +128,19 @@ class MAREX:
         except Exception as exc:
             raise MlsynthDataError(f"Error preparing MAREX inputs: {exc}") from exc
 
+        # Build the geographic restriction bundle against the panel's unit
+        # IndexSet -- the single source of truth for who is who.
+        from ..utils.marex_helpers.restrictions import build_restrictions
+        restrictions = build_restrictions(
+            self.df, self.unitid, panel.unit_index,
+            to_be_treated=self.to_be_treated,
+            not_to_be_treated=self.not_to_be_treated,
+            adjacency=self.adjacency, spillover_threshold=self.spillover_threshold,
+            size_col=self.size_col, min_size=self.min_size, max_size=self.max_size,
+            exclude_bordering_donors=self.exclude_bordering_donors,
+        )
+        restrictions = None if restrictions.is_empty else restrictions
+
         try:
             import cvxpy as cp
             results = solve_marex(
@@ -135,6 +157,7 @@ class MAREX:
                 solver=self.solver or cp.SCIP, verbose=self.verbose,
                 relaxed=self.relaxed, inference=self.inference,
                 unit_index=panel.unit_index, time_index=panel.time_index,
+                restrictions=restrictions,
             )
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/estimators/scexp.py
+++ b/mlsynth/estimators/scexp.py
@@ -134,6 +134,7 @@ class MAREX:
                 standardize=self.standardize,
                 solver=self.solver or cp.SCIP, verbose=self.verbose,
                 relaxed=self.relaxed, inference=self.inference,
+                unit_index=panel.unit_index, time_index=panel.time_index,
             )
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/tests/test_marex_restrictions.py
+++ b/mlsynth/tests/test_marex_restrictions.py
@@ -1,0 +1,67 @@
+"""TDD for the MAREX IndexSet refactor (Phase 1) + geographic restrictions.
+
+Phase 1 puts ``IndexSet`` in charge of unit/time identity: ``prepare_marex_panel``
+ingests through the canonical :func:`geoex_dataprep` (which enforces a strongly
+balanced panel) and carries ``unit_index`` / ``time_index`` IndexSets that are the
+single source of truth downstream. Behaviour on a balanced panel is unchanged.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthDataError
+from mlsynth.utils.fast_scm_helpers.structure import IndexSet
+from mlsynth.utils.marex_helpers.setup import prepare_marex_panel
+
+
+def _panel(N=8, T=14, seed=0, balanced=True):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2))
+    L = rng.uniform(0.3, 1.0, (N, 2))
+    lvl = rng.uniform(8.0, 12.0, N)
+    Y = lvl + F @ L.T + rng.normal(scale=0.3, size=(T, N))
+    region = ["A" if j < N // 2 else "B" for j in range(N)]
+    rows = []
+    for j in range(N):
+        for t in range(T):
+            rows.append({"unit": f"u{j}", "time": t, "Y": float(Y[t, j]),
+                         "region": region[j]})
+    df = pd.DataFrame(rows)
+    if not balanced:
+        df = df.iloc[3:]            # drop a few rows -> unbalanced panel
+    return df
+
+
+class TestMAREXIndexSet:
+    def _prep(self, df, **kw):
+        return prepare_marex_panel(
+            df, outcome="Y", unitid="unit", time="time", cluster="region",
+            T0=10, inference=False, blank_periods=0, T_post=None, **kw)
+
+    def test_panel_carries_indexsets(self):
+        panel = self._prep(_panel())
+        assert isinstance(panel.unit_index, IndexSet)
+        assert isinstance(panel.time_index, IndexSet)
+
+    def test_unit_index_is_source_of_truth(self):
+        # Y_full rows align to unit_index labels; clusters align to that order.
+        panel = self._prep(_panel())
+        assert list(panel.Y_full.index) == list(panel.unit_index.labels)
+        assert len(panel.clusters) == len(panel.unit_index)
+
+    def test_time_index_matches_columns(self):
+        panel = self._prep(_panel())
+        assert list(panel.Y_full.columns) == list(panel.time_index.labels)
+
+    def test_balance_enforced_via_geoex(self):
+        # geoex_dataprep rejects an unbalanced panel -> translated MlsynthDataError.
+        with pytest.raises(MlsynthDataError):
+            self._prep(_panel(balanced=False))
+
+    def test_behaviour_preserved_on_balanced_panel(self):
+        # The refactor preserves the unit order and the (units x time) Y_full.
+        panel = self._prep(_panel())
+        assert panel.Y_full.shape == (8, 14)
+        assert set(panel.unit_index.labels) == {f"u{j}" for j in range(8)}

--- a/mlsynth/tests/test_marex_restrictions.py
+++ b/mlsynth/tests/test_marex_restrictions.py
@@ -11,9 +11,14 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mlsynth.exceptions import MlsynthDataError
+from mlsynth import MAREX
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 from mlsynth.utils.fast_scm_helpers.structure import IndexSet
 from mlsynth.utils.marex_helpers.setup import prepare_marex_panel
+from mlsynth.utils.marex_helpers.restrictions import (
+    DesignRestrictions,
+    apply_restrictions_marex,
+)
 
 
 def _panel(N=8, T=14, seed=0, balanced=True):
@@ -23,11 +28,14 @@ def _panel(N=8, T=14, seed=0, balanced=True):
     lvl = rng.uniform(8.0, 12.0, N)
     Y = lvl + F @ L.T + rng.normal(scale=0.3, size=(T, N))
     region = ["A" if j < N // 2 else "B" for j in range(N)]
+    # Deterministic sizes with the same spread in each region, so a mid-band
+    # always leaves >=1 treatable unit per region (MAREX needs >=1 treated/cluster).
+    size = np.tile([2.0, 4.0, 6.0, 8.0], (N + 3) // 4)[:N]
     rows = []
     for j in range(N):
         for t in range(T):
             rows.append({"unit": f"u{j}", "time": t, "Y": float(Y[t, j]),
-                         "region": region[j]})
+                         "region": region[j], "size": float(size[j])})
     df = pd.DataFrame(rows)
     if not balanced:
         df = df.iloc[3:]            # drop a few rows -> unbalanced panel
@@ -65,3 +73,138 @@ class TestMAREXIndexSet:
         panel = self._prep(_panel())
         assert panel.Y_full.shape == (8, 14)
         assert set(panel.unit_index.labels) == {f"u{j}" for j in range(8)}
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- apply_restrictions_marex (constraint emission on z / v)
+# ----------------------------------------------------------------------
+
+class TestApplyRestrictionsMarex:
+    def _vars(self, N=6, K=2):
+        import cvxpy as cp
+        z = cp.Variable((N, K), boolean=True)
+        v = cp.Variable((N, K), nonneg=True)
+        M = np.zeros((N, K), dtype=bool)
+        for j in range(N):
+            M[j, 0 if j < N // 2 else 1] = True      # first half cluster 0, rest 1
+        return z, v, M
+
+    def test_force_forbid_conflict_counts(self):
+        z, v, M = self._vars()
+        r = DesignRestrictions(forced_in=[0], forbidden=[1, 2],
+                               conflict_pairs=[(0, 3)])
+        cons = apply_restrictions_marex(z, v, M, r)
+        assert len(cons) == 4                         # 1 forced + 2 forbidden + 1 conflict
+
+    def test_donor_exclusion_only_within_cluster(self):
+        z, v, M = self._vars()                        # u0,u1,u2 in cluster 0
+        # (0,1) same cluster -> 1 constraint; (0,4) cross cluster -> skipped.
+        r = DesignRestrictions(donor_exclusion=[(0, 1), (0, 4)])
+        cons = apply_restrictions_marex(z, v, M, r)
+        assert len(cons) == 1
+
+    def test_empty_restrictions_no_constraints(self):
+        z, v, M = self._vars()
+        assert apply_restrictions_marex(z, v, M, DesignRestrictions()) == []
+
+
+# ----------------------------------------------------------------------
+# Layer 3 -- the solved MAREX design honours the restrictions
+# ----------------------------------------------------------------------
+
+class TestMAREXRestrictionsEnforced:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", cluster="region",
+                 T0=10, m_max=1, solver="SCIP", verbose=False)
+
+    def _fit(self, **over):
+        return MAREX({"df": _panel(), **self._BASE, **over}).fit()
+
+    def _treated(self, res):
+        return set(map(str, res.assignment["treated"]))
+
+    def test_not_to_be_treated_excluded(self):
+        res = self._fit(not_to_be_treated=["u0", "u1", "u4"])
+        assert self._treated(res).isdisjoint({"u0", "u1", "u4"})
+
+    def test_to_be_treated_forced_in(self):
+        res = self._fit(to_be_treated=["u0", "u4"])
+        assert {"u0", "u4"} <= self._treated(res)
+
+    def test_adjacency_no_two_treated_border(self):
+        labels = [f"u{j}" for j in range(8)]
+        A = pd.DataFrame(0.0, index=labels, columns=labels)
+        # make the two natural treated picks (one per region) border-conflict
+        for a, b in [("u0", "u1"), ("u4", "u5")]:
+            A.loc[a, b] = A.loc[b, a] = 1.0
+        res = self._fit(adjacency=A, spillover_threshold=0.5)
+        treated = self._treated(res)
+        Ab = A.to_numpy()
+        idx = {labels.index(u) for u in treated}
+        assert not any(Ab[i, j] > 0 for i in idx for j in idx if i != j)
+
+    def test_size_band_excludes_out_of_band(self):
+        df = _panel()
+        size = df.drop_duplicates("unit").set_index("unit")["size"]
+        lo, hi = 3.0, 7.0                            # keeps sizes {4, 6} per region
+        res = MAREX({"df": df, **self._BASE, "size_col": "size",
+                     "min_size": lo, "max_size": hi}).fit()
+        treated = self._treated(res)
+        in_band = set(size[(size >= lo) & (size <= hi)].index)
+        assert treated <= in_band
+
+    def test_exclude_bordering_donors(self):
+        labels = [f"u{j}" for j in range(8)]
+        A = pd.DataFrame(0.0, index=labels, columns=labels)
+        for a, b in [("u0", "u2"), ("u4", "u6")]:    # within-region borders
+            A.loc[a, b] = A.loc[b, a] = 1.0
+        res = MAREX({"df": _panel(), **self._BASE, "m_max": 1,
+                     "adjacency": A, "spillover_threshold": 0.5,
+                     "exclude_bordering_donors": True}).fit()
+        treated = set(map(str, res.assignment["treated"]))
+        control = set(map(str, res.assignment["control"]))
+        Ab = A.to_numpy()
+        ti = {labels.index(u) for u in treated}
+        ci = {labels.index(u) for u in control}
+        assert not any(Ab[i, j] > 0 for i in ti for j in ci)   # no treated-donor border
+
+
+# ----------------------------------------------------------------------
+# Config / failure semantics
+# ----------------------------------------------------------------------
+
+class TestMAREXRestrictionsConfig:
+    _BASE = dict(outcome="Y", unitid="unit", time="time", cluster="region",
+                 T0=10, m_max=1)
+
+    def _make(self, **over):
+        return MAREX({"df": _panel(), **self._BASE, **over})
+
+    def test_unknown_forced_unit(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(to_be_treated=["ghost"]).fit()
+
+    def test_forced_forbidden_overlap(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(to_be_treated=["u0"], not_to_be_treated=["u0"])
+
+    def test_size_band_requires_col(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(min_size=2.0)
+
+    def test_exclude_bordering_needs_adjacency(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(exclude_bordering_donors=True)
+
+    def test_restrictions_reject_relaxed(self):
+        with pytest.raises(MlsynthConfigError):
+            self._make(relaxed=True, not_to_be_treated=["u0"])
+
+    def test_infeasible_restrictions_reported(self):
+        # Forbidding every unit of region B leaves its treated synthetic with no
+        # member (MAREX needs >=1 treated per cluster) -> translated estimation
+        # error naming the restrictions, not a bare solver status.
+        from mlsynth.exceptions import MlsynthEstimationError
+        with pytest.raises(MlsynthEstimationError) as ei:
+            MAREX({"df": _panel(), **self._BASE, "solver": "SCIP",
+                   "not_to_be_treated": ["u4", "u5", "u6", "u7"]}).fit()
+        assert "restriction" in str(ei.value).lower()

--- a/mlsynth/utils/marex_helpers/config.py
+++ b/mlsynth/utils/marex_helpers/config.py
@@ -30,7 +30,16 @@ class MAREXConfig(BaseMAREXConfig):
             "and an explicit ``T0`` argument is ignored."
         ),
     )
-    cluster: Optional[str] = Field(default=None, description="Column name for cluster membership.")
+    cluster: Optional[str] = Field(
+        default=None,
+        description="Column name for cluster membership. Each cluster is a "
+        "distinct experimental design with its own representativeness target "
+        "(its predictor mean Xbar_k) -- this is part of the objective, not a "
+        "constraint, and the per-cluster m_min/m_max IS the stratum quota. It is "
+        "the MAREX analog of SYNDES's `arm`, but baked into the objective rather "
+        "than run as separate solves, so the geographic restrictions compose "
+        "with it (they apply within each cluster). None (default) = one global "
+        "cluster (a single design against the whole-population mean).")
     design: str = Field(default="standard", description="Design type: 'standard', 'weakly_targeted', 'penalized', 'unit_penalized'.")
     covariates: Optional[List[str]] = Field(default=None, description="Time-invariant covariate columns matched on alongside pre-period outcomes (the paper's X = [Y^E ; Z]).")
     covariate_weight: float = Field(default=1.0, description="Scale applied to covariate predictors relative to outcomes.")

--- a/mlsynth/utils/marex_helpers/config.py
+++ b/mlsynth/utils/marex_helpers/config.py
@@ -72,6 +72,40 @@ class MAREXConfig(BaseMAREXConfig):
     inference: bool = Field(default=False, description="Whether to run post-fit inference (placebo CI/p-values).")
     T_post: Optional[int] = Field(default=None, description="Number of post-intervention periods for inference.")
 
+    # --- geographic design restrictions ---
+    # MAREX already covers region-clustering (`cluster`), stratum quotas
+    # (`m_min`/`m_max`), cost/budget, and same-region donors natively. These add
+    # the remaining SYNDES/GEOLIFT capabilities as constraints on the MIP. Only
+    # supported in the exact MIQP (not `relaxed=True`, whose post-hoc rounding
+    # cannot guarantee them).
+    to_be_treated: Optional[List] = Field(
+        default=None,
+        description="Units forced into the treated set; must be disjoint from "
+        "not_to_be_treated.")
+    not_to_be_treated: Optional[List] = Field(
+        default=None,
+        description="Units forbidden from treatment; they remain donors.")
+    adjacency: Optional[pd.DataFrame] = Field(
+        default=None,
+        description="Square border/spillover matrix (DataFrame keyed by unit "
+        "label); off-diagonal pairs above `spillover_threshold` may not both be "
+        "treated, and (with `exclude_bordering_donors`) are dropped from each "
+        "other's donor pool.")
+    spillover_threshold: float = Field(
+        default=0.0,
+        description="Off-diagonal `adjacency` entries strictly above this mark a "
+        "conflicting (bordering) pair.")
+    exclude_bordering_donors: bool = Field(
+        default=False,
+        description="Drop a treated market's bordering neighbours from its "
+        "(within-cluster) control pool. Requires `adjacency`.")
+    size_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit-constant size column; units outside "
+        "[min_size, max_size] lose treatment eligibility (stay donors).")
+    min_size: Optional[float] = Field(default=None, description="Lower size bound.")
+    max_size: Optional[float] = Field(default=None, description="Upper size bound.")
+
     @model_validator(mode="after")
     def validate_design_params(cls, values: Any) -> Any:
         df = values.df
@@ -230,6 +264,51 @@ class MAREXConfig(BaseMAREXConfig):
             raise MlsynthDataError(
                 f"blank_periods must satisfy 0 <= blank_periods < T0 "
                 f"(T0={T0_eff}, got {values.blank_periods})."
+            )
+
+        # --- geographic design restrictions ---
+        _restr = (values.to_be_treated is not None
+                  or values.not_to_be_treated is not None
+                  or values.adjacency is not None
+                  or values.exclude_bordering_donors
+                  or values.size_col is not None
+                  or values.min_size is not None or values.max_size is not None)
+        if _restr and values.relaxed:
+            raise MlsynthConfigError(
+                "design restrictions are only supported in the exact MIQP, not "
+                "with relaxed=True (its post-hoc rounding cannot guarantee them)."
+            )
+        units = set(df[values.unitid].unique())
+        forced = list(values.to_be_treated or [])
+        forbidden = list(values.not_to_be_treated or [])
+        unknown = [u for u in (forced + forbidden) if u not in units]
+        if unknown:
+            raise MlsynthConfigError(
+                "to_be_treated/not_to_be_treated contain units not in df: "
+                f"{sorted(map(str, set(unknown)))}."
+            )
+        clash = set(forced) & set(forbidden)
+        if clash:
+            raise MlsynthConfigError(
+                "units cannot be both to_be_treated and not_to_be_treated: "
+                f"{sorted(map(str, clash))}."
+            )
+        if values.size_col is not None and values.size_col not in df.columns:
+            raise MlsynthConfigError(
+                f"size_col '{values.size_col}' is not a column of df."
+            )
+        if (values.min_size is not None or values.max_size is not None) \
+                and values.size_col is None:
+            raise MlsynthConfigError("min_size / max_size require size_col.")
+        if values.min_size is not None and values.max_size is not None \
+                and values.min_size > values.max_size:
+            raise MlsynthConfigError(
+                f"min_size ({values.min_size}) must be <= max_size "
+                f"({values.max_size})."
+            )
+        if values.exclude_bordering_donors and values.adjacency is None:
+            raise MlsynthConfigError(
+                "exclude_bordering_donors requires an adjacency matrix."
             )
 
         return values

--- a/mlsynth/utils/marex_helpers/formulation.py
+++ b/mlsynth/utils/marex_helpers/formulation.py
@@ -142,8 +142,10 @@ def init_cvxpy_variables(N, K, boolean=True):
 
 
 def build_constraints(w, v, z, M, cluster_members, cluster_labels,
-                      m_eq, m_min, m_max, costs, budget_dict, exclusive):
-    """Simplex, disjointness, cardinality, cost, and exclusivity constraints."""
+                      m_eq, m_min, m_max, costs, budget_dict, exclusive,
+                      restrictions=None):
+    """Simplex, disjointness, cardinality, cost, exclusivity, and (optional)
+    geographic-restriction constraints."""
     N, K = M.shape
     constraints = []
     for k in range(K):
@@ -178,6 +180,10 @@ def build_constraints(w, v, z, M, cluster_members, cluster_labels,
     if exclusive:
         for j in range(N):
             constraints += [cp.sum(z[j, :]) <= 1]
+
+    if restrictions is not None:
+        from .restrictions import apply_restrictions_marex
+        constraints += apply_restrictions_marex(z, v, M, restrictions)
     return constraints
 
 

--- a/mlsynth/utils/marex_helpers/optimization.py
+++ b/mlsynth/utils/marex_helpers/optimization.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import cvxpy as cp
 import numpy as np
 
+from ...exceptions import MlsynthEstimationError
 from .formulation import (
     build_constraints,
     build_objective,
@@ -64,7 +65,7 @@ def solve_design(
     exclusive=True, design="standard", beta=1e-6, lambda1=0.0, lambda2=0.0, xi=0.0,
     lambda1_unit=0.0, lambda2_unit=0.0, costs=None, budget=None,
     covariates=None, covariate_weight=1.0, standardize=False,
-    solver=cp.SCIP, verbose=False,
+    solver=cp.SCIP, verbose=False, restrictions=None,
 ):
     """Exact mixed-integer MAREX design (was ``SCMEXP``)."""
     validate_scm_inputs(Y_full, T0, blank_periods, design, beta, lambda1,
@@ -79,13 +80,21 @@ def solve_design(
 
     w, v, z = init_cvxpy_variables(N, K)
     constraints = build_constraints(w, v, z, M, cluster_members, cluster_labels,
-                                    m_eq, m_min, m_max, costs_np, budget_dict, exclusive)
+                                    m_eq, m_min, m_max, costs_np, budget_dict,
+                                    exclusive, restrictions=restrictions)
     objective = build_objective(X_fit, Xbar_clusters, cluster_members, w, v, z,
                                design, beta, lambda1, lambda2, xi,
                                lambda1_unit, lambda2_unit, D1, D2_list)
     prob = cp.Problem(objective, constraints)
     prob.solve(solver=solver, verbose=verbose)
 
+    if z.value is None or w.value is None:
+        msg = f"MAREX optimization failed: {prob.status}"
+        if restrictions is not None and "infeasible" in str(prob.status).lower():
+            msg = ("MAREX design is infeasible under the active restrictions "
+                   "(forced/forbidden units, border conflicts, size band) and "
+                   "the cluster cardinality (m_min/m_max). Relax them.")
+        raise MlsynthEstimationError(msg)
     w_opt, v_opt, z_opt = w.value, v.value, z.value
     Y_full_T = Y_full_np.T
     rmse_cluster = []

--- a/mlsynth/utils/marex_helpers/orchestration.py
+++ b/mlsynth/utils/marex_helpers/orchestration.py
@@ -52,6 +52,7 @@ def solve_marex(
     random_state=42,
     unit_index=None,
     time_index=None,
+    restrictions=None,
 ) -> MAREXResults:
     """Solve the MAREX design and return a frozen :class:`MAREXResults`.
 
@@ -60,7 +61,7 @@ def solve_marex(
     placebo inference is computed for every cluster and the aggregate.
     """
     solve = solve_design_relaxed if relaxed else solve_design
-    raw = solve(
+    solve_kw = dict(
         Y_full=Y_full, T0=T0, clusters=clusters, blank_periods=blank_periods,
         m_eq=m_eq, m_min=m_min, m_max=m_max, exclusive=exclusive, design=design,
         beta=beta, lambda1=lambda1, lambda2=lambda2, xi=xi,
@@ -69,6 +70,11 @@ def solve_marex(
         covariate_weight=covariate_weight, standardize=standardize,
         solver=solver, verbose=verbose,
     )
+    # Restrictions are MIQP-only (the relaxed path's rounding can't guarantee
+    # them); the config rejects the combination, so only the exact solver sees it.
+    if not relaxed:
+        solve_kw["restrictions"] = restrictions
+    raw = solve(**solve_kw)
 
     df = raw["df"]
     Y_full_np = df.to_numpy() if hasattr(df, "to_numpy") else np.asarray(df)

--- a/mlsynth/utils/marex_helpers/orchestration.py
+++ b/mlsynth/utils/marex_helpers/orchestration.py
@@ -50,6 +50,8 @@ def solve_marex(
     alpha=0.05,
     max_combinations=1000,
     random_state=42,
+    unit_index=None,
+    time_index=None,
 ) -> MAREXResults:
     """Solve the MAREX design and return a frozen :class:`MAREXResults`.
 
@@ -70,7 +72,14 @@ def solve_marex(
 
     df = raw["df"]
     Y_full_np = df.to_numpy() if hasattr(df, "to_numpy") else np.asarray(df)
-    unit_labels = list(df.index) if hasattr(df, "index") else list(range(Y_full_np.shape[0]))
+    # Identity comes from the IndexSet (the single source of truth); fall back to
+    # the frame's own index only when a caller does not supply one.
+    if unit_index is not None:
+        unit_labels = list(unit_index.labels)
+    elif hasattr(df, "index"):
+        unit_labels = list(df.index)
+    else:
+        unit_labels = list(range(Y_full_np.shape[0]))
     w_opt, v_opt, z_opt = raw["w_opt"], raw["v_opt"], raw.get("z_opt")
     clusters_vec = raw["original_cluster_vector"]
     cluster_labels = raw["cluster_labels"]
@@ -194,7 +203,8 @@ def solve_marex(
         },
     )
     # The realized effect as a standardized EffectResult (the family adapter).
-    time_periods = (np.asarray(df.columns) if hasattr(df, "columns") else None)
+    time_periods = (np.asarray(time_index.labels) if time_index is not None
+                    else (np.asarray(df.columns) if hasattr(df, "columns") else None))
     intervention = (time_periods[T0_eff]
                     if time_periods is not None and T0_eff < time_periods.shape[0]
                     else None)

--- a/mlsynth/utils/marex_helpers/restrictions.py
+++ b/mlsynth/utils/marex_helpers/restrictions.py
@@ -1,0 +1,85 @@
+"""Geographic design restrictions for the MAREX MIP (Abadie & Zhao 2026).
+
+MAREX already carries most geographic structure natively: its ``cluster`` field
+is AZ's "region as a distinct experimental design", the per-cluster cardinality
+(``m_min`` / ``m_max``) is a stratum quota, ``costs`` / ``budget`` is AZ's cost
+bound, and the control synthetic ``v[.,k]`` is built only from cluster-``k``
+members, so donors are automatically same-region. This module adds the four
+remaining capabilities -- the same vocabulary SYNDES and GEOLIFT expose -- as
+linear constraints on the design variables:
+
+* ``to_be_treated``      -> ``sum_k z[j,k] = 1``  (force unit ``j`` treated)
+* ``not_to_be_treated`` /
+  ``size_col`` band       -> ``sum_k z[j,k] = 0``  (forbid treatment; stays donor)
+* ``adjacency`` /
+  ``spillover_threshold`` -> ``sum_k z[i,k] + sum_k z[j,k] <= 1`` (no two treated
+                            markets border each other)
+* ``exclude_bordering_donors`` -> within a cluster ``k``, ``v[j,k] <= 1 - z[i,k]``
+                            for every bordering pair ``(i,j)`` (a treated market's
+                            neighbours are dropped from its control pool)
+
+The index-level bundle is the shared, estimator-agnostic
+:class:`~mlsynth.utils.syndes_helpers.restrictions.DesignRestrictions`, built by
+the shared :func:`~mlsynth.utils.syndes_helpers.restrictions.build_restrictions`
+(which reuses the LEXSCM conflict graph and the GEOLIFT attribute/size helpers,
+all aligned to the unit ``IndexSet``). Only the *applier* differs from SYNDES,
+because MAREX's selection variable is the ``(N, K)`` matrix ``z`` and its control
+synthetic is per-cluster.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+# Shared, estimator-agnostic restriction infrastructure (the bundle + builder are
+# pure index/label machinery; only the applier below is MAREX-specific).
+from ..syndes_helpers.restrictions import (  # noqa: F401  (re-exported for callers)
+    DesignRestrictions,
+    build_restrictions,
+)
+
+
+def apply_restrictions_marex(z: Any, v: Any, M: np.ndarray,
+                             restrictions: DesignRestrictions) -> list:
+    """cvxpy constraints encoding ``restrictions`` on MAREX's ``z`` / ``v``.
+
+    Parameters
+    ----------
+    z : cvxpy.Variable
+        Binary selection matrix, shape ``(N, K)`` (``z[j,k]`` = unit ``j`` treated
+        in cluster ``k``). A unit's treated indicator is ``sum_k z[j,k]``.
+    v : cvxpy.Variable
+        Control-weight matrix, shape ``(N, K)``.
+    M : np.ndarray of bool
+        Unit-to-cluster membership mask, shape ``(N, K)``.
+    restrictions : DesignRestrictions
+        The index-level bundle (indices aligned to the unit ``IndexSet``).
+
+    Returns
+    -------
+    list of cvxpy.Constraint
+    """
+    import cvxpy as cp
+
+    if restrictions is None or restrictions.is_empty:
+        return []
+    N = M.shape[0]
+    cluster_of = {j: int(np.argmax(M[j])) for j in range(N)}   # each unit's cluster
+    cons: list = []
+    for j in restrictions.forced_in:
+        cons.append(cp.sum(z[j, :]) == 1)
+    for j in restrictions.forbidden:
+        cons.append(cp.sum(z[j, :]) == 0)
+    for i, j in restrictions.conflict_pairs:
+        cons.append(cp.sum(z[i, :]) + cp.sum(z[j, :]) <= 1)
+    # Donor (control) exclusion: "if i is treated, j may not be its donor". MAREX
+    # builds one control synthetic per cluster, so a donor for treated unit i is a
+    # control unit in i's cluster; the exclusion only binds when i and j share a
+    # cluster (otherwise v[j, cluster(i)] is already 0 by membership).
+    for i, j in restrictions.donor_exclusion:
+        ki = cluster_of[i]
+        if M[j, ki]:
+            cons.append(v[j, ki] <= 1 - z[i, ki])
+    return cons

--- a/mlsynth/utils/marex_helpers/setup.py
+++ b/mlsynth/utils/marex_helpers/setup.py
@@ -8,17 +8,28 @@ from typing import List, Optional, Tuple
 import numpy as np
 import pandas as pd
 
-from ..datautils import build_covariate_matrix
+from ..datautils import build_covariate_matrix, geoex_dataprep
+from ..fast_scm_helpers.structure import IndexSet
 
 
 @dataclass(frozen=True)
 class MAREXPanel:
-    """Prepared MAREX inputs."""
+    """Prepared MAREX inputs.
+
+    ``unit_index`` / ``time_index`` are the single source of truth for unit and
+    time identity (label <-> integer index). ``Y_full`` rows align to
+    ``unit_index.labels`` and its columns to ``time_index.labels``; the clusters
+    vector is in ``unit_index`` order. Every downstream consumer (optimizer,
+    orchestrator, restriction builder) indexes through these IndexSets rather
+    than re-deriving identity from a DataFrame.
+    """
 
     Y_full: pd.DataFrame          # units x time, indexed by unit label
     clusters: np.ndarray          # cluster label per unit, shape (N,)
     T0: int
     blank_periods: int
+    unit_index: IndexSet          # canonical unit identity (rows of Y_full)
+    time_index: IndexSet          # canonical time identity (columns of Y_full)
     covariates: Optional[np.ndarray] = None   # time-invariant predictors, (N, R)
     covariate_names: Tuple[str, ...] = ()     # column names aligned to ``covariates``
 
@@ -49,15 +60,24 @@ def prepare_marex_panel(
     to the combined ``[Y_fit; covariate_weight * Z]`` predictor matrix in
     :mod:`marex_helpers.optimization`) keeps its previous behaviour.
     """
+    # Canonical ingestion: geoex_dataprep enforces a strongly balanced panel and
+    # returns the wide outcome matrix + unit/time labels. We preserve the
+    # caller's unit order (df[unitid].unique()) so numerics are unchanged, then
+    # build the IndexSets that carry identity from here on.
+    prep = geoex_dataprep(df, unitid, time, outcome)
     unit_labels = df[unitid].unique()
+    Ywide = prep["Ywide"].reindex(columns=unit_labels)    # time x unit, caller order
+    Y_full = Ywide.T                                       # units x time
+    unit_index = IndexSet.from_labels(unit_labels)
+    time_index = IndexSet.from_labels(np.asarray(Ywide.index))
+
     if cluster is not None:
         clusters = (df.drop_duplicates(subset=[unitid]).set_index(unitid)[cluster]
                     .reindex(unit_labels).to_numpy())
     else:
         clusters = np.zeros(len(unit_labels), dtype=int)
 
-    Y_full = df.pivot(index=unitid, columns=time, values=outcome).reindex(unit_labels)
-    T_total = df[time].nunique()
+    T_total = int(prep["n_periods"])
     T0_eff = T0 if T0 is not None else T_total - 1
 
     cov: Optional[np.ndarray] = None
@@ -83,5 +103,6 @@ def prepare_marex_panel(
         )
 
     return MAREXPanel(Y_full=Y_full, clusters=clusters, T0=T0_eff,
-                      blank_periods=blanks, covariates=cov,
+                      blank_periods=blanks, unit_index=unit_index,
+                      time_index=time_index, covariates=cov,
                       covariate_names=tuple(covariates) if covariates else ())

--- a/mlsynth/utils/syndes_helpers/config.py
+++ b/mlsynth/utils/syndes_helpers/config.py
@@ -193,7 +193,14 @@ class SYNDESConfig(BaseMAREXConfig):
             "When given, SYNDES solves its design independently within each "
             "arm's units and returns SYNDESMultiArmResults (a dict of per-arm "
             "results); when None (default), a single SYNDESResults is "
-            "returned. K (if set) then applies per arm."
+            "returned. K (if set) then applies per arm. This is the SYNDES "
+            "analog of MAREX's `cluster` (a separate design per group, with "
+            "disjoint donor pools and K estimands); for one shared design that "
+            "merely covers every group, use the stratum quota (`stratum_col` + "
+            "`min_per_stratum`/`max_per_stratum`) instead. `arm` runs separate "
+            "solves, so it does not combine with the geographic restriction "
+            "fields -- loop a restricted SYNDES over each arm's sub-panel for "
+            "both."
         ),
     )
     power_weight: float = Field(


### PR DESCRIPTION
## Summary

Equips MAREX with the same geographic design vocabulary as SYNDES and GEOLIFT, on a refactored IndexSet foundation. Test-first throughout.

### Phase 1 — IndexSet + geoex_dataprep
MAREX derived unit/time identity ad hoc (`df[unitid].unique()`, `Y_full.index`, `df.columns`). `prepare_marex_panel` now ingests via the canonical `geoex_dataprep` (which enforces a strongly balanced panel) and carries `unit_index` / `time_index` IndexSets as the single source of truth, threaded through the optimizer and orchestrator. Unit order is preserved, so numerics are unchanged — all 116 existing MAREX tests stay green; the only behavioural change is balance enforcement (an unbalanced panel now raises a translated `MlsynthDataError`).

### Phase 2 — geographic restrictions
MAREX already had region-clustering, `m_min`/`m_max` quotas, cost/budget, and same-region donors natively (AZ p.13). This adds the rest as constraints on the MIP's `z`/`v`:
- `to_be_treated` / `not_to_be_treated`
- `adjacency` + `spillover_threshold` (no two treated markets border each other)
- `size_col` + `min/max_size`
- `exclude_bordering_donors` (within-cluster control exclusion)

Reuses the shared, estimator-agnostic `DesignRestrictions` / `build_restrictions` (same conflict-graph + size/attribute helpers, aligned to the unit IndexSet); only the applier is MAREX-specific. MIQP-only (rejected with `relaxed=True`); over-constrained designs raise a translated `MlsynthEstimationError`.

### Docs
A real-DMA gallery (CDC regions, grouped-factor sales, all four restrictions, every snippet run against the live geography), plus an "Across groups" disambiguation (cluster/arm vs. quotas vs. restrictions) in `syndes.rst`, `marex.rst`, and `choose.rst`, with field-docstring cross-references — `cluster` and `arm` are not obsolete and not special cases of the restrictions.

## Testing
New `test_marex_restrictions.py` (IndexSet refactor + applier emission + end-to-end enforcement of each restriction + config/failure + infeasibility), `restrictions.py` at 100% coverage; all 116 existing MAREX tests unchanged + result-contract conformance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_