### PR TITLE
Universal geographic-design constraints across all four design methods

### DIFF
--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -742,9 +742,12 @@ similar but are distinct -- pick by what you want, not by the word "group":
   study.
 * *One* design representative of *every* group (coverage): the stratum quota
   ``stratum_col`` + ``min_per_stratum`` / ``max_per_stratum`` -- one shared donor
-  pool, one estimand. In MAREX this quota is just the per-cluster cardinality.
+  pool, one estimand. Honoured by all four design methods; in MAREX it can also
+  be expressed as the per-cluster cardinality when each region is its own design.
 * *One* design with geographic / forcing limits: the restriction suite (force
-  in/out, border conflict, size band, donor rules) on SYNDES, MAREX, or GEOLIFT.
+  in/out, border conflict, cluster, coverage quota, size band) is honoured by all
+  four design methods -- SYNDES, GEOLIFT, LEXSCM, and MAREX -- so a constraint
+  binds whichever method (or comparison) you run.
 
 A constraint cannot turn one design into K designs, so ``cluster`` / ``arm`` are
 not special cases of the quota; the quota is the lighter choice when you only

--- a/docs/geolift.rst
+++ b/docs/geolift.rst
@@ -177,10 +177,13 @@ where the cardinality constraint :math:`|\mathcal{S}| = k` already lives and onl
 *shrink* the candidate set. If no region satisfies them (e.g.
 :math:`k` exceeds :math:`|\mathcal{C}|` or :math:`|\mathcal{G}_{\mathrm{elig}}|`,
 or :math:`|\mathcal{N}_{\mathrm{size}}| < k`) the design reports infeasibility
-(:class:`~mlsynth.exceptions.MlsynthConfigError`) rather than returning a
-degenerate region. With none of the constraints supplied,
-:math:`\mathbf{A} = \mathbf{0}` and every region is admissible — the unconstrained
-nomination.
+(:class:`~mlsynth.exceptions.MlsynthConfigError`). The error is itemised: it names
+every binding constraint together, each in a ``have vs need`` shape — the
+candidate-pool count, the coverage arithmetic (``min_per_stratum`` times the number
+of strata to cover), the per-stratum cap, and the largest conflict-free treated set
+versus :math:`k` — so the fix is read off the message rather than guessed. With
+none of the constraints supplied, :math:`\mathbf{A} = \mathbf{0}` and every region
+is admissible — the unconstrained nomination.
 
 Stage 2 — The synthetic control
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/lexscm.rst
+++ b/docs/lexscm.rst
@@ -558,6 +558,29 @@ than :math:`m` candidates inside the size band).
            "stratum_col": "region", "min_per_stratum": 1, "max_per_stratum": 2,
            "size_col": "population", "min_size": 50_000, "max_size": 2_000_000}).fit()
 
+Forced-in and forbidden markets
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Two hard market lists complete the treatment-criteria vocabulary, matching SYNDES
+and GeoLift. ``to_be_treated`` pins specified markets into the treated set: every
+candidate :math:`m`-tuple the search considers must contain them, which is useful
+when a market is decided in advance (a client insists on testing it) and the
+design only has to choose the rest around it. ``not_to_be_treated`` does the
+opposite -- those markets are removed from the treatment pool but stay available
+as donors -- for a market already running another campaign, with poor data, or
+earmarked as a clean control. A forced-in market must be a treatment candidate
+(``candidate_col`` true and within any size band), at most :math:`m` may be
+forced, and a market cannot appear in both lists; each violation raises
+:class:`~mlsynth.exceptions.MlsynthConfigError`. Forcing in a market that is hard
+to synthesize costs imbalance, so check the achieved fit.
+
+.. code-block:: python
+
+   # always test DMA 501; never test DMA 635 (it stays an eligible donor)
+   LEXSCM({"df": df, "outcome": "y", "unitid": "unit", "time": "year",
+           "candidate_col": "eligible", "m": 4,
+           "to_be_treated": [501], "not_to_be_treated": [635]}).fit()
+
 Stage 3 -- Power analysis (minimum detectable effect)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/marex.rst
+++ b/docs/marex.rst
@@ -185,6 +185,16 @@ constraints on the MIP:
 * ``size_col`` + ``min_size`` / ``max_size`` -- a treated-unit size band (the
   floor is a power minimum, the ceiling is synthesizability); out-of-band markets
   stay donors.
+* ``cluster_col`` -- at most one treated market per cluster value
+  (:math:`\sum_k z_{ik} + \sum_k z_{jk} \le 1` for same-cluster pairs), a
+  no-two-from-one-cluster rule for markets that share a media buy or retail
+  footprint. This is distinct from the ``cluster`` design grouping above: it adds
+  conflict constraints to the treated set rather than splitting the objective.
+* ``stratum_col`` + ``min_per_stratum`` / ``max_per_stratum`` -- a coverage quota
+  on the treated set of one design (at least / at most this many treated per
+  stratum). Use this when the design is a single cluster but the read still has to
+  span regions; when each region is its own design, ``cluster`` with per-cluster
+  ``m_min`` / ``m_max`` expresses the same quota.
 * ``exclude_bordering_donors`` -- drop a treated market's bordering neighbours
   from its (within-cluster) control pool, so a market partly treated by spillover
   never sits in its counterfactual. Requires ``adjacency``.

--- a/mlsynth/estimators/lexscm.py
+++ b/mlsynth/estimators/lexscm.py
@@ -187,6 +187,8 @@ class LEXSCM:
         self.size_col: Optional[str] = config.size_col
         self.min_size: Optional[float] = config.min_size
         self.max_size: Optional[float] = config.max_size
+        self.to_be_treated: Optional[list] = config.to_be_treated
+        self.not_to_be_treated: Optional[list] = config.not_to_be_treated
         self.frac_E: float = config.frac_E
 
         # =========================================================
@@ -332,6 +334,15 @@ class LEXSCM:
         size_band = (None if self.size_col is None
                      else (self.min_size, self.max_size))
 
+        # --- Forbidden treated markets (not_to_be_treated): drop from the
+        # treatment pool; they stay eligible as donors (same as a size-band
+        # exclusion). ---
+        if self.not_to_be_treated:
+            forbid = set(map(str, self.not_to_be_treated))
+            forbid_mask = np.array([str(lab) in forbid
+                                    for lab in unit_index.labels])
+            candidate_mask = np.asarray(candidate_mask, dtype=bool) & ~forbid_mask
+
         # The candidate pool is needed before the matrices are built, so report a
         # too-small pool here in the SAME shape the Stage-1 audit uses for every
         # other binding constraint (e.g. when a size band leaves fewer than m).
@@ -434,6 +445,21 @@ class LEXSCM:
                           .first().to_dict())
         strata = build_strata(unit_index, stratum_of)
 
+        # --- Forced-in treated markets (to_be_treated): map labels to indices;
+        # select_treated_designs enforces forced subset of the candidate pool and
+        # |forced| <= m. ---
+        forced_idx = None
+        if self.to_be_treated:
+            want = set(map(str, self.to_be_treated))
+            forced_idx = [i for i, lab in enumerate(unit_index.labels)
+                          if str(lab) in want]
+            missing = sorted(want - {str(unit_index.labels[i])
+                                     for i in forced_idx})
+            if missing:
+                raise MlsynthConfigError(
+                    f"to_be_treated markets {missing} are not in the panel."
+                )
+
         # ---------- Stage 1: treated-tuple selection (lexsearch) ----------
         search = select_treated_designs(
             G=G,
@@ -451,6 +477,7 @@ class LEXSCM:
             max_per_stratum=self.max_per_stratum,
             size_band=size_band,
             targeting_penalty=self.targeting_penalty,
+            forced=forced_idx,
         )
         selection_results = {"top_tuples": search["top_designs"], "stats": search["stats"]}
 

--- a/mlsynth/estimators/scexp.py
+++ b/mlsynth/estimators/scexp.py
@@ -96,6 +96,10 @@ class MAREX:
         self.size_col = config.size_col
         self.min_size = config.min_size
         self.max_size = config.max_size
