### PR TITLE
PPSCM: surface per-unit (per-cohort) fits alongside the pooled estimate

### DIFF
--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -143,6 +143,40 @@ full estimator (holding :math:`\nu` fixed), and form
 :math:`\widehat{\text{se}}^2 = \tfrac{N-1}{N}\sum_{j \in \mathcal{N}}(\widehat{\tau}_j - \bar{\tau})^2`
 for the overall ATT and each relative-time horizon, with Wald intervals.
 
+Per-unit fits alongside the pooled report
+-----------------------------------------
+
+Because partially pooled SCM fits a separate synthetic control per treated unit
+(or per cohort with ``time_cohort=True``) and averages them into the ATT, the
+unit-level estimates are the *components* of the pooled one -- so both are read
+off a single fit. ``results.per_unit`` is a dict keyed the same as
+``donor_weights_by_cohort``; each value is a ``PPSCMUnitFit`` carrying the unit's
+``att``, its relative-time ``tau`` path, its ``donor_weights``, its adoption time
+and member units, and its in-sample fit ``prefit_rmspe`` -- the root-mean-square
+pre-treatment imbalance :math:`q_j` of that unit's synthetic control.
+
+The two levels reconcile exactly, so the unit-level and pooled reports never
+disagree: the reported separate imbalance ``design.ind_l2`` equals
+:math:`\sqrt{\tfrac1J\sum_j q_j^2}`, and the ``n_units``-weighted per-horizon
+average of the unit ``tau`` paths reproduces ``event_study.tau`` and hence the
+aggregate ``effects.att``. This makes it a one-line switch to serve either
+request -- pooled error via ``design.ind_l2`` / ``global_l2`` and the aggregate
+ATT, or per-unit estimates and their in-sample error via ``results.per_unit``.
+
+A caveat worth surfacing to whoever reads the unit-level numbers: at a high
+:math:`\nu` (heavily pooled), the per-unit synthetic controls fit poorly, so a
+unit's ``att`` is only as trustworthy as its ``prefit_rmspe`` -- read the two
+together, and prefer a lower :math:`\nu` (toward separate SCM) when unit-level
+estimates are the deliverable.
+
+.. code-block:: python
+
+   res = PPSCM(config).fit()
+   res.design.ind_l2                       # pooled/separate in-sample error
+   res.effects.att                         # aggregate ATT
+   for label, uf in res.per_unit.items():  # per-unit estimates + in-sample error
+       print(label, uf.att, uf.prefit_rmspe)
+
 Empirical Illustration: mandatory collective bargaining
 -------------------------------------------------------
 

--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -37,6 +37,7 @@ from ..utils.ppscm_helpers.structures import (
     PPSCMEventStudy,
     PPSCMInference,
     PPSCMResults,
+    PPSCMUnitFit,
 )
 
 
@@ -54,7 +55,11 @@ class PPSCM:
     -------
     PPSCMResults
         Design (pooling level + balance diagnostics), relative-time event
