### PR TITLE
SHC: add exact CWZ (2021) conformal inference as a selectable option

### DIFF
--- a/mlsynth/estimators/shc.py
+++ b/mlsynth/estimators/shc.py
@@ -95,6 +95,9 @@ class SHC:
         self.m: int = config.m
         self.use_augmented: bool = config.use_augmented
         self.bandwidth_grid = config.bandwidth_grid
+        self.inference_method: str = config.inference_method
+        self.permutation_scheme: str = config.permutation_scheme
+        self.num_permutations = config.num_permutations
 
         self.display_graphs: bool = config.display_graphs
         self.save: Union[bool, str] = config.save
@@ -127,6 +130,9 @@ class SHC:
              window_time, fit_diagnostics) = summarize_effects(inputs, design)
             inference = run_conformal_inference(
                 inputs, design, observed, counterfactual,
+                method=self.inference_method,
+                permutation_scheme=self.permutation_scheme,
+                num_permutations=self.num_permutations,
             )
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/tests/test_shc_cwz_inference.py
+++ b/mlsynth/tests/test_shc_cwz_inference.py
@@ -1,0 +1,215 @@
+"""Tests for the exact Chernozhukov-Wuthrich-Zhu (2021) conformal test in SHC.
+
+The function under test is
+:func:`mlsynth.utils.shc_helpers.inference.cwz_conformal_test`, the *exact*
+permutation conformal inference of CWZ (2021) -- as distinct from the
+Chen-Yang-Yang (2024, footnote 21) with-replacement residual bootstrap already
+covered in ``test_shc_inference.py``.
+
+Key facts pinned here (CWZ 2021, Definitions 1-2, Figure 2):
+
+* test statistic ``S_q(u) = ( (1/sqrt(n)) * sum_{post} |u_t|^q )^{1/q}`` with
+  ``q = 1`` the default;
+* the reference distribution comes from *permutations* of the full residual
+  vector ``u = [pre, post]`` (length ``T = T0 + n``), evaluated on the trailing
+  ``n`` positions -- NOT a bootstrap from the pre-period pool;
+* ``scheme="moving_block"`` enumerates the ``T`` cyclic shifts ``Pi_->`` (exact
+  under stationary weak dependence); the identity shift is included so the
+  attainable p-values are multiples of ``1/T``;
+* ``scheme="iid"`` samples random permutations ``Pi_all`` (exact under
+  exchangeability), always including the identity so ``p >= 1/|Pi|``.
+
+Assertions are structural / hand-computable, not magic numbers from output.
+"""
+
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.shc_helpers.inference import cwz_conformal_test
+
+
+# --------------------------------------------------------------------------
+# success path -- structure
+# --------------------------------------------------------------------------
+def test_keys_and_ranges():
+    rng = np.random.default_rng(0)
+    pre = rng.standard_normal(40)
+    post = rng.standard_normal(5)
+    res = cwz_conformal_test(pre, post, scheme="moving_block")
+    for k in ("test_statistic", "p_value", "critical_values", "reject",
+              "null_distribution", "num_permutations", "scheme", "q", "levels"):
+        assert k in res
+    assert 0.0 <= res["p_value"] <= 1.0
+    assert np.isfinite(res["test_statistic"])
+    assert res["scheme"] == "moving_block"
+    assert set(res["critical_values"]) == set(res["reject"]) == {0.01, 0.05, 0.10}
+
+
+def test_statistic_is_cwz_s1():
+    # S_1 = (1/sqrt(n)) * sum |post|.
+    pre = np.zeros(6)
+    post = np.array([3.0, -4.0])
+    res = cwz_conformal_test(pre, post, q=1.0, scheme="moving_block")
+    assert res["test_statistic"] == pytest.approx((3.0 + 4.0) / np.sqrt(2))
+
+
+def test_statistic_general_q():
+    pre = np.zeros(6)
+    post = np.array([3.0, -4.0])
+    res = cwz_conformal_test(pre, post, q=2.0, scheme="moving_block")
+    expected = (np.sqrt((9.0 + 16.0) / np.sqrt(2)))  # (sum|.|^2 / sqrt(n))^{1/2}
+    assert res["test_statistic"] == pytest.approx(expected)
+
+
+# --------------------------------------------------------------------------
+# moving block -- exact, hand-computable
+# --------------------------------------------------------------------------
+def test_moving_block_enumerates_T_shifts():
+    pre = np.zeros(4)
+    post = np.array([1.0])
+    res = cwz_conformal_test(pre, post, scheme="moving_block")
+    # T = T0 + n = 4 + 1 = 5 cyclic shifts.
+    assert res["num_permutations"] == 5
+    assert res["null_distribution"].shape == (5,)
+
+
+def test_moving_block_single_post_pvalue_is_one_over_T():
+    # u = [0,0,0,0,10]; the trailing-1 block over the 5 cyclic shifts takes each
+    # element once, so only the identity hits |10|. p = 1/5.
+    pre = np.zeros(4)
+    post = np.array([10.0])
+    res = cwz_conformal_test(pre, post, scheme="moving_block")
+    assert res["p_value"] == pytest.approx(0.2)
+    assert res["test_statistic"] == pytest.approx(10.0)
+
+
+def test_moving_block_two_post_pvalue_hand_value():
+    # u = [0,0,0,6,8], n = 2. Cyclic trailing-2 blocks:
+    #   [6,8]->14, [8,0]->8, [0,0]->0, [0,0]->0, [0,6]->6  (all /sqrt(2)).
+    # Observed 14/sqrt(2) is the unique max -> p = 1/5.
+    pre = np.zeros(3)
+    post = np.array([6.0, 8.0])
+    res = cwz_conformal_test(pre, post, scheme="moving_block")
+    assert res["p_value"] == pytest.approx(0.2)
+    assert res["test_statistic"] == pytest.approx(14.0 / np.sqrt(2))
+
+
+def test_moving_block_identity_is_included():
+    # The observed statistic must appear in the null (j=0 shift), so the
+    # smallest attainable p-value is exactly 1/T.
+    pre = np.zeros(9)
+    post = np.array([100.0])
+    res = cwz_conformal_test(pre, post, scheme="moving_block")
+    assert res["p_value"] == pytest.approx(1.0 / 10.0)
+
+
+def test_moving_block_is_deterministic_without_seed_dependence():
+    # Moving block enumerates a fixed set; two calls match regardless of seed.
+    pre = np.linspace(-1, 1, 30)
+    post = np.array([0.3, -0.2, 0.5])
+    a = cwz_conformal_test(pre, post, scheme="moving_block", random_state=1)
+    b = cwz_conformal_test(pre, post, scheme="moving_block", random_state=999)
+    assert a["p_value"] == b["p_value"]
+    assert np.allclose(a["null_distribution"], b["null_distribution"])
+
+
+# --------------------------------------------------------------------------
+# iid permutations
+# --------------------------------------------------------------------------
+def test_iid_includes_identity_and_count():
+    rng = np.random.default_rng(2)
+    pre = rng.standard_normal(50)
+    post = rng.standard_normal(4)
+    res = cwz_conformal_test(pre, post, scheme="iid", num_permutations=200,
+                             random_state=0)
+    assert res["num_permutations"] == 200
+    assert res["null_distribution"].shape == (200,)
+    # identity is in the set, so p >= 1/|Pi|.
+    assert res["p_value"] >= 1.0 / 200 - 1e-12
+
+
+def test_iid_determinism():
+    rng = np.random.default_rng(3)
+    pre = rng.standard_normal(60)
+    post = rng.standard_normal(5)
+    a = cwz_conformal_test(pre, post, scheme="iid", num_permutations=300, random_state=7)
+    b = cwz_conformal_test(pre, post, scheme="iid", num_permutations=300, random_state=7)
+    assert a["p_value"] == b["p_value"]
+    assert np.allclose(a["null_distribution"], b["null_distribution"])
+
+
+def test_iid_default_num_permutations():
+    rng = np.random.default_rng(4)
+    pre = rng.standard_normal(40)
+    post = rng.standard_normal(3)
+    res = cwz_conformal_test(pre, post, scheme="iid")
+    assert res["num_permutations"] >= 1000  # sensible default
+
+
+# --------------------------------------------------------------------------
+# power / behaviour
+# --------------------------------------------------------------------------
+def test_large_effect_rejects_small_effect_does_not():
+    rng = np.random.default_rng(5)
+    pre = rng.standard_normal(60)
+    big = np.array([8.0, 9.0, 7.5])           # clear outliers vs N(0,1) pre
+    small = rng.standard_normal(3) * 0.5      # typical of the pre pool
+    p_big = cwz_conformal_test(pre, big, scheme="moving_block")["p_value"]
+    p_small = cwz_conformal_test(pre, small, scheme="moving_block")["p_value"]
+    assert p_big < p_small
+    assert p_big <= 0.05
+    assert p_small > 0.10
+
+
+def test_pvalue_monotone_in_effect_size():
+    rng = np.random.default_rng(6)
+    pre = rng.standard_normal(80)
+    ps = [cwz_conformal_test(pre, np.full(3, c), scheme="moving_block")["p_value"]
+          for c in (0.0, 1.0, 3.0, 6.0)]
+    assert ps[0] >= ps[1] >= ps[2] >= ps[3]
+
+
+def test_reject_consistent_with_critical_values():
+    rng = np.random.default_rng(7)
+    pre = rng.standard_normal(50)
+    post = np.array([5.0, 6.0])
+    res = cwz_conformal_test(pre, post, scheme="moving_block")
+    for lvl, cv in res["critical_values"].items():
+        assert res["reject"][lvl] == (res["test_statistic"] > cv)
+
+
+# --------------------------------------------------------------------------
+# error paths
+# --------------------------------------------------------------------------
+def test_empty_pre_raises():
+    with pytest.raises(MlsynthDataError):
+        cwz_conformal_test(np.array([]), np.array([1.0]))
+
+
+def test_empty_post_raises():
+    with pytest.raises(MlsynthDataError):
+        cwz_conformal_test(np.array([1.0, 2.0]), np.array([]))
+
+
+@pytest.mark.parametrize("bad_q", [0.0, -1.0])
+def test_nonpositive_q_raises(bad_q):
+    with pytest.raises(MlsynthConfigError):
+        cwz_conformal_test(np.zeros(5), np.array([1.0]), q=bad_q)
+
+
+def test_bad_scheme_raises():
+    with pytest.raises(MlsynthConfigError):
+        cwz_conformal_test(np.zeros(5), np.array([1.0]), scheme="bogus")
+
+
+def test_bad_num_permutations_raises():
+    with pytest.raises(MlsynthConfigError):
+        cwz_conformal_test(np.zeros(5), np.array([1.0]), scheme="iid",
+                           num_permutations=1)
+
+
+def test_accepts_list_and_2d_inputs():
+    res = cwz_conformal_test([0.0, 0.0, 0.0], [[1.0], [2.0]], scheme="moving_block")
+    assert np.isfinite(res["test_statistic"])
+    assert res["num_permutations"] == 5

