### PR TITLE
feat: save_spec/load_spec — serialize an analysis spec to JSON/YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ now returns and the back-compat guarantee.
 
 ## [Unreleased]
 
+### Added
+- `mlsynth.save_spec` / `mlsynth.load_spec`: serialize an analysis specification
+  to a portable JSON or YAML file and load it back into a ready-to-fit estimator.
+  Because a configuration is plain, validated data, everything but the
+  `DataFrame` (and any runtime arrays such as adjacency or spatial matrices) can
+  be written to a text record, version-controlled, and reloaded -- separating the
+  durable record of *what* analysis was run from the data it ran on. The
+  DataFrame and matrix payloads are dropped on save and re-attached at load time
+  (`load_spec(path, df=..., adjacency=...)`). Adds `PyYAML` as a dependency.
+  Covered by `tests/test_spec.py`, including a parametrized check that `load_spec`
+  resolves and behaves gracefully for every estimator the package ships.
+
 ## [1.0.0] - 2026-06-20
 
 First stable release, published to PyPI (``pip install mlsynth``).

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -68,8 +68,11 @@ from .utils.spcd_helpers.plotter import (
     plot_power_curves,
     plot_detectability,
 )
+from .spec import save_spec, load_spec
 
 __all__ = [
+    "save_spec",
+    "load_spec",
     "plot_spcd_design",
     "plot_mde_bars",
     "plot_power_curves",

--- a/mlsynth/spec.py
+++ b/mlsynth/spec.py
@@ -1,0 +1,251 @@
+"""Serialize an analysis specification to a portable text file, and load it back.
+
+A configuration in mlsynth is plain, validated data, so the *specification* of an
+analysis -- every column name and method option, everything except the
+``DataFrame`` (and any other runtime arrays such as adjacency or spatial
+matrices) -- can be written to a JSON or YAML file, version-controlled, and
+loaded back to drive a fit. This separates the durable record of *what* analysis
+was run from the data it ran on.
+
+The contract is two functions:
+
+``save_spec(obj, path, *, estimator=None)``
+    Write the text specification of ``obj`` (an estimator instance, a
+    configuration object, or a plain ``dict``) to ``path``. The DataFrame and any
+    non-text-serializable fields (numpy arrays, adjacency/spatial DataFrames) are
+    omitted -- they are runtime payloads, attached at load time. The format is
+    chosen from the file extension (``.json``, ``.yaml``, ``.yml``).
+
+``load_spec(path, df=None, *, estimator=None, **runtime)``
+    Read a specification file and return a ready-to-fit estimator instance. The
+    estimator is resolved by name from the spec (or the ``estimator=`` override);
+    ``df`` and any ``runtime`` payloads (e.g. ``adjacency=...``,
+    ``spatial_matrix=...``) are attached before the estimator validates them.
+
+Example
+-------
+>>> from mlsynth.spec import save_spec, load_spec
+>>> save_spec(VanillaSC({"df": panel, "outcome": "y", "treat": "treated",
+...                       "unitid": "unit", "time": "year"}), "study.yaml")
+>>> est = load_spec("study.yaml", df=panel)   # ready-to-fit estimator
+>>> res = est.fit()
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+from typing import Any, Dict, Union
+
+import mlsynth
+from .config_models import BaseEstimatorConfig
+from .exceptions import MlsynthConfigError
+
+__all__ = ["save_spec", "load_spec"]
+
+_JSON_SUFFIXES = {".json"}
+_YAML_SUFFIXES = {".yaml", ".yml"}
+
+
+def _is_jsonable(value: Any) -> bool:
+    """True if ``value`` can be written to JSON/YAML as plain text data."""
+    try:
+        json.dumps(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def _resolve_estimator(name: str) -> type:
+    """Resolve an estimator class by its public name, or raise a typed error."""
+    if not isinstance(name, str):
+        raise MlsynthConfigError(
+            f"estimator name must be a string, got {type(name).__name__}."
+        )
+    cls = getattr(mlsynth, name, None)
+    if cls is None or not (isinstance(cls, type) and hasattr(cls, "fit")):
+        raise MlsynthConfigError(
+            f"Unknown estimator {name!r}: not a fit()-bearing class exported by mlsynth."
+        )
+    return cls
+
+
+def _config_dict(obj: BaseEstimatorConfig) -> Dict[str, Any]:
+    """Plain-dict view of a configuration, keeping only fields the user set.
+
+    ``exclude_defaults`` keeps the required fields and any non-default options,
+    so the written record stays minimal and readable.
+    """
+    return dict(obj.model_dump(exclude_defaults=True))
+
+
+def save_spec(
+    obj: Any,
+    path: Union[str, Path],
+    *,
+    estimator: Union[str, None] = None,
+) -> Dict[str, Any]:
+    """Write the text specification of an analysis to ``path``.
+
+    Parameters
+    ----------
+    obj : estimator instance, configuration object, or dict
+        The thing to serialize. An estimator instance contributes its own name;
+        a configuration object or dict needs ``estimator=`` (or, for a dict, an
+        ``"estimator"`` key).
+    path : str or Path
+        Destination file; the suffix selects JSON (``.json``) or YAML
+        (``.yaml`` / ``.yml``).
+    estimator : str, optional
+        Estimator name, required when ``obj`` is a bare configuration object and
+        optional otherwise (overrides what is inferred).
+
+    Returns
+    -------
+    dict
+        The specification that was written (handy for inspection and tests).
+    """
+    path = Path(path)
+
+    # Resolve the estimator name and the configuration mapping.
+    config = getattr(obj, "config", None)
+    if isinstance(config, BaseEstimatorConfig):  # an estimator instance
+        name = estimator or type(obj).__name__
+        data = _config_dict(config)
+    elif isinstance(obj, BaseEstimatorConfig):  # a bare config object
+        if estimator is None:
+            raise MlsynthConfigError(
+                "save_spec needs the estimator name for a configuration object; "
+                "pass estimator='VanillaSC' (or similar)."
+            )
+        name = estimator
+        data = _config_dict(obj)
+    elif isinstance(obj, dict):  # a plain dict of fields
+        data = dict(obj)
+        name = estimator or data.pop("estimator", None)
+        data.pop("estimator", None)
+        if name is None:
+            raise MlsynthConfigError(
+                "save_spec needs an estimator name; pass estimator=... or include "
+                "an 'estimator' key in the dict."
+            )
+    else:
+        raise MlsynthConfigError(
+            "save_spec expects an estimator instance, a configuration object, or a "
+            f"dict of fields, got {type(obj).__name__}."
+        )
+
+    # Keep only text-serializable fields; drop df and any runtime payloads.
+    spec: Dict[str, Any] = {"estimator": name}
+    dropped_runtime = []
+    for key, value in data.items():
+        if key == "df":
+            continue
+        if _is_jsonable(value):
+            spec[key] = value
+        else:
+            dropped_runtime.append(key)
+
+    if dropped_runtime:
+        warnings.warn(
+            "save_spec did not write non-serializable field(s) "
+            f"{sorted(dropped_runtime)}; pass them to load_spec at load time.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    _write(path, spec)
+    return spec
+
+
+def load_spec(
+    path: Union[str, Path],
+    df: Any = None,
+    *,
+    estimator: Union[str, None] = None,
+    **runtime: Any,
+) -> Any:
+    """Read a specification file and return a ready-to-fit estimator instance.
+
+    Parameters
+    ----------
+    path : str or Path
+        Specification file (``.json`` / ``.yaml`` / ``.yml``).
+    df : pandas.DataFrame, optional
+        The panel to attach. Required by every estimator at fit time, but left
+        out of the text record.
+    estimator : str, optional
+        Override the estimator named in the file.
+    **runtime
+        Any non-text payloads the estimator needs (e.g. ``adjacency=...``,
+        ``spatial_matrix=...``, ``df_agg=...``), attached before validation.
+
+    Returns
+    -------
+    estimator instance
+        Constructed and validated; call ``.fit()`` on it.
+    """
+    spec = _read(Path(path))
+    if not isinstance(spec, dict):
+        raise MlsynthConfigError(
+            f"specification file {Path(path).name!r} must contain a mapping of fields."
+        )
+
+    spec = dict(spec)
+    name = estimator or spec.pop("estimator", None)
+    spec.pop("estimator", None)
+    if name is None:
+        raise MlsynthConfigError(
+            "specification does not name an estimator; add an 'estimator' key or "
+            "pass estimator=... to load_spec."
+        )
+
+    cls = _resolve_estimator(name)
+
+    config: Dict[str, Any] = dict(spec)
+    if df is not None:
+        config["df"] = df
+    config.update(runtime)
+
+    return cls(config)
+
+
+# --------------------------------------------------------------------------- #
+# Format I/O (extension-dispatched)
+# --------------------------------------------------------------------------- #
+def _write(path: Path, spec: Dict[str, Any]) -> None:
+    suffix = path.suffix.lower()
+    if suffix in _JSON_SUFFIXES:
+        path.write_text(json.dumps(spec, indent=2) + "\n")
+    elif suffix in _YAML_SUFFIXES:
+        yaml = _import_yaml()
+        path.write_text(yaml.safe_dump(spec, sort_keys=False))
+    else:
+        raise MlsynthConfigError(
+            f"unsupported spec extension {suffix!r}; use .json, .yaml, or .yml."
+        )
+
+
+def _read(path: Path) -> Any:
+    suffix = path.suffix.lower()
+    text = path.read_text()
+    if suffix in _JSON_SUFFIXES:
+        return json.loads(text)
+    if suffix in _YAML_SUFFIXES:
+        yaml = _import_yaml()
+        return yaml.safe_load(text)
+    raise MlsynthConfigError(
+        f"unsupported spec extension {suffix!r}; use .json, .yaml, or .yml."
+    )
+
+
+def _import_yaml():
+    try:
+        import yaml  # PyYAML
+    except ImportError as exc:  # pragma: no cover - PyYAML is a declared dependency
+        raise MlsynthConfigError(
+            "YAML support requires PyYAML; install mlsynth's dependencies or use a "
+            ".json spec file."
+        ) from exc
+    return yaml

--- a/mlsynth/tests/test_spec.py
+++ b/mlsynth/tests/test_spec.py
@@ -1,0 +1,287 @@
+"""Tests for mlsynth.spec -- save/load an analysis specification to a portable file.
+
+A configuration is plain, validated data, so the specification of an analysis
+(everything but the DataFrame and any runtime arrays) can be written to a JSON or
+YAML file, version-controlled, and loaded back to drive a fit. These tests pin
+that contract: round-trips preserve the spec, the DataFrame and matrix payloads
+are dropped and re-attached at load time, the formats are honoured, failures are
+reported as typed ``Mlsynth*`` errors, and ``load_spec`` behaves gracefully for
+every estimator the package ships.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import mlsynth
+from mlsynth.exceptions import MlsynthError, MlsynthConfigError
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def panel() -> pd.DataFrame:
+    """A small, well-posed balanced panel: 6 units, 20 periods, unit ``u0``
+    treated from period 15. Carries spare covariate / instrument columns so the
+    estimators with extra required fields can be constructed."""
+    rng = np.random.default_rng(0)
+    units = [f"u{i}" for i in range(6)]
+    periods = list(range(2000, 2020))
+    rows = []
+    for i, u in enumerate(units):
+        level = 10.0 + 2.0 * i
+        for t in periods:
+            base = level + 0.5 * (t - 2000) + rng.normal(0, 0.1)
+            treated = int(u == "u0" and t >= 2015)
+            rows.append(
+                {
+                    "unit": u,
+                    "year": t,
+                    "y": base + (3.0 if treated else 0.0),
+                    "treated": treated,
+                    "x1": base + rng.normal(0, 0.1),
+                    "z": base + rng.normal(0, 0.1),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _vanillasc_spec() -> dict:
+    return {
+        "estimator": "VanillaSC",
+        "outcome": "y",
+        "treat": "treated",
+        "unitid": "unit",
+        "time": "year",
+        "display_graphs": False,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Public surface
+# --------------------------------------------------------------------------- #
+def test_exports_from_package_root():
+    # The module is part of the public API.
+    assert hasattr(mlsynth, "save_spec")
+    assert hasattr(mlsynth, "load_spec")
+    from mlsynth.spec import save_spec, load_spec  # noqa: F401
+
+
+# --------------------------------------------------------------------------- #
+# Round-trips that fit (the headline property)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("suffix", [".json", ".yaml", ".yml"])
+def test_roundtrip_from_dict_fits(panel, tmp_path, suffix):
+    from mlsynth.spec import save_spec, load_spec
+
+    path = tmp_path / f"spec{suffix}"
+    save_spec(_vanillasc_spec(), path)
+    assert path.exists()
+
+    est = load_spec(path, df=panel)
+    assert isinstance(est, mlsynth.VanillaSC)
+    res = est.fit()
+    assert np.isfinite(float(res.effects.att))
+
+
+def test_roundtrip_from_estimator_instance(panel, tmp_path):
+    # save_spec should read the estimator name off the instance automatically.
+    from mlsynth.spec import save_spec, load_spec
+
+    spec = {k: v for k, v in _vanillasc_spec().items() if k != "estimator"}
+    est = mlsynth.VanillaSC({"df": panel, **spec})
+
+    path = tmp_path / "spec.json"
+    written = save_spec(est, path)
+    assert written["estimator"] == "VanillaSC"
+
+    est2 = load_spec(path, df=panel)
+    assert isinstance(est2, mlsynth.VanillaSC)
+    assert np.isfinite(float(est2.fit().effects.att))
+
+
+def test_saved_spec_is_text_only_without_dataframe(panel, tmp_path):
+    from mlsynth.spec import save_spec
+
+    path = tmp_path / "spec.json"
+    save_spec(_vanillasc_spec(), path)
+    on_disk = json.loads(path.read_text())
+
+    assert on_disk["estimator"] == "VanillaSC"
+    for col in ("outcome", "treat", "unitid", "time"):
+        assert col in on_disk
+    assert "df" not in on_disk  # the DataFrame never lands in the text record
+
+
+# --------------------------------------------------------------------------- #
+# Runtime payloads (df and matrices) are dropped and re-attached
+# --------------------------------------------------------------------------- #
+def test_runtime_matrix_dropped_and_reattached(panel, tmp_path):
+    # SpSyDiD requires a spatial_matrix ndarray; it must not enter the text spec,
+    # and must be re-attachable at load time.
+    from mlsynth.spec import save_spec, load_spec
+
+    W = np.eye(6)
+    spec = {
+        "estimator": "SpSyDiD",
+        "outcome": "y",
+        "treat": "treated",
+        "unitid": "unit",
+        "time": "year",
+        "spatial_matrix": W,  # runtime payload
+        "display_graphs": False,
+    }
+    path = tmp_path / "spec.yaml"
+    with pytest.warns(UserWarning):
+        written = save_spec(spec, path, estimator="SpSyDiD")
+    assert "spatial_matrix" not in written  # dropped from the text record
+
+    est = load_spec(path, df=panel, spatial_matrix=W)
+    assert isinstance(est, mlsynth.SpSyDiD)
+    assert np.array_equal(np.asarray(est.config.spatial_matrix), W)
+
+
+# --------------------------------------------------------------------------- #
+# Failure modes are reported as typed errors
+# --------------------------------------------------------------------------- #
+def test_unknown_estimator_raises_config_error(tmp_path):
+    from mlsynth.spec import load_spec
+
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps({"estimator": "NotAnEstimator", "outcome": "y"}))
+    with pytest.raises(MlsynthConfigError):
+        load_spec(path, df=pd.DataFrame())
+
+
+def test_unsupported_extension_raises(tmp_path):
+    from mlsynth.spec import save_spec, load_spec
+
+    with pytest.raises(MlsynthConfigError):
+        save_spec(_vanillasc_spec(), tmp_path / "spec.txt")
+
+    bad = tmp_path / "spec.txt"
+    bad.write_text("estimator: VanillaSC")
+    with pytest.raises(MlsynthConfigError):
+        load_spec(bad, df=pd.DataFrame())
+
+
+def test_save_config_object_requires_estimator_name(panel, tmp_path):
+    from mlsynth.spec import save_spec
+    from mlsynth.config_models import VanillaSCConfig
+
+    cfg = VanillaSCConfig(df=panel, outcome="y", treat="treated",
+                          unitid="unit", time="year", display_graphs=False)
+    with pytest.raises(MlsynthConfigError):
+        save_spec(cfg, tmp_path / "spec.json")  # no estimator= -> error
+
+    # With the name supplied it succeeds.
+    written = save_spec(cfg, tmp_path / "spec.json", estimator="VanillaSC")
+    assert written["estimator"] == "VanillaSC"
+
+
+def test_spec_without_estimator_name_raises(tmp_path):
+    from mlsynth.spec import load_spec
+
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps({"outcome": "y", "treat": "treated"}))
+    with pytest.raises(MlsynthConfigError):
+        load_spec(path, df=pd.DataFrame())
+
+
+def test_save_dict_without_estimator_name_raises(tmp_path):
+    from mlsynth.spec import save_spec
+
+    with pytest.raises(MlsynthConfigError):
+        save_spec({"outcome": "y", "treat": "treated"}, tmp_path / "spec.json")
+
+
+def test_save_unsupported_object_raises(tmp_path):
+    from mlsynth.spec import save_spec
+
+    with pytest.raises(MlsynthConfigError):
+        save_spec(["not", "a", "spec"], tmp_path / "spec.json", estimator="VanillaSC")
+
+
+def test_estimator_name_must_be_string(tmp_path):
+    from mlsynth.spec import load_spec
+
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps({"estimator": 5, "outcome": "y"}))
+    with pytest.raises(MlsynthConfigError):
+        load_spec(path, df=pd.DataFrame())
+
+
+def test_non_mapping_spec_file_raises(tmp_path):
+    from mlsynth.spec import load_spec
+
+    path = tmp_path / "spec.json"
+    path.write_text(json.dumps(["VanillaSC", "y"]))  # a list, not a mapping
+    with pytest.raises(MlsynthConfigError):
+        load_spec(path, df=pd.DataFrame())
+
+
+# --------------------------------------------------------------------------- #
+# Across all estimators: load_spec never crashes ungracefully
+# --------------------------------------------------------------------------- #
+def _all_estimators():
+    import inspect
+
+    return sorted(
+        n for n in mlsynth.__all__
+        if inspect.isclass(getattr(mlsynth, n)) and hasattr(getattr(mlsynth, n), "fit")
+    )
+
+
+# Extra required fields beyond the base contract, keyed by estimator.
+_EXTRAS = {
+    "CTSC": {"treatment_vars": ["y"]},
+    "LEXSCM": {"candidate_col": "unit", "m": 1},
+    "MLSC": {"agg_id": "unit", "unitid_agg": "unit", "unitid_disagg": "unit"},
+    "MicroSynth": {"covariates": ["x1"]},
+    "PANGEO": {"arm": "treated"},
+    "PROXIMAL": {"donors": ["u1", "u2"], "methods": ["PI"]},
+    "SI": {"inters": ["u1"]},
+    "SIV": {"instrument": "z"},
+    "SpSyDiD": {"spatial_matrix": np.eye(6)},
+    "TASC": {"d": 1},
+}
+
+
+@pytest.mark.parametrize("name", _all_estimators())
+def test_load_spec_graceful_for_every_estimator(panel, tmp_path, name):
+    """For every estimator, ``load_spec`` either returns the right instance or
+    fails with a typed ``Mlsynth*`` error -- never an unhandled crash, and never
+    an 'unknown estimator' (every name must resolve)."""
+    from mlsynth.spec import save_spec, load_spec
+
+    spec = {
+        "estimator": name,
+        "outcome": "y",
+        "treat": "treated",
+        "unitid": "unit",
+        "time": "year",
+        "display_graphs": False,
+    }
+    runtime = {}
+    for k, v in _EXTRAS.get(name, {}).items():
+        if isinstance(v, np.ndarray):
+            runtime[k] = v          # matrix -> runtime payload
+        else:
+            spec[k] = v             # text-serializable -> into the spec
+    if name in ("MLSC",):
+        runtime["df_agg"] = panel
+        runtime["df_disagg"] = panel
+
+    path = tmp_path / "spec.json"
+    save_spec(spec, path, estimator=name)
+
+    try:
+        est = load_spec(path, df=panel, **runtime)
+    except MlsynthError:
+        return  # a typed, reported failure is acceptable here
+    assert isinstance(est, getattr(mlsynth, name))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "ecos>=2.0.0",
     "pydantic>=2.0.0",
     "pyarrow>=14.0.0",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Adds `mlsynth.save_spec` / `mlsynth.load_spec`: because a configuration is plain, validated data, the specification of an analysis — every column name and option, everything but the `DataFrame` and runtime arrays — can be written to a portable JSON or YAML file, version-controlled, and loaded back into a ready-to-fit estimator. This separates the durable record of *what* analysis was run from the data it ran on.

## API
- `save_spec(obj, path, *, estimator=None)` — `obj` is an estimator instance (name read automatically), a config object, or a dict. Writes the text spec, dropping `df` and any non-serializable runtime fields (with a warning naming them). Format from the file extension (`.json` / `.yaml` / `.yml`).
- `load_spec(path, df=None, *, estimator=None, **runtime)` — resolves the estimator by name, attaches `df` and any matrix payloads (`adjacency=`, `spatial_matrix=`, `df_agg=`…), and returns a ready-to-`fit()` estimator, validated through its existing Pydantic config (so bad specs raise the usual typed `Mlsynth*` errors).

## Serializability tiers (from the config survey)
- Purely text-serializable (most estimators): only non-text field is `df`.
- Carry a binary payload beyond `df`, attached at load time: `MLSC` (`df_agg`/`df_disagg`, required), `SpSyDiD` (`spatial_matrix`, required), and `MAREX`/`SYNDES` (`adjacency`, `donor_exclusion`, optional — pairwise unit×unit matrices).

## Tests (test-first)
`tests/test_spec.py` — 62 tests, 100% coverage of `spec.py`: JSON+YAML round-trips that fit, estimator-instance and dict inputs, the runtime matrix drop-and-re-attach path, every typed failure mode, and a parametrized check that `load_spec` is graceful for all 47 estimators (36 construct on a minimal panel, 11 raise typed errors). No regressions in the existing suite.

Adds `PyYAML` as a dependency (`pyarrow` for Parquet was already present). Exported from `mlsynth`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_