### PR TITLE
compare_methods: add LEXSCM and MAREX as design-comparison methods

### DIFF
--- a/mlsynth/estimators/scexp.py
+++ b/mlsynth/estimators/scexp.py
@@ -174,9 +174,15 @@ class MAREX:
                 from ..utils.marex_helpers.optimization import solve_design_pool
                 from ..utils.marex_helpers.pool import build_marex_pool
                 from ..utils.marex_helpers.select import recommend_marex
+                # Hold out a blank tail of the pre-period so each pooled design
+                # can be ranked on its OUT-OF-SAMPLE (blank) fit, not in-sample
+                # overfit. Reuse the configured blank window if any, else the
+                # 30% pre-tail convention shared by the MAREX-family estimators.
+                pool_blank = (panel.blank_periods if panel.blank_periods > 0
+                              else max(1, int(0.3 * panel.T0)))
                 raws = solve_design_pool(
                     Y_full=panel.Y_full, T0=panel.T0, clusters=panel.clusters,
-                    top_K=self.config.top_K, blank_periods=panel.blank_periods,
+                    top_K=self.config.top_K, blank_periods=pool_blank,
                     m_eq=self.m_eq, m_min=self.m_min, m_max=self.m_max,
                     exclusive=self.exclusive, design=self.design, beta=self.beta,
                     lambda1=self.lambda1, lambda2=self.lambda2, xi=self.xi,

--- a/mlsynth/estimators/scexp.py
+++ b/mlsynth/estimators/scexp.py
@@ -164,6 +164,42 @@ class MAREX:
         except Exception as exc:
             raise MlsynthEstimationError(f"MAREX design failed: {exc}") from exc
 
+        # Solution pool + MDE power + recommendation (SYNDES parity): when
+        # top_K > 1, enumerate distinct designs via no-good cuts (exact MIQP),
+        # score each on a Newey-West MDE power curve, and attach the menu plus a
+        # composite recommendation. The primary result above is unchanged.
+        if self.config.top_K and self.config.top_K > 1:
+            try:
+                import cvxpy as cp
+                from ..utils.marex_helpers.optimization import solve_design_pool
+                from ..utils.marex_helpers.pool import build_marex_pool
+                from ..utils.marex_helpers.select import recommend_marex
+                raws = solve_design_pool(
+                    Y_full=panel.Y_full, T0=panel.T0, clusters=panel.clusters,
+                    top_K=self.config.top_K, blank_periods=panel.blank_periods,
+                    m_eq=self.m_eq, m_min=self.m_min, m_max=self.m_max,
+                    exclusive=self.exclusive, design=self.design, beta=self.beta,
+                    lambda1=self.lambda1, lambda2=self.lambda2, xi=self.xi,
+                    lambda1_unit=self.lambda1_unit, lambda2_unit=self.lambda2_unit,
+                    costs=self.costs, budget=self.budget, covariates=panel.covariates,
+                    covariate_weight=self.covariate_weight, standardize=self.standardize,
+                    solver=self.solver or cp.SCIP, verbose=self.verbose,
+                )
+                pool = build_marex_pool(
+                    raws, alpha=self.config.alpha, power=self.config.power_target,
+                    n_post=self.config.T_post or 1)
+                if pool:
+                    rec = recommend_marex(
+                        pool, power_weight=self.config.power_weight,
+                        fit_weight=self.config.fit_weight,
+                        max_shortlist=self.config.max_shortlist)
+                    results = results.model_copy(
+                        update={"pool": pool, "recommendation": rec})
+            except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
+                raise
+            except Exception as exc:
+                raise MlsynthEstimationError(f"MAREX pool failed: {exc}") from exc
+
         if self.display_graph:
             try:
                 plot_marex(results, plot_type="treatment")

--- a/mlsynth/tests/test_config_models.py
+++ b/mlsynth/tests/test_config_models.py
@@ -320,8 +320,14 @@ def test_sdid_config_valid(base_config_data: Dict[str, Any]):
 
 
 # ---------------------------
-# Numeric time column
+# Time axis is delegated to geoex_dataprep
 # ---------------------------
+# MAREX ingestion routes through ``geoex_dataprep`` (the same balanced-panel
+# prep GeoLift uses), which sorts the time axis and enforces a *balanced* panel.
+# The config validator therefore no longer imposes a dtype-specific
+# "consecutive time" requirement -- any orderable time (integer, datetime, or
+# ISO-date string) is accepted at construction. The fit-time behaviour (balance
+# check, date-string acceptance) is exercised in ``tests/test_marex.py``.
 def test_numeric_time_consecutive():
     df = pd.DataFrame({
         "unit": [1, 1, 2, 2],
@@ -329,16 +335,17 @@ def test_numeric_time_consecutive():
         "y": [0, 1, 2, 3]
     })
     # Should not raise
-    config = MAREXConfig(df=df, outcome="y", unitid="unit", time="time")
+    MAREXConfig(df=df, outcome="y", unitid="unit", time="time")
 
-def test_numeric_time_non_consecutive():
+def test_numeric_time_non_consecutive_is_accepted():
     df = pd.DataFrame({
         "unit": [1, 1, 2, 2],
-        "time": [1, 3, 1, 3],  # non-consecutive
+        "time": [1, 3, 1, 3],  # gap in the integer time index, but balanced
         "y": [0, 1, 2, 3]
     })
-    with pytest.raises(MlsynthDataError, match="Time periods in 'time' are not consecutive"):
-        MAREXConfig(df=df, outcome="y", unitid="unit", time="time")
+    # geoex_dataprep only requires a balanced panel, not consecutive time, so
+    # the config no longer rejects gapped time.
+    MAREXConfig(df=df, outcome="y", unitid="unit", time="time")
 
 # ---------------------------
 # Datetime time column
@@ -350,26 +357,21 @@ def test_datetime_time_consecutive():
         "y": [0, 1, 2, 3]
     })
     # Should not raise
-    config = MAREXConfig(df=df, outcome="y", unitid="unit", time="time")
+    MAREXConfig(df=df, outcome="y", unitid="unit", time="time")
 
 
-def test_datetime_time_non_consecutive():
-    import pandas as pd
-    import pytest
-    from datetime import datetime, timedelta
-    from mlsynth.config_models import MAREXConfig
-    from mlsynth.exceptions import MlsynthDataError
+def test_datetime_time_non_consecutive_is_accepted():
+    from datetime import datetime
 
     df = pd.DataFrame({
         "unit": [1, 1, 1],
         "time": [datetime(2020, 1, 1),
-                 datetime(2020, 1, 3),  # Gap here
+                 datetime(2020, 1, 3),  # Gap here -- balanced single unit
                  datetime(2020, 1, 4)],
         "y": [1, 2, 3]
     })
-
-    with pytest.raises(MlsynthDataError, match="Datetime time periods in 'time' are not consecutive"):
-        MAREXConfig(df=df, outcome="y", unitid="unit", time="time")
+    # Gapped datetime is accepted: geoex_dataprep sorts and balance-checks.
+    MAREXConfig(df=df, outcome="y", unitid="unit", time="time")
 
 
 
@@ -377,13 +379,14 @@ def test_datetime_time_non_consecutive():
 
 
 # ---------------------------
-# Unsupported dtype
+# String time column
 # ---------------------------
-def test_time_unsupported_dtype():
+def test_string_time_is_accepted():
     df = pd.DataFrame({
         "unit": [1, 1, 2, 2],
-        "time": ["a", "b", "a", "b"],  # string dtype
+        "time": ["a", "b", "a", "b"],  # string dtype -- orderable
         "y": [0, 1, 2, 3]
     })
-    with pytest.raises(MlsynthDataError, match="Unsupported dtype for time column"):
-        MAREXConfig(df=df, outcome="y", unitid="unit", time="time")
+    # String time is no longer rejected at the config level; geoex_dataprep
+    # sorts the labels at fit time.
+    MAREXConfig(df=df, outcome="y", unitid="unit", time="time")

--- a/mlsynth/tests/test_design_compare.py
+++ b/mlsynth/tests/test_design_compare.py
@@ -323,12 +323,11 @@ class TestLEXSCM:
         assert all(s.method == "LEXSCM" for s in specs)
         for s in specs:
             assert set(s.contrast) <= set(f"u{j}" for j in range(8))
-            # treated weights come from the full-precision solution weight_dict,
-            # so the treated side sums to one exactly (the MDE identity).
+            # both sides come from the full-precision weight dicts: the treated
+            # side sums to one and the net contrast is zero, exactly.
             treated_sum = sum(s.contrast[u] for u in s.treated)
             assert treated_sum == pytest.approx(1.0, abs=1e-9)
-            # net contrast ~ 0; control weights are LEXSCM's 3-decimal rounded.
-            assert sum(s.contrast.values()) == pytest.approx(0.0, abs=5e-3)
+            assert sum(s.contrast.values()) == pytest.approx(0.0, abs=1e-9)
 
     def test_compare_methods_lexscm_only(self):
         df, T, n_post = _shared_panel()

--- a/mlsynth/tests/test_design_compare.py
+++ b/mlsynth/tests/test_design_compare.py
@@ -323,9 +323,11 @@ class TestLEXSCM:
         assert all(s.method == "LEXSCM" for s in specs)
         for s in specs:
             assert set(s.contrast) <= set(f"u{j}" for j in range(8))
