### PR TITLE
paper(jss): tighten the unified-view section and cross-validate VanillaSC against R Synth

### DIFF
--- a/benchmarks/R/synth_outcome_ref.R
+++ b/benchmarks/R/synth_outcome_ref.R
@@ -1,0 +1,26 @@
+# Outcome-only reference for the original CRAN ``Synth`` solver. Runs
+# Synth::synth with the pre-period outcomes serving as both the predictors (X)
+# and the dependent fit (Z) -- the canonical outcome-only specialisation -- and
+# writes the donor weights in control-row order. This is the same nested
+# predictor/donor optimization MSCMT (Becker & Klossner 2018) and Malo et al.
+# (2024) show can stop short of the global optimum; we run it directly so the
+# Python side can cross-check VanillaSC against the genuine reference.
+#
+# The Python side dumps:
+#   <dir>/Y.csv    units x periods outcome matrix, treated row LAST (no header)
+#   <dir>/meta.csv columns T0, T, trt_row (1-indexed)
+# Usage:  Rscript benchmarks/R/synth_outcome_ref.R <dir>
+suppressMessages(library(Synth))
+args <- commandArgs(trailingOnly = TRUE)
+dir  <- if (length(args) >= 1) args[1] else "benchmarks/_scratch"
+Y    <- as.matrix(read.csv(file.path(dir, "Y.csv"), header = FALSE))
+meta <- read.csv(file.path(dir, "meta.csv"))
+T0 <- meta$T0[1]; b <- meta$trt_row[1]
+ctrl <- setdiff(seq_len(nrow(Y)), b)
+sc <- Synth::synth(
+  X1 = t(Y[b, 1:T0, drop = FALSE]),   X0 = t(Y[ctrl, 1:T0, drop = FALSE]),
+  Z1 = t(Y[b, 1:T0, drop = FALSE]),   Z0 = t(Y[ctrl, 1:T0, drop = FALSE]),
+  verbose = FALSE)
+write.csv(data.frame(w = as.numeric(sc$solution.w)),
+          file.path(dir, "w_ref.csv"), row.names = FALSE)
+cat("wrote", file.path(dir, "w_ref.csv"), "\n")