-        study, overall ATT with jackknife inference, and donor weights.
+        study, overall ATT with jackknife inference, donor weights, and
+        ``per_unit`` -- the per-treated-unit (or per-cohort) fits (``att``,
+        in-sample ``prefit_rmspe``, ``tau`` path, donor weights) that are the
+        components of the pooled estimate and reconstruct ``design.ind_l2`` and
+        the aggregate ATT.
     """
 
     def __init__(self, config: Union[PPSCMConfig, dict]) -> None:
@@ -160,9 +165,32 @@ class PPSCM:
                     str(inputs.units[i]): float(w[i]) for i in np.nonzero(w > 1e-8)[0]
                 }
 
+            # Per-unit (per-cohort) fits: the components of the pooled estimate at
+            # this ``nu``. ``prefit_rmspe`` aggregates to ``design.ind_l2`` and the
+            # n1-weighted ``tau`` paths reconstruct the pooled event study, so the
+            # unit-level report is the same fit as the aggregate one (no re-run).
+            M, nnz, tau_rel, n1 = fit["M"], fit["nnz"], fit["tau_rel"], fit["n1"]
+            per_unit: Dict[Any, PPSCMUnitFit] = {}
+            for k, g in enumerate(fit["groups"]):
+                key = (str(inputs.time_labels[fit["adopt_of"][g]]) if self.time_cohort
+                       else str(inputs.units[fit["members"][g][0]]))
+                tau_k = np.asarray(tau_rel[k, :], dtype=float)
+                per_unit[key] = PPSCMUnitFit(
+                    label=key,
+                    adoption_time=inputs.time_labels[fit["adopt_of"][g]],
+                    member_units=[str(inputs.units[i]) for i in fit["members"][g]],
+                    n_units=int(n1[k]),
+                    att=float(np.nanmean(tau_k)),
+                    prefit_rmspe=float(np.sqrt((M[:, k] ** 2).sum() / nnz[k])),
+                    tau=tau_k,
+                    pre_imbalance=np.asarray(M[:, k], dtype=float),
+                    donor_weights=donor_weights.get(key, {}),
+                )
+
             results = PPSCMResults(
                 inputs=inputs, design=design, event_study=event_study,
                 inference_detail=inference, donor_weights_by_cohort=donor_weights,
+                per_unit=per_unit,
                 metadata={"n_treated": int(np.isfinite(trt).sum()),
                           "n_control": int((~np.isfinite(trt)).sum())},
             )

--- a/mlsynth/tests/test_ppscm_perunit.py
+++ b/mlsynth/tests/test_ppscm_perunit.py
@@ -1,0 +1,118 @@
+"""Per-unit (per-cohort) outputs of PPSCM alongside the pooled aggregate.
+
+The partially-pooled estimator fits a separate synthetic control per treated unit
+(or per cohort with ``time_cohort=True``) and averages them into the ATT, so the
+unit-level estimates are the components of the pooled one. These tests pin that
+``PPSCMResults.per_unit`` exposes those components and that they *reconstruct* the
+reported aggregates -- so a manager asking for unit-level SC estimates and their
+in-sample error gets the same fit as the pooled/aggregated report, not a re-run:
+
+* per-unit in-sample error ``prefit_rmspe`` (``q_j``) satisfies
+  ``sqrt(mean_j q_j^2) == design.ind_l2`` (the reported separate imbalance);
+* per-unit event-study ``tau``, aggregated the estimator's way (n1-weighted per
+  horizon), reproduces the pooled event study and ATT;
+* keys align with ``donor_weights_by_cohort``; each fit carries its label,
+  adoption time, member units, donor weights, and effect.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PPSCM
+from mlsynth.utils.ppscm_helpers.structures import PPSCMResults, PPSCMUnitFit
+
+
+def _staggered_panel(*, seed=0, adoption_offsets=(10, 15, 20), N_donors=8, T=30,
+                     true_effect=-3.0, noise=0.4) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    factors = rng.standard_normal((T, 2))
+    ld = rng.standard_normal((N_donors, 2)) * 0.5
+    lt = ld.mean(axis=0)
+    rec = []
+    for j, Tj in enumerate(adoption_offsets):
+        s = factors @ (lt + 0.1 * rng.standard_normal(2)) + rng.standard_normal(T) * noise
+        s[Tj:] += true_effect
+        for t in range(T):
+            rec.append({"unit": f"treated_{j}", "year": 2000 + t,
+                        "y": float(s[t]), "tr": int(t >= Tj)})
+    for dd in range(N_donors):
+        s = factors @ ld[dd] + rng.standard_normal(T) * noise
+        for t in range(T):
+            rec.append({"unit": f"d_{dd}", "year": 2000 + t, "y": float(s[t]), "tr": 0})
+    return pd.DataFrame(rec)
+
+
+def _cfg(df, **kw):
+    base = dict(df=df, outcome="y", treat="tr", unitid="unit", time="year",
+                display_graphs=False, run_inference=False)
+    base.update(kw)
+    return base
+
+
+@pytest.fixture(scope="module")
+def fitted():
+    return PPSCM(_cfg(_staggered_panel())).fit()
+
+
+class TestPerUnitStructure:
+    def test_per_unit_present_by_default(self, fitted):
+        assert isinstance(fitted, PPSCMResults)
+        assert isinstance(fitted.per_unit, dict) and len(fitted.per_unit) >= 1
+        for v in fitted.per_unit.values():
+            assert isinstance(v, PPSCMUnitFit)
+
+    def test_keys_match_donor_weights(self, fitted):
+        assert set(fitted.per_unit) == set(fitted.donor_weights_by_cohort)
+
+    def test_fields_populated(self, fitted):
+        for key, uf in fitted.per_unit.items():
+            assert uf.label == key
+            assert np.isfinite(uf.att)
+            assert uf.prefit_rmspe >= 0.0
+            assert uf.n_units >= 1
+            assert len(uf.member_units) == uf.n_units
+            assert uf.tau.shape == (fitted.design.n_leads,)
+            # donor weights are a nonneg simplex (sum ~ 1)
+            assert abs(sum(uf.donor_weights.values()) - 1.0) < 1e-4
+            assert all(w >= -1e-9 for w in uf.donor_weights.values())
+
+    def test_att_is_mean_of_own_event_study(self, fitted):
+        for uf in fitted.per_unit.values():
+            assert uf.att == pytest.approx(float(np.nanmean(uf.tau)), abs=1e-9)
+
+
+class TestReconstructsAggregates:
+    def test_prefit_rmspe_reconstructs_ind_l2(self, fitted):
+        """sqrt(mean_j q_j^2) == the reported separate imbalance ind_l2."""
+        q = np.array([uf.prefit_rmspe for uf in fitted.per_unit.values()])
+        assert float(np.sqrt(np.mean(q ** 2))) == pytest.approx(
+            fitted.design.ind_l2, abs=1e-8)
+
+    def test_tau_reconstructs_pooled_event_study(self, fitted):
+        """n1-weighted per-horizon average of the unit taus == pooled event study."""
+        fits = list(fitted.per_unit.values())
+        H = fitted.design.n_leads
+        taus = np.vstack([uf.tau for uf in fits])           # (J, H)
+        n1 = np.array([uf.n_units for uf in fits], dtype=float)
+        denom = np.array([np.nansum(n1 * ~np.isnan(taus[:, h])) for h in range(H)])
+        per_time = np.array([np.nansum(n1 * taus[:, h]) / denom[h] if denom[h] > 0 else np.nan
+                             for h in range(H)])
+        np.testing.assert_allclose(per_time, fitted.event_study.tau, atol=1e-8, equal_nan=True)
+        assert float(np.nanmean(per_time)) == pytest.approx(fitted.effects.att, abs=1e-8)
+
+
+class TestTimeCohort:
+    def test_cohort_keyed_and_members_listed(self):
+        # two units share an adoption time -> one cohort group of size 2
+        df = _staggered_panel(adoption_offsets=(12, 12, 18))
+        res = PPSCM(_cfg(df, time_cohort=True)).fit()
+        sizes = sorted(uf.n_units for uf in res.per_unit.values())
+        assert sizes == [1, 2]                       # cohort {t0,t1} and {t2}
+        # every treated unit appears in exactly one cohort's member list
+        members = [m for uf in res.per_unit.values() for m in uf.member_units]
+        assert sorted(members) == ["treated_0", "treated_1", "treated_2"]
+        # invariant still holds for cohorts
+        q = np.array([uf.prefit_rmspe for uf in res.per_unit.values()])
+        assert float(np.sqrt(np.mean(q ** 2))) == pytest.approx(res.design.ind_l2, abs=1e-8)

