### PR TITLE
SPSC: fix conformal prediction bands to match the reference R package

### DIFF
--- a/benchmarks/cases/spsc_prop99.py
+++ b/benchmarks/cases/spsc_prop99.py
@@ -39,16 +39,29 @@ def _panel():
     return y, W, donors
 
 
+# T0 = 18 cannot support a 95% conformal level (the finest achievable is
+# 2/19 ~ 0.105), so the conformal cross-check runs at ~89%.
+_CONFORMAL_ALPHA = 0.11
+
+
 def run() -> dict:
     from benchmarks.reference.clone_spsc import run_reference
+    from mlsynth.utils.proximal_helpers.spsc.conformal import conformal_intervals
     from mlsynth.utils.proximal_helpers.spsc.estimation import estimate_spsc
 
     y, W, donors = _panel()
+    T1 = len(y) - _T0
     ref = run_reference(y, W, _T0, detrend=True, att_degree=1,
-                        detrend_linear=True, ridge_lambda=_LAMBDA)   # skips if no R
+                        detrend_linear=True, ridge_lambda=_LAMBDA,
+                        conformal_periods=list(range(1, T1 + 1)),
+                        conformal_alpha=_CONFORMAL_ALPHA)             # skips if no R
     out = estimate_spsc(y, W, _T0, detrend=True, ridge_lambda=_LAMBDA,
                         att_degree=1, detrend_basis="poly", detrend_degree=1)
     path, path_se = out[6], out[7]
+    band = conformal_intervals(
+        y, W, _T0, gamma=out[1], ridge_lambda=_LAMBDA, detrend=True,
+        spline_df=5, att_se=out[3], period_se=path_se, alpha=_CONFORMAL_ALPHA,
+        att_degree=1, detrend_basis="poly", detrend_degree=1)
     return {
         "att": float(out[2]),                       # mean of the fitted path
         "path_first": float(path[0]),
@@ -56,12 +69,16 @@ def run() -> dict:
         "n_donors": float(len(donors)),
         "path_vs_ref": float(np.max(np.abs(path - ref["effect_path"]))),
         "se_vs_ref": float(np.max(np.abs(path_se - ref["path_se"]))),
+        "conformal_lb_vs_ref": float(np.max(np.abs(band["lower"] - ref["conformal_lb"]))),
+        "conformal_ub_vs_ref": float(np.max(np.abs(band["upper"] - ref["conformal_ub"]))),
     }
 
 
 # Validated value-for-value against qkrcks0218/SPSC @ 054f1fbb (lambda = 10**0):
 # the linear effect path runs -4.845 ... -35.284 (mean -20.06), per-period SE
-# 0.0020 ... 0.0235; mlsynth reproduces both to solver tolerance.
+# 0.0020 ... 0.0235; mlsynth reproduces both to solver tolerance. The pointwise
+# conformal prediction intervals (level ~0.11, the finest T0=18 supports) run
+# from a width of 0.139 (1988) to 1.645 (2000) and match the reference to ~1e-3.
 EXPECTED = {
     "att": (-20.064, 0.05),
     "path_first": (-4.845, 0.02),
@@ -69,4 +86,6 @@ EXPECTED = {
     "n_donors": (38.0, 0.0),
     "path_vs_ref": (0.0, 5e-3),       # bit-for-bit vs the R package
     "se_vs_ref": (0.0, 5e-4),
+    "conformal_lb_vs_ref": (0.0, 3e-3),
+    "conformal_ub_vs_ref": (0.0, 3e-3),
 }

--- a/benchmarks/reference/clone_spsc.py
+++ b/benchmarks/reference/clone_spsc.py
@@ -50,13 +50,20 @@ def _have_rscript() -> bool:
 def run_reference(y: np.ndarray, W: np.ndarray, T0: int, *,
                   detrend: bool = True, att_degree: int = 0,
                   detrend_linear: bool = False,
-                  ridge_lambda: float | None = None) -> dict:
+                  ridge_lambda: float | None = None,
+                  conformal_periods=None,
+                  conformal_alpha: float = 0.05) -> dict:
     """Run the reference ``SPSC()`` on ``(y, W, T0)`` and parse its output.
 
     ``att_degree`` and ``detrend_linear`` mirror the package's ``att.ft`` and
     ``detrend.ft`` (``att_degree=1`` is a linear effect path; ``detrend_linear``
     swaps the spline trend for the linear ``(1, t)`` trend). Returns
     ``{"effect_path", "path_se"}`` as NumPy arrays.
+
+    When ``conformal_periods`` (1-based post-period indices) is given, the
+    reference's pointwise conformal prediction intervals are computed at level
+    ``conformal_alpha`` and returned as ``{"conformal_lb", "conformal_ub"}`` too
+    (the achievable discrete level needs ``conformal_alpha >= 2/(T0+1)``).
 
     Raises
     ------
@@ -75,6 +82,19 @@ def run_reference(y: np.ndarray, W: np.ndarray, T0: int, *,
               else "function(t){matrix(c(1),1,1)}")
     detrend_ft = ("function(t){matrix(c(1,t),1,2)}" if detrend_linear
                   else "function(t){Spline.Trend(t,T0,df=5)}")
+    want_conformal = conformal_periods is not None
+    if want_conformal:
+        periods_r = "c(" + ",".join(str(int(p)) for p in conformal_periods) + ")"
+        conf_line = (f"conformal.period={periods_r}, conformal.cover=FALSE, "
+                     f"true.effect=NULL, conformal.interval=TRUE, "
+                     f"conformal.pvalue={float(conformal_alpha)}")
+        conf_dump = ('cat("CILB", paste(s$conformal.interval[,1], collapse=" "), "\\n")\n'
+                     'cat("CIUB", paste(s$conformal.interval[,2], collapse=" "), "\\n")')
+    else:
+        conf_line = ("conformal.period=NULL, conformal.cover=FALSE, "
+                     "true.effect=NULL, conformal.interval=FALSE, "
+                     "conformal.pvalue=0.05")
+        conf_dump = ""
     with tempfile.TemporaryDirectory() as tmp:
         tmp = Path(tmp)
         np.savetxt(tmp / "y.csv", y, delimiter=",")
@@ -89,21 +109,30 @@ s <- SPSC(Y.Pre=y[1:T0], Y.Post=y[T0+1:T1], W.Pre=W[1:T0,], W.Post=W[T0+1:T1,],
           detrend={'TRUE' if detrend else 'FALSE'}, detrend.ft={detrend_ft},
           Y.basis=function(y){{matrix(c(y),1,1)}}, att.ft={att_ft},
           {lam_line}, lambda.grid=seq(-6,2,by=0.5), bootstrap.num=0,
-          conformal.period=NULL, conformal.cover=FALSE, true.effect=NULL,
-          conformal.interval=FALSE, conformal.pvalue=0.05)
+          {conf_line})
 cat("PATH", paste(as.numeric(s$ATT), collapse=" "), "\\n")
 cat("SE", paste(as.numeric(s$ASE.ATT), collapse=" "), "\\n")
+{conf_dump}
 """
         proc = subprocess.run(["Rscript", "-e", script], capture_output=True,
                               text=True, cwd=str(tmp))
         if proc.returncode != 0:
             raise BenchmarkSkipped(f"SPSC reference run failed: {proc.stderr[-300:]}")
