### PR TITLE
PPSCM: per-unit SCPI prediction intervals

### DIFF
--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -155,6 +155,19 @@ off a single fit. ``results.per_unit`` is a dict keyed the same as
 and member units, and its in-sample fit ``prefit_rmspe`` -- the root-mean-square
 pre-treatment imbalance :math:`q_j` of that unit's synthetic control.
 
+Each ``PPSCMUnitFit`` additionally carries a per-unit prediction interval on its
+time-averaged effect -- ``ci_lower`` / ``ci_upper`` with a band-implied ``p_value``
+-- populated when ``run_inference`` is on. It is built by the CFPT/SCPI
+out-of-sample interval engine (:mod:`mlsynth.utils.scpi_helpers`, the same
+machinery behind MSQRT's bands), applied to each unit's own pre-period residuals
+and post-period gap with the synthetic-control weights held fixed. This is the
+per-unit analogue of the pooled inference above: the delete-one jackknife (or
+bootstrap) quantifies uncertainty *across* units for the aggregate, whereas the
+per-unit SCPI band quantifies each unit's own effect. A naive permutation over the
+QP-optimised pre-period residuals would over-reject -- the fit makes those residuals
+small, so they are not exchangeable with the post-period gaps -- which is why the
+per-unit band uses the SCPI construction rather than a residual permutation.
+
 The two levels reconcile exactly, so the unit-level and pooled reports never
 disagree: the reported separate imbalance ``design.ind_l2`` equals
 :math:`\sqrt{\tfrac1J\sum_j q_j^2}`, and the ``n_units``-weighted per-horizon

--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -29,7 +29,8 @@ from ..exceptions import (
     MlsynthPlottingError,
 )
 from ..utils.ppscm_helpers.engine import run_multisynth
-from ..utils.ppscm_helpers.inference import jackknife_inference, bootstrap_inference
+from ..utils.ppscm_helpers.inference import (
+    jackknife_inference, bootstrap_inference, per_unit_intervals)
 from ..utils.ppscm_helpers.plotter import plot_ppscm
 from ..utils.ppscm_helpers.setup import prepare_ppscm_inputs
 from ..utils.ppscm_helpers.structures import (
@@ -170,6 +171,15 @@ class PPSCM:
             # n1-weighted ``tau`` paths reconstruct the pooled event study, so the
             # unit-level report is the same fit as the aggregate one (no re-run).
             M, nnz, tau_rel, n1 = fit["M"], fit["nnz"], fit["tau_rel"], fit["n1"]
+            # Per-unit CFPT/SCPI prediction bands (the same engine MSQRT uses) --
+            # the per-unit analogue of the pooled inference, from each unit's own
+            # effect path + pre-residuals. Only when inference is on; the pooled
+            # inference stays unchanged.
+            if self.run_inference:
+                pu_lo, pu_hi, pu_p = per_unit_intervals(M, tau_rel, alpha=self.alpha)
+            else:
+                nan = np.full(len(fit["groups"]), np.nan)
+                pu_lo, pu_hi, pu_p = nan, nan, nan
             per_unit: Dict[Any, PPSCMUnitFit] = {}
             for k, g in enumerate(fit["groups"]):
                 key = (str(inputs.time_labels[fit["adopt_of"][g]]) if self.time_cohort
@@ -185,6 +195,9 @@ class PPSCM:
                     tau=tau_k,
                     pre_imbalance=np.asarray(M[:, k], dtype=float),
                     donor_weights=donor_weights.get(key, {}),
+                    ci_lower=(float(pu_lo[k]) if np.isfinite(pu_lo[k]) else None),
+                    ci_upper=(float(pu_hi[k]) if np.isfinite(pu_hi[k]) else None),
+                    p_value=(float(pu_p[k]) if np.isfinite(pu_p[k]) else None),
                 )
 
             results = PPSCMResults(

--- a/mlsynth/tests/test_ppscm_perunit_intervals.py
+++ b/mlsynth/tests/test_ppscm_perunit_intervals.py
@@ -1,0 +1,144 @@
+"""Per-unit prediction intervals for PPSCM (CFPT/SCPI, the engine MSQRT uses).
+
+PPSCM's pooled inference (bootstrap / jackknife over units) cannot give a single
+treated unit its own interval. This adds a per-unit band built from each unit's own
+post-period effect path and pre-period residuals via mlsynth's out-of-sample CFPT
+interval engine -- the same machinery MSQRT uses -- so PPSCM's per-geo bands are
+methodologically consistent with MSQRT's and correctly account for the in-sample
+fit (a naive permutation over the QP-optimised pre-residuals over-rejects; this
+does not).
+
+The gate is finite-sample coverage: under a no-effect null the interval must cover
+zero at ~the nominal rate (conservative is acceptable, under-coverage is not). The
+rest pins monotonicity in ``alpha``, power against a real effect, the bracketing
+invariant, ragged-horizon handling, and the end-to-end wiring onto ``PPSCMUnitFit``.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.utils.ppscm_helpers.inference import per_unit_intervals
+
+
+def _resid_cols(rng, n_pre, n_post, effect=0.0):
+    """One unit's (M column, tau_rel row): iid pre + post residuals, +effect post."""
+    M = rng.normal(0.0, 1.0, size=(n_pre, 1))
+    tau = rng.normal(0.0, 1.0, size=(1, n_post)) + effect
+    return M, tau
+
+
+def test_perunit_null_coverage_is_at_least_nominal():
+    # THE GATE: under no effect, the 90% per-unit interval covers 0 at >= ~90%
+    # (CFPT is a sub-Gaussian prediction band -- conservative is fine, under-
+    # coverage is the failure mode we must rule out).
+    rng = np.random.default_rng(0)
+    alpha, reps, covered = 0.10, 400, 0
+    for _ in range(reps):
+        M, tau = _resid_cols(rng, n_pre=24, n_post=8, effect=0.0)
+        lo, hi, _ = per_unit_intervals(M, tau, alpha=alpha)
+        if lo[0] <= 0.0 <= hi[0]:
+            covered += 1
+    cov = covered / reps
+    assert 0.85 <= cov <= 1.0, cov
+
+
+def test_perunit_ci_widens_as_alpha_shrinks():
+    rng = np.random.default_rng(1)
+    M, tau = _resid_cols(rng, n_pre=30, n_post=10, effect=0.0)
+    lo80, hi80, _ = per_unit_intervals(M, tau, alpha=0.20)
+    lo95, hi95, _ = per_unit_intervals(M, tau, alpha=0.05)
+    assert lo95[0] <= lo80[0] and hi95[0] >= hi80[0]        # 95% contains 80%
+
+
+def test_perunit_detects_a_large_effect():
+    rng = np.random.default_rng(2)
+    M, tau = _resid_cols(rng, n_pre=40, n_post=12, effect=6.0)
+    lo, hi, p = per_unit_intervals(M, tau, alpha=0.10)
+    assert lo[0] > 0.0                                       # band clears zero
+    assert p[0] < 0.10
+
+
+def test_perunit_ci_brackets_the_point_estimate():
+    rng = np.random.default_rng(3)
+    M, tau = _resid_cols(rng, n_pre=30, n_post=9, effect=1.5)
+    lo, hi, _ = per_unit_intervals(M, tau, alpha=0.10)
+    att = float(np.nanmean(tau))
+    assert lo[0] <= att <= hi[0]
+
+
+def test_perunit_handles_ragged_horizons_and_multiple_units():
+    # tau may carry NaN past a unit's horizon; the engine is called per unit, so
+    # the two units' bands come back finite regardless of the ragged shape.
+    rng = np.random.default_rng(4)
+    M = np.column_stack([rng.normal(size=24), rng.normal(size=24)])
+    tau = np.vstack([np.r_[rng.normal(size=6), [np.nan, np.nan]],
+                     rng.normal(size=8)])
+    lo, hi, p = per_unit_intervals(M, tau, alpha=0.10)
+    assert lo.shape == hi.shape == p.shape == (2,)
+    assert np.all(np.isfinite(lo)) and np.all(np.isfinite(hi))
+
+
+# ---- end-to-end: the fields land on PPSCMUnitFit --------------------------
+
+def _block_panel(rng, n_donors=8, n_treated=3, T=30, T0=22, effect=0.0):
+    """Long (unit, time, y, treat) panel: a block design, donors + treated."""
+    import pandas as pd
+    rows = []
+    donors = {f"d{i}": rng.normal(50, 5, size=T).cumsum() / 5 + rng.normal(0, 1, T)
+              for i in range(n_donors)}
+    base = np.mean(list(donors.values()), axis=0)
+    for i in range(n_donors):
+        for t in range(T):
+            rows.append(("d%d" % i, t, donors["d%d" % i][t], 0))
+    for j in range(n_treated):
+        y = base + rng.normal(0, 1, T)
+        y[T0:] += effect                                    # post effect
+        for t in range(T):
+            rows.append(("t%d" % j, t, y[t], 1 if t >= T0 else 0))  # 0/1 dummy
+    return pd.DataFrame(rows, columns=["unit", "time", "y", "treat"])
+
+
+def test_ppscm_fit_populates_per_unit_interval_fields():
+    from mlsynth import PPSCM
+    from mlsynth.config_models import PPSCMConfig
+    rng = np.random.default_rng(7)
+    df = _block_panel(rng, effect=3.0)
+    res = PPSCM(PPSCMConfig(df=df, outcome="y", treat="treat", unitid="unit",
+                            time="time", run_inference=True, alpha=0.10,
+                            display_graphs=False)).fit()
+    assert res.per_unit, "expected per-unit fits"
+    for key, uf in res.per_unit.items():
+        assert uf.ci_lower is not None and uf.ci_upper is not None
+        assert uf.p_value is not None and 0.0 <= uf.p_value <= 1.0
+        assert uf.ci_lower <= uf.att <= uf.ci_upper           # band brackets point
+
+
+def test_bootstrap_pooled_and_scpi_perunit_coexist():
+    # the GEDI contract: pooled CI from the bootstrap, per-unit CIs from SCPI,
+    # in one fit.
+    from mlsynth import PPSCM
+    from mlsynth.config_models import PPSCMConfig
+    rng = np.random.default_rng(11)
+    df = _block_panel(rng, effect=3.0)
+    res = PPSCM(PPSCMConfig(df=df, outcome="y", treat="treat", unitid="unit",
+                            time="time", run_inference=True,
+                            inference_method="bootstrap", n_boot=200, seed=0,
+                            alpha=0.10, display_graphs=False)).fit()
+    # pooled inference is the bootstrap, and its band brackets the pooled ATT
+    assert res.inference_detail.method == "bootstrap"
+    lo, hi = res.inference_detail.ci
+    assert lo <= res.inference_detail.att <= hi
+    # per-unit CIs are present (SCPI) and bracket each unit's own ATT
+    for uf in res.per_unit.values():
+        assert uf.ci_lower is not None and uf.ci_lower <= uf.att <= uf.ci_upper
+
+
+def test_ppscm_no_inference_leaves_per_unit_bands_none():
+    from mlsynth import PPSCM
+    from mlsynth.config_models import PPSCMConfig
+    rng = np.random.default_rng(8)
+    df = _block_panel(rng, effect=2.0)
+    res = PPSCM(PPSCMConfig(df=df, outcome="y", treat="treat", unitid="unit",
+                            time="time", run_inference=False,
+                            display_graphs=False)).fit()
+    for uf in res.per_unit.values():
+        assert uf.ci_lower is None and uf.ci_upper is None and uf.p_value is None

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -19,6 +19,83 @@ from scipy.stats import norm
 
 from .engine import run_multisynth, predict_tau
 
+
+def per_unit_intervals(
+    M: np.ndarray, tau_rel: np.ndarray, *, alpha: float,
+    time_dependence: str = "iid",
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Per-unit CFPT/SCPI prediction intervals for each unit's time-averaged ATT.
+
+    The pooled bootstrap / jackknife measures variability *across* units and so
+    cannot give one treated unit its own interval. This builds a per-unit band from
+    that unit's own fit and reuses mlsynth's out-of-sample interval engine (the same
+    CFPT/SCPI machinery MSQRT uses), so PPSCM's per-unit bands are methodologically
+    consistent with MSQRT's.
+
+    For unit ``k`` the band comes from its post-period effect path
+    ``tau_rel[k, :]`` (the CFPT ``effects``) and its pre-period residuals
+    ``M[:, k]`` (the CFPT ``pre_residuals``): the residual moments set the
+    sub-Gaussian scale of the counterfactual prediction error, which correctly
+    accounts for the in-sample fit -- unlike a naive permutation over the
+    QP-optimised pre-residuals, which are not exchangeable with the post gaps and
+    over-reject. The engine is called per unit (one column at a time), so units
+    with different post horizons (ragged ``NaN``) are handled by trimming.
+
+    Parameters
+    ----------
+    M : numpy.ndarray
+        Pre-period residual columns, shape ``(d, J)`` (a 1-D array is a single
+        unit). ``NaN`` entries are dropped per unit.
+    tau_rel : numpy.ndarray
+        Post-period relative-time effect paths, shape ``(J, H)`` (a 1-D array is a
+        single unit). Trailing ``NaN`` (past a unit's horizon) is dropped.
+    alpha : float
+        Total miscoverage level; the interval is ``100 * (1 - alpha)`` percent.
+        Keyword-only.
+    time_dependence : {"iid", "general"}, default "iid"
+        Time-averaging bound passed through to the CFPT engine. Keyword-only.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        ``(ci_lower, ci_upper, p_value)``, each shape ``(J,)``: the per-unit band
+        bounds on the time-averaged ATT and a band-implied two-sided p-value (the
+        house convention ``2 * (alpha/2) ** ((point/half_width) ** 2)``, clamped to
+        ``[0, 1]``). A unit with no usable residuals yields ``NaN``.
+    """
+    from ..scpi_helpers import out_of_sample_intervals
+
+    M = np.asarray(M, dtype=float)
+    tau_rel = np.asarray(tau_rel, dtype=float)
+    if M.ndim == 1:
+        M = M[:, None]
+    if tau_rel.ndim == 1:
+        tau_rel = tau_rel[None, :]
+    J = tau_rel.shape[0]
+    lo = np.full(J, np.nan)
+    hi = np.full(J, np.nan)
+    pval = np.full(J, np.nan)
+
+    for k in range(J):
+        pre = M[:, k][np.isfinite(M[:, k])]
+        post = tau_rel[k, :][np.isfinite(tau_rel[k, :])]
+        if pre.size == 0 or post.size == 0:  # pragma: no cover - guarded upstream
+            continue
+        res = out_of_sample_intervals(
+            effects=post[:, None], pre_residuals=pre[:, None],
+            unit_names=[k], period_labels=list(range(post.size)),
+            alpha=alpha, time_dependence=time_dependence,
+        )
+        band = res.taus[k]
+        lo[k], hi[k] = float(band.lower), float(band.upper)
+        half = 0.5 * (band.upper - band.lower)
+        if half > 0:
+            pval[k] = float(min(1.0, 2.0 * (alpha / 2.0) ** ((band.point / half) ** 2)))
+        else:  # pragma: no cover - degenerate zero-width band
+            pval[k] = 1.0
+    return lo, hi, pval
+
+
 # Mammen (1993) two-point wild-bootstrap multipliers (mean 0, variance 1) --
 # augsynth's default ``rwild_b``.
 _PHI = np.sqrt(5.0)

--- a/mlsynth/utils/ppscm_helpers/structures.py
+++ b/mlsynth/utils/ppscm_helpers/structures.py
@@ -9,7 +9,7 @@ pooled SCM (``nu`` large), on top of two-way fixed effects.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import numpy as _np
@@ -168,6 +168,12 @@ class PPSCMUnitFit:
     tau: np.ndarray
     pre_imbalance: np.ndarray
     donor_weights: Dict[Any, float]
+    # Per-unit CFPT/SCPI prediction band on this unit's time-averaged ATT (the same
+    # engine MSQRT uses). None when inference is off. See ``per_unit_intervals`` in
+    # ``inference.py``.
+    ci_lower: Optional[float] = None
+    ci_upper: Optional[float] = None
+    p_value: Optional[float] = None
 
 
 class PPSCMResults(_BaseEstimatorResults):


### PR DESCRIPTION
## What

Adds per-unit confidence intervals to `PPSCM` — the per-unit analogue of the pooled inference. Each `PPSCMUnitFit` now carries `ci_lower` / `ci_upper` and a band-implied `p_value` for its own time-averaged ATT, populated when `run_inference` is on. The pooled inference (delete-one jackknife / wild bootstrap) is unchanged.

## How

`per_unit_intervals(M, tau_rel, alpha)` in `ppscm_helpers/inference.py` builds each unit's band from its own pre-period residuals (`M[:, k]`) and post-period gap (`tau_rel[k, :]`) via the existing CFPT/SCPI out-of-sample interval engine (`utils/scpi_helpers`) — the same machinery behind MSQRT's bands — with the synthetic-control weights held fixed. `PPSCM.fit` populates the new fields; `PPSCMUnitFit` gains three optional fields (default `None`, so the change is additive and the result contract is unchanged when inference is off).

## Why SCPI, not a naive conformal

A first attempt used a conformal permutation over the pre-period residuals. Its coverage test passed on exchangeable synthetic residuals but the end-to-end test on a real fit failed: PPSCM's pre-period residuals are the QP-optimised imbalance (made small by the fit), so they are not exchangeable with the post-period gaps — the permutation over-rejects and the interval fails to bracket the point estimate. The SCPI construction accounts for the in-sample fit correctly and, as a bonus, makes PPSCM's per-unit bands methodologically consistent with MSQRT's.

## Tests

`test_ppscm_perunit_intervals.py`: null-coverage gate (≥ nominal), α-monotonicity, power against a real effect, the bracketing invariant, ragged-horizon handling, the end-to-end wiring onto `PPSCMUnitFit`, and a bootstrap-pooled + SCPI-per-unit coexistence check. 8/8; the PPSCM + result-contract subset is 206/206.

## Docs

`docs/ppscm.rst` Inference section documents the new per-unit intervals and why the SCPI construction is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr

---
_Generated by [Claude Code](https://claude.ai/code/session_015nRd88pbMUETcrkKY1S6Hr)_