### PR TITLE
SCMO: add weights='pcr' (denoised PCR) scheme with rolling-origin CV metric weights

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -13,6 +13,8 @@ References
 
 .. [Amjad2018] Amjad, Muhammad, Devavrat Shah, and Dennis Shen. *"Robust Synthetic Control."* Journal of Machine Learning Research, vol. 19, no. 1, 2018, pp. 802–852.
 
+.. [Amjad2019] Amjad, Muhammad, Vishal Misra, Devavrat Shah, and Dennis Shen. *"mRSC: Multi-dimensional Robust Synthetic Control."* Proceedings of the ACM on Measurement and Analysis of Computing Systems, vol. 3, no. 2, 2019, Article 37. https://doi.org/10.1145/3326152.
+
 .. [MenchettiBojinov2022] Menchetti, Fiammetta, and Iavor Bojinov. *"Estimating the Effectiveness of Permanent Price Reductions for Competing Products Using Multivariate Bayesian Structural Time Series Models."* Annals of Applied Statistics, vol. 16, no. 1, 2022, pp. 414–435. https://doi.org/10.1214/21-AOAS1498.
 
 .. [Brodersen2015] Brodersen, Kay H., Fabian Gallusser, Jim Koehler, Nicolas Remy, and Steven L. Scott. *"Inferring Causal Impact Using Bayesian Structural Time-Series Models."* Annals of Applied Statistics, vol. 9, no. 1, 2015, pp. 247–274. https://doi.org/10.1214/14-AOAS788.

--- a/docs/scmo.rst
+++ b/docs/scmo.rst
@@ -242,6 +242,24 @@ misspecification). ``weights="pcr"`` is an alternative to ``augment="ridge"``,
 not a complement -- both relax the simplex, and requesting them together is an
 error.
 
+Choosing the metric weights (``pcr_metric_weights``)
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+mRSC weights each metric block by a scalar :math:`\delta_k` before the fit. The
+paper gives no closed form for it -- it is a cross-validation hyperparameter,
+equal across metrics by default (``pcr_metric_weights=None``). You may instead
+pass an explicit vector (in outcome order, primary first), or set
+``pcr_metric_weights="cv"`` to choose the auxiliary weight by *rolling-origin*
+cross-validation that minimizes out-of-sample pre-treatment MSE of the primary
+outcome. The CV uses an expanding window entirely inside the pre-period (fit on
+the earliest periods, score the next ``pcr_cv_horizon`` held-out period(s), roll
+the origin forward), so nothing leaks from the post-treatment window; the
+auxiliary weight is searched over ``pcr_cv_grid`` (equal weighting is always a
+candidate, so CV never does worse than equal in-sample). A metric that only adds
+noise is driven toward zero; one that carries signal is kept. The chosen weights
+and the per-candidate CV MSE are recorded in
+``result.method_details.parameters_used``.
+
 Assumptions
 -----------
 

--- a/docs/scmo.rst
+++ b/docs/scmo.rst
@@ -221,6 +221,27 @@ fixed effects); on a single outcome this reproduces ``VanillaSC(augment="ridge")
 up to SCMO's standardized matching design, and the disaggregated single-outcome
 fit reproduces ``augsynth``'s ridge baseline to the decimal.
 
