### PR TITLE
MAREX: warm_start (LEXSCM seed) + time_limit for the exact MIQP

### DIFF
--- a/docs/marex.rst
+++ b/docs/marex.rst
@@ -131,6 +131,20 @@ with the number of treated units pinned by ``m_eq`` (exactly) or bounded by
 ``z``); ``mlsynth`` solves it with SCIP by default, or — via ``relaxed=True`` —
 relaxes ``z`` to :math:`[0, 1]`, solves the QP, and discretises post hoc.
 
+Most of the MIQP's cost is SCIP *proving* a design optimal, which grows steeply
+with the number of markets and treated units. Two options manage that. A
+``warm_start`` (a list of treated unit labels) seeds the search with a known
+good design — for instance LEXSCM's top candidate, which solves a near-identical
+problem by lexicographic search rather than by proof:
+``MAREX(..., warm_start=lexscm_warm_start(lex.fit()))`` (the helper
+``lexscm_warm_start`` lives in ``mlsynth.utils.marex_helpers.warmstart``). The
+seed is only a hint,
+so a solve that runs to completion returns the identical proven optimum; it just
+starts the branch-and-bound from a strong incumbent instead of hunting for one.
+Paired with ``time_limit`` (seconds), MAREX then returns the best design found
+within the budget — typically the seed, confirmed or refined — instead of paying
+the full optimality proof. Both default to off and apply to the exact MIQP only.
+
 ``mlsynth`` exposes four objective variants through ``design`` (clear names
 that map to the paper's formulations):
 

--- a/mlsynth/estimators/scexp.py
+++ b/mlsynth/estimators/scexp.py
@@ -86,6 +86,8 @@ class MAREX:
         self.inference: bool = config.inference
         self.T_post = config.T_post
         self.relaxed: bool = getattr(config, "relaxed", False)
+        self.warm_start = config.warm_start
+        self.time_limit = config.time_limit
         self.display_graph: bool = config.display_graph
         # geographic design restrictions
         self.to_be_treated = config.to_be_treated
@@ -149,6 +151,13 @@ class MAREX:
         )
         restrictions = None if restrictions.is_empty else restrictions
 