-            # treated weights sum to +1 (the MDE identity); net contrast ~ 0.
-            # LEXSCM reports weights rounded to 3 decimals, so allow that residual.
-            assert sum(v for v in s.contrast.values() if v > 0) == pytest.approx(1.0, abs=5e-3)
+            # treated weights come from the full-precision solution weight_dict,
+            # so the treated side sums to one exactly (the MDE identity).
+            treated_sum = sum(s.contrast[u] for u in s.treated)
+            assert treated_sum == pytest.approx(1.0, abs=1e-9)
+            # net contrast ~ 0; control weights are LEXSCM's 3-decimal rounded.
             assert sum(s.contrast.values()) == pytest.approx(0.0, abs=5e-3)
 
     def test_compare_methods_lexscm_only(self):

--- a/mlsynth/tests/test_design_compare.py
+++ b/mlsynth/tests/test_design_compare.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 from mlsynth.utils.design_compare import (
     DesignComparison,
     DesignSpec,
@@ -23,6 +23,7 @@ from mlsynth.utils.design_compare import (
     compare_methods,
     compare_pareto,
     from_geolift,
+    from_lexscm,
     from_syndes,
     plot_compare_pareto,
     simulated_mde,
@@ -299,6 +300,75 @@ class TestCompareMethods:
             compare_methods(df, outcome="Y", unitid="unit", time="time",
                             treated_size=2, n_post=n_post, methods=("GEOLIFT",),
                             geolift_options={"not_a_real_option": 123})
+
+
+# ----------------------------------------------------------------------
+# LEXSCM as a third design method on the shared plane
+# ----------------------------------------------------------------------
+
+class TestLEXSCM:
+    # small search budgets keep the lexicographic fit quick in tests
+    _LEX = {"top_K": 4, "top_P": 3, "n_sims": 40, "max_shortlist": 4}
+
+    def test_from_lexscm_specs(self):
+        from mlsynth import LEXSCM
+        df, T, n_post = _shared_panel()
+        df = df.copy()
+        df["cand"] = True                                # every unit eligible
+        res = LEXSCM({"df": df, "outcome": "Y", "unitid": "unit", "time": "time",
+                      "candidate_col": "cand", "m": 2, "post_col": "post",
+                      **self._LEX}).fit()
+        specs = from_lexscm(res)
+        assert len(specs) == len(res.search.candidates)
+        assert all(s.method == "LEXSCM" for s in specs)
+        for s in specs:
+            assert set(s.contrast) <= set(f"u{j}" for j in range(8))
+            # treated weights sum to +1 (the MDE identity); net contrast ~ 0.
+            # LEXSCM reports weights rounded to 3 decimals, so allow that residual.
+            assert sum(v for v in s.contrast.values() if v > 0) == pytest.approx(1.0, abs=5e-3)
+            assert sum(s.contrast.values()) == pytest.approx(0.0, abs=5e-3)
+
+    def test_compare_methods_lexscm_only(self):
+        df, T, n_post = _shared_panel()
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, methods=("LEXSCM",),
+            lexscm_options=self._LEX,
+        )
+        assert set(cmp.table["method"]) == {"LEXSCM"}
+        assert cmp.lexscm is not None and cmp.syndes is None and cmp.geolift is None
+        assert {"fit_rmse", "mde_pct", "pareto"} <= set(cmp.table.columns)
+        assert cmp.table.groupby("method")["pareto"].any().all()
+
+    def test_compare_methods_all_three(self):
+        df, T, n_post = _shared_panel()
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, top_K=4,
+            methods=("SYNDES", "GEOLIFT", "LEXSCM"),
+            syndes_options={"time_limit": 3.0, "gap_limit": 0.2},
+            geolift_options={"ns": 120}, lexscm_options=self._LEX,
+        )
+        assert set(cmp.table["method"]) == {"SYNDES", "GEOLIFT", "LEXSCM"}
+        assert np.isfinite(cmp.table["fit_rmse"]).all()
+
+    def test_candidate_col_defaults_to_all_units(self):
+        # no candidate_col supplied -> compare_methods marks every unit eligible.
+        df, T, n_post = _shared_panel()
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, methods=("LEXSCM",), lexscm_options=self._LEX,
+        )
+        assert len(cmp.table) >= 1
+
+    def test_lexscm_options_are_forwarded(self):
+        # an unknown key must reach the LEXSCM config and raise, proving the
+        # override dict is not silently dropped.
+        df, T, n_post = _shared_panel()
+        with pytest.raises((MlsynthConfigError, MlsynthDataError)):
+            compare_methods(df, outcome="Y", unitid="unit", time="time",
+                            treated_size=2, n_post=n_post, methods=("LEXSCM",),
+                            lexscm_options={"not_a_real_option": 123})
 
 
 # ----------------------------------------------------------------------

--- a/mlsynth/tests/test_design_compare.py
+++ b/mlsynth/tests/test_design_compare.py
@@ -24,6 +24,7 @@ from mlsynth.utils.design_compare import (
     compare_pareto,
     from_geolift,
     from_lexscm,
+    from_marex,
     from_syndes,
     plot_compare_pareto,
     simulated_mde,
@@ -436,3 +437,100 @@ class TestSyndesOOSRanking:
         assert set(cmp.table["method"]) == {"SYNDES"}
         # IC is in-sample, so there is no holdout OOS error to report.
         assert cmp.table["oos_rmse"].isna().all()
+
+
+# ----------------------------------------------------------------------
+# MAREX adapter + cross-method integration
+# ----------------------------------------------------------------------
+
+class TestMAREX:
+    # small pool keeps the MIQP enumeration quick in tests
+    _MAR = {"top_K": 3}
+
+    def test_from_marex_specs(self):
+        from mlsynth import MAREX
+        df, T, n_post = _shared_panel()
+        res = MAREX({"df": df, "outcome": "Y", "unitid": "unit", "time": "time",
+                     "post_col": "post", "m_eq": 2, **self._MAR}).fit()
+        specs = from_marex(res)
+        assert len(specs) >= 1
+        assert all(s.method == "MAREX" for s in specs)
+        for s in specs:
+            assert set(s.contrast) <= {f"u{j}" for j in range(8)}
+            # treated side sums to +1 and the net contrast (treated - control)
+            # is zero -- both sides come from the simplex-constrained weights.
+            treated_sum = sum(s.contrast[u] for u in s.treated)
+            assert treated_sum == pytest.approx(1.0, abs=1e-6)
+            assert sum(s.contrast.values()) == pytest.approx(0.0, abs=1e-6)
+            # treated and control labels are disjoint
+            ctrl = [u for u, w in s.contrast.items() if w < 0]
+            assert set(ctrl).isdisjoint(set(s.treated))
+
+    def test_from_marex_single_design_fallback(self):
+        # top_K == 1 -> no pool; the adapter falls back to the aggregate design
+        # built from the per-cluster unit-weight maps.
+        from mlsynth import MAREX
+        df, T, n_post = _shared_panel()
+        res = MAREX({"df": df, "outcome": "Y", "unitid": "unit", "time": "time",
+                     "post_col": "post", "m_eq": 2}).fit()
+        assert res.pool is None
+        specs = from_marex(res)
+        assert len(specs) == 1
+        s = specs[0]
+        assert s.method == "MAREX" and len(s.treated) == 2
+        assert sum(s.contrast[u] for u in s.treated) == pytest.approx(1.0, abs=1e-6)
+        assert sum(s.contrast.values()) == pytest.approx(0.0, abs=1e-6)
+
+    def test_compare_methods_marex_only(self):
+        df, T, n_post = _shared_panel()
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, top_K=3, methods=("MAREX",),
+            marex_options=self._MAR,
+        )
+        assert set(cmp.table["method"]) == {"MAREX"}
+        assert cmp.marex is not None
+        assert cmp.syndes is None and cmp.geolift is None and cmp.lexscm is None
+        assert {"fit_rmse", "mde_pct", "pareto"} <= set(cmp.table.columns)
+        assert cmp.table.groupby("method")["pareto"].any().all()
+        assert np.isfinite(cmp.table["fit_rmse"]).all()
+
+    def test_marex_accepts_date_string_time(self):
+        # The whole point of routing MAREX through geoex_dataprep: ISO-date
+        # string time (as the geoex pipeline supplies) flows through unmodified.
+        df, T, n_post = _shared_panel()
+        weeks = pd.date_range("2025-01-06", periods=T, freq="W-MON").date
+        df = df.copy()
+        df["time"] = df["time"].map({t: weeks[t].isoformat() for t in range(T)})
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, top_K=3, methods=("MAREX",),
+            marex_options=self._MAR,
+        )
+        assert set(cmp.table["method"]) == {"MAREX"}
+        assert len(cmp.table) >= 1
+
+    def test_compare_methods_all_four(self):
+        df, T, n_post = _shared_panel()
+        cmp = compare_methods(
+            df, outcome="Y", unitid="unit", time="time", treated_size=2,
+            horizon=5, n_post=n_post, top_K=3,
+            methods=("SYNDES", "GEOLIFT", "LEXSCM", "MAREX"),
+            syndes_options={"time_limit": 3.0, "gap_limit": 0.2},
+            geolift_options={"ns": 120},
+            lexscm_options={"top_K": 3, "top_P": 3, "n_sims": 40,
+                            "max_shortlist": 3},
+            marex_options=self._MAR,
+        )
+        assert set(cmp.table["method"]) == {"SYNDES", "GEOLIFT", "LEXSCM",
+                                            "MAREX"}
+        assert np.isfinite(cmp.table["fit_rmse"]).all()
+
+    def test_marex_options_are_forwarded(self):
+        # an unknown key must reach the MAREX config and raise, proving the
+        # override dict is not silently dropped.
+        df, T, n_post = _shared_panel()
+        with pytest.raises((MlsynthConfigError, MlsynthDataError)):
+            compare_methods(df, outcome="Y", unitid="unit", time="time",
+                            treated_size=2, n_post=n_post, methods=("MAREX",),
+                            marex_options={"not_a_real_option": 123})