--- a/mlsynth/tests/test_shc_cwz_integration.py
+++ b/mlsynth/tests/test_shc_cwz_integration.py
@@ -1,0 +1,87 @@
+"""Config + end-to-end tests for selecting exact CWZ inference in SHC.
+
+Pins the new ``SHCConfig`` knobs (``inference_method``, ``permutation_scheme``,
+``num_permutations``) and that ``SHC.fit()`` routes through the exact
+permutation test when asked, while the default stays the CYY bootstrap (backward
+compatible).
+"""
+
+import numpy as np
+import pytest
+
+from mlsynth import SHC
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.shc_helpers import simulate_shc_panel
+
+
+def _panel(seed=0):
+    df, _ = simulate_shc_panel(
+        m=10, h=2, n=8, P=10, sigma=0.1, w_f=(1, 0), regular=True, seed=seed
+    )
+    return df
+
+
+def _base(df, **extra):
+    cfg = {
+        "df": df, "outcome": "y", "treat": "treated", "unitid": "unit",
+        "time": "time", "m": 10, "display_graphs": False,
+    }
+    cfg.update(extra)
+    return cfg
+
+
+# --------------------------------------------------------------------------
+# config validation
+# --------------------------------------------------------------------------
+def test_default_inference_is_bootstrap():
+    res = SHC(_base(_panel())).fit()
+    assert res.inference.method == "conformal_permutation"
+
+
+def test_exact_moving_block_runs_and_labels_method():
+    res = SHC(_base(_panel(), inference_method="exact",
+                    permutation_scheme="moving_block")).fit()
+    assert "exact" in res.inference.method
+    assert "moving_block" in res.inference.method
+    assert 0.0 <= res.inference.p_value <= 1.0
+    assert np.isfinite(res.inference_detail.test_statistic)
+
+
+def test_exact_iid_runs():
+    res = SHC(_base(_panel(), inference_method="exact",
+                    permutation_scheme="iid", num_permutations=500)).fit()
+    assert "iid" in res.inference.method
+    assert 0.0 <= res.inference.p_value <= 1.0
+
+
+def test_bad_inference_method_raises():
+    with pytest.raises(MlsynthConfigError):
+        SHC(_base(_panel(), inference_method="nope"))
+
+
+def test_bad_permutation_scheme_raises():
+    with pytest.raises(MlsynthConfigError):
+        SHC(_base(_panel(), permutation_scheme="nope"))
+
+
+def test_bad_num_permutations_raises():
+    with pytest.raises(MlsynthConfigError):
+        SHC(_base(_panel(), inference_method="exact",
+                  permutation_scheme="iid", num_permutations=1))
+
+
+def test_extra_field_still_forbidden():
+    # extra="forbid" on the config must reject unknown kwargs.
+    with pytest.raises(Exception):
+        SHC(_base(_panel(), not_a_real_field=3))
+
+
+def test_moving_block_pvalue_is_multiple_of_one_over_T():
+    # n + T0 cyclic shifts -> p-value lands on a 1/T grid.
+    df = _panel()
+    res = SHC(_base(df, inference_method="exact",
+                    permutation_scheme="moving_block")).fit()
+    null = res.inference_detail.null_distribution
+    T = null.shape[0]
+    grid_val = round(res.inference.p_value * T)
+    assert res.inference.p_value == pytest.approx(grid_val / T)