+        self.cluster_col = config.cluster_col
+        self.stratum_col = config.stratum_col
+        self.min_per_stratum = config.min_per_stratum
+        self.max_per_stratum = config.max_per_stratum
 
         if self.cluster and self.cluster not in self.df.columns:
             raise MlsynthDataError(f"Cluster column '{self.cluster}' not found in DataFrame.")
@@ -135,7 +139,11 @@ class MAREX:
             self.df, self.unitid, panel.unit_index,
             to_be_treated=self.to_be_treated,
             not_to_be_treated=self.not_to_be_treated,
+            cluster_col=self.cluster_col,
             adjacency=self.adjacency, spillover_threshold=self.spillover_threshold,
+            stratum_col=self.stratum_col,
+            min_per_stratum=self.min_per_stratum,
+            max_per_stratum=self.max_per_stratum,
             size_col=self.size_col, min_size=self.min_size, max_size=self.max_size,
             exclude_bordering_donors=self.exclude_bordering_donors,
         )

--- a/mlsynth/estimators/scexp.py
+++ b/mlsynth/estimators/scexp.py
@@ -198,6 +198,7 @@ class MAREX:
                     costs=self.costs, budget=self.budget, covariates=panel.covariates,
                     covariate_weight=self.covariate_weight, standardize=self.standardize,
                     solver=self.solver or cp.SCIP, verbose=self.verbose,
+                    restrictions=restrictions,
                 )
                 pool = build_marex_pool(
                     raws, alpha=self.config.alpha, power=self.config.power_target,

--- a/mlsynth/tests/test_compare_methods_constraints.py
+++ b/mlsynth/tests/test_compare_methods_constraints.py
@@ -1,0 +1,99 @@
+"""compare_methods routes geographic constraints to every requested method.
+
+All four design methods (SYNDES / GEOLIFT / LEXSCM / MAREX) now honour the same
+constraint vocabulary, so ``compare_methods(constraints=...)`` applies one
+constraint set uniformly and the resulting candidate designs -- whichever method
+produced them -- respect it. These tests pin that routing test-first.
+"""
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.utils.design_compare import compare_methods
+
+_ALL = ("SYNDES", "GEOLIFT", "LEXSCM", "MAREX")
+# keep the MIQP / lexicographic budgets small so the four-method fits stay quick
+_OPTS = dict(
+    syndes_options={"time_limit": 3.0, "gap_limit": 0.2},
+    geolift_options={"ns": 80},
+    lexscm_options={"top_K": 4, "top_P": 3, "n_sims": 30, "max_shortlist": 4},
+    marex_options={"solver": "SCIP"},
+)
+
+# 6 units; cluster/pair grouping for the no-two-from-one-cluster rule; region
+# strata for the coverage quota.
+_CLUSTER = {f"u{i}": f"C{i // 2}" for i in range(6)}        # C0..C2, pairs
+_REGION = {f"u{i}": ("R1" if i < 3 else "R2") for i in range(6)}
+
+
+def _panel(N=6, T=18, n_post=5, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2)); L = rng.uniform(0.3, 1.0, (N, 2))
+    lvl = rng.uniform(8.0, 12.0, N)
+    Y = lvl + F @ L.T + rng.normal(scale=0.3, size=(T, N))
+    rows = [{"unit": f"u{j}", "time": t, "Y": float(Y[t, j]),
+             "cluster": _CLUSTER[f"u{j}"], "region": _REGION[f"u{j}"],
+             "post": int(t >= T - n_post)}
+            for j in range(N) for t in range(T)]
+    return pd.DataFrame(rows), n_post
+
+
+def test_constraints_unknown_key_raises():
+    df, n_post = _panel()
+    with pytest.raises(ValueError, match="constraint"):
+        compare_methods(df, outcome="Y", unitid="unit", time="time",
+                        treated_size=2, n_post=n_post, methods=("GEOLIFT",),
+                        constraints={"not_a_real_constraint": 1})
+
+
+def test_cluster_col_routed_to_all_methods():
+    df, n_post = _panel()
+    cmp = compare_methods(
+        df, outcome="Y", unitid="unit", time="time", treated_size=2,
+        horizon=5, n_post=n_post, top_K=4, methods=_ALL,
+        constraints={"cluster_col": "cluster"}, **_OPTS,
+    )
+    assert set(cmp.table["method"]) == set(_ALL)
+    for _, row in cmp.table.iterrows():
+        clusters = [_CLUSTER[str(u)] for u in row["treated"]]
+        assert len(clusters) == len(set(clusters)), \
+            f"{row['method']} treated two from one cluster: {row['treated']}"
+
+
+def test_not_to_be_treated_routed_to_all_methods():
+    df, n_post = _panel()
+    cmp = compare_methods(
+        df, outcome="Y", unitid="unit", time="time", treated_size=2,
+        horizon=5, n_post=n_post, top_K=4, methods=_ALL,
+        constraints={"not_to_be_treated": ["u0"]}, **_OPTS,
+    )
+    for _, row in cmp.table.iterrows():
+        assert "u0" not in {str(u) for u in row["treated"]}, row["method"]
+
+
+def test_min_per_stratum_routed_to_all_methods():
+    df, n_post = _panel()
+    cmp = compare_methods(
+        df, outcome="Y", unitid="unit", time="time", treated_size=2,
+        horizon=5, n_post=n_post, top_K=4, methods=_ALL,
+        constraints={"stratum_col": "region", "min_per_stratum": 1}, **_OPTS,
+    )
+    for _, row in cmp.table.iterrows():
+        regions = {_REGION[str(u)] for u in row["treated"]}
+        assert regions == {"R1", "R2"}, f"{row['method']} missed a region: {row['treated']}"
+
+
+def test_unconstrained_runs_all_four():
+    df, n_post = _panel()
+    cmp = compare_methods(
+        df, outcome="Y", unitid="unit", time="time", treated_size=2,
+        horizon=5, n_post=n_post, top_K=4, methods=_ALL, **_OPTS,
+    )
+    assert set(cmp.table["method"]) == set(_ALL)
+    assert np.isfinite(cmp.table["fit_rmse"]).all()