+Denoised PCR weights (``weights="pcr"``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default the weights are convex (on the simplex). Setting ``weights="pcr"``
+instead solves them by denoised principal-component regression on the
+concatenated matching matrix: hard-truncate the donor design to its leading
+singular components, then take the pseudo-inverse. This is the weight rule of
+multi-dimensional Robust Synthetic Control (mRSC; [Amjad2019]_), and it reuses
+the same hard-singular-value-thresholding kernel as ``CLUSTERSC`` and ``SI``.
+Unlike the simplex fit, the resulting weights are unconstrained -- they may be
+negative and need not sum to one -- so a treated unit that lies *outside* the
+convex hull of the donors (an extrapolation the simplex must clip) can be
+matched exactly. The truncation rank is chosen by the cumulative-variance rule
+(``pcr_cumvar``, default 0.95) or fixed with ``pcr_rank``. The trade-off is the
+usual one: the unconstrained fit extracts more signal on data that genuinely
+follow the low-rank factor model, at the cost of the interpretability and
+built-in guardrails of convex weights (it can extrapolate badly under
+misspecification). ``weights="pcr"`` is an alternative to ``augment="ridge"``,
+not a complement -- both relax the simplex, and requesting them together is an
+error.
+
 Assumptions
 -----------
 

--- a/mlsynth/estimators/scmo.py
+++ b/mlsynth/estimators/scmo.py
@@ -114,6 +114,10 @@ class SCMO:
             weights=self.config.weights,
             pcr_rank=self.config.pcr_rank,
             pcr_cumvar=self.config.pcr_cumvar,
+            pcr_metric_weights=self.config.pcr_metric_weights,
+            pcr_cv_grid=self.config.pcr_cv_grid,
+            pcr_cv_horizon=self.config.pcr_cv_horizon,
+            pcr_cv_min_train=self.config.pcr_cv_min_train,
         )
         results = assemble_scmo_results(
             inputs, fits, selected_variant=schemes[0] if schemes else CONCATENATED

--- a/mlsynth/estimators/scmo.py
+++ b/mlsynth/estimators/scmo.py
@@ -50,8 +50,10 @@ class SCMO:
         Validated configuration. Beyond the common fields (``df``, ``outcome``,
         ``treat``, ``unitid``, ``time``, ``display_graphs``, ``save``, colors),
         SCMO reads ``spec`` (matching specification), ``schemes`` /
-        ``method``, ``demean``, ``inference``, ``addout`` and
-        ``conformal_alpha``.
+        ``method``, ``demean``, ``inference``, ``addout``,
+        ``conformal_alpha``, and ``weights`` (``"simplex"`` convex SC weights,
+        the default, or ``"pcr"`` for denoised principal-component-regression
+        weights with rank set by ``pcr_rank`` / ``pcr_cumvar``).
 
     References
     ----------
@@ -60,6 +62,9 @@ class SCMO:
 
     Sun, L., Ben-Michael, E., & Feller, A. (2025). Using Multiple Outcomes to
     Improve the Synthetic Control Method. Review of Economics and Statistics.
+
+    Amjad, M., Misra, V., Shah, D., & Shen, D. (2019). mRSC: Multi-dimensional
+    Robust Synthetic Control. Proc. ACM Meas. Anal. Comput. Syst., 3(2), Art. 37.
     """
 
     def __init__(self, config: Union[SCMOConfig, dict]) -> None:
@@ -106,6 +111,9 @@ class SCMO:
             conformal_q=self.config.conformal_q,
             augment=self.config.augment,
             ridge_lambda=self.config.ridge_lambda,
+            weights=self.config.weights,
+            pcr_rank=self.config.pcr_rank,
+            pcr_cumvar=self.config.pcr_cumvar,
         )
         results = assemble_scmo_results(
             inputs, fits, selected_variant=schemes[0] if schemes else CONCATENATED

--- a/mlsynth/tests/test_scmo.py
+++ b/mlsynth/tests/test_scmo.py
@@ -241,3 +241,99 @@ def test_ridge_lambda_nonpositive_raises(panel):
     with pytest.raises(MlsynthConfigError):
         SCMOConfig(df=panel, outcome="y1", treat="treat", unitid="unit",
                    time="time", augment="ridge", ridge_lambda=0.0)
+
+
+# --- weights='pcr' scheme (mRSC-style denoised PCR) ------------------------
+
+def _prepare(panel, addout="y2"):
+    """Build SCMOInputs the way SCMO.fit does (concatenated, outcome+addout)."""
+    treated_unit, intervention_time, pre_years = derive_treatment(
+        panel, unitid="unit", time="time", treat="treat")
+    spec = build_spec(None, "y1", addout, pre_years)
+    return prepare_scmo_inputs(
+        panel, unitid="unit", time="time", outcome="y1", spec=spec,
+        treated_unit=treated_unit, intervention_time=intervention_time)
+
+
+@pytest.fixture
+def extrapolation_panel() -> pd.DataFrame:
+    """Treated = 1.5*u1 - 0.5*u2 exactly on both outcomes (outside convex hull)."""
+    rng = np.random.default_rng(7)
+    T, T0 = 8, 6
+    donors = {}
+    for u in range(1, 5):
+        donors[u] = {"y1": rng.uniform(5, 15, T), "y2": rng.uniform(5, 15, T)}
+    rows = []
+    for u in range(1, 5):
+        for t in range(T):
+            rows.append(dict(unit=f"u{u}", time=1960 + t, treat=0,
+                             y1=donors[u]["y1"][t], y2=donors[u]["y2"][t]))
+    for t in range(T):
+        y1 = 1.5 * donors[1]["y1"][t] - 0.5 * donors[2]["y1"][t]
+        y2 = 1.5 * donors[1]["y2"][t] - 0.5 * donors[2]["y2"][t]
+        rows.append(dict(unit="u0", time=1960 + t, treat=int(t >= T0), y1=y1, y2=y2))
+    return pd.DataFrame(rows)
+
+
+def test_pcr_config_defaults_and_accept(panel):
+    cfg = SCMOConfig(df=panel, outcome="y1", treat="treat", unitid="unit", time="time")
+    assert cfg.weights == "simplex"                      # default unchanged
+    cfg2 = SCMOConfig(df=panel, outcome="y1", treat="treat", unitid="unit",
+                      time="time", weights="pcr", pcr_rank=3, pcr_cumvar=0.9)
+    assert cfg2.weights == "pcr" and cfg2.pcr_rank == 3
+
+
+def test_pcr_rank_requires_pcr(panel):
+    from mlsynth.exceptions import MlsynthConfigError
+    with pytest.raises(MlsynthConfigError):
+        SCMOConfig(df=panel, outcome="y1", treat="treat", unitid="unit",
+                   time="time", pcr_rank=3)             # weights defaults to simplex
+
+
+def test_pcr_incompatible_with_ridge(panel):
+    from mlsynth.exceptions import MlsynthConfigError
+    with pytest.raises(MlsynthConfigError):
+        SCMOConfig(df=panel, outcome="y1", treat="treat", unitid="unit",
+                   time="time", weights="pcr", augment="ridge")
+
+
+def test_pcr_rank_positive(panel):
+    from mlsynth.exceptions import MlsynthConfigError
+    with pytest.raises(MlsynthConfigError):
+        SCMOConfig(df=panel, outcome="y1", treat="treat", unitid="unit",
+                   time="time", weights="pcr", pcr_rank=0)
+
+
+def test_scmo_pcr_runs(panel):
+    cfg = SCMOConfig(df=panel, outcome="y1", treat="treat", unitid="unit",
+                     time="time", addout="y2", schemes=["concatenated"],
+                     weights="pcr", display_graphs=False)
+    res = SCMO(cfg).fit()
+    assert np.isfinite(res.att)
+    assert np.all(np.isfinite(res.time_series.counterfactual_outcome))
+
+
+def test_pcr_weights_matches_kernel(panel):
+    """SCMO's pcr scheme == direct pcr_weights on the matching matrix."""
+    from mlsynth.utils.pcr.core import pcr_weights
+    inputs = _prepare(panel)
+    fit = fit_scheme(inputs, CONCATENATED, weights="pcr", pcr_rank=4)
+    design = inputs.Z[inputs.donor_idx].T                # (P, J)
+    target = inputs.Z[inputs.treated_idx]                # (P,)
+    w_ref = pcr_weights(design, target, 4)
+    np.testing.assert_allclose(fit.weights, w_ref, atol=1e-10)
+    cf_ref = w_ref @ inputs.Y[inputs.donor_idx]
+    np.testing.assert_allclose(fit.counterfactual, cf_ref, atol=1e-10)
+
+
+def test_pcr_unconstrained_recovers_extrapolation(extrapolation_panel):
+    """PCR (unconstrained) recovers a negative-weight combo simplex cannot."""
+    inputs = _prepare(extrapolation_panel)
+    pcr = fit_scheme(inputs, CONCATENATED, weights="pcr", pcr_rank=4)
+    simplex = fit_scheme(inputs, CONCATENATED, weights="simplex")
+    # PCR recovers the exact linear combination -> ~zero pre-treatment error
+    assert pcr.pre_rmse < 1e-6
+    # a genuine negative weight is present (outside the simplex)
+    assert pcr.weights.min() < -0.1
+    # the convex solver cannot represent it
+    assert simplex.pre_rmse > 1e-3

--- a/mlsynth/tests/test_scmo.py
+++ b/mlsynth/tests/test_scmo.py
@@ -337,3 +337,155 @@ def test_pcr_unconstrained_recovers_extrapolation(extrapolation_panel):
     assert pcr.weights.min() < -0.1
     # the convex solver cannot represent it
     assert simplex.pre_rmse > 1e-3
+
+
+# --- rolling-origin CV for the PCR metric weights (delta) ------------------
+
+@pytest.fixture
+def aux_noise_panel() -> pd.DataFrame:
+    """Primary is an exact donor combo; the auxiliary outcome is pure noise.
+
+    Rolling-origin CV should down-weight the uninformative auxiliary metric.
+    """
+    rng = np.random.default_rng(3)
+    T, T0 = 12, 10
+    J = 5
+    dy1 = {u: rng.uniform(5, 15, T) for u in range(1, J + 1)}
+    coef = np.array([1.3, -0.3, 0.0, 0.0, 0.0])
+    rows = []
+    for u in range(1, J + 1):
+        for t in range(T):
+            rows.append(dict(unit=f"u{u}", time=1960 + t, treat=0,
+                             y1=dy1[u][t], y2=rng.uniform(5, 15)))   # aux = noise
+    ty1 = sum(coef[u - 1] * dy1[u] for u in range(1, J + 1))
+    for t in range(T):
+        rows.append(dict(unit="u0", time=1960 + t, treat=int(t >= T0),
+                         y1=ty1[t], y2=rng.uniform(5, 15)))          # aux = noise
+    return pd.DataFrame(rows)
+
+
+def test_pcr_metric_weights_requires_pcr(panel):
+    from mlsynth.exceptions import MlsynthConfigError
+    with pytest.raises(MlsynthConfigError):
+        SCMOConfig(df=panel, outcome="y1", treat="treat", unitid="unit",
+                   time="time", pcr_metric_weights="cv")     # weights=simplex
+
+
+def test_pcr_cv_horizon_positive(panel):
+    from mlsynth.exceptions import MlsynthConfigError
+    with pytest.raises(MlsynthConfigError):
+        SCMOConfig(df=panel, outcome="y1", treat="treat", unitid="unit",
+                   time="time", weights="pcr", pcr_metric_weights="cv",
+                   pcr_cv_horizon=0)
+
+
+def test_rolling_origin_cv_rejects_noise(aux_noise_panel):
+    """Primary is an exact donor combo; the noisy aux only hurts OOS, so CV
+    drives its weight to zero and OOS MSE rises monotonically with it."""
+    from mlsynth.utils.scmo_helpers import rolling_origin_pcr_cv
+    inputs = _prepare(aux_noise_panel)
+    grid = [0.0, 0.25, 0.5, 1.0, 2.0]
+    best, metric_order, mse_table = rolling_origin_pcr_cv(
+        inputs, grid=grid, pcr_rank=5)                   # full rank -> exact recovery
+    assert metric_order[0] == "y1"                       # primary anchored first
+    assert best[1] == 0.0                                # noise aux fully rejected
+    # more weight on the noisy metric strictly worsens out-of-sample MSE
+    mses = [mse_table[g] for g in grid]
+    assert all(mses[i] < mses[i + 1] for i in range(len(grid) - 1))
+    # CV is never worse than equal weighting (1.0 is in the grid)
+    assert min(mse_table.values()) <= mse_table[1.0] + 1e-12
+
+
+def test_rolling_origin_cv_deterministic(aux_noise_panel):
+    from mlsynth.utils.scmo_helpers import rolling_origin_pcr_cv
+    inputs = _prepare(aux_noise_panel)
+    a = rolling_origin_pcr_cv(inputs, grid=[0.0, 0.5, 1.0, 2.0])
+    b = rolling_origin_pcr_cv(inputs, grid=[0.0, 0.5, 1.0, 2.0])
+    assert a[0] == b[0] and a[2] == b[2]
+
+
+def test_cv_noop_without_auxiliary(aux_noise_panel):
+    """With a single metric there is nothing to tune -> equal weighting."""
+    from mlsynth.utils.scmo_helpers import rolling_origin_pcr_cv
+    inputs = _prepare(aux_noise_panel, addout=None)      # y1 only
+    best, order, mse_table = rolling_origin_pcr_cv(inputs, grid=[0.5, 2.0])  # no 1.0
+    assert order == ["y1"] and best == [1.0]
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"pcr_metric_weights": [1.0, -0.5]},                 # negative metric weight
+    {"pcr_metric_weights": []},                          # empty metric list
+    {"pcr_metric_weights": "cv", "pcr_cv_grid": [-1.0, 1.0]},   # negative grid
+    {"pcr_metric_weights": "cv", "pcr_cv_grid": []},     # empty grid
+    {"pcr_metric_weights": "cv", "pcr_cv_min_train": 0},  # bad min_train
+])
+def test_pcr_cv_config_validation(panel, kwargs):
+    from mlsynth.exceptions import MlsynthConfigError
+    with pytest.raises(MlsynthConfigError):
+        SCMOConfig(df=panel, outcome="y1", treat="treat", unitid="unit",
+                   time="time", weights="pcr", **kwargs)
+
+
+def test_pcr_metric_weights_wrong_length_raises(aux_noise_panel):
+    """An explicit weight vector must have one entry per metric."""
+    from mlsynth.exceptions import MlsynthDataError
+    cfg = SCMOConfig(df=aux_noise_panel, outcome="y1", treat="treat",
+                     unitid="unit", time="time", addout="y2",
+                     schemes=["concatenated"], weights="pcr",
+                     pcr_metric_weights=[1.0, 1.0, 1.0], display_graphs=False)
+    with pytest.raises(MlsynthDataError):
+        SCMO(cfg).fit()
+
+
+def test_cv_insufficient_preperiods_raises():
+    """Too few pre-periods for the requested window -> clear estimation error."""
+    from mlsynth.utils.scmo_helpers import rolling_origin_pcr_cv
+    from mlsynth.exceptions import MlsynthEstimationError
+    rng = np.random.default_rng(5)
+    rows = []
+    for u in range(4):
+        for t in range(3):                               # T=3, treat at t>=2 -> T0=2
+            rows.append(dict(unit=f"u{u}", time=t, treat=int(u == 0 and t >= 2),
+                             y1=rng.normal(), y2=rng.normal()))
+    inputs = _prepare(pd.DataFrame(rows))
+    with pytest.raises(MlsynthEstimationError):
+        rolling_origin_pcr_cv(inputs, grid=[0.0, 1.0], min_train=2, horizon=1)
+
+
+def test_scmo_pcr_cv_end_to_end(aux_noise_panel):
+    cfg = SCMOConfig(df=aux_noise_panel, outcome="y1", treat="treat",
+                     unitid="unit", time="time", addout="y2",
+                     schemes=["concatenated"], weights="pcr",
+                     pcr_metric_weights="cv", display_graphs=False)
+    res = SCMO(cfg).fit()
+    assert np.isfinite(res.att)
+    # the chosen weights are recorded for inspection
+    md = res.method_details.parameters_used
+    assert "pcr_metric_weights" in md and "pcr_cv_mse" in md
+
+
+def test_scmo_explicit_metric_weights_recorded(aux_noise_panel):
+    """Explicit per-metric weights run end-to-end and are recorded."""
+    cfg = SCMOConfig(df=aux_noise_panel, outcome="y1", treat="treat",
+                     unitid="unit", time="time", addout="y2",
+                     schemes=["concatenated"], weights="pcr",
+                     pcr_metric_weights=[1.0, 0.25], display_graphs=False)
+    res = SCMO(cfg).fit()
+    assert np.isfinite(res.att)
+    recorded = res.method_details.parameters_used["pcr_metric_weights"]
+    assert recorded == {"y1": 1.0, "y2": 0.25}
+
+
+def test_pcr_explicit_zero_aux_matches_primary_only(aux_noise_panel):
+    """pcr_metric_weights=[1, 0] drops the aux metric -> primary-only PCR."""
+    from mlsynth.utils.pcr.core import pcr_weights
+    inputs = _prepare(aux_noise_panel)
+    fit = fit_scheme(inputs, CONCATENATED, weights="pcr", pcr_rank=5,
+                     metric_weights=[1.0, 0.0])
+    # primary-only design: Z columns belonging to y1
+    labels = [str(l).split("@")[0] for l in inputs.predictor_labels]
+    y1_cols = np.array([i for i, l in enumerate(labels) if l == "y1"])
+    design = inputs.Z[np.ix_(inputs.donor_idx, y1_cols)].T
+    target = inputs.Z[inputs.treated_idx][y1_cols]
+    w_ref = pcr_weights(design, target, 5)
+    np.testing.assert_allclose(fit.weights, w_ref, atol=1e-9)

