### PR TITLE
Drop screenot/ecos deps; route SBC simplex solve through bespoke QP

### DIFF
--- a/mlsynth/tests/test_sbc.py
+++ b/mlsynth/tests/test_sbc.py
@@ -326,6 +326,40 @@ class TestSolveSBCWeights:
         assert w.shape == (4,)
         assert isinstance(b, float)
 
+    def test_simplex_matches_cvxpy_reference(self):
+        # The simplex solve now runs through the in-house FISTA QP
+        # (bilevel.simplex.simplex_lstsq) rather than cvxpy. Guard against
+        # drift by checking it against a direct cvxpy solve of the same
+        # program: min ||ct - cd w||^2 s.t. w >= 0, sum(w) = 1.
+        import cvxpy as cp
+
+        rng = np.random.default_rng(7)
+        ct = rng.standard_normal(40)
+        cd = rng.standard_normal((40, 5))
+        w, _ = solve_sbc_weights(ct, cd, weights_mode="simplex")
+
+        wv = cp.Variable(5, nonneg=True)
+        prob = cp.Problem(
+            cp.Minimize(cp.sum_squares(ct - cd @ wv)), [cp.sum(wv) == 1]
+        )
+        prob.solve(solver=cp.CLARABEL)
+        w_ref = np.asarray(wv.value, dtype=float)
+
+        # Objective values should agree even if the argmin is non-unique.
+        obj = float(np.sum((ct - cd @ w) ** 2))
+        obj_ref = float(np.sum((ct - cd @ w_ref) ** 2))
+        assert abs(obj - obj_ref) < 1e-4
+        np.testing.assert_allclose(w, w_ref, atol=1e-3)
+
+    def test_simplex_single_donor(self):
+        # Degenerate one-donor case: the only feasible weight is 1.0.
+        ct = np.arange(10, dtype=float)
+        cd = (2.0 * ct).reshape(-1, 1)
+        w, b = solve_sbc_weights(ct, cd, weights_mode="simplex")
+        assert w.shape == (1,)
+        np.testing.assert_allclose(w, [1.0])
+        assert b is None
+
     def test_unknown_mode_rejected(self):
         with pytest.raises(MlsynthEstimationError):
             solve_sbc_weights(np.zeros(5), np.zeros((5, 2)),

--- a/mlsynth/utils/sbc_helpers/synthetic.py
+++ b/mlsynth/utils/sbc_helpers/synthetic.py
@@ -15,10 +15,10 @@ from __future__ import annotations
 
 from typing import Optional, Tuple
 
-import cvxpy as cp
 import numpy as np
 
 from ...exceptions import MlsynthEstimationError
+from ..bilevel.simplex import simplex_lstsq
 
 
 def solve_sbc_weights(
@@ -69,25 +69,13 @@ def solve_sbc_weights(
         )
 
     if weights_mode == "simplex":
-        w = cp.Variable(n_donors, nonneg=True)
-        problem = cp.Problem(
-            cp.Minimize(cp.sum_squares(cycles_treated - cycles_donors @ w)),
-            [cp.sum(w) == 1],
-        )
-        # OSQP first (fast, and the historical default); fall back to more
-        # robust conic solvers when it stalls on large-magnitude cycles.
-        for solver in (cp.OSQP, cp.CLARABEL, cp.ECOS, cp.SCS):
-            try:
-                problem.solve(solver=solver, verbose=False)
-            except (cp.error.SolverError, Exception):
-                continue
-            if w.value is not None and problem.status in (
-                "optimal", "optimal_inaccurate"
-            ):
-                return np.asarray(w.value, dtype=float), None
-        raise MlsynthEstimationError(
-            "Simplex SCM on cycles failed to converge with all solvers."
-        )
+        # Eq. (3) is a simplex-constrained least squares
+        #   argmin_w ||cycles_treated - cycles_donors w||^2
+        #   s.t.  w >= 0,  sum(w) = 1.
+        # Solved in-house with the accelerated projected-gradient (FISTA)
+        # primitive, avoiding any external QP/conic solver dependency.
+        w = simplex_lstsq(cycles_donors, cycles_treated)
+        return np.asarray(w, dtype=float), None
 
     # Unrestricted: closed-form OLS with intercept.
     X = np.column_stack([np.ones(T_eff), cycles_donors])

--- a/mlsynth/utils/vanillasc_helpers/scpi.py
+++ b/mlsynth/utils/vanillasc_helpers/scpi.py
@@ -282,7 +282,7 @@ def scpi_intervals(
     hi = np.full((sims, n_rows), np.nan)   # max-branch  p'(w - x)
 
     def _solve(prob):
-        for solver in (cp.ECOS, cp.CLARABEL):
+        for solver in (cp.CLARABEL,):
             try:
                 prob.solve(solver=solver, warm_start=True)
                 if prob.status in ("optimal", "optimal_inaccurate") and x.value is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,6 @@ dependencies = [
     "cvxpy>=1.4.0",
     "pydantic>=2.0.0",
     "pyarrow>=14.0.0",
-    "screenot",
-    "ecos",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,8 @@ matplotlib>=3.7.0
 scipy>=1.10.0
 scikit-learn>=1.3.0
 scikit-optimize>=0.9.0
-cvxpy>=1.4.0  # Includes ECOS_BB by default
+cvxpy>=1.4.0  # bundles CLARABEL/OSQP/SCS solvers
 pyscipopt>=4.4.0  # For SCIP as fallback
-screenot
 statsmodels>=0.14.0
 pydantic>=2.0.0
-ecos
 pyarrow>=14.0.0  # read basedata/*.parquet benchmark assets


### PR DESCRIPTION
## What

Trims two unnecessary core dependencies and removes the now-inert `cp.ECOS` references they backed.

- `screenot` was never imported anywhere in the repo.
- `ecos` was only ever reachable through `cp.ECOS` inside two cvxpy solver-fallback loops. Modern cvxpy (>=1.5) no longer pulls in `ecos` transitively and bundles CLARABEL/OSQP/SCS, so neither package needs to be a core dependency.

## Changes

- `pyproject.toml`: remove the unused `screenot` and `ecos` core dependencies.
- `vanillasc_helpers/scpi.py`: drop `cp.ECOS` from the SCPI conformal-interval solver loop, leaving the bundled `CLARABEL` (SOCP-capable, the cvxpy default).
- `sbc_helpers/synthetic.py`: the simplex SCM-on-cycles step (Shi–Xi–Xie 2025, Eq. (3)) is a plain simplex-constrained least squares (`min ‖c_t − C w‖² s.t. w ≥ 0, Σw = 1`). Solve it in-house with the existing FISTA primitive `bilevel.simplex.simplex_lstsq` instead of cvxpy — no external QP/conic solver on this path.

## Verification (no numerical drift)

- `test_sbc.py` + `test_vanillasc.py` pass. Added a cvxpy-reference drift guard and a single-donor edge case to the SBC simplex solver tests.
- Benchmarks stay within tolerance:
  - `sbc_germany` — ATT −952.2 (exp −952), donor weights within tol.
  - `sbc_mc` — all Model 1–3 ratios within tol.
  - `vanillasc_prop99` — ATT −18.98 (exp −18.98), weights/gap/RMSPE within tol.

## Out of scope (intentionally left)

`laxscm` still lists `"ECOS"` as a user-selectable solver-name option (default is `CLARABEL`). It is not a default path; if a user explicitly selects ECOS without the package installed, cvxpy raises its own clear `SolverError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_