### PR TITLE
VanillaSC staggered: covariate (multi-feature) matching + exact ECOS conic

### DIFF
--- a/benchmarks/cases/scpi_staggered.py
+++ b/benchmarks/cases/scpi_staggered.py
@@ -1,9 +1,9 @@
 """Cross-validation benchmark: staggered VanillaSC vs the ``scpi`` package.
 
-Path A (empirical, runnable Python reference). Reproduces Cattaneo, Feng, Palomba
-and Titiunik's (2025) multiple-treated-unit synthetic control on the canonical
-Germany reunification panel (the public ``scpi_germany.csv`` shipped with the
-``scpi`` distribution), driven entirely through the public ``VanillaSC.fit()``.
+Path A (empirical). Reproduces Cattaneo, Feng, Palomba and Titiunik's (2025)
+multiple-treated-unit synthetic control on the canonical Germany reunification
+panel (``basedata/scpi_germany.csv``), driven entirely through the public
+``VanillaSC.fit()``.
 
 Two treated units adopt at different times -- West Germany in 1991 and Italy in
 1992 (the placebo unit from the package's own illustration) -- with the 15
@@ -12,14 +12,13 @@ never-treated countries as donors. Run outcome-only with a simplex constraint,
 per-unit, event-time, and overall *causal predictand* point estimates derived
 from them are reproduced by ``mlsynth`` to a few thousandths.
 
-Reference: ``scpi_pkg`` (PyPI, pinned at 4.0.0), ``scest`` /  ``scdataMulti``.
-The point estimates are deterministic SC quantities, so they match to the
-published digits. NOTE: this case validates the *point-estimate* family
-(``effect="unit"`` / ``"time"`` / ``"unit-time"``). The cross-unit prediction
-*intervals* (TSUA / TAUA) are not yet reproduced and are out of scope here.
+The ``scpi`` reference is hard-coded below rather than computed live: ``scpi`` is
+GPL-licensed and ``mlsynth`` is MIT, so the benchmark records ``scpi``'s ``scest``
+numbers once and checks ``fit()`` against them, with no run-time dependency on
+``scpi_pkg``. The point estimates are deterministic SC quantities, so they match
+to the published digits.
 
-Skips itself (``BenchmarkSkipped``) when ``scpi_pkg`` is absent, so it runs under
-``--all`` without a hard dependency.
+Reference: ``scpi_pkg`` (PyPI), ``scest`` / ``scdataMulti``.
 """
 from __future__ import annotations
 
@@ -29,11 +28,16 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from benchmarks.compare import BenchmarkSkipped
-
 _DATA = os.path.join(os.path.dirname(__file__), "..", "..",
                      "basedata", "scpi_germany.csv")
 _ADOPT = {"West Germany": 1991, "Italy": 1992}
+
+# scpi reference (scest, outcome-only simplex): per-unit average effects, the
+# overall unit-time ATT, and the event-time (effect="time") series.
+_SCPI_ATT = {"West Germany": -1.8476, "Italy": -1.1211, "overall": -1.4989}
+_SCPI_EVENT_TIME = np.array([
+    0.131, 0.0316, -0.4255, -0.67, -0.9013, -1.2304,
+    -1.2529, -1.6015, -2.2758, -2.6734, -2.8457, -3.0832])
 
 
 def _panel() -> pd.DataFrame:
@@ -44,39 +48,10 @@ def _panel() -> pd.DataFrame:
     return df
 
 
-def _scpi_gaps(df: pd.DataFrame) -> pd.Series:
-    """Per-cell post-treatment gaps from scpi's scest (effect='unit-time')."""
-    from scpi_pkg.scdataMulti import scdataMulti
-    from scpi_pkg.scest import scest
-    aux = scdataMulti(df=df, id_var="country", time_var="year",
-                      outcome_var="gdp", treatment_var="status", features=None,
-                      cov_adj=None, constant=False, cointegrated_data=False,
-                      effect="unit-time")
-    res = scest(aux, w_constr={"name": "simplex"})
-    gap = np.asarray(res.Y_post).ravel() - np.asarray(res.Y_post_fit).ravel()
-    return pd.Series(gap, index=res.Y_post.index)   # index: (unit, year)
-
-
-def _event_study(gaps_by_unit: dict, min_post: int) -> np.ndarray:
-    """Balanced event-study series: mean gap across units at each event time."""
-    return np.array([
-        np.mean([gaps_by_unit[u][ell] for u in gaps_by_unit])
-        for ell in range(min_post)
-    ])
-
-
 def run() -> dict:
-    try:
-        import scpi_pkg  # noqa: F401
-    except ImportError as exc:  # pragma: no cover - optional reference dep
-        raise BenchmarkSkipped("scpi_pkg not installed "
-                               "(`pip install scpi_pkg==4.0.0`)") from exc
-
     from mlsynth import VanillaSC
 
     df = _panel()
-
-    # --- mlsynth, through the public fit() ---
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         res = VanillaSC({"df": df, "outcome": "gdp", "treat": "status",
@@ -87,37 +62,24 @@ def run() -> dict:
     ml_event = res.additional_outputs["event_study"]            # {ell: effect}
     ml_overall = float(res.effects.att)
 
-    # --- scpi reference ---
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        gaps = _scpi_gaps(df)
-    sc_by_unit = {}
-    sc_unit = {}
-    for unit, yr in _ADOPT.items():
-        g = gaps.xs(unit, level=0).sort_index()
-        sc_by_unit[unit] = g.to_numpy(float)
-        sc_unit[unit] = float(g.mean())
-    sc_overall = float(gaps.mean())
-    min_post = min(len(v) for v in sc_by_unit.values())
-    sc_event = _event_study(sc_by_unit, min_post)
-    ml_event_arr = np.array([ml_event[k] for k in sorted(ml_event)])[:min_post]
+    ev = np.array([ml_event[k] for k in sorted(ml_event)])
+    n = min(len(ev), len(_SCPI_EVENT_TIME))
 
     return {
-        # mlsynth's own values (pinned to the published SC numbers)
         "att_west_germany": ml_unit["West Germany"],
         "att_italy": ml_unit["Italy"],
         "att_overall": ml_overall,
-        # cell-by-cell agreement with scpi (driven through fit())
+        # agreement with the recorded scpi reference (driven through fit())
         "per_unit_max_abs_diff_vs_scpi": max(
-            abs(ml_unit[u] - sc_unit[u]) for u in _ADOPT),
+            abs(ml_unit[u] - _SCPI_ATT[u]) for u in _ADOPT),
         "event_study_max_abs_diff_vs_scpi": float(
-            np.max(np.abs(ml_event_arr - sc_event))),
-        "overall_abs_diff_vs_scpi": abs(ml_overall - sc_overall),
+            np.max(np.abs(ev[:n] - _SCPI_EVENT_TIME[:n]))),
+        "overall_abs_diff_vs_scpi": abs(ml_overall - _SCPI_ATT["overall"]),
     }
 
 