--- a/mlsynth/utils/scmo_helpers/__init__.py
+++ b/mlsynth/utils/scmo_helpers/__init__.py
@@ -23,6 +23,7 @@ from .estimation import fit_scheme, model_average
 from .inference import conformal_inference
 from .results_assembly import assemble_scmo_results
 from .orchestration import resolve_schemes, derive_treatment, build_spec, run_scmo
+from .pcr_cv import rolling_origin_pcr_cv
 from .plotter import plot_scmo
 
 __all__ = [
@@ -31,5 +32,5 @@ __all__ = [
     "build_matching_matrix", "simplex_weights", "prepare_scmo_inputs",
     "fit_scheme", "model_average", "conformal_inference",
     "assemble_scmo_results", "resolve_schemes", "derive_treatment", "build_spec",
-    "run_scmo", "plot_scmo",
+    "run_scmo", "rolling_origin_pcr_cv", "plot_scmo",
 ]

--- a/mlsynth/utils/scmo_helpers/config.py
+++ b/mlsynth/utils/scmo_helpers/config.py
@@ -54,6 +54,19 @@ class SCMOConfig(BaseEstimatorConfig):
         default=None,
         description="Fixed ridge penalty for augment='ridge'; None selects it by leave-one-period-out cross-validation (augsynth's 1-SE rule).",
     )
