### PR TITLE
fix(spotsynth): scale-normalise the frequentist simplex SC solve

### DIFF
--- a/mlsynth/tests/test_spotsynth_scaling.py
+++ b/mlsynth/tests/test_spotsynth_scaling.py
@@ -1,0 +1,58 @@
+"""Scaling robustness for SPOTSYNTH's frequentist simplex SC solver.
+
+The paper (O'Riordan & Gilligan-Lee 2025, Algorithm 1 step 1) normalises the
+target and donors so the procedure is invariant to the scale of the outcome.
+``simplex_weights`` fed the raw outcomes to CLARABEL, so a large-magnitude panel
+(e.g. Spotify monthly-listener counts, ~1e7) produced a badly-scaled QP the
+solver could not solve. Scaling ``y`` and ``D`` by a common constant leaves the
+simplex argmin unchanged (the objective scales by ``c^2``), so the fix conditions
+the QP without altering a single weight.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.spotsynth_helpers import simplex_weights
+
+
+def _panel(scale: float, seed: int = 0):
+    """A small, well-posed SC panel scaled by ``scale``."""
+    rng = np.random.default_rng(seed)
+    T, J = 40, 5
+    D = rng.normal(0.0, 1.0, size=(T, J))
+    y = D @ np.array([0.4, 0.3, 0.2, 0.1, 0.0]) + rng.normal(0.0, 0.05, size=T)
+    return y * scale, D * scale
+
+
+class TestSimplexWeightsScaling:
+    def test_large_magnitude_panel_solves(self):
+        # A Spotify-magnitude panel (~1e7) that the raw CLARABEL solve chokes on.
+        y, D = _panel(scale=1e7)
+        w, cf = simplex_weights(y, D, T0=25)
+        assert np.isfinite(w).all()
+        assert np.isclose(w.sum(), 1.0, atol=1e-6)
+        assert np.all(w >= -1e-9)
+        assert cf.shape == (40,)
+
+    def test_weights_are_scale_invariant(self):
+        # The simplex argmin is invariant to a common rescaling of y and D, so
+        # the weights at scale 1 and scale 1e6 must coincide.
+        w1, _ = simplex_weights(*_panel(scale=1.0), T0=25)
+        w2, _ = simplex_weights(*_panel(scale=1e6), T0=25)
+        assert np.allclose(w1, w2, atol=1e-6)
+
+    def test_matches_golden_on_wellscaled_panel(self):
+        # On a panel the raw solver already handled, the scaled solver must
+        # reproduce the pre-fix weights (captured from the original CLARABEL fit).
+        golden = np.array([0.40154771137081924, 0.30283477708141837,
+                           0.19677718892426052, 0.09884032262350192, 0.0])
+        w, _ = simplex_weights(*_panel(scale=1.0), T0=25)
+        assert np.allclose(w, golden, atol=1e-6)
+
+    def test_counterfactual_is_on_the_raw_scale(self):
+        # The returned counterfactual must be D_raw @ w, i.e. on the input scale,
+        # not the internal solve scale.
+        y, D = _panel(scale=1e7)
+        w, cf = simplex_weights(y, D, T0=25)
+        assert np.allclose(cf, D @ w, atol=1e-3)

--- a/mlsynth/utils/spotsynth_helpers/sc.py
+++ b/mlsynth/utils/spotsynth_helpers/sc.py
@@ -39,8 +39,18 @@ def simplex_weights(y: np.ndarray, D: np.ndarray, T0: int) -> Tuple[np.ndarray, 
         raise MlsynthEstimationError("No donors available to build the synthetic control.")
     pre = slice(0, T0)
     n = D.shape[1]
+    # Common rescaling for conditioning: the simplex argmin of
+    # ``||y - D w||^2`` is invariant to a shared positive scaling of ``(y, D)``
+    # (the objective just scales by ``c^2``), so solving on a unit-magnitude
+    # version keeps CLARABEL well-conditioned on large-magnitude outcomes
+    # (e.g. streaming counts ~1e7, which otherwise yield "no solution"). This
+    # realises the paper's Algorithm 1 scale-normalisation for the frequentist
+    # solve; the counterfactual is returned on the raw scale via ``D @ weights``.
+    scale = float(np.sqrt(np.mean(np.square(D[pre]))))
+    if not np.isfinite(scale) or scale <= 0.0:
+        scale = 1.0
     w = cp.Variable(n, nonneg=True)
-    objective = cp.Minimize(cp.sum_squares(y[pre] - D[pre] @ w))
+    objective = cp.Minimize(cp.sum_squares(y[pre] / scale - (D[pre] / scale) @ w))
     problem = cp.Problem(objective, [cp.sum(w) == 1])
     try:
         problem.solve(solver=cp.CLARABEL)


### PR DESCRIPTION
## What

SPOTSYNTH's frequentist `simplex_weights` (`spotsynth_helpers/sc.py`) fed raw
outcomes to CLARABEL. On a large-magnitude panel — e.g. Spotify monthly-listener
counts (~1e7) — the resulting QP is too poorly scaled and CLARABEL returns no
solution (`"SC solver returned no solution."`). Because this "All donors"
baseline runs unconditionally in the pipeline, it breaks the entire fit even
under Bayesian inference.

The paper (O'Riordan & Gilligan-Lee 2025, Algorithm 1 step 1) normalises the
target and donors specifically so the procedure is invariant to the scale of the
outcome. The Bayesian solve (`bayes.py`) and the spillover screen (`screen.py`)
already standardise — this one frequentist path did not.

## Fix

Divide `y` and `D` by a common pre-period RMS before the solve. The simplex
argmin of `||y - D w||^2` is invariant to a shared positive scaling of `(y, D)`
(the objective just scales by `c^2`), so the weights are unchanged and only the
conditioning improves. The counterfactual is still returned on the raw scale via
`D @ weights`.

## Tests (test-first)

`test_spotsynth_scaling.py`:
- a large-magnitude (~1e7) panel now solves and returns a valid simplex point;
- weights are scale-invariant (scale 1 vs scale 1e6 coincide to 1e-6);
- on a well-scaled panel the result matches the pre-fix golden weights (the fix
  changes nothing where the solver already worked);
- the counterfactual stays on the raw input scale.

The existing SPOTSYNTH suite (`test_spotsynth*.py`, 76 tests) stays green.

## Effect

Unblocks SPOTSYNTH on large-magnitude outcomes. On the Tyla / "Water" panel the
spillover screen now runs end-to-end (screens 30 of 59 donors as
unforecastable; ATT ~23.6M monthly listeners, essentially unchanged by the
screen since the weight-carrying donors survive it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016M8nFbV4tKcug84GHsxZto

---
_Generated by [Claude Code](https://claude.ai/code/session_016M8nFbV4tKcug84GHsxZto)_