--- a/mlsynth/tests/test_geolift_feasibility.py
+++ b/mlsynth/tests/test_geolift_feasibility.py
@@ -1,0 +1,180 @@
+"""Up-front, itemised feasibility audit for GeoLift market selection.
+
+When no candidate test region satisfies the design constraints, GeoLift must say
+*which* constraint bound the search, in a uniform ``have vs need -> fix`` shape --
+mirroring LEXSCM's :func:`audit_feasibility`. These tests pin that diagnostic
+(both the standalone helper and its end-to-end wiring) test-first per the repo
+contract.
+"""
+
+import re
+
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.geolift_helpers.config import GeoLiftConfig
+from mlsynth.utils.geolift_helpers.marketselect.orchestration import run_design
+from mlsynth.utils.geolift_helpers.marketselect.helpers.constraints import (
+    build_conflict_graph,
+)
+from mlsynth.utils.geolift_helpers.marketselect.helpers.feasibility import (
+    audit_geolift_feasibility,
+)
+
+
+# === audit_geolift_feasibility: the standalone, itemised helper ===
+
+def test_audit_feasible_is_noop():
+    """A satisfiable design audits clean (no exception)."""
+    audit_geolift_feasibility(
+        ["a", "b", "c", "d"], 2,
+        stratum_map={"a": "R1", "b": "R1", "c": "R2", "d": "R2"},
+        max_per_stratum=1,
+    )
+
+
+def test_audit_candidate_pool_too_small():
+    with pytest.raises(MlsynthConfigError) as ei:
+        audit_geolift_feasibility(["a", "b"], 3)
+    msg = str(ei.value)
+    assert "binding constraint" in msg
+    assert "candidate pool" in msg
+    assert "2" in msg and "3" in msg          # have 2, need 3
+
+
+def test_audit_min_per_stratum_needs_more_than_treatment_size():
+    """min_per_stratum=1 over 3 required strata needs >= 3 treated, but k=2."""
+    sm = {"a": "R1", "b": "R2", "c": "R3", "d": "R1"}
+    required = {"R1", "R2", "R3"}
+    with pytest.raises(MlsynthConfigError) as ei:
+        audit_geolift_feasibility(
+            ["a", "b", "c", "d"], 2, stratum_map=sm,
+            min_per_stratum=1, required_strata=required,
+        )
+    msg = str(ei.value)
+    assert "coverage" in msg
+    assert ">= 3" in msg                       # the computed need
+    assert "min_per_stratum" in msg
+
+
+def test_audit_min_per_stratum_quota_arithmetic():
+    """min_per_stratum=2 over 4 strata needs >= 8 -- the user's actual case."""
+    sm = {f"u{i}": f"R{i % 4}" for i in range(8)}
+    required = {f"R{i}" for i in range(4)}
+    with pytest.raises(MlsynthConfigError) as ei:
+        audit_geolift_feasibility(
+            list(sm), 3, stratum_map=sm, min_per_stratum=2, required_strata=required,
+        )
+    assert ">= 8" in str(ei.value)             # 2 per stratum x 4 strata
+
+
+def test_audit_stratum_with_too_few_eligible():
+    """A required stratum that cannot meet its own min is named explicitly."""
+    sm = {"a": "R1", "b": "R1", "c": "R1", "d": "R2"}   # R2 has only 1 eligible
+    required = {"R1", "R2"}
+    with pytest.raises(MlsynthConfigError) as ei:
+        audit_geolift_feasibility(
+            ["a", "b", "c", "d"], 3, stratum_map=sm,    # k=3 clears the pool guard
+            min_per_stratum=2, required_strata=required,
+        )
+    msg = str(ei.value)
+    assert "R2" in msg                         # the short stratum is named
+
+
+def test_audit_max_per_stratum_caps_below_treatment_size():
+    """max_per_stratum=1 over 2 strata allows at most 2 treated, but k=3."""
+    sm = {"a": "R1", "b": "R1", "c": "R2", "d": "R2"}
+    with pytest.raises(MlsynthConfigError) as ei:
+        audit_geolift_feasibility(
+            ["a", "b", "c", "d"], 3, stratum_map=sm, max_per_stratum=1,
+        )
+    msg = str(ei.value)
+    assert "max_per_stratum" in msg
+    assert "at most 2" in msg
+
+
+def test_audit_cluster_independent_set_too_small():
+    """Three clusters -> largest conflict-free set is 3 < treatment_size=4."""
+    units = [f"u{i}" for i in range(6)]
+    g = build_conflict_graph(units, cluster_map={f"u{i}": f"C{i // 2}" for i in range(6)})
+    with pytest.raises(MlsynthConfigError) as ei:
+        audit_geolift_feasibility(units, 4, conflict=g)
+    msg = str(ei.value)
+    assert "spillover" in msg or "cluster" in msg
+    assert "3" in msg and "4" in msg           # largest 3 < need 4
+
+
+def test_audit_reports_multiple_binding_constraints_together():
+    """Two independent infeasibilities are reported in one error, itemised."""
+    sm = {"a": "R1", "b": "R2", "c": "R3"}
+    required = {"R1", "R2", "R3"}
+    g = build_conflict_graph(["a", "b", "c"],
+                             cluster_map={"a": "C0", "b": "C0", "c": "C0"})
+    with pytest.raises(MlsynthConfigError) as ei:
+        audit_geolift_feasibility(
+            ["a", "b", "c"], 3, conflict=g, stratum_map=sm,
+            min_per_stratum=2, required_strata=required,
+        )
+    msg = str(ei.value)
+    # itemised: more than one "  - " bullet
+    assert len(re.findall(r"\n\s*- ", msg)) >= 2
+
+
+# === end-to-end: run_design surfaces the diagnostic, not the vague message ===
+
+_REGION_OF = {"u0": "R1", "u1": "R1", "u2": "R2", "u3": "R2", "u4": "R3", "u5": "R3"}
+
+
+def _stratified_long(seed=5, T=24):
+    import numpy as np
+    rng = np.random.default_rng(seed)
+    base = np.arange(T) * 0.3
+    rows = []
+    for i in range(6):
+        u = f"u{i}"
+        s = base + rng.normal(scale=1.0, size=T) + i
+        for t in range(T):
+            rows.append({"unit": u, "time": t, "Y": float(s[t]),
+                         "region": _REGION_OF[u]})
+    return pd.DataFrame(rows)
+
+
+def test_run_design_min_per_stratum_infeasible_names_the_constraint():
+    """The old vague 'no candidate test region' message is replaced by an
+    itemised diagnostic that names coverage and the quota arithmetic."""
+    with pytest.raises(MlsynthConfigError) as ei:
+        run_design(GeoLiftConfig(
+            df=_stratified_long(), outcome="Y", unitid="unit", time="time",
+            treatment_size=2, durations=[4], effect_sizes=[0.0],
+            lookback_window=1, ns=20, seed=0,
+            stratum_col="region", min_per_stratum=1))
+    msg = str(ei.value)
+    assert "binding constraint" in msg
+    assert "coverage" in msg
+    assert ">= 3" in msg                       # 1 per region x 3 regions
+
+
+def _clustered_long(seed=3, T=24):
+    import numpy as np
+    rng = np.random.default_rng(seed)
+    base = np.arange(T) * 0.3
+    rows = []
+    for i in range(6):
+        s = base + rng.normal(scale=1.0, size=T) + i
+        for t in range(T):
+            rows.append({"unit": f"u{i}", "time": t, "Y": float(s[t]),
+                         "cluster": f"C{i // 2}"})
+    return pd.DataFrame(rows)
+
+
+def test_run_design_infeasible_cluster_names_independent_set():
+    with pytest.raises(MlsynthConfigError) as ei:
+        run_design(GeoLiftConfig(
+            df=_clustered_long(), outcome="Y", unitid="unit", time="time",
+            treatment_size=4, durations=[4], effect_sizes=[0.0],
+            lookback_window=1, ns=20, seed=0, cluster_col="cluster"))
+    msg = str(ei.value)
+    assert "binding constraint" in msg
+    assert "spillover" in msg or "cluster" in msg
+    assert "< treatment_size=4" in msg