+    weights: Literal["simplex", "pcr"] = Field(
+        default="simplex",
+        description="Weight solver on the matching matrix. 'simplex' -> convex SC weights (default). 'pcr' -> denoised unconstrained principal-component-regression weights (mRSC, Amjad-Misra-Shah-Shen 2019; reuses the pcr/core HSVT+PCR kernel). Intended for the concatenated scheme; weights may be negative and need not sum to one.",
+    )
+    pcr_rank: Optional[int] = Field(
+        default=None,
+        description="HSVT truncation rank for weights='pcr'. None selects it by the cumulative-variance rule (pcr_cumvar); an explicit integer forces a fixed rank.",
+    )
+    pcr_cumvar: float = Field(
+        default=0.95,
+        description="Cumulative-variance target for the weights='pcr' rank rule when pcr_rank is None.",
+        gt=0, le=1,
+    )
 
     @model_validator(mode="after")
     def _check_augment(self):
@@ -64,4 +77,15 @@ class SCMOConfig(BaseEstimatorConfig):
             if self.ridge_lambda <= 0:
                 raise MlsynthConfigError(
                     f"ridge_lambda must be > 0; got {self.ridge_lambda}.")
+        if self.weights == "pcr" and self.augment == "ridge":
+            raise MlsynthConfigError(
+                "weights='pcr' is incompatible with augment='ridge' "
+                "(they are alternative weight solvers).")
+        if self.pcr_rank is not None:
+            if self.weights != "pcr":
+                raise MlsynthConfigError(
+                    "pcr_rank is only used with weights='pcr'.")
+            if self.pcr_rank < 1:
+                raise MlsynthConfigError(
+                    f"pcr_rank must be a positive integer; got {self.pcr_rank}.")
         return self

--- a/mlsynth/utils/scmo_helpers/config.py
+++ b/mlsynth/utils/scmo_helpers/config.py
@@ -67,6 +67,22 @@ class SCMOConfig(BaseEstimatorConfig):
         description="Cumulative-variance target for the weights='pcr' rank rule when pcr_rank is None.",
         gt=0, le=1,
     )
+    pcr_metric_weights: Optional[Union[List[float], Literal["cv"]]] = Field(
+        default=None,
+        description="Per-metric weights (delta) for weights='pcr', in outcome order [outcome, *addout]. None -> equal weighting. A list -> those fixed weights. 'cv' -> choose the auxiliary weight by rolling-origin cross-validation minimizing out-of-sample pre-period MSE.",
+    )
+    pcr_cv_grid: Optional[List[float]] = Field(
+        default=None,
+        description="Candidate auxiliary-metric weights searched when pcr_metric_weights='cv' (shared across auxiliary metrics). None -> a default log-spaced grid. 1.0 (equal) is always included.",
+    )
+    pcr_cv_horizon: int = Field(
+        default=1,
+        description="Forecast horizon (number of periods ahead) scored at each rolling origin when pcr_metric_weights='cv'.",
+    )
+    pcr_cv_min_train: Optional[int] = Field(
+        default=None,
+        description="Initial number of pre-treatment periods in the expanding rolling-origin window (pcr_metric_weights='cv'). None -> max(2, T0 // 2).",
+    )
 
     @model_validator(mode="after")
     def _check_augment(self):
@@ -88,4 +104,24 @@ class SCMOConfig(BaseEstimatorConfig):
             if self.pcr_rank < 1:
                 raise MlsynthConfigError(
                     f"pcr_rank must be a positive integer; got {self.pcr_rank}.")
+        if self.pcr_metric_weights is not None and self.weights != "pcr":
+            raise MlsynthConfigError(
+                "pcr_metric_weights is only used with weights='pcr'.")
+        if isinstance(self.pcr_metric_weights, list):
+            if not self.pcr_metric_weights:
+                raise MlsynthConfigError("pcr_metric_weights list is empty.")
+            if any(w < 0 for w in self.pcr_metric_weights):
+                raise MlsynthConfigError(
+                    "pcr_metric_weights must be non-negative.")
+        if self.pcr_cv_grid is not None:
+            if not self.pcr_cv_grid:
+                raise MlsynthConfigError("pcr_cv_grid is empty.")
+            if any(w < 0 for w in self.pcr_cv_grid):
+                raise MlsynthConfigError("pcr_cv_grid values must be non-negative.")
+        if self.pcr_cv_min_train is not None and self.pcr_cv_min_train < 1:
+            raise MlsynthConfigError(
+                f"pcr_cv_min_train must be >= 1; got {self.pcr_cv_min_train}.")
+        if self.pcr_cv_horizon < 1:
+            raise MlsynthConfigError(
+                f"pcr_cv_horizon must be >= 1; got {self.pcr_cv_horizon}.")
         return self

