### PR TITLE
SYNDES: accelerate the large two-way MIP with the SDP bound as a valid cut

### DIFF
--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -506,6 +506,17 @@ and defaults them to the production-friendly setting:
   ``lower_bound`` :math:`\le` optimum :math:`\le` incumbent. The per-unit
   objective has an :math:`(N, N)` weight matrix, so no cheap tight bound exists;
   it returns ``certified=False`` rather than a misleading number.
+* ``accelerate`` (default ``True``) -- inject that same two-way SDP lower bound
+  back into the solve *as a valid cut* (plus a deterministic LEXSCM warm start),
+  so SCIP's dual bound is lifted to the SDP bound and the ordinary ``gap_limit``
+  certifies against it instead of the loose McCormick relaxation. Size-gated and
+  automatic (see "Accelerating the solve" below): it engages only for
+  ``two_way_global`` with an explicit ``K`` when the treated-tuple count
+  :math:`\binom{N}{K}` exceeds ``accel_min_tuples`` and :math:`N \le`
+  ``certify_sdp_n_max``, and is a no-op otherwise (small problems solve exactly,
+  unchanged). Unlike ``certify`` (a passive diagnostic), this changes the *path*
+  the solver takes, not the problem: the returned design is certified to
+  ``gap_limit`` against the SDP bound.
 
 This certificate is an mlsynth addition, not part of Doudchenko et al. (2021):
 the paper proves the design NP-hard and gives the mixed-integer program but
@@ -657,6 +668,50 @@ i.e. :math:`O(N^4)` -- intractable -- while the continuous relaxation is ~70%
 loose. Per-unit therefore returns ``certified=False`` with the valid-but-loose
 continuous bound. The two-way lift is :math:`O(N^3)`, which is what
 ``certify_sdp_n_max`` guards.
+
+Accelerating the solve
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``certify`` reports the SDP gap *beside* the solver. ``accelerate`` (default
+``True`` for the large two-way solve) feeds the same bound *into* it. Because the
+canonical two-way objective is minimized as an epigraph variable :math:`t` (with
+:math:`t \ge` the quadratic), adding the single linear constraint
+
+.. math::
+
+   t \;\ge\; L, \qquad L \coloneqq (1 - \varepsilon)\, p_{\mathrm{SDP}},
+
+lifts every node relaxation -- and hence SCIP's global dual bound -- to :math:`L`.
+The cut is valid whenever :math:`L \le p^\star`: no feasible design has objective
+below the optimum, so none is removed. Since :math:`p_{\mathrm{SDP}} \le p^\star`,
+the small safety margin :math:`\varepsilon` (``accel_safety_margin``, default
+:math:`0.01`) keeps :math:`L` a valid lower bound even under the first-order SDP
+solver's tolerance -- a too-high :math:`L` would inflate :math:`t` and return a
+garbage design, so the margin is a correctness requirement, not a tuning knob.
+As a backstop, if a bad :math:`L` ever pushes the recovered objective below the
+cut floor, the solve drops the cut and re-solves, so correctness always holds.
+
+With the dual bound sitting at :math:`L`, the ordinary ``gap_limit`` now measures
+against a *tight* bound: SCIP terminates as soon as the incumbent (seeded by the
+LEXSCM warm start, the same primal MAREX uses) is within ``gap_limit`` of
+:math:`L`, rather than climbing the McCormick bound for minutes to prove the same
+thing. The floor on the achievable gap is the SDP integrality gap itself
+(:math:`\sim 2\text{--}4\%`), so ``gap_limit`` below that will not terminate early
+-- set it at or above the certified gap you saw from ``certify``.
+
+The mechanism only helps in the sense of an early, *certified* stop -- it does not
+make SCIP prove exact optimality faster (the dual bound cannot climb above
+:math:`L` on its own). So ``accelerate`` is a size-gated change to the returned
+design's *contract*: at :math:`\binom{N}{K}` below ``accel_min_tuples`` the exact
+MIP is small and solved directly (unchanged, proven-optimal); above it -- where
+the exact two-way MIP does not terminate at any practical size, since the
+McCormick dual never closes -- SYNDES returns a design certified to ``gap_limit``
+against the SDP bound. On a two-way :math:`N = 100,\ K = 5` panel this turns a 60s
+time-out (an uncertified incumbent) into a :math:`\sim 25\text{s}` solve that SCIP
+*terminates* with a certified :math:`\sim 3\%` gap. This is an mlsynth addition,
+not part of Doudchenko et al. (2021); the shared machinery lives in
+:mod:`mlsynth.utils.miqp_accel` so other exact designs (MAREX, and the GEDI
+experimentation wrapper) can adopt it.
 
 Multiple Treatment Arms
 -----------------------

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -331,6 +331,9 @@ class SYNDES:
         self.time_limit: Optional[float] = config.time_limit
         self.certify: bool = config.certify
         self.certify_sdp_n_max: int = config.certify_sdp_n_max
+        self.accelerate: bool = config.accelerate
+        self.accel_min_tuples: int = config.accel_min_tuples
+        self.accel_safety_margin: float = config.accel_safety_margin
         self.relaxed_max_iter: int = config.relaxed_max_iter
         self.relaxed_decay: float = config.relaxed_decay
         self.display_graph: bool = config.display_graph
@@ -484,6 +487,30 @@ class SYNDES:
                 "requested K. Relax the restrictions or reduce K."
             )
 