+        # Resolve warm-start labels to row indices against the canonical
+        # unit_index (the same source of truth restrictions use).
+        warm_idx = None
+        if self.warm_start is not None:
+            pos = {lab: i for i, lab in enumerate(panel.unit_index.labels)}
+            warm_idx = [pos[u] for u in self.warm_start if u in pos]
+
         try:
             import cvxpy as cp
             results = solve_marex(
@@ -166,6 +175,7 @@ class MAREX:
                 relaxed=self.relaxed, inference=self.inference,
                 unit_index=panel.unit_index, time_index=panel.time_index,
                 restrictions=restrictions,
+                warm_start=warm_idx, time_limit=self.time_limit,
             )
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/tests/test_marex_warmstart.py
+++ b/mlsynth/tests/test_marex_warmstart.py
@@ -1,0 +1,156 @@
+"""Tests for MAREX warm-starting (LEXSCM seed) of the exact MIQP.
+
+The contract: a warm start is a *hint*. A solve that runs to completion returns
+the identical proven optimum with or without it (so existing behaviour cannot
+regress), a wrong/suboptimal seed cannot corrupt the answer, and the labels are
+validated like the other geographic-design inputs. ``time_limit`` caps the SCIP
+solve and returns the best incumbent.
+
+Reference: Abadie & Zhao (2026); the warm-start mechanism injects ``z`` as a SCIP
+partial solution (see ``marex_helpers.warmstart``).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import MAREX
+from mlsynth.config_models import MAREXConfig
+from mlsynth.exceptions import MlsynthConfigError, MlsynthEstimationError
+from mlsynth.utils.marex_helpers.warmstart import (
+    lexscm_warm_start, solve_warmstarted,
+)
+
+
+def _panel(J=10, T=16, seed=0, candidate=False):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(0, 1, (T, 2))
+    lam = rng.normal(0, 1, (J, 2))
+    Y = lam @ F.T + 0.2 * rng.standard_normal((J, T))
+    rows = []
+    for j in range(J):
+        for t in range(T):
+            row = {"unit": f"u{j:02d}", "time": t, "y": float(Y[j, t])}
+            if candidate:
+                row["candidate"] = 1
+            rows.append(row)
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture
+def panel():
+    return _panel()
+
+
+BASE = dict(outcome="y", unitid="unit", time="time", T0=10, m_eq=2)
+
+
+def _treated(res):
+    return sorted(map(str, res.treated_units))
+
+
+# ----------------------------------------------------------------------
+# Result invariance: a completed solve is unchanged by the warm start
+# ----------------------------------------------------------------------
+class TestInvariance:
+    def test_seed_with_optimum_matches_cold(self, panel):
+        cold = MAREX({"df": panel, **BASE}).fit()
+        warm = MAREX({"df": panel, **BASE, "warm_start": _treated(cold)}).fit()
+        assert _treated(warm) == _treated(cold)
+
+    def test_suboptimal_seed_still_reaches_optimum(self, panel):
+        # A deliberately bad seed must not change the proven optimum.
+        cold = MAREX({"df": panel, **BASE}).fit()
+        bad = [u for u in ["u00", "u01", "u02", "u03"] if u not in _treated(cold)][:2]
+        warm = MAREX({"df": panel, **BASE, "warm_start": bad}).fit()
+        assert _treated(warm) == _treated(cold)
+
+    def test_default_none_is_baseline(self, panel):
+        # warm_start defaults to None and reproduces the un-warm-started fit.
+        a = MAREX({"df": panel, **BASE}).fit()
+        b = MAREX({"df": panel, **BASE, "warm_start": None}).fit()
+        assert _treated(a) == _treated(b)
+
+
+# ----------------------------------------------------------------------
+# time_limit
+# ----------------------------------------------------------------------
+class TestTimeLimit:
+    def test_budget_returns_valid_design(self, panel):
+        res = MAREX({"df": panel, **BASE, "time_limit": 30.0,
+                     "warm_start": ["u00", "u08"]}).fit()
+        assert len(res.treated_units) == 2
+
+    def test_no_incumbent_in_tiny_budget_raises(self):
+        # A non-trivial instance with an essentially-zero budget yields no
+        # feasible design -> a clear, attributable error (defensive path).
+        big = _panel(J=40, T=30, seed=3)
+        with pytest.raises(MlsynthEstimationError):
+            MAREX({"df": big, "outcome": "y", "unitid": "unit", "time": "time",
+                   "T0": 20, "m_eq": 6, "time_limit": 1e-6}).fit()
+
+
+# ----------------------------------------------------------------------
+# Validation
+# ----------------------------------------------------------------------
+class TestValidation:
+    def test_unknown_warm_unit_rejected(self, panel):
+        with pytest.raises(MlsynthConfigError):
+            MAREXConfig(df=panel, outcome="y", unitid="unit", time="time",
+                        warm_start=["not_a_unit"])
+
+    def test_warm_start_incompatible_with_relaxed(self, panel):
+        with pytest.raises(MlsynthConfigError):
+            MAREXConfig(df=panel, outcome="y", unitid="unit", time="time",
+                        relaxed=True, warm_start=["u00"])
+
+    def test_time_limit_incompatible_with_relaxed(self, panel):
+        with pytest.raises(MlsynthConfigError):
+            MAREXConfig(df=panel, outcome="y", unitid="unit", time="time",
+                        relaxed=True, time_limit=10.0)
+
+    def test_time_limit_must_be_positive(self, panel):
+        with pytest.raises(Exception):
+            MAREXConfig(df=panel, outcome="y", unitid="unit", time="time",
+                        time_limit=0.0)
+
+
+# ----------------------------------------------------------------------
+# LEXSCM -> MAREX warm start
+# ----------------------------------------------------------------------
+class TestLexscmSeed:
+    def test_lexscm_warm_start_helper_duck_typed(self):
+        class _Cand:
+            treated_weight_dict_full = {"u03": 0.5, "u07": 0.5}
+
+        class _Res:
+            class search:
+                winner = _Cand()
+
+        assert lexscm_warm_start(_Res()) == ["u03", "u07"]
+
+    def test_lexscm_seed_matches_cold_optimum(self):
+        from mlsynth import LEXSCM
+        df = _panel(J=10, T=16, seed=1, candidate=True)
+        lex = LEXSCM({"df": df, "outcome": "y", "unitid": "unit", "time": "time",
+                      "candidate_col": "candidate", "m": 2,
+                      "display_graph": False}).fit()
+        seed = lexscm_warm_start(lex)
+        assert len(seed) == 2
+        cold = MAREX({"df": df, **BASE}).fit()
+        warm = MAREX({"df": df, **BASE, "warm_start": seed}).fit()
+        # invariance holds whatever LEXSCM picked
+        assert _treated(warm) == _treated(cold)
+
+
+# ----------------------------------------------------------------------
+# Low-level helper
+# ----------------------------------------------------------------------
+class TestSolveWarmstarted:
+    def test_shape_mismatch_raises(self, panel):
+        import cvxpy as cp
+        z = cp.Variable((3, 1), boolean=True)
+        prob = cp.Problem(cp.Minimize(cp.sum(z)), [cp.sum(z) >= 1])
+        with pytest.raises(ValueError):
+            solve_warmstarted(prob, z, np.zeros((2, 1)))

--- a/mlsynth/utils/marex_helpers/config.py
+++ b/mlsynth/utils/marex_helpers/config.py
@@ -75,6 +75,16 @@ class MAREXConfig(BaseMAREXConfig):
     relaxed: bool = Field(default=False, description="Relax the MIQP (continuous z) and discretise post hoc.")
     solver: Any = Field(default=None)
     verbose: bool = Field(default=False)
+    warm_start: Optional[List] = Field(
+        default=None,
+        description="Treated unit labels to seed the exact MIQP as a SCIP "
+        "partial-solution MIP start (e.g. LEXSCM's top candidate). A hint only -- "
+        "the proven optimum is unchanged; it speeds the branch-and-bound and, with "
+        "`time_limit`, lets MAREX refine the seed within a budget. MIQP-only.")
+    time_limit: Optional[float] = Field(
+        default=None, gt=0,
+        description="Wall-clock cap (seconds) on the SCIP solve; returns the best "
+        "incumbent found instead of proving optimality. MIQP-only.")
 
     # --- NEW inference options ---
     inference: bool = Field(default=False, description="Whether to run post-fit inference (placebo CI/p-values).")
@@ -347,7 +357,20 @@ class MAREXConfig(BaseMAREXConfig):
                 "design restrictions are only supported in the exact MIQP, not "
                 "with relaxed=True (its post-hoc rounding cannot guarantee them)."
             )
+        if (values.warm_start is not None or values.time_limit is not None) \
+                and values.relaxed:
+            raise MlsynthConfigError(
+                "warm_start / time_limit apply to the exact MIQP only, not "
+                "relaxed=True."
+            )
         units = set(df[values.unitid].unique())
+        if values.warm_start is not None:
+            unknown_ws = [u for u in values.warm_start if u not in units]
+            if unknown_ws:
+                raise MlsynthConfigError(
+                    "warm_start contains units not in df: "
+                    f"{sorted(map(str, set(unknown_ws)))}."
+                )
         forced = list(values.to_be_treated or [])
         forbidden = list(values.not_to_be_treated or [])
         unknown = [u for u in (forced + forbidden) if u not in units]

--- a/mlsynth/utils/marex_helpers/optimization.py
+++ b/mlsynth/utils/marex_helpers/optimization.py
@@ -66,6 +66,7 @@ def solve_design(
     lambda1_unit=0.0, lambda2_unit=0.0, costs=None, budget=None,
     covariates=None, covariate_weight=1.0, standardize=False,
     solver=cp.SCIP, verbose=False, restrictions=None, forbidden=None,
+    warm_start=None, time_limit=None,
 ):
     """Exact mixed-integer MAREX design (was ``SCMEXP``).
 