--- a/mlsynth/utils/ppscm_helpers/__init__.py
+++ b/mlsynth/utils/ppscm_helpers/__init__.py
@@ -25,6 +25,7 @@ Layout:
 
 from .structures import (
     PPSCMInputs, PPSCMDesign, PPSCMEventStudy, PPSCMInference, PPSCMResults,
+    PPSCMUnitFit,
 )
 from .setup import prepare_ppscm_inputs
 from .engine import run_multisynth, fit_feff
@@ -33,6 +34,6 @@ from .plotter import plot_ppscm
 
 __all__ = [
     "PPSCMInputs", "PPSCMDesign", "PPSCMEventStudy", "PPSCMInference",
-    "PPSCMResults", "prepare_ppscm_inputs", "run_multisynth", "fit_feff",
-    "jackknife_inference", "plot_ppscm",
+    "PPSCMResults", "PPSCMUnitFit", "prepare_ppscm_inputs", "run_multisynth",
+    "fit_feff", "jackknife_inference", "plot_ppscm",
 ]

--- a/mlsynth/utils/ppscm_helpers/engine.py
+++ b/mlsynth/utils/ppscm_helpers/engine.py
@@ -182,5 +182,10 @@ def run_multisynth(
         "weights": W, "n1": n1, "tau_rel": tau_rel, "per_time": per_time, "att": att,
         "nu_used": nu_used, "global_l2": fin_global, "ind_l2": fin_ind,
         "scaled_global_l2": fin_global / unif_global, "scaled_ind_l2": fin_ind / unif_ind,
+        # Per-cohort final imbalance columns ``M`` (d, J) and the ``nnz`` counts
+        # from the separate fit -- the components of ``ind_l2`` (each cohort's
+        # in-sample error is ``sqrt((M[:,k]**2).sum() / nnz[k])``), returned so the
+        # estimator can surface per-unit fit without recomputing the QP.
+        "M": M, "nnz": np.asarray(nnz, dtype=float),
         "res": res, "n": n, "n_leads": n_leads,
     }