+    def _accel_kwargs(self, inputs, mode_internal) -> dict:
+        """Warm start + SDP objective cut for the eligible large two-way solve.
+
+        Size-gated auto policy (see ``SYNDESConfig.accelerate``): engages only for
+        two-way with an explicit ``K`` when the treated-tuple count ``C(N, K)``
+        exceeds ``accel_min_tuples`` and ``N <= certify_sdp_n_max``. Returns the
+        extra ``solve_synthetic_design`` kwargs, or an empty dict (no-op) so small
+        problems solve exactly, unchanged. Only the plain single-solve path is
+        accelerated; the pool / holdout / ic selectors are left untouched.
+        """
+        if not self.accelerate or mode_internal != "global_2way" or self.K is None:
+            return {}
+        from math import comb
+        N = int(inputs.Y_pre.shape[1])
+        if N > self.certify_sdp_n_max:
+            return {}
+        if comb(N, int(self.K)) <= self.accel_min_tuples:
+            return {}
+        from ..utils.syndes_helpers.accelerate import two_way_accel_inputs
+        warm_D, L_safe = two_way_accel_inputs(
+            inputs.Y_pre, self.K, self.lam, margin=self.accel_safety_margin,
+        )
+        return {"warm_start_D": warm_D, "objective_lower_bound": L_safe}
+
     def _fit_mip(self, inputs, restrictions=None) -> SYNDESResults:
         mode_internal = _MODE_TO_INTERNAL[self.mode_public]
 
@@ -529,7 +556,8 @@ class SYNDES:
             design = pool_designs[0]
             pool = _syndes_pool_menu(pool_designs, inputs, self.costs, self.alpha)
         else:
-            design = solve_synthetic_design(**solve_kw)
+            design = solve_synthetic_design(
+                **solve_kw, **self._accel_kwargs(inputs, mode_internal))
 
         # Re-tag with the paper-aligned mode label so the design surface
         # the user sees uses SYNDES vocabulary.

--- a/mlsynth/tests/test_miqp_accel.py
+++ b/mlsynth/tests/test_miqp_accel.py
@@ -1,0 +1,117 @@
+"""Tests for the shared warm-start + objective-cut MIQP accelerator.
+
+``mlsynth.utils.miqp_accel.solve_warm_cut`` injects two things into cvxpy's SCIP
+solve that cvxpy does not forward on its own:
+
+* a *warm start* -- a binary MIP start (an initial incumbent), and
+* a valid *objective lower-bound cut* ``c^T x >= L`` -- which raises SCIP's dual
+  bound to ``L`` so the existing gap tolerance certifies against a tight bound
+  instead of SCIP's loose McCormick relaxation.
+
+The contract these tests pin:
+
+* neither injection changes the proven optimum (both are valid);
+* the cut actually raises the reported dual bound to ``L``;
+* a too-high (invalid) ``L`` is caught -- the solve falls back to the un-cut
+  problem and still returns the true optimum rather than a wrong/infeasible one;
+* the warm-start shape guard fires on a mismatch.
+"""
+import numpy as np
+import cvxpy as cp
+import pytest
+
+from mlsynth.utils.miqp_accel import solve_warm_cut, AccelInfo
+from mlsynth.utils.syndes_helpers.formulation import build_syndes_problem_components
+from mlsynth.utils.syndes_helpers.optimization import estimate_lambda
+from mlsynth.utils.syndes_helpers.certificate import _sdp_moment_bound_two_way
+
+
+def _make(N=7, K=2, T=10, seed=1):
+    """Deterministic small two-way instance; returns (Y, lam, builder)."""
+    rng = np.random.default_rng(seed)
+    Y = rng.standard_normal((T, N))
+    lam = float(estimate_lambda(Y))
+
+    def build():
+        D = cp.Variable(N, boolean=True)
+        comp = build_syndes_problem_components(Y=Y, D=D, K=K, lam=lam, mode="global_2way")
+        prob = cp.Problem(cp.Minimize(comp.objective), list(comp.constraints))
+        return prob, D
+
+    return Y, lam, build
+
+
+def _plain_opt(build):
+    prob, _ = build()
+    prob.solve(solver=cp.SCIP)
+    return float(prob.value)
+
+
+class TestSolveWarmCut:
+    def test_neutral_no_warm_no_cut_matches_plain(self):
+        """With neither injection the objective matches a plain SCIP solve."""
+        _, _, build = _make()
+        ref = _plain_opt(build)
+        prob, D = build()
+        prob, info = solve_warm_cut(prob, D, time_limit=30.0)
+        assert isinstance(info, AccelInfo)
+        assert not info.cut_applied and not info.warm_applied and not info.fell_back
+        assert prob.value == pytest.approx(ref, abs=1e-4)
+
+    def test_cut_raises_dual_bound_and_keeps_optimum(self):
+        """A valid SDP lower bound, injected as a cut, raises the dual bound to L
+        without changing the optimum."""
+        Y, lam, build = _make()
+        ref = _plain_opt(build)
+        L = _sdp_moment_bound_two_way(Y, K=2, lam=lam)
+        L_cut = L * 0.99                      # safety-margined, still valid
+        prob, D = build()
+        prob, info = solve_warm_cut(prob, D, objective_lower_bound=L_cut,
+                                    gap_limit=1e-4, time_limit=30.0)
+        assert info.cut_applied and not info.fell_back
+        # dual bound lifted to (at least) the injected cut
+        assert info.dual_bound >= L_cut - 1e-6
+        # the returned design still respects the bound and equals the true optimum
+        assert prob.value >= L_cut - 1e-6
+        assert prob.value == pytest.approx(ref, abs=5e-3)
+
+    def test_warm_start_applied_keeps_optimum(self):
+        """A feasible K-hot warm start is accepted and the optimum is unchanged."""
+        _, _, build = _make(N=7, K=2)
+        ref = _plain_opt(build)
+        warm = np.zeros(7); warm[[0, 1]] = 1.0
+        prob, D = build()
+        prob, info = solve_warm_cut(prob, D, warm_bits=warm, time_limit=30.0)
+        assert info.warm_applied
+        assert prob.value == pytest.approx(ref, abs=1e-4)
+
+    def test_warm_and_cut_together(self):
+        """Warm start and cut compose; both flags set, optimum preserved."""
+        Y, lam, build = _make()
+        ref = _plain_opt(build)
+        L = _sdp_moment_bound_two_way(Y, K=2, lam=lam) * 0.99
+        warm = np.zeros(7); warm[[0, 1]] = 1.0
+        prob, D = build()
+        prob, info = solve_warm_cut(prob, D, warm_bits=warm,
+                                    objective_lower_bound=L,
+                                    gap_limit=1e-4, time_limit=30.0)
+        assert info.cut_applied and info.warm_applied
+        assert prob.value == pytest.approx(ref, abs=5e-3)
+
+    def test_too_high_bound_falls_back_to_uncut(self):
+        """An invalid (too-high) L makes the cut infeasible; the solve must fall
+        back to the un-cut problem and return the true optimum, never a wrong or
+        infeasible answer."""
+        _, _, build = _make()
+        ref = _plain_opt(build)
+        prob, D = build()
+        prob, info = solve_warm_cut(prob, D, objective_lower_bound=1e6,
+                                    time_limit=30.0)
+        assert info.fell_back
+        assert prob.value == pytest.approx(ref, abs=1e-4)
+
+    def test_warm_shape_mismatch_raises(self):
+        _, _, build = _make(N=7, K=2)
+        prob, D = build()
+        with pytest.raises(ValueError):
+            solve_warm_cut(prob, D, warm_bits=np.zeros(5))