--- a/mlsynth/tests/test_lexscm_forced.py
+++ b/mlsynth/tests/test_lexscm_forced.py
@@ -1,0 +1,148 @@
+"""Forced-in / forbidden treated markets for LEXSCM.
+
+LEXSCM already honours the cluster / adjacency / stratum-quota / size-band
+constraints; the one gap versus SYNDES and GeoLift is the pair of hard market
+lists ``to_be_treated`` (always treated) and ``not_to_be_treated`` (never
+treated, stays a donor). These tests pin that behaviour test-first, at both the
+search layer (``select_treated_designs`` with ``forced``, exact and heuristic
+paths) and the estimator layer (``LEXSCM`` config).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.fast_scm_helpers.lexsearch import select_treated_designs
+
+
+# === search layer: forced indices, exact enumeration ===
+
+def _gram(n, seed=0):
+    """A PSD Gram matrix over n units (random but reproducible)."""
+    rng = np.random.default_rng(seed)
+    A = rng.normal(size=(n, n))
+    return A @ A.T + np.eye(n)
+
+
+def test_forced_index_in_every_enumerated_design():
+    G = _gram(8)
+    out = select_treated_designs(G, candidate_idx=list(range(8)), m=3, top_K=5,
+                                 method="enumerate", forced=[2])
+    assert out["top_designs"]
+    for design in out["top_designs"]:
+        assert 2 in set(np.asarray(design.indices).tolist())
+
+
+def test_multiple_forced_indices_all_present():
+    G = _gram(9)
+    out = select_treated_designs(G, candidate_idx=list(range(9)), m=4, top_K=5,
+                                 method="enumerate", forced=[1, 7])
+    assert out["top_designs"]
+    for design in out["top_designs"]:
+        s = set(np.asarray(design.indices).tolist())
+        assert {1, 7} <= s
+
+
+def test_forced_equals_m_yields_exactly_that_set():
+    G = _gram(8)
+    out = select_treated_designs(G, candidate_idx=list(range(8)), m=3, top_K=5,
+                                 method="enumerate", forced=[0, 3, 5])
+    designs = out["top_designs"]
+    assert len(designs) == 1                       # only one feasible tuple
+    assert set(np.asarray(designs[0].indices).tolist()) == {0, 3, 5}
+
+
+def test_forced_index_in_every_heuristic_design():
+    """The heuristic path (large pool) must also pin the forced units."""
+    G = _gram(14, seed=2)
+    out = select_treated_designs(G, candidate_idx=list(range(14)), m=4, top_K=6,
+                                 method="heuristic", forced=[5], n_starts=8,
+                                 random_state=1)
+    assert out["top_designs"]
+    for design in out["top_designs"]:
+        assert 5 in set(np.asarray(design.indices).tolist())
+
+
+def test_forced_subset_of_candidates_required():
+    G = _gram(6)
+    with pytest.raises(MlsynthConfigError):
+        select_treated_designs(G, candidate_idx=[0, 1, 2, 3], m=2,
+                               method="enumerate", forced=[5])   # 5 not a candidate
+
+
+def test_too_many_forced_for_m_raises():
+    G = _gram(6)
+    with pytest.raises(MlsynthConfigError, match="forced|to_be_treated"):
+        select_treated_designs(G, candidate_idx=list(range(6)), m=2,
+                               method="enumerate", forced=[0, 1, 2])
+
+
+# === estimator layer: LEXSCM config to_be_treated / not_to_be_treated ===
+
+def _panel(seed=4, T=24, n=8):
+    """A small long panel with a candidate flag (all eligible)."""
+    rng = np.random.default_rng(seed)
+    base = np.arange(T) * 0.3
+    rows = []
+    for i in range(n):
+        s = base + rng.normal(scale=1.0, size=T) + i
+        for t in range(T):
+            rows.append({"unit": f"u{i}", "time": t, "Y": float(s[t]),
+                         "elig": True})
+    return pd.DataFrame(rows)
+
+
+def _fit(df, **over):
+    from mlsynth.estimators.lexscm import LEXSCM
+    cfg = dict(df=df, outcome="Y", unitid="unit", time="time",
+               candidate_col="elig", m=3, top_K=5, display_graph=False,
+               verbose=False)
+    cfg.update(over)
+    return LEXSCM(cfg).fit()
+
+
+def _treated_sets(res):
+    return [set(c.treated_weight_dict_full) for c in res.search.candidates]
+
+
+def test_estimator_not_to_be_treated_never_treated():
+    res = _fit(_panel(), not_to_be_treated=["u3"])
+    for s in _treated_sets(res):
+        assert "u3" not in s
+
+
+def test_estimator_not_to_be_treated_still_a_donor():
+    """A forbidden market is removed from treatment but stays an eligible donor."""
+    res = _fit(_panel(), not_to_be_treated=["u3"])
+    donors_seen = set()
+    for c in res.search.candidates:
+        donors_seen |= set(c.control_weight_dict_full)
+    assert "u3" in donors_seen
+
+
+def test_estimator_to_be_treated_always_treated():
+    res = _fit(_panel(), to_be_treated=["u1"])
+    sets = _treated_sets(res)
+    assert sets
+    for s in sets:
+        assert "u1" in s
+
+
+def test_estimator_forced_and_forbidden_together():
+    res = _fit(_panel(), to_be_treated=["u1"], not_to_be_treated=["u5"])
+    for s in _treated_sets(res):
+        assert "u1" in s and "u5" not in s
+
+
+def test_estimator_forced_unit_must_be_candidate():
+    df = _panel()
+    df.loc[df.unit == "u2", "elig"] = False        # u2 not a candidate
+    with pytest.raises(MlsynthConfigError):
+        _fit(df, to_be_treated=["u2"])
+
+
+def test_estimator_overlap_forced_forbidden_raises():
+    # LEXSCM surfaces config-validation failures as MlsynthDataError.
+    with pytest.raises(MlsynthDataError, match="both|overlap|to_be_treated"):
+        _fit(_panel(), to_be_treated=["u1"], not_to_be_treated=["u1"])

--- a/mlsynth/tests/test_marex_cluster_stratum.py
+++ b/mlsynth/tests/test_marex_cluster_stratum.py
@@ -1,0 +1,95 @@
+"""MAREX: cluster_col (no-two-same-cluster) and stratum coverage quotas.
+
+MAREX already honours forced/forbidden lists, adjacency, size bands and donor
+exclusion (see ``test_marex_restrictions.py``). The two remaining items in the
+SYNDES/GeoLift constraint vocabulary are:
+
+* ``cluster_col`` -- at most one treated market per cluster value (a no-two-from-
+  one-cluster rule, distinct from MAREX's ``cluster`` design grouping), and
+* ``stratum_col`` + ``min_per_stratum`` / ``max_per_stratum`` -- a coverage quota
+  on the treated set.
+
+Both reduce to linear constraints on MAREX's binary ``z``; these tests pin the
+behaviour and the config validation test-first.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import MAREX
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+
+
+# 8 units, one design cluster (no `cluster` grouping). Two attributes:
+#   region (stratum): u0-u3 -> R1, u4-u7 -> R2
+#   pair  (cluster_col): u0,u1 -> P0; u2,u3 -> P1; u4,u5 -> P2; u6,u7 -> P3
+_REGION = {f"u{i}": ("R1" if i < 4 else "R2") for i in range(8)}
+_PAIR = {f"u{i}": f"P{i // 2}" for i in range(8)}
+
+
+def _panel(N=8, T=14, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2))
+    L = rng.uniform(0.3, 1.0, (N, 2))
+    lvl = rng.uniform(8.0, 12.0, N)
+    Y = lvl + F @ L.T + rng.normal(scale=0.3, size=(T, N))
+    rows = []
+    for j in range(N):
+        u = f"u{j}"
+        for t in range(T):
+            rows.append({"unit": u, "time": t, "Y": float(Y[t, j]),
+                         "region": _REGION[u], "pair": _PAIR[u]})
+    return pd.DataFrame(rows)
+
+
+_BASE = dict(outcome="Y", unitid="unit", time="time", T0=10,
+             inference=False, display_graph=False, verbose=False)
+
+
+def _treated(res):
+    """The set of treated unit labels across all clusters."""
+    out = set()
+    for cd in res.clusters.values():
+        out |= set(cd.unit_weight_map.get("Treated", {}))
+    return {str(u) for u in out}
+
+
+def test_cluster_col_no_two_from_one_cluster():
+    res = MAREX({"df": _panel(), **_BASE, "m_eq": 2, "cluster_col": "pair"}).fit()
+    treated = _treated(res)
+    pairs = [_PAIR[u] for u in treated]
+    assert len(pairs) == len(set(pairs))            # never two from one pair
+
+
+def test_stratum_min_per_covers_every_region():
+    res = MAREX({"df": _panel(), **_BASE, "m_eq": 2,
+                 "stratum_col": "region", "min_per_stratum": 1}).fit()
+    treated = _treated(res)
+    assert {_REGION[u] for u in treated} == {"R1", "R2"}
+
+
+def test_stratum_max_per_caps_region_count():
+    res = MAREX({"df": _panel(), **_BASE, "m_eq": 2,
+                 "stratum_col": "region", "max_per_stratum": 1}).fit()
+    treated = _treated(res)
+    regions = [_REGION[u] for u in treated]
+    assert all(regions.count(r) <= 1 for r in set(regions))
+
+
+def test_stratum_quota_requires_stratum_col():
+    with pytest.raises((MlsynthConfigError, MlsynthDataError), match="stratum"):
+        MAREX({"df": _panel(), **_BASE, "m_eq": 2, "min_per_stratum": 1})
+
+
+def test_stratum_min_exceeds_max_raises():
+    with pytest.raises((MlsynthConfigError, MlsynthDataError), match="stratum|max"):
+        MAREX({"df": _panel(), **_BASE, "m_eq": 2, "stratum_col": "region",
+               "min_per_stratum": 2, "max_per_stratum": 1})
+
+
+def test_unconstrained_still_works():
+    """No cluster_col / stratum_col -> behaviour unchanged (smoke)."""
+    res = MAREX({"df": _panel(), **_BASE, "m_eq": 2}).fit()
+    assert len(_treated(res)) == 2

