### PR TITLE
paper: reflect CMBSTS in the packages-and-equivalents table

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -534,6 +534,16 @@ lastchecked = {2026-06-22}
   pages   = {1--33}
 }
 
+@article{menchetti2022estimating,
+  author  = {Menchetti, Fiammetta and Bojinov, Iavor},
+  title   = {Estimating the Effectiveness of Permanent Price Reductions for Competing Products Using Multivariate {Bayesian} Structural Time Series Models},
+  journal = {The Annals of Applied Statistics},
+  year    = {2022},
+  volume  = {16},
+  number  = {1},
+  pages   = {414--435}
+}
+
 @misc{causalpy2024,
   author       = {{PyMC Labs}},
   title        = {\pkg{CausalPy}: A Python Package for Causal Inference in Quasi-Experimental Settings},

--- a/paper/paper.qmd
+++ b/paper/paper.qmd
@@ -312,14 +312,17 @@ as contemporaneous regressors under a spike-and-slab prior, and `mbsts`
 [@qiu2018multivariate] extends that idea to multiple outcomes; in Python,
 `CausalPy` [@causalpy2024] places a Bayesian synthetic control alongside regression
 discontinuity, difference-in-differences, and interrupted-time-series designs on a
-`PyMC` backend. These tools target a related but distinct counterfactual, a fitted
-state-space (or multi-design) model rather than a weighted combination of donors, so
-they solve a different estimation problem and `mlsynth` does not reproduce them. Its
-own Bayesian offering, [BVSS]{.pkg}, the Bayesian soft-simplex estimator of
-@xu2025bayesian, stays inside the synthetic-control family: it puts a spike-and-slab
-prior over the donors and a soft simplex constraint on their weights and returns full
-posteriors for the weights and the effect path. It is a Bayesian way to fit donor
-weights, not a port of these structural time-series tools.
+`PyMC` backend. `mlsynth` brings this state-space route inside its interface as
+[CMBSTS]{.pkg}, a port of the `CausalMBSTS` package of @menchetti2022estimating that
+fits the causal multivariate Bayesian structural time-series counterfactual and is
+cross-checked cell by cell against the R reference (@tbl-related); the wider menu of
+`CausalPy`, which steps outside the synthetic-control family to regression
+discontinuity, difference-in-differences, and interrupted time series, is the part
+`mlsynth` does not target. A second Bayesian offering, [BVSS]{.pkg}, the Bayesian
+soft-simplex estimator of @xu2025bayesian, stays inside the weighted-donor family
+rather than the state-space one: it puts a spike-and-slab prior over the donors and a
+soft simplex constraint on their weights and returns full posteriors for the weights
+and the effect path.
 
 The Python options for synthetic control itself are fewer and narrower.
 `SyntheticControlMethods` [@engelbrektson2020synthetic] implements the classic
@@ -359,7 +362,7 @@ the source paper at validation time (@tbl-related).
 | `microsynth` | R | calibrated SCM for micro-level panels | [MicroSynth]{.pkg} | weights vs R package |
 | `causaltensor` | Python | matrix completion, factor models | [MCNNM]{.pkg}, [SNN]{.pkg} | n/a |
 | `CausalImpact` | R | Bayesian structural time series | — | n/a |
-| `mbsts` | R | multivariate Bayesian structural time series | — | n/a |
+| `mbsts` | R | multivariate Bayesian structural time series | [CMBSTS]{.pkg} | cell-by-cell vs `CausalMBSTS` |
 | `CausalPy` | Python | Bayesian SC, RD, DiD, ITS (`PyMC`) | — | n/a |
 | `tidysynth` | R | simplex SCM (tidyverse API) | [VanillaSC]{.pkg} | n/a |
 | `SyntheticControlMethods` | Python | classic / Bayesian / robust SCM | [VanillaSC]{.pkg} | n/a |


### PR DESCRIPTION
The `tbl-related` comparison (synthetic-control packages and their `mlsynth` equivalents) marked the multivariate-BSTS family with a dash — "not in `mlsynth`" — written before CMBSTS existed. Now that `mlsynth` ports `CausalMBSTS` (Menchetti & Bojinov 2022) as CMBSTS, this updates the paper to match.

## Changes (`paper/paper.qmd`, `paper/paper.bib`)

- `mbsts` row: the "In `mlsynth`" cell goes from "—" to `[CMBSTS]{.pkg}`; the "Checked" cell becomes "cell-by-cell vs `CausalMBSTS`" (the package CMBSTS actually reproduces, not Qiu et al.'s `mbsts`).
- Revised the Bayesian-strand paragraph: drops the now-false blanket "`mlsynth` does not reproduce them," replacing it with CMBSTS as the state-space Bayesian offering (port of `CausalMBSTS`, cross-checked against the R reference) and BVSS as the weighted-donor one; only `CausalPy`'s wider non-SC design menu (RD/DiD/ITS) stays out of scope.
- Added the `menchetti2022estimating` bib entry.

`CausalImpact` / `CausalPy` keep their dashes; the per-estimator catalogue (`tbl-catalogue`) already lists CMBSTS, so no change there.

## Notes

- CMBSTS ports `CausalMBSTS` (Menchetti–Bojinov), which is not itself a row in `tbl-related`; the `mbsts` row was chosen because its descriptor ("multivariate Bayesian structural time series") is exactly CMBSTS's, and the Checked cell names the real reference. A dedicated `CausalMBSTS` row is an easy alternative if preferred.
- I could not render the Quarto PDF in this environment (needs the Quarto/R/LaTeX toolchain); `paper_render.yml` CI is the real check. Edits are structurally verified: the citation key resolves and the table row is well-formed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_