--- a/mlsynth/tests/test_syndes_accelerate.py
+++ b/mlsynth/tests/test_syndes_accelerate.py
@@ -1,0 +1,168 @@
+"""Tests for the large-N two-way SYNDES accelerator (SDP-cut + warm start).
+
+The accelerator injects a valid SDP objective cut and a deterministic LEXSCM warm
+start into the two-way MIP so the existing ``gap_limit`` certifies against a tight
+dual bound (the SDP/moment bound) instead of SCIP's loose McCormick relaxation.
+
+Policy (size-gated auto): it engages only for the two-way mode with an explicit
+``K``, when the treated-tuple count ``C(N, K)`` exceeds ``accel_min_tuples`` and
+``N <= certify_sdp_n_max``. Small problems solve exactly, unchanged. ``gap_limit``
+is the certified-gap target (reused, not a new knob). These tests pin engagement,
+the gating, and that engaging never changes a small instance's optimum.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SYNDES
+from mlsynth.config_models import SYNDESConfig
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.syndes_helpers.accelerate import (
+    two_way_accel_inputs,
+    warm_treated_vector,
+)
+from mlsynth.utils.syndes_helpers.optimization import (
+    solve_synthetic_design,
+    estimate_lambda,
+)
+from mlsynth.utils.syndes_helpers.certificate import _sdp_moment_bound_two_way
+
+
+def _panel(n_units=12, T=14, n_post=4, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.standard_normal((T, 3))
+    L = rng.standard_normal((3, n_units))
+    Y = F @ L + 0.3 * rng.standard_normal((T, n_units))
+    rows = []
+    for j in range(n_units):
+        for t in range(T):
+            rows.append({"unit": f"u{j}", "time": t, "y": Y[t, j],
+                         "post": int(t >= T - n_post)})
+    return pd.DataFrame(rows)
+
+
+class TestAccelInputs:
+    def test_warm_vector_is_khot(self):
+        rng = np.random.default_rng(1)
+        Y = rng.standard_normal((12, 20))
+        w = warm_treated_vector(Y, K=4)
+        assert w.shape == (20,)
+        assert set(np.unique(w)).issubset({0.0, 1.0})
+        assert int(w.sum()) == 4
+
+    def test_warm_vector_deterministic(self):
+        rng = np.random.default_rng(2)
+        Y = rng.standard_normal((12, 20))
+        assert np.array_equal(warm_treated_vector(Y, 4), warm_treated_vector(Y, 4))
+
+    def test_bound_is_margined_below_sdp(self):
+        rng = np.random.default_rng(3)
+        Y = rng.standard_normal((10, 12))
+        lam = float(estimate_lambda(Y))
+        L = _sdp_moment_bound_two_way(Y, K=3, lam=lam)
+        _, L_safe = two_way_accel_inputs(Y, K=3, lam=lam, margin=0.01)
+        assert 0.0 < L_safe < L
+        assert L_safe == pytest.approx(L * 0.99, rel=1e-9)
+
+
+class TestSolveSyntheticDesignAccel:
+    def test_accel_matches_plain_optimum(self):
+        """Injecting warm + a valid cut yields the same optimum as a plain solve
+        on a small instance, and records accel diagnostics."""
+        rng = np.random.default_rng(4)
+        Y = rng.standard_normal((10, 8))
+        lam = float(estimate_lambda(Y))
+        ref = solve_synthetic_design(Y, K=2, mode="global_2way", lam=lam)
+        warm, L_safe = two_way_accel_inputs(Y, K=2, lam=lam)
+        acc = solve_synthetic_design(
+            Y, K=2, mode="global_2way", lam=lam, gap_limit=1e-4,
+            warm_start_D=warm, objective_lower_bound=L_safe,
+        )
+        assert acc.objective_value == pytest.approx(ref.objective_value, abs=5e-3)
+        assert "accel" in acc.raw_results
+        assert acc.raw_results["accel"]["cut_applied"]
+
+    def test_accel_params_default_none_is_plain(self):
+        """Omitting the accel params leaves the solve byte-identical to before."""
+        rng = np.random.default_rng(5)
+        Y = rng.standard_normal((10, 8))
+        d = solve_synthetic_design(Y, K=2, mode="global_2way")
+        assert "accel" not in d.raw_results
+
+
+class TestEstimatorPolicy:
+    def test_engages_for_large_tuple_count(self):
+        """With a low tuple gate the two-way estimator engages the accelerator."""
+        df = _panel(n_units=12)
+        cfg = SYNDESConfig(df=df, outcome="y", unitid="unit", time="time",
+                           K=3, mode="two_way_global", post_col="post",
+                           accel_min_tuples=50, run_inference=False)
+        res = SYNDES(cfg).fit()
+        assert res.design.raw_results.get("accel") is not None
+        assert int(res.design.assignment.sum()) == 3
+
+    def test_skips_for_small_tuple_count(self):
+        """Default gate: a tiny panel solves exactly, no accel."""
+        df = _panel(n_units=8)
+        cfg = SYNDESConfig(df=df, outcome="y", unitid="unit", time="time",
+                           K=2, mode="two_way_global", post_col="post",
+                           run_inference=False)   # C(8,2)=28 << default 2000
+        res = SYNDES(cfg).fit()
+        assert res.design.raw_results.get("accel") is None
+
+    def test_accelerate_false_disables(self):
+        df = _panel(n_units=12)
+        cfg = SYNDESConfig(df=df, outcome="y", unitid="unit", time="time",
+                           K=3, mode="two_way_global", post_col="post",
+                           accel_min_tuples=50, accelerate=False,
+                           run_inference=False)
+        res = SYNDES(cfg).fit()
+        assert res.design.raw_results.get("accel") is None
+
+    @pytest.mark.parametrize("mode", ["one_way_global", "per_unit"])
+    def test_only_two_way(self, mode):
+        df = _panel(n_units=12)
+        cfg = SYNDESConfig(df=df, outcome="y", unitid="unit", time="time",
+                           K=3, mode=mode, post_col="post",
+                           accel_min_tuples=50, run_inference=False)
+        res = SYNDES(cfg).fit()
+        assert res.design.raw_results.get("accel") is None
+
+    def test_requires_explicit_K(self):
+        """K=None two-way cannot be accelerated (no cardinality for the SDP)."""
+        df = _panel(n_units=12)
+        cfg = SYNDESConfig(df=df, outcome="y", unitid="unit", time="time",
+                           K=None, mode="two_way_global", post_col="post",
+                           accel_min_tuples=1, run_inference=False)
+        res = SYNDES(cfg).fit()
+        assert res.design.raw_results.get("accel") is None
+
+    def test_accel_still_respects_restrictions(self):
+        """The cut stays valid under restrictions, and the accelerated design must
+        still honor them even though the (unrestricted) warm start may not."""
+        df = _panel(n_units=12)
+        cfg = SYNDESConfig(df=df, outcome="y", unitid="unit", time="time",
+                           K=3, mode="two_way_global", post_col="post",
+                           accel_min_tuples=50, not_to_be_treated=["u0", "u1"],
+                           run_inference=False)
+        res = SYNDES(cfg).fit()
+        treated = set(np.asarray(res.design.selected_unit_labels).tolist())
+        assert "u0" not in treated and "u1" not in treated
+        assert int(res.design.assignment.sum()) == 3
+
+
+class TestConfig:
+    def test_defaults(self):
+        df = _panel()
+        cfg = SYNDESConfig(df=df, outcome="y", unitid="unit", time="time",
+                           K=3, mode="two_way_global", post_col="post")
+        assert cfg.accelerate is True
+        assert cfg.accel_min_tuples >= 1
+        assert 0.0 < cfg.accel_safety_margin < 1.0
+
+    def test_bad_margin_rejected(self):
+        df = _panel()
+        with pytest.raises((MlsynthConfigError, ValueError)):
+            SYNDESConfig(df=df, outcome="y", unitid="unit", time="time",
+                         K=3, mode="two_way_global", post_col="post",
+                         accel_safety_margin=1.5)

--- a/mlsynth/utils/miqp_accel.py
+++ b/mlsynth/utils/miqp_accel.py
@@ -92,6 +92,10 @@ class _WarmCutSCIP(_CvxSCIP):
         self._L = objective_lower_bound
         self.warm_applied = False
         self.cut_applied = False
+        # The built SCIP model, kept so the caller can read the dual bound / gap /
+        # status directly rather than through cvxpy's solution dict, whose keys
+        # ("model", "scip_status") are internal and vary across cvxpy versions.
+        self.model = None
 
     def solve_via_data(self, data, warm_start, verbose, solver_opts,
                        solver_cache=None):
@@ -124,6 +128,7 @@ class _WarmCutSCIP(_CvxSCIP):
                 model.addSol(sol)
                 self.warm_applied = True
 
+        self.model = model
         return self._solve(model, variables, constraints, data, dims)
 
 
@@ -203,12 +208,22 @@ def solve_warm_cut(
             prob.unpack(chain.invert(raw, inv))
             fell_back = True
 
-    model = raw.get("model")
+    # Read diagnostics from the SCIP model we built (version-robust), not from
+    # cvxpy's solution dict whose keys differ across cvxpy releases.
+    model = solver.model
+    if model is not None:
+        dual_bound = float(model.getDualbound())
+        gap = float(model.getGap())
+        status = str(model.getStatus())
+        solve_time = float(model.getSolvingTime())
+    else:                                   # pragma: no cover - model always built
+        dual_bound = gap = solve_time = float("nan")
+        status = "unknown"
     info = AccelInfo(
-        status=str(raw.get("scip_status")),
-        dual_bound=float(model.getDualbound()) if model is not None else float("nan"),
-        gap=float(model.getGap()) if model is not None else float("nan"),
-        solve_time=float(raw.get(s.SOLVE_TIME, float("nan"))),
+        status=status,
+        dual_bound=dual_bound,
+        gap=gap,
+        solve_time=solve_time,
         cut_applied=solver.cut_applied,
         warm_applied=solver.warm_applied,
         fell_back=fell_back,

--- a/mlsynth/utils/miqp_accel.py
+++ b/mlsynth/utils/miqp_accel.py
@@ -1,0 +1,216 @@
+"""Warm-start + valid objective-cut accelerator for cvxpy MIQP solves on SCIP.
+
+Two levers a mixed-integer solver uses to finish fast are a good incumbent (so it
+stops *hunting* for one) and a tight dual bound (so it can *prove* the incumbent
+is good and stop). cvxpy forwards neither to SCIP. This module supplies both:
+
+* a *warm start* -- a binary MIP start injected via pyscipopt's
+  ``createPartialSol`` / ``setSolVal`` / ``addSol``; and
+* a valid *objective lower-bound cut* ``c^T x >= L`` -- a single linear
+  constraint on the canonicalised objective. Because SCIP *minimises* ``c^T x``,
+  this forces every node relaxation (hence the global dual bound) up to ``L``. It
+  is a valid cut whenever ``L`` is a true lower bound on the optimum: no feasible
+  point has objective below the optimum, so none is removed.
+
+The dual-bound lever is the one SCIP cannot supply itself for the hard MIQPs in
+this library (SYNDES/MAREX two-way): SCIP's own dual bound is the McCormick
+relaxation, which is very loose, so it keeps branching long after its incumbent is
+essentially optimal. Handing it an external bound (e.g. an SDP/moment bound) as a
+cut lets the ordinary ``gap_limit`` certify against a tight bound and terminate.
+
+Safety. A cut with an ``L`` above the true optimum would remove the optimum (a
+correctness bug, not a slowdown). Callers must margin ``L`` below the bound. As a
+backstop, if the cut renders the model infeasible (``L`` above *every* feasible
+objective), the solve falls back to the un-cut problem and reports ``fell_back``,
+so a bad bound degrades to a correct-but-unaccelerated solve rather than a wrong
+or infeasible answer.
+
+Offset. The cut is written on the canonical objective vector ``c`` assuming the
+canonicalised objective has no constant term (``objective = c^T x``), which holds
+for the homogeneous quadratic objectives in this library. A nonzero offset would
+misalign the cut, so this helper is intended for those objectives.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import cvxpy as cp
+import cvxpy.settings as s
+import numpy as np
+from cvxpy.reductions.solvers.conic_solvers.scip_conif import SCIP as _CvxSCIP
+
+
+@dataclass(frozen=True)
+class AccelInfo:
+    """Diagnostics from an accelerated solve.
+
+    Attributes
+    ----------
+    status : str
+        SCIP's terminal status (``"optimal"``, ``"gaplimit"``, ``"timelimit"``,
+        ``"infeasible"``, ...).
+    dual_bound : float
+        SCIP's global dual (lower) bound at termination -- lifted to the injected
+        cut ``L`` when one was applied.
+    gap : float
+        SCIP's reported relative optimality gap.
+    solve_time : float
+        SCIP solving time in seconds.
+    cut_applied : bool
+        Whether the objective lower-bound cut was added.
+    warm_applied : bool
+        Whether the binary warm start was accepted (length matched the model's
+        boolean variables).
+    fell_back : bool
+        Whether the cut was dropped and the solve retried un-cut because the cut
+        made the model infeasible (a too-high ``L``).
+    """
+
+    status: str
+    dual_bound: float
+    gap: float
+    solve_time: float
+    cut_applied: bool
+    warm_applied: bool
+    fell_back: bool
+
+
+class _WarmCutSCIP(_CvxSCIP):
+    """cvxpy SCIP solver that optionally injects a warm start and an objective cut.
+
+    ``warm_bits`` is a 1-D 0/1 array aligned to ``data[BOOL_IDX]`` (cvxpy's
+    column-major boolean-variable order); ``objective_lower_bound`` is ``L`` in
+    the cut ``c^T x >= L``. Either may be ``None``. The ``*_applied`` attributes
+    record what actually took effect.
+    """
+
+    def __init__(self, warm_bits: Optional[np.ndarray] = None,
+                 objective_lower_bound: Optional[float] = None) -> None:
+        super().__init__()
+        self._warm = None if warm_bits is None else np.asarray(warm_bits, dtype=float)
+        self._L = objective_lower_bound
+        self.warm_applied = False
+        self.cut_applied = False
+
+    def solve_via_data(self, data, warm_start, verbose, solver_opts,
+                       solver_cache=None):
+        from pyscipopt import quicksum
+        from pyscipopt.scip import Model
+
+        model = Model()
+        model.redirectOutput()
+        A, b, c, dims = self._define_data(data)
+        variables = self._create_variables(model, data, c)
+        constraints = self._add_constraints(model, variables, A, b, dims)
+        self._set_params(model, verbose, solver_opts, data, dims)
+
+        # Objective lower-bound cut: c^T x >= L. SCIP minimises c^T x, so this
+        # lifts the dual bound to L. Only the nonzero objective coefficients
+        # contribute (the objective is a handful of epigraph/aux variables).
+        if self._L is not None:
+            nz = np.nonzero(c)[0]
+            model.addCons(quicksum(float(c[i]) * variables[i] for i in nz)
+                          >= float(self._L))
+            self.cut_applied = True
+
+        # Binary warm start (partial MIP start on the boolean variables).
+        if self._warm is not None:
+            bidx = list(data[s.BOOL_IDX])
+            if len(bidx) == len(self._warm):
+                sol = model.createPartialSol()
+                for pos, vpos in enumerate(bidx):
+                    model.setSolVal(sol, variables[vpos], float(self._warm[pos]))
+                model.addSol(sol)
+                self.warm_applied = True
+
+        return self._solve(model, variables, constraints, data, dims)
+
+
+def solve_warm_cut(
+    prob: cp.Problem,
+    bool_var: cp.Variable,
+    *,
+    warm_bits: Optional[np.ndarray] = None,
+    objective_lower_bound: Optional[float] = None,
+    gap_limit: Optional[float] = None,
+    time_limit: Optional[float] = None,
+    verbose: bool = False,
+) -> Tuple[cp.Problem, AccelInfo]:
+    """Solve MIQP ``prob`` on SCIP, injecting a warm start and/or a valid cut.
+
+    Parameters
+    ----------
+    prob : cvxpy.Problem
+        A mixed-integer problem whose binary variable is ``bool_var``.
+    bool_var : cvxpy.Variable
+        The problem's boolean variable (used to align/validate ``warm_bits``).
+    warm_bits : np.ndarray, optional
+        A 0/1 array of ``bool_var``'s shape -- the initial incumbent. ``None``
+        skips the warm start. Raises ``ValueError`` on a shape mismatch.
+    objective_lower_bound : float, optional
+        ``L`` in the valid cut ``objective >= L``. Must be a true lower bound on
+        the optimum (margin it below any first-order relaxation bound). ``None``
+        skips the cut.
+    gap_limit, time_limit : float, optional
+        Forwarded to SCIP as ``limits/gap`` / ``limits/time``.
+    verbose : bool, optional
+        SCIP verbosity.
+
+    Returns
+    -------
+    (prob, AccelInfo)
+        ``prob`` is solved in place (``prob.value`` / ``bool_var.value``
+        populated). ``AccelInfo`` carries the solve diagnostics.
+    """
+    if warm_bits is not None:
+        warm_bits = np.asarray(warm_bits, dtype=float)
+        if warm_bits.shape != tuple(bool_var.shape):
+            raise ValueError(
+                f"warm_bits shape {warm_bits.shape} does not match bool var "
+                f"{tuple(bool_var.shape)}")
+        # cvxpy stacks matrix variables column-major; align to that order.
+        warm_flat = warm_bits.flatten(order="F")
+    else:
+        warm_flat = None
+
+    scip_params: dict = {}
+    if gap_limit is not None:
+        scip_params["limits/gap"] = float(gap_limit)
+    if time_limit is not None:
+        scip_params["limits/time"] = float(time_limit)
+    opts = {"scip_params": scip_params} if scip_params else {}
+
+    data, chain, inv = prob.get_problem_data(cp.SCIP)
+    solver = _WarmCutSCIP(warm_flat, objective_lower_bound)
+    raw = solver.solve_via_data(data, False, verbose, dict(opts))
+    prob.unpack(chain.invert(raw, inv))
+
+    # Validity backstop for a too-high L. The objective is an epigraph variable
+    # ``t`` (minimise ``t`` s.t. ``t >= quadratic``), so the cut is really
+    # ``t >= L``: an L above the true optimum does not make the model infeasible,
+    # it inflates ``t`` and returns a garbage design. The signature is that the
+    # *recovered* design's true objective drops below the cut floor -- impossible
+    # for a valid L, where every feasible objective is >= optimum >= L. When it
+    # happens, drop the cut and re-solve so correctness always holds.
+    fell_back = False
+    if objective_lower_bound is not None:
+        L = float(objective_lower_bound)
+        val = None if prob.value is None else float(prob.value)
+        if val is None or val < L - 1e-6 * max(1.0, abs(L)):
+            solver = _WarmCutSCIP(warm_flat, None)
+            raw = solver.solve_via_data(data, False, verbose, dict(opts))
+            prob.unpack(chain.invert(raw, inv))
+            fell_back = True
+
+    model = raw.get("model")
+    info = AccelInfo(
+        status=str(raw.get("scip_status")),
+        dual_bound=float(model.getDualbound()) if model is not None else float("nan"),
+        gap=float(model.getGap()) if model is not None else float("nan"),
+        solve_time=float(raw.get(s.SOLVE_TIME, float("nan"))),
+        cut_applied=solver.cut_applied,
+        warm_applied=solver.warm_applied,
+        fell_back=fell_back,
+    )
+    return prob, info