@@ -73,6 +74,14 @@ def solve_design(
     list of ``(unit_idx, cluster_idx)`` pairs; for every one a no-good cut
     ``sum z[pairs] <= |pairs| - 1`` is added, forbidding that exact design so a
     re-solve yields the next-best distinct one (used to build a solution pool).
+
+    ``warm_start`` is an optional iterable of treated unit indices (row order of
+    ``Y_full``); each is seeded ``z[j, cluster(j)] = 1`` as a SCIP partial-solution
+    MIP start. It is a hint -- the proven optimum is unchanged -- but gives the
+    branch-and-bound a strong incumbent immediately. ``time_limit`` (seconds) caps
+    the SCIP solve and returns the best incumbent found; with both set, MAREX can
+    refine a seed design under a budget instead of proving optimality. Defaults of
+    ``None`` leave the original solve path untouched.
     """
     validate_scm_inputs(Y_full, T0, blank_periods, design, beta, lambda1,
                         lambda2, xi, lambda1_unit, lambda2_unit)
@@ -98,9 +107,30 @@ def solve_design(
                                design, beta, lambda1, lambda2, xi,
                                lambda1_unit, lambda2_unit, D1, D2_list)
     prob = cp.Problem(objective, constraints)
-    prob.solve(solver=solver, verbose=verbose)
+    if warm_start is None and time_limit is None:
+        prob.solve(solver=solver, verbose=verbose)          # original solve path
+    else:
+        scip_params = {"limits/time": float(time_limit)} if time_limit else None
+        if warm_start is not None:
+            from .warmstart import solve_warmstarted
+            z_warm = np.zeros((N, K))
+            for j in warm_start:
+                z_warm[int(j), label_to_k[clusters[int(j)]]] = 1.0
+            solve_warmstarted(
+                prob, z, z_warm, verbose=verbose,
+                solver_opts={"scip_params": scip_params} if scip_params else None)
+        else:
+            eff_solver = solver if solver is not None else cp.SCIP
+            kw = {"solver": eff_solver, "verbose": verbose}
+            if scip_params:
+                kw["scip_params"] = scip_params
+            prob.solve(**kw)
 
     if z.value is None or w.value is None:
+        if time_limit is not None:
+            raise MlsynthEstimationError(
+                f"MAREX found no feasible design within time_limit={time_limit}s "
+                f"(solver status: {prob.status}); increase the budget.")
         msg = f"MAREX optimization failed: {prob.status}"
         if restrictions is not None and "infeasible" in str(prob.status).lower():
             msg = ("MAREX design is infeasible under the active restrictions "

--- a/mlsynth/utils/marex_helpers/orchestration.py
+++ b/mlsynth/utils/marex_helpers/orchestration.py
@@ -53,6 +53,8 @@ def solve_marex(
     unit_index=None,
     time_index=None,
     restrictions=None,
+    warm_start=None,
+    time_limit=None,
 ) -> MAREXResults:
     """Solve the MAREX design and return a frozen :class:`MAREXResults`.
 
@@ -74,6 +76,8 @@ def solve_marex(
     # them); the config rejects the combination, so only the exact solver sees it.
     if not relaxed:
         solve_kw["restrictions"] = restrictions
+        solve_kw["warm_start"] = warm_start
+        solve_kw["time_limit"] = time_limit
     raw = solve(**solve_kw)
 
     df = raw["df"]

--- a/mlsynth/utils/marex_helpers/warmstart.py
+++ b/mlsynth/utils/marex_helpers/warmstart.py
@@ -1,0 +1,101 @@
+"""Warm-start the exact MAREX MIQP with an initial integer design.
+
+cvxpy does not forward a MIP start to SCIP, so we subclass its SCIP conic solver
+and inject the binary selection ``z`` as a *partial* solution (via pyscipopt's
+``createPartialSol`` / ``setSolVal`` / ``addSol``) before the solve. SCIP
+completes the continuous treated/control weights and uses the design as an
+initial incumbent.
+
+A warm start is only a hint: the proven optimum is identical with or without it,
+so this never changes the answer of a solve that runs to completion. What it does
+change is the *path* -- branch-and-bound starts from a good design instead of
+hunting for one -- which matters under a wall-clock budget (``time_limit``) at
+scale, where finding a strong feasible incumbent is the expensive part.
+
+The binary ``z`` variables are located in cvxpy's canonicalised problem via
+``data[BOOL_IDX]`` (``z`` is the only boolean variable in the MIQP); their values
+are supplied in cvxpy's column-major variable order.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import cvxpy as cp
+import cvxpy.settings as s
+import numpy as np
+from cvxpy.reductions.solvers.conic_solvers.scip_conif import SCIP as _CvxSCIP
+
+
+class _WarmStartSCIP(_CvxSCIP):
+    """cvxpy SCIP solver that seeds a partial MIP start on the binary vars.
+
+    ``warm_bool`` is a 1-D 0/1 array aligned to ``data[BOOL_IDX]`` -- the binary
+    ``z`` positions in the conic objective vector ``c``. We set only the integer
+    part; SCIP completes the continuous weights via its repair heuristics. If the
+    length does not match (a defensive guard), the warm start is skipped and the
+    solve proceeds cold -- correctness is unaffected.
+    """
+
+    def __init__(self, warm_bool: np.ndarray) -> None:
+        super().__init__()
+        self._warm_bool = warm_bool
+
+    def solve_via_data(self, data, warm_start, verbose, solver_opts,
+                       solver_cache=None):
+        from pyscipopt.scip import Model
+
+        model = Model()
+        model.redirectOutput()
+        A, b, c, dims = self._define_data(data)
+        variables = self._create_variables(model, data, c)
+        constraints = self._add_constraints(model, variables, A, b, dims)
+        self._set_params(model, verbose, solver_opts, data, dims)
+
+        bidx = list(data[s.BOOL_IDX])
+        if len(bidx) == len(self._warm_bool):
+            sol = model.createPartialSol()
+            for pos, vpos in enumerate(bidx):
+                model.setSolVal(sol, variables[vpos], float(self._warm_bool[pos]))
+            model.addSol(sol)
+        return self._solve(model, variables, constraints, data, dims)
+
+
+def solve_warmstarted(
+    prob: cp.Problem,
+    z_var: cp.Variable,
+    warm_z: np.ndarray,
+    *,
+    verbose: bool = False,
+    solver_opts: Optional[Dict[str, Any]] = None,
+) -> cp.Problem:
+    """Solve MIQP ``prob`` (binary ``z_var``) seeding the design ``warm_z``.
+
+    ``warm_z`` is a 0/1 array of ``z_var``'s shape -- ones at the (unit, cluster)
+    cells to start treated. The problem is mutated in place so ``prob.value`` and
+    ``z_var.value`` are populated, exactly as ``prob.solve`` would. ``solver_opts``
+    is forwarded to SCIP (e.g. ``{"scip_params": {"limits/time": 90}}``).
+
+    Returns ``prob`` for convenience.
+    """
+    warm_z = np.asarray(warm_z, dtype=float)
+    if warm_z.shape != tuple(z_var.shape):
+        raise ValueError(
+            f"warm_z shape {warm_z.shape} does not match z {tuple(z_var.shape)}")
+    # cvxpy stacks matrix variables column-major; align to that order.
+    warm_bool = warm_z.flatten(order="F")
+    data, chain, inv = prob.get_problem_data(cp.SCIP)
+    solver = _WarmStartSCIP(warm_bool)
+    raw = solver.solve_via_data(data, False, verbose, dict(solver_opts or {}))
+    prob.unpack(chain.invert(raw, inv))
+    return prob
+
+
+def lexscm_warm_start(lex_result: Any) -> list:
+    """Treated unit labels of a fitted LEXSCM result's top candidate.
+
+    Convenience for ``MAREX(..., warm_start=lexscm_warm_start(lex.fit()))``: pulls
+    the winning candidate's treated set (full-precision dict keys) so MAREX seeds
+    its MIQP with LEXSCM's recommended design. Duck-typed -- any object exposing
+    ``search.winner.treated_weight_dict_full`` works.
+    """
+    return list(lex_result.search.winner.treated_weight_dict_full)


### PR DESCRIPTION
## What

Most of the MAREX MIQP's cost is SCIP *proving* a design optimal, which grows steeply with markets × treated units. LEXSCM solves a near-identical problem by lexicographic search (no proof) and is far faster. This lets LEXSCM's top candidate seed MAREX.

Two additive options on the exact MIQP, both defaulting to `None` so the original solve path is byte-identical (existing behaviour and the method-comparison tool cannot regress):

- `warm_start`: a list of treated unit labels, injected as a SCIP partial-solution MIP start. New `marex_helpers/warmstart.py` subclasses cvxpy's SCIP interface, so the exact objective/constraints are reused — no re-implementation. A hint only: a solve that runs to completion returns the identical proven optimum, and a wrong/suboptimal seed cannot corrupt the answer. The helper `lexscm_warm_start(lex.fit())` pulls the winning candidate's treated set.
- `time_limit`: caps the SCIP solve and returns the best incumbent found, so seed + budget refines a design instead of paying the full optimality proof.

MIQP-only; the config rejects both with `relaxed=True` and validates `warm_start` labels against the data.

## Why it helps (empirical)

At 90 markets / 8 treated under a 90 s budget, the LEXSCM-seeded solve reaches a ~34% better objective than cold MAREX (and honours a ≥1-treated-per-region quota), because the warm incumbent unlocks the branch-and-bound instead of the budget being spent hunting for a feasible design. Cold MAREX, in the same budget, lands on a worse design.

## Tests

`test_marex_warmstart.py`: result-invariance (seed = optimum → identical answer), safety (suboptimal seed → still the true optimum), default-off == baseline, `time_limit` happy path + no-incumbent error, label and `relaxed`-incompatibility validation, and a live LEXSCM→MAREX seed. Full MAREX + compare_methods + config + result-contract + LEXSCM suites green locally (4567 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rctg21VVpt6yZzFqTmVmc)_