-    path, se = None, None
+    path, se, lb, ub = None, None, None, None
     for line in proc.stdout.splitlines():
         if line.startswith("PATH"):
             path = np.array([float(x) for x in line.split()[1:]])
         elif line.startswith("SE"):
             se = np.array([float(x) for x in line.split()[1:]])
+        elif line.startswith("CILB"):
+            lb = np.array([float(x) for x in line.split()[1:]])
+        elif line.startswith("CIUB"):
+            ub = np.array([float(x) for x in line.split()[1:]])
     if path is None or se is None:  # pragma: no cover - defensive
         raise BenchmarkSkipped("could not parse SPSC reference output")
-    return {"effect_path": path, "path_se": se}
+    out = {"effect_path": path, "path_se": se}
+    if want_conformal:
+        if lb is None or ub is None:  # pragma: no cover - defensive
+            raise BenchmarkSkipped("could not parse SPSC conformal interval")
+        out["conformal_lb"], out["conformal_ub"] = lb, ub
+    return out

--- a/docs/replications/spsc.rst
+++ b/docs/replications/spsc.rst
@@ -62,10 +62,18 @@ standard errors value-for-value:
    * - average ATT
      - :math:`-20.06`
      - :math:`-20.06`
+   * - conformal band width (1988 … 2000)
+     - :math:`0.139 \,\dots\, 1.645`
+     - :math:`0.139 \,\dots\, 1.645`
 
 The case runs the R package live and asserts the path and SE agree to solver
-tolerance (``path_vs_ref`` and ``se_vs_ref`` are zero to five digits). Durable
-case ``spsc_prop99``.
+tolerance (``path_vs_ref`` and ``se_vs_ref`` are zero to five digits). It also
+cross-checks the pointwise conformal prediction intervals for the per-period
+effect: a short pre-period (:math:`T_0 = 18`) supports only a coarse discrete
+level (the finest is :math:`2/19 \approx 0.105`), so the band is taken at
+:math:`\alpha \approx 0.11`; its endpoints match the reference to
+:math:`\sim 10^{-3}` at every post period (``conformal_lb_vs_ref`` /
+``conformal_ub_vs_ref``). Durable case ``spsc_prop99``.
 
 Cross-validation — Panic of 1907
 --------------------------------

--- a/mlsynth/tests/test_spsc_flexible.py
+++ b/mlsynth/tests/test_spsc_flexible.py
@@ -20,6 +20,10 @@ import pytest
 from mlsynth import PROXIMAL
 from mlsynth.config_models import PROXIMALConfig
 from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.proximal_helpers.spsc.conformal import (
+    _conformal_pvalue,
+    conformal_intervals,
+)
 from mlsynth.utils.proximal_helpers.spsc.estimation import (
     _att_basis,
     _build_detrend_matrix,
@@ -167,3 +171,56 @@ def test_california_linear_config_reproduces_reference():
                        0.0145, 0.0163, 0.0181, 0.0199, 0.0217, 0.0235])
     np.testing.assert_allclose(out[6], ref, atol=2e-3)
     np.testing.assert_allclose(out[7], ref_se, atol=2e-4)
