### PR TITLE
test(opthelper): pin solver to CLARABEL to avoid MOSEK-license dependency

### DIFF
--- a/mlsynth/tests/test_opthelper.py
+++ b/mlsynth/tests/test_opthelper.py
@@ -294,7 +294,7 @@ def test_full_optimization_loss_constraints(small_problem, intercept, constraint
     loss = OptHelpers.squared_loss(y, X, w, b0=b0_use)
     cons = OptHelpers.build_constraints(w, constraint_type=constraint_type)
     prob = cp.Problem(cp.Minimize(loss), cons)
-    prob.solve()
+    prob.solve(solver=cp.CLARABEL)
     assert prob.status == cp.OPTIMAL
     if constraint_type in ["simplex", "affine"]:
         assert np.isclose(np.sum(w.value), 1, atol=1e-6)
@@ -322,7 +322,7 @@ def test_full_optimization_with_penalty(small_problem, penalty_type):
     obj = loss + pen
     cons = OptHelpers.simplex_constraints(w)  # Suitable for all, esp. entropy/el
     prob = cp.Problem(cp.Minimize(obj), cons)
-    prob.solve()
+    prob.solve(solver=cp.CLARABEL)
     assert prob.status == cp.OPTIMAL
     assert np.isclose(np.sum(w.value), 1, atol=1e-6)
     assert np.all(w.value >= -1e-8)
@@ -335,7 +335,7 @@ def test_full_optimization_with_relaxed_balance(small_problem, objective_type):
         w, constraint_type="simplex", X=X, y=y, b0=b0, tau=0.1, objective_type=objective_type
     )
     prob = cp.Problem(cp.Minimize(loss), cons)
-    prob.solve()
+    prob.solve(solver=cp.CLARABEL)
     assert prob.status == cp.OPTIMAL
     assert np.isclose(np.sum(w.value), 1, atol=1e-6)
     assert np.all(w.value >= -1e-8)


### PR DESCRIPTION
## Summary

Fixes the 4 pre-existing `test_opthelper.py` failures that surfaced during the #158 full-suite run.

The penalty tests (`test_full_optimization_with_penalty[elastic_l2|l2_only|entropy|el]`) call `cp.Problem.solve()` with no solver, so cvxpy defaults to MOSEK when MOSEK is installed. In environments without a MOSEK license (CI, dev containers) this raises `mosek.Error: rescode.err_missing_license_file` before solving.

Pinning all three `prob.solve()` sites to `cp.CLARABEL` — an open conic solver that handles the SOCP and exponential-cone (entropy/el) problems here, and already the repo's default (used 30× elsewhere) — makes the suite deterministic regardless of whether MOSEK is installed.

## Verification

`python -m pytest mlsynth/tests/test_opthelper.py` → **64 passed** (previously 4 failed on the MOSEK license error). No production code touched — test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_