### PR TITLE
ci(benchmarks): shard the daily suite + cache CRAN R packages (fix timeout)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,13 +5,15 @@ name: Daily benchmark validation
 # cross-checks actually execute instead of self-skipping.
 #
 # The reference dependencies do not all coexist in one environment, so the work
-# is split across four jobs:
+# is split across several jobs:
 #
 #   suite                    -- mlsynth[all] (the design/SCIP + bayes/JAX extras,
 #                               which need numpy>=2 / pandas>=3) plus the R
 #                               reference stack. The R-backed live cross-checks
 #                               (Synth, augsynth, pensynth, MSCMT, orthsc, ...)
 #                               run here; git-based references self-clone on demand.
+#                               Sharded across parallel jobs + R packages cached
+#                               (see the suite job's own note).
 #   python-refs-causaltensor -- causaltensor alone (see note below).
 #   python-refs-relax        -- kneed / toolz / scmrelax.
 #   python-refs-spsydid      -- libpysal only (kept apart from scmrelax/mosek).
@@ -51,10 +53,29 @@ jobs:
   # ---------------------------------------------------------------------------
   # Main suite: mlsynth[all] + the R reference stack. Runs every registered case;
   # the R-backed live cross-checks execute because R is provisioned here.
+  #
+  # SHARDED: the live-reference run is the slow part, so it is split round-robin
+  # across NUM_SHARDS parallel jobs (run_benchmarks.py --shard i --num-shards N).
+  # Each shard runs ~1/N of the cases, keeping every shard well under the
+  # timeout. To change the shard count, edit BOTH the matrix list and NUM_SHARDS.
+  #
+  # R CACHE: the CRAN references (requirements.R -> Synth/synthdid/did + their
+  # dependencies -- the heaviest compiles) install into a user-writable
+  # R_LIBS_USER that is cached across runs. requirements.R self-skips packages
+  # already present, so the cache is a pure speed-up with no risk of silently
+  # skipping a cross-check. The commit-pinned GitHub leaves still compile each
+  # run (best-effort, into the system library).
   # ---------------------------------------------------------------------------
   suite:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    env:
+      NUM_SHARDS: "4"
+      R_LIBS_USER: ${{ github.workspace }}/.rlibs
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -70,32 +91,43 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e '.[all]'
 
-      # Bring up R and the CRAN references (Synth, synthdid, did), then the
-      # commit-pinned GitHub references. Each provisioner is best-effort: a build
-      # that fails leaves its cross-check skipping, surfaced in the log, without
-      # failing the job. The benchmark run itself is the gate.
-      - name: Provision R reference toolchain
+      - name: Install R
         run: |
-          set -x
           sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             r-base r-base-dev build-essential cmake gfortran
-          sudo Rscript benchmarks/R/requirements.R || echo "::warning::requirements.R partial"
+
+      - name: Cache CRAN reference packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: rlibs-${{ runner.os }}-R-${{ hashFiles('benchmarks/R/requirements.R') }}
+
+      # The CRAN references install into the cached user library (requirements.R
+      # self-skips those already restored). The commit-pinned GitHub leaves are
+      # best-effort: a build that fails leaves its cross-check skipping, surfaced
+      # in the log, without failing the job. The benchmark run itself is the gate.
+      - name: Provision R reference toolchain
+        run: |
+          set -x
+          mkdir -p "$R_LIBS_USER"
+          Rscript benchmarks/R/requirements.R || echo "::warning::requirements.R partial"
           for s in benchmarks/R/install_*.sh; do
             echo "::group::$s"
             sudo bash "$s" || echo "::warning::provisioner failed: $s (its cross-check will skip)"
             echo "::endgroup::"
           done
 
-      - name: Run benchmark suite (live references)
+      - name: Run benchmark suite shard (live references)
         run: |
-          python -u benchmarks/run_benchmarks.py --all --with-reference --report
+          python -u benchmarks/run_benchmarks.py --all --with-reference --report \
+            --shard "${{ matrix.shard }}" --num-shards "${NUM_SHARDS}"
 
       - name: Upload benchmark report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-report
+          name: benchmark-report-shard-${{ matrix.shard }}
           path: |
             benchmarks/REPORT.md
             benchmarks/report.json

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -96,6 +96,23 @@ def write_report(results: list, out_dir: Path) -> None:
     print(f"\nwrote {report_json} and {out_dir / 'REPORT.md'}")
 
 
+def select_cases(names, needs_reference, *, with_reference, shard, num_shards):
+    """The ordered case names to run for a selection, filter and shard.
+
+    Reference-only cases are dropped unless ``with_reference``. With
+    ``num_shards > 1`` the filtered list is split round-robin
+    (``names[shard::num_shards]``) so the heavy R-backed cases --- scattered
+    through the registry --- spread evenly across shards; the shards partition
+    the list exactly (disjoint and, unioned, exhaustive).
+    """
+    if not with_reference:
+        needs = set(needs_reference)
+        names = [n for n in names if n not in needs]
+    if num_shards > 1:
+        names = names[shard::num_shards]
+    return names
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--all", action="store_true")
@@ -104,11 +121,21 @@ def main() -> int:
                     help="also run cases that require an R reference implementation")
     ap.add_argument("--report", action="store_true",
                     help="write benchmarks/REPORT.md and benchmarks/report.json")