--- a/mlsynth/tests/test_marex.py
+++ b/mlsynth/tests/test_marex.py
@@ -72,6 +72,36 @@ class TestMAREXConfig:
             MAREX({"df": panel, "outcome": "y", "unitid": "unit", "time": "time",
                    "cluster": "missing", "m_eq": 1})
 
+    def test_date_string_time_is_accepted(self):
+        # ISO-date string time (as the geoex pipeline supplies) must be accepted,
+        # not rejected as an "unsupported dtype".
+        df = _panel(J=6, T=12)
+        weeks = pd.date_range("2025-01-06", periods=12, freq="W-MON").date
+        df["time"] = df["time"].map({t: weeks[t].isoformat() for t in range(12)})
+        res = MAREX({"df": df, "outcome": "y", "unitid": "unit", "time": "time",
+                     "T0": 9, "m_eq": 2}).fit()
+        assert res is not None
+
+    def test_non_consecutive_time_is_accepted(self):
+        # Ingestion is delegated to geoex_dataprep, which only requires a
+        # *balanced* panel (every unit observed at every period) and sorts the
+        # time axis -- it does not require consecutive time. A balanced panel
+        # with a gap in the integer time index must therefore be accepted.
+        df = _panel(J=6, T=12)
+        df["time"] = df["time"].map(lambda t: t if t < 6 else t + 5)  # gap
+        res = MAREX({"df": df, "outcome": "y", "unitid": "unit", "time": "time",
+                     "T0": 9, "m_eq": 2}).fit()
+        assert res is not None
+
+    def test_unbalanced_panel_rejected(self):
+        # geoex_dataprep owns the balance check: dropping a single unit-time
+        # observation makes the panel unbalanced and must raise MlsynthDataError.
+        df = _panel(J=6, T=12)
+        df = df[~((df["unit"] == "u00") & (df["time"] == 0))]
+        with pytest.raises(MlsynthDataError):
+            MAREX({"df": df, "outcome": "y", "unitid": "unit", "time": "time",
+                   "T0": 9, "m_eq": 2}).fit()
+
 
 # ----------------------------------------------------------------------
 # Estimation

--- a/mlsynth/tests/test_marex_pool.py
+++ b/mlsynth/tests/test_marex_pool.py
@@ -73,6 +73,14 @@ class TestPool:
         assert all(isinstance(e["mde_pct"], float) for e in res.pool)
         assert any(np.isfinite(e["mde_pct"]) for e in res.pool)
 
+    def test_fit_metric_is_the_held_out_blank_rmse(self):
+        # the ranking fit metric (objective) is the out-of-sample blank RMSE,
+        # not the in-sample pre-period RMSE
+        res = MAREX(_cfg(top_K=3)).fit()
+        for e in res.pool:
+            assert e["blank_rmse"] is not None
+            assert e["objective"] == pytest.approx(e["blank_rmse"])
+
 
 class TestRecommendation:
     def test_recommendation_present_and_consistent(self):

--- a/mlsynth/tests/test_marex_pool.py
+++ b/mlsynth/tests/test_marex_pool.py
@@ -1,0 +1,88 @@
+"""TDD for the MAREX solution-pool + MDE power + recommendation (SYNDES parity).
+
+``top_K=1`` (default) keeps the single-design behaviour. ``top_K>1`` enumerates a
+menu of distinct designs via no-good cuts, scores each on a Newey-West MDE power
+curve (the same power analysis SYNDES uses), and returns a composite
+recommendation. Mirrors tests/test_syndes_pool.py in spirit.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+from mlsynth import MAREX
+from mlsynth.utils.marex_helpers.structures import MAREXResults
+
+
+def _panel(J=8, T=16, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(0, 1, (T, 2))
+    lam = rng.normal(0, 1, (J, 2))
+    Y = lam @ F.T + 0.2 * rng.standard_normal((J, T))
+    return pd.DataFrame([{"unit": f"u{j:02d}", "time": t, "y": float(Y[j, t])}
+                         for j in range(J) for t in range(T)])
+
+
+def _cfg(**over):
+    base = dict(df=_panel(), outcome="y", unitid="unit", time="time", T0=12, m_eq=2)
+    base.update(over)
+    return base
+
+
+# ---- Stage A: scaffolding (config knobs + default behaviour) ----------------
+
+class TestPoolConfig:
+    def test_default_top_K_returns_no_pool(self):
+        res = MAREX(_cfg()).fit()
+        assert isinstance(res, MAREXResults)
+        assert res.pool is None
+        assert res.recommendation is None
+
+    def test_bad_top_K_rejected(self):
+        with pytest.raises((ValidationError, Exception)):
+            MAREX(_cfg(top_K=0))
+
+    def test_power_weights_must_be_positive(self):
+        with pytest.raises((ValidationError, Exception)):
+            MAREX(_cfg(top_K=2, power_weight=0.0))
+
+
+# ---- Stage B-E: the pool, MDE, and recommendation ---------------------------
+
+class TestPool:
+    def test_pool_returned_with_menu_fields(self):
+        res = MAREX(_cfg(top_K=3)).fit()
+        assert res.pool is not None
+        assert 1 <= len(res.pool) <= 3
+        entry = res.pool[0]
+        for key in ("markets", "control_group", "objective", "mde_pct", "power_curve"):
+            assert key in entry, f"pool entry missing '{key}'"
+        assert isinstance(entry["markets"], list) and len(entry["markets"]) == 2
+
+    def test_pool_designs_are_distinct(self):
+        # no-good cuts must yield distinct treated sets
+        res = MAREX(_cfg(top_K=3)).fit()
+        sets = [tuple(sorted(e["markets"])) for e in res.pool]
+        assert len(sets) == len(set(sets))
+
+    def test_pool_mde_is_computed(self):
+        res = MAREX(_cfg(top_K=3)).fit()
+        # every entry has a numeric (possibly inf) MDE percent
+        assert all(isinstance(e["mde_pct"], float) for e in res.pool)
+        assert any(np.isfinite(e["mde_pct"]) for e in res.pool)
+
+
+class TestRecommendation:
+    def test_recommendation_present_and_consistent(self):
+        res = MAREX(_cfg(top_K=3)).fit()
+        rec = res.recommendation
+        assert rec is not None
+        assert isinstance(rec.winner, dict) and "markets" in rec.winner
+        assert len(rec.shortlist) >= 1
+        # the winner is one of the pooled designs
+        pooled = {tuple(sorted(e["markets"])) for e in res.pool}
+        assert tuple(sorted(rec.winner["markets"])) in pooled
+        # weights are normalised to sum to one
+        assert rec.weights["power"] + rec.weights["fit"] == pytest.approx(1.0, abs=1e-9)

--- a/mlsynth/tests/test_syndes_holdout.py
+++ b/mlsynth/tests/test_syndes_holdout.py
@@ -184,9 +184,16 @@ class TestSYNDESHoldoutIntegration:
             assert e["oos_rmse"] == pytest.approx(
                 oos_contrast_rmse(e["design"], Y_val))
 
-    def test_default_none_preserves_in_sample_pool(self):
-        # No holdout: pool ranked by the MIP objective and oos_rmse is absent/None.
+    def test_pool_defaults_to_holdout(self):
+        # A pool (top_K>1) now holdout-validates by default: oos_rmse is populated.
         res = self._fit(top_K=4)
+        assert res.pool is not None
+        assert all(e.get("oos_rmse") is not None
+                   and np.isfinite(e["oos_rmse"]) for e in res.pool)
+
+    def test_explicit_in_sample_opts_out_of_holdout(self):
+        # selection='in_sample' keeps the paper-faithful in-sample pool (no oos).
+        res = self._fit(top_K=4, selection="in_sample")
         assert res.pool is not None
         assert all(e.get("oos_rmse") is None for e in res.pool)
 

--- a/mlsynth/tests/test_syndes_pool.py
+++ b/mlsynth/tests/test_syndes_pool.py
@@ -98,7 +98,9 @@ class TestEstimatorPool:
         assert res.design.selected_unit_indices.size == 3
 
     def test_pool_menu_returned(self):
-        res = SYNDES(self._cfg(top_K=4)).fit()
+        # in-sample selection ranks the pool by the MIP objective (a pool now
+        # holdout-validates by default, so opt in to in-sample for this check)
+        res = SYNDES(self._cfg(top_K=4, selection="in_sample")).fit()
         assert res.pool is not None and len(res.pool) == 4
         # ranked by MSE (the objective), non-decreasing
         objs = [e["objective"] for e in res.pool]

--- a/mlsynth/utils/design_compare.py
+++ b/mlsynth/utils/design_compare.py
@@ -246,17 +246,15 @@ def from_lexscm(res) -> List[DesignSpec]:
     sums to ``+1`` and the control side to ``-1`` -- the same convention as
     :func:`from_syndes` / :func:`from_geolift`.
 
-    Treated weights are taken from the candidate's solution ``weight_dict``,
-    which is full precision (so the treated side sums to one exactly and the MDE
-    additive identity is exact). Control weights come from
-    ``control_weight_dict``, which LEXSCM reports rounded to three decimals --
-    an immaterial perturbation of the synthetic level for fit/power scoring.
+    Weights are taken from the candidate's full-precision dicts
+    (``treated_weight_dict_full`` / ``control_weight_dict_full``), so both sides
+    sum to one exactly and the net contrast is exactly zero -- the rounded
+    ``*_weight_dict`` views are for display only.
     """
     specs: List[DesignSpec] = []
     for cand in res.search.candidates:
-        treated_w = {str(u): float(w)
-                     for u, w in cand.identification.solution.weight_dict.items()}
-        control_w = {str(u): float(v) for u, v in cand.control_weight_dict.items()}
+        treated_w = {str(u): float(w) for u, w in cand.treated_weight_dict_full.items()}
+        control_w = {str(u): float(v) for u, v in cand.control_weight_dict_full.items()}
         treated = sorted(treated_w)
         contrast: Dict[Any, float] = dict(treated_w)
         for u, v in control_w.items():

--- a/mlsynth/utils/design_compare.py
+++ b/mlsynth/utils/design_compare.py
@@ -239,6 +239,28 @@ def from_geolift(res) -> List[DesignSpec]:
     return specs
 
 
+def from_lexscm(res) -> List[DesignSpec]:
+    """Build DesignSpecs from a fitted LEXSCM result (its candidate search).
+
+    Each ``SEDCandidate`` exposes ``treated_weight_dict`` (sums to one) and
+    ``control_weight_dict`` (sums to one); the cross-method contrast is their
+    difference, so the treated side sums to ``+1`` and the control side to
+    ``-1`` -- the same convention as :func:`from_syndes` / :func:`from_geolift`.
+    """
+    specs: List[DesignSpec] = []
+    for cand in res.search.candidates:
+        treated_w = {str(u): float(w) for u, w in cand.treated_weight_dict.items()}
+        control_w = {str(u): float(v) for u, v in cand.control_weight_dict.items()}
+        treated = sorted(treated_w)
+        contrast: Dict[Any, float] = dict(treated_w)
+        for u, v in control_w.items():
+            contrast[u] = contrast.get(u, 0.0) - v
+        specs.append(DesignSpec(
+            "LEXSCM", f"L:{'+'.join(map(str, treated))}", contrast, treated,
+        ))
+    return specs
+
+
 _SYNDES_DEFAULTS: Dict[str, Any] = dict(
     mode="two_way_global", gap_limit=0.05, time_limit=20.0, run_inference=False,
 )
@@ -246,6 +268,7 @@ _GEOLIFT_DEFAULTS: Dict[str, Any] = dict(
     effect_sizes=[0.0, 0.1], lookback_window=1, how="mean",
     fixed_effects=True, ns=200, seed=0, display_graphs=False,
 )
+_LEXSCM_DEFAULTS: Dict[str, Any] = dict(display_graph=False, verbose=False)
 
 
 @dataclass(frozen=True)
@@ -258,7 +281,7 @@ class DesignComparison:
         One row per design across all requested methods, with ``method``,
         ``label``, ``treated``, ``fit_rmse``, ``mde_pct`` (at ``horizon``), and a
         per-method ``pareto`` flag -- the dataframe form of the comparison.
-    syndes, geolift : optional
+    syndes, geolift, lexscm : optional
         The underlying fitted results (``None`` for any method not requested),
         kept for inspection.
     specs : list of DesignSpec
@@ -270,6 +293,7 @@ class DesignComparison:
     table: pd.DataFrame
     syndes: Any = None
     geolift: Any = None
+    lexscm: Any = None
     specs: List[DesignSpec] = field(default_factory=list)
     horizon: int = 5
 
@@ -296,8 +320,9 @@ def compare_methods(
     syndes_holdout_frac: Optional[float] = 0.3,
     syndes_options: Optional[Dict[str, Any]] = None,
     geolift_options: Optional[Dict[str, Any]] = None,
+    lexscm_options: Optional[Dict[str, Any]] = None,
 ) -> DesignComparison:
-    """Fit GEOLIFT and SYNDES on one panel and compare them on the shared plane.
+    """Fit SYNDES, GEOLIFT, and/or LEXSCM on one panel and compare them.
 
     A one-call wrapper around the adapters + :func:`compare_pareto`: it fits each
     requested method on the same data with the same treated-set size and post
