### PR TITLE
ci: fix docs-only PR failures (pip cache) and declare missing ecos dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
+          # No pip cache here. This job's install step is conditional (skipped on
+          # docs/benchmarks-only PRs), and setup-python's cache post-step errors
+          # when nothing was installed -- which failed this job on every docs-only
+          # PR. The build job above keeps the cache (its install is unconditional).
 
       - name: Install dependencies
         if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'

--- a/.github/workflows/paper_render.yml
+++ b/.github/workflows/paper_render.yml
@@ -3,8 +3,10 @@ name: Render Quarto Report
 on:
   push:
     paths:
-      - '**.qmd'
-      - '**/requirements.txt'
+      - '**.qmd'      # render only when a Quarto source changes; the root
+                      # requirements.txt is unrelated to the paper and used to
+                      # spuriously trigger this job (which then failed, having
+                      # no .qmd to render).
   workflow_dispatch:
     inputs:
       target_qmd:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ scipy>=1.10.0
 scikit-learn>=1.3.0
 scikit-optimize>=0.9.0
 cvxpy>=1.4.0  # bundles CLARABEL/OSQP/SCS solvers
+ecos>=2.0.0  # ECOS conic solver for the staggered-covariate SCM engine (mirrors pyproject)
 pyscipopt>=4.4.0  # For SCIP as fallback
 statsmodels>=0.14.0
 pydantic>=2.0.0


### PR DESCRIPTION
Two CI-health fixes that together make `pyversions` green again.

## 1. pip-cache post-step on docs-only PRs

Every docs/paper-only PR (#142, #143, #144) turned red on `pyversions (3.10/3.12/3.13)`. The job gates its install/test steps on `dorny/paths-filter` (correctly skipping the slow suite on docs-only PRs), but `setup-python` had `cache: pip`. With nothing installed, the cache post-step errors (`Cache folder path ... doesn't exist on disk`) and fails the job. Removed `cache: pip` from the `pyversions` job; the `build` job keeps it (its install is unconditional).

## 2. Missing `ecos` dependency (exposed once the suite ran)

With fix 1 in place, the matrix actually runs the suite on 3.10/3.12/3.13 — and it failed with `ModuleNotFoundError: No module named 'ecos'` (6 tests + 1 collection error). The staggered-covariate engine hard-imports `ecos`, and `ecos>=2.0.0` is declared in `pyproject.toml` — but CI installs via `pip install -r requirements.txt`, where it was absent. It only reached 3.11 transitively (via cvxpy), which is why `build` passed while the matrix failed. Mirrored the pyproject dependency into `requirements.txt`.

## Validation

Both `build.yml` and `requirements.txt` are in the paths-filter `code` set, so this PR runs the full suite on all four matrix entries. A green `pyversions` here proves both fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr