### PR TITLE
feat(pangeo): solve the exact-cover partition MIP via highspy directly

### DIFF
--- a/mlsynth/tests/test_pangeo_highspy.py
+++ b/mlsynth/tests/test_pangeo_highspy.py
@@ -1,0 +1,123 @@
+"""Differential tests: the highspy MIP backend must match the cvxpy oracle.
+
+PANGEO's exact-cover partition MIP is solved by highspy directly when available
+(dropping the cvxpy middleman), falling back to cvxpy otherwise. The two must
+return the same optimum -- the same total score over a valid exact cover -- on
+every instance. Ties in score can yield a different but equally optimal cover,
+so the contract is on the objective value and cover validity, not the exact
+selection.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthEstimationError
+from mlsynth.utils.pangeo_helpers.mip import (
+    solve_partition,
+    _solve_partition_highspy,
+    _solve_partition_cvxpy,
+    _highspy_available,
+)
+
+pytestmark = pytest.mark.skipif(
+    not _highspy_available(), reason="highspy not installed")
+
+
+def _pair(members, score):
+    m = [int(u) for u in members]
+    half = len(m) // 2
+    return {"members": m, "score": float(score),
+            "side_a": m[:half], "side_b": m[half:]}
+
+
+def _rand_instance(seed, n_units, extra=10, allow_supergeo=True):
+    """Random FEASIBLE candidate set: a base perfect matching + random extras."""
+    rng = np.random.default_rng(seed)
+    pairs = [_pair([i, i + 1], rng.uniform(0.1, 3.0))
+             for i in range(0, n_units, 2)]
+    for _ in range(extra):
+        k = int(rng.choice([2, 4])) if allow_supergeo else 2
+        k = min(k, n_units - (n_units % 2))
+        if k < 2:
+            continue
+        mem = sorted(rng.choice(n_units, size=k, replace=False).tolist())
+        pairs.append(_pair(mem, rng.uniform(0.1, 3.0)))
+    return np.arange(n_units), pairs
+
+
+def _cover_ok(chosen, units):
+    covered = [int(u) for p in chosen for u in p["members"]]
+    return sorted(covered) == sorted(int(u) for u in units)
+
+
+def _obj(chosen):
+    return sum(p["score"] for p in chosen)
+
+
+class TestHighspyMatchesCvxpy:
+    @pytest.mark.parametrize("seed", range(30))
+    def test_same_objective_and_valid_cover(self, seed):
+        units, pairs = _rand_instance(seed, n_units=6)
+        ch_h = _solve_partition_highspy(pairs, units, min_pairs=1)
+        ch_c = _solve_partition_cvxpy(pairs, units, min_pairs=1)
+        assert _cover_ok(ch_h, units), "highspy returned an invalid cover"
+        assert _cover_ok(ch_c, units), "cvxpy returned an invalid cover"
+        assert _obj(ch_h) == pytest.approx(_obj(ch_c), abs=1e-6)
+
+    @pytest.mark.parametrize("n_units", [4, 8, 10])
+    def test_larger_arms(self, n_units):
+        units, pairs = _rand_instance(7, n_units=n_units, extra=16)
+        ch_h = _solve_partition_highspy(pairs, units, 1)
+        ch_c = _solve_partition_cvxpy(pairs, units, 1)
+        assert _cover_ok(ch_h, units) and _cover_ok(ch_c, units)
+        assert _obj(ch_h) == pytest.approx(_obj(ch_c), abs=1e-6)
+
+    @pytest.mark.parametrize("min_pairs", [1, 2, 3])
+    def test_min_pairs_constraint(self, min_pairs):
+        units, pairs = _rand_instance(9, n_units=8, extra=14)
+        ch_h = _solve_partition_highspy(pairs, units, min_pairs)
+        ch_c = _solve_partition_cvxpy(pairs, units, min_pairs)
+        assert len(ch_h) >= min_pairs and len(ch_c) >= min_pairs
+        assert _cover_ok(ch_h, units) and _cover_ok(ch_c, units)
+        assert _obj(ch_h) == pytest.approx(_obj(ch_c), abs=1e-6)
+
+
+class TestHighspyContract:
+    def test_no_candidates_raises(self):
+        with pytest.raises(MlsynthEstimationError):
+            _solve_partition_highspy([], np.arange(4), 1)
+
+    def test_uncoverable_unit_raises_with_reason(self):
+        pairs = [_pair([0, 1], 1.0), _pair([0, 2], 1.0)]   # unit 3 in no pair
+        with pytest.raises(MlsynthEstimationError, match="uncoverable"):
+            _solve_partition_highspy(pairs, np.arange(4), 1)
+
+    def test_diagnostics_schema(self):
+        units, pairs = _rand_instance(1, 6)
+        chosen, diag = _solve_partition_highspy(
+            pairs, units, 1, return_diagnostics=True)
+        assert diag["path"] == "exact_mip"
+        assert diag["status"] == "optimal"
+        assert diag["n_selected_pairs"] == len(chosen)
+        for k in ("mip_gap", "dual_bound", "node_count", "simplex_iterations",
+                  "objective_value", "n_candidate_pairs", "solve_seconds",
+                  "solver_name"):
+            assert k in diag
+        assert diag["objective_value"] == pytest.approx(_obj(chosen), abs=1e-6)
+
+
+class TestDispatch:
+    def test_solve_partition_prefers_highspy(self):
+        units, pairs = _rand_instance(3, 6)
+        chosen = solve_partition(pairs, units, 1)
+        assert _cover_ok(chosen, units)
+        _, diag = solve_partition(pairs, units, 1, return_diagnostics=True)
+        assert diag["path"] == "exact_mip"
+
+    def test_falls_back_to_cvxpy_when_highspy_absent(self, monkeypatch):
+        import mlsynth.utils.pangeo_helpers.mip as mip
+        monkeypatch.setattr(mip, "_highspy_available", lambda: False)
+        units, pairs = _rand_instance(5, 6)
+        chosen = mip.solve_partition(pairs, units, 1)   # routes to the cvxpy MIP
+        assert _cover_ok(chosen, units)

--- a/mlsynth/utils/pangeo_helpers/mip.py
+++ b/mlsynth/utils/pangeo_helpers/mip.py
@@ -122,7 +122,124 @@ def _infeasibility_reason(candidate_pairs: List[dict],
     return "; ".join(reasons)
 
 
+def _highspy_available() -> bool:
+    """True if the standalone ``highspy`` HiGHS interface is importable."""
+    try:
+        import highspy  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 def solve_partition(
+    candidate_pairs: List[dict],
+    unit_indices: np.ndarray,
+    min_pairs: int = 1,
+    return_diagnostics: bool = False,
+):
+    """Select the exact-cover set of supergeo pairs of minimum total score.
+
+    Dispatches to the standalone ``highspy`` HiGHS backend when available
+    (dropping the cvxpy middleman for the MIP), otherwise falls back to the
+    cvxpy MIP. Both solve the identical exact-cover program and return the same
+    optimum; see :func:`_solve_partition_highspy` / :func:`_solve_partition_cvxpy`.
+    """
+    if _highspy_available():
+        return _solve_partition_highspy(
+            candidate_pairs, unit_indices, min_pairs, return_diagnostics)
+    return _solve_partition_cvxpy(
+        candidate_pairs, unit_indices, min_pairs, return_diagnostics)
+
+
+def _solve_partition_highspy(
+    candidate_pairs: List[dict],
+    unit_indices: np.ndarray,
+    min_pairs: int = 1,
+    return_diagnostics: bool = False,
+):
+    """Exact-cover partition MIP solved with ``highspy`` (HiGHS) directly.
+
+    Builds the same program as :func:`_solve_partition_cvxpy` -- one boolean
+    variable per candidate pair, an exact-cover equality per unit, an optional
+    ``sum(x) >= min_pairs``, minimise total score -- but hands it to HiGHS via
+    ``highspy`` with no cvxpy canonicalisation. Returns the chosen pairs (or
+    ``(chosen, diagnostics)``), matching the cvxpy backend's contract.
+    """
+    import highspy
+
+    n_units = len(unit_indices)
+    n_cand = len(candidate_pairs)
+    if n_cand == 0:
+        raise MlsynthEstimationError(
+            "PANGEO: no admissible supergeo pairs (need >= 2 units per arm)."
+        )
+
+    pos = {int(u): j for j, u in enumerate(unit_indices)}
+    cost = [float(p["score"]) for p in candidate_pairs]
+    # Candidates covering each unit position (empty => that unit is uncoverable).
+    cover: List[List[int]] = [[] for _ in range(n_units)]
+    for c, pair in enumerate(candidate_pairs):
+        for u in pair["members"]:
+            cover[pos[int(u)]].append(c)
+
+    h = highspy.Highs()
+    h.setOptionValue("output_flag", False)
+    x = h.addBinaries(n_cand)
+    for i in range(n_units):
+        cs = cover[i]
+        if cs:
+            h.addConstr(sum(x[c] for c in cs) == 1)      # exact cover
+        else:
+            # Uncoverable unit -> empty row fixed to 1 (0 == 1): infeasible.
+            h.addRow(1.0, 1.0, 0,
+                     np.empty(0, dtype=np.int32), np.empty(0, dtype=np.float64))
+    if min_pairs > 1:
+        h.addConstr(sum(x[c] for c in range(n_cand)) >= min_pairs)
+
+    t0 = time.perf_counter()
+    h.minimize(sum(cost[c] * x[c] for c in range(n_cand)))
+    solve_seconds = time.perf_counter() - t0
+
+    status = h.getModelStatus()
+    if status != highspy.HighsModelStatus.kOptimal:
+        raise MlsynthEstimationError(
+            f"PANGEO partition MIP did not solve "
+            f"(status={h.modelStatusToString(status)}); "
+            f"{_infeasibility_reason(candidate_pairs, unit_indices)}."
+        )
+
+    values = np.asarray(h.getSolution().col_value, dtype=float)
+    chosen = [candidate_pairs[c] for c in range(n_cand) if values[c] > 0.5]
+    if not return_diagnostics:
+        return chosen
+
+    info = h.getInfo()
+
+    def _f(v):
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return v
+
+    diagnostics = {
+        "path": "exact_mip",
+        "n_candidate_pairs": int(n_cand),
+        "objective_value": float(h.getObjectiveValue()),
+        "status": "optimal",                          # kOptimal -> cvxpy's label
+        "solve_seconds": float(solve_seconds),
+        "n_selected_pairs": len(chosen),
+        "solver_name": "HiGHS",
+        "mip_gap": _f(getattr(info, "mip_gap", None)),
+        "dual_bound": _f(getattr(info, "mip_dual_bound", None)),
+        "node_count": _f(getattr(info, "mip_node_count", None)),
+        "simplex_iterations": _f(getattr(info, "simplex_iteration_count", None)),
+    }
+    return chosen, diagnostics
+
+
+def _solve_partition_cvxpy(
     candidate_pairs: List[dict],
     unit_indices: np.ndarray,
     min_pairs: int = 1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,14 +53,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# SYNDES / MAREX mixed-integer experimental designs (SCIP solver).
-design = ["pyscipopt>=4.4.0"]
+# SYNDES / MAREX mixed-integer experimental designs (SCIP solver), and the
+# PANGEO exact-cover partition MIP solved directly via HiGHS (``highspy``).
+design = ["pyscipopt>=4.4.0", "highspy>=1.7.0"]
 # HCW best-subset exact certification via the SCIP mixed-integer backend.
 scip = ["pyscipopt>=4.4.0"]
 # SPOTSYNTH Bayesian synthetic control (NumPyro / JAX).
 bayes = ["numpyro"]
 # Everything optional, for the full feature set.
-all = ["pyscipopt>=4.4.0", "numpyro"]
+all = ["pyscipopt>=4.4.0", "highspy>=1.7.0", "numpyro"]
 
 [project.urls]
 Homepage = "https://github.com/jgreathouse9/mlsynth"


### PR DESCRIPTION
## What

PANGEO's supergeo partition is an exact-cover set-partitioning MIP (boolean var
per candidate pair, exact-cover equality per unit, optional `sum(x) >= min_pairs`,
minimise total score). It was solved through cvxpy, which itself dispatches to
HiGHS. This adds a direct `highspy` backend that builds the identical program and
hands it straight to HiGHS, dropping the cvxpy canonicalisation layer.

`solve_partition` now prefers `highspy` when importable and falls back to the
cvxpy MIP otherwise, so behaviour is unchanged where `highspy` is absent. The
error/diagnostics contract is preserved exactly (`status`, `objective_value`,
`mip_gap`, `dual_bound`, `node_count`, `simplex_iterations`, `path="exact_mip"`,
IIS-style infeasibility reasons).

## Why

This is the "drop the cvxpy middleman while keeping the MIP's exactness and
scale for all Q" path. Because it's the same set-partitioning program handed to
the same solver (HiGHS), it inherits HiGHS's scaling and returns the identical
optimum — it just skips cvxpy's per-solve canonicalisation.

Measured against the cvxpy oracle (same total score over a valid exact cover):

| units | candidates | highspy | cvxpy | objective |
|---|---|---|---|---|
| 12 | 66 | 13.6 ms | 25.4 ms | match |
| 20 | 210 | 16.4 ms | 22.6 ms | match |
| 30 | 450 | 946 ms | 919 ms | match |

Faster where canonicalisation was a meaningful fraction; on par where the HiGHS
solve itself dominates. The full PANGEO suite (197 tests) and the supergeo
benchmark pass through the highspy backend unchanged.

## Tests (test-first)

`test_pangeo_highspy.py` — differential highspy-vs-cvxpy on random feasible
instances (objective value + cover validity), `min_pairs` and larger-arm
parametrisations, Q>1 supergeos, the diagnostics schema, the infeasible /
no-candidate error contracts, and the cvxpy fallback dispatch. Skips cleanly if
`highspy` is unavailable.

`highspy` added to the `design` / `all` optional-dependency extras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016M8nFbV4tKcug84GHsxZto

---
_Generated by [Claude Code](https://claude.ai/code/session_016M8nFbV4tKcug84GHsxZto)_