--- a/mlsynth/utils/syndes_helpers/accelerate.py
+++ b/mlsynth/utils/syndes_helpers/accelerate.py
@@ -1,0 +1,66 @@
+"""Large-N two-way SYNDES accelerator: warm start + valid SDP objective cut.
+
+For the two-way objective SCIP's own (McCormick) dual bound is very loose, so the
+exact MIP times out even at modest N -- it keeps branching to *prove* an incumbent
+that is already near-optimal. This module supplies the two levers SCIP lacks and
+feeds them to :func:`mlsynth.utils.miqp_accel.solve_warm_cut`:
+
+* a deterministic *warm start* -- the treated tuple LEXSCM's fast search
+  recommends on the pre-period Gram matrix (the same primal seed MAREX uses); and
+* a valid *objective lower-bound cut* -- the SDP/moment bound (Shor level-1) that
+  :mod:`mlsynth.utils.syndes_helpers.certificate` validates, margined below its
+  value to stay valid under the SDP solver's first-order tolerance.
+
+The cut lifts SCIP's dual bound to the SDP bound, so the ordinary ``gap_limit``
+certifies against a tight bound and SCIP stops early with a validated gap instead
+of timing out. The returned design is certified-near-optimal, not proven-optimal;
+this is an mlsynth addition, not part of Doudchenko et al. (2021).
+"""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import numpy as np
+
+from .certificate import _sdp_moment_bound_two_way
+from .optimization import estimate_lambda
+from ..fast_scm_helpers.lexsearch import select_treated_designs
+
+
+def warm_treated_vector(Y: np.ndarray, K: int, *, random_state: int = 0) -> np.ndarray:
+    """Deterministic 0/1 warm start: LEXSCM's recommended treated ``K``-tuple.
+
+    Runs LEXSCM's fast search (exact enumeration or seeded multi-start local
+    search, depending on ``C(N, K)``) on the pre-period Gram matrix ``Y'Y`` and
+    returns the top tuple as a length-``N`` indicator vector -- a good, fully
+    deterministic initial incumbent for the two-way MIP.
+    """
+    N = int(Y.shape[1])
+    G = np.asarray(Y, dtype=float).T @ np.asarray(Y, dtype=float)
+    res = select_treated_designs(G, list(range(N)), int(K), top_K=1,
+                                 random_state=random_state)
+    designs = res.get("top_designs") or []
+    D = np.zeros(N, dtype=float)
+    if designs:
+        D[np.asarray(designs[0].indices, dtype=int)] = 1.0
+    return D
+
+
+def two_way_accel_inputs(
+    Y: np.ndarray,
+    K: int,
+    lam: Optional[float] = None,
+    *,
+    margin: float = 0.01,
+    random_state: int = 0,
+) -> Tuple[np.ndarray, float]:
+    """``(warm_D, L_safe)`` for an accelerated two-way solve.
+
+    ``L_safe = L * (1 - margin)`` where ``L`` is the SDP/moment lower bound; the
+    margin keeps the cut strictly below the bound so it stays valid under the SDP
+    solver's (first-order) tolerance. ``warm_D`` is the LEXSCM warm start.
+    """
+    lam_value = float(estimate_lambda(Y)) if lam is None else float(lam)
+    warm_D = warm_treated_vector(Y, K, random_state=random_state)
+    L = _sdp_moment_bound_two_way(np.asarray(Y, dtype=float), int(K), lam_value)
+    return warm_D, float(L) * (1.0 - float(margin))