--- a/mlsynth/utils/design_compare.py
+++ b/mlsynth/utils/design_compare.py
@@ -321,6 +321,17 @@ _GEOLIFT_DEFAULTS: Dict[str, Any] = dict(
     fixed_effects=True, ns=200, seed=0, display_graphs=False,
 )
 _LEXSCM_DEFAULTS: Dict[str, Any] = dict(display_graph=False, verbose=False)
+
+# The geographic-design constraint vocabulary, identical across all four method
+# configs (SYNDES / GEOLIFT / LEXSCM / MAREX). ``compare_methods`` routes a single
+# ``constraints`` dict of these to every requested method, so a constraint binds
+# the comparison uniformly instead of having to be hand-coded per method.
+_GEO_CONSTRAINT_KEYS = frozenset({
+    "to_be_treated", "not_to_be_treated",
+    "cluster_col", "adjacency", "spillover_threshold",
+    "stratum_col", "min_per_stratum", "max_per_stratum",
+    "size_col", "min_size", "max_size",
+})
 _MAREX_DEFAULTS: Dict[str, Any] = dict(design="standard", display_graph=False,
                                        verbose=False)
 
@@ -372,6 +383,7 @@ def compare_methods(
     power_target: float = 0.80,
     effects_pct: Optional[Sequence[float]] = None,
     methods: Sequence[str] = ("SYNDES", "GEOLIFT"),
+    constraints: Optional[Dict[str, Any]] = None,
     syndes_holdout_frac: Optional[float] = 0.3,
     syndes_options: Optional[Dict[str, Any]] = None,
     geolift_options: Optional[Dict[str, Any]] = None,
@@ -408,6 +420,17 @@ def compare_methods(
     methods : sequence of str, default ``("SYNDES", "GEOLIFT")``
         Which methods to fit and compare. Any of ``"SYNDES"``, ``"GEOLIFT"``,
         ``"LEXSCM"``, ``"MAREX"``.
+    constraints : dict, optional
+        Geographic-design constraints applied uniformly to *every* requested
+        method, so a constraint binds the whole comparison (all four methods now
+        honour the same vocabulary). Any of ``to_be_treated`` /
+        ``not_to_be_treated`` (forced-in / forbidden markets), ``cluster_col``
+        (no two treated markets from one cluster), ``adjacency`` +
+        ``spillover_threshold`` (no two bordering markets treated), ``stratum_col``
+        + ``min_per_stratum`` / ``max_per_stratum`` (coverage quota), and
+        ``size_col`` + ``min_size`` / ``max_size`` (treated-unit size band). A
+        key set in a per-method ``*_options`` dict overrides the routed value for
+        that method.
     syndes_holdout_frac : float or None, default 0.3
         Holdout fraction for SYNDES design selection: SYNDES learns its pool on
         the leading ``1 - syndes_holdout_frac`` of the pre-period and is ranked
@@ -440,6 +463,17 @@ def compare_methods(
                          "'MAREX'.")
     if not methods:
         raise ValueError("methods must name at least one estimator.")
+
+    # Geographic constraints are routed uniformly to every requested method (the
+    # config field names are identical across the four), so a constraint binds the
+    # whole comparison rather than one method. Per-method options still override.
+    constraints = dict(constraints or {})
+    unknown_c = set(constraints) - _GEO_CONSTRAINT_KEYS
+    if unknown_c:
+        raise ValueError(
+            f"Unknown constraint(s): {sorted(unknown_c)}; expected any of "
+            f"{sorted(_GEO_CONSTRAINT_KEYS)}."
+        )
 
     times = sorted(df[time].unique())
     df = df.copy()
@@ -481,6 +515,7 @@ def compare_methods(
                 # SYNDES now holdout-validates pools by default, so to honour
                 # syndes_holdout_frac=None (disable) we ask for in-sample.
                 sk["selection"] = "in_sample"
+        sk.update(constraints)
         sk.update(syn_over)
         syn = SYNDES(sk).fit()
         specs += from_syndes(syn)
@@ -489,7 +524,7 @@ def compare_methods(
         from ..estimators.geolift import GEOLIFT
         gk = {**_GEOLIFT_DEFAULTS, **common, "treatment_size": treated_size,
               "durations": [n_post_resolved], "alpha": alpha,
-              **(geolift_options or {})}
+              **constraints, **(geolift_options or {})}
         gl = GEOLIFT(gk).fit()
         specs += from_geolift(gl)
 
@@ -504,7 +539,7 @@ def compare_methods(
             cand_col = "__compare_candidate__"
             df[cand_col] = True
         lk = {**_LEXSCM_DEFAULTS, **common, "candidate_col": cand_col,
-              "m": treated_size, "alpha": alpha, **lex_over}
+              "m": treated_size, "alpha": alpha, **constraints, **lex_over}
         lex = LEXSCM(lk).fit()
         specs += from_lexscm(lex)
 
@@ -518,6 +553,7 @@ def compare_methods(
               "power_target": power_target}
         if not ({"m_eq", "m_min", "m_max"} & set(mar_over)):
             mk["m_eq"] = treated_size
+        mk.update(constraints)
         mk.update(mar_over)
         mar = MAREX(mk).fit()
         specs += from_marex(mar)

--- a/mlsynth/utils/fast_scm_helpers/config.py
+++ b/mlsynth/utils/fast_scm_helpers/config.py
@@ -142,8 +142,35 @@ class LEXSCMConfig(BaseMAREXConfig):
                     "reproduced by a convex combination of others (e.g. mega-markets)."
     )
 
+    # =========================================================
+    # FORCED-IN / FORBIDDEN TREATED MARKETS
+    # =========================================================
+
+    to_be_treated: Optional[List] = Field(
+        default=None,
+        description="Market labels that must always be in the treated set "
+                    "(forced in). Each must be a treatment candidate "
+                    "(candidate_col True and within the size band); the count "
+                    "cannot exceed m."
+    )
+
+    not_to_be_treated: Optional[List] = Field(
+        default=None,
+        description="Market labels that must never be treated (forbidden); they "
+                    "are removed from the treatment pool but remain eligible as "
+                    "donors."
+    )
+
     @model_validator(mode="after")
     def _validate_coverage_and_size(self) -> "LEXSCMConfig":
+        if self.to_be_treated and self.not_to_be_treated:
+            overlap = set(map(str, self.to_be_treated)) & set(
+                map(str, self.not_to_be_treated))
+            if overlap:
+                raise ValueError(
+                    f"markets {sorted(overlap)} appear in both to_be_treated and "
+                    f"not_to_be_treated; a market cannot be forced in and out."
+                )
         if (self.min_per_stratum is not None or self.max_per_stratum is not None) \
                 and self.stratum_col is None:
             raise ValueError(

--- a/mlsynth/utils/fast_scm_helpers/lexsearch.py
+++ b/mlsynth/utils/fast_scm_helpers/lexsearch.py
@@ -186,11 +186,23 @@ def _budget_feasible_candidates(candidate_idx, m, unit_costs, budget):
 
 def _enumerate(G, cand, m, top_K, unit_costs, budget, iters, chunk=300_000,
                conflict=None, strata=None, min_per=None, max_per=None,
-               required=None):
+               required=None, forced=None):
     cand = np.sort(np.asarray(cand))
     from itertools import combinations, chain
-    combs = np.fromiter(chain.from_iterable(combinations(cand.tolist(), m)), dtype=int)
-    combs = combs.reshape(-1, m)
+    forced = sorted({int(f) for f in (forced or [])})
+    if forced:
+        # Every tuple must contain ``forced``: enumerate the remaining m-|forced|
+        # over the non-forced candidates and prepend the forced units. With
+        # k==0 (forced fills the set) combinations yields the lone forced tuple.
+        free = [int(c) for c in cand.tolist() if int(c) not in set(forced)]
+        k = m - len(forced)
+        rows = [sorted(forced + list(r)) for r in combinations(free, k)]
+        combs = (np.array(rows, dtype=int).reshape(-1, m) if rows
+                 else np.empty((0, m), dtype=int))
+    else:
+        combs = np.fromiter(chain.from_iterable(combinations(cand.tolist(), m)),
+                            dtype=int)
+        combs = combs.reshape(-1, m)
     if unit_costs is not None and budget is not None and not np.isinf(budget):
         feasible = unit_costs[combs].sum(1) <= budget
         combs = combs[feasible]
@@ -223,7 +235,7 @@ def _cost_ok(idx_list, unit_costs, budget):
 
 def _local_search(G, cand, m, top_K, unit_costs, budget, n_starts, rng, iters,
                   n_kicks=4, conflict=None, strata=None, min_per=None,
-                  max_per=None, required=None):
+                  max_per=None, required=None, forced=None):
     """Multi-start best-improvement swap search with basin-hopping kicks.
 
     Returns (ranked_designs, n_distinct_subsets, consensus) where ``consensus``
@@ -232,9 +244,15 @@ def _local_search(G, cand, m, top_K, unit_costs, budget, n_starts, rng, iters,
     local optima were seen, and the incumbent-improvement trail.
 
     Every generated tuple is required to be both budget-feasible and an
-    independent set of ``conflict`` (the spillover "No interference" constraint).
+    independent set of ``conflict`` (the spillover "No interference" constraint),
+    and -- when ``forced`` is given -- to contain every forced (``to_be_treated``)
+    unit, which is pinned across the greedy build, the descent swaps, and the
+    basin-hopping kicks.
     """
     cand = list(np.sort(np.asarray(cand)))
+    forced = sorted({int(f) for f in (forced or [])})
+    forced_set = set(forced)
+    free = [j for j in cand if j not in forced_set]   # the swappable candidates
 
     def _ok(S):
         # max-per-stratum is partial-safe (prunes during construction); the min
@@ -262,9 +280,13 @@ def _local_search(G, cand, m, top_K, unit_costs, budget, n_starts, rng, iters,
         return v
 
     def greedy(start):
-        S = [start]
+        # Always seed with the forced units; the random ``start`` only adds a
+        # non-forced unit (forced are pinned and never dropped).
+        S = list(forced)
+        if start not in forced_set and len(S) < m and _ok(sorted(S + [start])):
+            S = sorted(S + [start])
         while len(S) < m:
-            rem = [j for j in cand if j not in S and _ok(S + [j])]
+            rem = [j for j in free if j not in S and _ok(S + [j])]
             if not rem:
                 return None
             cands = [sorted(S + [j]) for j in rem]
@@ -275,8 +297,10 @@ def _local_search(G, cand, m, top_K, unit_costs, budget, n_starts, rng, iters,
         improved = True
         while improved:
             improved = False
+            # Only swap out non-forced positions; forced units stay put.
+            swap_pos = [a for a in range(m) if S[a] not in forced_set]
             moves = [sorted(S[:a] + S[a + 1:] + [j])
-                     for a in range(m) for j in cand
+                     for a in swap_pos for j in free
                      if j not in S and _ok(S[:a] + S[a + 1:] + [j])]
             if not moves:
                 break
@@ -287,12 +311,18 @@ def _local_search(G, cand, m, top_K, unit_costs, budget, n_starts, rng, iters,
         return S
 
     def kick(S):
+        # Evict only non-forced *values* and refill from free units, so the kick
+        # never drops a forced unit (works regardless of sort order).
+        swappable = [x for x in S if x not in forced_set]
+        if not swappable:                             # forced fills the set: nothing to kick
+            return S
+        n_kick = min(2, len(swappable))
         for _ in range(20):
-            T = sorted(S)
-            for a in rng.choice(m, size=min(2, m), replace=False):
-                free = [j for j in cand if j not in T]
-                if free:
-                    T = sorted(T[:a] + T[a + 1:] + [int(rng.choice(free))])
+            evict = set(rng.choice(swappable, size=n_kick, replace=False).tolist())
+            T = [x for x in S if x not in evict]
+            avail = [j for j in free if j not in T]
+            if len(avail) >= n_kick:
+                T = sorted(T + rng.choice(avail, size=n_kick, replace=False).tolist())
             if len(set(T)) == m and _ok(T):
                 return T
         return S
@@ -365,6 +395,7 @@ def select_treated_designs(
     max_per_stratum: Optional[int] = None,
     size_band: Optional[Any] = None,
     targeting_penalty: float = 0.0,
+    forced: Optional[Sequence[int]] = None,
 ) -> Dict[str, Any]:
     """Select the ``top_K`` treated m-tuples with smallest imbalance.
 
@@ -403,6 +434,23 @@ def select_treated_designs(
         raise MlsynthConfigError(
             f"targeting_penalty (gamma) must be >= 0; got {targeting_penalty}."
         )
+
+    # Forced-in units (``to_be_treated``): every selected m-tuple must contain
+    # them. Validate against the candidate pool and m before the search.
+    forced = sorted({int(f) for f in (forced or [])})
+    if forced:
+        cand_set = {int(c) for c in candidate_idx}
+        missing = [f for f in forced if f not in cand_set]
+        if missing:
+            raise MlsynthConfigError(
+                f"forced (to_be_treated) units {missing} are not in the candidate "
+                f"pool; a forced market must be eligible for treatment."
+            )
+        if len(forced) > m:
+            raise MlsynthConfigError(
+                f"forced (to_be_treated) names {len(forced)} units but m={m}; "
+                f"cannot force in more markets than the treated-set size."
+            )
     # Weakly-targeted ridge: search and weight-solve on G + gamma I; the true
     # targeting imbalance is read off the original G at the penalized weights.
     Gsearch = G + targeting_penalty * np.eye(G.shape[0]) if targeting_penalty > 0 else G
@@ -434,7 +482,7 @@ def select_treated_designs(
         raw, n_eval = _enumerate(Gsearch, cand, m, top_K, unit_costs, budget, iters,
                                  conflict=conflict, strata=strata,
                                  min_per=min_per_stratum, max_per=max_per_stratum,
-                                 required=required)
+                                 required=required, forced=forced)
         exact = True
     elif method == "heuristic":
         raw, n_eval, consensus = _local_search(Gsearch, cand, m, top_K, unit_costs,
@@ -442,7 +490,7 @@ def select_treated_designs(
                                                conflict=conflict, strata=strata,
                                                min_per=min_per_stratum,
                                                max_per=max_per_stratum,
-                                               required=required)
+                                               required=required, forced=forced)
         exact = False
     else:
         raise ValueError(f"unknown method {method!r}")

--- a/mlsynth/utils/geolift_helpers/marketselect/helpers/feasibility.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/helpers/feasibility.py
@@ -1,0 +1,170 @@
+"""Up-front, itemised feasibility audit for GeoLift market selection.
+
+When the design constraints admit no candidate test region, the analyst needs to
+know *which* constraint bound the search -- not a catch-all "no candidate
+satisfies the constraints". This module reports every individually-infeasible
+constraint **together** in one :class:`MlsynthConfigError`, each line in a
+uniform ``have vs need -> minimal fix`` shape.
+
+It mirrors LEXSCM's :func:`mlsynth.utils.fast_scm_helpers.feasibility.audit_feasibility`
+(same shape, same contract: it *reports*, it never silently relaxes a constraint
+the analyst set), re-implemented label-based here so GeoLift owns its constraint
+layer. The audit is a no-op when the design is feasible.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Hashable, Iterable, List, Mapping, Optional
+
+from mlsynth.exceptions import MlsynthConfigError
+
+from .constraints import ConflictGraph
+
+
+def _greedy_independent_set_size(
+    markets: Iterable[Hashable], conflict: ConflictGraph
+) -> int:
+    """Greedy minimum-degree independent-set size over ``markets`` (a lower bound
+    on the maximum independent set).
+
+    Sound as a *necessary* feasibility signal: the true maximum is at least this,
+    so reporting ``largest < k`` only when the greedy bound itself falls short
+    would risk a false positive. For the pure-cluster conflict graph (the common
+    case) the greedy bound is exact -- it equals the number of distinct clusters
+    present -- so the reported number is the real largest conflict-free set there.
+    """
+    markets = list(markets)
+    remaining = set(markets)
+    chosen = 0
+    while remaining:
+        # pick the minimum-degree remaining market (fewest conflicts inside the set)
+        pick = min(remaining, key=lambda u: len(conflict.get(u, frozenset()) & remaining))
+        chosen += 1
+        remaining.discard(pick)
+        remaining -= conflict.get(pick, frozenset())
+    return chosen
+
+
+def audit_geolift_feasibility(
+    eligible: Iterable[Hashable],
+    treatment_size: int,
+    *,
+    conflict: Optional[ConflictGraph] = None,
+    stratum_map: Optional[Mapping[Hashable, Hashable]] = None,
+    min_per_stratum: Optional[int] = None,
+    max_per_stratum: Optional[int] = None,
+    required_strata: Optional[Iterable[Hashable]] = None,
+) -> None:
+    """Raise a single, itemised :class:`MlsynthConfigError` if any active design
+    constraint makes a size-``treatment_size`` treated set impossible. No-op when
+    feasible.
+
+    Parameters
+    ----------
+    eligible : iterable of hashable
+        Markets eligible for treatment (after the size band and
+        ``not_to_be_treated`` have been removed).
+    treatment_size : int
+        The requested number of treated markets ``k``.
+    conflict : ConflictGraph, optional
+        Cluster / adjacency conflict graph; a treated set must be an independent
+        set of it.
+    stratum_map : mapping, optional
+        ``{market: stratum}`` for the coverage quota.
+    min_per_stratum, max_per_stratum : int, optional
+        Coverage quota bounds.
+    required_strata : iterable, optional
+        The strata that ``min_per_stratum`` must cover (those with at least one
+        eligible market), supplied by the caller.
+    """
+    eligible = list(eligible)
+    M = len(eligible)
+    problems: List[str] = []
+
+    # 1. Candidate pool -- the precondition for everything else.
+    if M < treatment_size:
+        problems.append(
+            f"candidate pool: only {M} eligible market(s), but "
+            f"treatment_size={treatment_size}. Widen eligibility / the size band, "
+            f"or reduce treatment_size."
+        )
+        _raise(problems)        # the other checks are meaningless with too few units
+
+    # 2. Coverage / quota.
+    if stratum_map is not None:
+        problems += _quota_problems(
+            eligible, treatment_size, stratum_map,
+            min_per_stratum, max_per_stratum, required_strata,
+        )
+
+    # 3. Cluster / adjacency -- a treated set must be a size-k independent set.
+    if conflict is not None:
+        largest = _greedy_independent_set_size(eligible, conflict)
+        if largest < treatment_size:
+            problems.append(
+                f"spillover/cluster: the largest conflict-free treated set is "
+                f"{largest} < treatment_size={treatment_size}. Relax the "
+                f"cluster/adjacency constraint, widen the candidate pool, or "
+                f"reduce treatment_size."
+            )
+
+    _raise(problems)
+
+
+def _quota_problems(
+    eligible: List[Hashable],
+    k: int,
+    stratum_map: Mapping[Hashable, Hashable],
+    min_per: Optional[int],
+    max_per: Optional[int],
+    required: Optional[Iterable[Hashable]],
+) -> List[str]:
+    """Coverage/quota infeasibilities, each with its have-vs-need arithmetic."""
+    problems: List[str] = []
+    counts = Counter(
+        stratum_map[u] for u in eligible
+        if u in stratum_map and stratum_map[u] is not None
+    )
+
+    if min_per is not None and required is not None:
+        req = list(required)
+        need = min_per * len(req)
+        if need > k:
+            problems.append(
+                f"coverage: min_per_stratum={min_per} over {len(req)} required "
+                f"stratum(s) needs >= {need} treated market(s), but "
+                f"treatment_size={k}. Raise treatment_size to >= {need}, lower "
+                f"min_per_stratum, or shrink the universe."
+            )
+        short = sorted(
+            (str(s) for s in req if counts.get(s, 0) < min_per)
+        )
+        if short:
+            problems.append(
+                f"coverage: stratum(s) {short} have fewer than "
+                f"min_per_stratum={min_per} eligible market(s). Widen the "
+                f"universe / size band so each required stratum can supply "
+                f"{min_per}, or lower min_per_stratum."
+            )
+
+    if max_per is not None:
+        n_strata = len(counts)
+        cap = max_per * n_strata
+        if cap < k:
+            problems.append(
+                f"quota: max_per_stratum={max_per} over {n_strata} stratum(s) "
+                f"allows at most {cap} treated market(s), but treatment_size={k}. "
+                f"Raise max_per_stratum, add eligible strata, or reduce "
+                f"treatment_size."
+            )
+
+    return problems
+
+
+def _raise(problems: List[str]) -> None:
+    if problems:
+        raise MlsynthConfigError(
+            "GeoLift design is infeasible -- the binding constraint(s):\n  - "
+            + "\n  - ".join(problems)
+        )

--- a/mlsynth/utils/geolift_helpers/marketselect/orchestration.py
+++ b/mlsynth/utils/geolift_helpers/marketselect/orchestration.py
@@ -28,6 +28,7 @@ from .helpers.constraints import (
     eligible_by_size,
     unit_attribute_map,
 )
+from .helpers.feasibility import audit_geolift_feasibility
 from .helpers.design import design_fit, CandidateDesign
 
 
@@ -155,7 +156,19 @@ def run_design(config: GeoLiftConfig) -> GEOLIFTResults:
             max_per_stratum=config.max_per_stratum, required_strata=required_strata,
         )
         if not candidates:
-            raise MlsynthConfigError(
+            # No admissible region: report *which* constraint bound the search,
+            # itemised in have-vs-need shape, rather than a catch-all message.
+            audit_geolift_feasibility(
+                eligible_for_treatment, config.treatment_size,
+                conflict=conflict, stratum_map=stratum_map,
+                min_per_stratum=config.min_per_stratum,
+                max_per_stratum=config.max_per_stratum,
+                required_strata=required_strata,
+            )
+            # The audit's individual checks did not pinpoint the cause (a rare
+            # interaction of constraints, or forced-in markets that interfere);
+            # fall back to the catch-all so the failure is still reported.
+            raise MlsynthConfigError(            # pragma: no cover - audit covers the common cases
                 "no candidate test region satisfies the design constraints "
                 "(e.g. treatment_size exceeds the number of clusters/strata to "
                 "cover, or the forced-in markets interfere). Relax the constraint "

--- a/mlsynth/utils/marex_helpers/config.py
+++ b/mlsynth/utils/marex_helpers/config.py
@@ -113,6 +113,27 @@ class MAREXConfig(BaseMAREXConfig):
         "[min_size, max_size] lose treatment eligibility (stay donors).")
     min_size: Optional[float] = Field(default=None, description="Lower size bound.")
     max_size: Optional[float] = Field(default=None, description="Upper size bound.")
+    cluster_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit-constant column whose value defines an interference "
+        "cluster: at most one treated market per cluster value (a no-two-from-one-"
+        "cluster rule). Distinct from `cluster` (the design grouping); enforced as "
+        "conflict constraints on the treated set, the same as SYNDES/GeoLift's "
+        "cluster_col.")
+    stratum_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit-constant column defining coverage strata for a "
+        "treated-set quota via `min_per_stratum` / `max_per_stratum`. (For a "
+        "per-region representativeness target use `cluster`; this is a coverage "
+        "constraint on one design.)")
+    min_per_stratum: Optional[int] = Field(
+        default=None, ge=1,
+        description="At least this many treated markets in every stratum that has "
+        "a treatable member. Requires `stratum_col`.")
+    max_per_stratum: Optional[int] = Field(
+        default=None, ge=1,
+        description="At most this many treated markets per stratum. Requires "
+        "`stratum_col`.")
 
     # --- solution pool + power-based recommendation (mirrors SYNDES) ---
     top_K: int = Field(
@@ -147,6 +168,19 @@ class MAREXConfig(BaseMAREXConfig):
         default=0.80, gt=0.0, lt=1.0,
         description="Target power (1 - beta) for the MDE.",
     )
+
+    @model_validator(mode="after")
+    def _validate_geo_quota(self) -> "MAREXConfig":
+        if (self.min_per_stratum is not None or self.max_per_stratum is not None) \
+                and self.stratum_col is None:
+            raise MlsynthConfigError(
+                "min_per_stratum / max_per_stratum require `stratum_col`.")
+        if (self.min_per_stratum is not None and self.max_per_stratum is not None
+                and self.min_per_stratum > self.max_per_stratum):
+            raise MlsynthConfigError(
+                f"min_per_stratum ({self.min_per_stratum}) cannot exceed "
+                f"max_per_stratum ({self.max_per_stratum}).")
+        return self
 
     @model_validator(mode="after")
     def validate_design_params(cls, values: Any) -> Any:

--- a/mlsynth/utils/marex_helpers/optimization.py
+++ b/mlsynth/utils/marex_helpers/optimization.py
@@ -111,6 +111,28 @@ def solve_design(
     if w_opt is None or z_opt is None:
         raise MlsynthEstimationError(
             f"MAREX design is infeasible (solver status: {prob.status}).")
+
+    # Guard against a solver that reports "optimal" but returns a point that
+    # violates the integer cardinality (SCIP can do this intermittently on the
+    # harder constrained re-solves of the no-good-cut pool, yielding a degenerate
+    # all-units design). Reject such a solve so it never poisons the pool; the
+    # pool loop treats this as the feasible region being exhausted.
+    z_round = np.asarray(z_opt) > 0.5
+    for k_idx, lab in enumerate(cluster_labels):
+        members = cluster_members[k_idx]
+        sel = int(z_round[members, k_idx].sum())
+        me = get_per_cluster_param(m_eq, lab)
+        mn = get_per_cluster_param(m_min, lab)
+        mx = get_per_cluster_param(m_max, lab)
+        if ((me is not None and sel != int(me))
+                or (mn is not None and sel < int(mn))
+                or (mx is not None and sel > int(mx))):
+            raise MlsynthEstimationError(
+                f"MAREX solver returned a cardinality-violating design for "
+                f"cluster {lab!r} (selected {sel}; expected m_eq={me}, "
+                f"m_min={mn}, m_max={mx}); treating the feasible region as "
+                f"exhausted."
+            )
     Y_full_T = Y_full_np.T
     rmse_cluster = []
     for k_idx in range(K):

--- a/mlsynth/utils/marex_helpers/pool.py
+++ b/mlsynth/utils/marex_helpers/pool.py
@@ -24,8 +24,20 @@ def build_marex_pool(raws: List[Dict[str, Any]], *, alpha: float = 0.05,
         v_agg = np.asarray(raw["v_agg"], dtype=float)
         labels = (list(df.index) if hasattr(df, "index")
                   else list(range(w_agg.size)))
+        # Treated/control identity comes from the integer selection ``z`` (mapped
+        # through the unit order), NOT from thresholding the continuous weights:
+        # a solver can leak tiny weights (~1e-7) onto non-selected units, which
+        # would otherwise misreport the treated set. Zeroing the leakage against
+        # ``z`` also cleans the contrast used for fit / power.
+        z_opt = raw.get("z_opt")
+        if z_opt is not None:
+            treated_mask = (np.asarray(z_opt) > 0.5).any(axis=1)
+        else:                                       # pragma: no cover - z always present
+            treated_mask = w_agg > 1e-8
+        w_agg = np.where(treated_mask, w_agg, 0.0)
+        v_agg = np.where(treated_mask, 0.0, v_agg)
         contrast = w_agg - v_agg
-        treated_idx = np.where(w_agg > 1e-8)[0]
+        treated_idx = np.where(treated_mask)[0]
         control_idx = np.where(v_agg > 1e-8)[0]
         markets = [str(labels[i]) for i in treated_idx]
         control_group = [str(labels[i]) for i in control_idx]

--- a/mlsynth/utils/marex_helpers/restrictions.py
+++ b/mlsynth/utils/marex_helpers/restrictions.py
@@ -74,6 +74,14 @@ def apply_restrictions_marex(z: Any, v: Any, M: np.ndarray,
         cons.append(cp.sum(z[j, :]) == 0)
     for i, j in restrictions.conflict_pairs:
         cons.append(cp.sum(z[i, :]) + cp.sum(z[j, :]) <= 1)
+    # Stratum coverage quotas: a unit's treated indicator is sum_k z[j,k], so the
+    # treated count in a stratum is the sum of z over its members across clusters.
+    for members, lo, hi in restrictions.strata:
+        treated_in_stratum = cp.sum(z[list(members), :])
+        if lo is not None:
+            cons.append(treated_in_stratum >= lo)
+        if hi is not None:
+            cons.append(treated_in_stratum <= hi)
     # Donor (control) exclusion: "if i is treated, j may not be its donor". MAREX
     # builds one control synthetic per cluster, so a donor for treated unit i is a
     # control unit in i's cluster; the exclusion only binds when i and j share a


### PR DESCRIPTION
Makes the full geographic-design constraint vocabulary — forced/forbidden markets, cluster (no-two-from-one), adjacency/spillover, coverage quotas, and size bands — honoured by every design method (SYNDES, GEOLIFT, LEXSCM, MAREX), and routes them uniformly through `compare_methods`. SYNDES and GeoLift already had the full set; this closes the gaps in LEXSCM and MAREX and makes the comparison wrapper apply one constraint set to all.

## Changes

- GeoLift: the catch-all "no candidate test region satisfies the design constraints" error is replaced by an itemised audit (mirroring LEXSCM's `audit_feasibility`) that names every binding constraint in `have vs need` shape — candidate pool, coverage arithmetic (`min_per_stratum` × strata), per-stratum cap, and the largest conflict-free set vs `treatment_size`.
- LEXSCM: adds `to_be_treated` / `not_to_be_treated` (the only gap vs SYNDES/GeoLift). Forced-in markets are pinned into every selected tuple in both the exact-enumeration and heuristic search paths; forbidden markets leave the treatment pool but stay donors.
- MAREX: adds `cluster_col` (no-two-from-one-cluster, distinct from the `cluster` design grouping) and `stratum_col` + `min`/`max_per_stratum` coverage quotas, as linear constraints on the binary selection `z`. Also hardens the MAREX solution pool, which this exposed: the no-good-cut re-solves now receive the restrictions; `solve_design` rejects a solver-returned design that violates the integer cardinality (SCIP can intermittently report such a point as optimal); and the pool derives treated/control identity from the integer selection `z` rather than thresholding continuous weights a solver can leak mass onto.
- `compare_methods`: new `constraints=` kwarg routes one constraint set to every requested method (per-method `*_options` still override), so a constraint binds the whole comparison instead of being hand-coded per method.

## Tests

New, test-first: `test_geolift_feasibility.py` (10), `test_lexscm_forced.py` (12), `test_marex_cluster_stratum.py` (6), `test_compare_methods_constraints.py` (5). Full suite green: 4557 passed, 1 skipped.

## Docs

`lexscm.rst`, `marex.rst`, `geolift.rst`, and the `choose.rst` decision tree updated so the constraint vocabulary and the itemised diagnostic are documented and attributed to all four methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_