### PR TITLE
ci(paper): install mlsynth + Jupyter in the Quarto render job

### DIFF
--- a/.github/workflows/paper_render.yml
+++ b/.github/workflows/paper_render.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Install mlsynth and Jupyter (for executable .qmd chunks)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install jupyter pyyaml
+
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
         with:


### PR DESCRIPTION
## What

`paper/paper.qmd` (merged in #142) is the first executable `.qmd` in the repo. The `paper_render.yml` runner ships Quarto and TinyTeX but no Python kernel, so the Jupyter engine failed to start:

```
Starting python3 kernel...Traceback ... ModuleNotFoundError: No module named 'yaml'
Jupyter is not available in this Python installation.
```

This adds a step to install the package (editable) plus `jupyter`/`pyyaml` before rendering, so the executable chunks run in CI.

## Validation

The workflow-file change does not match `paper_render.yml`'s `push` path filters (`**.qmd`, `**/requirements.txt`), so it won't auto-run on this PR. I dispatched the render workflow manually on this branch (`target_qmd=paper/paper.qmd`) to confirm it goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_