@@ -334,9 +359,12 @@ def compare_methods(
         selection (``oos_rmse`` is ``NaN``). Ignored when ``top_K < 2`` (a pool
         is required to validate). An explicit ``holdout_frac`` in
         ``syndes_options`` overrides this.
-    syndes_options, geolift_options : dict, optional
+    syndes_options, geolift_options, lexscm_options : dict, optional
         Per-method overrides merged over the defaults (e.g.
-        ``{"time_limit": 20.0}`` to give SYNDES a larger budget).
+        ``{"time_limit": 20.0}`` to give SYNDES a larger budget, or
+        ``{"top_K": 8}`` to widen LEXSCM's search). For LEXSCM, ``treated_size``
+        maps to ``m`` and every unit is marked eligible unless an explicit
+        ``candidate_col`` is supplied in ``lexscm_options``.
 
     Returns
     -------
@@ -344,10 +372,10 @@ def compare_methods(
         ``.table`` (dataframe form) and ``.plot()`` (plot form).
     """
     methods = tuple(methods)
-    unknown = set(methods) - {"SYNDES", "GEOLIFT"}
+    unknown = set(methods) - {"SYNDES", "GEOLIFT", "LEXSCM"}
     if unknown:
         raise ValueError(f"Unknown method(s): {sorted(unknown)}; "
-                         "expected 'SYNDES' and/or 'GEOLIFT'.")
+                         "expected any of 'SYNDES', 'GEOLIFT', 'LEXSCM'.")
     if not methods:
         raise ValueError("methods must name at least one estimator.")
 
@@ -371,7 +399,7 @@ def compare_methods(
 
     common = dict(df=df, outcome=outcome, unitid=unitid, time=time,
                   post_col=post_col)
-    syn = gl = None
+    syn = gl = lex = None
     specs: List[DesignSpec] = []
 
     if "SYNDES" in methods:
@@ -399,6 +427,21 @@ def compare_methods(
         gl = GEOLIFT(gk).fit()
         specs += from_geolift(gl)
 
+    if "LEXSCM" in methods:
+        from ..estimators.lexscm import LEXSCM
+        lex_over = lexscm_options or {}
+        # LEXSCM needs a per-unit eligibility column; compare_methods treats
+        # every unit as a candidate, so inject an all-eligible column unless the
+        # caller names their own. treated_size maps to LEXSCM's `m`.
+        cand_col = lex_over.get("candidate_col")
+        if cand_col is None:
+            cand_col = "__compare_candidate__"
+            df[cand_col] = True
+        lk = {**_LEXSCM_DEFAULTS, **common, "candidate_col": cand_col,
+              "m": treated_size, "alpha": alpha, **lex_over}
+        lex = LEXSCM(lk).fit()
+        specs += from_lexscm(lex)
+
     table = compare_pareto(specs, Ywide, n_pre, horizon=horizon,
                            effects_pct=effects_pct, alpha=alpha,
                            power_target=power_target)
@@ -410,8 +453,8 @@ def compare_methods(
         syn_sorted = table[syn_mask].sort_values("oos_rmse", kind="stable")
         table = pd.concat([syn_sorted, table[~syn_mask]], ignore_index=True)
 
-    return DesignComparison(table=table, syndes=syn, geolift=gl, specs=specs,
-                            horizon=horizon)
+    return DesignComparison(table=table, syndes=syn, geolift=gl, lexscm=lex,
+                            specs=specs, horizon=horizon)
 
 
 def plot_compare_pareto(frame: pd.DataFrame, ax=None):

--- a/mlsynth/utils/design_compare.py
+++ b/mlsynth/utils/design_compare.py
@@ -414,12 +414,16 @@ def compare_methods(
         # picks a selection rule (or holdout_frac) explicitly, defer to it and
         # do not inject the default holdout (they are mutually exclusive).
         explicit = "selection" in syn_over or "holdout_frac" in syn_over
-        holdout = (None if explicit
-                   else (syndes_holdout_frac
-                         if (syndes_holdout_frac is not None and top_K >= 2)
-                         else None))
         sk = {**_SYNDES_DEFAULTS, **common, "K": treated_size, "top_K": top_K,
-              "alpha": alpha, "holdout_frac": holdout, **syn_over}
+              "alpha": alpha}
+        if not explicit:
+            if syndes_holdout_frac is not None and top_K >= 2:
+                sk["holdout_frac"] = syndes_holdout_frac
+            else:
+                # SYNDES now holdout-validates pools by default, so to honour
+                # syndes_holdout_frac=None (disable) we ask for in-sample.
+                sk["selection"] = "in_sample"
+        sk.update(syn_over)
         syn = SYNDES(sk).fit()
         specs += from_syndes(syn)
 

--- a/mlsynth/utils/design_compare.py
+++ b/mlsynth/utils/design_compare.py
@@ -265,6 +265,54 @@ def from_lexscm(res) -> List[DesignSpec]:
     return specs
 
 
+def from_marex(res) -> List[DesignSpec]:
+    """Build DesignSpecs from a fitted MAREX result.
+
+    Uses the solution-pool menu when present (``top_K > 1``), else the single
+    aggregate design. Each design's contrast is ``w_treated - v_control`` over
+    units (treated side sums to +1, control to -1), matching the convention of
+    the other adapters.
+    """
+    def _spec(labels, w, v, treated):
+        w = np.asarray(w, dtype=float)
+        v = np.asarray(v, dtype=float)
+        contrast = {str(labels[i]): float(w[i] - v[i]) for i in range(len(labels))
+                    if abs(float(w[i] - v[i])) > 1e-12}
+        treated = sorted(str(t) for t in treated)
+        return DesignSpec("MAREX", f"M:{'+'.join(treated)}", contrast, treated)
+
+    pool = getattr(res, "pool", None)
+    if pool:
+        out = []
+        for e in pool:
+            raw = e["design"]
+            # raw["df"] is the units x time panel; its index carries the unit
+            # labels the aggregate weight vectors are aligned to.
+            labels = list(raw["df"].index)
+            out.append(_spec(labels, raw["w_agg"], raw["v_agg"], e["markets"]))
+        return out
+
+    # Single-design fallback (top_K == 1): globres.Y_full is a bare ndarray with
+    # no labels, so assemble the contrast from the per-cluster unit-weight maps,
+    # which carry the unit labels. Size-weight clusters so the treated/control
+    # sides each sum to +1 / -1 across the whole design (matching *_weights_agg).
+    clusters = list(res.clusters.values())
+    sizes = np.array([float(c.cardinality) for c in clusters], dtype=float)
+    total = float(sizes.sum()) or 1.0
+    multi = len(clusters) > 1
+    contrast: Dict[str, float] = {}
+    treated: List[str] = []
+    for c, sz in zip(clusters, sizes):
+        scale = (sz / total) if multi else 1.0
+        for u, w in c.unit_weight_map.get("Treated", {}).items():
+            contrast[str(u)] = contrast.get(str(u), 0.0) + scale * float(w)
+            treated.append(str(u))
+        for u, v in c.unit_weight_map.get("Control", {}).items():
+            contrast[str(u)] = contrast.get(str(u), 0.0) - scale * float(v)
+    treated = sorted(set(treated))
+    return [DesignSpec("MAREX", f"M:{'+'.join(treated)}", contrast, treated)]
+
+
 _SYNDES_DEFAULTS: Dict[str, Any] = dict(
     mode="two_way_global", gap_limit=0.05, time_limit=20.0, run_inference=False,
 )
@@ -273,6 +321,8 @@ _GEOLIFT_DEFAULTS: Dict[str, Any] = dict(
     fixed_effects=True, ns=200, seed=0, display_graphs=False,
 )
 _LEXSCM_DEFAULTS: Dict[str, Any] = dict(display_graph=False, verbose=False)
+_MAREX_DEFAULTS: Dict[str, Any] = dict(design="standard", display_graph=False,
+                                       verbose=False)
 
 
 @dataclass(frozen=True)
@@ -285,7 +335,7 @@ class DesignComparison:
         One row per design across all requested methods, with ``method``,
         ``label``, ``treated``, ``fit_rmse``, ``mde_pct`` (at ``horizon``), and a
         per-method ``pareto`` flag -- the dataframe form of the comparison.
-    syndes, geolift, lexscm : optional
+    syndes, geolift, lexscm, marex : optional
         The underlying fitted results (``None`` for any method not requested),
         kept for inspection.
     specs : list of DesignSpec
@@ -298,6 +348,7 @@ class DesignComparison:
     syndes: Any = None
     geolift: Any = None
     lexscm: Any = None
+    marex: Any = None
     specs: List[DesignSpec] = field(default_factory=list)
     horizon: int = 5
 
@@ -325,8 +376,9 @@ def compare_methods(
     syndes_options: Optional[Dict[str, Any]] = None,
     geolift_options: Optional[Dict[str, Any]] = None,
     lexscm_options: Optional[Dict[str, Any]] = None,
+    marex_options: Optional[Dict[str, Any]] = None,
 ) -> DesignComparison:
-    """Fit SYNDES, GEOLIFT, and/or LEXSCM on one panel and compare them.
+    """Fit SYNDES, GEOLIFT, LEXSCM, and/or MAREX on one panel and compare them.
 
     A one-call wrapper around the adapters + :func:`compare_pareto`: it fits each
     requested method on the same data with the same treated-set size and post
@@ -354,7 +406,8 @@ def compare_methods(
     effects_pct : sequence of float, optional
         Common effect grid (percent of baseline) for the MDE simulation.
     methods : sequence of str, default ``("SYNDES", "GEOLIFT")``
-        Which methods to fit and compare.
+        Which methods to fit and compare. Any of ``"SYNDES"``, ``"GEOLIFT"``,
+        ``"LEXSCM"``, ``"MAREX"``.
     syndes_holdout_frac : float or None, default 0.3
         Holdout fraction for SYNDES design selection: SYNDES learns its pool on
         the leading ``1 - syndes_holdout_frac`` of the pre-period and is ranked
@@ -363,12 +416,16 @@ def compare_methods(
         selection (``oos_rmse`` is ``NaN``). Ignored when ``top_K < 2`` (a pool
         is required to validate). An explicit ``holdout_frac`` in
         ``syndes_options`` overrides this.
-    syndes_options, geolift_options, lexscm_options : dict, optional
+    syndes_options, geolift_options, lexscm_options, marex_options : dict, optional
         Per-method overrides merged over the defaults (e.g.
         ``{"time_limit": 20.0}`` to give SYNDES a larger budget, or
         ``{"top_K": 8}`` to widen LEXSCM's search). For LEXSCM, ``treated_size``
         maps to ``m`` and every unit is marked eligible unless an explicit
-        ``candidate_col`` is supplied in ``lexscm_options``.
+        ``candidate_col`` is supplied in ``lexscm_options``. For MAREX,
+        ``treated_size`` maps to the per-cluster ``m_eq`` (the exact number of
+        treated units) and ``top_K`` drives its solution-pool menu, unless the
+        caller supplies their own cardinality keys (``m_eq`` / ``m_min`` /
+        ``m_max``) in ``marex_options``.
 
     Returns
     -------
@@ -376,10 +433,11 @@ def compare_methods(
         ``.table`` (dataframe form) and ``.plot()`` (plot form).
     """
     methods = tuple(methods)
-    unknown = set(methods) - {"SYNDES", "GEOLIFT", "LEXSCM"}
+    unknown = set(methods) - {"SYNDES", "GEOLIFT", "LEXSCM", "MAREX"}
     if unknown:
         raise ValueError(f"Unknown method(s): {sorted(unknown)}; "
-                         "expected any of 'SYNDES', 'GEOLIFT', 'LEXSCM'.")
+                         "expected any of 'SYNDES', 'GEOLIFT', 'LEXSCM', "
+                         "'MAREX'.")
     if not methods:
         raise ValueError("methods must name at least one estimator.")
 
@@ -403,7 +461,7 @@ def compare_methods(
 
     common = dict(df=df, outcome=outcome, unitid=unitid, time=time,
                   post_col=post_col)
-    syn = gl = lex = None
+    syn = gl = lex = mar = None
     specs: List[DesignSpec] = []
 
     if "SYNDES" in methods:
@@ -450,6 +508,20 @@ def compare_methods(
         lex = LEXSCM(lk).fit()
         specs += from_lexscm(lex)
 
+    if "MAREX" in methods:
+        from ..estimators.scexp import MAREX
+        mar_over = marex_options or {}
+        # treated_size -> MAREX's per-cluster exact count m_eq, unless the caller
+        # specifies their own cardinality (m_eq / m_min / m_max). top_K drives
+        # the solution-pool menu the adapter reduces to DesignSpecs.
+        mk = {**_MAREX_DEFAULTS, **common, "top_K": top_K, "alpha": alpha,
+              "power_target": power_target}
+        if not ({"m_eq", "m_min", "m_max"} & set(mar_over)):
+            mk["m_eq"] = treated_size
+        mk.update(mar_over)
+        mar = MAREX(mk).fit()
+        specs += from_marex(mar)
+
     table = compare_pareto(specs, Ywide, n_pre, horizon=horizon,
                            effects_pct=effects_pct, alpha=alpha,
                            power_target=power_target)
@@ -462,7 +534,7 @@ def compare_methods(
         table = pd.concat([syn_sorted, table[~syn_mask]], ignore_index=True)
 
     return DesignComparison(table=table, syndes=syn, geolift=gl, lexscm=lex,
-                            specs=specs, horizon=horizon)
+                            marex=mar, specs=specs, horizon=horizon)
 
 
 def plot_compare_pareto(frame: pd.DataFrame, ax=None):

--- a/mlsynth/utils/design_compare.py
+++ b/mlsynth/utils/design_compare.py
@@ -242,14 +242,20 @@ def from_geolift(res) -> List[DesignSpec]:
 def from_lexscm(res) -> List[DesignSpec]:
     """Build DesignSpecs from a fitted LEXSCM result (its candidate search).
 
-    Each ``SEDCandidate`` exposes ``treated_weight_dict`` (sums to one) and
-    ``control_weight_dict`` (sums to one); the cross-method contrast is their
-    difference, so the treated side sums to ``+1`` and the control side to
-    ``-1`` -- the same convention as :func:`from_syndes` / :func:`from_geolift`.
+    The cross-method contrast is ``w_treated - w_control``; the treated side
+    sums to ``+1`` and the control side to ``-1`` -- the same convention as
+    :func:`from_syndes` / :func:`from_geolift`.
+
+    Treated weights are taken from the candidate's solution ``weight_dict``,
+    which is full precision (so the treated side sums to one exactly and the MDE
+    additive identity is exact). Control weights come from
+    ``control_weight_dict``, which LEXSCM reports rounded to three decimals --
+    an immaterial perturbation of the synthetic level for fit/power scoring.
     """
     specs: List[DesignSpec] = []
     for cand in res.search.candidates:
-        treated_w = {str(u): float(w) for u, w in cand.treated_weight_dict.items()}
+        treated_w = {str(u): float(w)
+                     for u, w in cand.identification.solution.weight_dict.items()}
         control_w = {str(u): float(v) for u, v in cand.control_weight_dict.items()}
         treated = sorted(treated_w)
         contrast: Dict[Any, float] = dict(treated_w)

--- a/mlsynth/utils/fast_scm_helpers/fast_scm_control.py
+++ b/mlsynth/utils/fast_scm_helpers/fast_scm_control.py
@@ -154,6 +154,20 @@ def evaluate_candidates(
             if (r := round(float(w[i]), 3)) > 0.001
         }
 
+        # Full-precision, label-keyed weights (the rounded dicts above are for
+        # display): consumers that need exact weights -- e.g. reapplying a frozen
+        # design to measure an effect -- use these.
+        control_weights_full = {
+            index_set.labels[i]: float(v[i])
+            for i in range(len(v))
+            if abs(float(v[i])) > 1e-10
+        }
+        treated_weights_full = {
+            index_set.labels[treated_idx[i]]: float(w[i])
+            for i in range(len(treated_idx))
+            if abs(float(w[i])) > 1e-10
+        }
+
         synth_treated = X[:, treated_idx] @ w
         synth_control = X @ v
         effects = synth_treated - synth_control
@@ -215,7 +229,9 @@ def evaluate_candidates(
 
             # NEW structured metadata
             treated_weight_dict=treated_weights,
-            control_weight_dict=control_weights
+            control_weight_dict=control_weights,
+            treated_weight_dict_full=treated_weights_full,
+            control_weight_dict_full=control_weights_full,
         )
 
         results.append(candidate)

--- a/mlsynth/utils/fast_scm_helpers/structure.py
+++ b/mlsynth/utils/fast_scm_helpers/structure.py
@@ -200,6 +200,11 @@ class SEDCandidate:
     treated_weight_dict: Dict[str, float] = field(default_factory=dict)
     control_weight_dict: Dict[str, float] = field(default_factory=dict)
 
+    # Full-precision, label-keyed weights (the dicts above are rounded for
+    # display); use these when exact weights matter (e.g. reapplying a design).
+    treated_weight_dict_full: Dict[str, float] = field(default_factory=dict)
+    control_weight_dict_full: Dict[str, float] = field(default_factory=dict)
+
     # -------- Useful derived helpers --------
     @property
     def treated_size(self) -> int:

--- a/mlsynth/utils/marex_helpers/config.py
+++ b/mlsynth/utils/marex_helpers/config.py
@@ -7,7 +7,6 @@ Co-located with the helper package; re-exported from
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Union
-import numpy as np
 import pandas as pd
 import warnings
 from pydantic import Field, model_validator
@@ -202,19 +201,12 @@ class MAREXConfig(BaseMAREXConfig):
             raise MlsynthDataError(
                 f"design must be one of {sorted(valid_designs)}, got '{design}'")
 
-        # --- consecutive time check ---
-        time_vals = df[time_col].sort_values().unique()
-        time_dtype = df[time_col].dtype
-        if pd.api.types.is_numeric_dtype(time_dtype):
-            if not np.all(np.diff(time_vals) == 1):
-                raise MlsynthDataError(f"Time periods in '{time_col}' are not consecutive: {time_vals}")
-        elif pd.api.types.is_datetime64_any_dtype(time_dtype):
-            diffs = np.diff(time_vals)
-            if len(diffs) > 0 and not np.all(diffs == diffs[0]):
-                raise MlsynthDataError(f"Datetime time periods in '{time_col}' are not consecutive.")
-
-        else:
-            raise MlsynthDataError(f"Unsupported dtype for time column '{time_col}': {time_dtype}")
+        # --- time axis ---
+        # Time handling is delegated to ``geoex_dataprep`` (the same balanced-
+        # panel prep GeoLift uses), invoked in ``prepare_marex_panel``: it sorts
+        # the time index, so any orderable time — integer, datetime, or ISO-date
+        # string as the geoex pipeline supplies — is accepted, and it enforces a
+        # strongly balanced panel. No dtype-specific check is needed here.
 
         # --- cluster handling ---
         if cluster_col is not None:

--- a/mlsynth/utils/marex_helpers/config.py
+++ b/mlsynth/utils/marex_helpers/config.py
@@ -115,6 +115,40 @@ class MAREXConfig(BaseMAREXConfig):
     min_size: Optional[float] = Field(default=None, description="Lower size bound.")
     max_size: Optional[float] = Field(default=None, description="Upper size bound.")
 
+    # --- solution pool + power-based recommendation (mirrors SYNDES) ---
+    top_K: int = Field(
+        default=1, ge=1,
+        description=(
+            "Size of the returned solution pool. ``1`` (default) returns only the "
+            "MSE-optimal design and no pool. ``>1`` enumerates the top-K distinct "
+            "designs via no-good cuts (forbid each chosen treated set and re-solve "
+            "for the next-best), each scored on a minimum-detectable-effect (MDE) "
+            "power curve, and attaches them as ``results.pool`` plus a composite "
+            "``results.recommendation`` -- the SYNDES-style menu."),
+    )
+    power_weight: float = Field(
+        default=0.51, gt=0.0,
+        description=("Weight on power (MDE) in the composite recommendation score, "
+                     "normalised against ``fit_weight`` to sum to one."),
+    )
+    fit_weight: float = Field(
+        default=0.49, gt=0.0,
+        description=("Weight on fit (the design objective) in the composite "
+                     "recommendation score, normalised against ``power_weight``."),
+    )
+    max_shortlist: int = Field(
+        default=5, ge=1,
+        description="Maximum number of designs in results.recommendation.shortlist.",
+    )
+    alpha: float = Field(
+        default=0.05, gt=0.0, lt=1.0,
+        description="Two-sided significance level for the MDE power curve.",
+    )
+    power_target: float = Field(
+        default=0.80, gt=0.0, lt=1.0,
+        description="Target power (1 - beta) for the MDE.",
+    )
+
     @model_validator(mode="after")
     def validate_design_params(cls, values: Any) -> Any:
         df = values.df

--- a/mlsynth/utils/marex_helpers/optimization.py
+++ b/mlsynth/utils/marex_helpers/optimization.py
@@ -65,9 +65,15 @@ def solve_design(
     exclusive=True, design="standard", beta=1e-6, lambda1=0.0, lambda2=0.0, xi=0.0,
     lambda1_unit=0.0, lambda2_unit=0.0, costs=None, budget=None,
     covariates=None, covariate_weight=1.0, standardize=False,
-    solver=cp.SCIP, verbose=False, restrictions=None,
+    solver=cp.SCIP, verbose=False, restrictions=None, forbidden=None,
 ):
-    """Exact mixed-integer MAREX design (was ``SCMEXP``)."""
+    """Exact mixed-integer MAREX design (was ``SCMEXP``).
+
+    ``forbidden`` is an optional list of previously-chosen assignments, each a
+    list of ``(unit_idx, cluster_idx)`` pairs; for every one a no-good cut
+    ``sum z[pairs] <= |pairs| - 1`` is added, forbidding that exact design so a
+    re-solve yields the next-best distinct one (used to build a solution pool).
+    """
     validate_scm_inputs(Y_full, T0, blank_periods, design, beta, lambda1,
                         lambda2, xi, lambda1_unit, lambda2_unit)
     Y_full_np, clusters, N, cluster_labels, K, label_to_k = prepare_clusters(Y_full, clusters)
@@ -82,6 +88,12 @@ def solve_design(
     constraints = build_constraints(w, v, z, M, cluster_members, cluster_labels,
                                     m_eq, m_min, m_max, costs_np, budget_dict,
                                     exclusive, restrictions=restrictions)
+    # no-good cuts: forbid each previously chosen assignment so a re-solve finds
+    # the next-best distinct design (solution pool).
+    for pairs in (forbidden or []):
+        if pairs:
+            constraints = constraints + [
+                cp.sum([z[int(j), int(k)] for (j, k) in pairs]) <= len(pairs) - 1]
     objective = build_objective(X_fit, Xbar_clusters, cluster_members, w, v, z,
                                design, beta, lambda1, lambda2, xi,
                                lambda1_unit, lambda2_unit, D1, D2_list)
@@ -96,6 +108,9 @@ def solve_design(
                    "the cluster cardinality (m_min/m_max). Relax them.")
         raise MlsynthEstimationError(msg)
     w_opt, v_opt, z_opt = w.value, v.value, z.value
+    if w_opt is None or z_opt is None:
+        raise MlsynthEstimationError(
+            f"MAREX design is infeasible (solver status: {prob.status}).")
     Y_full_T = Y_full_np.T
     rmse_cluster = []
     for k_idx in range(K):
@@ -114,7 +129,32 @@ def solve_design(
         "T_fit": T_fit, "Y_fit": Y_fit, "Y_blank": Y_blank,
         "rmse_cluster": rmse_cluster, "design": design,
         "original_cluster_vector": clusters,
+        "objective": float(prob.value) if prob.value is not None else float("nan"),
     }
+
+
+def solve_design_pool(Y_full, T0, clusters, *, top_K=1, **kwargs):
+    """Enumerate up to ``top_K`` distinct exact designs via no-good cuts.
+
+    Calls :func:`solve_design` repeatedly, forbidding each chosen assignment so
+    the next solve returns the next-best distinct design. Stops early when the
+    feasible region is exhausted (the solver becomes infeasible).
+    """
+    designs: list = []
+    forbidden: list = []
+    for _ in range(int(top_K)):
+        try:
+            raw = solve_design(Y_full=Y_full, T0=T0, clusters=clusters,
+                               forbidden=forbidden, **kwargs)
+        except MlsynthEstimationError:
+            break
+        designs.append(raw)
+        z_opt = np.asarray(raw["z_opt"])
+        pairs = [(int(j), int(k)) for j, k in zip(*np.where(z_opt > 0.5))]
+        if not pairs:                       # nothing selected -> cannot cut further
+            break
+        forbidden.append(pairs)
+    return designs
 
 
 def post_hoc_discretize(w_opt, v_opt, cluster_members, cluster_labels,

--- a/mlsynth/utils/marex_helpers/pool.py
+++ b/mlsynth/utils/marex_helpers/pool.py
@@ -30,12 +30,26 @@ def build_marex_pool(raws: List[Dict[str, Any]], *, alpha: float = 0.05,
         markets = [str(labels[i]) for i in treated_idx]
         control_group = [str(labels[i]) for i in control_idx]
 
-        Y_fit = np.asarray(raw["Y_fit"], dtype=float)
-        g = Y_fit.T @ contrast                       # pre-period contrast series
-        pre_fit_rmse = float(np.sqrt(np.mean(g ** 2)))
-        baseline = (float(np.mean(Y_fit[treated_idx, :]))
+        Y_fit = np.asarray(raw["Y_fit"], dtype=float)              # leading (fit) window
+        Y_blank = raw.get("Y_blank")
+        Y_blank = None if Y_blank is None else np.asarray(Y_blank, dtype=float)
+
+        # In-sample fit (for transparency) and the held-out BLANK fit (the
+        # ranking metric): the design's weights are tuned on Y_fit, so the blank
+        # window is genuinely out-of-sample.
+        pre_fit_rmse = float(np.sqrt(np.mean((Y_fit.T @ contrast) ** 2)))
+        if Y_blank is not None and Y_blank.size:
+            blank_rmse = float(np.sqrt(np.mean((Y_blank.T @ contrast) ** 2)))
+            full_pre = np.concatenate([Y_fit, Y_blank], axis=1)
+        else:
+            blank_rmse = None
+            full_pre = Y_fit
+        fit_metric = blank_rmse if blank_rmse is not None else pre_fit_rmse
+
+        # Power on the full pre-period; the fit axis uses the held-out blank.
+        baseline = (float(np.mean(full_pre[treated_idx, :]))
                     if treated_idx.size else float("nan"))
-        curve = marex_mde_curve(Y_fit, contrast, horizons=range(1, 13),
+        curve = marex_mde_curve(full_pre, contrast, horizons=range(1, 13),
                                 alpha=alpha, power=power, baseline=baseline)
         h = max(1, min(int(n_post), 12))
         mde_pct = float(curve["mde_pct"][h - 1])
@@ -43,7 +57,8 @@ def build_marex_pool(raws: List[Dict[str, Any]], *, alpha: float = 0.05,
         menu.append({
             "markets": markets, "control_group": control_group,
             "n_treated": len(markets), "n_control": len(control_group),
-            "objective": pre_fit_rmse,            # fit metric for ranking
+            "objective": fit_metric,              # fit metric for ranking (held-out blank RMSE)
+            "blank_rmse": blank_rmse,
             "pre_fit_rmse": pre_fit_rmse,
             "mip_objective": float(raw.get("objective", float("nan"))),
             "mde_pct": mde_pct, "power_curve": curve,

--- a/mlsynth/utils/marex_helpers/pool.py
+++ b/mlsynth/utils/marex_helpers/pool.py
@@ -1,0 +1,52 @@
+"""Assemble the MAREX solution-pool menu from raw design solves.
+
+For each design returned by :func:`optimization.solve_design_pool`, build a menu
+entry mirroring SYNDES's pool: the treated ``markets`` and ``control_group``, the
+pre-period fit, and an MDE power curve (the same Newey-West power analysis SYNDES
+uses) scored on the design's aggregate contrast.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+
+from .power import marex_mde_curve
+
+
+def build_marex_pool(raws: List[Dict[str, Any]], *, alpha: float = 0.05,
+                     power: float = 0.80, n_post: int = 1) -> List[Dict[str, Any]]:
+    """Build the pool menu (one entry per raw design) with fit + MDE power."""
+    menu: List[Dict[str, Any]] = []
+    for raw in raws:
+        df = raw["df"]
+        w_agg = np.asarray(raw["w_agg"], dtype=float)
+        v_agg = np.asarray(raw["v_agg"], dtype=float)
+        labels = (list(df.index) if hasattr(df, "index")
+                  else list(range(w_agg.size)))
+        contrast = w_agg - v_agg
+        treated_idx = np.where(w_agg > 1e-8)[0]
+        control_idx = np.where(v_agg > 1e-8)[0]
+        markets = [str(labels[i]) for i in treated_idx]
+        control_group = [str(labels[i]) for i in control_idx]
+
+        Y_fit = np.asarray(raw["Y_fit"], dtype=float)
+        g = Y_fit.T @ contrast                       # pre-period contrast series
+        pre_fit_rmse = float(np.sqrt(np.mean(g ** 2)))
+        baseline = (float(np.mean(Y_fit[treated_idx, :]))
+                    if treated_idx.size else float("nan"))
+        curve = marex_mde_curve(Y_fit, contrast, horizons=range(1, 13),
+                                alpha=alpha, power=power, baseline=baseline)
+        h = max(1, min(int(n_post), 12))
+        mde_pct = float(curve["mde_pct"][h - 1])
+
+        menu.append({
+            "markets": markets, "control_group": control_group,
+            "n_treated": len(markets), "n_control": len(control_group),
+            "objective": pre_fit_rmse,            # fit metric for ranking
+            "pre_fit_rmse": pre_fit_rmse,
+            "mip_objective": float(raw.get("objective", float("nan"))),
+            "mde_pct": mde_pct, "power_curve": curve,
+            "design": raw,
+        })
+    return menu

--- a/mlsynth/utils/marex_helpers/power.py
+++ b/mlsynth/utils/marex_helpers/power.py
@@ -1,0 +1,53 @@
+"""MAREX power analysis: the minimum detectable effect (MDE) of a design.
+
+Mirrors the SYNDES power analysis (``utils/syndes_helpers/power.py``): from a
+design's unit-level contrast ``c = w_treated - w_control``, form the pre-period
+contrast series ``g_t = (Y_pre^T c)``, estimate its long-run (serial-correlation
+-robust, Newey-West) standard deviation, and report the MDE at each post-period
+horizon ``h`` as ``(z_{1-alpha/2} + z_power) * sigma / sqrt(h)``.
+
+Reusing SYNDES's ``_newey_west_sigma`` keeps the power math identical across the
+two design methods, so MAREX and SYNDES designs are scored the same way.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+import numpy as np
+from scipy.stats import norm
+
+from ..syndes_helpers.power import _newey_west_sigma
+
+
+def marex_mde_curve(Y_fit: np.ndarray, contrast: np.ndarray, *,
+                    horizons: Iterable[int] = range(1, 13),
+                    alpha: float = 0.05, power: float = 0.80,
+                    baseline: float | None = None) -> Dict[str, Any]:
+    """MDE curve for one design's contrast.
+
+    Parameters
+    ----------
+    Y_fit : np.ndarray
+        Pre-period outcomes, shape ``(N, T_fit)`` (units x time).
+    contrast : np.ndarray
+        Unit-level contrast ``w_treated - w_control``, shape ``(N,)``.
+    horizons : iterable of int
+        Post-period horizons to evaluate (default 1..12).
+    alpha, power : float
+        Two-sided significance level and target power.
+    baseline : float, optional
+        Treated baseline level for the percent MDE; ``None``/0 -> percent is inf.
+    """
+    Y_fit = np.asarray(Y_fit, dtype=float)
+    c = np.asarray(contrast, dtype=float)
+    per_period = Y_fit.T @ c                       # (T_fit,)
+    sigma = _newey_west_sigma(per_period)
+    mult = float(norm.ppf(1.0 - alpha / 2.0) + norm.ppf(power))
+    h = np.asarray(list(horizons), dtype=float)
+    mde_abs = mult * sigma / np.sqrt(h)
+    if baseline is None or not np.isfinite(baseline) or abs(baseline) < 1e-12:
+        mde_pct = np.full_like(h, np.inf)
+    else:
+        mde_pct = 100.0 * mde_abs / abs(float(baseline))
+    return {"horizons": h.astype(int), "mde_abs": mde_abs, "mde_pct": mde_pct,
+            "long_run_sigma": float(sigma), "baseline": baseline}

--- a/mlsynth/utils/marex_helpers/select.py
+++ b/mlsynth/utils/marex_helpers/select.py
@@ -1,0 +1,59 @@
+"""Composite power-vs-fit recommendation over a MAREX solution pool.
+
+Mirrors ``utils/syndes_helpers/select.py``: each design is ranked (dense) on fit
+(lower ``objective`` better) and on power (lower ``mde_pct`` better); the
+composite score is a normalised weighted sum of the two ranks, and the winner is
+the lowest-scoring power-feasible design. Also reports the fit-vs-power Pareto
+front.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import numpy as np
+from scipy.stats import rankdata
+
+from .structures import MAREXRecommendation
+
+
+def _pareto_front(fit: np.ndarray, mde: np.ndarray) -> List[int]:
+    """Indices on the non-dominated (fit downwards, mde downwards) front."""
+    n = len(fit)
+    keep: List[int] = []
+    for i in range(n):
+        dominated = False
+        for j in range(n):
+            if i == j:
+                continue
+            if (fit[j] <= fit[i] and mde[j] <= mde[i]
+                    and (fit[j] < fit[i] or mde[j] < mde[i])):
+                dominated = True
+                break
+        if not dominated:
+            keep.append(i)
+    return keep
+
+
+def recommend_marex(pool: List[Dict[str, Any]], *, power_weight: float = 0.51,
+                    fit_weight: float = 0.49,
+                    max_shortlist: int = 5) -> MAREXRecommendation:
+    """Recommend a design from the pool on a composite power-vs-fit score."""
+    s = power_weight + fit_weight
+    pw, fw = power_weight / s, fit_weight / s
+    fit = np.array([float(e["objective"]) for e in pool], dtype=float)
+    mde = np.array([e["mde_pct"] if np.isfinite(e["mde_pct"]) else np.inf
+                    for e in pool], dtype=float)
+    rank_fit = rankdata(fit, method="dense")
+    rank_pow = rankdata(mde, method="dense")
+    scores = fw * rank_fit + pw * rank_pow
+    order = [int(i) for i in np.argsort(scores, kind="stable")]
+    pareto = _pareto_front(fit, mde)
+
+    feasible = [i for i in order if np.isfinite(mde[i])]
+    winner_idx = feasible[0] if feasible else order[0]
+    status = "OK" if feasible else "POWER_NOT_ESTABLISHED"
+    shortlist = [pool[i] for i in order[:max_shortlist]]
+    return MAREXRecommendation(
+        winner=pool[winner_idx], shortlist=shortlist, pareto=pareto,
+        weights={"power": pw, "fit": fw}, status=status,
+    )

--- a/mlsynth/utils/marex_helpers/structures.py
+++ b/mlsynth/utils/marex_helpers/structures.py
@@ -151,6 +151,33 @@ class MAREXGlobalDesign:
     inference: Optional[MAREXInference] = None
 
 
+@dataclass(frozen=True)
+class MAREXRecommendation:
+    """Composite power-vs-fit recommendation over a MAREX solution pool.
+
+    Parameters
+    ----------
+    winner : dict
+        The recommended pool entry (lowest composite score among power-feasible
+        designs).
+    shortlist : list of dict
+        Pool entries ordered by composite score, truncated to ``max_shortlist``.
+    pareto : list of int
+        Indices (into the pool) of the designs on the fit-vs-power Pareto front.
+    weights : dict
+        Normalised ``{"power": pw, "fit": fw}`` (sum to one).
+    status : str
+        ``"OK"`` when at least one design has a finite MDE, else
+        ``"POWER_NOT_ESTABLISHED"``.
+    """
+
+    winner: Dict[str, Any]
+    shortlist: List[Dict[str, Any]]
+    pareto: List[int]
+    weights: Dict[str, float]
+    status: str
+
+
 class MAREXResults(DesignResult):
     """User-facing output of the MAREX estimator.
 
@@ -185,6 +212,8 @@ class MAREXResults(DesignResult):
     study: MAREXStudy
     globres: MAREXGlobalDesign
     post_fit: Optional[Any] = None      # SyntheticControlPostFit; Any to dodge import cycle
+    pool: Optional[List[Dict[str, Any]]] = None    # top-K menu when top_K > 1
+    recommendation: Optional[Any] = None           # MAREXRecommendation when a pool exists
 
     @property
     def mode(self) -> str:

--- a/mlsynth/utils/syndes_helpers/config.py
+++ b/mlsynth/utils/syndes_helpers/config.py
@@ -340,6 +340,16 @@ class SYNDESConfig(BaseMAREXConfig):
         n_periods = df[values.time].nunique()
 
         # Resolve the design-selection rule (None infers from holdout_frac).
+        # A solution pool (top_K >= 2) is holdout-validated by default: rank the
+        # candidate designs by out-of-sample fit rather than in-sample overfit.
+        # The in-sample (paper-faithful) rule stays available via
+        # selection="in_sample"; single designs (top_K < 2) and the annealed
+        # mode (no candidate pool) are unaffected.
+        if (values.selection is None and values.holdout_frac is None
+                and values.top_K is not None and values.top_K >= 2
+                and values.mode != "two_way_global_annealed"):
+            values.holdout_frac = 0.3
+
         resolved = values.selection or (
             "holdout" if values.holdout_frac is not None else "in_sample"
         )

--- a/mlsynth/utils/syndes_helpers/select.py
+++ b/mlsynth/utils/syndes_helpers/select.py
@@ -33,11 +33,16 @@ from scipy.stats import rankdata
 
 
 def _fit_value(d: "SYNDESDesignMetrics") -> float:
-    """Fit criterion: pre-period RMSE (treated vs weighted control), lower better.
+    """Fit criterion (lower better): the held-out RMSE when a holdout window
+    exists, else the in-sample pre-period RMSE, else the MIP objective.
 
-    Falls back to the MIP objective when a design carries no RMSE (e.g. a mode
-    that does not populate it), so the recommender is always well-defined.
+    The held-out (``oos_rmse``) fit is preferred because it measures how the
+    design generalises beyond the window it was tuned on, rather than rewarding
+    in-sample overfit. It is only defined in holdout selection mode; otherwise
+    the recommender falls back to the in-sample RMSE so it is always defined.
     """
+    if d.oos_rmse is not None and np.isfinite(d.oos_rmse):
+        return float(d.oos_rmse)
     if d.pre_fit_rmse is not None and np.isfinite(d.pre_fit_rmse):
         return float(d.pre_fit_rmse)
     return float(d.objective)
@@ -81,6 +86,7 @@ class SYNDESDesignMetrics:
     mde_feasible: bool
     cost: Optional[float] = None
     pre_fit_rmse: Optional[float] = None
+    oos_rmse: Optional[float] = None
     design: Any = field(default=None, repr=False)
 
 
@@ -202,6 +208,9 @@ def recommend_syndes(
         )
 
     def _entry_fit(e: Dict[str, Any]) -> float:
+        oos = e.get("oos_rmse")
+        if oos is not None and np.isfinite(oos):
+            return float(oos)
         r = e.get("pre_fit_rmse")
         if r is not None and np.isfinite(r):
             return float(r)
@@ -222,6 +231,8 @@ def recommend_syndes(
             cost=(None if e.get("cost") is None else float(e["cost"])),
             pre_fit_rmse=(None if e.get("pre_fit_rmse") is None
                           else float(e["pre_fit_rmse"])),
+            oos_rmse=(None if e.get("oos_rmse") is None
+                      else float(e["oos_rmse"])),
             design=e.get("design"),
         )
         for rank, e in enumerate(ordered)


### PR DESCRIPTION
## Summary

Extends mlsynth's cross-estimator design comparison (`utils/design_compare.py`) from two methods (SYNDES, GeoLift) to four, adding LEXSCM and MAREX so every design optimizer can be scored on the one shared fit-vs-power plane. Test-first; the new modules are at 100% coverage and the touched suites are green.

This is rebuilt cleanly on top of current `main` (the work originated on an older branch that had drifted ~186 commits behind; the conflicting MAREX internals — `setup.py`/`optimization.py`/`config.py` — were reconciled against main's current code, keeping main's `IndexSet` ingestion and geographic-restriction fields intact).

### LEXSCM in `compare_methods`
- `from_lexscm` adapter reduces a fitted LEXSCM result's candidate search to the common `w_treated − w_control` contrast (treated side sums to +1, net contrast exactly 0), using the candidate's full-precision weight dicts.
- LEXSCM exposes full-precision treated/control weights (`fast_scm_helpers`) so the rounded display dicts aren't the only view; the adapter consumes them.

### MAREX in `compare_methods`
- MAREX gains a SYNDES-style solution pool: `solve_design_pool` enumerates the top-K distinct designs via no-good cuts, each scored on a Newey–West MDE power curve (`marex_helpers/power.py`), with a composite power-vs-fit recommendation (`marex_helpers/select.py`, `pool.py`, plus `MAREXRecommendation`). The fit metric is the held-out blank-period RMSE.
- `from_marex` adapter reduces the pool (or the single aggregate design) to the shared contrast; `compare_methods` maps `treated_size → m_eq` and `top_K → pool`, with a `marex_options` pass-through.

### SYNDES selection
- The solution pool holdout-validates by default; `compare_methods` ranks SYNDES rows by out-of-sample (`oos_rmse`) error. The recommendation fit metric is the held-out RMSE for both SYNDES and MAREX.

## Testing

New/extended: `test_design_compare` (LEXSCM + MAREX adapters, single-design fallbacks, method-only and all-four runs, date-string time, option forwarding), `test_marex_pool`, `test_marex` (date-string / non-consecutive time accepted, unbalanced rejected), `test_syndes_pool` / `test_syndes_holdout` (holdout-default), `test_config_models` (time delegated to `geoex_dataprep`). Verified green against current main: design-compare + MAREX + config-models (190 passed) and SYNDES + LEXSCM (159 passed). `design_compare.py` and the new MAREX helper modules at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_