--- a/mlsynth/utils/scmo_helpers/estimation.py
+++ b/mlsynth/utils/scmo_helpers/estimation.py
@@ -86,11 +86,17 @@ def _counterfactual(w: np.ndarray, Y_donors: np.ndarray, y: np.ndarray, T0: int,
     return w @ Y_donors
 
 
-def _pcr_scheme_weights(M, treated_idx, donor_idx, pcr_rank, pcr_cumvar):
+def _pcr_scheme_weights(M, treated_idx, donor_idx, pcr_rank, pcr_cumvar,
+                        col_scale=None):
     """Denoised unconstrained PCR weights (mRSC): HSVT-truncate the donor design
-    and apply the pseudo-inverse. Reuses the shared pcr/core + pcr/rank kernel."""
+    and apply the pseudo-inverse. Reuses the shared pcr/core + pcr/rank kernel.
+
+    ``col_scale`` (length P) applies per-metric ``sqrt(delta)`` weights to the
+    matching-matrix columns before the HSVT + PCR step."""
     from ..pcr.core import pcr_weights
     from ..pcr.rank import select_rank
+    if col_scale is not None:
+        M = M * np.asarray(col_scale, dtype=float)[None, :]
     design = M[donor_idx].T                       # (P, J): weights over J donors
     target = M[treated_idx]                        # (P,)
     if pcr_rank is not None:
@@ -101,10 +107,12 @@ def _pcr_scheme_weights(M, treated_idx, donor_idx, pcr_rank, pcr_cumvar):
 
 
 def _scheme_weights(M, treated_idx, donor_idx, augment, ridge_lambda,
-                    weights="simplex", pcr_rank=None, pcr_cumvar=0.95):
+                    weights="simplex", pcr_rank=None, pcr_cumvar=0.95,
+                    col_scale=None):
     """Weights on the matching matrix: simplex (optionally ridge-augmented) or PCR."""
     if weights == "pcr":
-        return _pcr_scheme_weights(M, treated_idx, donor_idx, pcr_rank, pcr_cumvar)
+        return _pcr_scheme_weights(M, treated_idx, donor_idx, pcr_rank,
+                                   pcr_cumvar, col_scale)
     if augment == "ridge":
         from ..bilevel.ridge_augment import ridge_augment_weights
         ra = ridge_augment_weights(
@@ -118,12 +126,12 @@ def _fit_core(
     T0: int, scheme: str, col_period: Optional[np.ndarray], demean: bool,
     augment: Optional[str] = None, ridge_lambda: Optional[float] = None,
     weights: str = "simplex", pcr_rank: Optional[int] = None,
-    pcr_cumvar: float = 0.95,
+    pcr_cumvar: float = 0.95, col_scale: Optional[np.ndarray] = None,
 ) -> Tuple[np.ndarray, np.ndarray, float, float, np.ndarray]:
     """Solve weights + counterfactual for any (treated, donors) selection."""
     M = _matching_vectors(Z, Y, T0, scheme, col_period, demean)
     w = _scheme_weights(M, treated_idx, donor_idx, augment, ridge_lambda,
-                        weights, pcr_rank, pcr_cumvar)
+                        weights, pcr_rank, pcr_cumvar, col_scale)
     cf = _counterfactual(w, Y[donor_idx], Y[treated_idx], T0, demean)
     att, pre_rmse, gap = _effects(Y[treated_idx], cf, T0)
     return w, cf, att, pre_rmse, gap
@@ -133,19 +141,32 @@ def fit_scheme(inputs: SCMOInputs, scheme: str, demean: bool = False,
                augment: Optional[str] = None,
                ridge_lambda: Optional[float] = None,
                weights: str = "simplex", pcr_rank: Optional[int] = None,
-               pcr_cumvar: float = 0.95) -> SCMOMethodFit:
-    """Fit one weighting scheme on the real treated unit."""
+               pcr_cumvar: float = 0.95,
+               metric_weights: Optional[List[float]] = None) -> SCMOMethodFit:
+    """Fit one weighting scheme on the real treated unit.
+
+    ``metric_weights`` (length = number of metrics, primary outcome first)
+    applies per-metric ``delta`` weights to the concatenated PCR fit; it has no
+    effect on the simplex solver or the averaged/separate schemes, whose
+    matching matrices do not carry per-metric columns.
+    """
+    col_scale = None
+    if weights == "pcr" and scheme == CONCATENATED and metric_weights is not None:
+        from .pcr_cv import metric_ids, metric_order, column_scale
+        ids = metric_ids(inputs.predictor_labels)
+        col_scale = column_scale(metric_weights, ids, metric_order(ids))
     w, cf, att, pre_rmse, gap = _fit_core(
         inputs.Z, inputs.Y, inputs.treated_idx, inputs.donor_idx,
         inputs.T0, scheme, inputs.col_period, demean, augment, ridge_lambda,
-        weights, pcr_rank, pcr_cumvar,
+        weights, pcr_rank, pcr_cumvar, col_scale,
     )
     donor_labels = inputs.donor_labels
     donor_weights = {donor_labels[i]: float(round(w[i], 4)) for i in range(len(w))}
     return SCMOMethodFit(
         name=scheme, weights=w, counterfactual=cf, gap=gap, att=att,
         pre_rmse=pre_rmse, donor_weights=donor_weights,
-        metadata={"demean": demean, "augment": augment, "weights": weights},
+        metadata={"demean": demean, "augment": augment, "weights": weights,
+                  "metric_weights": metric_weights},
     )
 
 

--- a/mlsynth/utils/scmo_helpers/estimation.py
+++ b/mlsynth/utils/scmo_helpers/estimation.py
@@ -86,8 +86,25 @@ def _counterfactual(w: np.ndarray, Y_donors: np.ndarray, y: np.ndarray, T0: int,
     return w @ Y_donors
 
 
-def _scheme_weights(M, treated_idx, donor_idx, augment, ridge_lambda):
-    """Simplex SC weights on the matching matrix, optionally ridge-augmented."""
+def _pcr_scheme_weights(M, treated_idx, donor_idx, pcr_rank, pcr_cumvar):
+    """Denoised unconstrained PCR weights (mRSC): HSVT-truncate the donor design
+    and apply the pseudo-inverse. Reuses the shared pcr/core + pcr/rank kernel."""
+    from ..pcr.core import pcr_weights
+    from ..pcr.rank import select_rank
+    design = M[donor_idx].T                       # (P, J): weights over J donors
+    target = M[treated_idx]                        # (P,)
+    if pcr_rank is not None:
+        r = select_rank(design, method="fixed", r=pcr_rank)
+    else:
+        r = select_rank(design, method="cumvar", cumvar_threshold=pcr_cumvar)
+    return pcr_weights(design, target, r)
+
+
+def _scheme_weights(M, treated_idx, donor_idx, augment, ridge_lambda,
+                    weights="simplex", pcr_rank=None, pcr_cumvar=0.95):
+    """Weights on the matching matrix: simplex (optionally ridge-augmented) or PCR."""
+    if weights == "pcr":
+        return _pcr_scheme_weights(M, treated_idx, donor_idx, pcr_rank, pcr_cumvar)
     if augment == "ridge":
         from ..bilevel.ridge_augment import ridge_augment_weights
         ra = ridge_augment_weights(
@@ -100,10 +117,13 @@ def _fit_core(
     Z: np.ndarray, Y: np.ndarray, treated_idx: int, donor_idx: np.ndarray,
     T0: int, scheme: str, col_period: Optional[np.ndarray], demean: bool,
     augment: Optional[str] = None, ridge_lambda: Optional[float] = None,
+    weights: str = "simplex", pcr_rank: Optional[int] = None,
+    pcr_cumvar: float = 0.95,
 ) -> Tuple[np.ndarray, np.ndarray, float, float, np.ndarray]:
     """Solve weights + counterfactual for any (treated, donors) selection."""
     M = _matching_vectors(Z, Y, T0, scheme, col_period, demean)
-    w = _scheme_weights(M, treated_idx, donor_idx, augment, ridge_lambda)
+    w = _scheme_weights(M, treated_idx, donor_idx, augment, ridge_lambda,
+                        weights, pcr_rank, pcr_cumvar)
     cf = _counterfactual(w, Y[donor_idx], Y[treated_idx], T0, demean)
     att, pre_rmse, gap = _effects(Y[treated_idx], cf, T0)
     return w, cf, att, pre_rmse, gap
@@ -111,18 +131,21 @@ def _fit_core(
 
 def fit_scheme(inputs: SCMOInputs, scheme: str, demean: bool = False,
                augment: Optional[str] = None,
-               ridge_lambda: Optional[float] = None) -> SCMOMethodFit:
+               ridge_lambda: Optional[float] = None,
+               weights: str = "simplex", pcr_rank: Optional[int] = None,
+               pcr_cumvar: float = 0.95) -> SCMOMethodFit:
     """Fit one weighting scheme on the real treated unit."""
     w, cf, att, pre_rmse, gap = _fit_core(
         inputs.Z, inputs.Y, inputs.treated_idx, inputs.donor_idx,
         inputs.T0, scheme, inputs.col_period, demean, augment, ridge_lambda,
+        weights, pcr_rank, pcr_cumvar,
     )
     donor_labels = inputs.donor_labels
     donor_weights = {donor_labels[i]: float(round(w[i], 4)) for i in range(len(w))}
     return SCMOMethodFit(
         name=scheme, weights=w, counterfactual=cf, gap=gap, att=att,
         pre_rmse=pre_rmse, donor_weights=donor_weights,
-        metadata={"demean": demean, "augment": augment},
+        metadata={"demean": demean, "augment": augment, "weights": weights},
     )
 
 

--- a/mlsynth/utils/scmo_helpers/orchestration.py
+++ b/mlsynth/utils/scmo_helpers/orchestration.py
@@ -59,6 +59,31 @@ def build_spec(
     return {"year": pre_years, "vars": {o: o for o in outcomes}}
 
 
+def _resolve_metric_weights(
+    inputs: SCMOInputs, weights: str, pcr_metric_weights, pcr_cv_grid,
+    pcr_cv_horizon: int, pcr_cv_min_train, pcr_rank, pcr_cumvar,
+) -> Tuple[Optional[List[float]], Dict[str, Any]]:
+    """Resolve the per-metric PCR weights (equal / explicit / rolling-origin CV)."""
+    if weights != "pcr" or pcr_metric_weights is None:
+        return None, {}
+    from .pcr_cv import metric_ids, metric_order, rolling_origin_pcr_cv
+
+    order = metric_order(metric_ids(inputs.predictor_labels))
+    if pcr_metric_weights == "cv":
+        resolved, order, mse_table = rolling_origin_pcr_cv(
+            inputs, grid=pcr_cv_grid, horizon=pcr_cv_horizon,
+            min_train=pcr_cv_min_train, pcr_rank=pcr_rank, pcr_cumvar=pcr_cumvar)
+        info = {"pcr_metric_weights": {order[i]: resolved[i] for i in range(len(order))},
+                "pcr_cv_mse": {float(k): float(v) for k, v in mse_table.items()}}
+        return resolved, info
+    resolved = [float(w) for w in pcr_metric_weights]
+    if len(resolved) != len(order):
+        raise MlsynthDataError(
+            f"pcr_metric_weights has length {len(resolved)}, expected one per "
+            f"metric ({len(order)}: {order}).")
+    return resolved, {"pcr_metric_weights": {order[i]: resolved[i] for i in range(len(order))}}
+
+
 def run_scmo(
     inputs: SCMOInputs,
     schemes: List[str],
@@ -70,12 +95,23 @@ def run_scmo(
     weights: str = "simplex",
     pcr_rank: Optional[int] = None,
     pcr_cumvar: float = 0.95,
+    pcr_metric_weights=None,
+    pcr_cv_grid: Optional[List[float]] = None,
+    pcr_cv_horizon: int = 1,
+    pcr_cv_min_train: Optional[int] = None,
 ) -> Dict[str, SCMOMethodFit]:
     """Fit each requested scheme and attach CWZ conformal inference to every fit."""
+    metric_weights, mw_info = _resolve_metric_weights(
+        inputs, weights, pcr_metric_weights, pcr_cv_grid, pcr_cv_horizon,
+        pcr_cv_min_train, pcr_rank, pcr_cumvar)
+
     base = [s for s in schemes if s != MA]
     fits: Dict[str, SCMOMethodFit] = {
         s: fit_scheme(inputs, s, demean, augment, ridge_lambda,
-                      weights, pcr_rank, pcr_cumvar) for s in base}
+                      weights, pcr_rank, pcr_cumvar, metric_weights) for s in base}
+    if mw_info and CONCATENATED in fits:
+        f = fits[CONCATENATED]
+        fits[CONCATENATED] = replace(f, metadata={**f.metadata, **mw_info})
 
     if MA in schemes:
         components = [fits[s] for s in (CONCATENATED, AVERAGED) if s in fits]

--- a/mlsynth/utils/scmo_helpers/orchestration.py
+++ b/mlsynth/utils/scmo_helpers/orchestration.py
@@ -67,11 +67,15 @@ def run_scmo(
     conformal_q: float = 1.0,
     augment: Optional[str] = None,
     ridge_lambda: Optional[float] = None,
+    weights: str = "simplex",
+    pcr_rank: Optional[int] = None,
+    pcr_cumvar: float = 0.95,
 ) -> Dict[str, SCMOMethodFit]:
     """Fit each requested scheme and attach CWZ conformal inference to every fit."""
     base = [s for s in schemes if s != MA]
     fits: Dict[str, SCMOMethodFit] = {
-        s: fit_scheme(inputs, s, demean, augment, ridge_lambda) for s in base}
+        s: fit_scheme(inputs, s, demean, augment, ridge_lambda,
+                      weights, pcr_rank, pcr_cumvar) for s in base}
 
     if MA in schemes:
         components = [fits[s] for s in (CONCATENATED, AVERAGED) if s in fits]

--- a/mlsynth/utils/scmo_helpers/pcr_cv.py
+++ b/mlsynth/utils/scmo_helpers/pcr_cv.py
@@ -1,0 +1,141 @@
+"""Rolling-origin cross-validation for the PCR metric weights (delta).
+
+The concatenated PCR scheme (mRSC; [Amjad2019]_) weights each metric block of
+the standardized matching matrix by ``sqrt(delta_k)`` before the HSVT + PCR
+step. The paper gives no closed form for ``delta`` -- it is a cross-validation
+hyperparameter, equal by default. This module chooses the auxiliary-metric
+weight by *rolling-origin* (expanding-window, forward-chaining) cross-validation
+that minimizes out-of-sample pre-treatment MSE of the primary outcome: for each
+origin we fit the weights on the earliest pre-periods and score the next
+``horizon`` held-out pre-period(s), all before treatment, so nothing leaks from
+the post-period.
+
+Everything is pure NumPy and deterministic (no RNG), operating on the arrays in
+:class:`SCMOInputs`; the primary outcome is scored on the raw panel ``Y`` while
+the weights are fit on the standardized matching matrix ``Z`` -- the same
+train/predict split the point estimate uses.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from ..pcr.core import pcr_weights
+from ..pcr.rank import select_rank
+
+_DEFAULT_GRID = [0.0, 0.25, 0.5, 1.0, 2.0, 4.0]
+
+
+def metric_ids(predictor_labels) -> np.ndarray:
+    """Metric (outcome) identity of each matching-matrix column.
+
+    Labels are ``name`` (single period) or ``name@period`` (stacked periods);
+    the metric is the ``name`` part, matching the spec's outcome column.
+    """
+    return np.asarray([str(l).split("@")[0] for l in predictor_labels])
+
+
+def metric_order(ids: np.ndarray) -> List[str]:
+    """Distinct metrics in order of first appearance (primary outcome first)."""
+    seen: List[str] = []
+    for m in ids:
+        if m not in seen:
+            seen.append(m)
+    return seen
+
+
+def column_scale(metric_weights: List[float], ids: np.ndarray,
+                 order: List[str]) -> np.ndarray:
+    """Per-column ``sqrt(delta)`` scale vector from per-metric weights."""
+    w_by_metric = {m: float(metric_weights[i]) for i, m in enumerate(order)}
+    return np.sqrt(np.asarray([w_by_metric[m] for m in ids], dtype=float))
+
+
+def _pcr_predict(Z_scaled: np.ndarray, treated_idx: int, donor_idx: np.ndarray,
+                 train_cols: np.ndarray, Y_donors_test: np.ndarray,
+                 pcr_rank: Optional[int], pcr_cumvar: float) -> np.ndarray:
+    """Fit PCR weights on the training columns, predict the primary outcome."""
+    design = Z_scaled[np.ix_(donor_idx, train_cols)].T        # (P_train, J)
+    target = Z_scaled[treated_idx, train_cols]                # (P_train,)
+    if pcr_rank is not None:
+        r = select_rank(design, method="fixed", r=pcr_rank)
+    else:
+        r = select_rank(design, method="cumvar", cumvar_threshold=pcr_cumvar)
+    w = pcr_weights(design, target, r)
+    return w @ Y_donors_test                                  # (horizon,)
+
+
+def rolling_origin_pcr_cv(
+    inputs,
+    grid: Optional[List[float]] = None,
+    horizon: int = 1,
+    min_train: Optional[int] = None,
+    pcr_rank: Optional[int] = None,
+    pcr_cumvar: float = 0.95,
+) -> Tuple[List[float], List[str], Dict[float, float]]:
+    """Pick the auxiliary-metric weight by rolling-origin CV.
+
+    Returns
+    -------
+    best_weights : list of float
+        Per-metric weights in ``metric_order`` (primary fixed at 1.0, the
+        auxiliaries share the selected weight).
+    order : list of str
+        The metric order (primary outcome first).
+    mse_table : dict
+        ``{candidate auxiliary weight: out-of-sample MSE}``.
+    """
+    ids = metric_ids(inputs.predictor_labels)
+    order = metric_order(ids)
+    K = len(order)
+
+    grid = list(_DEFAULT_GRID if grid is None else grid)
+    if 1.0 not in grid:                       # equal weighting is always a candidate
+        grid = grid + [1.0]
+
+    if K < 2:                                 # no auxiliary metric -> nothing to tune
+        return [1.0] * K, order, {1.0: 0.0}
+
+    # chronological pre-periods and their columns in Y
+    col_period = inputs.col_period
+    pre_labels = list(dict.fromkeys(col_period.tolist()))
+    y_cols = [int(inputs.time_index.get_index([p])[0]) for p in pre_labels]
+    chrono = np.argsort(y_cols)
+    periods_sorted = [pre_labels[i] for i in chrono]
+    ycols_sorted = [y_cols[i] for i in chrono]
+    P = len(periods_sorted)
+
+    if min_train is None:
+        min_train = max(2, inputs.T0 // 2)
+    origins = list(range(min_train, P - horizon + 1))
+    if not origins:
+        from ...exceptions import MlsynthEstimationError
+        raise MlsynthEstimationError(
+            f"Not enough pre-periods for rolling-origin CV: need > "
+            f"min_train + horizon ({min_train} + {horizon}), have {P}.")
+
+    Y = inputs.Y
+    mse_table: Dict[float, float] = {}
+    for g in grid:
+        weights = [1.0] + [g] * (K - 1)                       # primary anchored
+        scale = column_scale(weights, ids, order)
+        Z_scaled = inputs.Z * scale[None, :]
+        sse = 0.0
+        n = 0
+        for o in origins:
+            train_periods = set(periods_sorted[:o])
+            train_cols = np.where(np.isin(col_period, list(train_periods)))[0]
+            test_ycols = ycols_sorted[o:o + horizon]
+            pred = _pcr_predict(
+                Z_scaled, inputs.treated_idx, inputs.donor_idx, train_cols,
+                Y[np.ix_(inputs.donor_idx, test_ycols)], pcr_rank, pcr_cumvar)
+            truth = Y[inputs.treated_idx, test_ycols]
+            sse += float(np.sum((truth - pred) ** 2))
+            n += len(test_ycols)
+        mse_table[g] = sse / n
+
+    best_g = min(mse_table, key=lambda k: (mse_table[k], k))
+    best_weights = [1.0] + [best_g] * (K - 1)
+    return best_weights, order, mse_table

--- a/mlsynth/utils/scmo_helpers/structures.py
+++ b/mlsynth/utils/scmo_helpers/structures.py
@@ -192,7 +192,8 @@ class SCMOResults(BaseEstimatorResults):
         if inf is not None:
             object.__setattr__(self, "inference", inf)
         object.__setattr__(self, "method_details", MethodDetailsResults(
-            method_name=f"SCMO ({self.selected_variant})", is_recommended=True))
+            method_name=f"SCMO ({self.selected_variant})", is_recommended=True,
+            parameters_used={k: v for k, v in fit.metadata.items() if v is not None}))
         return self
 
     @property


