### PR TITLE
agents_tests: codify cross-implementation differential TDD

### DIFF
--- a/agents/agents_tests.md
+++ b/agents/agents_tests.md
@@ -55,6 +55,104 @@ the levels are *non-optional* and come *first*.
 
 ---
 
+# Cross-Implementation Differential TDD (matching a reference)
+
+Most of `mlsynth` is validated against a **reference implementation** — the
+paper's R package, a reference repo, an authoritative competitor (the
+replication contract in `CLAUDE.md` and `agents_benchmarking.md`: Path A / Path
+B / cross-validation). When a port *disagrees* with its reference — a number is
+off, a band is too wide, a weight vector drifts — the temptation is to stare at
+the Python and guess. Don't. **Use TDD across the two implementations**: treat
+the reference as a chain of testable units and assert mlsynth against it at
+every joint, the same way you'd red→green a single function — except the
+"expected" value is dumped from the other implementation.
+
+This is what turns "the output is wrong somewhere" into "the disagreement is
+`Calculate.PValue`, and it's `1 - mean(<)` vs `mean(>=)` at the discrete
+threshold." It works because a faithful port has a faithful *seam structure*:
+the two implementations compute the same intermediates in the same order, so
+they can be compared intermediate-by-intermediate, not just end-to-end.
+
+## The recipe
+
+1. **Decompose both sides into matching units.** Find the function boundaries
+   that correspond across the implementations (`Spline.Trend` ↔
+   `_build_detrend_matrix`, `MASS::ginv` ↔ `_ridge_ginv`, `CV.lambda` ↔
+   `_cv_lambda`, `HAC.Meat` ↔ `_hac_meat`, `Calculate.PValue` ↔
+   `_conformal_pvalue`). The seams are where you'll compare.
+2. **Dump the seam, not just the endpoint.** Have the reference write its
+   intermediates out (`write.csv` of the moment matrix, the weight vector at one
+   grid point, the per-step p-values) and load them in Python. The breakthroughs
+   come from pinning the *intermediate*, not the final answer — the final answer
+   only tells you *that* it's wrong, a dumped seam tells you *where*.
+3. **Share the input.** Feed both sides the *identical* input at the seam you're
+   testing — same matrix, same grid, same λ. Differential testing only assigns
+   blame if the input is held fixed; otherwise a mismatch could be either side's
+   fault. (Feeding mlsynth the reference's exact grid is what proved a residual
+   gap was the *grid*, not the refit — the p-values matched to 1e-17 on the
+   shared grid.)
+4. **Bisect the disagreement.** Confirm agreement upstream, unit by unit; the
+   fault lies downstream of the last seam that still agrees. Walk inward until it
+   collapses onto one boundary. "Everything up to the HAC matches, so it's the
+   HAC or below" is the move that makes a six-cause bug tractable.
+5. **Reason about each disagreement — it is usually meaningful.** A seam
+   mismatch is a finding, not noise: a different solver root, a truncation
+   tolerance, a floating-point reassociation. Name *why* before you "fix" it, so
+   the fix is faithful rather than a fudge that happens to match on this dataset.
+6. **Pin the resolved boundary.** Distill each differential probe into a
+   permanent unit test that pins the *reference form* (e.g. the p-value is
+   `1 - mean(|r| < s)`, including the boundary case), and add a **durable
+   benchmark** (`benchmarks/cases/<name>.py`) that re-runs the reference live and
+   cross-checks the end-to-end output. The scratch probes are scaffolding; the
+   unit test + benchmark are the standing guard.
+
+## Lessons (learned the hard way)
+
+- **Audit your own harness first.** The comparison scaffold can be the bug. A
+  driver that did `T <- length(y)` silently shadowed R's built-in `T` (=`TRUE`),
+  corrupting `bs(intercept=T)` and inventing a phantom disagreement. If the
+  reference suddenly disagrees with *itself* across two runs, suspect the
+  harness, not the library.
+- **Algebraically equal ≠ bit-for-bit.** `1 - mean(x < s)` and `mean(x >= s)`
+  differ by one ULP at a discrete threshold; the inversion's `>= valid_p` test
+  then includes/excludes a boundary point and the interval width jumps ~13%.
+  Match the reference's *exact* expression, not a tidier equivalent.
+- **Estimators have method-dependent roots.** statsmodels' default state-space
+  AR(1) ML and R's `arima` (CSS-ML) converge to *different* coefficients on a
+  near-unit-root series; `innovations_mle` reproduces R's. When a plug-in
+  (bandwidth, tolerance, penalty) is fed by a sub-estimate, the sub-estimate's
+  *method* is part of the contract.
+- **Near-singular truncation is λ-dependent.** A pseudo-inverse cut on a raw
+  rank test deviates from `MASS::ginv`'s cut on the *penalised* eigenvalue once a
+  ridge floor lifts the borderline direction — match the tolerance the reference
+  actually applies.
+- **Mind the achievable discrete level.** A short pre-period caps the conformal
+  level (the finest is `2/(T0+1)`); the reference errors or coarsens there, and
+  the comparison must use the same achievable α rather than a nominal 0.05.
+
+## Worked example — the SPSC conformal bands
+
+`mlsynth`'s SPSC conformal intervals ran ~13% too wide and were flat for a
+time-varying ATT, vs `qkrcks0218/SPSC`. Walking the seams pinned **six** stacked
+causes — none visible from `conformal.py` alone, because mlsynth agreed with
+*itself* perfectly:
+
+| Reference unit            | mlsynth unit                       | Verdict                                            |
+| ------------------------- | ---------------------------------- | -------------------------------------------------- |
+| `Spline.Trend`            | `_build_detrend_matrix`            | match (1e-16)                                      |
+| `MASS::ginv`              | `_ridge_ginv`                      | fixed — cut on `s² + 10^λ`, not a raw rank test    |
+| `CV.lambda`               | `_cv_lambda`                       | match (same λ)                                     |
+| `arima` AR(1) → bandwidth | `_ar1_params`                      | fixed — `innovations_mle` matches R's root         |
+| `HAC.Meat` → `Scale`      | `_scaled_detrend_basis`            | refit must run on the *rescaled* basis             |
+| `Calculate.PValue`        | `_conformal_pvalue`                | fixed — `1 - mean(<)`, the ULP that set band width |
+| narrow-grid refinement    | `interval_for`                     | per-period SE grid + `10*unit` edge extension      |
+
+The end state is pinned by unit tests (the p-value form incl. the boundary ULP)
+and the `spsc_prop99` durable benchmark, which now cross-checks the conformal
+LB/UB against live R — so the six-cause bug can never silently come back.
+
+---
+
 # Core Testing Philosophy
 
 The architecture of `mlsynth` is intentionally layered:

--- a/agents/agents_tests.md
+++ b/agents/agents_tests.md
@@ -75,6 +75,14 @@ they can be compared intermediate-by-intermediate, not just end-to-end.
 
 ## The recipe
 
+0. **Pre-flight: confirm the reference implements the *same version* of the
+   spec.** Before mapping a single seam, check that the reference targets the
+   paper (and the *edition* of the paper) you target. A method can evolve between
+   a working paper and its published version, and two faithful implementations of
+   "the same" estimator can then optimize genuinely different objectives. If you
+   skip this, the seam will "disagree" and you will be tempted to *break* a
+   correct port to match a reference that is solving a different problem. Verify
+   first; only a same-spec reference earns a bit-for-bit comparison.
 1. **Decompose both sides into matching units.** Find the function boundaries
    that correspond across the implementations (`Spline.Trend` ↔
    `_build_detrend_matrix`, `MASS::ginv` ↔ `_ridge_ginv`, `CV.lambda` ↔
@@ -150,6 +158,36 @@ causes — none visible from `conformal.py` alone, because mlsynth agreed with
 The end state is pinned by unit tests (the p-value form incl. the boundary ULP)
 and the `spsc_prop99` durable benchmark, which now cross-checks the conformal
 LB/UB against live R — so the six-cause bug can never silently come back.
+
+## Worked example — CTSC vs `pgsc` (the pre-flight catch)
+
+`mlsynth`'s `CTSC` is Powell's generalized synthetic control; Philip Barrett's
+`pgsc` R package is "the" reference implementation. Mapping the very first seam —
+the objective — showed an immediate "disagreement": `pgsc` optimizes a *single
+shared* coefficient `b` across all units, while `CTSC` fits *per-unit* slopes
+`b_i` and averages them (`α^AE = Σ π_i α_i`). The tempting conclusion was a
+`CTSC` bug. It was the opposite. **The reference implements a different edition
+of the paper.** Powell's 2017 working paper (which `pgsc` and its vignette cite)
+used a shared `α₀`; the published 2022 JBES version's baseline is the per-unit
+`α_i` with an average-effect summary — exactly what `CTSC` implements (its
+docstring cites Powell 2022). The shared-`b` form survives only as the published
+paper's §3.3.3 "homogeneous effects" *simplification*. Had we "fixed" `CTSC` to
+match `pgsc` bit-for-bit, we'd have regressed it *away* from the paper it
+correctly follows.
+
+Once the version skew was understood, the comparison was reframed as
+corroboration on the vignette's homogeneous DGP (true `b = (1,2)`), where both
+estimators are consistent for the same truth:
+
+| Estimator | `CTSC` (published, per-unit AE) | `pgsc` (2017, shared `b`) | truth  |
+| --------- | ------------------------------- | ------------------------- | ------ |
+| one-step  | `[0.886, 1.782]`                | `[0.874, 1.897]`          | `(1,2)`|
+| two-step  | `[0.997, 1.992]`                | `[0.987, 1.993]` (aggte)  | `(1,2)`|
+
+The two-step estimates agree to ~1%, both recovering the truth, with the residual
+gap explained by per-unit-average vs jointly-shared — not a bug in either. The
+lesson: the pre-flight version check (recipe step 0) is not optional; here it was
+the entire finding.
 
 ---
 


### PR DESCRIPTION
Adds a **Cross-Implementation Differential TDD** section to `agents/agents_tests.md` — the method that diagnosed the SPSC conformal disagreement and (in the second example) caught a version skew on CTSC before it became a wrong "fix".

The recipe: confirm the reference implements the same *edition* of the spec (step 0) → decompose both sides into matching units → dump the seam, not the endpoint → share the input so a mismatch assigns blame → bisect to the failing boundary → reason about *why* each seam disagrees → pin the result with a unit test plus a durable benchmark.

Includes the hard-won lessons (audit your own harness; algebraically-equal forms differ by a ULP; method-dependent estimator roots; λ-dependent truncation; achievable discrete levels) and two worked examples:

- **SPSC conformal bands** — six stacked causes pinned seam-by-seam vs `qkrcks0218/SPSC`, none visible from `conformal.py` alone.
- **CTSC vs `pgsc`** — the first seam "disagreed", but it was a version skew (pgsc = Powell 2017 working paper, shared `b`; CTSC = published 2022 JBES, per-unit `α_i`). The pre-flight check stopped a fix that would have regressed mlsynth away from the paper it correctly follows; reframed as corroboration on the homogeneous DGP (two-step estimates agree to ~1%).

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_