### PR TITLE
fix(spillsynth): iterative SCM exposes treated_synthetic_pre (uniform pre-fit / RMSE)

### DIFF
--- a/mlsynth/tests/test_spillsynth_iterative.py
+++ b/mlsynth/tests/test_spillsynth_iterative.py
@@ -56,6 +56,26 @@ def test_iterative_outcome_only_structure(german_panel):
     assert f.spillover_panel["Austria"].shape == (T1,)
 
 
+def test_iterative_exposes_treated_synthetic_pre(german_panel):
+    """iterative must expose the pre-period synthetic series, like iscm/grossi,
+    so observed-vs-fitted plots and pre-treatment RMSE are uniform across every
+    spillover method in the dispatcher (previously only ``pre_rmspe`` was given,
+    forcing callers to special-case this method)."""
+    res = SPILLSYNTH(_cfg(german_panel, iscm_intercept=True)).fit()
+    f = res.iterative
+    T0 = int(german_panel.year.lt(1990).groupby(german_panel.country).sum().max())
+    # the pre-period synthetic is exposed, correctly shaped and finite
+    assert f.treated_synthetic_pre is not None
+    assert f.treated_synthetic_pre.shape == (T0,)
+    assert np.all(np.isfinite(f.treated_synthetic_pre))
+    # and it is exactly consistent with the reported pre-treatment RMSPE
+    obs_pre = (german_panel[(german_panel.country == "West Germany")
+                            & (german_panel.year < 1990)]
+               .sort_values("year")["gdp"].to_numpy())
+    rmse = float(np.sqrt(np.mean((obs_pre - f.treated_synthetic_pre) ** 2)))
+    assert rmse == pytest.approx(f.pre_rmspe, rel=1e-9, abs=1e-9)
+
+
 def test_iterative_cleans_only_post_period(german_panel):
     # The waterfall replaces affected donors' POST outcomes only; the treated
     # unit's pre-fit is therefore the naive pre-fit (weights unchanged).

--- a/mlsynth/utils/spillsynth_helpers/iterative/pipeline.py
+++ b/mlsynth/utils/spillsynth_helpers/iterative/pipeline.py
@@ -106,5 +106,6 @@ def run_iterative(inputs: SpillSynthInputs, *, bilevel_solver: str = "mscmt",
         cleaned_units=[names[i] for i in affected],
         n_clean=len(clean),
         pre_rmspe=float(pre_rmspe),
+        treated_synthetic_pre=np.asarray(cf_f[:T0]),
         bilevel_solver=solver_label,
     )

--- a/mlsynth/utils/spillsynth_helpers/plotter.py
+++ b/mlsynth/utils/spillsynth_helpers/plotter.py
@@ -96,7 +96,7 @@ def _plot_single_treated(
     t_treat_cutoff = t[inputs.T0 - 1] if inputs.T0 >= 1 else None  # pragma: no branch
 
     y_treated = inputs.Y[0]
-    if results.method in ("iscm", "grossi"):
+    if results.method in ("iscm", "grossi", "iterative"):
         # These methods have no Cao-Dowd a/B artifacts; the treated unit's
         # pre-period synthetic is stored directly.
         sc_full_pre = np.asarray(cd.treated_synthetic_pre)

--- a/mlsynth/utils/spillsynth_helpers/structures.py
+++ b/mlsynth/utils/spillsynth_helpers/structures.py
@@ -444,6 +444,12 @@ class IterativeFit:
         Number of clean (never-affected) controls.
     pre_rmspe : float
         Treated unit's pre-treatment RMSPE on the cleaned pool.
+    treated_synthetic_pre : np.ndarray
+        Treated unit's pre-treatment synthetic fit, shape ``(T0,)`` -- the same
+        series ``ISCMFit`` and ``GrossiFit`` expose, so observed-vs-fitted plots
+        and pre-treatment RMSE are uniform across every spillover method. By
+        construction ``sqrt(mean((Y_treated_pre - treated_synthetic_pre)**2))``
+        equals ``pre_rmspe``.
     bilevel_solver : str
         Backend used for the per-unit SCM (``"mscmt"`` / ``"malo"`` /
         ``"outcome-only"``).
@@ -461,6 +467,7 @@ class IterativeFit:
     cleaned_units: list
     n_clean: int
     pre_rmspe: float
+    treated_synthetic_pre: np.ndarray
     bilevel_solver: str = "mscmt"
 
     # SP-dialect aliases for the shared accessors / plotter.


### PR DESCRIPTION
## Problem

`IterativeFit` (SPILLSYNTH `method="iterative"`, Melnychuk 2024) reported `pre_rmspe` but, unlike `ISCMFit` and `GrossiFit`, did not expose `treated_synthetic_pre` — the pre-period synthetic series itself. Two consequences:

1. Callers building observed-vs-fitted plots or a uniform pre-treatment RMSE across the spillover methods had to special-case `iterative` (there was no pre-fit series to read).
2. The shared plotter crashed for `iterative` with `display_graphs=True`: it routes `iscm`/`grossi` to `treated_synthetic_pre` and everything else to the Cao–Dowd `a`/`B` artifacts, which `IterativeFit` does not have.

## Fix

`run_iterative` already computes the full counterfactual `cf_f`; it stored `cf_f[T0:]` (post) but discarded `cf_f[:T0]` (the pre-period fit). Now:

- `IterativeFit` gains a `treated_synthetic_pre: np.ndarray` field, populated with `cf_f[:T0]`.
- The plotter's direct-pre-fit branch includes `iterative`.
- A test pins the invariant: `sqrt(mean((y_pre − treated_synthetic_pre)²)) == pre_rmspe` exactly, with the correct `(T0,)` shape and finiteness.

## Verification

- New test `test_iterative_exposes_treated_synthetic_pre` is red before the change (no such attribute), green after.
- Full spillsynth suite: 153 passed, no regressions.
- Manual: `treated_synthetic_pre` shape `(30,)`, RMSE 0.0609 = `pre_rmspe`, and `display_graphs=True` no longer crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_