### PR DESCRIPTION
## What

Extracts the SCMO `weights='pcr'` work — two self-contained commits cherry-picked cleanly off the `claude/paper-review-xejd2p` branch so the estimator improvement can land on its own, independent of that branch's unrelated (unmerged) UK mini-budget data work.

Two commits:

1. `Add weights='pcr' (denoised PCR) scheme to SCMO` — a denoised principal-component-regression weighting option for SCMO, wired through the config, estimation, and orchestration helpers with docs and tests.
2. `SCMO weights='pcr': choose metric weights (delta) by rolling-origin CV` — selects the PCR metric weights by rolling-origin cross-validation (new `scmo_helpers/pcr_cv.py`), rather than a fixed delta.

Touches only SCMO and its helpers/tests/docs:

- `mlsynth/estimators/scmo.py`
- `mlsynth/utils/scmo_helpers/{config,estimation,orchestration,structures,__init__}.py`, new `pcr_cv.py`
- `mlsynth/tests/test_scmo.py`
- `docs/scmo.rst`, `docs/references.rst`

## Note on overlap

This is distinct from the existing `pcr` references in `clustersc.py` (ClusterSC's PCR-RSC path) — that is a different estimator. SCMO had no `weights='pcr'` scheme before this.

## Test

`pytest mlsynth/tests/test_scmo.py mlsynth/tests/test_result_contract.py` — 176 passed, 4 skipped on current `main`. The new behavior ships test-first per the repo contract (smoke + invariants + rolling-origin CV coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012y2a5QT6AVGcoizpCuc8zW)_