--- a/mlsynth/tests/test_shc_inference.py
+++ b/mlsynth/tests/test_shc_inference.py
@@ -254,6 +254,55 @@ def test_run_conformal_inference_returns_inference_object():
     assert res.num_resamples == 200
 
 
+def test_run_conformal_inference_exact_method_moving_block():
+    T, T0, m = 12, 9, 3
+    n = T - T0
+    inputs = _make_inputs(T, T0, m)
+    design = _make_design(T0, m, n)
+    rng = np.random.default_rng(1)
+    observed = rng.standard_normal(m + n)
+    counterfactual = observed - 0.2
+
+    res = run_conformal_inference(
+        inputs, design, observed, counterfactual,
+        method="exact", permutation_scheme="moving_block",
+    )
+    assert isinstance(res, SHCInference)
+    assert res.method == "conformal_exact_moving_block"
+    # moving block enumerates T = T0 + n cyclic shifts.
+    assert res.null_distribution.shape == (T0 + n,)
+    assert res.num_resamples == T0 + n
+    assert 0.0 <= res.p_value <= 1.0
+
+
+def test_run_conformal_inference_exact_method_iid():
+    T, T0, m = 12, 9, 3
+    n = T - T0
+    inputs = _make_inputs(T, T0, m)
+    design = _make_design(T0, m, n)
+    rng = np.random.default_rng(2)
+    observed = rng.standard_normal(m + n)
+    counterfactual = observed - 0.2
+
+    res = run_conformal_inference(
+        inputs, design, observed, counterfactual,
+        method="exact", permutation_scheme="iid", num_permutations=250,
+    )
+    assert res.method == "conformal_exact_iid"
+    assert res.num_resamples == 250
+
+
+def test_run_conformal_inference_bad_method_raises():
+    inputs = _make_inputs()
+    design = _make_design()
+    observed = np.zeros(6)
+    counterfactual = np.zeros(6)
+    with pytest.raises(MlsynthConfigError):
+        run_conformal_inference(
+            inputs, design, observed, counterfactual, method="bogus",
+        )
+
+
 def test_run_conformal_inference_custom_miscoverage_rate():
     T, T0, m = 12, 9, 3
     n = T - T0