+    ap.add_argument("--num-shards", type=int, default=1,
+                    help="split the selected cases into this many shards "
+                         "(round-robin), for parallel CI jobs")
+    ap.add_argument("--shard", type=int, default=0,
+                    help="0-based index of the shard to run (with --num-shards)")
     args = ap.parse_args()
+    if args.num_shards < 1:
+        ap.error("--num-shards must be >= 1")
+    if not (0 <= args.shard < args.num_shards):
+        ap.error("--shard must be in [0, num_shards)")
 
-    names = ([args.case] if args.case else list(registry.CASES))
-    if not args.with_reference:
-        names = [n for n in names if n not in registry.NEEDS_REFERENCE]
+    base = [args.case] if args.case else list(registry.CASES)
+    names = select_cases(
+        base, registry.NEEDS_REFERENCE, with_reference=args.with_reference,
+        shard=args.shard, num_shards=args.num_shards)
 
     results = [run_one(n) for n in names]
     n_pass = sum(r["status"] == "pass" for r in results)

--- a/benchmarks/tests/test_shard_selection.py
+++ b/benchmarks/tests/test_shard_selection.py
@@ -1,0 +1,58 @@
+"""Unit tests for the benchmark runner's case selection + sharding.
+
+The daily benchmark ``suite`` job is sharded across parallel CI jobs via
+``run_benchmarks.py --num-shards N --shard i``; these pin that the round-robin
+split is a genuine partition (disjoint, exhaustive) so no case is dropped or
+double-run, and that reference filtering still applies.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+# Import the driver module directly (it is a script, not an installed package).
+_SPEC = importlib.util.spec_from_file_location(
+    "run_benchmarks",
+    Path(__file__).resolve().parents[1] / "run_benchmarks.py",
+)
+run_benchmarks = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(run_benchmarks)
+select_cases = run_benchmarks.select_cases
+
+ALL = [f"c{i}" for i in range(10)]
+NEEDS = {"c2", "c7"}
+
+
+def test_no_reference_filters_needs_reference():
+    got = select_cases(ALL, NEEDS, with_reference=False, shard=0, num_shards=1)
+    assert got == [c for c in ALL if c not in NEEDS]
+
+
+def test_with_reference_keeps_all():
+    got = select_cases(ALL, NEEDS, with_reference=True, shard=0, num_shards=1)
+    assert got == ALL
+
+
+def test_shards_partition_exactly():
+    n = 4
+    shards = [select_cases(ALL, NEEDS, with_reference=True, shard=i, num_shards=n)
+              for i in range(n)]
+    flat = [c for s in shards for c in s]
+    # disjoint + exhaustive (a true partition, order-independent)
+    assert sorted(flat) == sorted(ALL)
+    assert len(flat) == len(set(flat)) == len(ALL)
+
+
+def test_shard_is_round_robin_slice():
+    got = select_cases(ALL, NEEDS, with_reference=True, shard=1, num_shards=3)
+    assert got == ALL[1::3]
+
+
+def test_sharding_applies_after_reference_filter():
+    n = 3
+    shards = [select_cases(ALL, NEEDS, with_reference=False, shard=i, num_shards=n)
+              for i in range(n)]
+    flat = [c for s in shards for c in s]
+    kept = [c for c in ALL if c not in NEEDS]
+    assert sorted(flat) == sorted(kept)  # needs-reference cases never appear


### PR DESCRIPTION
## Problem

The daily benchmark `suite` job has been ending `cancelled` on every scheduled run. Cause: a job timeout, not a regression. Inspecting the last run's `suite` job — `timeout-minutes: 120`, ~21 min to provision the R toolchain, then the live-reference run was still going at the 2-hour mark and got killed (a `timeout-minutes` kill reports as `cancelled`, not `failure`). The other three `python-refs-*` jobs finish in ~1 min each; only `suite` overruns.

## Fix

**Shard the suite** (the timeout fix). `run_benchmarks.py` gains `--num-shards`/`--shard`: a round-robin slice of the selected cases, applied *after* the reference filter. The `suite` job becomes a `fail-fast: false` matrix over 4 shards. The 107 cases split `[27, 27, 27, 26]`, so each shard's live-reference run is ~1/4 the time — comfortably under a new 90-min timeout. Reports upload per shard.

**Cache CRAN references** (the speed-up). `requirements.R` (Synth / synthdid / did + their heavy dependencies) now installs into a cached, user-writable `R_LIBS_USER` instead of the system library. Because `requirements.R` self-skips packages already present, the cache is a pure speed-up with **no** risk of silently skipping a cross-check (it never gates provisioning on a cache flag). The commit-pinned GitHub leaves still compile each run, best-effort as before.

## Notes

- The benchmark workflow only runs on `schedule` / `workflow_dispatch`, so this does **not** run on PR CI. The unit change to the runner (`select_cases`) is covered by a new test: the shard split is a genuine partition (disjoint + exhaustive), the reference filter still applies, and the unsharded default is unchanged.
- To change the shard count, edit both the matrix list and `NUM_SHARDS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016M8nFbV4tKcug84GHsxZto)_