--- a/mlsynth/utils/ppscm_helpers/structures.py
+++ b/mlsynth/utils/ppscm_helpers/structures.py
@@ -118,6 +118,58 @@ class PPSCMInference:
     method: str
 
 
+@dataclass(frozen=True)
+class PPSCMUnitFit:
+    """The synthetic-control fit for one treated unit (or cohort) in the pool.
+
+    Partially-pooled SCM fits a separate synthetic control per treated unit (or
+    per adoption cohort with ``time_cohort=True``) and averages them into the ATT,
+    so these are the *components* of the pooled estimate at the chosen ``nu`` -- not
+    a separate re-run. The two aggregates reconstruct exactly: the reported
+    ``design.ind_l2`` equals ``sqrt(mean_j prefit_rmspe_j**2)``, and the n1-weighted
+    per-horizon average of the ``tau`` paths reproduces the pooled event study.
+
+    Attributes
+    ----------
+    label : str
+        The unit label (``time_cohort=False``) or adoption-time label
+        (``time_cohort=True``); matches the key in ``donor_weights_by_cohort``.
+    adoption_time : Any
+        The (public) time label at which this unit / cohort adopts treatment.
+    member_units : list of str
+        Treated unit label(s) in this group (one unless a cohort pools several).
+    n_units : int
+        Cohort size (``len(member_units)``); the aggregation weight ``n1``.
+    att : float
+        This unit's/cohort's average post-treatment effect (mean of ``tau``).
+    prefit_rmspe : float
+        Pre-treatment in-sample fit error ``q_j`` -- the root-mean-square
+        pre-period imbalance of this synthetic control (residual, fixed-effect-
+        removed space, matching the estimator's balance objective). A large value
+        flags a poorly fit unit whose ``att`` should not be over-trusted (the
+        ``nu``-pooling caveat). Aggregates to ``design.ind_l2``.
+    tau : np.ndarray
+        Relative-time effect path (length ``n_leads``); ``NaN`` past this unit's
+        observed horizon.
+    pre_imbalance : np.ndarray
+        The pre-treatment imbalance vector (front-padded to the balance window)
+        whose weighted RMS is ``prefit_rmspe``; the per-period in-sample residual.
+    donor_weights : dict
+        ``{donor_label: weight}`` for this unit's synthetic control (nonneg,
+        sums to 1).
+    """
+
+    label: str
+    adoption_time: Any
+    member_units: List[str]
+    n_units: int
+    att: float
+    prefit_rmspe: float
+    tau: np.ndarray
+    pre_imbalance: np.ndarray
+    donor_weights: Dict[Any, float]
+
+
 class PPSCMResults(_BaseEstimatorResults):
     """Top-level container returned by :meth:`mlsynth.PPSCM.fit`.
 
@@ -138,6 +190,7 @@ class PPSCMResults(_BaseEstimatorResults):
     event_study: PPSCMEventStudy
     inference_detail: PPSCMInference
     donor_weights_by_cohort: Dict[Any, Dict[Any, float]]
+    per_unit: Dict[Any, PPSCMUnitFit] = _PydField(default_factory=dict)
     metadata: Dict[str, Any] = _PydField(default_factory=dict)
 
     @property


### PR DESCRIPTION
## What

Partially pooled SCM fits a separate synthetic control per treated unit (or per cohort with `time_cohort=True`) and averages them into the ATT — so the unit-level estimates are the *components* of the pooled one. But `PPSCMResults` previously exposed only the aggregate (pooled event study, ATT, and the two scalar imbalances `global_l2` / `ind_l2`). Managers routinely need both the pooled/aggregated error *and* the per-unit SC estimates with their in-sample error; this adds the latter, from the same fit, no re-run.

## Change

`PPSCMResults` gains `per_unit`: a dict (keyed like `donor_weights_by_cohort`) of `PPSCMUnitFit` — each unit's/cohort's `att`, in-sample `prefit_rmspe` (the pre-treatment RMS imbalance `q_j`), `tau` path, `pre_imbalance`, adoption time, member units, and donor weights. The engine already computed the per-cohort imbalance matrix `M` and the `nnz` normalization; those are now returned so the estimator builds `per_unit` with no extra QP.

## Reconciliation (demonstrate-first, then pinned in tests)

The two levels reconcile exactly, so the unit-level and pooled reports never disagree:
- `sqrt(mean_j prefit_rmspe_j²) == design.ind_l2` (the reported separate imbalance), and
- the `n_units`-weighted per-horizon average of the unit `tau` paths reproduces `event_study.tau` and hence `effects.att`.

So it's a one-line switch to serve either request: pooled error via `design.ind_l2` and the aggregate ATT, or per-unit estimates and their in-sample error via `results.per_unit`.

## Safety / scope

Additive only — `per_unit` defaults to `{}`, default behavior and the result contract are byte-identical. Full PPSCM + result-contract suites green (151 passed).

## Caveat surfaced in docs

At a high `ν` (heavily pooled), the per-unit synthetic controls fit poorly, so a unit's `att` is only as trustworthy as its `prefit_rmspe` — the docs tell readers to read the two together and prefer lower `ν` when unit-level estimates are the deliverable.

## Tests

`test_ppscm_perunit.py`: structure + field population, keys match `donor_weights_by_cohort`, `att == mean` of own event study, `prefit_rmspe` reconstructs `ind_l2`, `tau` reconstructs the pooled event study + ATT, and the `time_cohort` path (cohort keying + member listing + the same invariant).

Docs: a "Per-unit fits alongside the pooled report" section on `docs/ppscm.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rctg21VVpt6yZzFqTmVmc)_