--- a/mlsynth/utils/syndes_helpers/config.py
+++ b/mlsynth/utils/syndes_helpers/config.py
@@ -169,10 +169,47 @@ class SYNDESConfig(BaseMAREXConfig):
     certify_sdp_n_max: int = Field(
         default=120, ge=1,
         description=(
-            "Largest N for which the two-way SDP certificate is attempted (it "
-            "is O(N^3)); above it the two-way certificate falls back to the "
-            "loose continuous bound with certified=False. Only used when "
-            "``certify=True``."
+            "Largest N for which the two-way SDP bound is attempted (it is "
+            "O(N^3)). Governs both the ``certify=True`` certificate (above it the "
+            "two-way certificate falls back to the loose continuous bound with "
+            "certified=False) and the ``accelerate`` accelerator (above it the "
+            "large two-way solve is left un-accelerated)."
+        ),
+    )
+    accelerate: bool = Field(
+        default=True,
+        description=(
+            "Speed up the large two-way MIP by injecting a valid SDP objective "
+            "lower-bound cut and a deterministic LEXSCM warm start, so the "
+            "existing ``gap_limit`` certifies against the tight SDP/moment bound "
+            "instead of SCIP's loose McCormick relaxation (which makes the exact "
+            "two-way MIP time out even at modest N). Size-gated and automatic: it "
+            "engages only for ``mode='two_way_global'`` with an explicit ``K`` "
+            "when the treated-tuple count C(N, K) exceeds ``accel_min_tuples`` and "
+            "N <= ``certify_sdp_n_max``; otherwise it is a no-op and the solve is "
+            "unchanged. The returned design is certified-near-optimal (to "
+            "``gap_limit`` against the SDP bound), not proven-optimal. An mlsynth "
+            "addition -- not part of Doudchenko et al. (2021)."
+        ),
+    )
+    accel_min_tuples: int = Field(
+        default=2000, ge=1,
+        description=(
+            "Combinatorial-size gate for ``accelerate``: the two-way accelerator "
+            "engages only when the number of treated K-tuples C(N, K) exceeds "
+            "this. Below it the exact MIP is small and fast, so it is solved "
+            "directly (unchanged). Mirrors LEXSCM's enumerate-vs-search size "
+            "switch."
+        ),
+    )
+    accel_safety_margin: float = Field(
+        default=0.01, gt=0.0, lt=1.0,
+        description=(
+            "The SDP lower bound is injected as the cut ``objective >= L*(1 - "
+            "accel_safety_margin)`` so it stays a valid lower bound under the SDP "
+            "solver's first-order tolerance (a too-high cut would remove the "
+            "optimum). A small positive fraction; larger is safer but slightly "
+            "loosens the certified gap."
         ),
     )
     display_graph: bool = Field(default=False,

--- a/mlsynth/utils/syndes_helpers/optimization.py
+++ b/mlsynth/utils/syndes_helpers/optimization.py
@@ -208,6 +208,8 @@ def solve_synthetic_design(
     time_limit: Optional[float] = None,
     forbidden_sets: Optional[list] = None,
     restrictions: Optional[Any] = None,
+    warm_start_D: Optional[np.ndarray] = None,
+    objective_lower_bound: Optional[float] = None,
 ) -> SYNDESDesign:
     """
     Solve the SYNDES synthetic design optimization problem.
@@ -309,8 +311,26 @@ def solve_synthetic_design(
         if scip_params:
             solve_kwargs["scip_params"] = scip_params
 
+    # Accelerated path: when a warm start and/or a valid objective lower-bound
+    # cut are supplied (SCIP only), route through ``miqp_accel.solve_warm_cut``,
+    # which injects the binary MIP start and the cut ``objective >= L`` so SCIP's
+    # dual bound is lifted to ``L`` and ``gap_limit`` certifies against it. When
+    # both are None the original ``problem.solve`` path is byte-identical.
+    accel_info = None
+    use_accel = (str(solver).upper() == "SCIP"
+                 and (warm_start_D is not None or objective_lower_bound is not None))
     try:
-        problem.solve(**solve_kwargs)
+        if use_accel:
+            from ..miqp_accel import solve_warm_cut
+            warm_bits = (None if warm_start_D is None
+                         else np.asarray(warm_start_D, dtype=float).reshape(-1))
+            _, accel_info = solve_warm_cut(
+                problem, D, warm_bits=warm_bits,
+                objective_lower_bound=objective_lower_bound,
+                gap_limit=gap_limit, time_limit=time_limit, verbose=verbose,
+            )
+        else:
+            problem.solve(**solve_kwargs)
     except Exception as exc:
         raise MlsynthEstimationError(
             f"SYNDES optimization failed to solve: {exc}"
@@ -370,6 +390,17 @@ def solve_synthetic_design(
         "status": problem.status,
         "solver": solver,
     }
+    if accel_info is not None:
+        raw_results["accel"] = {
+            "status": accel_info.status,
+            "dual_bound": accel_info.dual_bound,
+            "gap": accel_info.gap,
+            "solve_time": accel_info.solve_time,
+            "cut_applied": accel_info.cut_applied,
+            "warm_applied": accel_info.warm_applied,
+            "fell_back": accel_info.fell_back,
+            "objective_lower_bound": objective_lower_bound,
+        }
 
     return SYNDESDesign(
         mode=mode,


### PR DESCRIPTION
## What

The two-way objective's McCormick dual bound is so loose that the exact SYNDES MIP does not terminate at any practical size — even N=20/K=5 times out — so SCIP keeps branching to *prove* an incumbent that is already near-optimal. The `certify=True` SDP/moment bound (#188) closes ~90% of that gap, but only as a diagnostic *beside* the solver. This PR feeds the same bound *into* the solve.

Because the canonical two-way objective is minimized as an epigraph variable `t` (`t ≥ quadratic`), adding the single linear cut `t ≥ L` with `L = (1−margin)·p_SDP` lifts SCIP's global dual bound to `L`. It is valid whenever `L ≤ optimum` (no feasible design is removed), which the safety margin guarantees under the first-order SDP solver's tolerance. With the dual bound tight, the existing `gap_limit` certifies against the SDP bound instead of McCormick, so SCIP terminates early with a validated gap. A deterministic LEXSCM warm start (the primal MAREX already uses) seeds the incumbent.

On two-way N=100/K=5 this turns a 60s time-out (uncertified incumbent) into a ~25s solve that SCIP *terminates* with a certified ~3% gap — and a slightly better design.

## Default policy (size-gated auto)

`accelerate=True` reuses the existing `gap_limit` as the certified-gap target and engages only for `two_way_global` with an explicit `K` when `C(N,K) > accel_min_tuples` and `N ≤ certify_sdp_n_max`. Below the tuple gate the exact MIP is small and solved directly — unchanged, proven-optimal — so all existing tests and the BLS replication (N=10) are byte-identical. Above it the returned design is certified to `gap_limit` against the SDP bound, not proven-optimal; an mlsynth addition, not part of Doudchenko et al. (2021).

## Safety

A too-high `L` does not make the model infeasible (the epigraph `t` just inflates), it returns a garbage design. The signature is the recovered objective dropping below the cut floor — impossible for a valid `L`; when detected the solve drops the cut and re-solves, so correctness always holds. Covered by a deliberately-too-high-`L` test and a test that the accelerated design still honors design restrictions the (unrestricted) warm start may violate.

## Changes

- New `utils/miqp_accel.py` — `solve_warm_cut` (warm-start MIP start + valid objective cut, with the fallback). Shared so MAREX and the GEDI wrapper can adopt it.
- New `utils/syndes_helpers/accelerate.py` — LEXSCM warm tuple + margined SDP bound.
- `solve_synthetic_design` gains `warm_start_D` / `objective_lower_bound` (both `None` → byte-identical to before).
- `SYNDESConfig` gains `accelerate` / `accel_min_tuples` / `accel_safety_margin`.
- `docs/syndes.rst`: "Accelerating the solve" subsection + an `accelerate` bullet.

## Tests

20 new (`test_miqp_accel.py`: neutral == plain solve, cut raises the dual bound, warm accepted, too-high-`L` fallback, shape guard; `test_syndes_accelerate.py`: bound margined below SDP, deterministic k-hot warm, accel == plain optimum on small instances, size/mode/K gating, `accelerate=False` disables, restriction respected). Full SYNDES + result-contract suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rctg21VVpt6yZzFqTmVmc)_