### PR TITLE
PPSCM: accept a datetime time column (fix isfinite on Timestamp adoption times)

### DIFF
--- a/mlsynth/tests/test_ppscm.py
+++ b/mlsynth/tests/test_ppscm.py
@@ -66,6 +66,30 @@ def test_prepare_inputs(panel):
     assert inp.n_pre == 20                            # periods before last adoption (offset 20)
 
 
+def test_prepare_inputs_datetime_time():
+    """A datetime ``time`` column must not break the adoption-time check.
+
+    The adoption time of each treated unit is a ``pd.Timestamp`` when ``time`` is
+    datetime; the never-treated sentinel stays ``np.inf``. The treated/never-
+    treated split must come out identical to the integer-time panel.
+    """
+    df = _staggered_panel()
+    df["date"] = pd.to_datetime(df["year"].astype(str) + "-01-01")
+    inp = prepare_ppscm_inputs(df, outcome="y", treat="tr", unitid="unit", time="date")
+    assert isinstance(inp, PPSCMInputs)
+    assert np.isfinite(inp.trt).sum() == 3        # three treated cohorts
+    assert (~np.isfinite(inp.trt)).sum() == 8     # eight never-treated controls
+    assert inp.n_pre == 20
+
+
+def test_fit_with_datetime_time_runs():
+    """End-to-end PPSCM fit succeeds on a datetime ``time`` column."""
+    df = _staggered_panel()
+    df["date"] = pd.to_datetime(df["year"].astype(str) + "-01-01")
+    res = PPSCM(_cfg(df, time="date")).fit()
+    assert np.isfinite(res.effects.att)
+
+
 def test_fit_feff_two_way_keys_and_shape():
     rng = np.random.default_rng(0)
     Xy = rng.standard_normal((6, 8))

--- a/mlsynth/utils/ppscm_helpers/setup.py
+++ b/mlsynth/utils/ppscm_helpers/setup.py
@@ -14,6 +14,17 @@ from ...exceptions import MlsynthDataError
 from .structures import PPSCMInputs
 
 
+def _adopted(a) -> bool:
+    """True if ``a`` is an actual adoption time, False for the never-treated
+    sentinel ``np.inf``.
+
+    Adoption times are whatever the ``time`` column holds -- an integer/float
+    year or a ``pd.Timestamp`` -- so we cannot use ``np.isfinite`` (it rejects
+    datetimes). Only the never-treated units carry the float ``np.inf`` marker.
+    """
+    return not (isinstance(a, float) and np.isinf(a))
+
+
 def prepare_ppscm_inputs(df: pd.DataFrame, *, outcome: str, treat: str,
                          unitid: str, time: str) -> PPSCMInputs:
     t_vec = np.sort(pd.unique(df[time]))
@@ -23,14 +34,14 @@ def prepare_ppscm_inputs(df: pd.DataFrame, *, outcome: str, treat: str,
     for u, g in df.groupby(unitid):
         yrs = g.loc[g[treat] == 1, time]
         adopt[u] = yrs.min() if len(yrs) else np.inf
-    finite = [a for a in adopt.values() if np.isfinite(a)]
+    finite = [a for a in adopt.values() if _adopted(a)]
     if not finite:
         raise MlsynthDataError("PPSCM requires at least one treated unit.")
     if len(finite) == len(units):
         raise MlsynthDataError("PPSCM requires at least one never-treated (control) unit.")
 
     trt = np.array([
-        (int(np.where(t_vec == adopt[u])[0][0]) if np.isfinite(adopt[u]) else np.inf)
+        (int(np.where(t_vec == adopt[u])[0][0]) if _adopted(adopt[u]) else np.inf)
         for u in units
     ], dtype=float)
 


### PR DESCRIPTION
## Problem

`PPSCM(...).fit()` raises `MlsynthEstimationError` on any panel whose `time` column is a datetime:

```
PPSCM estimation failed: ufunc 'isfinite' not supported for the input types,
and the inputs could not be safely coerced to any supported types ...
```

`prepare_ppscm_inputs` derives each unit's adoption time as the min of its treated periods, then filters the never-treated sentinel with `np.isfinite(a)` (`ppscm_helpers/setup.py`). When `time` is datetime, the adoption time is a `pd.Timestamp` and `np.isfinite` rejects it. SDID on the identical panel works, so the failure is surprising and surfaces in real use (it came up building a staggered-adoption vaccine-mandate analysis on a monthly `Date` column).

## Fix

The `np.isfinite(adoption)` checks were really asking "is this unit treated?" — only never-treated units carry the float `np.inf` marker. Replace the two checks with a small `_adopted()` helper that treats `np.inf` as never-treated and any real time value (int, float, or `Timestamp`) as treated. No change to numeric-time behavior.

## Tests (test-first)

- `test_prepare_inputs_datetime_time` — the staggered panel with a datetime `time` column splits into the same 3 treated / 8 never-treated cohorts as the integer-time panel.
- `test_fit_with_datetime_time_runs` — end-to-end `PPSCM(...).fit()` succeeds and returns a finite ATT.

Both failed with the `isfinite` `TypeError` before the fix and pass after. Full PPSCM suite (18 tests) green; the new `_adopted` helper and both call sites are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_