+
+
+# --------------------------------------------------------------------------- #
+# Conformal prediction intervals
+# --------------------------------------------------------------------------- #
+def test_conformal_pvalue_uses_reference_complement_form():
+    """``_conformal_pvalue`` is ``1 - mean(|r| < s_base)``, matching R's
+    ``Calculate.PValue`` -- not the algebraically-equal ``mean(|r| >= s_base)``.
+
+    The two forms differ by one ULP at the discrete conformal threshold, and the
+    interval inversion compares the p-value to ``valid_p = k/(T0+1)`` with
+    ``>=``; the complement form lands just below ``valid_p`` exactly where the
+    reference excludes the boundary, which is what stops the band running wide.
+    """
+    rng = np.random.default_rng(0)
+    resid = rng.normal(size=37)
+    assert _conformal_pvalue(resid) == 1.0 - np.mean(np.abs(resid) < abs(resid[-1]))
+
+    # A boundary case (n = 230, count_ge = 11) where the two forms disagree by
+    # one ULP: the complement form is strictly below the direct fraction, so a
+    # ``>= 11/230`` test rejects it where the naive form would accept.
+    r = np.arange(230.0)
+    r[-1] = 219.0                              # exactly 11 entries (219..229) tie/exceed it
+    pv = _conformal_pvalue(r)
+    assert pv == 1.0 - 219.0 / 230.0
+    assert pv < 11.0 / 230.0                   # one ULP below -> excluded at the threshold
+    assert pv < float(np.mean(np.abs(r) >= abs(r[-1])))
+
+
+def test_conformal_band_brackets_point_effect():
+    """The conformal interval for each post period contains the point effect and
+    has finite, ordered endpoints (smoke + invariant on the Prop 99 panel)."""
+    df = pd.read_csv(_SMOKING)
+    donors = [s for s in dict.fromkeys(df["state"]) if s != "California"]
+    W = np.column_stack([df["cigsale"][df["state"] == s].to_numpy(float)
+                         for s in donors])
+    y = df["cigsale"][df["state"] == "California"].to_numpy(float)
+    T0 = 18
+    out = estimate_spsc(y, W, T0, detrend=True, ridge_lambda=0.0, att_degree=1,
+                        detrend_basis="poly", detrend_degree=1)
+    gamma, se = out[1], out[3]
+    # The interval is for the per-period effect xi_t = y_t - W_t gamma (the raw
+    # gap it centers the search grid on), not the fitted linear path.
+    gap_post = (y - W @ gamma)[T0:]
+    # T0 = 18 cannot support a 95% conformal level (finest is 2/19); use ~89%.
+    res = conformal_intervals(y, W, T0, gamma=gamma, ridge_lambda=0.0,
+                              detrend=True, spline_df=5, att_se=se, alpha=0.11,
+                              att_degree=1, detrend_basis="poly", detrend_degree=1)
+    lo, hi = res["lower"], res["upper"]
+    assert lo.shape == hi.shape == gap_post.shape
+    assert np.all(np.isfinite(lo)) and np.all(np.isfinite(hi))
+    assert np.all(lo <= hi)
+    assert np.all(lo <= gap_post + 1e-9) and np.all(gap_post - 1e-9 <= hi)

--- a/mlsynth/tests/test_spsc_flexible.py
+++ b/mlsynth/tests/test_spsc_flexible.py
@@ -224,3 +224,33 @@ def test_conformal_band_brackets_point_effect():
     assert np.all(np.isfinite(lo)) and np.all(np.isfinite(hi))
     assert np.all(lo <= hi)
     assert np.all(lo <= gap_post + 1e-9) and np.all(gap_post - 1e-9 <= hi)
+
+
+def test_conformal_band_reproduces_california_reference():
+    """The Prop 99 (linear-ATT) conformal band reproduces qkrcks0218/SPSC
+    value-for-value: the band grows with the horizon and matches R's endpoints
+    to ~1e-3 (exercises the per-period SE grid and the 10*unit edge extension)."""
+    df = pd.read_csv(_SMOKING)
+    donors = [s for s in dict.fromkeys(df["state"]) if s != "California"]
+    W = np.column_stack([df["cigsale"][df["state"] == s].to_numpy(float)
+                         for s in donors])
+    y = df["cigsale"][df["state"] == "California"].to_numpy(float)
+    T0 = 18
+    out = estimate_spsc(y, W, T0, detrend=True, ridge_lambda=0.0, att_degree=1,
+                        detrend_basis="poly", detrend_degree=1)
+    gamma, se, path_se = out[1], out[3], out[7]
+    res = conformal_intervals(y, W, T0, gamma=gamma, ridge_lambda=0.0,
+                              detrend=True, spline_df=5, att_se=se,
+                              period_se=path_se, alpha=0.11, att_degree=1,
+                              detrend_basis="poly", detrend_degree=1)
+    # Reference endpoints from qkrcks0218/SPSC @ 054f1fbb (conformal.pvalue=0.11).
+    r_lb = np.array([-4.2369, -8.3921, -8.0471, -13.5131, -13.5930, -18.1992,
+                     -21.8254, -25.2814, -26.6277, -28.5783, -30.8327, -34.1152,
+                     -33.3970])
+    r_ub = np.array([-4.0974, -8.1272, -7.6571, -12.9974, -12.9525, -17.4323,
+                     -20.9334, -24.2641, -25.4844, -27.3094, -29.4385, -32.5956,
+                     -31.7520])
+    np.testing.assert_allclose(res["lower"], r_lb, atol=2e-3)
+    np.testing.assert_allclose(res["upper"], r_ub, atol=2e-3)
+    widths = res["upper"] - res["lower"]
+    assert np.all(np.diff(widths) > 0)        # grows with the horizon

--- a/mlsynth/utils/proximal_helpers/orchestration.py
+++ b/mlsynth/utils/proximal_helpers/orchestration.py
@@ -125,6 +125,9 @@ def _run_spsc(inputs: PROXIMALInputs) -> ProximalMethodFit:
             detrend=inputs.spsc_detrend, spline_df=inputs.spsc_spline_df,
             att_se=se, periods=inputs.spsc_conformal_periods,
             basis_degree=inputs.spsc_basis_degree,
