### PR TITLE
ci(render): skip gracefully when a PR changes no .qmd (unblocks docs-only PRs)

### DIFF
--- a/.github/workflows/paper_render.yml
+++ b/.github/workflows/paper_render.yml
@@ -58,8 +58,9 @@ jobs:
             fi
 
             if [ -z "$last_qmd" ]; then
-              echo "No .qmd file changes detected. Exiting."
-              exit 1
+              echo "No .qmd file changes detected -- nothing to render, skipping."
+              echo "target_qmd=" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
 
             echo "Found modified .qmd file: $last_qmd"
@@ -67,6 +68,7 @@ jobs:
           fi
 
       - name: Install requirements one level below .qmd file
+        if: steps.select_qmd.outputs.target_qmd != ''
         run: |
           qmd_file="${{ steps.select_qmd.outputs.target_qmd }}"
           qmd_dir=$(dirname "$qmd_file")
@@ -81,6 +83,7 @@ jobs:
           fi
 
       - name: Render selected .qmd file
+        if: steps.select_qmd.outputs.target_qmd != ''
         run: |
           qmd_file="${{ steps.select_qmd.outputs.target_qmd }}"
           dir=$(dirname "$qmd_file")
@@ -105,6 +108,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload rendered PDFs (for verification)
+        if: steps.select_qmd.outputs.target_qmd != ''
         uses: actions/upload-artifact@v4
         with:
           name: rendered-pdf


### PR DESCRIPTION
The "Render Quarto Report" workflow selected the last-modified `.qmd` from the PR diff and `exit 1`'d when none was found — so any run that triggered without a `.qmd` change (a docs-only PR, or a spurious path-filter match on a force-push, as happened on #170) went red even though there was nothing to render.

Fix: when no `.qmd` is found, set an empty `target_qmd` and `exit 0` (skip), and gate the install / render / upload steps on `target_qmd != ''` so the job succeeds as a no-op. Behaviour is unchanged when a `.qmd` actually changes (the paper still renders and, on `main`, commits the PDF).

This unblocks #170 (SPSC benchmarks), whose code checks are all green but which caught a false render red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_