-# Deterministic SC point estimates: mlsynth's fit() reproduces scpi's scest to a
-# few thousandths across the per-unit, event-time, and overall predictands.
+# Deterministic SC point estimates: mlsynth's fit() reproduces scpi's recorded
+# scest numbers across the per-unit, event-time, and overall predictands.
 EXPECTED = {
     "att_west_germany": (-1.8476, 0.01),     # scpi scest, effect="unit"
     "att_italy": (-1.1211, 0.01),

--- a/benchmarks/cases/scpi_staggered_covariate.py
+++ b/benchmarks/cases/scpi_staggered_covariate.py
@@ -1,0 +1,85 @@
+"""Cross-validation benchmark: covariate staggered VanillaSC vs the ``scpi``
+multiple-treated-unit illustration.
+
+Path A (empirical). Reproduces the covariate (multi-feature) staggered synthetic
+control of Cattaneo, Feng, Palomba & Titiunik (2025) -- their ``scpi``
+multiple-treated illustration (``scpi_illustration-multi.py``) -- on the Germany
+reunification panel, driven through the public ``VanillaSC.fit()`` with a
+``staggered_spec``. The shared specification matches on GDP and trade with a
+constant-and-trend covariate adjustment and cointegrated differencing; the
+treated units (West Germany 1991, Italy 1992) come from the treatment indicator,
+never named in the spec.
+
+The ``EXPECTED`` values are the ``scpi`` numbers, pinned as constants rather than
+computed live: ``scpi``'s multi-feature design produces duplicate donor-column
+names that current ``scikit-learn`` / ``narwhals`` reject, so ``scpi_pkg`` cannot
+compute these prediction intervals in a modern environment. The per-unit average
+effects are deterministic ``scest`` quantities reproduced exactly; the
+event-time prediction-interval widths were generated against ``scpi`` (with a
+one-line column-name coercion) at ``seed=8894``, ``sims=500``, and the engine
+reproduces ``scpi``'s draw sequence, so they are stable. This case therefore
+needs no ``scpi_pkg`` at run time -- it pins the published reference and checks
+``fit()`` against it.
+
+Reference: ``scpi_pkg`` (PyPI), ``scpi_illustration-multi.py``.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import numpy as np
+import pandas as pd
+
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..",
+                     "basedata", "scpi_germany.csv")
+_ADOPT = {"West Germany": 1991, "Italy": 1992}
+_SPEC = {"features": ["gdp", "trade"], "cov_adj": ["constant", "trend"],
+         "constant": True, "cointegrated": True}
+
+
+def _panel() -> pd.DataFrame:
+    df = pd.read_csv(os.path.abspath(_DATA))
+    df["status"] = 0
+    for unit, yr in _ADOPT.items():
+        df.loc[(df["country"] == unit) & (df["year"] >= yr), "status"] = 1
+    return df
+
+
+def run() -> dict:
+    from mlsynth import VanillaSC
+
+    df = _panel()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = VanillaSC({
+            "df": df, "outcome": "gdp", "treat": "status", "unitid": "country",
+            "time": "year", "display_graphs": False, "inference": "scpi",
+            "scpi_sims": 500, "seed": 8894, "scpi_compat": True,
+            "staggered_spec": _SPEC,
+        }).fit()
+
+    pu = res.additional_outputs["per_unit_att"]
+    es = res.additional_outputs["event_study"]
+    esi = res.additional_outputs["event_study_intervals"]
+    w1 = esi[1]["synthetic_ci"][1] - esi[1]["synthetic_ci"][0]
+
+    return {
+        "per_unit_att_italy": float(pu["Italy"]),
+        "per_unit_att_west_germany": float(pu["West Germany"]),
+        "overall_att": float(res.effects.att),
+        "event_study_ell1": float(es[1]),
+        "event1_synthetic_ci_width": float(w1),
+    }
+
+
+# scpi reference: per-unit average effects are the deterministic scest values;
+# the overall ATT, event-time effect and prediction-interval width are the
+# scpi-reproduced numbers at seed=8894, sims=500 (see module docstring).
+EXPECTED = {
+    "per_unit_att_italy": (-0.8902, 0.005),          # scpi scest
+    "per_unit_att_west_germany": (-1.7467, 0.005),   # scpi scest
+    "overall_att": (-1.3356, 0.01),
+    "event_study_ell1": (0.2831, 0.01),
+    "event1_synthetic_ci_width": (2.8624, 0.1),      # scpi CI_all_gaussian width
+}

--- a/benchmarks/cases/scpi_staggered_pi.py
+++ b/benchmarks/cases/scpi_staggered_pi.py
@@ -1,31 +1,34 @@
 """Cross-validation benchmark: staggered VanillaSC prediction intervals vs scpi.
 
-Path A (empirical, runnable Python reference). Reproduces the multiple-treated-
-unit *prediction intervals* of Cattaneo, Feng, Palomba & Titiunik (2025),
-Section 4 -- the cross-unit (event-time, TSUA) bands -- on the canonical Germany
-reunification panel (``basedata/scpi_germany.csv``), driven through the public
-``VanillaSC.fit()`` with ``inference="scpi"``.
+Path A (empirical). Reproduces the multiple-treated-unit *prediction intervals*
+of Cattaneo, Feng, Palomba & Titiunik (2025), Section 4 -- the cross-unit
+(event-time, TSUA) bands -- on the Germany reunification panel
+(``basedata/scpi_germany.csv``), driven through the public ``VanillaSC.fit()``
+with ``inference="scpi"``.
 
 Two treated units adopt at different times (West Germany 1991, Italy 1992) with
-the 15 never-treated countries as donors. Outcome-only, simplex weights. The
-``scpi`` package's ``scpi`` (with ``scdataMulti(effect="time")``) produces the
-event-time prediction intervals; ``mlsynth``'s clean-room staggered engine
-reproduces the full sub-Gaussian band to solver tolerance in ``scpi``-compat
-mode (``scpi_compat=True``).
+the 15 never-treated countries as donors. Outcome-only, simplex weights. In
+``scpi``-compatibility mode the event-time band reproduces ``scpi``'s
+``scpi(scdataMulti(effect="time"))`` band (its ``CI_all_gaussian``) to solver
+tolerance.
+
+The ``scpi`` reference is hard-coded below rather than computed live: ``scpi`` is
+GPL-licensed and ``mlsynth`` is MIT, so the benchmark records ``scpi``'s numbers
+once (here, ``effect="time"``, ``seed=1234``, ``sims=500``) and checks ``fit()``
+against them, with no run-time dependency on ``scpi_pkg``.
 
 This case also documents a published-quirk finding. ``scpi`` divides the
 predictand matrix ``P`` by the number of treated units ``iota`` in
 ``scdataMulti`` (correct -- it forms the average) and then divides the simulated
 in-sample draws by ``iota`` a *second* time in ``scpi_in_diag``, so its
 time-aggregated in-sample interval carries a ``1 / iota**2`` scaling, while the
-point estimate and out-of-sample term use the statistically correct single
-``1 / iota``. Verified against ``scpi`` at machine precision: with iota = 2 the
-correct (default) in-sample band is exactly 2x wider than ``scpi``'s at every
-event time. ``mlsynth`` defaults to the correct ``1 / iota`` and exposes
-``scpi_compat=True`` to reproduce ``scpi`` bit-for-bit; both are checked here
-through ``fit()``.
+point estimate and out-of-sample term use the correct single ``1 / iota``.
+Verified against ``scpi`` at machine precision: with iota = 2 the correct
+(default) in-sample band is exactly 2x wider than ``scpi``'s at every event time.
+``mlsynth`` defaults to the correct ``1 / iota`` and exposes ``scpi_compat=True``
+to reproduce ``scpi`` bit-for-bit; both are checked here through ``fit()``.
 
-Reference: ``scpi_pkg`` (PyPI). Skips itself (``BenchmarkSkipped``) when absent.
+Reference: ``scpi_pkg`` (PyPI), ``scpi`` / ``scdataMulti``.
 """
 from __future__ import annotations
 
@@ -35,13 +38,20 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from benchmarks.compare import BenchmarkSkipped
-
 _DATA = os.path.join(os.path.dirname(__file__), "..", "..",
                      "basedata", "scpi_germany.csv")
 _ADOPT = {"West Germany": 1991, "Italy": 1992}
 _SIMS = 500
 _SEED = 1234
+
+# scpi reference: CI_all_gaussian for effect="time" (outcome-only simplex),
+# seed=1234, sims=500. Lower / upper synthetic-prediction band per event time.
+_SCPI_BAND_LO = np.array([
+    20.1216, 20.7404, 21.4774, 22.4745, 23.2487, 24.1386,
+    24.9211, 25.9213, 27.6635, 28.9156, 29.6055, 30.2987])
+_SCPI_BAND_HI = np.array([
+    20.6777, 21.1925, 21.8918, 22.9157, 23.9393, 25.1013,
+    25.8044, 27.0253, 29.0674, 30.6037, 31.4226, 32.0415])
 
 
 def _panel() -> pd.DataFrame:
@@ -69,41 +79,18 @@ def _fit_tsua(df: pd.DataFrame, *, scpi_compat: bool):
     return ells, full, insample
 
 
-def _scpi_tsua(df: pd.DataFrame) -> np.ndarray:
-    """scpi effect='time' full sub-Gaussian band (CI_all_gaussian)."""
-    from scpi_pkg.scdataMulti import scdataMulti
-    from scpi_pkg.scpi import scpi
-    aux = scdataMulti(df=df, id_var="country", time_var="year", outcome_var="gdp",
-                      treatment_var="status", features=None, cov_adj=None,
-                      constant=False, cointegrated_data=False, effect="time")
-    np.random.seed(_SEED)
-    res = scpi(aux, w_constr={"name": "simplex"}, sims=_SIMS, cores=1,
-               e_method="gaussian", u_alpha=0.05, e_alpha=0.05)
-    ci = res.CI_all_gaussian
-    return np.column_stack([np.asarray(ci.iloc[:, 0], float),
-                            np.asarray(ci.iloc[:, 1], float)])
-
-
 def run() -> dict:
-    try:
-        import scpi_pkg  # noqa: F401
-    except ImportError as exc:  # pragma: no cover - optional reference dep
-        raise BenchmarkSkipped("scpi_pkg not installed "
-                               "(`pip install scpi_pkg`)") from exc
-
     df = _panel()
-
-    # --- mlsynth through fit(): scpi-compat (matches scpi) and default (correct) ---
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         _, full_compat, insample_compat = _fit_tsua(df, scpi_compat=True)
         _, _, insample_default = _fit_tsua(df, scpi_compat=False)
-        sc_band = _scpi_tsua(df)
 
+    sc_band = np.column_stack([_SCPI_BAND_LO, _SCPI_BAND_HI])
     n = min(len(full_compat), len(sc_band))
     fc, scb = full_compat[:n], sc_band[:n]
 
-    # full-band agreement (the reproduction claim, through fit())
+    # full-band agreement with the recorded scpi band (the reproduction claim)
     sc_w = scb[:, 1] - scb[:, 0]
     ml_w = fc[:, 1] - fc[:, 0]
     tsua_width_max_rel = float(np.max(np.abs(ml_w - sc_w) / sc_w))
@@ -123,9 +110,10 @@ def run() -> dict:
     }
 
 
-# scpi-compat fit() reproduces scpi's event-time bands to solver tolerance; the
-# correct default in-sample band is exactly iota (= 2) times scpi's, documenting
-# the 1/iota**2 scaling in scpi's time-aggregated in-sample interval.
+# scpi-compat fit() reproduces scpi's recorded event-time band to solver
+# tolerance; the correct default in-sample band is exactly iota (= 2) times
+# scpi's, documenting the 1/iota**2 scaling in scpi's time-aggregated in-sample
+# interval.
 EXPECTED = {
     "tsua_full_band_width_max_rel_diff_vs_scpi": (0.0, 0.05),    # within 5%
     "tsua_full_band_endpoint_max_abs_diff_vs_scpi": (0.0, 0.05),

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -94,6 +94,7 @@ CASES = {
     "microsynth_seattle": "benchmarks.cases.microsynth_seattle",  # cross-val vs R microsynth panel method (Seattle DMI)
     "scpi_staggered": "benchmarks.cases.scpi_staggered",  # cross-val vs scpi: staggered point estimates (Germany)
     "scpi_staggered_pi": "benchmarks.cases.scpi_staggered_pi",  # cross-val vs scpi: staggered TSUA prediction intervals (Germany)
+    "scpi_staggered_covariate": "benchmarks.cases.scpi_staggered_covariate",  # cross-val vs scpi: covariate (multi-feature) staggered illustration (Germany)
     # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
 }
 

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -91,6 +91,8 @@ Path A — empirical replications
      - scpi staggered point estimates, Germany (Cattaneo et al. 2025)
    * - ``scpi_staggered_pi``
      - scpi staggered TSUA prediction intervals, Germany (Cattaneo et al. 2025)
+   * - ``scpi_staggered_covariate``
+     - scpi covariate (multi-feature) staggered illustration, Germany (Cattaneo et al. 2025)
    * - ``sparse_sc_prop99``
      - L1 predictor selection (Prop 99)
    * - ``spcd_prop99``

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -219,6 +219,45 @@ Q1.1 · Are your donors contaminated by the treatment (SUTVA / spillovers)?
 * Yes, and the treated unit sits outside the donor hull (but is itself a useful
   donor for others) -- :doc:`iscm`.
 
+*Which spillover method? (the beast).* mlsynth offers a whole family here because
+spillover problems differ along three axes: whether you *know which* donors are
+contaminated, whether the contamination is *spatial / network-structured*, and
+whether the spillover is a *nuisance to purge* or an *effect to estimate*. Take
+them in turn. When you do **not** know which donors are affected -- a large pool
+with no a-priori validity knowledge, or a suspiciously good-fitting donor --
+:doc:`spotsynth` (O'Riordan and Gilligan-Lee, 2025) *detects* it: a theorem from
+proximal causal inference says a clean donor's post-treatment values are
+forecastable from pre-treatment data alone, so a donor that fails that forecast
+test has either changed regime or been hit by spillover; it screens out the
+failures and bounds the residual bias by sensitivity analysis. When you **do**
+know the affected set, the rest of the family (the :doc:`spillsynth` dispatcher,
+plus :doc:`spsydid`) divides as follows. If the spillover is *spatial* with a
+known weight matrix :math:`W`: :doc:`spsydid` (Serenini and Masek) extends
+*synthetic* DiD, so it keeps SyDiD's intercept and time weights (a robust direct
+effect under relaxed parallel trends) and splits the effect into direct and
+indirect parts -- use it when you want the spillover *and* DiD-style robustness;
+``method="sar"`` (Sakaguchi and Tagawa, 2026) instead models the outcomes with a
+spatial-autoregressive process and does *Bayesian* inference (horseshoe priors),
+the better choice in small samples (few units, short pre-period). If the spillover
+is not spatial but its *structure* is specifiable (linear in unknown parameters),
+``method="cd"`` (Cao and Dowd) estimates direct and spillover effects from *all*
+units -- the one option that still works when *every* unit is contaminated, and it
+ships a test for the assumed structure. If the spillover is itself a quantity of
+*interest* and you have clean, far-away donors that still fit well,
+``method="grossi"`` (Grossi et al., 2025) restricts the pool to the unaffected
+units and estimates direct *and* spillover effects under partial interference.
+Finally, if excluding the affected donors would *wreck* the pre-treatment fit --
+the textbook case being a heavily weighted affected donor, like Austria's 42
+percent in synthetic West Germany -- ``method="iscm"`` (Di Stefano and Mellace,
+2024; also :doc:`iscm`) *keeps* those donors and nets out their intervention
+effects through a small system of equations; Melnychuk's (2024) simulation study
+finds iSCM the most accurate of the family, with his ``method="iterative"``
+waterfall a close, simpler-to-implement second. In short: unknown affected set ->
+``spotsynth``; spatial -> :doc:`spsydid` (robust direct effect) or ``sar``
+(Bayesian, small samples); specifiable structure with everyone possibly hit ->
+``cd``; spillover of interest with clean donors -> ``grossi``; affected donors
+too good to drop -> ``iscm`` (or ``iterative`` for simplicity).
+
 Q1.2 · Is the treated unit outside the donors' convex hull even without
 spillovers (a true outlier)?
 

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -347,9 +347,33 @@ Q1.4 · Are there persistent latent factors / time-varying dynamics / heavy
 observation noise?
 
 * No -- next question.
-* Yes -- :doc:`tasc` (time-aware state-space model), :doc:`fma` (PC factors with
-  a residual-bootstrap test), or :doc:`dscar` (time-varying weights for strongly
-  autocorrelated panels with time-varying confounders).
+* Yes -- :doc:`tasc` (time-aware state-space model) or :doc:`fma` (PC factors
+  with a residual-bootstrap test). (For micro panels with observed time-varying
+  *confounders* and autoregressive outcomes, :doc:`dscar` is a different
+  paradigm -- see the remark below.)
+
+*DSCAR -- a different beast.* :doc:`dscar` (Zheng and Chen, 2024) is not a variant
+of the synthetic control above; it is best understood by contrast with the vanilla
+method. Standard SC builds *fixed* weights that match the treated unit's whole
+pre-treatment outcome *trajectory*, identifies the counterfactual through a latent
+factor model and the convex hull, and is built for a single aggregate treated unit
+with no time-varying confounders. DSCAR changes nearly all of that. It is designed
+for *micro-level* panels -- many units, often many treated ones (monitoring sites,
+wearables, individuals) -- in which the outcome is strongly *autoregressive*, the
+confounders are *time-varying* and observed, and the units are *spatially
+dependent*. Instead of one fixed weight vector it constructs *dynamic*
+(time-varying) weights by maximising an empirical likelihood subject to matching
+the *current* state of the time-varying confounders and the lagged outcome at each
+period; because the match is to the current confounder state rather than to a long
+pre-treatment path, an exact match is attainable with probability approaching one.
+And it identifies the effect through *unconfoundedness* conditional on the
+covariates and the lagged outcome -- a selection-on-observables assumption testable
+on the pre-period -- rather than SC's factor structure. So prefer :doc:`dscar` over
+:doc:`vanillasc` when the data are micro-level with observed time-varying
+confounders, autocorrelated outcomes, spatial dependence, or multiple treated
+units; stay with the vanilla synthetic control when you have a single aggregate
+treated unit, time-invariant structure, and the factor-model / convex-hull premise
+is what you are willing to assume.
 
 Q1.5 · Is the untreated outcome a nonlinear function of the predictors?
 

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -255,6 +255,33 @@ match?
 * Yes -- decompose first: :doc:`sbc` (Hamilton trend/cycle split, match the
   cycle) or :doc:`hsc` (soft levels-vs-differences allocation).
 
+*Spurious fit on nonstationary data -- SBC versus HSC versus plain SC.* Both
+papers behind this gate warn that the standard synthetic control of Part 1 is
+unsafe on nonstationary macro series: a convex combination of donors can track
+the treated unit's pre-period through *coincidental* co-movement of unit-specific
+stochastic trends, giving an excellent in-sample fit with no out-of-sample
+validity -- the *spurious synthetic control* problem (Shi, Xi and Xie, 2025; Liu
+and Xu, 2026), an instance of spurious regression that, crucially, does *not* go
+away as the pre-period lengthens. So plain :doc:`vanillasc` is appropriate only
+when the outcome is stationary (or its stochastic trend is genuinely shared
+across units). The two fixes differ in how much they assume. :doc:`sbc` (Shi, Xi
+and Xie, 2025) commits to a trend/cycle split: it treats the nonstationary
+*trend* as unit-specific and forecasts it from the treated unit's own history,
+and uses the donors *only* for the common business *cycle* -- the right division
+when comovement genuinely lives in the cycle (a country's idiosyncratic growth
+path plus a synchronised global cycle). :doc:`hsc` (Liu and Xu, 2026) refuses to
+commit, because whether the stochastic trend is *shared* (which SC should keep for
+matching) or *idiosyncratic* (which it must remove) is usually unknown ex ante,
+and a binary choice to difference or not fails in whichever regime is wrong. HSC
+instead *softly allocates* between donor matching and a treated-unit-specific
+self-forecast, with a tuning parameter chosen by rolling-origin cross-validation
+that interpolates continuously between SC on differenced outcomes and SC on raw
+outcomes with a trend; it adapts across regimes where an estimator fixed to one
+can fail. So prefer :doc:`sbc` when you are confident the matchable comovement is
+the business cycle and the trend is the treated unit's own; prefer :doc:`hsc`
+when you are unsure whether the nonstationarity is shared or idiosyncratic and
+want the data to decide.
+
 Q1.4 · Are there persistent latent factors / time-varying dynamics / heavy
 observation noise?
 

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -153,6 +153,36 @@ the ATT still be biased.
 * Neither -- selection is on the latent factors only (SC's standard premise) --
   continue.
 
+*Within the proximal family: instrument, two proxies, one proxy, or surrogates.*
+These methods share a single premise -- some donors are not valid members of the
+synthetic control but are still informative about the latent confounder, so they
+can be repurposed as proxies (or negative controls) rather than discarded -- yet
+the authors motivate four distinct entry points. Shi, Li, Miao and Tchetgen
+Tchetgen (2026) give the foundational :doc:`proximal` framework: classical SC was
+built for settings with a near-perfect pre-treatment fit, and when that fit is
+poor even with a long pre-period, control units that do not help the fit can
+serve as proxies of the unmeasured confounders, identifying the ATT through a
+confounding bridge function (and extending naturally to nonlinear, binary, and
+count outcomes the standard linear SC literature leaves understudied). Their
+construction needs two kinds of proxy. Qiu, Shi, Miao, Dobriban and Tchetgen
+Tchetgen (2024) relax the modelling burden: their doubly robust variant pairs an
+outcome model with a weighting model and stays consistent if *either* is correct,
+so you are not forced to specify the confounding-bridge outcome model exactly.
+Park and Tchetgen Tchetgen (2025) cut the proxy requirement instead of the model
+requirement: their single-proxy approach views the donor outcomes themselves as
+the only proxies needed -- no separate group of treatment proxies -- and pairs it
+with conformal inference, which buys valid intervals without a long
+post-treatment series. Liu, Tchetgen Tchetgen and Varjão (2024) point the
+framework forward in time: when the pre-period is short or the post-period long,
+post-intervention *surrogates* (time-varying correlates of the effect) sharpen
+estimation, and they show conditions under which post-treatment data alone can
+identify the effect. So reach for :doc:`siv` when you hold a genuine instrument
+and the worry is endogenous exposure; reach for :doc:`proximal` when you hold
+proxies/negative controls instead -- the doubly robust route when you distrust
+your outcome model, the single-proxy route when you have only one kind of proxy
+and a short post-period, and the surrogate route when the leverage is in
+post-treatment correlates rather than a long clean pre-period.
+
 Q0.5 · Do parallel trends hold, and are you in a fixed-T / large-N regime?
 
 * Yes -- you may not need synthetic control at all: plain

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -221,11 +221,32 @@ a persistent level difference remains -- SCM is biased, while PDA's free weights
 and intercept stay unbiased, and PDA's accuracy improves as the pre-period
 lengthens. So prefer SCM when you have a genuine convex match; prefer :doc:`pda`
 when the treated unit sits outside the hull or at a different level. With a large
-donor pool the unconstrained regression must be regularised: best-subset / AICc
-(the original Hsiao--Ching--Wan, ``method="hcw"``) or Lasso when only a few
-donors matter, and L2-relaxation (Shi and Wang 2024, ``method="l2"``) when the
-donors instead share a dense latent-factor structure with no sparse few standing
-out.
+donor pool the unconstrained regression must be regularised -- which PDA variant
+to use is the next remark.
+
+*Within PDA: which regulariser?* :doc:`pda` bundles four ways to fit the
+unconstrained regression, and the choice is governed by the size of the donor
+pool relative to the pre-period and by whether a few donors or many carry the
+signal. The original Hsiao--Ching--Wan best subset (``method="hcw"``) picks the
+donor subset by AICc; it is exact and certifiable but enumerates :math:`2^N`
+candidate models and, being least squares, needs fewer donors than pre-periods
+(:math:`N < T_0`) -- so it suits a *small* pool. When the pool is large,
+best-subset becomes infeasible and HCW's fixed-:math:`N`, large-:math:`T`
+asymptotics degrade. Li and Bell (2017) propose **Lasso** (``method="lasso"``)
+for exactly this case: it allows more donors than pre-periods (:math:`N > T_0`),
+is far cheaper than AICc/BIC, and lowers the ATE's predictive error -- use it when
+a *sparse* handful of donors is plausibly relevant. Shi and Huang (2023) propose
+**forward selection** (``method="fs"``): a sequence of OLS fits that approximates
+best-subset at scale (valid even as :math:`N/T \to \infty`) and -- its headline
+contribution -- supplies *valid post-selection inference* on the ATE (a
+conditional :math:`t`-test), whether the underlying coefficients are sparse *or*
+dense; use it when you want HCW-style selection with a defensible standard error
+in a large pool. Shi and Wang (2024) **L2-relaxation** (``method="l2"``) targets
+the opposite end of the sparse--dense axis: when the donors share a latent-factor
+structure so that *all* of them are weakly relevant and no sparse few stand out,
+its dense weighting diversifies prediction risk and attains oracle accuracy. In
+short: small pool -> ``hcw``; large and sparse -> ``lasso`` (or ``fs`` when you
+also want inference); large and dense -> ``l2``.
 
 Q1.3 · Is the outcome nonstationary, so a tight pre-fit might be a *spurious*
 match?

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -92,6 +92,7 @@ At a glance
    Same adoption time?  ─► SDID            (micro units ─► MicroSynth; two-level ─► MLSC)
      + many treated at once, disaggregated/high-dim donors ─► MSQRT
    Staggered (different times)?  ─► SDID · ROLLDID (rolling-transformation DiD)
+     + simplex SC per unit, never-treated pool, CFPT intervals ─► VanillaSC (staggered)
      + want pooling / oracle efficiency  ─► PPSCM · SequentialSDID
      + long pre-period, few never-treated, event study ─► SSC
      + spillovers                        ─► SpSyDiD
@@ -201,7 +202,8 @@ spillovers (a true outlier)?
 
 * No -- next question.
 * Yes -- relax the simplex: :doc:`nsc` (affine weights), :doc:`rescm`
-  (penalised / :math:`L_\infty`), or the unconstrained :doc:`pda`.
+  (penalised / :math:`L_\infty`), or the unconstrained :doc:`pda` (the
+  Hsiao--Ching--Wan panel-data regression and its modern penalised cousins).
 
 Q1.3 · Is the outcome nonstationary, so a tight pre-fit might be a *spurious*
 match?
@@ -229,9 +231,11 @@ the pre-period and predict the post-period worse.
 
 * No -- next question.
 * Yes -- escalate, roughly easiest first: :doc:`fscm` (tune the donor *count*),
-  :doc:`sparse_sc` (L1 predictor/covariate selection), :doc:`pda`
-  (L2-relaxation / Lasso / forward), :doc:`rescm` (one program from simplex SC
-  to :math:`L_\infty` to DiD), :doc:`clustersc` (denoise + cluster donors), or
+  :doc:`sparse_sc` (L1 predictor/covariate selection), :doc:`pda` (the Panel Data
+  Approach: L2-relaxation, Lasso, Shi--Huang forward selection, or the original
+  Hsiao--Ching--Wan best-subset regression -- ``method="hcw"``, the classic
+  unconstrained PDA), :doc:`rescm` (one program from simplex SC to
+  :math:`L_\infty` to DiD), :doc:`clustersc` (denoise + cluster donors), or
   :doc:`bvss` (Bayesian spike-and-slab with a soft simplex).
 
 Q1.7 · Are there missing cells in the panel?
@@ -297,6 +301,22 @@ Q2.2 · Staggered: do you just want the overall / event-study ATT?
   included), so it needs no never-treated pool, and gives event-time ATTs with
   Andrews end-of-sample inference. Best with a long pre-period (large :math:`T`,
   moderate :math:`N`).
+* Staggered, with a clean never-treated donor pool, and you want the *simplex*
+  synthetic-control answer -- one synthetic control per treated unit, on its own
+  pre-period -- with the full Cattaneo--Feng--Palomba--Titiunik causal
+  predictands (per-unit ATTs, the event-time average effect, the overall ATT)
+  and their prediction intervals -- :doc:`vanillasc` handles staggered adoption
+  natively. It detects the multiple treated units from the treatment column,
+  fits each on the never-treated donors and aggregates, with or without
+  covariate (multi-feature) matching, reproducing the ``scpi`` package. It is the
+  staggered counterpart of the textbook simplex SC from Part 1, and the same
+  trade-off decides between it and the :doc:`sdid` base case: prefer :doc:`sdid`
+  when matching the cohorts adequately *requires* an intercept (a level shift
+  between a cohort and its synthetic control) or time weights -- which SDID
+  carries and vanilla SCM, by construction, does not -- and prefer staggered
+  :doc:`vanillasc` when the simplex fit already tracks the cohorts on levels, so
+  you keep genuine convex synthetic-control weights and the CFPT prediction
+  intervals without leaning on a DiD intercept or reweighted periods.
 * Staggered *and* spillovers onto donors -- :doc:`spsydid`.
 * Staggered *and* missing cells / gaps -- :doc:`mcnnm` (matrix completion handles
   staggered missingness natively).
@@ -416,7 +436,8 @@ A reverse lookup: the symptom, and the method named for it.
    * - Many treated at once, high-dimensional donor pool (block design)
      - :doc:`msqrt`
    * - Many treated, staggered adoption
-     - :doc:`sdid`, :doc:`rolldid`, :doc:`ppscm`, :doc:`seq_sdid`, :doc:`mcnnm`
+     - :doc:`sdid`, :doc:`vanillasc` (simplex SC per unit, CFPT intervals),
+       :doc:`rolldid`, :doc:`ppscm`, :doc:`seq_sdid`, :doc:`mcnnm`
    * - Staggered, long pre-period, few never-treated (event study)
      - :doc:`ssc`
    * - Designing for the ATT

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -459,6 +459,33 @@ Q1.7 · Are there missing cells in the panel?
   nuclear-norm completion) to impute the treated counterfactual; it reduces to a
   low-rank completion when the covariates are uninformative.
 
+*Which matrix-completion estimator -- and why the missingness mechanism decides.*
+The three estimators differ less in the imputation machinery than in what they
+assume about *why* cells are missing. :doc:`mcnnm` (Athey, Bayati, Doudchenko,
+Imbens and Khosravi (2021)) imputes the untreated potential outcomes by
+nuclear-norm-regularised low-rank completion of the whole panel, with two-way
+fixed effects. Their headline argument is regime-robustness: synthetic control
+and the unconfoundedness/horizontal regression each work well only in one shape
+of panel -- unconfoundedness fails when :math:`T \gg N`, synthetic control fails
+when :math:`N \gg T` -- whereas the completion objective nests both as special
+cases (differing only in how hard a restriction they place on the factorisation)
+and stays accurate across all regimes and arbitrary, staggered missing patterns.
+That argument presumes the *pattern* of missingness is essentially ignorable
+(missing at random given the low-rank structure). :doc:`snn` (Agarwal, Dahleh,
+Shah and Shen (2021)) is built for exactly the case MCNNM sets aside: missingness
+that is *not* at random -- the probability a cell is observed depends on the
+cell's own latent value (a policymaker adopts where outcomes are favourable; a
+user only rates films they chose to watch), entries can be deterministically
+missing (positivity violated), and the missingness of one cell can depend on
+others. SNN imputes each target cell from a fully observed *anchor* block of rows
+and columns and delivers entry-wise (max-norm) guarantees -- accurate inference
+for each individual :math:`(i,j)` cell rather than for a row average. So prefer
+:doc:`mcnnm` when the gaps are plausibly incidental and you want one estimator
+that travels across short, long, and square panels; prefer :doc:`snn` when the
+gaps are informative -- selected on the outcome itself -- and you need a credible
+counterfactual for specific cells; reach for :doc:`rmsi` when the missing block is
+the treated region and you have margin covariates that carry signal about it.
+
 Q1.8 · Is your estimand or treatment effect non-standard (not a scalar mean ATT
 for one binary treatment)?
 
@@ -467,6 +494,20 @@ for one binary treatment)?
 * A continuous or multi-valued dose with no clean control -- :doc:`ctsc`.
 * Several related outcomes (helps most with a short pre-period) -- :doc:`scmo`.
 * Several distinct intervention arms to compare -- :doc:`si`.
+
+*When to reach for Synthetic Interventions.* :doc:`si` (Agarwal, Shah and Shen
+(2024)) is the multi-arm member of this same low-rank family, and the comparison
+is cleanest stated through the question it answers. Standard synthetic control
+recovers one slice of the potential-outcomes array -- outcomes under a single
+treatment, usually control -- because its matrix factor model carries latent
+factors only for units and time. SI lifts that to a *tensor* factor model with an
+added latent factorisation over treatments, so the same panel can be completed
+under interventions a unit never actually received: what would California's
+cigarette sales have been under a tax increase rather than the program it
+adopted? Prefer :doc:`si` when you have several intervention arms and want each
+unit's counterfactual under arms it did not take -- the multi-treatment
+generalisation Abadie (2021) posed as an open question -- rather than a single
+average contrast against one control condition.
 
 Q1.9 · Are you worried about interpolation bias -- the synthetic control having
 to *interpolate* across donors that are individually far from the treated unit,

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -372,6 +372,36 @@ Q2.2 · Staggered: do you just want the overall / event-study ATT?
 * Staggered *and* missing cells / gaps -- :doc:`mcnnm` (matrix completion handles
   staggered missingness natively).
 
+*Which staggered synthetic control?* Three SC-family methods target this same
+setting on different arguments, and the choice turns on your donor pool, sample
+length, and estimand. Staggered :doc:`vanillasc` (Cattaneo, Feng, Palomba and
+Titiunik, 2025) fits the canonical *convex* SC for each treated unit on a
+*never-treated* donor pool and is built around *non-asymptotic* (finite-sample)
+prediction intervals -- the authors stress these precisely because SC
+applications usually have small samples; reach for it when you have clean
+never-treated donors, want non-extrapolating convex weights, and need valid
+intervals even with a short pre-period. :doc:`ppscm` (Ben-Michael, Feller and
+Rothstein, 2022) instead targets the *average* effect across treated units: it
+shows that fitting weights separately per unit (good unit fits, poor average) or
+pooling them (good average, poor unit fits) each biases one of the two
+imbalances, and proposes *partially pooled* SCM that trades them off, with a
+de-meaning (intercept) step that turns it into a weighted
+difference-in-differences; reach for it when the average ATT is the headline
+estimand and a level shift between treated units and donors must be absorbed.
+:doc:`ssc` (Cao, Lu and Wu, 2026) drops the never-treated requirement
+altogether -- it builds each unit's control from *all other units,
+not-yet-treated included*, explicitly because methods that lean on never-treated
+units deteriorate when those are scarce -- and bases inference on Andrews'
+end-of-sample test under large-:math:`T` asymptotics; reach for it when most
+units are eventually treated, the pre-period is long, and you want event-time ATT
+inference without parallel trends. The distinct case of *many* treated units in a
+high-dimensional, disaggregated panel adopting at the *same* time (Q2.1) is
+:doc:`msqrt` (Shen, Song and Abadie, 2025): it pools the treated units into one
+matrix regression with a tuning-free square-root-lasso, chosen for computational
+efficiency and to preserve *individual* counterfactuals where fitting each unit
+separately is slow and aggregating them would blur unit-level effects or add
+interpolation bias.
+
 Part 3 — Designing an experiment
 --------------------------------
 

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -205,6 +205,28 @@ spillovers (a true outlier)?
   (penalised / :math:`L_\infty`), or the unconstrained :doc:`pda` (the
   Hsiao--Ching--Wan panel-data regression and its modern penalised cousins).
 
+*PDA versus SCM.* This convex-hull gate is exactly where the panel data approach
+and synthetic control part ways, and the two camps argue it on their own terms.
+Wan, Xie and Hsiao (2018) cast it as constrained versus unconstrained
+regression: SCM forces convex weights (non-negative, summing to one) and no
+intercept, whereas PDA leaves the weights free and adds an intercept that absorbs
+a level (fixed-effect) gap between the treated unit and its donors. When SCM's
+constraints hold -- the treated unit lies in the donors' convex hull and shares
+their level -- they are *valid* restrictions and SCM is the more efficient
+estimator; Gardeazabal and Vega-Bayo (2017) find it then gives a smaller,
+tighter-spread post-treatment error (more so with covariates and a longer
+pre-period) and is more robust to changes in the donor pool. When the constraints
+are *invalid* -- no convex combination of donors reproduces the treated unit, or
+a persistent level difference remains -- SCM is biased, while PDA's free weights
+and intercept stay unbiased, and PDA's accuracy improves as the pre-period
+lengthens. So prefer SCM when you have a genuine convex match; prefer :doc:`pda`
+when the treated unit sits outside the hull or at a different level. With a large
+donor pool the unconstrained regression must be regularised: best-subset / AICc
+(the original Hsiao--Ching--Wan, ``method="hcw"``) or Lasso when only a few
+donors matter, and L2-relaxation (Shi and Wang 2024, ``method="l2"``) when the
+donors instead share a dense latent-factor structure with no sparse few standing
+out.
+
 Q1.3 · Is the outcome nonstationary, so a tight pre-fit might be a *spurious*
 match?
 

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -672,6 +672,34 @@ You are choosing *whom* to treat, not estimating an effect; these return
 assignments and power / MDE curves, not ATTs. Order by what estimand you care
 about, easiest target first.
 
+*Why design at all, and which design method.* The shared premise of this family,
+argued most directly by Doudchenko et al. (2021) and Abadie and Zhao (2026), is
+that when treatment can only be applied to a few large, expensive units (media
+markets, regions, whole products) randomization is unbiased *ex ante* but, over
+the single assignment you actually run, routinely hands you treated and control
+groups with very different baselines -- a draw you cannot average away. If you
+hold pre-treatment panel data, you can do better by *choosing* the split. The
+methods then split on two axes: the estimand they target, and how they solve the
+(NP-hard) assignment problem. Doudchenko et al. cast the joint choice of treated
+set and donor weights as a mixed-integer program that directly minimises the
+*ATT estimator's* mean squared error (:doc:`syndes`) -- provably optimal but
+combinatorial. Lu, Li, Ying and Blanchet (2022) attack the same covariate-
+balancing design but reformulate it as a phase-synchronisation problem solved by
+a spectrally-initialised power method (:doc:`spcd`), trading the MIP's
+exactness for a *global* optimality guarantee under the linear factor model and
+a runtime in seconds rather than minutes -- prefer it when the unit count makes
+the MIP slow. Abadie and Zhao instead target the *population* ATE: they choose
+synthetic-treated and synthetic-control groups whose pre-experiment predictors
+match the population means (:doc:`marex`), a convex design that lowers bias
+relative to randomization and (their Theorem 1) shifts structure from unobserved
+loadings into observed covariates. Vives-i-Bastida (2022) extends that framework
+to multiple outcomes and adds the minimum-detectable-effect machinery and
+practical exclusion / fairness constraints that :doc:`lexscm` uses to optimise
+validity first and power second. The two geo-rollout members -- :doc:`pangeo`
+(no unit left untreated, trajectory-matched supergeos) and :doc:`geolift` /
+:doc:`multicellgeolift` (market selection under a budget) -- are the
+applied-marketing specialisations; the questions below route to each.
+
 Q3.1 · Do you only care about the ATT (the effect on the treated units)?
 
 * Yes -- :doc:`syndes` (a MIP that minimises the *ATT estimator's* MSE, exactly

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -308,15 +308,22 @@ Q2.2 · Staggered: do you just want the overall / event-study ATT?
   and their prediction intervals -- :doc:`vanillasc` handles staggered adoption
   natively. It detects the multiple treated units from the treatment column,
   fits each on the never-treated donors and aggregates, with or without
-  covariate (multi-feature) matching, reproducing the ``scpi`` package. It is the
-  staggered counterpart of the textbook simplex SC from Part 1, and the same
-  trade-off decides between it and the :doc:`sdid` base case: prefer :doc:`sdid`
-  when matching the cohorts adequately *requires* an intercept (a level shift
-  between a cohort and its synthetic control) or time weights -- which SDID
-  carries and vanilla SCM, by construction, does not -- and prefer staggered
-  :doc:`vanillasc` when the simplex fit already tracks the cohorts on levels, so
-  you keep genuine convex synthetic-control weights and the CFPT prediction
-  intervals without leaning on a DiD intercept or reweighted periods.
+  covariate (multi-feature) matching, reproducing the ``scpi`` package. The
+  choice between it and the :doc:`sdid` base case follows the two methods' own
+  arguments. Arkhangelsky et al. (2021) motivate SDID by its unit fixed effects,
+  which match cohorts on pre-treatment *trends* rather than levels -- absorbing a
+  constant level gap, and so deliberately loosening synthetic control's
+  requirement that the treated unit lie inside the donors' convex hull -- plus
+  time weights that downweight uninformative pre-periods. Cattaneo, Feng, Palomba
+  and Titiunik (2025) build instead on the canonical *convex* (simplex) SC, which
+  does not extrapolate, and contribute non-asymptotic prediction intervals whose
+  guarantees hold in the small samples SC applications typically have. So prefer
+  :doc:`sdid` when no convex combination of donors can match a cohort's *level*
+  (you need the intercept to absorb the gap) or some pre-periods are
+  unrepresentative; prefer staggered :doc:`vanillasc` when the simplex fit
+  already tracks the cohorts on levels -- keeping interpretable, non-extrapolating
+  weights and the finite-sample CFPT intervals, with no DiD intercept or
+  reweighted periods.
 * Staggered *and* spillovers onto donors -- :doc:`spsydid`.
 * Staggered *and* missing cells / gaps -- :doc:`mcnnm` (matrix completion handles
   staggered missingness natively).

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -260,6 +260,28 @@ the pre-period and predict the post-period worse.
   :math:`L_\infty` to DiD), :doc:`clustersc` (denoise + cluster donors), or
   :doc:`bvss` (Bayesian spike-and-slab with a soft simplex).
 
+*Dense versus sparse weights -- when to relax SCM.* Standard synthetic control
+constrains the weights to the simplex, which (as Doudchenko and Imbens (2016)
+observe) tends to produce *sparse* solutions loading on a handful of donors. Two
+recent papers argue this sparsity is a mechanical byproduct of the optimisation
+rather than a virtue, and motivate the :doc:`rescm` family -- a relaxed program
+spanning simplex SC, the :math:`L_\infty` (dense) norm, and DiD. Liao, Shi and
+Zheng (2025) note that once you have invested in a large donor pool there is
+often no reason to believe only a few controls are relevant: a *dense* scheme
+that uses them all -- spreading weight evenly within latent donor groups --
+diversifies prediction risk and reaches oracle accuracy even when the donor count
+exceeds the pre-period (:math:`J \gg T_0`). Wang, Xing and Ye (2025) make the same
+case via the :math:`L_\infty` norm: concentrating weight on a few units amplifies
+sensitivity to their idiosyncrasies (higher variance, and bias if one key donor
+deviates), which bites hardest in volatile environments or when control units
+differ in dynamics; their dense scheme reduces that over-reliance, raises the
+chance of satisfying parallel trends, and -- like DiD -- admits a level intercept
+and valid long-panel asymptotics. So prefer :doc:`rescm` over standard SCM when
+the donor pool is large and broadly relevant, when robustness to any single donor
+matters, or when the outcome is volatile; keep the sparse, transparent standard
+SC when a few genuinely similar donors match well in a stable setting (the
+canonical Proposition 99 case).
+
 Q1.7 · Are there missing cells in the panel?
 
 * No -- next question.

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -183,6 +183,28 @@ if the Forward Parallel Trends Assumption does not hold and you want a formal
 pre-trends test, use :doc:`tssc`. If none of the escalations below applies, you
 are done.
 
+*FDID versus SCM.* Forward DiD is arguably simpler than synthetic control and, as
+Li (2024) frames it, the natural first stop. Standard difference-in-differences
+puts *equal* weights on *all* donors and so needs every donor to parallel-trend
+with the treated unit -- usually too much to ask; synthetic control instead
+solves for *convex* weights, which is more flexible but estimates one weight per
+donor (and can overfit), requires the treated unit inside the donors' convex hull,
+carries no intercept, and -- Li stresses -- relies on inference theory that does
+not hold under nonstationarity of unknown structure. Forward DiD splits the
+difference: it forward-*selects* the subset of donors that best matches the
+treated unit's pre-period and then runs plain DiD on that subset. Each candidate
+model has a *single* unknown parameter (the DiD intercept :math:`\alpha`), so
+there is no overfitting however many donors there are; the intercept absorbs a
+level gap (as in DiD, unlike SCM); the pre-period :math:`R^2` is a transparent fit
+diagnostic; and the inference is valid for stationary *and* nonstationary data. So
+when a selected subset of donors genuinely parallel-trends with the treated unit
+-- a condition you can read off that :math:`R^2` -- Forward DiD is the simpler,
+lower-variance choice and you need go no further. Escalate to :doc:`vanillasc`
+when even the best equal-weighted subset cannot track the treated unit and you
+need flexible convex weights to balance heterogeneous factor loadings: that is the
+off-ramp back to SCM, taken only when FDID's parallel-trends-on-a-subset
+assumption fails.
+
 Now walk the escalations, easy to hard:
 
 Q1.1 · Are your donors contaminated by the treatment (SUTVA / spillovers)?

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -539,6 +539,31 @@ Q2.1 · Do all treated units adopt at the same time?
   treated units instead of fitting each noisily on its own.
 * No -- adoption is staggered -- continue.
 
+*Micro-level versus disaggregated: two ways to use granular data.* :doc:`microsynth`
+and :doc:`mlsc` both reach below the level at which treatment is assigned, but
+they answer different questions and the authors motivate them differently.
+Robbins, Saunders and Kilmer (2017) design :doc:`microsynth` for settings where
+the treated region itself is a bundle of many micro-units (census blocks in a
+neighbourhood) measured on many covariates and several outcomes at once. Their
+contribution is *calibration*: weights are chosen so the synthetic control
+matches the treated region exactly across all of those covariates and outcomes
+simultaneously -- a survey-weighting construction rather than a single-outcome
+fit -- and inference comes from a permutation procedure over placebo areas plus
+an omnibus statistic that tests jointly across outcomes and post-periods, so the
+many-outcome problem is handled without ad hoc multiple-comparison patching. Use
+it when the granularity is in the *treated unit* and you need one set of weights
+to balance a wide panel of characteristics and outcomes. Bottmer (2025) frames
+:doc:`mlsc` around a different decision: when outcomes are observed below the
+assignment level (county outcomes under a state policy), should you fit
+aggregated, disaggregated, or some blend? Disaggregating the *controls* expands
+the donor pool and can sharply improve aggregate-level precision, but enlarging
+it past the pre-period count risks overfitting and non-uniqueness. mlSC makes the
+aggregation choice data-driven, regularising toward the classical aggregated SC
+and letting the data decide how much disaggregated control variation to exploit.
+Prefer :doc:`mlsc` when the question is how aggressively to disaggregate a donor
+pool, and :doc:`microsynth` when the treated side is a granular many-outcome
+bundle you need to balance exactly.
+
 Q2.2 · Staggered: do you just want the overall / event-study ATT?
 
 * Yes, just staggered -- :doc:`sdid` (per-cohort + aggregate) is the simplest. A

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -375,6 +375,40 @@ units; stay with the vanilla synthetic control when you have a single aggregate
 treated unit, time-invariant structure, and the factor-model / convex-hull premise
 is what you are willing to assume.
 
+*Low-rank (matrix) methods -- when the donor matrix has factor structure.* This
+gate is also the entry point to a family that takes the latent-factor view
+literally: if a few common factors drive every unit, the untreated outcome matrix
+is approximately *low-rank*, so one can *denoise* or *complete* it before fitting
+weights. They divide by what corruption they guard against. When the data are
+*disaggregate* (individual-level: health records, income, store sales) so the
+donor count dwarfs the pre-period (:math:`n \gg T_0`) and the panel is noisy,
+:doc:`clustersc` (Rho et al., 2025) first *clusters* donors by their
+latent-factor signature -- keeping only the group that behaves like the target --
+then denoises: ``method="pcr"`` keeps the top singular values by hard thresholding
+(Amjad et al., 2018; Agarwal et al., 2021), good for *Gaussian* noise, while
+``method="rpca"`` uses robust PCA / principal component pursuit (Candes et al.),
+separating a low-rank part from a *sparse* one and so tolerating *outliers and
+missing entries*. :doc:`fma` (Li and Sonnier, 2023) takes the factor model
+head-on -- it projects the donors onto a low-dimensional factor space and
+regresses the treated unit on the estimated loadings with *no* simplex or
+convex-hull constraint, so it handles a treated unit *outside* the donors' range
+and many treated units; its contribution is a *formal* inference theory (valid
+confidence intervals without the equal-variance assumption the usual factor-model
+bootstrap needs), at the cost of overfitting if the donor pool is large.
+:doc:`tasc` (Rho et al., 2025) observes that all of the above are *time-agnostic*
+-- permuting the time index leaves the matrix spectrum unchanged -- and embeds the
+low-rank panel in a *state-space* model (Kalman filter / RTS smoother) to exploit
+the temporal structure too, which pays off under *strong trends and high
+observation noise*. And :doc:`rmsi` (Agarwal et al., 2026) extends low-rank
+*completion* to use row- and column-side *covariates*, decomposing the matrix into
+covariate-driven and residual low-rank parts -- preferable when you have
+informative side information and *missing* cells (including the block-missing
+pattern of a causal panel). Rule of thumb: disaggregate and noisy ->
+:doc:`clustersc` (``pcr`` for noise, ``rpca`` for outliers/missing); treated
+outside the hull or you need valid factor-model inference -> :doc:`fma`; strong
+trends plus noise -> :doc:`tasc`; informative covariates with missing cells ->
+:doc:`rmsi`.
+
 Q1.5 · Is the untreated outcome a nonlinear function of the predictors?
 
 * No -- next question.

--- a/docs/replications/vanillasc_staggered.rst
+++ b/docs/replications/vanillasc_staggered.rst
@@ -1,7 +1,7 @@
 .. _replication-vanillasc-staggered:
 
 VanillaSC — Staggered-Adoption Prediction Intervals (Cattaneo et al. 2025)
-=========================================================================
+==========================================================================
 
 :Estimator: :doc:`../vanillasc` — :class:`mlsynth.VanillaSC`
 :Source: Cattaneo, Matias D., Yingjie Feng, Filippo Palomba and Rocío
@@ -124,3 +124,24 @@ within five percent (it agrees to about 0.05 percent) and that the correct
 default in-sample band is exactly :math:`\iota` times the compatibility band.
 The point-estimate benchmark lives in ``benchmarks/cases/scpi_staggered.py``.
 Both skip themselves when ``scpi_pkg`` is not installed.
+
+Covariate matching
+------------------
+
+The same engine reproduces scpi's *covariate* multiple-treated illustration
+(``scpi_illustration-multi.py``): multi-feature matching (GDP and trade) with a
+constant-and-trend covariate adjustment and cointegrated differencing, supplied
+through a shared ``staggered_spec`` (the treated units are still detected from
+the treatment indicator, never named). On the Germany panel the per-unit average
+effects reproduce scpi's ``scest`` (West Germany :math:`-1.75`, Italy
+:math:`-0.89`) and the event-time bands match its ``CI_all_gaussian``.
+
+The in-sample conic here uses scpi's exact second-order-cone construction solved
+with ``ecos``: the per-cell predictand exercises the near-null directions of a
+rank-deficient :math:`\mathbf{Q}` (collinear covariates under cointegration),
+where a generic cvxpy reformulation diverged. Because scpi's multi-feature design
+produces duplicate donor-column names that recent ``scikit-learn`` rejects, the
+upstream package cannot compute these covariate intervals in a current
+environment; the reference was generated with a one-line column-name coercion,
+and the durable benchmark ``benchmarks/cases/scpi_staggered_covariate.py`` pins
+the resulting ``scpi`` numbers and checks ``fit()`` against them.

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -894,6 +894,46 @@ event-time bands reproduce ``scpi``'s to solver tolerance (durable benchmarks
 ``scpi_staggered`` and ``scpi_staggered_pi``). See
 :doc:`replications/vanillasc_staggered`.
 
+Covariate (multi-feature) matching
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Everything above matches on the outcome alone. To match on several series at
+once -- scpi's *features* framework, with covariate adjustment and cointegration
+-- attach a ``staggered_spec`` to the config. The spec is shared across treated
+units and never names them; the treated units come from the treatment indicator,
+as everywhere else in mlsynth.
+
+.. code-block:: python
+
+   res = VanillaSC({"df": df, "outcome": "gdp", "treat": "status",
+                    "unitid": "country", "time": "year",
+                    "inference": "scpi", "display_graphs": False,
+                    "staggered_spec": {
+                        "features": ["gdp", "trade"],     # match GDP and trade
+                        "cov_adj": ["constant", "trend"], # per-feature adjustment
+                        "constant": True,                 # global constant
+                        "cointegrated": True}}).fit()     # difference the data
+
+With a ``staggered_spec`` each treated unit is fit on the stacked features with
+the covariate-adjustment terms partialled out (and the data differenced when
+``cointegrated`` is set), and ``fit()`` returns the same three predictands -- the
+per-unit ATTs, the event study and the overall ATT -- now with covariate
+matching. The spec mirrors scpi's ``scdataMulti`` arguments (``features``,
+``cov_adj``, ``constant``, ``cointegrated_data``) but applies them uniformly:
+mlsynth detects who is treated, so there is no per-unit naming. This reproduces
+scpi's multiple-treated illustration; on the Germany panel the per-unit average
+effects match scpi's ``scest`` (West Germany :math:`-1.75`, Italy
+:math:`-0.89`) and the event-time prediction intervals match its
+``CI_all_gaussian`` (durable benchmark ``scpi_staggered_covariate``).
+
+.. note::
+
+   scpi's multi-feature design produces duplicate donor-column names that recent
+   ``scikit-learn`` releases reject, so the upstream package cannot compute these
+   covariate prediction intervals in a current environment; mlsynth's clean-room
+   engine does, and was validated against scpi with a one-line column-name
+   coercion.
+
 Ridge augmentation (Augmented SCM)
 ----------------------------------
 

--- a/mlsynth/tests/test_staggered_engine.py
+++ b/mlsynth/tests/test_staggered_engine.py
@@ -11,11 +11,17 @@ keeping the (cvxpy) cost low.
 
 from __future__ import annotations
 
+import os
+
 import numpy as np
 import pandas as pd
 import pytest
 
+from mlsynth.utils.vanillasc_helpers import staggered_engine as E
 from mlsynth.utils.vanillasc_helpers.staggered_engine import staggered_pi_bands
+
+_GERMANY = os.path.join(os.path.dirname(__file__), "..", "..",
+                        "basedata", "scpi_germany.csv")
 
 
 def _panel(seed: int = 0, n_donor: int = 5, T: int = 14, r: int = 2):
@@ -72,3 +78,37 @@ def test_default_band_is_wider_than_compat():
     d = staggered_pi_bands(df, scpi_compat=False, **_COMMON)
     c = staggered_pi_bands(df, scpi_compat=True, **_COMMON)
     assert np.all((d["ub"] - d["lb"]) >= (c["ub"] - c["lb"]) - 1e-9)
+
+
+def _germany_covariate_unit_time():
+    """scpi's multi-illustration unit-time spec: shared multi-features, constant,
+    cointegration, constant+trend adjustment -- the case that exercises the
+    near-null conic directions per cell."""
+    df = pd.read_csv(os.path.abspath(_GERMANY))
+    df["status"] = 0
+    df.loc[(df.country == "West Germany") & (df.year >= 1991), "status"] = 1
+    df.loc[(df.country == "Italy") & (df.year >= 1992), "status"] = 1
+    md = E.scdata_multi(df, "gdp", {"features": ["gdp", "trade"]},
+                        {"cov_adj": ["constant", "trend"]}, True, True, "unit-time")
+    return E.scest(md)
+
+
+def test_covariate_per_cell_conic_stays_bounded():
+    """Per-cell (unit-time) bands with covariates + cointegration must stay
+    finite and bounded -- the ECOS construction handles the near-null Q
+    directions where a cvxpy reformulation produced an unbounded-ray blowup."""
+    est = _germany_covariate_unit_time()
+    out = E.scpi(est, sims=120, seed=8894, tsua_double_divide=True)
+    lo, hi = out["sc_l_1"], out["sc_r_1"]
+    assert np.all(np.isfinite(lo)) and np.all(np.isfinite(hi))
+    assert np.max(hi - lo) < 50.0           # the blowup bug gave widths ~8e3
+    assert np.all(hi >= lo)
+
+
+def test_covariate_point_estimates_match_scpi_reference():
+    """The synthetic predictions for the covariate unit-time spec are the
+    deterministic scest quantities; pinned to the scpi-reproduced values."""
+    est = _germany_covariate_unit_time()
+    yf = np.asarray(est["Y_post_fit"], float).ravel()
+    assert len(yf) == 25
+    np.testing.assert_allclose(yf[:3], [19.6354, 20.2760, 21.1597], atol=1e-3)

--- a/mlsynth/tests/test_vanillasc_staggered.py
+++ b/mlsynth/tests/test_vanillasc_staggered.py
@@ -235,3 +235,33 @@ def test_single_treated_unit_has_no_event_study_intervals(germany_staggered):
     df.loc[df["country"] == "Italy", "status"] = 0    # only West Germany treated
     res = _fit_scpi(df, scpi_sims=60)
     assert res.additional_outputs.get("event_study_intervals") is None
+
+
+# ---------------------------------------------------------------------------
+# Covariate (multi-feature) staggered matching -- scpi's multi illustration
+# ---------------------------------------------------------------------------
+def test_covariate_staggered_matches_scpi_per_unit():
+    """With a shared multi-feature spec (gdp+trade, constant+trend, cointegrated)
+    the per-unit average effects reproduce scpi's scest to the published digits.
+    The spec never names treated units -- they come from the treatment column."""
+    df = pd.read_csv(os.path.abspath(_DATA))     # full panel (trade, infrate, ...)
+    df["status"] = 0
+    df.loc[(df["country"] == "West Germany") & (df["year"] >= 1991), "status"] = 1
+    df.loc[(df["country"] == "Italy") & (df["year"] >= 1992), "status"] = 1
+    res = VanillaSC({
+        "df": df, "outcome": "gdp", "treat": "status",
+        "unitid": "country", "time": "year", "display_graphs": False,
+        "inference": "scpi", "scpi_sims": 80, "seed": 8894, "scpi_compat": True,
+        "staggered_spec": {"features": ["gdp", "trade"],
+                           "cov_adj": ["constant", "trend"],
+                           "constant": True, "cointegrated": True},
+    }).fit()
+    pu = res.additional_outputs["per_unit_att"]
+    assert pu["Italy"] == pytest.approx(-0.8902, abs=2e-3)        # scpi scest
+    assert pu["West Germany"] == pytest.approx(-1.7467, abs=2e-3)
+    # full predictand set is populated, with intervals
+    esi = res.additional_outputs["event_study_intervals"]
+    assert esi and all("synthetic_ci" in d and "effect_ci" in d for d in esi.values())
+    assert res.inference is not None
+    assert np.isfinite(res.effects.att)
+    assert len(res.additional_outputs["per_cell_effects"]) == 25

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -11,9 +11,51 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ...config_models import BaseEstimatorConfig
+
+
+class StaggeredSCMSpec(BaseModel):
+    """Covariate (multi-feature) matching spec for staggered VanillaSC.
+
+    Mirrors the ``scpi`` package's ``scdataMulti`` specification, applied
+    uniformly to every treated unit. The treated units are detected from the
+    treatment indicator -- the spec never names them. When a ``staggered_spec``
+    is attached to a multi-treated panel, ``VanillaSC`` builds one synthetic
+    control per treated unit on these features and reproduces the Cattaneo-Feng-
+    Palomba-Titiunik (2025) point estimates and prediction intervals for all
+    three causal predictands.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    features: List[str] = Field(
+        ...,
+        description="Matching features (outcome-like series), shared across all "
+                    "treated units. Must include the outcome.",
+    )
+    cov_adj: Optional[List[Any]] = Field(
+        default=None,
+        description="Covariate-adjustment terms per feature (e.g. "
+                    "['constant', 'trend']). None -> no adjustment.",
+    )
+    constant: bool = Field(
+        default=False,
+        description="Include a global constant (scpi's 'constant').",
+    )
+    cointegrated: bool = Field(
+        default=False,
+        description="Difference the data for cointegration (scpi's "
+                    "'cointegrated_data').",
+    )
+
+    @field_validator("features")
+    @classmethod
+    def _features_nonempty(cls, v: List[str]) -> List[str]:
+        if not v:
+            raise ValueError("staggered_spec.features must be non-empty.")
+        return v
 
 
 class VanillaSCConfig(BaseEstimatorConfig):
@@ -139,6 +181,15 @@ class VanillaSCConfig(BaseEstimatorConfig):
     scpi_e_method: Literal["gaussian", "empirical"] = Field(
         default="gaussian",
         description="SCPI out-of-sample location-scale tabulation.",
+    )
+    staggered_spec: Optional[StaggeredSCMSpec] = Field(
+        default=None,
+        description="Staggered adoption only. Covariate (multi-feature) matching "
+                    "spec (scpi's scdataMulti specification). When set on a "
+                    "multi-treated panel, VanillaSC reproduces the Cattaneo-Feng-"
+                    "Palomba-Titiunik (2025) point estimates and prediction "
+                    "intervals for all three predictands with covariates. None "
+                    "(default) -> outcome-only staggered matching.",
     )
     scpi_compat: bool = Field(
         default=False,

--- a/mlsynth/utils/vanillasc_helpers/staggered.py
+++ b/mlsynth/utils/vanillasc_helpers/staggered.py
@@ -181,8 +181,134 @@ def _aggregate_att_interval(unit_fits: Dict[str, StaggeredUnitFit],
     )
 
 
+def _covariate_observed(config):
+    """Per-unit post-treatment treated outcomes keyed by ``(unit, year)`` and
+    the adoption year per unit (from the 0/1 treatment indicator)."""
+    df = config.df
+    treated = df[df[config.treat] == 1]
+    obs = {(str(u), int(y)): float(v) for u, y, v in zip(
+        treated[config.unitid], treated[config.time], treated[config.outcome])}
+    adopt = {str(u): int(y) for u, y in
+             treated.groupby(config.unitid)[config.time].min().items()}
+    return obs, adopt
+
+
+def _effect_from_band(band, observed):
+    """Treatment effect point and intervals from a synthetic-prediction band.
+
+    The engine returns the band on the synthetic (counterfactual) prediction;
+    the effect is ``observed - synthetic`` (bounds reverse). Returns
+    ``(effect, effect_lo, effect_hi)`` plus the synthetic full and in-sample
+    bands as ``(lo, hi)`` tuples.
+    """
+    syn = band["point"]
+    eff = observed - syn
+    return (eff, observed - band["ub"], observed - band["lb"],
+            (band["lb"], band["ub"]), (band["insample_lb"], band["insample_ub"]))
+
+
+def _run_covariate_staggered(config, prep: Dict[str, Any]) -> BaseEstimatorResults:
+    """Staggered VanillaSC with covariate (multi-feature) matching.
+
+    Drives the clean-room engine for all three causal predictands (per-unit,
+    unit-time, event-time) under the ``staggered_spec`` matching specification,
+    reproducing scpi's covariate staggered illustration through ``fit()``.
+    """
+    from .staggered_engine import staggered_pi_bands
+
+    spec = config.staggered_spec
+    common = dict(
+        outcome=config.outcome, unitid=config.unitid, time=config.time,
+        treat=config.treat, sims=config.scpi_sims, u_alpha=config.alpha,
+        e_alpha=config.alpha, seed=config.seed, scpi_compat=config.scpi_compat,
+        features=spec.features, cov_adj=spec.cov_adj,
+        feature_constant=spec.constant, cointegrated=spec.cointegrated,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        b_unit = staggered_pi_bands(config.df, effect="unit", **common)
+        b_time = staggered_pi_bands(config.df, effect="time", **common)
+        b_ut = staggered_pi_bands(config.df, effect="unit-time", **common)
+    obs, adopt = _covariate_observed(config)
+
+    # per-unit average effect (TAUS)
+    units = [str(lab[0]) for lab in b_unit["index"]]
+    obs_unit = np.array([np.mean([v for (uu, _), v in obs.items() if uu == u])
+                         for u in units])
+    eff_u, lo_u, hi_u, _, _ = _effect_from_band(b_unit, obs_unit)
+    per_unit_att = {u: float(eff_u[i]) for i, u in enumerate(units)}
+    per_unit_ci = {u: (float(lo_u[i]), float(hi_u[i])) for i, u in enumerate(units)}
+
+    # event-time average effect (TSUA)
+    ev = [int(lab) for lab in b_time["index"]]
+    obs_time = np.array([
+        np.mean([obs[(u, adopt[u] + ell - 1)] for u in adopt
+                 if (u, adopt[u] + ell - 1) in obs]) for ell in ev])
+    eff_t, lo_t, hi_t, (slb, sub), (silb, siub) = _effect_from_band(b_time, obs_time)
+    event_study = {ell: float(eff_t[i]) for i, ell in enumerate(ev)}
+    event_study_intervals = {
+        ell: {"effect": float(eff_t[i]),
+              "effect_ci": (float(lo_t[i]), float(hi_t[i])),
+              "synthetic_ci": (float(slb[i]), float(sub[i])),
+              "insample_synthetic_ci": (float(silb[i]), float(siub[i]))}
+        for i, ell in enumerate(ev)}
+
+    # per-cell (TSUS) and overall (TAUA)
+    cells = [(str(lab[0]), int(lab[1])) for lab in b_ut["index"]]
+    obs_ut = np.array([obs[c] for c in cells])
+    eff_ut, lo_ut, hi_ut, _, _ = _effect_from_band(b_ut, obs_ut)
+    overall_att = float(np.mean(eff_ut))
+    overall_lo = float(np.mean(lo_ut))
+    overall_hi = float(np.mean(hi_ut))
+
+    inference = InferenceResults(
+        ci_lower=overall_lo, ci_upper=overall_hi,
+        confidence_level=1.0 - 2.0 * config.alpha,
+        method=("staggered SCPI prediction intervals, covariate matching "
+                "(Cattaneo, Feng, Palomba & Titiunik 2025)"),
+        details={"aggregation": "pointwise mean of per-cell effect intervals",
+                 "per_unit_att_ci": per_unit_ci},
+    )
+
+    return BaseEstimatorResults(
+        effects=EffectsResults(
+            att=overall_att,
+            additional_effects={
+                "aggregation": "unit-time", "n_treated_units": len(units),
+                "per_unit_att": per_unit_att},
+        ),
+        time_series=TimeSeriesResults(),
+        weights=WeightsResults(summary_stats={
+            "constraint": "per-unit simplex (staggered, covariate matching)"}),
+        inference=inference,
+        fit_diagnostics=FitDiagnosticsResults(),
+        method_details=MethodDetailsResults(
+            method_name="VanillaSC[staggered,covariate]",
+            parameters_used={
+                "n_treated_units": len(units), "donor_pool": "never-treated",
+                "features": spec.features, "cov_adj": spec.cov_adj,
+                "constant": spec.constant, "cointegrated": spec.cointegrated},
+        ),
+        sub_method_results={
+            u: {"att": per_unit_att[u], "att_ci": per_unit_ci[u]} for u in units},
+        additional_outputs={
+            "event_study": event_study,
+            "event_study_intervals": event_study_intervals,
+            "per_unit_att": per_unit_att,
+            "per_unit_intervals": per_unit_ci,
+            "per_cell_effects": {cells[i]: float(eff_ut[i]) for i in range(len(cells))},
+            "per_cell_intervals": {
+                cells[i]: (float(lo_ut[i]), float(hi_ut[i])) for i in range(len(cells))},
+            "predictand_spec": "covariate (multi-feature) matching",
+        },
+    )
+
+
 def run_vanillasc_staggered(config, prep: Dict[str, Any]) -> BaseEstimatorResults:
     """Fit per-unit synthetic controls under staggered adoption and aggregate."""
+    if getattr(config, "staggered_spec", None) is not None:
+        return _run_covariate_staggered(config, prep)
+
     cohorts = prep["cohorts"]
     time_labels = np.asarray(prep.get("time_labels"))
 

--- a/mlsynth/utils/vanillasc_helpers/staggered_engine.py
+++ b/mlsynth/utils/vanillasc_helpers/staggered_engine.py
@@ -1091,6 +1091,26 @@ def scpi(est, sims=200, u_alpha=0.05, e_alpha=0.05, rho='type-2', rho_max=0.2,
 # ===========================================================================
 # Public entry point: outcome-only staggered VanillaSC prediction intervals
 # ===========================================================================
+def _normalize_spec(features, cov_adj, feature_constant, cointegrated,
+                    outcome, treated_units):
+    """Map a user spec (outcome-only, shared, or per-unit) to the engine's
+    ``scdata_multi`` argument forms. ``features`` / ``cov_adj`` may be a list
+    (shared across units) or a ``{unit: ...}`` dict; ``feature_constant`` /
+    ``cointegrated`` may be a bool or a per-unit dict."""
+    if features is None:
+        return ({tr: [outcome] for tr in treated_units},
+                {tr: None for tr in treated_units}, False, False)
+    feats = ({"features": list(features)}
+             if isinstance(features, (list, tuple)) else dict(features))
+    if cov_adj is None:
+        cadj = {tr: None for tr in treated_units}
+    elif isinstance(cov_adj, (list, tuple)):
+        cadj = {"cov_adj": list(cov_adj)}
+    else:
+        cadj = dict(cov_adj)
+    return feats, cadj, feature_constant, cointegrated
+
+
 def staggered_pi_bands(
     df,
     *,
@@ -1104,13 +1124,18 @@ def staggered_pi_bands(
     e_alpha=0.05,
     seed=8894,
     scpi_compat=False,
+    features=None,
+    cov_adj=None,
+    feature_constant=False,
+    cointegrated=False,
 ):
-    """Outcome-only staggered synthetic-control prediction intervals.
+    """Staggered synthetic-control prediction intervals for one predictand.
 
-    Drives the clean-room engine on a long panel for one causal predictand and
-    returns the point estimates and prediction-interval bands. Outcome-only
-    (no covariate adjustment, simplex weights), matching the scalar ``VanillaSC``
-    contract; the donor pool is the never-treated units.
+    Drives the clean-room engine on a long panel and returns the synthetic
+    (counterfactual) point estimates and prediction-interval bands. Outcome-only
+    by default (simplex weights, never-treated donor pool); pass ``features`` /
+    ``cov_adj`` / ``feature_constant`` / ``cointegrated`` to reproduce scpi's
+    covariate (multi-feature) staggered specification.
 
     Parameters
     ----------
@@ -1129,8 +1154,19 @@ def staggered_pi_bands(
         Seed for the in-sample Gaussian draws.
     scpi_compat : bool
         When True, reproduce ``scpi``'s ``1 / iota**2`` in-sample scaling of the
-        time-aggregated band; when False (default), use the statistically
-        correct ``1 / iota``. Only affects ``effect="time"``.
+        time-aggregated band; when False (default), the statistically correct
+        ``1 / iota``. Only affects ``effect="time"``.
+    features : list or {unit: list}, optional
+        Matching features (outcome-like series). A list is shared across units;
+        a dict gives per-unit feature sets. ``None`` -> outcome-only.
+    cov_adj : list or {unit: ...}, optional
+        Covariate-adjustment terms (e.g. ``["constant", "trend"]``), shared or
+        per-unit.
+    feature_constant : bool or {unit: bool}
+        Whether to include a global constant (scpi's ``constant``).
+    cointegrated : bool or {unit: bool}
+        Whether to difference the data for cointegration (scpi's
+        ``cointegrated_data``).
 
     Returns
     -------
@@ -1144,11 +1180,11 @@ def staggered_pi_bands(
     data = df.rename(columns=ren).copy()
     treated_units = sorted(
         data.loc[data["status"] == 1, "country"].unique().tolist())
-    features = {tr: [outcome] for tr in treated_units}
-    cov_adj = {tr: None for tr in treated_units}
+    feats, cadj, const, coint = _normalize_spec(
+        features, cov_adj, feature_constant, cointegrated, outcome, treated_units)
 
-    md = scdata_multi(data, outcome, features, cov_adj,
-                      constant=False, cointegrated_data=False, effect=effect)
+    md = scdata_multi(data, outcome, feats, cadj,
+                      constant=const, cointegrated_data=coint, effect=effect)
     est = scest(md)
     out = scpi(est, sims=sims, u_alpha=u_alpha, e_alpha=e_alpha, seed=seed,
                tsua_double_divide=scpi_compat)

--- a/mlsynth/utils/vanillasc_helpers/staggered_engine.py
+++ b/mlsynth/utils/vanillasc_helpers/staggered_engine.py
@@ -5,10 +5,14 @@ intervals of Cattaneo, Feng, Palomba & Titiunik (2025), Section 4. No part of
 the GPL ``scpi`` package is imported: data preparation, simplex weight
 estimation, the in-sample conic prediction intervals (sub-Gaussian / location-
 scale / quantile out-of-sample, plus the joint/uniform band) are all
-reimplemented from the published methodology. Convex programs are solved with
-``cvxpy`` (CLARABEL backend, the library default). The engine has been validated
-numerically against ``scpi`` to solver tolerance on the canonical Germany
-reunification panel (per-cell and event-time bands agree to ~3-4 decimals).
+reimplemented from the published methodology. Weight estimation uses ``cvxpy``
+(CLARABEL); the in-sample conic prediction-interval program uses ``scpi``'s exact
+second-order-cone construction solved directly with ``ecos`` (a cvxpy
+reformulation diverges on the near-null directions the per-cell predictand
+exercises). The engine has been validated numerically against ``scpi`` to solver
+tolerance on the canonical Germany reunification panel -- point estimates and the
+unit / unit-time / time prediction intervals, with and without covariates, agree
+to a few decimals.
 
 The cross-unit (effect="time", TSUA) in-sample interval carries a subtle scaling
 choice. ``scpi`` divides the predictand matrix ``P`` by the number of treated
@@ -30,8 +34,10 @@ import numpy as np
 import pandas as pd
 from math import sqrt, log, ceil
 import scipy.linalg
+from scipy import sparse
 from scipy.linalg import eigh, sqrtm
 import cvxpy as cp
+import ecos
 import statsmodels.api as sm
 from sklearn.linear_model import LinearRegression
 
@@ -592,53 +598,89 @@ def u_sigma_est_HC1(u_mean, res, Z, V, TT, df):
 # ---------------------------------------------------------------------------
 # Conic in-sample optimisation (mirrors scpi_in_diag, simplex)
 # ---------------------------------------------------------------------------
-def _Qfactor(Q):
-    """Return F (r x n) with F'F = Q, dropping ~0 eigen-directions (matRegularize)."""
-    wv, V = eigh(np.asarray(Q, dtype=float))
+def mat_regularize(Q):
+    """Reduce ``Q`` to its non-null factor ``Qreg`` (rows x n) with
+    ``Qreg' Qreg = Q / scale`` on the kept subspace, dropping near-null
+    eigen-directions. Returns ``(scale, Qreg)``; ``Qreg`` is empty when ``Q`` is
+    ~0. Mirrors scpi's ``matRegularize``."""
+    Qa = np.asarray(Q, dtype=float)
+    n = Qa.shape[0]
+    w, V = eigh(Qa)
     cond = 1e6 * np.finfo(float).eps
-    scale = max(abs(wv))
+    scale = float(np.max(np.abs(w))) if w.size else 0.0
     if scale < cond:
-        return np.zeros((0, Q.shape[0]))
-    wsc = wv / scale
-    mask = wsc > cond
-    F = (V[:, mask] * np.sqrt(wsc[mask] * scale)).T
-    return F
+        return 0.0, np.zeros((0, n))
+    wsc = w / scale
+    maskp = wsc > cond
+    Qreg = (V[:, maskp] * np.sqrt(wsc[maskp])).T      # (nkeep, n), Qreg'Qreg = Q/scale
+    return scale, Qreg
+
+
+def _ecos_simplex_dims_AB(n, J, Qsum, red):
+    """Constant ECOS pieces for the single-unit simplex QCQP: cone dims, the
+    sum-to-one equality (A, b). ``ns = 1`` slack (the SOC epigraph ``t``)."""
+    ns = 1
+    dims = {"l": J + 1, "q": [n + 2 - red]}
+    A = np.zeros((1, n + ns))
+    A[0, 0:J] = 1.0
+    A = sparse.csc_matrix(A)
+    b = np.array([Qsum], dtype=float)
+    return ns, dims, A, b
 
 
 def conic_bounds_unit(beta, Q, P_rows, lb, Qsum, zeta_unit, sims):
-    """For one treated unit, solve min/max p.(beta-x) over the localized set
-    for every simulation draw and every post-treatment horizon."""
+    """For one treated unit, solve min/max ``p.(beta-x)`` over the localized set
+    for every simulation draw and post-treatment horizon, using scpi's exact
+    ECOS second-order-cone construction.
+
+    The constraint ``(x-beta)'Q(x-beta) - 2 G'(x-beta) <= 0`` is encoded as a
+    rotated SOC with the scaled, dimension-reduced factor ``Qreg`` (see
+    :func:`mat_regularize`): the linear part uses the full ``Q`` (via ``beta_q``,
+    ``beta_q_beta``) and the cone uses ``Qreg`` / ``scale``. Solving with ``ecos``
+    (rather than a cvxpy reformulation) reproduces scpi cell-for-cell, including
+    the near-null-direction handling that the per-cell predictands exercise.
+    """
+    beta = np.asarray(beta, dtype=float)
     n = len(beta)
     J = len(lb)
-    F = _Qfactor(Q)
+    Qa = np.asarray(Q, dtype=float)
+    lb = np.asarray(lb, dtype=float)
+
+    scale, Qreg = mat_regularize(Qa)
+    red = n - Qreg.shape[0]
+    ns, dims, A, b = _ecos_simplex_dims_AB(n, J, Qsum, red)
+
+    beta_q = beta.dot(Qa)                 # full Q, as in scpi
+    beta_q_beta = float(beta.dot(Qa.dot(beta)))
+
+    # constant G rows (lower bounds + SOC epigraph + quadratic), built once
+    G_lb = np.concatenate((-np.eye(J), np.zeros((J, n - J + ns))), axis=1)
+    G_soc_t = np.array([[0.0] * n + [-1.0], [0.0] * n + [1.0]])
+    G_quad = -2.0 * np.concatenate((Qreg, np.zeros((Qreg.shape[0], ns))), axis=1)
+    h_const_tail = np.concatenate(([-ll for ll in lb], [1.0, 1.0],
+                                   np.zeros(Qreg.shape[0])))
+
     res_lb = np.full((sims, len(P_rows)), np.nan)
     res_ub = np.full((sims, len(P_rows)), np.nan)
-
-    x = cp.Variable(n)
-    G = cp.Parameter(n)
-    pt = cp.Parameter(n)
-    base = [cp.sum(x[0:J]) == Qsum, x[0:J] >= np.asarray(lb)]
-    quad = cp.sum_squares(F @ (x - beta)) - 2 * G @ (x - beta) <= 0
-    cons = base + [quad]
-    prob_max = cp.Problem(cp.Maximize(pt @ x), cons)   # lb bound
-    prob_min = cp.Problem(cp.Minimize(pt @ x), cons)   # ub bound
+    OK = ("Optimal solution found", "Close to optimal solution found")
 
     for s in range(sims):
-        G.value = zeta_unit[:, s]
-        for h, p in enumerate(P_rows):
-            pt.value = p
-            try:
-                prob_max.solve(solver=cp.CLARABEL, warm_start=True)
-                if prob_max.status in ('optimal', 'optimal_inaccurate'):
-                    res_lb[s, h] = float(p @ (beta - x.value))
-            except cp.error.SolverError:
-                pass
-            try:
-                prob_min.solve(solver=cp.CLARABEL, warm_start=True)
-                if prob_min.status in ('optimal', 'optimal_inaccurate'):
-                    res_ub[s, h] = float(p @ (beta - x.value))
-            except cp.error.SolverError:
-                pass
+        Gd = zeta_unit[:, s]
+        a = -2.0 * Gd - 2.0 * beta_q
+        d = 2.0 * float(Gd.dot(beta)) + beta_q_beta
+        G_lin = np.concatenate((a, [scale]))[None, :]
+        Gmat = sparse.csc_matrix(np.concatenate((G_lin, G_lb, G_soc_t, G_quad), axis=0))
+        h = np.concatenate(([-d], h_const_tail))
+        for hor, p in enumerate(P_rows):
+            p = np.asarray(p, dtype=float)
+            c_lb = np.concatenate((-p, np.zeros(ns)))
+            sol = ecos.solve(c_lb, Gmat, h, dims, A=A, b=b, verbose=False)
+            if sol["info"]["infostring"] in OK:
+                res_lb[s, hor] = float(p.dot(beta - sol["x"][0:n]))
+            c_ub = np.concatenate((p, np.zeros(ns)))
+            sol = ecos.solve(c_ub, Gmat, h, dims, A=A, b=b, verbose=False)
+            if sol["info"]["infostring"] in OK:
+                res_ub[s, hor] = float(p.dot(beta - sol["x"][0:n]))
     return res_lb, res_ub
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "scikit-optimize>=0.9.0",
     "statsmodels>=0.14.0",
     "cvxpy>=1.4.0",
+    "ecos>=2.0.0",
     "pydantic>=2.0.0",
     "pyarrow>=14.0.0",
 ]


### PR DESCRIPTION
## Summary

Extends staggered `VanillaSC` to reproduce scpi's **covariate** multiple-treated illustration (`scpi_illustration-multi.py`) through the public `fit()`, for all three causal predictands — and fixes the in-sample conic so the per-cell predictand matches scpi exactly.

Builds on #140 (outcome-only staggered, already merged).

## Exact ECOS conic (fixes `unit-time`)

With covariates + cointegration the treated block's `Q` is rank-deficient; per-cell predictands escape through the dropped near-null directions, so the cvxpy/CLARABEL conic returned an unbounded ray (band widths ~8e3) and even ECOS-as-solver diverged ~10%. Replaced it with scpi's exact second-order-cone construction (simplex branch) solved directly with `ecos`. Now **all three predictands match scpi to solver tolerance, with and without covariates** (`unit-time` went from ~10% to 1e-4); outcome-only is unchanged (0.05% on the TSUA band); and it's faster. Adds `ecos` as a declared dependency.

## Covariate matching through fit() — no naming treated units

A shared `staggered_spec` on `VanillaSCConfig`: `features` (list), `cov_adj`, `constant`, `cointegrated`, applied uniformly to the **auto-detected** treated units (the spec never names them, per mlsynth's convention). `fit()` returns per-unit ATTs, the event study, the overall ATT and per-cell effects, each with intervals.

Validated against scpi on the Germany panel (shared gdp+trade, constant+trend, cointegrated): per-unit ATTs reproduce scpi's `scest` to ~2e-6 (West Germany −1.7467, Italy −0.8902); event-time bands match scpi's `CI_all_gaussian` to ~5e-4. (scpi itself can't compute these PIs under current scikit-learn — duplicate donor-column names — so the reference was generated with a one-line coercion.)

## Benchmarks hard-coded (GPL → MIT)

scpi is GPL and mlsynth is MIT, so the scpi cross-validation benchmarks no longer import `scpi_pkg` even optionally — they pin scpi's recorded numbers and check `fit()` against them, with no run-time GPL dependency. Converted `scpi_staggered` and `scpi_staggered_pi` to hard-coded references; added `scpi_staggered_covariate`.

## Changes
- `staggered_engine.py` — exact ECOS conic (`mat_regularize` + `ecos.solve`); generalized `staggered_pi_bands` to accept the covariate spec
- `config.py` — `StaggeredSCMSpec` model + `staggered_spec` field (shared-only, no unit names)
- `staggered.py` — covariate `fit()` path for all three predictands
- Tests: covariate fit() match + per-cell conic boundedness regression
- Benchmarks: `scpi_staggered_covariate`; `scpi_staggered`/`scpi_staggered_pi` hard-coded
- Docs: "Covariate matching" sections on the VanillaSC + replication pages; `ecos` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_