+            att_degree=inputs.spsc_att_degree,
+            detrend_basis=inputs.spsc_detrend_basis,
+            detrend_degree=inputs.spsc_detrend_degree,
         )
     return ProximalMethodFit(
         name=SPSC,

--- a/mlsynth/utils/proximal_helpers/orchestration.py
+++ b/mlsynth/utils/proximal_helpers/orchestration.py
@@ -124,6 +124,7 @@ def _run_spsc(inputs: PROXIMALInputs) -> ProximalMethodFit:
             gamma=gamma, ridge_lambda=lam,
             detrend=inputs.spsc_detrend, spline_df=inputs.spsc_spline_df,
             att_se=se, periods=inputs.spsc_conformal_periods,
+            period_se=path_se,
             basis_degree=inputs.spsc_basis_degree,
             att_degree=inputs.spsc_att_degree,
             detrend_basis=inputs.spsc_detrend_basis,

--- a/mlsynth/utils/proximal_helpers/spsc/conformal.py
+++ b/mlsynth/utils/proximal_helpers/spsc/conformal.py
@@ -21,7 +21,7 @@ from typing import Dict, Optional, Sequence
 
 import numpy as np
 
-from .estimation import _build_detrend_matrix, _poly_basis, _ridge_ginv
+from .estimation import _poly_basis, _ridge_ginv, _scaled_detrend_basis
 
 
 def _refit_gamma(y_aug, W_aug, D_aug, lam, detrend, degree=1):
@@ -67,6 +67,9 @@ def conformal_intervals(
     window: float = 25.0,
     grid_size: int = 101,
     basis_degree: int = 1,
+    att_degree: int = 0,
+    detrend_basis: str = "bspline",
+    detrend_degree: int = 1,
 ) -> Dict[str, np.ndarray]:
     """Pointwise conformal prediction intervals for the per-period effect.
 
@@ -86,6 +89,14 @@ def conformal_intervals(
         Whether the SPSC fit detrends (must match the point fit).
     spline_df : int
         Detrend B-spline degrees of freedom.
+    att_degree : int, default 0
+        ATT-basis polynomial degree of the point fit (reference ``att.ft``);
+        only affects the detrend ``Scale`` via the HAC bandwidth, so it must
+        match the point fit.
+    detrend_basis : {"bspline", "poly"}, default "bspline"
+        Detrend trend family of the point fit (must match it).
+    detrend_degree : int, default 1
+        Polynomial degree when ``detrend_basis="poly"``.
     att_se : float
         Asymptotic ATT standard error, used to scale the search grid. If
         not finite, a data-driven width is used.
@@ -114,7 +125,13 @@ def conformal_intervals(
         periods = list(range(T0, T))
     periods = [int(p) for p in periods]
 
-    D_full = _build_detrend_matrix(T0, T, spline_df) if detrend else None
+    # Refit on the SAME rescaled detrend basis the point fit used: the ridge
+    # ginv truncation depends on the instrument magnitudes, so an unscaled basis
+    # gives a different gamma and a band that drifts from the reference.
+    D_full = (_scaled_detrend_basis(y, W, T0, spline_df, ridge_lambda,
+                                    basis_degree, att_degree, detrend_basis,
+                                    detrend_degree)
+              if detrend else None)
     pre_idx = np.arange(T0)
 
     # Achievable discrete level (reference: max of {2/(T0+1),...,1} <= alpha).

--- a/mlsynth/utils/proximal_helpers/spsc/conformal.py
+++ b/mlsynth/utils/proximal_helpers/spsc/conformal.py
@@ -189,18 +189,19 @@ def conformal_intervals(
         hi = center
         while hi + 1 < grid_size and accept[hi + 1]:
             hi += 1
-        # Narrow refinement just outside each edge.
+        # Narrow refinement just outside each edge. When the accepted run already
+        # reaches a grid boundary the true edge lies past the coarse window, so
+        # extend the search by ``10 * unit`` there (reference behaviour) rather
+        # than the one-step refinement used for an interior edge.
         step = grid[1] - grid[0]
-        lower = grid[lo]
-        if lo > 0:
-            fine = np.linspace(grid[lo] - step, grid[lo], 51)
-            acc = np.array([pvalue(idx, xi) >= valid_p for xi in fine])
-            lower = fine[acc].min() if acc.any() else grid[lo]
-        upper = grid[hi]
-        if hi < grid_size - 1:
-            fine = np.linspace(grid[hi], grid[hi] + step, 51)
-            acc = np.array([pvalue(idx, xi) >= valid_p for xi in fine])
-            upper = fine[acc].max() if acc.any() else grid[hi]
+        bll = grid[lo] - step if lo > 0 else grid[lo] - 10.0 * unit
+        fine = np.linspace(bll, grid[lo], 51)
+        acc = np.array([pvalue(idx, xi) >= valid_p for xi in fine])
+        lower = fine[acc].min() if acc.any() else grid[lo]
+        buu = grid[hi] + step if hi < grid_size - 1 else grid[hi] + 10.0 * unit
+        fine = np.linspace(grid[hi], buu, 51)
+        acc = np.array([pvalue(idx, xi) >= valid_p for xi in fine])
+        upper = fine[acc].max() if acc.any() else grid[hi]
         return float(lower), float(upper)
 
     lowers, uppers = [], []

--- a/mlsynth/utils/proximal_helpers/spsc/conformal.py
+++ b/mlsynth/utils/proximal_helpers/spsc/conformal.py
@@ -21,11 +21,17 @@ from typing import Dict, Optional, Sequence
 
 import numpy as np
 
-from .estimation import _build_detrend_matrix, _poly_basis
+from .estimation import _build_detrend_matrix, _poly_basis, _ridge_ginv
 
 
 def _refit_gamma(y_aug, W_aug, D_aug, lam, detrend, degree=1):
-    """Re-fit the ridge SC weights on an augmented all-pre sample (fixed lam)."""
+    """Re-fit the ridge SC weights on an augmented all-pre sample (fixed lam).
+
+    Uses the same ``ginv`` ridge solve as the point fit (:func:`_ridge_ginv`):
+    a plain ``solve`` at the small CV penalty makes the refit gamma swing with
+    the single appended period, which inflates and skews the conformal band
+    away from the reference.
+    """
     if detrend:
         eta = np.linalg.lstsq(D_aug, y_aug, rcond=None)[0]
         g = np.column_stack([D_aug, _poly_basis(y_aug - D_aug @ eta, degree)])
@@ -34,7 +40,7 @@ def _refit_gamma(y_aug, W_aug, D_aug, lam, detrend, degree=1):
     N = W_aug.shape[1]
     GY = (g * y_aug[:, None]).mean(0)
     GW = np.stack([(g * W_aug[:, n: n + 1]).mean(0) for n in range(N)], axis=1)
-    return np.linalg.solve(GW.T @ GW + (10.0 ** lam) * np.eye(N), GW.T @ GY)
+    return _ridge_ginv(GW, GY, lam)
 
 
 def _conformal_pvalue(residuals: np.ndarray) -> float:

--- a/mlsynth/utils/proximal_helpers/spsc/conformal.py
+++ b/mlsynth/utils/proximal_helpers/spsc/conformal.py
@@ -71,6 +71,7 @@ def conformal_intervals(
     spline_df: int,
     att_se: float,
     periods: Optional[Sequence[int]] = None,
+    period_se: Optional[Sequence[float]] = None,
     alpha: float = 0.05,
     window: float = 25.0,
     grid_size: int = 101,
@@ -111,6 +112,12 @@ def conformal_intervals(
     periods : sequence of int, optional
         Post-treatment period indices (absolute, in ``[T0, T)``) to cover.
         Defaults to every post-treatment period.
+    period_se : sequence of float, optional
+        Per-post-period ATT standard errors (length ``T1``, the reference
+        ``ASE.ATT``). When given, the search grid for post period ``idx`` is
+        scaled by ``period_se[idx - T0]`` rather than the scalar ``att_se`` --
+        required for a time-varying ATT path, whose per-period SE grows with the
+        horizon. Falls back to ``att_se`` where missing or non-finite.
     alpha : float, default 0.05
         Target miscoverage (95% interval).
     window : float, default 25.0
@@ -132,6 +139,8 @@ def conformal_intervals(
     if periods is None:
         periods = list(range(T0, T))
     periods = [int(p) for p in periods]
+    period_se = (np.asarray(period_se, dtype=float).ravel()
+                 if period_se is not None else None)
 
     # Refit on the SAME rescaled detrend basis the point fit used: the ridge
     # ginv truncation depends on the instrument magnitudes, so an unscaled basis
@@ -158,8 +167,15 @@ def conformal_intervals(
 
     def interval_for(idx: int):
         point = y[idx] - W[idx] @ gamma
-        unit = att_se if (att_se is not None and np.isfinite(att_se) and att_se > 0) else \
-            float(np.std(y[T0:] - (W[T0:] @ gamma))) or 1.0
+        # Per-period SE scales the search grid (reference: window.unit =
+        # ASE.ATT[period]). For a time-varying ATT path the per-period SE grows
+        # with the horizon, so a single scalar would give constant-width bands;
+        # fall back to the scalar att_se, then a data-driven width.
+        unit = period_se[idx - T0] if (period_se is not None
+                                       and np.isfinite(period_se[idx - T0])
+                                       and period_se[idx - T0] > 0) else att_se
+        if not (unit is not None and np.isfinite(unit) and unit > 0):
+            unit = float(np.std(y[T0:] - (W[T0:] @ gamma))) or 1.0
         center = grid_size // 2
         grid = point + np.linspace(-window, window, grid_size) * unit
         accept = np.array([pvalue(idx, xi) >= valid_p for xi in grid])

--- a/mlsynth/utils/proximal_helpers/spsc/conformal.py
+++ b/mlsynth/utils/proximal_helpers/spsc/conformal.py
@@ -47,10 +47,18 @@ def _conformal_pvalue(residuals: np.ndarray) -> float:
     """Rank-based conformal p-value: fraction of |residual| >= the appended one.
 
     The appended (hypothesized post) period is the last row. Mirrors the
-    reference ``Calculate.PValue`` with a single post period.
+    reference ``Calculate.PValue`` with a single post period, which returns
+    ``1 - mean(|residual| < s_base)`` -- *not* the algebraically-equal
+    ``mean(|residual| >= s_base)``. The two differ by one ULP at the discrete
+    threshold (``1 - 219/230`` rounds just below ``11/230`` while the direct
+    fraction equals it exactly), and the interval inversion compares the
+    p-value to ``valid_p = k/(T0+1)`` with ``>=``. Matching R's exact form is
+    what keeps the boundary grid points -- where the p-value lands on
+    ``valid_p`` -- excluded as the reference excludes them, so the band width
+    agrees instead of running ~13% wide.
     """
     s_base = abs(residuals[-1])
-    return float(np.mean(np.abs(residuals) >= s_base))
+    return float(1.0 - np.mean(np.abs(residuals) < s_base))
 
 
 def conformal_intervals(

--- a/mlsynth/utils/proximal_helpers/spsc/estimation.py
+++ b/mlsynth/utils/proximal_helpers/spsc/estimation.py
@@ -126,15 +126,23 @@ def _ridge_ginv(GW: np.ndarray, GY: np.ndarray, lam: float) -> np.ndarray:
     The real instability is a *near-collinear* instrument: ``GW`` (``m`` rows)
     can have a singular value so small that ``solve`` inverts it and lets its
     direction dominate ``gamma``, while ``ginv`` truncates it. Solve through the
-    thin SVD of ``GW = U diag(s) V^T`` and drop the directions ``ginv`` would --
-    those whose eigenvalue ``s^2 + 10^lam`` of ``GW'GW + 10^lam I`` falls below
-    its ``sqrt(eps)`` relative tolerance -- then
-    ``gamma = V diag(s / (s^2 + 10^lam)) U^T GY`` over the kept directions. This
-    avoids forming the rank-deficient ``N x N`` Gram and matches the reference.
+    thin SVD of ``GW = U diag(s) V^T``. The non-trivial eigenvalues of
+    ``GW'GW + 10^lam I`` are ``s^2 + 10^lam`` (the ``N - m`` null directions sit
+    at ``10^lam`` but carry no ``GW'GY`` mass, so they never enter ``gamma``).
+    Drop exactly the directions ``MASS::ginv`` would -- those whose eigenvalue
+    ``s^2 + 10^lam`` is below ``sqrt(eps)`` times the largest -- then
+    ``gamma = V diag(s / (s^2 + 10^lam)) U^T GY`` over the kept directions. The
+    cutoff is on the *penalised* eigenvalue, so the ridge floor ``10^lam`` makes
+    it ``lambda``-aware exactly as the reference: a near-collinear direction is
+    truncated at a small penalty but retained once ``10^lam`` lifts it above the
+    tolerance, which is what keeps the CV ``lambda`` choice (and hence the
+    conformal band) aligned with ``MASS::ginv``. This avoids forming the
+    rank-deficient ``N x N`` Gram and matches the reference to machine precision.
     """
     U, s, Vt = np.linalg.svd(GW, full_matrices=False)   # GW (m, N): U (m, m), s (m,), Vt (m, N)
-    keep = s > np.sqrt(_GINV_RCOND) * s.max()            # drop near-collinear instruments (rank cutoff)
-    scale = np.where(keep, s / (s ** 2 + 10.0 ** lam), 0.0)
+    eig = s ** 2 + 10.0 ** lam                           # eigenvalues of GW'GW + 10^lam I (instrument block)
+    keep = eig > _GINV_RCOND * eig.max()                 # MASS::ginv sqrt(eps) tol on that matrix
+    scale = np.where(keep, s / eig, 0.0)
     return Vt.T @ (scale * (U.T @ GY))
 
 

--- a/mlsynth/utils/proximal_helpers/spsc/estimation.py
+++ b/mlsynth/utils/proximal_helpers/spsc/estimation.py
@@ -271,13 +271,23 @@ def _grad_psi(theta, y, W, A, D, B_post, degree=1, eps: float = 1e-6) -> np.ndar
 
 
 def _ar1_params(x: np.ndarray) -> Tuple[float, float]:
-    """AR(1) coefficient and innovation variance for the auto-bandwidth rule."""
+    """AR(1) coefficient and innovation variance for the auto-bandwidth rule.
+
+    Uses the exact-likelihood ``innovations_mle`` fit to match the reference,
+    which fits the AR(1) with R's ``arima(order=c(1,0,0))`` (its default
+    ``CSS-ML`` lands on the exact-ML optimum). statsmodels' default state-space
+    optimiser converges to a different root for these near-unit-root moment
+    series (e.g. ``rho`` 0.9535 vs R's 0.9512), which shifts the Andrews
+    bandwidth -- through ``(1 - rho)`` -- and hence the HAC meat enough to move
+    the detrend ``Scale`` ~8% and the conformal band ~13%. ``innovations_mle``
+    reproduces R's ``rho``/``sigma2`` to ~1e-5.
+    """
     from statsmodels.tsa.arima.model import ARIMA
 
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            fit = ARIMA(x, order=(1, 0, 0)).fit(method_kwargs={"warn_convergence": False})
+            fit = ARIMA(x, order=(1, 0, 0), trend="c").fit(method="innovations_mle")
         return float(fit.arparams[0]), float(fit.params[-1])
     except Exception:
         return 0.0, float(np.var(x))

--- a/mlsynth/utils/proximal_helpers/spsc/estimation.py
+++ b/mlsynth/utils/proximal_helpers/spsc/estimation.py
@@ -193,6 +193,40 @@ def _effect(y, W, A, D, lam, lam_grid, B_post, degree=1):
     return dict(eta=eta, gamma=gamma, beta=beta, lam=lam)
 
 
+def _scaled_detrend_basis(y, W, T0, spline_df, ridge_lambda, basis_degree,
+                          att_degree, detrend_basis, detrend_degree):
+    """Detrend basis after the reference ``Scale`` rescaling, shape ``(T, nd)``.
+
+    The point fit rescales the detrend columns so the trend-moment (``YDT``) and
+    proxy-moment (``GYb``) blocks of the HAC meat have matched magnitude
+    (reference ``SPSC()``: ``Scale``). The conformal refit must run on this same
+    rescaled basis: the ridge ``ginv`` truncation depends on the instrument
+    magnitudes, so an unscaled basis yields a different ``gamma`` and a band that
+    no longer matches ``MASS::ginv``. Factored out so the point fit and the
+    conformal refit share one definition.
+    """
+    T = len(y)
+    T1 = T - T0
+    D = _build_detrend_matrix(T0, T, spline_df, detrend_basis, int(detrend_degree))
+    if T1 <= 1:
+        return D
+    degree = int(basis_degree)
+    nd = D.shape[1]
+    A = (np.arange(T) >= T0).astype(float)
+    B_post = _att_basis(T, T0, int(att_degree))
+    nb = B_post.shape[1]
+    theta = _effect(y, W, A, D, ridge_lambda, _LAMBDA_GRID, B_post, degree)
+    ncol = _psi(theta, y, W, A, D, B_post, degree).shape[1]
+    beta_pos = list(range(ncol - nb, ncol))
+    diag = np.diag(_hac_meat(_psi(theta, y, W, A, D, B_post, degree), beta_pos))
+    ydt_mean = np.mean(diag[0:nd])
+    gyb_mean = np.mean(diag[2 * nd: 2 * nd + degree])
+    scale = np.sqrt(gyb_mean / ydt_mean) if ydt_mean > 0 else 1.0
+    if not np.isfinite(scale):
+        scale = 1.0
+    return D * scale
+
+
 def _psi(theta, y, W, A, D, B_post, degree=1) -> np.ndarray:
     """Stacked moment matrix (rows = periods). Mirrors the reference ``Psi.Ft``."""
     pre = 1 - A
@@ -371,27 +405,19 @@ def estimate_spsc(
     B_post = _att_basis(T, T0, int(att_degree))      # (T, att_degree+1)
     nb = B_post.shape[1]
 
-    D = (_build_detrend_matrix(T0, T, spline_df, detrend_basis, int(detrend_degree))
-         if detrend else None)
+    # Build the detrend basis, applying the reference "Scale" rescaling (which
+    # balances the trend- and proxy-moment magnitudes before the variance step).
+    if detrend:
+        D = (_scaled_detrend_basis(y, W, T0, spline_df, ridge_lambda, degree,
+                                   int(att_degree), detrend_basis, int(detrend_degree))
+             if T1 > 1 else
+             _build_detrend_matrix(T0, T, spline_df, detrend_basis, int(detrend_degree)))
+    else:
+        D = None
     theta = _effect(y, W, A, D, ridge_lambda, _LAMBDA_GRID, B_post, degree)
     nd = len(theta["eta"]) if detrend else 0
     _ncol = _psi(theta, y, W, A, D, B_post, degree).shape[1]
     beta_pos = list(range(_ncol - nb, _ncol))         # the ATT-basis moment block
-
-    # Detrend rescaling: balance the trend-moment and proxy-moment magnitudes
-    # before the variance step (reference SPSC(), "Scale"): the ratio of the
-    # mean GYb-block diagonal to the mean YDT-block diagonal of the meat.
-    if detrend and T1 > 1:
-        Psi0 = _psi(theta, y, W, A, D, B_post, degree)
-        Sig0 = _hac_meat(Psi0, beta_pos)
-        diag = np.diag(Sig0)
-        ydt_mean = np.mean(diag[0:nd])
-        gyb_mean = np.mean(diag[2 * nd: 2 * nd + degree])
-        scale = np.sqrt(gyb_mean / ydt_mean) if ydt_mean > 0 else 1.0
-        if not np.isfinite(scale):
-            scale = 1.0
-        D = D * scale
-        theta = _effect(y, W, A, D, ridge_lambda, _LAMBDA_GRID, B_post, degree)
 
     gamma = theta["gamma"]
     counterfactual = W @ gamma

--- a/mlsynth/utils/proximal_helpers/spsc/estimation.py
+++ b/mlsynth/utils/proximal_helpers/spsc/estimation.py
@@ -112,17 +112,38 @@ def _instruments(y: np.ndarray, D_pre: Optional[np.ndarray], T0: int,
     return np.column_stack([D_pre, _poly_basis(residual, degree)]), eta
 
 
-def _ridge_gamma(g_pre: np.ndarray, y_pre: np.ndarray, W_pre: np.ndarray, lam: float) -> np.ndarray:
-    """Ridge-GMM weights solving ``(GW' GW + 10^lam I) gamma = GW' GY``.
+def _ridge_ginv(GW: np.ndarray, GY: np.ndarray, lam: float) -> np.ndarray:
+    """Ridge-GMM donor weights ``(GW' GW + 10^lam I)^+ (GW' GY)``, solved stably.
 
-    The ``10^lam I`` ridge makes the system full rank, so a deterministic
-    ``solve`` matches R's ``ginv`` here while avoiding the run-to-run
-    instability of a multithreaded pseudo-inverse on a near-singular matrix.
+    The GMM is under-identified -- ``GW`` is ``(m, N)`` with only ``m`` moments
+    for ``N`` donors -- so ``GW' GW`` is rank-``m`` and ``10^lam I`` merely
+    floors its ``N - m`` null eigenvalues at ``10^lam``. A plain ``solve``
+    inverts that floor (``1 / 10^lam``) and blows the null-space noise up into
+    ``gamma`` when the penalty is small (the CV choice can be ``10^-5`` or
+    less), which is what skewed and inflated the conformal band; R's
+    ``MASS::ginv`` truncates those directions instead.
+
+    The real instability is a *near-collinear* instrument: ``GW`` (``m`` rows)
+    can have a singular value so small that ``solve`` inverts it and lets its
+    direction dominate ``gamma``, while ``ginv`` truncates it. Solve through the
+    thin SVD of ``GW = U diag(s) V^T`` and drop the directions ``ginv`` would --
+    those whose eigenvalue ``s^2 + 10^lam`` of ``GW'GW + 10^lam I`` falls below
+    its ``sqrt(eps)`` relative tolerance -- then
+    ``gamma = V diag(s / (s^2 + 10^lam)) U^T GY`` over the kept directions. This
+    avoids forming the rank-deficient ``N x N`` Gram and matches the reference.
     """
+    U, s, Vt = np.linalg.svd(GW, full_matrices=False)   # GW (m, N): U (m, m), s (m,), Vt (m, N)
+    keep = s > np.sqrt(_GINV_RCOND) * s.max()            # drop near-collinear instruments (rank cutoff)
+    scale = np.where(keep, s / (s ** 2 + 10.0 ** lam), 0.0)
+    return Vt.T @ (scale * (U.T @ GY))
+
+
+def _ridge_gamma(g_pre: np.ndarray, y_pre: np.ndarray, W_pre: np.ndarray, lam: float) -> np.ndarray:
+    """Ridge-GMM donor weights (reference ``SPSC.Effect``); see :func:`_ridge_ginv`."""
     N = W_pre.shape[1]
     GY = (g_pre * y_pre[:, None]).mean(0)
     GW = np.stack([(g_pre * W_pre[:, n: n + 1]).mean(0) for n in range(N)], axis=1)
-    return np.linalg.solve(GW.T @ GW + (10.0 ** lam) * np.eye(N), GW.T @ GY)
+    return _ridge_ginv(GW, GY, lam)
 
 
 def _cv_lambda(g_pre: np.ndarray, y_pre: np.ndarray, W_pre: np.ndarray, grid: np.ndarray) -> float:
@@ -136,7 +157,7 @@ def _cv_lambda(g_pre: np.ndarray, y_pre: np.ndarray, W_pre: np.ndarray, grid: np
             g, yy, ww = g_pre[idx], y_pre[idx], W_pre[idx]
             GY = (g * yy[:, None]).mean(0)
             GW = np.stack([(g * ww[:, n: n + 1]).mean(0) for n in range(N)], axis=1)
-            gamma = np.linalg.solve(GW.T @ GW + (10.0 ** lam) * np.eye(N), GW.T @ GY)
+            gamma = _ridge_ginv(GW, GY, lam)
             resid[j] = y_pre[j] - W_pre[j] @ gamma
         err = np.log(np.mean(resid ** 2))
         if err < best_err:


### PR DESCRIPTION
mlsynth's SPSC conformal prediction intervals (Park & Tchetgen Tchetgen 2025) ran ~13% too wide on the Panic-of-1907 figure and came out flat (constant width) for a time-varying ATT path, instead of matching the authors' R package (`qkrcks0218/SPSC`). This diagnoses and fixes the disagreement function-by-function against the reference, and pins both the panic and Prop 99 bands to the R output.

## Root causes (each fixed in its own commit)

1. **`_ridge_ginv` truncation was λ-independent.** It dropped near-collinear `GW` directions by a rank test on `GW` itself, deviating from R's `MASS::ginv` at larger penalties. Cut on the penalised eigenvalue `s² + 10^λ` instead — now exact vs the reference across the whole log10-λ grid.

2. **The conformal refit used an unscaled detrend basis.** The point fit rescales the detrend columns (reference `Scale`, ×~11.6 on the panic case); R's inversion refits on that rescaled `GMM.Data`, but mlsynth rebuilt an unscaled basis, so the ridge truncation saw different instrument magnitudes. Factored the scaling into a shared `_scaled_detrend_basis` helper used by both the point fit and the conformal refit.

3. **The HAC bandwidth AR(1) fit diverged.** statsmodels' default state-space ML converges to a different root than R's `arima(order=c(1,0,0))` for these near-unit-root moment series (ρ 0.9535 vs 0.9512), shifting the Andrews bandwidth and the detrend `Scale` ~8%. Switching to exact-likelihood `innovations_mle` reproduces R's ρ/σ² to ~1e-5.

4. **The conformal p-value used `mean(|r| >= s_base)`, the reference uses `1 - mean(|r| < s_base)`.** Algebraically equal, but they differ by one ULP at the discrete threshold (`1 − 219/230` rounds just below `11/230`); the inversion test is `>= valid_p`, so the naive form kept the boundary points R rejects — widening every edge ~13%. This was the dominant cause of the panic over-width.

5. **The search grid used a single scalar `att_se`.** A time-varying ATT path's per-period SE grows with the horizon (reference `window.unit = ASE.ATT[period]`), so a scalar gave constant-width bands. Thread the per-period SE through.

6. **The edge refinement stopped at the grid boundary.** When the accepted run saturates a grid edge (short pre-period + lax discrete level), the reference extends the search by `10*unit` there; mlsynth capped at the grid span, giving Prop 99 bands ~0.71× the reference. Mirror the extension.

## Validation

- **Panic of 1907** (spline detrend, CV λ=−6, T0=229): bands match the R package **bit-for-bit** across all post periods.
- **Prop 99 / California** (linear detrend + linear ATT, λ=10⁰, T0=18): bands match to **~1e-3** across all 13 post periods; width grows 0.139 → 1.645 as the reference does.
- New TDD tests pin the reference p-value form (including the boundary-ULP case) and the Prop 99 band; the `spsc_prop99` durable benchmark now also cross-checks the conformal LB/UB against the live R package.
- Full proximal/SPSC suite green; `spsc_prop99` and `spsc_panic` benchmarks pass (point fit unchanged, bit-for-bit ATT).

This is the conformal fix referenced in #172 — once this lands, the Panic-of-1907 figure re-renders with the corrected bands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_