### PR TITLE
paper: use the authors' SPSC configuration in the Panic-of-1907 figure

### DIFF
--- a/paper/paper.qmd
+++ b/paper/paper.qmd
@@ -1235,7 +1235,8 @@ spillover contamination and then debiases through the donors it excludes.
 #| label: fit-proximal
 prox_base = dict(df=panic, treat="Panic", time="date", outcome="prc_log", unitid="ID",
                  vars={"donorproxies": ["bid_itp"], "surrogatevars": ["ask_itp"]},
-                 donors=normal, surrogates=affected, display_graphs=False)
+                 donors=normal, surrogates=affected, display_graphs=False,
+                 spsc_spline_df=6)   # the authors' six-dim cubic B-spline detrend B_6(t)
 spot_base = dict(df=panic, outcome="prc_log", treat="Panic", time="time", unitid="ID",
                  display_graphs=False, selection="S1", forecast="loo")
 


### PR DESCRIPTION
The `fig-proximal-intervals` SPSC call used mlsynth's default detrend (a 5-df cubic B-spline). Park & Tchetgen Tchetgen's Panic of 1907 application (Sec. 5) specifies the six-dimensional cubic B-spline trend `D_t = B₆(t)` for SPSC-DT with a constant ATT. This sets `spsc_spline_df=6` in `prox_base` so the paper's SPSC uses the authors' published parameterisation; the dynamic ATT/interval numbers and the figure re-render accordingly.

This is the last piece of the SPSC workstream (decisions 1 + 2). The detrend config is correct and faithful to the paper.

⚠️ Note for review: a separate finding (see session discussion) is that mlsynth's SPSC *conformal prediction bands* are currently too wide and grow with the horizon vs the authors' R package (a pre-existing `conformal.py` bug, independent of this change). This PR's `df=6` does not worsen that — the bands were already wide on `main` — but Figure 6's bands won't be correct until the conformal fix lands. Consider holding this merge until that fix is in, so the paper re-renders with the corrected (flat ~0.12, and ultimately the authors' ~0.068 time-varying) bands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_