--- a/mlsynth/utils/shc_helpers/config.py
+++ b/mlsynth/utils/shc_helpers/config.py
@@ -16,6 +16,30 @@ class SHCConfig(BaseEstimatorConfig):
     m: int = Field(default=1, description="Length of the evaluation window.")
     bandwidth_grid: Optional[List[float]] = Field(default=None, description="Bandwidth grid for LOOCV.")
     use_augmented: bool = Field(default=False, description="Use Augmented SHC (ASHC) variant.")
+    inference_method: str = Field(
+        default="bootstrap",
+        description=(
+            "Conformal inference variant: 'bootstrap' (Chen-Yang-Yang 2024 "
+            "with-replacement residual resampling, the default) or 'exact' "
+            "(Chernozhukov-Wuthrich-Zhu 2021 permutation test)."
+        ),
+    )
+    permutation_scheme: str = Field(
+        default="moving_block",
+        description=(
+            "Permutation family for inference_method='exact': 'moving_block' "
+            "(cyclic shifts, for stationary weakly-dependent errors) or 'iid' "
+            "(random permutations, exact under exchangeability)."
+        ),
+    )
+    num_permutations: Optional[int] = Field(
+        default=None,
+        description=(
+            "Permutation count for inference_method='exact' with "
+            "permutation_scheme='iid' (>= 2). Ignored for 'moving_block' "
+            "(always T). Defaults to 1000 for 'iid'."
+        ),
+    )
 
     @model_validator(mode="after")
     def check_shc_params(self) -> "SHCConfig":
