### PR TITLE
docs(smc): fix malformed machine-precision table in the replication page

### DIFF
--- a/docs/replications/smc.rst
+++ b/docs/replications/smc.rst
@@ -31,16 +31,24 @@ predictor weights fixed to one, so the oracle is deterministic. The mlsynth
 weight computation :func:`mlsynth.utils.smc_helpers.smc_weights` is fed the
 identical matrix. Every quantity agrees:
 
-  =========================  ==================
-  Quantity                   max \|mlsynth − R\|
-  =========================  ==================
-  :math:`\widehat{\theta}_j` (all donors)   5.3e-15
-  box weights :math:`\mathbf{w}`            1.9e-14
-  combined :math:`\widehat{\theta}_j w_j`   2.0e-14
-  ``bias``                                  6.3e-14
-  :math:`\widehat{\sigma}^2`                2.4e-14
-  counterfactual (43 years)                 1.7e-13
-  =========================  ==================
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - Quantity
+     - max \|mlsynth − R\|
+   * - :math:`\widehat{\theta}_j` (all donors)
+     - 5.3e-15
+   * - box weights :math:`\mathbf{w}`
+     - 1.9e-14
+   * - combined :math:`\widehat{\theta}_j w_j`
+     - 2.0e-14
+   * - ``bias``
+     - 6.3e-14
+   * - :math:`\widehat{\sigma}^2`
+     - 2.4e-14
+   * - counterfactual (43 years)
+     - 1.7e-13
 
 The synthesis QP is the load-bearing step. mlsynth solves it with an exact
 active-set box solver (:func:`mlsynth.utils.smc_helpers.solver.solve_box_qp`),


### PR DESCRIPTION
## Summary

The cross-validation table on the SMC replication page (`docs/replications/smc.rst`) did not render — the results were missing between the intro paragraph and "The synthesis QP".

Root cause: it was written as an RST **simple table**, but the first column's `:math:` inline markup (e.g. `:math:\`\widehat{\theta}_j\` (all donors)`, ~39 chars) is wider than the column's `===` span (25 chars). Sphinx flags `Malformed table` / "Text in column margin" and drops it.

Fix: rewritten as a `list-table`, which has no column-width alignment constraint and handles inline markup fine.

Verified with docutils that the new page renders a proper `<table>` with all six values present (5.3e-15 … 1.7e-13), and that the old version produced the `Malformed table` error.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012y2a5QT6AVGcoizpCuc8zW

---
_Generated by [Claude Code](https://claude.ai/code/session_012y2a5QT6AVGcoizpCuc8zW)_