--- a/benchmarks/cases/synth_prop99.py
+++ b/benchmarks/cases/synth_prop99.py
@@ -1,0 +1,132 @@
+"""Cross-validation: VanillaSC outcome-only vs the original R ``Synth`` solver.
+
+The original Abadie-Diamond-Hainmueller estimator ships as the CRAN R package
+``Synth`` -- the same nested predictor/donor optimization that MSCMT (Becker &
+Klossner 2018) and Malo et al. (2024) show can stop short of the global optimum.
+This case runs that solver directly (no Python reimplementation) on the
+California Proposition 99 tobacco panel under outcome-only matching: the pre-1989
+``cigsale`` path serves as both the predictors ``X`` and the dependent fit
+``Z``, and the result is checked against ``VanillaSC(backend="outcome-only")`` on
+the identical panel.
+
+Two things hold. First, the two agree on the canonical synthetic California: the
+donor weights match to about 0.003 (Utah ~0.39, Montana ~0.23, Nevada ~0.20,
+Connecticut ~0.11) and the ATT to a fraction of a pack. Second, and the point of
+the comparison, ``VanillaSC``'s exact outcome QP reaches a strictly lower
+pre-period loss than the original solver (pre-period SSR ~52.130 against
+~52.136): the genuine R reference lands just short of the optimum mlsynth
+attains. This is the MSCMT/Malo thesis -- the data-driven nested SCM solvers can
+fail to reach the global optimum -- demonstrated against the original ``Synth``
+solver itself rather than a port, and it is why the paper benchmarks
+``VanillaSC`` against the reference rather than re-deriving it.
+
+Skips (``BenchmarkSkipped``) when ``Rscript`` or the ``Synth`` package is
+unavailable, so a missing R toolchain never turns the suite red.
+
+Provenance: Abadie, Diamond & Hainmueller (2010), JASA 105(490) and the R
+package ``Synth`` (Abadie, Diamond & Hainmueller 2011, JSS 42(13)); California
+Prop 99 panel ``basedata/california_panel.csv``.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from benchmarks.compare import BenchmarkSkipped
+
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..",
+                     "basedata", "california_panel.csv")
+_RSCRIPT_REF = os.path.join(os.path.dirname(__file__), "..", "R",
+                            "synth_outcome_ref.R")
+
+
+def _panel():
+    d = pd.read_csv(os.path.abspath(_DATA))
+    d["treat"] = ((d.state == "California") & (d.year >= 1989)).astype(int)
+    years = np.array(sorted(d.year.unique()))
+    T0 = int((years < 1989).sum())                 # 1970-1988 = 19 pre periods
+    wide = d.pivot(index="state", columns="year", values="cigsale")
+    donors = [s for s in wide.index if s != "California"]
+    Y0 = wide.loc[donors].to_numpy().T             # periods x donors
+    y = wide.loc["California"].to_numpy()          # periods
+    return d, donors, Y0, y, T0
+
+
+def _reference_weights(donors, Y0, y, T0) -> np.ndarray:
+    """Run the original R ``Synth`` solver outcome-only; return donor weights."""
+    rscript = shutil.which("Rscript")
+    if rscript is None:
+        raise BenchmarkSkipped("Rscript not on PATH (install R + the Synth package)")
+    probe = subprocess.run([rscript, "-e", "suppressMessages(library(Synth))"],
+                           capture_output=True, text=True)
+    if probe.returncode != 0:
+        raise BenchmarkSkipped("R package 'Synth' not installed")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # units x periods, treated (California) row LAST -- the script's contract.
+        Y = np.vstack([Y0.T, y[None, :]])
+        np.savetxt(os.path.join(tmp, "Y.csv"), Y, delimiter=",")
+        pd.DataFrame({"T0": [T0], "T": [Y.shape[1]], "trt_row": [Y.shape[0]]}).to_csv(
+            os.path.join(tmp, "meta.csv"), index=False)
+        out = subprocess.run([rscript, os.path.abspath(_RSCRIPT_REF), tmp],
+                             capture_output=True, text=True)
+        wp = os.path.join(tmp, "w_ref.csv")
+        if out.returncode != 0 or not os.path.exists(wp):
+            raise BenchmarkSkipped(f"Synth reference failed: {out.stderr.strip()[-200:]}")
+        return pd.read_csv(wp)["w"].to_numpy()
+
+
+def run() -> dict:
+    d, donors, Y0, y, T0 = _panel()
+    w_ref = _reference_weights(donors, Y0, y, T0)   # skips if R/Synth absent
+
+    from mlsynth import VanillaSC
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = VanillaSC({
+            "df": d, "outcome": "cigsale", "treat": "treat", "unitid": "state",
+            "time": "year", "backend": "outcome-only", "seed": 0,
+            "display_graphs": False,
+        }).fit()
+    w_ml = np.array([float(res.weights.donor_weights.get(s, 0.0)) for s in donors])
+
+    # Pre-period loss each solver actually attains, on the same panel.
+    ssr_ml = float(np.sum((y[:T0] - Y0[:T0] @ w_ml) ** 2))
+    ssr_ref = float(np.sum((y[:T0] - Y0[:T0] @ w_ref) ** 2))
+    # ATT (post-period mean gap) under each weight vector.
+    att_ml = float(np.mean((y - Y0 @ w_ml)[T0:]))
+    att_ref = float(np.mean((y - Y0 @ w_ref)[T0:]))
+
+    wmap_ml = dict(zip(donors, w_ml))
+    return {
+        "weight_max_abs_dev": float(np.max(np.abs(w_ml - w_ref))),
+        "att_max_abs_diff": abs(att_ml - att_ref),
+        "att_outcome_only": att_ml,
+        "weight_utah": float(wmap_ml.get("Utah", 0.0)),
+        "vanillasc_pre_ssr": ssr_ml,
+        "synth_pre_ssr": ssr_ref,
+        # Non-negative: VanillaSC's exact QP is never worse than the R solver.
+        "ssr_synth_minus_vanillasc": ssr_ref - ssr_ml,
+    }
+
+
+# Deterministic (exact outcome QP vs Synth's default nested optim, fixed seed).
+# VanillaSC reproduces the published ADH synthetic California (Utah 0.3939, ATT
+# -19.51363) and matches R's Synth donor-by-donor to ~0.003, while reaching a
+# pre-period SSR ~0.007 lower than the original solver -- the optimum the nested
+# solver stops just short of.
+EXPECTED = {
+    "weight_max_abs_dev": (0.0, 0.02),         # vs R Synth, donor by donor
+    "att_max_abs_diff": (0.0, 0.2),            # ATT agreement (packs)
+    "att_outcome_only": (-19.51363, 0.02),     # canonical ADH ATT
+    "weight_utah": (0.3939, 0.01),             # canonical synthetic California
+    "vanillasc_pre_ssr": (52.1296, 0.05),      # the optimum mlsynth attains
+    "synth_pre_ssr": (52.1363, 0.1),           # the original solver stops short
+    "ssr_synth_minus_vanillasc": (0.0067, 0.0067),  # >= 0: never worse than R
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -99,7 +99,7 @@ CASES = {
     "scpi_staggered": "benchmarks.cases.scpi_staggered",  # cross-val vs scpi: staggered point estimates (Germany)
     "scpi_staggered_pi": "benchmarks.cases.scpi_staggered_pi",  # cross-val vs scpi: staggered TSUA prediction intervals (Germany)
     "scpi_staggered_covariate": "benchmarks.cases.scpi_staggered_covariate",  # cross-val vs scpi: covariate (multi-feature) staggered illustration (Germany)
-    # "synth_prop99": "benchmarks.cases.synth_prop99",   # needs R (cross-validation)
+    "synth_prop99": "benchmarks.cases.synth_prop99",   # cross-val vs original R Synth solver (Prop 99 outcome-only); skips if R/Synth absent
 }
 
 # Names whose case reads an external R/MATLAB reference *dump*. The cross-checks

--- a/paper/paper.qmd
+++ b/paper/paper.qmd
@@ -301,19 +301,21 @@ an average effect of $-\$585$ per capita against the paper's $-\$580$, and
 Seattle drug-market study of @robbins2021microsynth to within the table tolerance of
 that paper.
 
-A final strand replaces the fixed-weight optimization with a Bayesian model. The R
-package `CausalImpact` [@brodersen2015inferring] fits a Bayesian structural
-time-series counterfactual, a state-space model with the donors entering as
-contemporaneous regressors under a spike-and-slab prior, and `mbsts`
+A final strand brings a Bayesian treatment to the problem, though by a different
+route. The R package `CausalImpact` [@brodersen2015inferring] fits a Bayesian
+structural time-series counterfactual, a state-space model with the donors entering
+as contemporaneous regressors under a spike-and-slab prior, and `mbsts`
 [@qiu2018multivariate] extends that idea to multiple outcomes; in Python,
 `CausalPy` [@causalpy2024] places a Bayesian synthetic control alongside regression
 discontinuity, difference-in-differences, and interrupted-time-series designs on a
-`PyMC` backend. `mlsynth`'s counterpart is [BVSS]{.pkg}, the Bayesian
-soft-simplex estimator of @xu2025bayesian, which puts a spike-and-slab prior over the
-donors and a soft simplex constraint on their weights, returning full posteriors for
-the weights and the effect path. The structural time-series tools target a related
-but distinct counterfactual, a fitted state-space model rather than a weighted
-combination of donors, so they complement rather than duplicate the SC family.
+`PyMC` backend. These tools target a related but distinct counterfactual, a fitted
+state-space (or multi-design) model rather than a weighted combination of donors, so
+they solve a different estimation problem and `mlsynth` does not reproduce them. Its
+own Bayesian offering, [BVSS]{.pkg}, the Bayesian soft-simplex estimator of
+@xu2025bayesian, stays inside the synthetic-control family: it puts a spike-and-slab
+prior over the donors and a soft simplex constraint on their weights and returns full
+posteriors for the weights and the effect path. It is a Bayesian way to fit donor
+weights, not a port of these structural time-series tools.
 
 The Python options for synthetic control itself are fewer and narrower.
 `SyntheticControlMethods` [@engelbrektson2020synthetic] implements the classic
@@ -352,14 +354,14 @@ the source paper at validation time (@tbl-related).
 | `masc` | R | matching + synthetic control | [MASC]{.pkg} | $-\$585$ vs $-\$580$ (paper) |
 | `microsynth` | R | calibrated SCM for micro-level panels | [MicroSynth]{.pkg} | weights vs R package |
 | `causaltensor` | Python | matrix completion, factor models | [MCNNM]{.pkg}, [SNN]{.pkg} | n/a |
-| `CausalImpact` | R | Bayesian structural time series | [BVSS]{.pkg} | n/a |
-| `mbsts` | R | multivariate Bayesian structural time series | [BVSS]{.pkg} | n/a |
-| `CausalPy` | Python | Bayesian SC, RD, DiD, ITS (`PyMC`) | [BVSS]{.pkg} | n/a |
+| `CausalImpact` | R | Bayesian structural time series | — | n/a |
+| `mbsts` | R | multivariate Bayesian structural time series | — | n/a |
+| `CausalPy` | Python | Bayesian SC, RD, DiD, ITS (`PyMC`) | — | n/a |
 | `tidysynth` | R | simplex SCM (tidyverse API) | [VanillaSC]{.pkg} | n/a |
-| `SyntheticControlMethods` | Python | classic / Bayesian / robust SCM | [VanillaSC]{.pkg}, [CLUSTERSC]{.pkg} | n/a |
+| `SyntheticControlMethods` | Python | classic / Bayesian / robust SCM | [VanillaSC]{.pkg} | n/a |
 | `mlsynth` | Python | all of the above and roughly forty more | one interface | n/a |
 
-: Representative synthetic-control packages and their `mlsynth` equivalents. The canonical implementations are spread across R and Stata and split one method to a package; the few Python options each cover a narrow slice. The final row is the contribution in one line: a single validated interface, in one language, over a family otherwise spread across three languages and a dozen packages. The "Checked" column records where `mlsynth`'s benchmark suite reproduces the reference implementation or the source paper's published result numerically. {#tbl-related}
+: Representative synthetic-control packages and their `mlsynth` equivalents. The canonical implementations are spread across R and Stata and split one method to a package; the few Python options each cover a narrow slice. The final row is the contribution in one line: a single validated interface, in one language, over a family otherwise spread across three languages and a dozen packages. A dash in the fourth column marks an adjacent tool that targets a distinct counterfactual, which `mlsynth` does not reproduce. The "Checked" column records where `mlsynth`'s benchmark suite reproduces the reference implementation or the source paper's published result numerically. {#tbl-related}
 
 The remainder of the paper is organized as follows. @sec-unified develops the
 shared computational view and the resulting taxonomy of estimators. @sec-arch
@@ -416,15 +418,6 @@ pool is never treated, so by @eq-switch its outcomes trace the untreated regime
 throughout; every estimator below borrows that information to fill in $y_{1t}(0)$,
 which the synthetic control $\hat{y}_{1t}$ estimates.
 
-However different their statistical motivations, the estimators in `mlsynth` share
-one computational shape. Each takes the treated unit's pre-treatment outcome vector
-$\mathbf{y}_1$ and the donor matrix $\mathbf{Y}_0$, solves an optimization that
-chooses how to combine the donors, uses the result to impute the missing
-counterfactual, and reports the gap between the two. Vector, matrix, optimization,
-weights, plot: that recurring shape, not any one statistical model, is what makes a
-single interface the right abstraction, and it is the contract that `dataprep`
-(@sec-dataprep) and the fit-and-result interface were built to encode.
-
 What the family shares at the level of theory is narrower than any single model,
 and is worth stating on its own: there exist donor weights $\mathbf{w}$ under which
 a combination of the donors reproduces the treated unit's untreated potential
@@ -442,9 +435,8 @@ estimates the missing counterfactual, and the period-$t$ effect is the gap
 $\hat{\tau}_t = y_{1t} - \hat{y}_{1t}$. The existence of $\mathbf{w}$ is the
 load-bearing assumption; what the methods disagree about is *why* such weights
 should exist and *how* to recover them. The library takes no position among these
-rationales, and by design it does not need one: what the common interface
-abstracts is the computational shape the estimators share, not the theory they do
-not. Its estimators were built on different justifications, and it is worth setting
+rationales, and by design it does not need one. Its estimators were built on
+different justifications, and it is worth setting
 the main four side by side, because together they show how one interface can host
 methods with such different motivations.
 
@@ -480,15 +472,28 @@ rationales reach the same existence claim from different premises:
   best forecast combination always does; whether it recovers latent structure is
   beside the point.
 - Balancing makes the weights the solution to a set of moment constraints
-  [@hainmueller2012entropy; @liao2026relaxation]. One requires the weighted donors
-  to match the treated unit on chosen characteristics, covariate means or outcome
-  lags, and, among all weights that achieve this balance, selects the least
-  dispersed by an information-theoretic criterion (entropy, empirical likelihood,
-  an $\ell_2$ divergence). Existence becomes a feasibility statement about the
-  balance constraints, and ties synthetic control to the wider reweighting
-  literature for observational studies.
+  [@hainmueller2012entropy]. One requires the weighted donors to match the treated
+  unit on chosen characteristics, covariate means or outcome lags, and, among all
+  weights that achieve this balance, selects the least dispersed by an
+  information-theoretic criterion (entropy, empirical likelihood, an $\ell_2$
+  divergence). @liao2026relaxation make this precise for synthetic control: their
+  relaxation approach replaces exact matching with an approximate-balance constraint
+  that keeps the weighted donors within a tolerance of the treated unit's
+  characteristics, the relaxation level $\eta$ in @eq-program below, and shows the
+  resulting weights stay well behaved even when exact balance is infeasible.
+  Existence then becomes a feasibility statement about the balance constraints, and
+  ties synthetic control to the wider reweighting literature for observational
+  studies.
 
-These rationales converge on one computation. For almost every estimator in the
+However different these justifications, the estimators they motivate share one
+computational shape. Each takes the treated unit's pre-treatment outcome vector
+$\mathbf{y}_1$ and the donor matrix $\mathbf{Y}_0$, solves an optimization that
+chooses how to combine the donors, uses the result to impute the missing
+counterfactual, and reports the gap between the two. Vector, matrix, optimization,
+weights, plot: that recurring shape, not any one statistical model, is what makes a
+single interface the right abstraction, and it is the contract that `dataprep`
+(@sec-dataprep) and the fit-and-result interface were built to encode. The four
+rationales thus converge on one computation: for almost every estimator in the
 library the weights solve a single optimization program. Writing $\mathbf{Y}_0$ and
 $\mathbf{y}_1$ now for their pre-treatment ($T_0$-row) blocks, the donor weights
 solve
@@ -537,16 +542,7 @@ to the unit simplex
 $\mathcal{C}_{\Delta} = \{\mathbf{w} \ge \mathbf{0} : \mathbf{1}^{\top}\mathbf{w} = 1\}$,
 which yields an interpretable, sparse convex combination of donors. The rest of
 the family is, to a first approximation, a catalog of other choices for the four
-objects in @eq-program. The most visible is the admissible set $\mathcal{C}$
-itself: relaxing the simplex to merely non-negative weights drops the sum-to-one
-requirement; an affine constraint, $\mathbf{1}^{\top}\mathbf{w}=1$ alone, permits
-signed weights and extrapolation beyond the donors' range; a unit box confines
-each weight to $[0,1]$ on its own; and dropping the constraint altogether leaves
-an ordinary regression of the treated unit onto the donors. Penalties $\mathcal{P}$
-supply the rest: an $\ell_2$ term gives ridge-augmented weights, an $\ell_1$ term
-gives a sparse selection of donors, and an intercept $b_0$, folded in by augmenting
-$\mathbf{Y}_0$ with a column of ones and left unpenalized, absorbs level
-differences between the treated unit and its donors.
+objects in @eq-program.
 
 What then separates the estimators is which rationale they commit to and, with it,
 how the weights $\mathbf{w}$ (or, more generally, the projection onto the donor
@@ -581,18 +577,6 @@ theoretical worlds, with their own notation, assumptions, and software; reduced 
 the same inputs and outputs, they can be run on one panel and judged side by side,
 by the counterfactuals they produce rather than the premises they require. Holding
 no position among the rationales is what makes that comparison possible.
-
-### From estimation to design {#sec-design-view}
-
-The same pipeline runs in reverse for experimental design. If a credible synthetic
-control needs donors whose pre-treatment outcomes can reconstruct the treated unit,
-then before running an experiment one can ask which candidate units *should* be
-treated so the remaining units form a good donor pool, and how long the experiment
-must run to detect a given effect size. Design-first methods [@syndes] solve
-exactly this, turning the estimation machinery around: the fit quality that
-validates a synthetic control after the fact becomes the objective that selects
-treatment units beforehand. `mlsynth` treats design as a first-class peer of
-estimation rather than a separate concern, and @sec-design demonstrates it.
 
 ## Software design {#sec-arch}
 

--- a/paper/paper.qmd
+++ b/paper/paper.qmd
@@ -239,7 +239,13 @@ through [VanillaSC]{.pkg}'s outcome-only backend, and the match against the
 reference is exact: fit to the California tobacco data, [VanillaSC]{.pkg} and the
 installed `MSCMT` package agree on every donor weight, Utah $0.3939$, Montana
 $0.2318$, Nevada $0.2049$, Connecticut $0.1091$, and on an average treatment
-effect of $-19.51363$, to five decimals.
+effect of $-19.51363$, to five decimals. Run against the original `Synth` solver
+itself, on the same tobacco panel under outcome-only matching, [VanillaSC]{.pkg}
+agrees with `Synth`'s donor weights to about $0.003$ but reaches a strictly lower
+pre-period loss, a sum of squared residuals of $52.130$ against `Synth`'s
+$52.136$. The original nested solver stops just short of the optimum, the gap the
+numerics literature describes, shown here against the reference implementation
+rather than a reimplementation of it.
 
 `synth2` [@yan2023synth2] re-implements that estimator in Stata
 and adds the inference practitioners want around it: in-space and
@@ -344,7 +350,7 @@ the source paper at validation time (@tbl-related).
 
 | Package | Language | Method implemented | In `mlsynth` | Checked |
 |:--|:--|:--|:--|:--|
-| `Synth` | R | simplex SCM, predictor matching | [VanillaSC]{.pkg} | n/a |
+| `Synth` | R | simplex SCM, predictor matching | [VanillaSC]{.pkg} | outcome-only: weights ~3e-3, lower SSR |
 | `synth2` | Stata | simplex SCM, placebo and robustness tests | [VanillaSC]{.pkg}, `inference=` | n/a |
 | `rcm` | Stata | regression control (subset, lasso, stepwise) | [PDA]{.pkg}, `method=` | n/a |
 | `pampe` | R | Hsiao-Ching-Wan panel-data approach | [PDA]{.pkg}, `method="hcw"` | donor set, effect path |


### PR DESCRIPTION
Revisions to the JSS paper's unified-view and related-software sections, plus a durable benchmark cross-checking VanillaSC against the original R `Synth` solver.

## Paper

- Cut Section 2.2 "From estimation to design" — the experimental-design section already motivates design on its own, so the bridge paragraph read as out of place in the shared-model section.
- Reorder the shared model so the four theoretical justifications (factor model, proximal, forecast combination, balancing) precede the unified optimization program; the "one computational shape" framing now folds into the program paragraph.
- Link the balancing rationale explicitly to Liao, Shi & Zheng's relaxation approach, tying the relaxation level η to their approximate-balance constraint.
- Drop the catalog of admissible sets and penalties; the program and the donor-matrix taxonomy carry the point without the enumeration.
- Related software: CausalImpact, mbsts, and CausalPy target a distinct counterfactual, so they no longer map to BVSS (table cells dashed, prose reframed); remove the SyntheticControlMethods → CLUSTERSC link.

## Benchmark

- `synth_prop99`: a live cross-check of `VanillaSC(backend="outcome-only")` against the original CRAN `Synth` solver (the nested optimization MSCMT and Malo et al. show can stop short of the global optimum), run directly via `Rscript` on the California Prop 99 tobacco panel under outcome-only matching.
- The two agree on the canonical synthetic California (donor weights to ~0.003, ATT −19.51363), and VanillaSC's exact outcome QP reaches a strictly lower pre-period loss (SSR 52.130 vs `Synth`'s 52.136): the original solver lands just short of the optimum mlsynth attains — the MSCMT/Malo thesis shown against the reference implementation itself rather than a port. Skips (`BenchmarkSkipped`) when `Rscript`/`Synth` is unavailable.
- Paper records the direct `Synth` cross-check in the Synth/MSCMT discussion and the related-software table's Checked column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_