@@ -32,5 +56,16 @@ class SHCConfig(BaseEstimatorConfig):
                 raise MlsynthConfigError("All elements in 'bandwidth_grid' must be numeric.")
             if not all(h > 0 for h in self.bandwidth_grid):
                 raise MlsynthConfigError("All bandwidth values must be strictly positive.")
+
+        if self.inference_method not in ("bootstrap", "exact"):
+            raise MlsynthConfigError(
+                "'inference_method' must be 'bootstrap' or 'exact'."
+            )
+        if self.permutation_scheme not in ("moving_block", "iid"):
+            raise MlsynthConfigError(
+                "'permutation_scheme' must be 'moving_block' or 'iid'."
+            )
+        if self.num_permutations is not None and self.num_permutations < 2:
+            raise MlsynthConfigError("'num_permutations' must be >= 2.")
 
         return self

--- a/mlsynth/utils/shc_helpers/inference.py
+++ b/mlsynth/utils/shc_helpers/inference.py
@@ -245,12 +245,147 @@ def shc_conformal_test(
 
 
 
+def cwz_conformal_test(
+    pre_intervention_residuals: np.ndarray,
+    post_intervention_residuals: np.ndarray,
+    q: float = 1.0,
+    scheme: str = "moving_block",
+    num_permutations: int | None = None,
+    levels: Tuple[float, ...] = (0.01, 0.05, 0.10),
+    random_state: int = 0,
+) -> dict:
+    r"""Exact permutation conformal test of Chernozhukov, Wuthrich & Zhu (2021).
+
+    This is the *exact* conformal inference of CWZ (2021), as opposed to the
+    Chen-Yang-Yang (2024, footnote 21) with-replacement residual bootstrap in
+    :func:`shc_conformal_test`. It tests the sharp null
+    :math:`H_0: \delta_t = 0` over the post window using the CWZ statistic
+    (their Definition 1)
+
+    .. math::
+
+       S_q(u) = \Bigl( \tfrac{1}{\sqrt{n}}
+                 \sum_{t = T_o + 1}^{T_o + n} |u_t|^q \Bigr)^{1/q},
+
+    evaluated on the trailing ``n`` positions of the full residual vector
+    :math:`u = (\hat\varepsilon_1^0, \dots, \hat\varepsilon_{T_o}^0,
+    \hat\delta_1, \dots, \hat\delta_n)` of length :math:`T = T_o + n`. The
+    reference distribution is obtained by *permuting* ``u`` (CWZ Definition 2,
+    Figure 2), not by resampling from the pre-period pool:
+
+    * ``scheme="moving_block"`` -- the :math:`T` cyclic shifts
+      :math:`\Pi_{\rightarrow}` (:math:`\pi_j(i) = i + j \bmod T`), valid under
+      stationary weak dependence. The set is fully enumerated, so the test is
+      deterministic and its p-values lie on the :math:`1/T` grid.
+    * ``scheme="iid"`` -- random permutations from :math:`\Pi_{\mathrm{all}}`,
+      exact under exchangeability; ``num_permutations`` are drawn (the identity
+      is always included so :math:`\hat p \ge 1/|\Pi|`).
+
+    Parameters
+    ----------
+    pre_intervention_residuals : np.ndarray
+        Pre-period residuals :math:`\hat\varepsilon_t^0`, shape ``(T_o,)``.
+    post_intervention_residuals : np.ndarray
+        Post-period residuals (estimated gaps), shape ``(n,)``.
+    q : float, optional
+        Norm exponent of the test statistic. Default ``1.0`` (CWZ's :math:`S_1`,
+        which matches the bootstrap statistic in :func:`shc_conformal_test`).
+    scheme : {"moving_block", "iid"}, optional
+        Permutation family. Default ``"moving_block"``.
+    num_permutations : int or None, optional
+        Number of permutations for ``scheme="iid"`` (>= 2). Ignored for
+        ``"moving_block"`` (always ``T``). Defaults to ``1000`` for ``"iid"``.
+    levels : tuple of float, optional
+        Significance levels for critical values / reject decisions.
+    random_state : int, optional
+        Seed for the ``"iid"`` permutation RNG (unused for ``"moving_block"``).
+
+    Returns
+    -------
+    dict
+        Keys ``test_statistic``, ``p_value`` (:math:`\Pr(S^* \ge S)`),
+        ``critical_values``, ``reject``, ``null_distribution``,
+        ``num_permutations``, ``scheme``, ``q``, ``levels``.
+
+    Raises
+    ------
+    MlsynthDataError
+        If either residual array is empty.
+    MlsynthConfigError
+        If ``q <= 0``, ``scheme`` is unknown, or ``num_permutations < 2``.
+    """
+    pre = np.asarray(pre_intervention_residuals, dtype=float).ravel()
+    post = np.asarray(post_intervention_residuals, dtype=float).ravel()
+    if pre.size == 0:
+        raise MlsynthDataError("pre_intervention_residuals cannot be empty.")
+    if post.size == 0:
+        raise MlsynthDataError("post_intervention_residuals cannot be empty.")
+    if not q > 0:
+        raise MlsynthConfigError("q must be positive.")
+    if scheme not in ("moving_block", "iid"):
+        raise MlsynthConfigError(
+            f"scheme must be 'moving_block' or 'iid', got {scheme!r}."
+        )
+
+    n = post.size
+    T0 = pre.size
+    u = np.concatenate([pre, post])           # full residual vector, length T
+    T = u.size
+    inv_sqrt_n = 1.0 / np.sqrt(n)
+
+    def stat(block: np.ndarray) -> float:
+        return float((inv_sqrt_n * np.sum(np.abs(block) ** q)) ** (1.0 / q))
+
+    test_statistic = stat(post)
+
+    if scheme == "moving_block":
+        # The T cyclic shifts; trailing-n block of np.roll(u, -j) for j=0..T-1.
+        # j = 0 is the identity (the observed statistic), so it is included.
+        null_distribution = np.array(
+            [stat(np.roll(u, -j)[T0:]) for j in range(T)], dtype=float
+        )
+        num_permutations = T
+    else:  # scheme == "iid"
+        if num_permutations is None:
+            num_permutations = 1000
+        if num_permutations < 2:
+            raise MlsynthConfigError("num_permutations must be >= 2 for 'iid'.")
+        rng = np.random.default_rng(random_state)
+        stats = np.empty(num_permutations, dtype=float)
+        stats[0] = test_statistic                     # identity always included
+        for i in range(1, num_permutations):
+            stats[i] = stat(rng.permutation(u)[T0:])
+        null_distribution = stats
+
+    p_value = float(np.mean(null_distribution >= test_statistic))
+    critical_values = {
+        lvl: float(np.quantile(null_distribution, 1.0 - lvl)) for lvl in levels
+    }
+    reject = {lvl: bool(test_statistic > critical_values[lvl]) for lvl in levels}
+
+    return {
+        "test_statistic": test_statistic,
+        "p_value": p_value,
+        "critical_values": critical_values,
+        "reject": reject,
+        "null_distribution": null_distribution,
+        "num_permutations": int(num_permutations),
+        "scheme": scheme,
+        "q": float(q),
+        "levels": tuple(levels),
+    }
+
+
 def run_conformal_inference(
     inputs: SHCInputs,
     design: SHCDesign,
     observed: np.ndarray,
     counterfactual: np.ndarray,
     *,
+    method: str = "bootstrap",
+    permutation_scheme: str = "moving_block",
+    num_permutations: int | None = None,
+    q: float = 1.0,
     miscoverage_rate: float = 0.10,
     num_resamples: int = 1000,
     levels: Sequence[float] = (0.01, 0.05, 0.10),
@@ -266,10 +401,26 @@ def run_conformal_inference(
         Fitted design (supplies ``latent_pre`` for the pre-period residuals).
     observed, counterfactual : np.ndarray
         Observed and SHC series over the ``m + n`` block window.
+    method : {"bootstrap", "exact"}
+        ``"bootstrap"`` (default) is the Chen-Yang-Yang (2024) with-replacement
+        residual bootstrap (:func:`shc_conformal_test`); ``"exact"`` is the
+        Chernozhukov-Wuthrich-Zhu (2021) permutation test
+        (:func:`cwz_conformal_test`).
+    permutation_scheme : {"moving_block", "iid"}
+        Permutation family for ``method="exact"``.
+    num_permutations : int or None
+        Permutation count for ``method="exact"`` with ``permutation_scheme="iid"``.
+    q : float
+        Norm exponent of the exact-test statistic.
     miscoverage_rate : float
         ``1 - coverage`` for the Andrews-Genton bands (0.10 -> 90%).
     num_resamples, levels, random_state
-        Forwarded to :func:`shc_conformal_test`.
+        Forwarded to the selected test.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``method`` is not ``"bootstrap"`` or ``"exact"``.
     """
     m = inputs.m
     T0 = inputs.T0
@@ -279,13 +430,32 @@ def run_conformal_inference(
     pre_residuals = inputs.y[:T0] - np.asarray(design.latent_pre).ravel()
     post_residuals = observed[m:] - counterfactual[m:]
 
-    test = shc_conformal_test(
-        pre_intervention_residuals=pre_residuals,
-        post_intervention_residuals=post_residuals,
-        num_resamples=num_resamples,
-        levels=tuple(levels),
-        random_state=random_state,
-    )
+    if method == "bootstrap":
+        test = shc_conformal_test(
+            pre_intervention_residuals=pre_residuals,
+            post_intervention_residuals=post_residuals,
+            num_resamples=num_resamples,
+            levels=tuple(levels),
+            random_state=random_state,
+        )
+        method_label = "conformal_permutation"
+        n_draws = test["num_resamples"]
+    elif method == "exact":
+        test = cwz_conformal_test(
+            pre_intervention_residuals=pre_residuals,
+            post_intervention_residuals=post_residuals,
+            q=q,
+            scheme=permutation_scheme,
+            num_permutations=num_permutations,
+            levels=tuple(levels),
+            random_state=random_state,
+        )
+        method_label = f"conformal_exact_{test['scheme']}"
+        n_draws = test["num_permutations"]
+    else:
+        raise MlsynthConfigError(
+            f"method must be 'bootstrap' or 'exact', got {method!r}."
+        )
 
     lower, upper = ag_conformal(
         actual_outcomes_pre_treatment=observed[:m],
@@ -296,12 +466,12 @@ def run_conformal_inference(
     )
 
     return SHCInference(
-        method="conformal_permutation",
+        method=method_label,
         test_statistic=test["test_statistic"],
         p_value=test["p_value"],
         critical_values=test["critical_values"],
         reject=test["reject"],
-        num_resamples=test["num_resamples"],
+        num_resamples=n_draws,
         null_distribution=test["null_distribution"],
         conformal_lower=lower[m:],
         conformal_upper=upper[m:],


### PR DESCRIPTION
## Summary

SHC's inference was the Chen–Yang–Yang (2024, footnote 21) with-replacement residual *bootstrap*. This adds the **exact** permutation conformal test of Chernozhukov, Wüthrich & Zhu (2021) as a selectable option, so SHC can report exact finite-sample p-values rather than a resampling approximation.

### What changed
- **`cwz_conformal_test()`** in `shc_helpers/inference.py` — CWZ's $S_q$ statistic (default $q=1$, matching the bootstrap statistic), with the reference distribution built from *permutations of the full residual vector* evaluated on the trailing $n$ positions, in two schemes:
  - `moving_block` ($\Pi_\rightarrow$) — the $T$ cyclic shifts, valid under stationary weak dependence; fully enumerated, so p-values land on the $1/T$ grid.
  - `iid` ($\Pi_{\mathrm{all}}$) — random permutations, exact under exchangeability; the identity is always included so $\hat p \ge 1/|\Pi|$.
- **`run_conformal_inference()`** now dispatches between `method="bootstrap"` (default — backward compatible) and `method="exact"`.
- **`SHCConfig`** gains `inference_method` (`"bootstrap"`/`"exact"`), `permutation_scheme` (`"moving_block"`/`"iid"`), and `num_permutations`, all validated (`extra="forbid"` preserved).

### Tests (test-first)
- `test_shc_cwz_inference.py` — statistic forms ($S_1$, general $q$), hand-computable moving-block p-values, iid determinism, power/monotonicity, and error paths.
- `test_shc_cwz_integration.py` — config validation + end-to-end routing through `SHC.fit()`.
- Added `run_conformal_inference` dispatch + failure tests to `test_shc_inference.py`.

New inference code is at 100% line coverage; the full SHC + result-contract suites pass with no regression. Default behavior is unchanged (bootstrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_