### PR TITLE
Inject a fixed penalized lambda in VanillaSC (skip cross-validation)

### DIFF
--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -194,7 +194,13 @@ The covariate path exposes three reliable solvers via ``backend=``:
     leave-one-out :math:`\lambda` selection, giving a unique, sparse
     :math:`\mathbf{w}`. Works with or without covariates. The solver is
     cross-validated against the authors' own ``wsoll1`` (durable case
-    ``pensynth_prop99``); see :doc:`replications/pensynth`.
+    ``pensynth_prop99``); see :doc:`replications/pensynth`. Set
+    ``penalized_lambda`` to supply :math:`\lambda` directly and skip the
+    cross-validation: a large value approaches nearest-neighbour matching, an
+    infinitesimal value gives the lexicographic (fit-preserving) tie-break that
+    resolves non-uniqueness without distorting the fit, and ``0`` recovers the
+    unpenalized synthetic control. ``penalized_cv`` selects the CV criterion
+    only when ``penalized_lambda`` is ``None``.
 
 The identification diagnostic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/mlsynth/tests/test_vanillasc_penalized_lambda.py
+++ b/mlsynth/tests/test_vanillasc_penalized_lambda.py
@@ -1,0 +1,133 @@
+"""Fixed penalty for the penalized (Abadie-L'Hour) VanillaSC backend.
+
+``VanillaSCConfig.penalized_lambda`` lets the user inject their own penalty
+``lambda`` instead of cross-validating it: a numeric value is used as a fixed
+penalty (skipping CV entirely), ``None`` preserves the CV behavior selected by
+``penalized_cv``. Written test-first.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import VanillaSC
+from mlsynth.exceptions import MlsynthConfigError
+
+
+def _panel(J: int = 8, T_pre: int = 15, T_post: int = 6, seed: int = 0):
+    """Factor panel with a unit-level covariate; unit 0 is treated."""
+    rng = np.random.default_rng(seed)
+    T = T_pre + T_post
+    F = rng.standard_normal((T, 2))
+    lam = rng.standard_normal((J + 1, 2))
+    Y = F @ lam.T + 0.2 * rng.standard_normal((T, J + 1))
+    x = lam[:, 0] * 3.0 + rng.standard_normal(J + 1) * 0.1   # unit-level covariate
+    rows = [
+        {"unit": j, "time": t, "y": float(Y[t, j]), "x": float(x[j]),
+         "D": int(j == 0 and t >= T_pre)}
+        for j in range(J + 1) for t in range(T)
+    ]
+    return pd.DataFrame(rows)
+
+
+def _weights(res) -> dict:
+    return {k: v for k, v in (res.weights.donor_weights or {}).items()}
+
+
+def _fit(df, **over):
+    cfg = dict(df=df, outcome="y", treat="D", unitid="unit", time="time",
+               covariates=["x"], backend="penalized", display_graphs=False)
+    cfg.update(over)
+    return VanillaSC(cfg).fit()
+
+
+@pytest.fixture
+def df():
+    return _panel()
+
+
+# ----------------------------------------------------------------------
+# The fixed penalty is honored (skips CV)
+# ----------------------------------------------------------------------
+
+class TestFixedLambda:
+    def test_used_lambda_equals_injected(self, df):
+        res = _fit(df, penalized_lambda=0.7)
+        assert res.method_details.parameters_used["penalized_lambda"] == pytest.approx(0.7)
+
+    def test_lambda_zero_allowed(self, df):
+        res = _fit(df, penalized_lambda=0.0)
+        assert res.method_details.parameters_used["penalized_lambda"] == pytest.approx(0.0)
+        assert res.att is not None and np.isfinite(res.att)
+
+    def test_fixed_lambda_overrides_cv(self, df):
+        # A numeric penalty must ignore penalized_cv entirely.
+        w_holdout = _fit(df, penalized_lambda=0.5, penalized_cv="holdout")
+        w_loo = _fit(df, penalized_lambda=0.5, penalized_cv="loo")
+        a = np.array(list(_weights(w_holdout).values()))
+        b = np.array(list(_weights(w_loo).values()))
+        assert np.allclose(a, b, atol=1e-8)
+
+    def test_deterministic(self, df):
+        a = np.array(list(_weights(_fit(df, penalized_lambda=0.3)).values()))
+        b = np.array(list(_weights(_fit(df, penalized_lambda=0.3)).values()))
+        assert np.allclose(a, b, atol=1e-10)
+
+    def test_larger_lambda_more_concentrated(self, df):
+        # Abadie-L'Hour: larger lambda -> nearer-neighbour -> more concentrated.
+        small = _weights(_fit(df, penalized_lambda=1e-6))
+        large = _weights(_fit(df, penalized_lambda=50.0))
+        assert max(large.values()) >= max(small.values()) - 1e-9
+
+    def test_infinitesimal_lambda_is_lexicographic(self, df):
+        # An infinitesimal-surrogate penalty stays feasible and finite.
+        res = _fit(df, penalized_lambda=1e-10)
+        w = np.array(list(_weights(res).values()))
+        assert w.min() >= -1e-9
+        assert w.sum() == pytest.approx(1.0, abs=1e-6)
+        assert np.isfinite(res.att)
+
+
+# ----------------------------------------------------------------------
+# None preserves cross-validation
+# ----------------------------------------------------------------------
+
+class TestNonePreservesCV:
+    def test_none_runs_cv(self, df):
+        res = _fit(df, penalized_lambda=None)      # default
+        lam = res.method_details.parameters_used["penalized_lambda"]
+        assert lam is not None and np.isfinite(lam) and lam >= 0.0
+
+    def test_fixed_differs_from_cv_when_far(self, df):
+        # A deliberately large fixed penalty should not coincide with the
+        # CV-selected weights.
+        cv = np.array(list(_weights(_fit(df, penalized_lambda=None)).values()))
+        fixed = np.array(list(_weights(_fit(df, penalized_lambda=100.0)).values()))
+        assert not np.allclose(cv, fixed, atol=1e-6)
+
+
+# ----------------------------------------------------------------------
+# Validation
+# ----------------------------------------------------------------------
+
+class TestValidation:
+    def test_negative_lambda_rejected(self, df):
+        with pytest.raises(MlsynthConfigError):
+            VanillaSC(dict(df=df, outcome="y", treat="D", unitid="unit",
+                           time="time", covariates=["x"], backend="penalized",
+                           penalized_lambda=-0.5))
+
+    def test_fixed_lambda_ignored_without_covariates(self, df):
+        # The Abadie-L'Hour pairwise penalty needs covariate predictors; with
+        # none, the engine routes backend='penalized' to the exact outcome-only
+        # simplex, so penalized_lambda has no effect and is surfaced as None.
+        base = dict(df=df, outcome="y", treat="D", unitid="unit", time="time",
+                    display_graphs=False)
+        res = VanillaSC({**base, "backend": "penalized", "penalized_lambda": 0.2}).fit()
+        assert res.method_details.parameters_used["penalized_lambda"] is None
+        oo = VanillaSC({**base, "backend": "outcome-only"}).fit()
+        a = np.array(list(_weights(res).values()))
+        b = np.array(list(_weights(oo).values()))
+        assert np.allclose(a, b, atol=1e-8)

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -268,5 +268,16 @@ class VanillaSCConfig(BaseEstimatorConfig):
         description="Lambda selector for backend='penalized'. 'holdout'/'loo' "
                     "are Abadie-L'Hour time-split criteria; 'pensynth' is van "
                     "Kesteren's cv_pensynth (fit on covariates, validate on the "
-                    "held-out pre-period outcome path; needs covariates).",
+                    "held-out pre-period outcome path; needs covariates). "
+                    "Ignored when 'penalized_lambda' is set.",
+    )
+    penalized_lambda: Optional[float] = Field(
+        default=None, ge=0.0,
+        description="Fixed Abadie-L'Hour penalty for backend='penalized'. When "
+                    "set (>= 0), it is used directly and cross-validation "
+                    "('penalized_cv') is skipped; larger values approach "
+                    "nearest-neighbour matching, an infinitesimal value gives "
+                    "the lexicographic (fit-preserving) tie-break, and 0 is the "
+                    "unpenalized synthetic control. 'None' (default) selects "
+                    "lambda by cross-validation. Ignored for other backends.",
     )

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -255,6 +255,13 @@ def run_vanillasc(config) -> BaseEstimatorResults:
             X1, X0 = Xs[:, 0], Xs[:, 1:]
             pred_names = list(covariates)
 
+        # A fixed penalized penalty (numeric ``lam``) is passed straight to the
+        # penalized solver, which then skips cross-validation; ``None`` keeps
+        # the CV path selected by ``penalized_cv``.
+        penalized_lam_kwargs = (
+            {"lam": float(config.penalized_lambda)}
+            if config.penalized_lambda is not None else {}
+        )
         engine = BilevelSCM(
             config.backend,
             canonical_v=config.canonical_v,
@@ -266,6 +273,7 @@ def run_vanillasc(config) -> BaseEstimatorResults:
             popsize=config.mscmt_popsize,
             prune_shady=config.mscmt_prune_shady,
             cv=config.penalized_cv,
+            **penalized_lam_kwargs,
         )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
@@ -493,6 +501,12 @@ def run_vanillasc(config) -> BaseEstimatorResults:
                 "covariates": covariates,
                 "canonical_v": config.canonical_v,
                 "v_agreement": res.v_agreement,
+                "penalized_lambda": (
+                    float(res.diagnostics["lambda"])
+                    if res.backend == "penalized"
+                    and res.diagnostics.get("lambda") is not None
+                    else None
+                ),
             },
         ),
         additional_outputs={


### PR DESCRIPTION
## Summary

Adds `penalized_lambda` to `VanillaSCConfig` so the Abadie–L'Hour penalized backend can take a user-supplied penalty directly instead of always cross-validating it.

- A numeric value (`>= 0`) is forwarded to the penalized solver as a fixed `lam`, which skips CV and overrides `penalized_cv`.
- `None` (the default) preserves the existing CV behavior selected by `penalized_cv`.
- The λ actually used is surfaced in `method_details.parameters_used["penalized_lambda"]`.

Semantics of the fixed value: a large λ approaches nearest-neighbour matching; an infinitesimal λ gives the lexicographic, fit-preserving tie-break that resolves donor-weight non-uniqueness without distorting the fit; `0` recovers the unpenalized synthetic control.

Motivation: the penalized backend previously always ran a CV selector (`penalized_cv`), with no way to pass a fixed penalty through the public API. This blocks (a) supplying a known/chosen λ, (b) the infinitesimal-ε lexicographic tie-break, and (c) sidestepping the CV path, which is slow on wide donor pools. The engine (`BilevelSCM`) already accepted a fixed `lam`; this surfaces it in `VanillaSCConfig` and plumbs it through `run_vanillasc`.

## Changes

- `utils/vanillasc_helpers/config.py`: new `penalized_lambda: Optional[float]` field (`ge=0.0`; negative → `MlsynthConfigError` via the config's `ValidationError` translation).
- `utils/vanillasc_helpers/pipeline.py`: forward a numeric `penalized_lambda` into the `BilevelSCM(...)` construction as `lam=` when set; surface the used penalty (from the penalized solver diagnostics) in `parameters_used`.
- `docs/vanillasc.rst`: document the field in the penalized-backend section.
- `tests/test_vanillasc_penalized_lambda.py`: 10 tests, written test-first.

## Tests (written first, red → green)

- Fixed λ is honored and surfaced (`used == injected`); `0` allowed; deterministic; larger λ is more concentrated; infinitesimal λ stays simplex-feasible and finite.
- A numeric λ overrides `penalized_cv` (holdout vs loo give identical weights).
- `None` preserves CV (a positive λ is selected) and differs from a deliberately far fixed λ.
- Negative λ raises `MlsynthConfigError`.
- Edge case pinned as discovered: with no covariates, `backend="penalized"` routes to the exact outcome-only simplex (the pairwise penalty needs predictors), so `penalized_lambda` is correctly a no-op and surfaced as `None`.

All 10 pass; the broader VanillaSC suite (`test_vanillasc`, `test_vanillasc_ascm`, `test_vanillasc_fit_window`) stays green (68 passed, 1 skipped) — no regression. Change is additive: `penalized_lambda=None` reproduces prior behavior exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7bVBZsrWUPQJbnGGCG1qD)_