### PR TITLE
SRC: rename from SMC, notation to canon, and SIRS/FPCA donor screening

### DIFF
--- a/benchmarks/cases/src_basque.py
+++ b/benchmarks/cases/src_basque.py
@@ -1,8 +1,8 @@
-"""SMC cross-validation + Path A: the Basque Country / ETA-terrorism study.
+"""SRC cross-validation + Path A: the Basque Country / ETA-terrorism study.
 
-Zhu, Rong J. B. (2023), *"Synthetic Matching Control Method,"* arXiv:2306.02584,
+Zhu, Rong J. B. (2023), *"Synthetic Regressing Control,"* arXiv:2306.02584,
 re-examines the Abadie & Gardeazabal (2003) study of the per-capita GDP cost of
-ETA terrorism (17 Spanish regions, 1955-1997). SMC matches each donor to the
+ETA terrorism (17 Spanish regions, 1955-1997). SRC matches each donor to the
 Basque Country by a univariate regression, then synthesises the matched controls
 with box-``[0, 1]`` weights chosen by a Mallows/Cp unbiased-risk criterion.
 
@@ -11,7 +11,7 @@ implementation** (``Code_SMC.R``): on the identical Basque matching matrix, the
 mlsynth weight computation matches the reference ``SMCV`` (per-donor OLS + the
 Cp box-QP solved by ``solve.QP``) to machine precision -- ``theta``, the box
 weights, the combined coefficients, ``bias`` and ``sigma^2`` all agree to
-``< 2e-13`` (see ``docs/replications/smc.rst`` for the harness).
+``< 2e-13`` (see ``docs/replications/src.rst`` for the harness).
 
 This case runs two arms through the public estimator on
 ``basedata/basque_data.csv``:
@@ -26,7 +26,7 @@ This case runs two arms through the public estimator on
   is asserted only structurally.
 
   =========================  ==============  ==============================
-  Quantity                   mlsynth SMC     note
+  Quantity                   mlsynth SRC     note
   =========================  ==============  ==============================
   pre-period RMSE            ~0.048          tight pre-treatment fit
   mean post-1969 ATT         ~-0.858         terrorism depresses GDP/capita
@@ -61,7 +61,7 @@ _WINS = {**{c: (1964, 1969) for c in
 
 
 def run() -> dict:
-    from mlsynth import SMC
+    from mlsynth import SRC
 
     df = pd.read_csv(os.path.abspath(_DATA))
     df["treat"] = ((df["regionname"] == _TREATED) & (df["year"] >= 1970)).astype(int)
@@ -69,12 +69,12 @@ def run() -> dict:
                 time="year", display_graphs=False)
 
     # Arm 1: deterministic Algorithm 1 (outcome-only).
-    res = SMC(base).fit()
+    res = SRC(base).fit()
     w = {str(k): float(v) for k, v in res.donor_weights.items()}
     gap = res.time_series.observed_outcome - res.time_series.counterfactual_outcome
 
     # Arm 2: the paper's Algorithm 3 spec (covariates + fit window + seeded V search).
-    pap = SMC({**base, "covariates": _COVS, "covariate_windows": _WINS,
+    pap = SRC({**base, "covariates": _COVS, "covariate_windows": _WINS,
                "fit_window": (1960, 1969), "v_search": "de", "v_seed": 0}).fit()
     pw = {str(k): float(v) for k, v in pap.donor_weights.items()}
     top = max(pw, key=lambda k: abs(pw[k]))

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -52,7 +52,7 @@ CASES = {
     "cwz_ttest": "benchmarks.cases.cwz_ttest",                # Path A: CWZ 2025 Table 5 carbon-tax debiased t-test
     "cwz_mc": "benchmarks.cases.cwz_mc",                      # Path B: CWZ 2025 Table 3 application-based Monte Carlo
     "masc_basque": "benchmarks.cases.masc_basque",            # Path A: MASC Basque/ETA (KMPT Sec 5)
-    "smc_basque": "benchmarks.cases.smc_basque",              # cross-val vs R Code_SMC + Path A: SMC Basque/ETA (Zhu 2023)
+    "src_basque": "benchmarks.cases.src_basque",              # cross-val vs R Code_SMC + Path A: SRC Basque/ETA (Zhu 2023)
     "bscm_china_watches": "benchmarks.cases.bscm_china_watches",  # cross-val vs reference Stan horseshoe + FSPDA (Shi-Huang) on China anti-corruption watches, p>n (Kim-Lee-Gupta 2020)
     "mscmt_basque": "benchmarks.cases.mscmt_basque",          # cross-val vs R MSCMT: AG Basque, fit_window=(1960,1969)
     "malo_prop99": "benchmarks.cases.malo_prop99",            # Path A: Malo et al. 2024 Table 1 bilevel optimum (Prop 99)

--- a/docs/bscm.rst
+++ b/docs/bscm.rst
@@ -47,7 +47,7 @@ Do not use BSCM when:
 * You want a soft simplex kept, with Bayesian inference on top. That is
   :doc:`bvss` (Xu-Zhou), which layers a spike-and-slab on a soft simplex prior.
 * You need a deterministic, seed-free point estimate with a risk-criterion
-  weighting. That is :doc:`smc` (Zhu), the frequentist per-donor matching
+  weighting. That is :doc:`src` (Zhu), the frequentist per-donor matching
   cousin.
 * There are multiple treated units, spillovers, or a continuous dose -- BSCM
   encodes a single binary intervention on one unit.

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -293,7 +293,7 @@ spillovers (a true outlier)?
 
 * No -- next question.
 * Yes -- relax the simplex: :doc:`nsc` (affine weights), :doc:`rescm`
-  (penalised / :math:`L_\infty`), :doc:`smc` (per-donor matching plus a
+  (penalised / :math:`L_\infty`), :doc:`src` (per-donor matching plus a
   Mallows-:math:`C_p` box synthesis that regularises the extrapolation and
   stays deterministic), :doc:`bscm` (Bayesian shrinkage -- horseshoe or
   spike-and-slab -- on unconstrained weights, with a credible interval on the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -269,7 +269,7 @@ headline numbers.
    mlsc
    fscm
    masc
-   smc
+   src
    msqrt
    sparse_sc
    beast

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -464,9 +464,9 @@ References
     *Journal of the American Statistical Association*, 116(536): 1804-1816, 2021.
     DOI: https://doi.org/10.1080/01621459.2021.1979562
 
-.. [SMC2023]
+.. [SRC2023]
     Zhu, Rong J. B.
-    *"Synthetic Matching Control Method."*
+    *"Synthetic Regressing Control."*
     arXiv:2306.02584, 2023. https://arxiv.org/abs/2306.02584
 
 .. [BSCM2020]

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -51,7 +51,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    :caption: Dedicated replication pages
 
    replications/fdid
-   replications/smc
+   replications/src
    replications/bscm
    replications/tssc
    replications/vanillasc

--- a/docs/replications/src.rst
+++ b/docs/replications/src.rst
@@ -1,11 +1,11 @@
-.. _replication-smc:
+.. _replication-src:
 
-SMC — Synthetic Matching Control (Zhu 2023)
-===========================================
+SRC — Synthetic Regressing Control (Zhu 2023)
+=============================================
 
-:Estimator: :doc:`../smc` — :class:`mlsynth.SMC`
-:Source: Zhu, Rong J. B. (2023), *"Synthetic Matching Control Method,"*
-   arXiv:2306.02584 [SMC2023]_.
+:Estimator: :doc:`../src` — :class:`mlsynth.SRC`
+:Source: Zhu, Rong J. B. (2023), *"Synthetic Regressing Control,"*
+   arXiv:2306.02584 [SRC2023]_.
 :Replication type: cross-validation against the author's reference R
    implementation (``Code_SMC.R``), plus Path A — the Basque / ETA study.
 :Status: verified — the weight computation matches the reference to machine
@@ -14,7 +14,7 @@ SMC — Synthetic Matching Control (Zhu 2023)
 Validation strategy
 -------------------
 
-SMC ships an R reference implementation (``Code_SMC.R``): a function ``SMCV``
+SRC ships an R reference implementation (``Code_SMC.R``): a function ``SMCV``
 that, given a matching matrix and predictor weights, computes the per-donor
 univariate coefficients :math:`\widehat{\theta}_j`, the plug-in
 :math:`\widehat{\sigma}^2`, and the Mallows / :math:`C_p` box weights via
@@ -28,7 +28,7 @@ Cross-validation — machine precision
 We build the Abadie-Gardeazabal Basque matching matrix through
 ``Synth::dataprep`` (the reference's own path) and run ``SMCV`` with the
 predictor weights fixed to one, so the oracle is deterministic. The mlsynth
-weight computation :func:`mlsynth.utils.smc_helpers.smc_weights` is fed the
+weight computation :func:`mlsynth.utils.src_helpers.src_weights` is fed the
 identical matrix. Every quantity agrees:
 
 .. list-table::
@@ -51,7 +51,7 @@ identical matrix. Every quantity agrees:
      - 1.7e-13
 
 The synthesis QP is the load-bearing step. mlsynth solves it with an exact
-active-set box solver (:func:`mlsynth.utils.smc_helpers.solver.solve_box_qp`),
+active-set box solver (:func:`mlsynth.utils.src_helpers.solver.solve_box_qp`),
 the box-``[0, 1]`` analogue of the repository's simplex active-set solver. On
 the Basque problem it reproduces ``solve.QP`` to ``2e-14`` with a KKT residual
 below ``1.5e-14`` — tighter than ``solve.QP``'s own residual — and pins the box
@@ -60,23 +60,23 @@ order QP (OSQP) it is an order of magnitude faster at synthetic-control donor
 sizes; against an interior-point QP (CLARABEL) it agrees on the objective but,
 unlike CLARABEL, leaves no donor microscopically off its bound. The solver is
 fuzz-tested against an independent cvxpy oracle over hundreds of random
-problems (``mlsynth/tests/test_smc.py``).
+problems (``mlsynth/tests/test_src.py``).
 
 Path A — the Basque study
 -------------------------
 
 Run through the public estimator on ``basedata/basque_data.csv`` (outcome-only
-matching, treatment in 1970), SMC reproduces the Abadie-Gardeazabal result:
+matching, treatment in 1970), SRC reproduces the Abadie-Gardeazabal result:
 
 .. code-block:: python
 
    import pandas as pd
-   from mlsynth import SMC
+   from mlsynth import SRC
 
    df = pd.read_csv("basedata/basque_data.csv")
    df["treat"] = ((df["regionname"] == "Basque Country (Pais Vasco)")
                   & (df["year"] >= 1970)).astype(int)
-   res = SMC({"df": df, "outcome": "gdpcap", "treat": "treat",
+   res = SRC({"df": df, "outcome": "gdpcap", "treat": "treat",
               "unitid": "regionname", "time": "year",
               "display_graphs": False}).fit()
 
@@ -85,7 +85,7 @@ gives a pre-period RMSE of about 0.048, a mean post-1969 ATT of about
 capita), with the combined donor coefficients concentrated on Murcia
 (:math:`0.63`), Madrid (:math:`0.37`) and Castilla y León (:math:`0.24`). The
 divergence traces the familiar economic cost of ETA terrorism. The durable case
-is ``benchmarks/cases/smc_basque.py``.
+is ``benchmarks/cases/src_basque.py``.
 
 The covariate / predictor-weight variant (Table 5)
 --------------------------------------------------
@@ -98,7 +98,7 @@ the paper's matching matrix from the raw panel and reproduces its Basque result:
 
 .. code-block:: python
 
-   res = SMC({
+   res = SRC({
        "df": df, "outcome": "gdpcap", "treat": "treat",
        "unitid": "regionname", "time": "year",
        "covariates": [...],                 # the 12 Abadie predictors

--- a/docs/smc.rst
+++ b/docs/smc.rst
@@ -161,11 +161,28 @@ freedom floored at one when :math:`N_0 \ge T_0` (a minimum-norm fit; a small
 :math:`\sigma^2` and enters the penalty as the per-donor complexity charge
 :math:`2\widehat{\sigma}^2`, which shrinks weight toward zero unless a matched
 control earns its place. That charge -- not a sum-to-one constraint -- is what
-identifies :math:`\widehat{\mathbf{w}}`. (Zhu's display form, his eq. 19, uses
-the diagonal of :math:`\mathbf{Y}_0^{\top}\mathbf{Q}\mathbf{Y}_0`; mlsynth
-follows the author's reference ``Code_SMC.R``, the full-regression residual
-variance above, cross-validated to :math:`< 2\text{e-}13` in the Verification
-section.)
+identifies :math:`\widehat{\mathbf{w}}`.
+
+   A note on the paper's display formula. Zhu's eq. 19 writes
+   :math:`\widehat{\sigma}^2 = \lVert \mathbf{Q}\mathbf{y}_1 -
+   \mathbf{Q}\mathbf{Y}_0[\operatorname{diag}(\mathbf{Y}_0^{\top}
+   \mathbf{Q}\mathbf{Y}_0)]^{-1}\mathbf{Y}_0^{\top}\mathbf{Q}\mathbf{y}_1
+   \rVert_2^2`, which reduces to the residual of the *equal-weight* sum of all
+   :math:`N_0` univariate fits, :math:`\lVert \mathbf{Q}\mathbf{y}_1 -
+   \widetilde{\mathbf{Y}}_0\mathbf{1} \rVert_2^2`. Because that sum stacks
+   :math:`N_0` controls that each already track the treated unit, it overshoots
+   by roughly a factor of :math:`N_0`, so the quantity scales with
+   :math:`N_0^2`, not with the noise level: in simulations with a known
+   :math:`\sigma^2` it over-estimates by two orders of magnitude, and the
+   resulting penalty is large enough to drive *every* weight to zero (a
+   degenerate flat-at-the-pre-mean counterfactual) in both the paper's
+   donors-fewer-than-periods regime and out of it. The author's reference
+   ``Code_SMC.R`` does not use eq. 19; it uses the full-regression residual
+   variance given above, which recovers the true :math:`\sigma^2` to within a
+   few percent. mlsynth follows the reference implementation (cross-validated to
+   :math:`< 2\text{e-}13`; see Verification), and reads the printed eq. 19 as an
+   uncorrected typo rather than the estimator the paper's own non-degenerate
+   Basque results were produced with.
 
 Assumptions
 -----------

--- a/docs/smc.rst
+++ b/docs/smc.rst
@@ -40,51 +40,132 @@ Do not use SMC when:
 Notation
 --------
 
-We use the synthetic-control canon. Let :math:`j = 1` denote the treated unit
-and :math:`\mathcal{N}_0 \coloneqq \{2, \ldots, J + 1\}` the donor pool. The
-intervention takes effect after period :math:`T_0`. Write
-:math:`\mathbf{y}_1 \in \mathbb{R}^{T_0}` for the treated unit's pre-treatment
-outcome path and :math:`\mathbf{y}_j \in \mathbb{R}^{T_0}` for donor
-:math:`j`'s. Optional covariates add matching rows stacked on top of the
-pre-treatment outcomes; the stacked matrix has :math:`n` rows.
+We use the synthetic-control canon. Let :math:`\mathcal{N} \coloneqq
+\{1, \ldots, N\}` index the units, with :math:`j = 1` the treated unit and
+:math:`\mathcal{N}_0 \coloneqq \mathcal{N} \setminus \{1\} = \{2, \ldots, N\}`
+the donor pool of :math:`N_0 \coloneqq N - 1` controls. Time is
+:math:`t \in \mathcal{T} \coloneqq \{1, \ldots, T\}`; the intervention takes
+effect after :math:`T_0`, so the pre-period is :math:`\mathcal{T}_1 \coloneqq
+\{t \in \mathcal{T} : t \le T_0\}` with :math:`|\mathcal{T}_1| = T_0` and the
+post-period is :math:`\mathcal{T}_2 \coloneqq \{t \in \mathcal{T} : t > T_0\}`
+with length :math:`T_2 \coloneqq |\mathcal{T}_2|`.
 
-Unit matching. For each donor separately, a univariate ordinary least squares
-regression rescales that donor to the treated unit,
+Notation bridge. Zhu (2023) indexes the treated unit as one of :math:`j = 1,
+\ldots, J + 1` with :math:`J` controls, and writes the pre-period as
+:math:`\mathcal{T}_0`; his :math:`J` is our :math:`N_0`, and his
+:math:`\mathcal{T}_0` is our :math:`\mathcal{T}_1`. He names the method
+Synthetic Regressing Control (SRC); mlsynth ships it as SMC.
+
+Panel objects. Write the treated unit's pre-period outcome path as
+:math:`\mathbf{y}_1 \coloneqq (y_{1t})_{t \in \mathcal{T}_1} \in
+\mathbb{R}^{T_0}` and stack the donors' pre-period paths columnwise into the
+donor matrix :math:`\mathbf{Y}_0 \coloneqq [\mathbf{y}_j]_{j \in \mathcal{N}_0}
+\in \mathbb{R}^{T_0 \times N_0}`, one column
+:math:`\mathbf{y}_j = (y_{jt})_{t \in \mathcal{T}_1} \in \mathbb{R}^{T_0}` per
+donor. These :math:`n \coloneqq T_0` matching rows are the pre-period outcomes in
+the default specification; the covariate variant (below) stacks standardized
+covariate rows on top, giving an :math:`n \times N_0` matching matrix with
+:math:`n > T_0`, and every formula below carries over with :math:`T_0` replaced
+by that row count :math:`n`. Centering (demeaning) uses the projector
+:math:`\mathbf{Q} \coloneqq \mathbf{I}_{T_0} - T_0^{-1}
+\mathbf{1}\mathbf{1}^{\top}`, and :math:`\bar{y}_j \coloneqq T_0^{-1}
+\sum_{t \in \mathcal{T}_1} y_{jt}` is donor :math:`j`'s pre-period mean, so
+:math:`\mathbf{Q}\mathbf{y}_j = \mathbf{y}_j - \bar{y}_j \mathbf{1}` is the
+centered column.
+
+Unit regression. SMC first rescales each donor to the treated unit by a
+*separate* demeaned univariate least-squares fit -- Zhu's "unit regression":
 
 .. math::
 
    \widehat{\theta}_j
-     = \frac{\mathbf{y}_j^{\top} \mathbf{y}_1}{\mathbf{y}_j^{\top} \mathbf{y}_j},
+     \coloneqq \frac{(\mathbf{y}_j - \bar{y}_j \mathbf{1})^{\top}
+                     (\mathbf{y}_1 - \bar{y}_1 \mathbf{1})}
+                    {\lVert \mathbf{y}_j - \bar{y}_j \mathbf{1} \rVert_2^2},
+   \qquad j \in \mathcal{N}_0.
 
-giving a matched control :math:`\widehat{\theta}_j \mathbf{y}_j`. Because
-:math:`\widehat{\theta}_j` is unconstrained, the matched control can already
-extrapolate.
-
-Synthesis. The matched controls are combined with weights :math:`\mathbf{w}` on
-the box :math:`\mathcal{H} \coloneqq \{ w_j \in [0, 1] \}` -- note there is no
-sum-to-one constraint. The SMC counterfactual is
-
-.. math::
-
-   \widehat{Y}_{1t}(0) = \sum_{j=2}^{J+1} w_j\, \widehat{\theta}_j\, Y_{jt},
-
-so the effective coefficient on donor :math:`j` is
-:math:`\widehat{\theta}_j w_j`, which may be negative.
-
-Weights. The box weights minimise a Mallows / :math:`C_p` unbiased-risk
-criterion (the estimator of the synthetic estimator's squared risk),
+The regressed (matched) control for donor :math:`j` is the centered, rescaled
+column :math:`\widehat{\theta}_j (\mathbf{y}_j - \bar{y}_j \mathbf{1})`; because
+:math:`\widehat{\theta}_j` is unconstrained it can already extrapolate. Collect
+these columnwise into the regressed-control matrix
 
 .. math::
 
-   \mathcal{C}(\mathbf{w})
-     = \bigl\lVert \mathbf{y}_1 - \mathbf{E}\, \mathbf{w} \bigr\rVert^2
-       + 2 \widehat{\sigma}^2 \sum_{j=2}^{J+1} w_j,
+   \widetilde{\mathbf{Y}}_0
+     \coloneqq \bigl[\, \widehat{\theta}_j (\mathbf{y}_j - \bar{y}_j \mathbf{1})
+                 \,\bigr]_{j \in \mathcal{N}_0}
+     = (\mathbf{Q}\mathbf{Y}_0)\operatorname{diag}(\widehat{\boldsymbol{\theta}})
+     \in \mathbb{R}^{T_0 \times N_0},
 
-where column :math:`j` of :math:`\mathbf{E}` is the matched control
-:math:`\widehat{\theta}_j \mathbf{y}_j` and :math:`\widehat{\sigma}^2` is the
-full-model residual variance. The penalty :math:`2 \widehat{\sigma}^2
-\sum_j w_j` is what identifies :math:`\mathbf{w}`: it is a per-donor complexity
-charge that shrinks weight toward zero unless a matched control earns its place.
+whose column :math:`j` is donor :math:`j`'s matched control (the object the
+previous version of this page wrote :math:`\mathbf{E}`).
+
+Synthesis. The matched controls are combined by box weights :math:`\mathbf{w}
+\in \mathcal{C}_{\mathrm{box}} \coloneqq [0, 1]^{N_0} = \{\mathbf{w} \in
+\mathbb{R}^{N_0} : 0 \le w_j \le 1\}` -- note there is *no* sum-to-one
+constraint, which is what separates SMC from a simplex synthetic control (Zhu
+writes this set :math:`\mathcal{H}_J`). With the level
+:math:`\widehat{b}_0 \coloneqq \bar{y}_1 - \sum_{j \in \mathcal{N}_0}
+\widehat{w}_j \widehat{\theta}_j \bar{y}_j` that restores the mean removed by
+centering, the SMC counterfactual is
+
+.. math::
+
+   \widehat{y}_{1t}
+     = \bar{y}_1 + \sum_{j \in \mathcal{N}_0}
+        w_j\, \widehat{\theta}_j\, (y_{jt} - \bar{y}_j)
+     = \widehat{b}_0 + \sum_{j \in \mathcal{N}_0}
+        w_j \widehat{\theta}_j\, y_{jt},
+   \qquad t \in \mathcal{T},
+
+which estimates the no-intervention outcome :math:`y_{1t}^N`. The effective
+coefficient on donor :math:`j` is :math:`\widehat{\theta}_j w_j`, which may be
+negative. The per-period effect is the scalar :math:`\tau_t \coloneqq y_{1t} -
+\widehat{y}_{1t}`, and the ATT is :math:`\widehat{\tau} \coloneqq T_2^{-1}
+\sum_{t \in \mathcal{T}_2} \tau_t`.
+
+Weights. The box weights minimise a Mallows :math:`C_p` criterion -- an unbiased
+estimator of the synthetic estimator's squared risk -- written in the canon's
+loss-plus-penalty form,
+
+.. math::
+
+   \widehat{\mathbf{w}}
+     \in \operatorname*{argmin}_{\mathbf{w} \in \mathcal{C}_{\mathrm{box}}}
+       \; \underbrace{\bigl\lVert \mathbf{Q}\mathbf{y}_1
+                      - \widetilde{\mathbf{Y}}_0 \mathbf{w} \bigr\rVert_2^2
+                     }_{\mathcal{L}(\mathbf{w})}
+       + \underbrace{2\,\widehat{\sigma}^2 \lVert \mathbf{w} \rVert_1
+                    }_{\mathcal{P}(\mathbf{w})},
+
+where :math:`\lVert \mathbf{w} \rVert_1 = \sum_{j \in \mathcal{N}_0} w_j`
+because :math:`\mathbf{w} \ge \mathbf{0}` on the box. The noise level
+:math:`\widehat{\sigma}^2` is the plug-in residual variance of the full
+(multivariate) demeaned regression of the treated path on the donor matrix,
+
+.. math::
+
+   \widehat{\sigma}^2
+     \coloneqq \frac{1}{\max(T_0 - N_0,\, 1)}
+       \bigl\lVert \mathbf{Q}\mathbf{y}_1
+         - (\mathbf{Q}\mathbf{Y}_0)\,\widehat{\boldsymbol{\beta}}
+       \bigr\rVert_2^2,
+   \qquad
+   \widehat{\boldsymbol{\beta}} \coloneqq (\mathbf{Q}\mathbf{Y}_0)^{+}\,
+     \mathbf{Q}\mathbf{y}_1,
+
+with :math:`(\cdot)^{+}` the Moore--Penrose pseudoinverse and the degrees of
+freedom floored at one when :math:`N_0 \ge T_0` (a minimum-norm fit; a small
+``ridge`` then keeps the synthesis QP strictly convex). This
+:math:`\widehat{\sigma}^2` estimates the working-model noise level
+:math:`\sigma^2` and enters the penalty as the per-donor complexity charge
+:math:`2\widehat{\sigma}^2`, which shrinks weight toward zero unless a matched
+control earns its place. That charge -- not a sum-to-one constraint -- is what
+identifies :math:`\widehat{\mathbf{w}}`. (Zhu's display form, his eq. 19, uses
+the diagonal of :math:`\mathbf{Y}_0^{\top}\mathbf{Q}\mathbf{Y}_0`; mlsynth
+follows the author's reference ``Code_SMC.R``, the full-regression residual
+variance above, cross-validated to :math:`< 2\text{e-}13` in the Verification
+section.)
 
 Assumptions
 -----------
@@ -100,9 +181,11 @@ Assumptions
    uses the full-model residual, so more pre-periods than donors gives it
    degrees of freedom.
 
-   Remark. When donors are not fewer than matching rows (:math:`J \ge n`) the
-   residual degrees of freedom are floored at one and a minimum-norm fit is
-   used; a small ``ridge`` keeps the synthesis QP well posed. For a
+   Remark. When donors are not fewer than matching rows
+   (:math:`N_0 \ge T_0`, or :math:`N_0 \ge n` with stacked covariates) the
+   residual degrees of freedom :math:`\max(T_0 - N_0, 1)` are floored at one and
+   :math:`\widehat{\boldsymbol{\beta}}` is the minimum-norm (pseudoinverse) fit;
+   a small ``ridge`` keeps the synthesis QP strictly convex. For a
    high-dimensional donor pool, screen first (see the paper's SIRS extension)
    or use :doc:`clustersc`.
 
@@ -171,7 +254,15 @@ Reproducing the paper's covariate specification
 -----------------------------------------------
 
 The paper's Basque result uses Algorithm 3: covariate matching with an Abadie
-predictor-weight (:math:`\mathbf{V}`) optimisation over the matching rows. That
+predictor-weight optimisation over the matching rows. Stack the standardized
+covariate rows on top of the outcome rows to form the :math:`n \times N_0`
+matching matrix, and let :math:`\mathbf{V} \coloneqq \operatorname{diag}(v_1,
+\ldots, v_n)` with :math:`v_i \ge 0` be the diagonal predictor weights on those
+rows. Every quantity above is then computed on the :math:`\mathbf{V}^{1/2}`-
+scaled rows -- the treated matching vector becomes :math:`\mathbf{V}^{1/2}
+\mathbf{y}_1` and the donor matrix :math:`\mathbf{V}^{1/2}\mathbf{Y}_0` before
+centering -- so :math:`\mathbf{V}` sets each matching row's relative importance
+in the unit regression and the :math:`C_p` synthesis. Choosing :math:`\mathbf{V}`
 is an explicit, seeded opt-in in mlsynth -- ``covariates`` with per-covariate
 ``covariate_windows``, the ``fit_window`` for the outcome rows, and
 ``v_search="de"``:
@@ -210,7 +301,8 @@ Verification
 The SMC weight computation is cross-validated against the author's reference R
 implementation (``Code_SMC.R``): on the identical Basque matching matrix, the
 per-donor :math:`\widehat{\theta}_j`, the box weights, the combined
-coefficients, ``bias`` and :math:`\widehat{\sigma}^2` all match the reference
+coefficients, the intercept :math:`\widehat{b}_0` (``bias``) and
+:math:`\widehat{\sigma}^2` all match the reference
 ``SMCV`` (whose synthesis QP is solved by ``solve.QP``) to ``< 2e-13``. The
 active-set box QP in :mod:`mlsynth.utils.smc_helpers.solver` reproduces
 ``solve.QP`` to machine precision while pinning the box bounds exactly. With the

--- a/docs/src.rst
+++ b/docs/src.rst
@@ -1,17 +1,17 @@
-Synthetic Matching Control (SMC)
-================================
+Synthetic Regressing Control (SRC)
+==================================
 
 .. currentmodule:: mlsynth
 
-When to use SMC -- and when not to
+When to use SRC -- and when not to
 ----------------------------------
 
-Synthetic Matching Control (Zhu 2023) is for the case where the ordinary
+Synthetic Regressing Control (Zhu 2023) is for the case where the ordinary
 synthetic control fits the treated unit's pre-treatment path poorly. The
 canonical synthetic control restricts the donor weights to the unit simplex
 (non-negative, summing to one), which keeps the counterfactual inside the
 convex hull of the donors but cannot track a treated unit that sits near or
-outside that hull -- the interpolation-bias / imperfect-pre-fit problem. SMC
+outside that hull -- the interpolation-bias / imperfect-pre-fit problem. SRC
 relaxes that restriction in a disciplined way and is a good choice when:
 
 * You have a single treated unit and a donor pool with real heterogeneity, and
@@ -19,22 +19,22 @@ relaxes that restriction in a disciplined way and is a good choice when:
 * You are willing to let the counterfactual extrapolate a little beyond the
   donor hull, but want the amount of extrapolation regularised rather than
   unbounded (as an unconstrained regression would give).
-* You want a deterministic, reproducible estimate. By default SMC's weights are
+* You want a deterministic, reproducible estimate. By default SRC's weights are
   pinned by the risk criterion, not by an Abadie predictor-weight (``V``) search,
   so there is no optimiser-seed dependence. (The paper's covariate + ``V``-search
   variant is available as a seeded opt-in; see below.)
 
-Do not use SMC when:
+Do not use SRC when:
 
 * A simplex synthetic control already fits well and you want an interpretable
-  convex weighting. Use canonical SCM (:doc:`vanillasc`) or :doc:`tssc`; SMC's
+  convex weighting. Use canonical SCM (:doc:`vanillasc`) or :doc:`tssc`; SRC's
   combined coefficients can be negative and do not sum to one.
 * You want an explicit bias--variance trade-off between matching and synthetic
   control chosen by cross-validation. That is :doc:`masc`.
 * You want denoising of a low-rank donor matrix before weighting. Use
   :doc:`clustersc` (robust PCA / PCR) or :doc:`snn`.
 * You need posterior uncertainty on the weights. Use :doc:`bvss`.
-* There are multiple treated units, spillovers, or a continuous dose -- SMC
+* There are multiple treated units, spillovers, or a continuous dose -- SRC
   encodes a single binary intervention on one unit.
 
 Notation
@@ -54,7 +54,7 @@ Notation bridge. Zhu (2023) indexes the treated unit as one of :math:`j = 1,
 \ldots, J + 1` with :math:`J` controls, and writes the pre-period as
 :math:`\mathcal{T}_0`; his :math:`J` is our :math:`N_0`, and his
 :math:`\mathcal{T}_0` is our :math:`\mathcal{T}_1`. He names the method
-Synthetic Regressing Control (SRC); mlsynth ships it as SMC.
+Synthetic Regressing Control (SRC); mlsynth ships it as SRC.
 
 Panel objects. Write the treated unit's pre-period outcome path as
 :math:`\mathbf{y}_1 \coloneqq (y_{1t})_{t \in \mathcal{T}_1} \in
@@ -73,7 +73,7 @@ by that row count :math:`n`. Centering (demeaning) uses the projector
 :math:`\mathbf{Q}\mathbf{y}_j = \mathbf{y}_j - \bar{y}_j \mathbf{1}` is the
 centered column.
 
-Unit regression. SMC first rescales each donor to the treated unit by a
+Unit regression. SRC first rescales each donor to the treated unit by a
 *separate* demeaned univariate least-squares fit -- Zhu's "unit regression":
 
 .. math::
@@ -103,11 +103,11 @@ previous version of this page wrote :math:`\mathbf{E}`).
 Synthesis. The matched controls are combined by box weights :math:`\mathbf{w}
 \in \mathcal{C}_{\mathrm{box}} \coloneqq [0, 1]^{N_0} = \{\mathbf{w} \in
 \mathbb{R}^{N_0} : 0 \le w_j \le 1\}` -- note there is *no* sum-to-one
-constraint, which is what separates SMC from a simplex synthetic control (Zhu
+constraint, which is what separates SRC from a simplex synthetic control (Zhu
 writes this set :math:`\mathcal{H}_J`). With the level
 :math:`\widehat{b}_0 \coloneqq \bar{y}_1 - \sum_{j \in \mathcal{N}_0}
 \widehat{w}_j \widehat{\theta}_j \bar{y}_j` that restores the mean removed by
-centering, the SMC counterfactual is
+centering, the SRC counterfactual is
 
 .. math::
 
@@ -190,7 +190,7 @@ Assumptions
 #. Single treated unit, balanced panel. One unit is treated after
    :math:`T_0`; every unit is observed at every period.
 
-   Remark. The setup boundary (:mod:`mlsynth.utils.smc_helpers.setup`) enforces
+   Remark. The setup boundary (:mod:`mlsynth.utils.src_helpers.setup`) enforces
    both, translating a violation to :class:`~mlsynth.exceptions.MlsynthDataError`.
 
 #. At least two pre-treatment periods. The univariate matches and the risk
@@ -211,13 +211,13 @@ Assumptions
    bounds how much.
 
    Remark. If extrapolation is unacceptable for the application (you need a
-   convex, interpretable weighting), SMC is the wrong tool -- use a simplex SCM.
+   convex, interpretable weighting), SRC is the wrong tool -- use a simplex SCM.
 
 Inference and diagnostics
 -------------------------
 
-SMC returns a point estimate. The primary diagnostic is the pre-treatment fit
-(``res.fit_diagnostics.rmse_pre``): SMC's reason for being is a tighter
+SRC returns a point estimate. The primary diagnostic is the pre-treatment fit
+(``res.fit_diagnostics.rmse_pre``): SRC's reason for being is a tighter
 pre-fit than a simplex SCM, so compare the two. The combined coefficients
 ``res.weights_vector`` (which may be negative) and the box weights
 ``res.box_weights`` are both exposed; a donor with a hard zero box weight is
@@ -231,13 +231,13 @@ Example
 .. code-block:: python
 
    import pandas as pd
-   from mlsynth import SMC
+   from mlsynth import SRC
 
    df = pd.read_csv("basedata/basque_data.csv")
    df["treat"] = ((df["regionname"] == "Basque Country (Pais Vasco)")
                   & (df["year"] >= 1970)).astype(int)
 
-   res = SMC({
+   res = SRC({
        "df": df, "outcome": "gdpcap", "treat": "treat",
        "unitid": "regionname", "time": "year",
        "display_graphs": False,
@@ -256,7 +256,7 @@ This prints::
      Madrid (Comunidad De)        +0.370
      Castilla Y Leon              +0.242
 
-The Basque Country tracks its SMC counterfactual to a pre-period RMSE of about
+The Basque Country tracks its SRC counterfactual to a pre-period RMSE of about
 0.048 (thousand-1986-USD per capita), then diverges steadily -- the familiar
 Abadie-Gardeazabal shape of the economic cost of ETA terrorism -- recovered
 here by the box-weighted matched controls rather than a simplex.
@@ -286,7 +286,7 @@ is an explicit, seeded opt-in in mlsynth -- ``covariates`` with per-covariate
 
 .. code-block:: python
 
-   res = SMC({
+   res = SRC({
        "df": df, "outcome": "gdpcap", "treat": "treat",
        "unitid": "regionname", "time": "year",
        "covariates": ["school.illit", "school.prim", "school.med", "school.high",
@@ -315,25 +315,25 @@ single reproducible weighting, use the default.
 Verification
 ------------
 
-The SMC weight computation is cross-validated against the author's reference R
+The SRC weight computation is cross-validated against the author's reference R
 implementation (``Code_SMC.R``): on the identical Basque matching matrix, the
 per-donor :math:`\widehat{\theta}_j`, the box weights, the combined
 coefficients, the intercept :math:`\widehat{b}_0` (``bias``) and
 :math:`\widehat{\sigma}^2` all match the reference
 ``SMCV`` (whose synthesis QP is solved by ``solve.QP``) to ``< 2e-13``. The
-active-set box QP in :mod:`mlsynth.utils.smc_helpers.solver` reproduces
+active-set box QP in :mod:`mlsynth.utils.src_helpers.solver` reproduces
 ``solve.QP`` to machine precision while pinning the box bounds exactly. With the
 paper's covariate specification and ``v_search="de"`` the estimator additionally
 reproduces the Table 5 / Figure 1 donor structure and ATT magnitude (subject to
 the :math:`\mathbf{V}` non-identification noted above). See the replication page
-:doc:`replications/smc` and the durable case ``benchmarks/cases/smc_basque.py``.
+:doc:`replications/src` and the durable case ``benchmarks/cases/src_basque.py``.
 The solver, weight computation, the covariate / ``V``-search paths, setup and
-result contract are unit-tested (``mlsynth/tests/test_smc.py``, full coverage).
+result contract are unit-tested (``mlsynth/tests/test_src.py``, full coverage).
 
 Core API
 --------
 
-.. automodule:: mlsynth.estimators.smc
+.. automodule:: mlsynth.estimators.src
    :members:
    :undoc-members:
    :show-inheritance:
@@ -341,16 +341,16 @@ Core API
 Configuration
 -------------
 
-.. autoclass:: mlsynth.config_models.SMCConfig
+.. autoclass:: mlsynth.config_models.SRCConfig
    :members:
    :undoc-members:
 
 Result Containers
 -----------------
 
-``SMC.fit()`` returns a
-:class:`~mlsynth.utils.smc_helpers.structures.SMCResults` -- an
+``SRC.fit()`` returns a
+:class:`~mlsynth.utils.src_helpers.structures.SRCResults` -- an
 ``EffectResult`` whose standardized sub-models carry the ATT, counterfactual,
-gap and pre-RMSE, with the SMC-specific ``theta`` rescalings, box weights and
+gap and pre-RMSE, with the SRC-specific ``theta`` rescalings, box weights and
 :math:`\widehat{\sigma}^2` on ``res.fit``. The prepared NumPy panel is exposed
-as a :class:`~mlsynth.utils.smc_helpers.structures.SMCInputs`.
+as a :class:`~mlsynth.utils.src_helpers.structures.SRCInputs`.

--- a/docs/src.rst
+++ b/docs/src.rst
@@ -203,8 +203,8 @@ Assumptions
    residual degrees of freedom :math:`\max(T_0 - N_0, 1)` are floored at one and
    :math:`\widehat{\boldsymbol{\beta}}` is the minimum-norm (pseudoinverse) fit;
    a small ``ridge`` keeps the synthesis QP strictly convex. For a
-   high-dimensional donor pool, screen first (see the paper's SIRS extension)
-   or use :doc:`clustersc`.
+   high-dimensional donor pool, screen first (``screen="sirs"``, below) or use
+   :doc:`clustersc`.
 
 #. Regularised extrapolation is acceptable. The combined coefficients can leave
    the simplex, so the counterfactual can extrapolate; the :math:`C_p` penalty
@@ -212,6 +212,50 @@ Assumptions
 
    Remark. If extrapolation is unacceptable for the application (you need a
    convex, interpretable weighting), SRC is the wrong tool -- use a simplex SCM.
+
+Screening a wide donor pool
+---------------------------
+
+When the pool is not small relative to the pre-period (:math:`N_0 \ge T_0`, and
+the paper recommends screening already at :math:`N_0 \ge 4T_0/5`), the unit
+regression is ill-posed: the centered pre-period system :math:`\mathbf{Q}
+\mathbf{y}_1 \approx \mathbf{Q}\mathbf{Y}_0\boldsymbol{\beta}` has more donor
+coefficients than periods, so the full-model residual collapses,
+:math:`\widehat{\sigma}^2 \to 0`, and the :math:`C_p` penalty switches off --
+the box fit then interpolates the pre-period with no complexity charge. The
+paper's Algorithm 2 handles this by screening the pool *before* Algorithm 1.
+Set ``screen="sirs"``:
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import SRC
+
+   df = pd.read_csv("basedata/basque_data.csv")
+   df["treat"] = ((df["regionname"] == "Basque Country (Pais Vasco)")
+                  & (df["year"] >= 1975)).astype(int)
+   res = SRC({"df": df, "outcome": "gdpcap", "treat": "treat",
+              "unitid": "regionname", "time": "year",
+              "screen": "sirs", "display_graphs": False}).fit()
+
+Donors are ranked by the sure-independent-ranking-and-screening (SIRS) marginal
+utility of Zhu, Fan, Li & Zhu (2011) on the pre-period outcomes -- a model-free
+measure of dependence between each donor and the treated path -- and the top
+:math:`k \coloneqq \min\bigl(\lfloor T_0/\log(T_0/2)\rfloor,\, T_0 - 1\bigr)` are
+kept (override with ``n_screen``). The :math:`T_0 - 1` cap guarantees the
+screened pool is smaller than the pre-period, so the fit is well posed and
+:math:`\widehat{\sigma}^2 > 0`. On the 1975-treated Basque panel
+(:math:`T_0 = 20`, :math:`N_0 = 16`) screening keeps :math:`k = 8` donors and
+lifts :math:`\widehat{\sigma}^2` by roughly two orders of magnitude, so the
+penalty is active rather than switched off.
+
+Two cautions. Screening is a well-posedness and reproducibility device, not a
+route to the paper's Basque weight cells: even a screened pool that contains
+Cantabria still lands on the same Rioja/Madrid decomposition, because the
+remaining freedom lives on the non-identified :math:`\mathbf{V}` manifold (see
+below), not in the pool. And the SIRS statistic is scale-free by construction
+(donor paths are standardised); the paper's printed Eq. 22 carries the inner
+term as :math:`Y_{jt}`, which we read as the cited-form :math:`Y_{j\ell}`.
 
 Inference and diagnostics
 -------------------------

--- a/docs/src.rst
+++ b/docs/src.rst
@@ -249,6 +249,22 @@ screened pool is smaller than the pre-period, so the fit is well posed and
 lifts :math:`\widehat{\sigma}^2` by roughly two orders of magnitude, so the
 penalty is active rather than switched off.
 
+A shape-based alternative: ``screen="fpca"``. SIRS ranks donors by marginal
+dependence; ``screen="fpca"`` instead selects an economically coherent peer
+group by *clustering* the pre-period trajectories and keeping the donors in the
+treated unit's cluster. It reuses :doc:`clustersc`'s own donor-clustering
+routines -- functional PCA (cubic-B-spline smoothing then a PCA truncated at
+95% variance) followed by silhouette-chosen k-means (Bayani 2021,
+:func:`~mlsynth.utils.clustersc_helpers.rpca.fpca.compute_fpca_features` and
+:func:`~mlsynth.utils.clustersc_helpers.rpca.clustering.assign_clusters`) -- so
+the two estimators screen donors by the same principle. The cluster size is
+data-driven (no ``n_screen``), and the selection is deterministic. On the
+1975-treated Basque panel it keeps the developed / service regions
+(Baleares, Cataluña, Madrid) in the Basque Country's cluster, where SIRS instead
+ranks in Aragón; the two rules give genuinely different pools, and hence
+different counterfactuals -- a reminder that donor selection is a modelling
+choice, not an objective one.
+
 Two cautions. Screening is a well-posedness and reproducibility device, not a
 route to the paper's Basque weight cells: even a screened pool that contains
 Cantabria still lands on the same Rioja/Madrid decomposition, because the

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -21,7 +21,7 @@ from .estimators.nsc import NSC # Check
 from .estimators.sdid import SDID # Check
 from .estimators.musc import MUSC                              # noqa: F401
 from .estimators.masc import MASC                              # noqa: F401
-from .estimators.smc import SMC                                # noqa: F401
+from .estimators.src import SRC                                # noqa: F401
 from .estimators.shc import SHC # Check
 from .estimators.laxscm import RESCM # Check
 from .estimators.scexp import MAREX
@@ -103,7 +103,7 @@ __all__ = [
     "PROXIMAL",
     "FSCM",
     "SCMO",
-    "SMC",
+    "SRC",
     "PROPSC",
     "SCTA",
     "SCUL",

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -578,7 +578,7 @@ _RELOCATED_CONFIGS = {
     "DSCARConfig": "mlsynth.utils.dscar_helpers.config",
     "PROXIMALConfig": "mlsynth.utils.proximal_helpers.config",
     "SCMOConfig": "mlsynth.utils.scmo_helpers.config",
-    "SMCConfig": "mlsynth.utils.smc_helpers.config",
+    "SRCConfig": "mlsynth.utils.src_helpers.config",
     "PROPSCConfig": "mlsynth.utils.propsc_helpers.config",
     "SCTAConfig": "mlsynth.utils.scta_helpers.config",
     "SCULConfig": "mlsynth.utils.scul_helpers.config",

--- a/mlsynth/estimators/src.py
+++ b/mlsynth/estimators/src.py
@@ -1,7 +1,7 @@
-"""Synthetic Matching Control (SMC) estimator.
+"""Synthetic Regressing Control (SRC) estimator.
 
-A thin, NumPy-first orchestration over :mod:`mlsynth.utils.smc_helpers`.
-SMC (Zhu 2023) addresses the imperfect-pre-fit problem of the simplex synthetic
+A thin, NumPy-first orchestration over :mod:`mlsynth.utils.src_helpers`.
+SRC (Zhu 2023) addresses the imperfect-pre-fit problem of the simplex synthetic
 control in two deterministic steps. First, *unit matching*: each donor is
 rescaled to the treated unit by a univariate OLS, ``theta_j``, giving a matched
 control ``theta_j x_j`` that can already extrapolate (``theta_j`` is
@@ -12,13 +12,13 @@ criterion; the combined donor coefficient is ``theta_j w_j``. The Cp penalty on
 the estimator is reproducible.
 
 The synthesis QP is solved exactly by an active-set box solver
-(:func:`~mlsynth.utils.smc_helpers.solver.solve_box_qp`) that matches the
+(:func:`~mlsynth.utils.src_helpers.solver.solve_box_qp`) that matches the
 reference R ``solve.QP`` to machine precision. Optional ``covariates`` add
 predictor rows (Algorithm 3) at equal predictor weight.
 
 References
 ----------
-Zhu, Rong J. B. (2023). *Synthetic Matching Control Method.* arXiv:2306.02584.
+Zhu, Rong J. B. (2023). *Synthetic Regressing Control.* arXiv:2306.02584.
 https://arxiv.org/abs/2306.02584
 """
 
@@ -28,7 +28,7 @@ from typing import Union
 
 import pandas as pd
 
-from ..config_models import SMCConfig
+from ..config_models import SRCConfig
 from ..exceptions import (
     MlsynthConfigError,
     MlsynthDataError,
@@ -36,32 +36,32 @@ from ..exceptions import (
     MlsynthPlottingError,
 )
 from ..utils.datautils import balance
-from ..utils.smc_helpers import (
-    SMCResults,
-    plot_smc,
-    prepare_smc_inputs,
-    run_smc,
+from ..utils.src_helpers import (
+    SRCResults,
+    plot_src,
+    prepare_src_inputs,
+    run_src,
 )
 
 
-class SMC:
-    """Synthetic Matching Control estimator.
+class SRC:
+    """Synthetic Regressing Control estimator.
 
     Parameters
     ----------
-    config : SMCConfig or dict
+    config : SRCConfig or dict
         Validated configuration. Beyond the common fields (``df``, ``outcome``,
         ``treat``, ``unitid``, ``time``, ``display_graphs``, ``save``, colours),
-        SMC reads ``ridge`` (the Cp box-QP stabiliser) and ``covariates``
+        SRC reads ``ridge`` (the Cp box-QP stabiliser) and ``covariates``
         (optional predictor columns for Algorithm 3).
     """
 
-    def __init__(self, config: Union[SMCConfig, dict]) -> None:
+    def __init__(self, config: Union[SRCConfig, dict]) -> None:
         if isinstance(config, dict):
             try:
-                config = SMCConfig(**config)
+                config = SRCConfig(**config)
             except Exception as exc:
-                raise MlsynthConfigError(f"Invalid SMC configuration: {exc}") from exc
+                raise MlsynthConfigError(f"Invalid SRC configuration: {exc}") from exc
         self.config = config
         self.df: pd.DataFrame = config.df
         self.outcome: str = config.outcome
@@ -73,12 +73,12 @@ class SMC:
         self.counterfactual_color = config.counterfactual_color
         self.treated_color = config.treated_color
 
-    def fit(self) -> SMCResults:
-        """Run SMC end to end and return :class:`SMCResults`.
+    def fit(self) -> SRCResults:
+        """Run SRC end to end and return :class:`SRCResults`.
 
         Returns
         -------
-        SMCResults
+        SRCResults
             Container with the ATT, the counterfactual and gap paths, the
             combined donor coefficients (``theta * w``), the box weights, the
             pre-period RMSE, and the standardized sub-models.
@@ -86,7 +86,7 @@ class SMC:
         Raises
         ------
         MlsynthDataError
-            If the panel violates SMC's requirements (single treated unit,
+            If the panel violates SRC's requirements (single treated unit,
             balanced panel, at least two pre-treatment periods, a donor pool).
         MlsynthEstimationError
             If the weight computation fails at runtime.
@@ -97,11 +97,11 @@ class SMC:
             balance(self.df, self.unitid, self.time)
         except Exception as exc:
             raise MlsynthDataError(
-                f"SMC: panel failed the balance / structure check: {exc}"
+                f"SRC: panel failed the balance / structure check: {exc}"
             ) from exc
 
         try:
-            inputs = prepare_smc_inputs(
+            inputs = prepare_src_inputs(
                 self.df,
                 outcome=self.outcome, treat=self.treat,
                 unitid=self.unitid, time=self.time,
@@ -113,10 +113,10 @@ class SMC:
             raise
         except Exception as exc:  # pragma: no cover - defensive translation of an
             raise MlsynthDataError(  # unexpected prepare failure
-                f"SMC: failed to prepare inputs: {exc}") from exc
+                f"SRC: failed to prepare inputs: {exc}") from exc
 
         try:
-            fit = run_smc(
+            fit = run_src(
                 inputs, ridge=self.config.ridge,
                 v_search=self.config.v_search, v_seed=self.config.v_seed,
                 v_maxiter=self.config.v_maxiter, v_popsize=self.config.v_popsize,
@@ -125,12 +125,12 @@ class SMC:
             raise                                           # already translated
         except Exception as exc:  # pragma: no cover - defensive translation
             raise MlsynthEstimationError(
-                f"SMC: estimation pipeline failed: {exc}") from exc
+                f"SRC: estimation pipeline failed: {exc}") from exc
 
-        results = SMCResults(inputs=inputs, fit=fit)
+        results = SRCResults(inputs=inputs, fit=fit)
         if self.display_graphs:
             try:
-                plot_smc(
+                plot_src(
                     results,
                     outcome=self.outcome, time=self.time,
                     treated_color=self.treated_color,
@@ -142,5 +142,5 @@ class SMC:
                     save=self.save,
                 )
             except Exception as exc:  # pragma: no cover - defensive translation
-                raise MlsynthPlottingError(f"SMC: plotting failed: {exc}") from exc
+                raise MlsynthPlottingError(f"SRC: plotting failed: {exc}") from exc
         return results

--- a/mlsynth/estimators/src.py
+++ b/mlsynth/estimators/src.py
@@ -118,6 +118,7 @@ class SRC:
         try:
             fit = run_src(
                 inputs, ridge=self.config.ridge,
+                screen=self.config.screen, n_screen=self.config.n_screen,
                 v_search=self.config.v_search, v_seed=self.config.v_seed,
                 v_maxiter=self.config.v_maxiter, v_popsize=self.config.v_popsize,
             )

--- a/mlsynth/tests/test_src.py
+++ b/mlsynth/tests/test_src.py
@@ -1,14 +1,14 @@
-"""Tests for the SMC (Zhu 2023, Synthetic Matching Control) estimator.
+"""Tests for the SRC (Zhu 2023, Synthetic Regressing Control) estimator.
 
 Layer 1 -- solver primitive: the exact box QP matches an independent cvxpy
 oracle to solver tolerance, certifies its own KKT point, pins the box bounds,
 and is warm-start invariant.
 Layer 2 -- weight computation: Algorithm 1 recovers an exact donor combination,
 is deterministic, and tolerates a rank-deficient (collinear) donor block.
-Layer 3 -- data setup: prepare_smc_inputs identifies the treated unit, enforces
+Layer 3 -- data setup: prepare_src_inputs identifies the treated unit, enforces
 a balanced panel with a donor pool and enough pre-periods.
-Layer 4 -- estimator integration: SMC.fit() runs end-to-end (with and without
-covariates), reproduces the Basque study, and returns an SMCResults respecting
+Layer 4 -- estimator integration: SRC.fit() runs end-to-end (with and without
+covariates), reproduces the Basque study, and returns an SRCResults respecting
 the standardized contract.
 Layer 5 -- public API / failure contracts: dict-vs-config equivalence, config
 validation, and exception translation (failures are reported, not swallowed).
@@ -22,21 +22,21 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from mlsynth import SMC
-from mlsynth.config_models import SMCConfig
+from mlsynth import SRC
+from mlsynth.config_models import SRCConfig
 from mlsynth.exceptions import (
     MlsynthConfigError,
     MlsynthDataError,
 )
-from mlsynth.utils.smc_helpers import (
-    SMCFit,
-    SMCInputs,
-    SMCResults,
+from mlsynth.utils.src_helpers import (
+    SRCFit,
+    SRCInputs,
+    SRCResults,
     counterfactual,
     optimize_v,
-    prepare_smc_inputs,
-    run_smc,
-    smc_weights,
+    prepare_src_inputs,
+    run_src,
+    src_weights,
     solve_box_qp,
 )
 
@@ -94,7 +94,7 @@ def _cfg(df, **kw):
     base = dict(df=df, outcome="y", treat="treat", unitid="unit", time="t",
                 display_graphs=False)
     base.update(kw)
-    return SMCConfig(**base)
+    return SRCConfig(**base)
 
 
 # --------------------------------------------------------------------------- #
@@ -151,47 +151,47 @@ def test_box_qp_bad_shape_raises():
 # --------------------------------------------------------------------------- #
 # Layer 2 -- the weight computation (Algorithm 1)
 # --------------------------------------------------------------------------- #
-def test_smc_weights_recovers_exact_combination():
+def test_src_weights_recovers_exact_combination():
     rng = np.random.default_rng(0)
     X = rng.standard_normal((30, 6))
     true = np.array([0.5, 0.0, 0.3, 0.0, 0.0, 0.0])
     y = X @ true                                    # treated is an exact donor combo
-    r = smc_weights(X, y)
+    r = src_weights(X, y)
     cf = counterfactual(X, r)
     assert np.sqrt(np.mean((y - cf) ** 2)) < 1e-2   # near-perfect in-sample fit
     assert r.w.min() >= -1e-9 and r.w.max() <= 1 + 1e-9
 
 
-def test_smc_weights_deterministic():
+def test_src_weights_deterministic():
     rng = np.random.default_rng(1)
     X = rng.standard_normal((25, 8)); y = rng.standard_normal(25)
-    a = smc_weights(X, y); b = smc_weights(X, y)
+    a = src_weights(X, y); b = src_weights(X, y)
     assert np.array_equal(a.combined, b.combined)
     assert a.bias == b.bias
 
 
-def test_smc_weights_rank_deficient_collinear():
+def test_src_weights_rank_deficient_collinear():
     rng = np.random.default_rng(2)
     base = rng.standard_normal((8, 4))
     X = np.hstack([base, base + 1e-8 * rng.standard_normal((8, 4))])  # collinear pairs
     y = rng.standard_normal(8)
-    r = smc_weights(X, y)                            # ridge keeps it finite
+    r = src_weights(X, y)                            # ridge keeps it finite
     assert np.all(np.isfinite(r.combined)) and np.isfinite(r.bias)
 
 
-def test_smc_weights_V_equal_weights_noop():
+def test_src_weights_V_equal_weights_noop():
     rng = np.random.default_rng(4)
     X = rng.standard_normal((20, 5)); y = rng.standard_normal(20)
-    a = smc_weights(X, y)
-    b = smc_weights(X, y, V=np.ones(20))            # equal V == deterministic default
+    a = src_weights(X, y)
+    b = src_weights(X, y, V=np.ones(20))            # equal V == deterministic default
     assert np.allclose(a.combined, b.combined)
 
 
-def test_smc_weights_combined_can_extrapolate():
+def test_src_weights_combined_can_extrapolate():
     # theta unconstrained -> combined coefficient may exceed the box / go negative.
     rng = np.random.default_rng(5)
     X = rng.standard_normal((20, 4)); y = 3.0 * X[:, 0] - 2.0 * X[:, 1]
-    r = smc_weights(X, y)
+    r = src_weights(X, y)
     assert r.combined.max() > 1.0 or r.combined.min() < 0.0
 
 
@@ -199,7 +199,7 @@ def test_smc_weights_combined_can_extrapolate():
 # Layer 3 -- data setup
 # --------------------------------------------------------------------------- #
 def test_prepare_inputs_shapes(panel):
-    inp = prepare_smc_inputs(panel, outcome="y", treat="treat", unitid="unit", time="t")
+    inp = prepare_src_inputs(panel, outcome="y", treat="treat", unitid="unit", time="t")
     assert inp.treated_label == "u0"
     assert inp.J == 5 and inp.T == 15 and inp.T0 == 10 and inp.T1 == 5
     assert inp.Y_donors.shape == (15, 5)
@@ -209,7 +209,7 @@ def test_prepare_inputs_shapes(panel):
 def test_prepare_inputs_no_treated_raises(panel):
     bad = panel.copy(); bad["treat"] = 0
     with pytest.raises(MlsynthDataError):
-        prepare_smc_inputs(bad, outcome="y", treat="treat", unitid="unit", time="t")
+        prepare_src_inputs(bad, outcome="y", treat="treat", unitid="unit", time="t")
 
 
 def test_prepare_inputs_empty_donor_pool_raises():
@@ -217,27 +217,27 @@ def test_prepare_inputs_empty_donor_pool_raises():
     df = _toy_panel(n_donors=1, T=12, T0=8)
     df = df[df["unit"] == "u0"].copy()
     with pytest.raises(MlsynthDataError):
-        prepare_smc_inputs(df, outcome="y", treat="treat", unitid="unit", time="t")
+        prepare_src_inputs(df, outcome="y", treat="treat", unitid="unit", time="t")
 
 
 def test_prepare_inputs_multiple_treated_raises(panel):
     bad = panel.copy()
     bad.loc[(bad["unit"] == "u1") & (bad["t"] >= 10), "treat"] = 1   # a 2nd treated unit
     with pytest.raises(MlsynthDataError):
-        prepare_smc_inputs(bad, outcome="y", treat="treat", unitid="unit", time="t")
+        prepare_src_inputs(bad, outcome="y", treat="treat", unitid="unit", time="t")
 
 
 def test_prepare_inputs_too_few_preperiods_raises():
     df = _toy_panel(T=6, T0=1)
     with pytest.raises(MlsynthDataError):
-        prepare_smc_inputs(df, outcome="y", treat="treat", unitid="unit", time="t")
+        prepare_src_inputs(df, outcome="y", treat="treat", unitid="unit", time="t")
 
 
 def test_prepare_inputs_nan_outcome_raises(panel):
     bad = panel.copy()
     bad.loc[(bad["unit"] == "u1") & (bad["t"] == 0), "y"] = np.nan   # balanced but NaN
     with pytest.raises(MlsynthDataError):
-        prepare_smc_inputs(bad, outcome="y", treat="treat", unitid="unit", time="t")
+        prepare_src_inputs(bad, outcome="y", treat="treat", unitid="unit", time="t")
 
 
 def test_prepare_inputs_missing_covariate_raises(panel):
@@ -245,7 +245,7 @@ def test_prepare_inputs_missing_covariate_raises(panel):
     df["x1"] = 1.0
     df.loc[df["unit"] == "u3", "x1"] = np.nan       # covariate absent for one unit
     with pytest.raises(MlsynthDataError):
-        prepare_smc_inputs(df, outcome="y", treat="treat", unitid="unit", time="t",
+        prepare_src_inputs(df, outcome="y", treat="treat", unitid="unit", time="t",
                            covariates=["x1"])
 
 
@@ -253,31 +253,31 @@ def test_prepare_inputs_missing_covariate_raises(panel):
 # Layer 4 -- estimator integration
 # --------------------------------------------------------------------------- #
 def test_fit_smoke(panel):
-    res = SMC(_cfg(panel)).fit()
-    assert isinstance(res, SMCResults)
+    res = SRC(_cfg(panel)).fit()
+    assert isinstance(res, SRCResults)
     T = panel["t"].nunique()
     assert len(res.time_series.counterfactual_outcome) == T
     assert np.isfinite(res.att)
     # standardized sub-models born-populated
     assert res.effects is not None and res.weights is not None
-    assert res.fit_diagnostics is not None and res.method_details.method_name == "SMC"
+    assert res.fit_diagnostics is not None and res.method_details.method_name == "SRC"
 
 
 def test_fit_recovers_negative_effect(panel):
-    res = SMC(_cfg(panel)).fit()
+    res = SRC(_cfg(panel)).fit()
     assert res.att < -0.5                            # planted effect is -2.0
     assert res.box_weights.min() >= -1e-9 and res.box_weights.max() <= 1 + 1e-9
 
 
 def test_fit_gap_identity(panel):
-    res = SMC(_cfg(panel)).fit()
+    res = SRC(_cfg(panel)).fit()
     ts = res.time_series
     assert np.allclose(ts.estimated_gap,
                        ts.observed_outcome - ts.counterfactual_outcome)
 
 
 def test_fit_deterministic(panel):
-    a = SMC(_cfg(panel)).fit(); b = SMC(_cfg(panel)).fit()
+    a = SRC(_cfg(panel)).fit(); b = SRC(_cfg(panel)).fit()
     assert np.allclose(a.weights_vector, b.weights_vector)
     assert a.att == b.att
 
@@ -286,14 +286,14 @@ def test_fit_with_covariates(panel):
     df = panel.copy()
     rng = np.random.default_rng(7)
     df["x1"] = rng.uniform(size=len(df)); df["x2"] = rng.uniform(size=len(df))
-    res = SMC(_cfg(df, covariates=["x1", "x2"])).fit()
+    res = SRC(_cfg(df, covariates=["x1", "x2"])).fit()
     assert np.isfinite(res.att)
     assert res.weights.summary_stats["n_covariates"] == 2
     assert res.weights.summary_stats["n_matching_rows"] == 12  # 10 pre-outcomes + 2 covs
 
 
 def test_basque_reproduction(basque):
-    res = SMC(SMCConfig(df=basque, outcome="gdpcap", treat="treat",
+    res = SRC(SRCConfig(df=basque, outcome="gdpcap", treat="treat",
                         unitid="regionname", time="year", display_graphs=False)).fit()
     assert res.fit_diagnostics.rmse_pre < 0.1        # tight pre-fit (~0.048)
     assert res.att < 0                               # terrorism depresses GDP
@@ -302,7 +302,7 @@ def test_basque_reproduction(basque):
 
 
 def test_fit_window_restricts_outcome_rows(panel):
-    inp = prepare_smc_inputs(panel, outcome="y", treat="treat", unitid="unit", time="t",
+    inp = prepare_src_inputs(panel, outcome="y", treat="treat", unitid="unit", time="t",
                              fit_window=(2, 6))       # pre-periods 2..6 inclusive
     assert list(inp.fit_idx) == [2, 3, 4, 5, 6]
 
@@ -310,7 +310,7 @@ def test_fit_window_restricts_outcome_rows(panel):
 def test_covariate_window_aggregates_over_window(panel):
     df = panel.copy()
     df["x"] = df["t"].astype(float)                    # x == t, so window mean is known
-    inp = prepare_smc_inputs(df, outcome="y", treat="treat", unitid="unit", time="t",
+    inp = prepare_src_inputs(df, outcome="y", treat="treat", unitid="unit", time="t",
                              covariates=["x"], covariate_windows={"x": (2, 4)})
     assert np.isclose(inp.cov_treated[0], 3.0)         # mean of {2,3,4}
 
@@ -318,19 +318,19 @@ def test_covariate_window_aggregates_over_window(panel):
 def test_covariate_window_out_of_range_raises(panel):
     df = panel.copy(); df["x"] = 1.0
     with pytest.raises(MlsynthDataError):
-        prepare_smc_inputs(df, outcome="y", treat="treat", unitid="unit", time="t",
+        prepare_src_inputs(df, outcome="y", treat="treat", unitid="unit", time="t",
                            covariates=["x"], covariate_windows={"x": (999, 1000)})
 
 
 def test_fit_window_too_narrow_raises(panel):
     with pytest.raises(MlsynthDataError):
-        prepare_smc_inputs(panel, outcome="y", treat="treat", unitid="unit", time="t",
+        prepare_src_inputs(panel, outcome="y", treat="treat", unitid="unit", time="t",
                            fit_window=(3, 3))            # a single pre-period
 
 
 def test_paper_reproduction_via_vsearch(basque):
     # Algorithm 3 config: covariate matching + SSR fit window + seeded V search.
-    res = SMC(SMCConfig(
+    res = SRC(SRCConfig(
         df=basque, outcome="gdpcap", treat="treat", unitid="regionname", time="year",
         covariates=_BASQUE_COVS, covariate_windows=_BASQUE_WINS, fit_window=(1960, 1969),
         v_search="de", v_seed=0, v_maxiter=25, v_popsize=6, display_graphs=False,
@@ -349,8 +349,8 @@ def test_vsearch_deterministic_by_seed(basque):
               time="year", covariates=_BASQUE_COVS, covariate_windows=_BASQUE_WINS,
               fit_window=(1960, 1969), v_search="de", v_seed=1, v_maxiter=12,
               v_popsize=5, display_graphs=False)
-    a = SMC(SMCConfig(**kw)).fit()
-    b = SMC(SMCConfig(**kw)).fit()
+    a = SRC(SRCConfig(**kw)).fit()
+    b = SRC(SRCConfig(**kw)).fit()
     assert np.allclose(a.weights_vector, b.weights_vector)
 
 
@@ -368,15 +368,15 @@ def test_optimize_v_reproducible():
 def test_plotting_smoke(panel, tmp_path):
     import matplotlib
     matplotlib.use("Agg")
-    out = str(tmp_path / "smc.png")
-    SMC(_cfg(panel, display_graphs=True, save=out)).fit()
+    out = str(tmp_path / "src.png")
+    SRC(_cfg(panel, display_graphs=True, save=out)).fit()
     assert os.path.exists(out)
 
 
 def test_plotting_show_branch(panel):
     import matplotlib
     matplotlib.use("Agg")                            # show() is a no-op under Agg
-    res = SMC(_cfg(panel, display_graphs=True, save=False)).fit()
+    res = SRC(_cfg(panel, display_graphs=True, save=False)).fit()
     assert res is not None
 
 
@@ -386,8 +386,8 @@ def test_plotting_show_branch(panel):
 def test_dict_config_equivalence(panel):
     cfg = dict(df=panel, outcome="y", treat="treat", unitid="unit", time="t",
                display_graphs=False)
-    a = SMC(cfg).fit()
-    b = SMC(_cfg(panel)).fit()
+    a = SRC(cfg).fit()
+    b = SRC(_cfg(panel)).fit()
     assert np.allclose(a.weights_vector, b.weights_vector)
 
 
@@ -395,7 +395,7 @@ def test_bad_dict_config_raises_config_error(panel):
     cfg = dict(df=panel, outcome="y", treat="treat", unitid="unit", time="t",
                ridge=0.0, display_graphs=False)               # ridge must be > 0
     with pytest.raises(MlsynthConfigError):
-        SMC(cfg)
+        SRC(cfg)
 
 
 def test_ridge_must_be_positive(panel):
@@ -426,10 +426,10 @@ def test_extra_field_forbidden(panel):
 def test_no_treated_raises_data_error(panel):
     bad = panel.copy(); bad["treat"] = 0
     with pytest.raises(MlsynthDataError):
-        SMC(_cfg(bad)).fit()
+        SRC(_cfg(bad)).fit()
 
 
 def test_unbalanced_panel_raises_data_error(panel):
     bad = panel.drop(panel[(panel["unit"] == "u3") & (panel["t"] == 4)].index)
     with pytest.raises(MlsynthDataError):
-        SMC(_cfg(bad)).fit()
+        SRC(_cfg(bad)).fit()

--- a/mlsynth/tests/test_src_screening.py
+++ b/mlsynth/tests/test_src_screening.py
@@ -1,0 +1,203 @@
+"""Tests for SRC's SIRS donor screening (Zhu 2023, Algorithm 2).
+
+Written test-first. Covers the SIRS statistic, the screening count, the
+donor-selection mechanism, the config surface, and the end-to-end effect on a
+wide (donors >= pre-periods) panel where screening restores a well-posed fit.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SRC
+from mlsynth.config_models import SRCConfig
+from mlsynth.exceptions import MlsynthConfigError
+
+
+# --------------------------------------------------------------------------- #
+# unit: the SIRS statistic and the screening count / selection
+# --------------------------------------------------------------------------- #
+def _import_screening():
+    from mlsynth.utils.src_helpers import screening
+    return screening
+
+
+def test_sirs_scores_shape_nonneg_finite_deterministic():
+    scr = _import_screening()
+    rng = np.random.default_rng(0)
+    T0, J = 20, 8
+    treated = rng.normal(size=T0)
+    donors = rng.normal(size=(T0, J))
+    s1 = scr.sirs_scores(donors, treated)
+    s2 = scr.sirs_scores(donors, treated)
+    assert s1.shape == (J,)
+    assert np.all(np.isfinite(s1))
+    assert np.all(s1 >= 0.0)
+    assert np.array_equal(s1, s2)  # deterministic, no RNG
+
+
+def test_sirs_prefers_comoving_and_antimoving_over_constant():
+    """A donor that (anti-)tracks the treated ranks above a flat donor."""
+    scr = _import_screening()
+    rng = np.random.default_rng(1)
+    T0 = 30
+    treated = np.linspace(0, 5, T0) + 0.01 * rng.normal(size=T0)
+    comove = treated + 0.01 * rng.normal(size=T0)         # tracks treated
+    antimove = -treated + 0.01 * rng.normal(size=T0)      # anti-tracks (still useful: theta<0)
+    constant = np.full(T0, 3.0)                           # no variation
+    donors = np.column_stack([comove, antimove, constant])
+    s = scr.sirs_scores(donors, treated)
+    assert s[0] > s[2]          # co-moving beats constant
+    assert s[1] > s[2]          # anti-moving also beats constant (SIRS captures dependence, not sign)
+    assert s[2] == pytest.approx(0.0, abs=1e-12)  # zero-variance donor screens to 0
+
+
+def test_screen_count_matches_paper_formula_and_is_well_posed():
+    scr = _import_screening()
+    # k = min(floor(T0 / log(T0/2)), T0 - 1); always < T0 so the screened fit is well posed
+    for T0, expected in [(15, 7), (20, 8), (40, 13), (60, 17)]:
+        assert scr.screen_count(T0) == expected
+    for T0 in range(3, 80):
+        k = scr.screen_count(T0)
+        assert 1 <= k <= T0 - 1
+
+
+def test_screen_count_tiny_T0_is_safe():
+    scr = _import_screening()
+    assert scr.screen_count(2) >= 1
+    assert scr.screen_count(3) >= 1
+
+
+def test_screen_donors_selects_top_k_indices():
+    scr = _import_screening()
+    rng = np.random.default_rng(2)
+    T0, J = 25, 12
+    treated = np.linspace(0, 1, T0)
+    donors = rng.normal(size=(T0, J))
+    # inject three donors that clearly track the treated -> must be kept
+    for j in (3, 7, 11):
+        donors[:, j] = treated * (j + 1) + 0.001 * rng.normal(size=T0)
+    k = scr.screen_count(T0)
+    keep = scr.screen_donors(donors, treated, n_screen=None)
+    assert keep.shape == (k,)
+    assert len(set(keep.tolist())) == k                    # unique
+    assert np.all((keep >= 0) & (keep < J))                # in range
+    assert set([3, 7, 11]).issubset(set(keep.tolist()))    # trackers survive
+    # exactly the top-k by score
+    scores = scr.sirs_scores(donors, treated)
+    assert set(keep.tolist()) == set(np.argsort(scores)[::-1][:k].tolist())
+
+
+def test_screen_donors_noop_when_pool_not_larger_than_k():
+    scr = _import_screening()
+    rng = np.random.default_rng(3)
+    T0, J = 40, 5                    # k(40)=13 > J=5 -> keep all
+    treated = rng.normal(size=T0)
+    donors = rng.normal(size=(T0, J))
+    keep = scr.screen_donors(donors, treated, n_screen=None)
+    assert np.array_equal(keep, np.arange(J))
+
+
+def test_screen_donors_respects_n_screen_override():
+    scr = _import_screening()
+    rng = np.random.default_rng(4)
+    T0, J = 25, 12
+    treated = rng.normal(size=T0)
+    donors = rng.normal(size=(T0, J))
+    keep = scr.screen_donors(donors, treated, n_screen=3)
+    assert keep.shape == (3,)
+
+
+# --------------------------------------------------------------------------- #
+# config surface
+# --------------------------------------------------------------------------- #
+def _df():  # minimal balanced panel for config-construction tests
+    rows = []
+    for u in range(4):
+        for t in range(6):
+            rows.append({"unit": f"u{u}", "t": t, "y": float(u + t),
+                         "treat": int(u == 0 and t >= 4)})
+    return pd.DataFrame(rows)
+
+
+def test_config_accepts_screen_sirs():
+    cfg = SRCConfig(df=_df(), outcome="y", treat="treat", unitid="unit",
+                    time="t", screen="sirs")
+    assert cfg.screen == "sirs"
+
+
+def test_config_screen_defaults_to_none():
+    cfg = SRCConfig(df=_df(), outcome="y", treat="treat", unitid="unit", time="t")
+    assert cfg.screen == "none"
+
+
+def test_config_rejects_bogus_screen():
+    with pytest.raises(Exception):
+        SRCConfig(df=_df(), outcome="y", treat="treat", unitid="unit",
+                  time="t", screen="bogus")
+
+
+def test_config_rejects_nonpositive_n_screen():
+    with pytest.raises(Exception):
+        SRCConfig(df=_df(), outcome="y", treat="treat", unitid="unit",
+                  time="t", screen="sirs", n_screen=0)
+
+
+# --------------------------------------------------------------------------- #
+# integration: screening restores a well-posed fit on a wide panel
+# --------------------------------------------------------------------------- #
+def _wide_panel(seed=0):
+    """A panel with J=10 donors > T0=8 pre-periods -> unscreened SRC degenerates."""
+    rng = np.random.default_rng(seed)
+    T, T0, N, r = 12, 8, 11, 2
+    F = rng.normal(size=(T, r))
+    L = rng.normal(size=(N, r))
+    Y = F @ L.T + 0.1 * rng.normal(size=(T, N))
+    Y[T0:, 0] += -3.0            # treatment effect on unit 0 after T0
+    rows = []
+    for u in range(N):
+        for t in range(T):
+            rows.append({"unit": f"u{u}", "t": t, "y": float(Y[t, u]),
+                         "treat": int(u == 0 and t >= T0)})
+    return pd.DataFrame(rows), T0
+
+
+def test_fit_screening_reduces_pool_and_fixes_degeneracy():
+    from mlsynth.utils.src_helpers import screening
+    df, T0 = _wide_panel()
+    base = dict(df=df, outcome="y", treat="treat", unitid="unit", time="t",
+                display_graphs=False)
+
+    res_no = SRC({**base, "screen": "none"}).fit()
+    res_sc = SRC({**base, "screen": "sirs"}).fit()
+
+    J = len(res_no.weights.donor_weights)
+    k = screening.screen_count(T0)
+    assert J == 10                                   # full pool
+    assert len(res_sc.weights.donor_weights) == k    # screened pool
+    assert k < J
+    # unscreened is degenerate (donors >= pre-periods => sigma^2 ~ 0);
+    # screening restores a real noise estimate.
+    assert res_no.fit.sigma2 < 1e-8
+    assert res_sc.fit.sigma2 > 1e-6
+
+
+def test_fit_screening_is_deterministic():
+    df, _ = _wide_panel()
+    base = dict(df=df, outcome="y", treat="treat", unitid="unit", time="t",
+                display_graphs=False, screen="sirs")
+    a = SRC(base).fit()
+    b = SRC(base).fit()
+    assert a.att == pytest.approx(b.att)
+    assert a.weights.donor_weights == b.weights.donor_weights
+
+
+def test_fit_screen_none_matches_default():
+    df, _ = _wide_panel()
+    base = dict(df=df, outcome="y", treat="treat", unitid="unit", time="t",
+                display_graphs=False)
+    default = SRC(base).fit()
+    explicit = SRC({**base, "screen": "none"}).fit()
+    assert default.att == pytest.approx(explicit.att)
+    assert default.weights.donor_weights == explicit.weights.donor_weights

--- a/mlsynth/tests/test_src_screening.py
+++ b/mlsynth/tests/test_src_screening.py
@@ -201,3 +201,90 @@ def test_fit_screen_none_matches_default():
     explicit = SRC({**base, "screen": "none"}).fit()
     assert default.att == pytest.approx(explicit.att)
     assert default.weights.donor_weights == explicit.weights.donor_weights
+
+
+# --------------------------------------------------------------------------- #
+# FPCA + clustering donor selection (reuses ClusterSC's helpers)
+# --------------------------------------------------------------------------- #
+def _fpca_cluster_arrays(seed=0):
+    """Two clean shape-clusters: treated + group A ~ sine; group B ~ parabola."""
+    rng = np.random.default_rng(seed)
+    T0 = 12
+    t = np.linspace(0.0, 1.0, T0)
+    f1 = np.sin(2 * np.pi * t)          # cols 0..3 shape (with treated)
+    f2 = (t - 0.5) ** 2                 # cols 4..8 shape
+    treated = f1 + 0.02 * rng.normal(size=T0)
+    A = np.column_stack([f1 + 0.02 * rng.normal(size=T0) for _ in range(4)])
+    B = np.column_stack([f2 + 0.02 * rng.normal(size=T0) for _ in range(5)])
+    donors = np.column_stack([A, B])
+    return donors, treated, [0, 1, 2, 3], [4, 5, 6, 7, 8]
+
+
+def test_fpca_donors_selects_treated_shape_cluster():
+    scr = _import_screening()
+    donors, treated, groupA, groupB = _fpca_cluster_arrays()
+    keep = scr.fpca_donors(donors, treated)
+    assert keep.size >= 1
+    assert set(keep.tolist()).issubset(set(groupA))      # only the similar-shape donors
+    assert set(keep.tolist()).isdisjoint(set(groupB))    # none of the dissimilar ones
+    assert keep.size < donors.shape[1]                   # genuinely reduced the pool
+
+
+def test_fpca_donors_deterministic_and_valid_indices():
+    scr = _import_screening()
+    donors, treated, _, _ = _fpca_cluster_arrays()
+    k1 = scr.fpca_donors(donors, treated)
+    k2 = scr.fpca_donors(donors, treated)
+    assert np.array_equal(k1, k2)                        # seeded k-means -> deterministic
+    assert np.array_equal(k1, np.sort(k1))               # ascending
+    assert len(set(k1.tolist())) == k1.size              # unique
+    assert np.all((k1 >= 0) & (k1 < donors.shape[1]))
+
+
+def test_fpca_donors_keeps_all_when_no_shape_structure():
+    """With no cross-sectional shape variation (identical paths -> FPC rank 0),
+    clustering is degenerate and the whole pool is kept (a no-op)."""
+    scr = _import_screening()
+    T0, J = 12, 6
+    t = np.linspace(0.0, 1.0, T0)
+    shape = np.sin(2 * np.pi * t)
+    treated = shape.copy()
+    donors = np.column_stack([shape.copy() for _ in range(J)])   # identical -> rank 0
+    keep = scr.fpca_donors(donors, treated)
+    assert np.array_equal(keep, np.arange(J))            # no-op: all donors kept
+
+
+def test_config_accepts_screen_fpca():
+    cfg = SRCConfig(df=_df(), outcome="y", treat="treat", unitid="unit",
+                    time="t", screen="fpca")
+    assert cfg.screen == "fpca"
+
+
+def test_fit_screen_fpca_reduces_pool_and_is_deterministic():
+    """End-to-end: FPCA selects the treated unit's cluster, deterministically."""
+    rng = np.random.default_rng(2)
+    T, T0 = 16, 12
+    t = np.linspace(0.0, 1.0, T)
+    f1 = np.sin(2 * np.pi * t)
+    f2 = (t - 0.5) ** 2
+    cols = {"u0": f1 + 0.02 * rng.normal(size=T)}        # treated
+    for j in range(4):
+        cols[f"a{j}"] = f1 + 0.02 * rng.normal(size=T)   # similar
+    for j in range(5):
+        cols[f"b{j}"] = f2 + 0.02 * rng.normal(size=T)   # dissimilar
+    rows = []
+    for u, series in cols.items():
+        for ti in range(T):
+            rows.append({"unit": u, "t": ti, "y": float(series[ti]),
+                         "treat": int(u == "u0" and ti >= T0)})
+    df = pd.DataFrame(rows)
+    base = dict(df=df, outcome="y", treat="treat", unitid="unit", time="t",
+                display_graphs=False)
+    full = SRC({**base, "screen": "none"}).fit()
+    fpca = SRC({**base, "screen": "fpca"}).fit()
+    assert len(full.weights.donor_weights) == 9
+    assert len(fpca.weights.donor_weights) < 9           # pool reduced to the cluster
+    assert all(lbl.startswith("a") for lbl in fpca.weights.donor_weights)  # only 'a' donors
+    again = SRC({**base, "screen": "fpca"}).fit()
+    assert fpca.att == pytest.approx(again.att)
+    assert fpca.weights.donor_weights == again.weights.donor_weights

--- a/mlsynth/utils/src_helpers/__init__.py
+++ b/mlsynth/utils/src_helpers/__init__.py
@@ -1,4 +1,4 @@
-"""Synthetic Matching Control (SMC) helper subpackage.
+"""Synthetic Regressing Control (SRC) helper subpackage.
 
 NumPy-first implementation of Zhu (2023): per-donor univariate matching plus a
 Mallows/Cp box-``[0, 1]`` synthesis, solved exactly by an active-set box QP.
@@ -8,24 +8,24 @@ machine precision.
 
 from __future__ import annotations
 
-from .estimation import SMCWeights, counterfactual, smc_weights
-from .orchestration import run_smc
-from .plotter import plot_smc
-from .setup import prepare_smc_inputs
+from .estimation import SRCWeights, counterfactual, src_weights
+from .orchestration import run_src
+from .plotter import plot_src
+from .setup import prepare_src_inputs
 from .solver import solve_box_qp
-from .structures import SMCFit, SMCInputs, SMCResults
+from .structures import SRCFit, SRCInputs, SRCResults
 from .vsearch import optimize_v
 
 __all__ = [
-    "SMCFit",
-    "SMCInputs",
-    "SMCResults",
-    "SMCWeights",
+    "SRCFit",
+    "SRCInputs",
+    "SRCResults",
+    "SRCWeights",
     "counterfactual",
     "optimize_v",
-    "plot_smc",
-    "prepare_smc_inputs",
-    "run_smc",
-    "smc_weights",
+    "plot_src",
+    "prepare_src_inputs",
+    "run_src",
+    "src_weights",
     "solve_box_qp",
 ]

--- a/mlsynth/utils/src_helpers/config.py
+++ b/mlsynth/utils/src_helpers/config.py
@@ -70,17 +70,21 @@ class SRCConfig(BaseEstimatorConfig):
             "period. Set it to reproduce a paper's fit window."
         ),
     )
-    screen: Literal["none", "sirs"] = Field(
+    screen: Literal["none", "sirs", "fpca"] = Field(
         default="none",
         description=(
-            "Donor screening before the fit (Algorithm 2). 'none' (default) "
-            "keeps every donor. 'sirs' ranks donors by the SIRS marginal utility "
-            "(Zhu et al. 2011) on the pre-period outcomes and keeps the top "
-            "``min(floor(T0/log(T0/2)), T0-1)`` (override with ``n_screen``). "
-            "Use it when donors are not few relative to pre-periods "
-            "(``J >= 4*T0/5``): screening restores a well-posed, non-degenerate "
-            "Cp fit. It does not recover the paper's exact Basque weight cells "
-            "(those are on the non-identified V manifold)."
+            "Donor screening before the fit. 'none' (default) keeps every donor. "
+            "'sirs' ranks donors by the SIRS marginal utility (Zhu et al. 2011) "
+            "on the pre-period outcomes and keeps the top "
+            "``min(floor(T0/log(T0/2)), T0-1)`` (override with ``n_screen``) -- "
+            "the paper's Algorithm 2. 'fpca' instead clusters the pre-period "
+            "trajectories and keeps the treated unit's cluster, reusing "
+            "ClusterSC's FPCA + silhouette k-means (Bayani 2021); it selects an "
+            "economically coherent peer group and is fully deterministic. Use "
+            "screening when donors are not few relative to pre-periods "
+            "(``J >= 4*T0/5``): it restores a well-posed, non-degenerate Cp fit. "
+            "Neither recovers the paper's exact Basque weight cells (those are on "
+            "the non-identified V manifold)."
         ),
     )
     n_screen: Optional[int] = Field(

--- a/mlsynth/utils/src_helpers/config.py
+++ b/mlsynth/utils/src_helpers/config.py
@@ -1,4 +1,4 @@
-"""Configuration for the SMC estimator.
+"""Configuration for the SRC estimator.
 
 Co-located with the helper package; re-exported from
 :mod:`mlsynth.config_models` for backward compatibility.
@@ -14,10 +14,10 @@ from ...config_models import BaseEstimatorConfig
 from ...exceptions import MlsynthConfigError
 
 
-class SMCConfig(BaseEstimatorConfig):
-    """Configuration for the Synthetic Matching Control estimator (Zhu 2023).
+class SRCConfig(BaseEstimatorConfig):
+    """Configuration for the Synthetic Regressing Control estimator (Zhu 2023).
 
-    SMC matches each donor to the treated unit by a univariate regression, then
+    SRC matches each donor to the treated unit by a univariate regression, then
     synthesises the matched controls with box-``[0, 1]`` weights chosen by a
     Mallows/Cp unbiased-risk criterion. The combined donor coefficients may be
     negative (controlled extrapolation), and the Cp penalty -- not a predictor
@@ -30,7 +30,7 @@ class SMCConfig(BaseEstimatorConfig):
 
     References
     ----------
-    Zhu, Rong J. B. (2023). *Synthetic Matching Control Method.*
+    Zhu, Rong J. B. (2023). *Synthetic Regressing Control.*
     arXiv:2306.02584.
     """
 
@@ -97,18 +97,18 @@ class SMCConfig(BaseEstimatorConfig):
     )
 
     @model_validator(mode="after")
-    def _check(self) -> "SMCConfig":
+    def _check(self) -> "SRCConfig":
         if self.covariates is not None and len(self.covariates) == 0:
             raise MlsynthConfigError(
-                "SMC 'covariates' must be a non-empty list or None."
+                "SRC 'covariates' must be a non-empty list or None."
             )
         if self.covariate_windows and not self.covariates:
             raise MlsynthConfigError(
-                "SMC 'covariate_windows' requires 'covariates'."
+                "SRC 'covariate_windows' requires 'covariates'."
             )
         if self.v_search == "de" and not self.covariates:
             raise MlsynthConfigError(
-                "SMC v_search='de' optimises predictor weights and therefore "
+                "SRC v_search='de' optimises predictor weights and therefore "
                 "requires 'covariates'."
             )
         return self

--- a/mlsynth/utils/src_helpers/config.py
+++ b/mlsynth/utils/src_helpers/config.py
@@ -70,6 +70,26 @@ class SRCConfig(BaseEstimatorConfig):
             "period. Set it to reproduce a paper's fit window."
         ),
     )
+    screen: Literal["none", "sirs"] = Field(
+        default="none",
+        description=(
+            "Donor screening before the fit (Algorithm 2). 'none' (default) "
+            "keeps every donor. 'sirs' ranks donors by the SIRS marginal utility "
+            "(Zhu et al. 2011) on the pre-period outcomes and keeps the top "
+            "``min(floor(T0/log(T0/2)), T0-1)`` (override with ``n_screen``). "
+            "Use it when donors are not few relative to pre-periods "
+            "(``J >= 4*T0/5``): screening restores a well-posed, non-degenerate "
+            "Cp fit. It does not recover the paper's exact Basque weight cells "
+            "(those are on the non-identified V manifold)."
+        ),
+    )
+    n_screen: Optional[int] = Field(
+        default=None, ge=1,
+        description=(
+            "Override the number of donors kept by ``screen='sirs'``. None "
+            "(default) uses the paper's ``min(floor(T0/log(T0/2)), T0-1)``."
+        ),
+    )
     v_search: Literal["none", "de"] = Field(
         default="none",
         description=(

--- a/mlsynth/utils/src_helpers/estimation.py
+++ b/mlsynth/utils/src_helpers/estimation.py
@@ -1,4 +1,4 @@
-"""The SMC weight computation (Zhu 2023, Algorithm 1).
+"""The SRC weight computation (Zhu 2023, Algorithm 1).
 
 Two steps, both cheap and deterministic:
 
@@ -12,8 +12,8 @@ Two steps, both cheap and deterministic:
    full-model residual variance. The combined donor coefficient is
    ``theta_j * w_j`` (which may be negative -> controlled extrapolation).
 
-The QP is solved exactly by :func:`~mlsynth.utils.smc_helpers.solver.solve_box_qp`.
-The Cp penalty on ``sum(w)`` is what identifies ``w`` -- SMC needs no predictor
+The QP is solved exactly by :func:`~mlsynth.utils.src_helpers.solver.solve_box_qp`.
+The Cp penalty on ``sum(w)`` is what identifies ``w`` -- SRC needs no predictor
 (``V``) search to pin down the weights, which is why the estimator is
 deterministic. An optional ``V`` (diagonal predictor weighting) is threaded
 through for the covariate-augmented variant.
@@ -28,8 +28,8 @@ import numpy as np
 from .solver import solve_box_qp
 
 
-class SMCWeights(NamedTuple):
-    """Output of the SMC weight computation on a matching matrix."""
+class SRCWeights(NamedTuple):
+    """Output of the SRC weight computation on a matching matrix."""
 
     theta: np.ndarray      # (J,) per-donor univariate OLS coefficients
     w: np.ndarray          # (J,) box-[0, 1] synthesis weights
@@ -38,14 +38,14 @@ class SMCWeights(NamedTuple):
     sigma2: float          # plug-in full-model residual variance
 
 
-def smc_weights(
+def src_weights(
     X: np.ndarray,
     y: np.ndarray,
     *,
     ridge: float = 1e-3,
     V: Optional[np.ndarray] = None,
-) -> SMCWeights:
-    """Compute SMC donor coefficients on a matching matrix.
+) -> SRCWeights:
+    """Compute SRC donor coefficients on a matching matrix.
 
     Parameters
     ----------
@@ -64,7 +64,7 @@ def smc_weights(
 
     Returns
     -------
-    SMCWeights
+    SRCWeights
     """
     X = np.asarray(X, dtype=float)
     y = np.asarray(y, dtype=float).ravel()
@@ -96,11 +96,11 @@ def smc_weights(
 
     combined = theta * w
     bias = float(y0.mean() - (X0 @ combined).mean())
-    return SMCWeights(theta=theta, w=w, combined=combined, bias=bias, sigma2=sigma2)
+    return SRCWeights(theta=theta, w=w, combined=combined, bias=bias, sigma2=sigma2)
 
 
-def counterfactual(Y_full: np.ndarray, weights: SMCWeights) -> np.ndarray:
-    """Full-path SMC counterfactual ``Y_hat = bias + Y_full @ (theta * w)``.
+def counterfactual(Y_full: np.ndarray, weights: SRCWeights) -> np.ndarray:
+    """Full-path SRC counterfactual ``Y_hat = bias + Y_full @ (theta * w)``.
 
     ``Y_full`` is the donor outcomes over every period (``(T, J)``); the combined
     coefficients are applied to the raw (unweighted) donor outcomes.

--- a/mlsynth/utils/src_helpers/orchestration.py
+++ b/mlsynth/utils/src_helpers/orchestration.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from ...exceptions import MlsynthEstimationError
 from .estimation import counterfactual, src_weights
+from .screening import screen_donors, screen_inputs
 from .structures import SRCFit, SRCInputs
 from .vsearch import optimize_v
 
@@ -45,6 +46,8 @@ def run_src(
     inputs: SRCInputs,
     *,
     ridge: float = 1e-3,
+    screen: str = "none",
+    n_screen: Optional[int] = None,
     v_search: str = "none",
     v_seed: int = 0,
     v_maxiter: int = 60,
@@ -52,9 +55,20 @@ def run_src(
 ) -> SRCFit:
     """Fit SRC (deterministic Algorithm 1 / 3) and return the point estimate.
 
-    With ``v_search="de"`` the predictor weights ``V`` are chosen by a seeded
-    global search (the paper's Algorithm 3); otherwise ``V = I``.
+    With ``screen="sirs"`` the donor pool is first reduced by SIRS screening
+    (Algorithm 2) to ``n_screen`` donors (default the paper's count). With
+    ``v_search="de"`` the predictor weights ``V`` are chosen by a seeded global
+    search (the paper's Algorithm 3); otherwise ``V = I``.
     """
+    n_screened_out = 0
+    if screen == "sirs":
+        keep = screen_donors(
+            inputs.Y_donors[:inputs.T0], inputs.Y_treated[:inputs.T0],
+            n_screen=n_screen,
+        )
+        if keep.size < inputs.J:
+            n_screened_out = int(inputs.J - keep.size)
+            inputs = screen_inputs(inputs, keep)
     try:
         X, y, n_out = _build_matching_matrix(inputs)
         V: Optional[np.ndarray] = None
@@ -89,4 +103,5 @@ def run_src(
         v_search=v_search,
         v=V,
         donor_weights=donor_weights,
+        n_screened_out=n_screened_out,
     )

--- a/mlsynth/utils/src_helpers/orchestration.py
+++ b/mlsynth/utils/src_helpers/orchestration.py
@@ -1,4 +1,4 @@
-"""Assemble the SMC point estimate from pivoted inputs (``run_smc``)."""
+"""Assemble the SRC point estimate from pivoted inputs (``run_src``)."""
 
 from __future__ import annotations
 
@@ -7,13 +7,13 @@ from typing import Optional, Tuple
 import numpy as np
 
 from ...exceptions import MlsynthEstimationError
-from .estimation import counterfactual, smc_weights
-from .structures import SMCFit, SMCInputs
+from .estimation import counterfactual, src_weights
+from .structures import SRCFit, SRCInputs
 from .vsearch import optimize_v
 
 
-def _build_matching_matrix(inputs: SMCInputs) -> Tuple[np.ndarray, np.ndarray, int]:
-    """Return ``(X, y, n_outcome_rows)`` for the SMC weight computation.
+def _build_matching_matrix(inputs: SRCInputs) -> Tuple[np.ndarray, np.ndarray, int]:
+    """Return ``(X, y, n_outcome_rows)`` for the SRC weight computation.
 
     The outcome matching rows are the treated/donor outcomes over the fit window
     (``inputs.fit_idx``; all pre-periods by default). Pure Algorithm 1 (no
@@ -41,16 +41,16 @@ def _build_matching_matrix(inputs: SMCInputs) -> Tuple[np.ndarray, np.ndarray, i
     return X, y, X_out.shape[0]
 
 
-def run_smc(
-    inputs: SMCInputs,
+def run_src(
+    inputs: SRCInputs,
     *,
     ridge: float = 1e-3,
     v_search: str = "none",
     v_seed: int = 0,
     v_maxiter: int = 60,
     v_popsize: int = 12,
-) -> SMCFit:
-    """Fit SMC (deterministic Algorithm 1 / 3) and return the point estimate.
+) -> SRCFit:
+    """Fit SRC (deterministic Algorithm 1 / 3) and return the point estimate.
 
     With ``v_search="de"`` the predictor weights ``V`` are chosen by a seeded
     global search (the paper's Algorithm 3); otherwise ``V = I``.
@@ -61,10 +61,10 @@ def run_smc(
         if v_search == "de":
             V = optimize_v(X, y, n_out, ridge=ridge, seed=v_seed,
                            maxiter=v_maxiter, popsize=v_popsize)
-        weights = smc_weights(X, y, ridge=ridge, V=V)
+        weights = src_weights(X, y, ridge=ridge, V=V)
         cf = counterfactual(inputs.Y_donors, weights)
-    except Exception as exc:  # pragma: no cover - defensive; smc_weights is total
-        raise MlsynthEstimationError(f"SMC estimation failed: {exc}") from exc
+    except Exception as exc:  # pragma: no cover - defensive; src_weights is total
+        raise MlsynthEstimationError(f"SRC estimation failed: {exc}") from exc
 
     obs = inputs.Y_treated
     gap = obs - cf
@@ -74,7 +74,7 @@ def run_smc(
     donor_weights = {
         lbl: float(c) for lbl, c in zip(inputs.donor_labels, weights.combined)
     }
-    return SMCFit(
+    return SRCFit(
         att=att,
         weights=weights.combined,
         theta=weights.theta,

--- a/mlsynth/utils/src_helpers/orchestration.py
+++ b/mlsynth/utils/src_helpers/orchestration.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from ...exceptions import MlsynthEstimationError
 from .estimation import counterfactual, src_weights
-from .screening import screen_donors, screen_inputs
+from .screening import fpca_donors, screen_donors, screen_inputs
 from .structures import SRCFit, SRCInputs
 from .vsearch import optimize_v
 
@@ -56,16 +56,18 @@ def run_src(
     """Fit SRC (deterministic Algorithm 1 / 3) and return the point estimate.
 
     With ``screen="sirs"`` the donor pool is first reduced by SIRS screening
-    (Algorithm 2) to ``n_screen`` donors (default the paper's count). With
-    ``v_search="de"`` the predictor weights ``V`` are chosen by a seeded global
-    search (the paper's Algorithm 3); otherwise ``V = I``.
+    (Algorithm 2) to ``n_screen`` donors (default the paper's count); with
+    ``screen="fpca"`` it is reduced to the treated unit's FPCA cluster (reusing
+    ClusterSC's routines). With ``v_search="de"`` the predictor weights ``V`` are
+    chosen by a seeded global search (the paper's Algorithm 3); otherwise
+    ``V = I``.
     """
     n_screened_out = 0
-    if screen == "sirs":
-        keep = screen_donors(
-            inputs.Y_donors[:inputs.T0], inputs.Y_treated[:inputs.T0],
-            n_screen=n_screen,
-        )
+    if screen in ("sirs", "fpca"):
+        Dpre = inputs.Y_donors[:inputs.T0]
+        ypre = inputs.Y_treated[:inputs.T0]
+        keep = (screen_donors(Dpre, ypre, n_screen=n_screen) if screen == "sirs"
+                else fpca_donors(Dpre, ypre))
         if keep.size < inputs.J:
             n_screened_out = int(inputs.J - keep.size)
             inputs = screen_inputs(inputs, keep)

--- a/mlsynth/utils/src_helpers/plotter.py
+++ b/mlsynth/utils/src_helpers/plotter.py
@@ -1,6 +1,6 @@
-"""Plotting for SMC: the treated trajectory vs the SMC counterfactual.
+"""Plotting for SRC: the treated trajectory vs the SRC counterfactual.
 
-Delegates to the shared :class:`~mlsynth.utils.plotting.Plotter` so SMC matches
+Delegates to the shared :class:`~mlsynth.utils.plotting.Plotter` so SRC matches
 the library's visual archetype.
 """
 
@@ -11,11 +11,11 @@ from typing import List, Union
 import numpy as np
 
 from ..plotting import Plotter, mlsynth_style
-from .structures import SMCResults
+from .structures import SRCResults
 
 
-def plot_smc(
-    results: SMCResults,
+def plot_src(
+    results: SRCResults,
     *,
     outcome: str,
     time: str,
@@ -23,7 +23,7 @@ def plot_smc(
     counterfactual_color: Union[str, List[str]] = "red",
     save: Union[bool, str] = False,
 ) -> None:
-    """Overlay the treated unit and its SMC counterfactual (``bias + Y0 (theta*w)``)."""
+    """Overlay the treated unit and its SRC counterfactual (``bias + Y0 (theta*w)``)."""
     import matplotlib.pyplot as plt
 
     inputs = results.inputs
@@ -39,17 +39,17 @@ def plot_smc(
             times,
             inputs.Y_treated,
             results.counterfactual,
-            labels=["SMC"],
+            labels=["SRC"],
             treated_label=inputs.treated_label,
             intervention=inputs.intervention_time,
             outcome=outcome,
             time=time,
-            title="Treated vs. SMC counterfactual",
+            title="Treated vs. SRC counterfactual",
             ax=ax,
         )
         fig.tight_layout()
         if save:
-            fname = save if isinstance(save, str) else "smc_fit.png"
+            fname = save if isinstance(save, str) else "src_fit.png"
             fig.savefig(fname, dpi=130, bbox_inches="tight")
         else:
             plt.show()

--- a/mlsynth/utils/src_helpers/screening.py
+++ b/mlsynth/utils/src_helpers/screening.py
@@ -107,6 +107,49 @@ def screen_donors(
     return np.sort(keep)
 
 
+def fpca_donors(
+    donors: np.ndarray,
+    treated: np.ndarray,
+    *,
+    cumvar_threshold: float = 0.95,
+    k_clusters: Optional[int] = None,
+    k_max: int = 8,
+    random_state: int = 0,
+) -> np.ndarray:
+    """Select donors by FPCA + clustering, reusing ClusterSC's routines.
+
+    A shape-based alternative to :func:`screen_donors`: instead of ranking by
+    marginal dependence, it clusters the pre-period trajectories and keeps the
+    donors in the treated unit's cluster. It reuses ClusterSC's
+    :func:`~mlsynth.utils.clustersc_helpers.rpca.fpca.compute_fpca_features`
+    (cubic-B-spline smoothing then PCA truncated at ``cumvar_threshold``) and
+    :func:`~mlsynth.utils.clustersc_helpers.rpca.clustering.assign_clusters`
+    (silhouette-chosen k-means; Bayani 2021), so the selected pool is an
+    economically coherent peer group rather than a dependence ranking.
+
+    Deterministic (seeded k-means). If the treated unit's cluster contains no
+    donors, the whole pool is kept (a no-op).
+    """
+    from ..clustersc_helpers.rpca.clustering import assign_clusters
+    from ..clustersc_helpers.rpca.fpca import compute_fpca_features
+
+    D = np.asarray(donors, dtype=float)
+    y = np.asarray(treated, dtype=float).ravel()
+    J = D.shape[1]
+    # rows are units (treated first), columns are pre-period time points
+    pre_units = np.vstack([y[None, :], D.T])
+    feat = compute_fpca_features(pre_units, cumvar_threshold=cumvar_threshold)
+    clust = assign_clusters(
+        feat.scores, treated_row=0,
+        k_clusters=k_clusters, k_max=k_max, random_state=random_state,
+    )
+    keep = np.asarray(clust.donor_indices, dtype=int) - 1   # unit rows -> donor cols
+    keep = keep[keep >= 0]
+    if keep.size == 0:
+        return np.arange(J)
+    return np.sort(keep)
+
+
 def screen_inputs(inputs, keep: np.ndarray):
     """Return a copy of ``SRCInputs`` restricted to the kept donor columns."""
     keep = np.asarray(keep, dtype=int)

--- a/mlsynth/utils/src_helpers/screening.py
+++ b/mlsynth/utils/src_helpers/screening.py
@@ -1,0 +1,121 @@
+"""SIRS donor screening for SRC (Zhu 2023, Algorithm 2).
+
+When the donor pool is not small relative to the pre-period length
+(:math:`J \\ge T_0`, recommended in the paper at :math:`J \\ge 4T_0/5`), the
+unit-regression fit is ill-posed: the pre-period system has more donor
+coefficients than periods, so the noise estimate :math:`\\widehat{\\sigma}^2`
+collapses and the Cp penalty switches off. Algorithm 2 screens the pool down to
+a subset of active donors *before* running Algorithm 1, restoring a well-posed
+fit.
+
+Screening ranks donors by the sure-independent-ranking-and-screening (SIRS)
+marginal utility of Zhu, Fan, Li & Zhu (2011), which the paper adopts. For a
+standardized donor path :math:`\\mathbf{z}_j` and the treated path
+:math:`\\mathbf{y}_1` over the pre-period,
+
+.. math::
+
+   \\widehat{\\omega}_j = \\frac{1}{T_0}\\sum_{t=1}^{T_0}
+     \\Bigl[\\frac{1}{T_0}\\sum_{\\ell=1}^{T_0}
+       z_{j\\ell}\\,\\mathbf{1}\\{y_{1\\ell} \\le y_{1t}\\}\\Bigr]^2 .
+
+It is a model-free measure of dependence between donor :math:`j` and the treated
+outcome: a donor whose (standardized) path co-moves -- or anti-moves, since the
+inner term is squared and SRC allows negative :math:`\\theta_j` -- with the
+treated's ordering scores high; a flat / noise donor scores near zero.
+
+Note on the paper's Eq. 22. As printed, Eq. 22 carries the inner term as
+:math:`Y_{jt}` (independent of the summation index :math:`\\ell`), which would
+factor out of the inner sum; we read it as the cited-form :math:`z_{j\\ell}`
+(Zhu et al. 2011) and standardize the donor paths, as SIRS requires for a
+scale-free ranking.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+from typing import Optional
+
+import numpy as np
+
+
+def sirs_scores(donors: np.ndarray, treated: np.ndarray) -> np.ndarray:
+    """SIRS marginal-utility score for each donor over the pre-period.
+
+    Parameters
+    ----------
+    donors : np.ndarray, shape (T0, J)
+        Donor pre-period outcome paths (one column per donor).
+    treated : np.ndarray, shape (T0,)
+        Treated unit's pre-period outcome path.
+
+    Returns
+    -------
+    np.ndarray, shape (J,)
+        Non-negative SIRS scores; higher means stronger dependence on the
+        treated outcome. A zero-variance (constant) donor scores exactly zero.
+    """
+    D = np.asarray(donors, dtype=float)
+    y = np.asarray(treated, dtype=float).ravel()
+    T0 = y.shape[0]
+    sd = D.std(axis=0, ddof=0)
+    Z = (D - D.mean(axis=0)) / np.where(sd > 0, sd, 1.0)
+    Z[:, sd == 0] = 0.0                                   # constant donor -> score 0
+    ind = (y[None, :] <= y[:, None]).astype(float)        # ind[t, l] = 1{y_l <= y_t}
+    cond = (ind @ Z) / T0                                 # (T0, J) inner conditional means
+    return (cond ** 2).mean(axis=0)
+
+
+def screen_count(T0: int) -> int:
+    """Number of active donors to keep: ``min(floor(T0 / log(T0/2)), T0 - 1)``.
+
+    The floor is the paper's rule (Zhu et al. 2011, adopted by Zhu 2023). The
+    ``T0 - 1`` cap is a well-posedness guard beyond the paper: it guarantees the
+    screened pool is strictly smaller than the pre-period length, so the Cp fit
+    is never degenerate. In the paper's regime (large ``T0``) the cap never
+    binds; it only tames pathologically small ``T0``.
+    """
+    T0 = int(T0)
+    if T0 <= 2:
+        return max(1, T0 - 1)
+    denom = math.log(T0 / 2.0)
+    k = int(np.floor(T0 / denom)) if denom > 0 else T0 - 1
+    return int(max(1, min(k, T0 - 1)))
+
+
+def screen_donors(
+    donors: np.ndarray,
+    treated: np.ndarray,
+    *,
+    n_screen: Optional[int] = None,
+) -> np.ndarray:
+    """Return the indices of the donors to keep, ranked by SIRS.
+
+    Keeps the top ``k`` donors, where ``k = n_screen`` if given else
+    :func:`screen_count`. If ``k >= J`` the whole pool is kept (a no-op, so
+    screening a pool already smaller than ``k`` changes nothing). Returned
+    indices are sorted ascending for a stable downstream donor ordering.
+    """
+    D = np.asarray(donors, dtype=float)
+    T0, J = D.shape
+    k = int(n_screen) if n_screen is not None else screen_count(T0)
+    k = max(1, min(k, J))
+    if k >= J:
+        return np.arange(J)
+    scores = sirs_scores(D, treated)
+    keep = np.argsort(scores, kind="stable")[::-1][:k]
+    return np.sort(keep)
+
+
+def screen_inputs(inputs, keep: np.ndarray):
+    """Return a copy of ``SRCInputs`` restricted to the kept donor columns."""
+    keep = np.asarray(keep, dtype=int)
+    cov_donors = (inputs.cov_donors[:, keep]
+                  if inputs.cov_donors is not None else None)
+    return replace(
+        inputs,
+        Y_donors=inputs.Y_donors[:, keep],
+        donor_labels=tuple(np.asarray(inputs.donor_labels, dtype=object)[keep]),
+        cov_donors=cov_donors,
+        J=int(keep.size),
+    )

--- a/mlsynth/utils/src_helpers/setup.py
+++ b/mlsynth/utils/src_helpers/setup.py
@@ -1,4 +1,4 @@
-"""Long-DataFrame -> NumPy boundary for SMC (the only pandas touchpoint)."""
+"""Long-DataFrame -> NumPy boundary for SRC (the only pandas touchpoint)."""
 
 from __future__ import annotations
 
@@ -8,10 +8,10 @@ import numpy as np
 import pandas as pd
 
 from ...exceptions import MlsynthDataError
-from .structures import SMCInputs
+from .structures import SRCInputs
 
 
-def prepare_smc_inputs(
+def prepare_src_inputs(
     df: pd.DataFrame,
     *,
     outcome: str,
@@ -21,8 +21,8 @@ def prepare_smc_inputs(
     covariates: Optional[Sequence[str]] = None,
     covariate_windows: Optional[Dict[str, Tuple[Any, Any]]] = None,
     fit_window: Optional[Tuple[Any, Any]] = None,
-) -> SMCInputs:
-    """Pivot ``df`` into SMC's ``(Y_treated, Y_donors, T0)`` matrices.
+) -> SRCInputs:
+    """Pivot ``df`` into SRC's ``(Y_treated, Y_donors, T0)`` matrices.
 
     Single treated unit only: the treated unit is the one with any ``treat == 1``
     row, the donor pool is every never-treated unit. Requires a balanced panel
@@ -33,12 +33,12 @@ def prepare_smc_inputs(
     treated_rows = df.loc[df[treat] == 1, [unitid, time]]
     if treated_rows.empty:
         raise MlsynthDataError(
-            f"SMC requires at least one row with {treat}=1; none found."
+            f"SRC requires at least one row with {treat}=1; none found."
         )
     treated_units = treated_rows[unitid].unique()
     if treated_units.size != 1:
         raise MlsynthDataError(
-            f"SMC supports a single treated unit; found {treated_units.size}."
+            f"SRC supports a single treated unit; found {treated_units.size}."
         )
     treated_label = treated_units[0]
     intervention_time = treated_rows[time].min()
@@ -49,7 +49,7 @@ def prepare_smc_inputs(
         if u != treated_label and df.loc[df[unitid] == u, treat].sum() == 0
     ]
     if len(donors) == 0:
-        raise MlsynthDataError("SMC: donor pool is empty.")
+        raise MlsynthDataError("SRC: donor pool is empty.")
 
     Y_wide = df.pivot(index=time, columns=unitid, values=outcome).sort_index()
     time_index = Y_wide.index.to_numpy()
@@ -57,7 +57,7 @@ def prepare_smc_inputs(
     Y_donors = Y_wide[donors].to_numpy(dtype=float)
     if not (np.isfinite(Y_treated).all() and np.isfinite(Y_donors).all()):
         raise MlsynthDataError(
-            "SMC requires a balanced panel with no missing outcomes."
+            "SRC requires a balanced panel with no missing outcomes."
         )
 
     treatment_period = int(np.argmax(time_index >= intervention_time)) + 1
@@ -66,11 +66,11 @@ def prepare_smc_inputs(
     T1 = T - T0
     if T0 < 2:
         raise MlsynthDataError(
-            f"SMC needs at least 2 pre-treatment periods; got T0={T0}."
+            f"SRC needs at least 2 pre-treatment periods; got T0={T0}."
         )
     if T1 < 1:  # pragma: no cover - unreachable: a treated period forces T1 >= 1
         raise MlsynthDataError(
-            f"SMC needs at least 1 post-treatment period; got T1={T1}."
+            f"SRC needs at least 1 post-treatment period; got T1={T1}."
         )
 
     pre_mask = time_index < intervention_time
@@ -110,13 +110,13 @@ def prepare_smc_inputs(
             [i for i in pre_positions if start <= time_index[i] <= end], dtype=int)
         if fit_idx.size < 2:
             raise MlsynthDataError(
-                f"SMC fit_window {fit_window!r} selects fewer than 2 pre-treatment "
+                f"SRC fit_window {fit_window!r} selects fewer than 2 pre-treatment "
                 "periods."
             )
     else:
         fit_idx = pre_positions.astype(int)
 
-    return SMCInputs(
+    return SRCInputs(
         Y_treated=Y_treated,
         Y_donors=Y_donors,
         treated_label=treated_label,

--- a/mlsynth/utils/src_helpers/solver.py
+++ b/mlsynth/utils/src_helpers/solver.py
@@ -1,11 +1,11 @@
-"""Exact box-constrained QP for the SMC Cp criterion.
+"""Exact box-constrained QP for the SRC Cp criterion.
 
 Minimise ``f(w) = 1/2 w' D w - d' w`` subject to ``lo <= w <= hi`` via a primal
 active-set method with a ratio test. For a strictly-convex ``D`` (any
 ``ridge > 0``) this terminates in finitely many pivots at the exact KKT point --
 the box analogue of :func:`mlsynth.utils.bilevel.active_set.solve_simplex_qp`.
 
-Why not a first-order / interior-point QP: SMC re-solves this problem in the hot
+Why not a first-order / interior-point QP: SRC re-solves this problem in the hot
 placebo and bootstrap loops, and the reported weights must pin the box bounds
 *exactly* (a donor at zero is exactly zero -- that is the sparsity the estimator
 reports). An active-set method delivers both: it matches the reference R

--- a/mlsynth/utils/src_helpers/structures.py
+++ b/mlsynth/utils/src_helpers/structures.py
@@ -1,7 +1,7 @@
-"""Typed result containers for the SMC estimator (Zhu 2023).
+"""Typed result containers for the SRC estimator (Zhu 2023).
 
-``SMCInputs`` holds the pivoted panel; ``SMCFit`` the single deterministic
-point estimate; ``SMCResults`` lifts the fit into the standardized
+``SRCInputs`` holds the pivoted panel; ``SRCFit`` the single deterministic
+point estimate; ``SRCResults`` lifts the fit into the standardized
 ``BaseEstimatorResults`` sub-models so the flat accessors resolve through the
 shared contract.
 """
@@ -25,8 +25,8 @@ from ...config_models import (
 
 
 @dataclass(frozen=True)
-class SMCInputs:
-    """Pre-pivoted inputs for a single-treated-unit SMC fit."""
+class SRCInputs:
+    """Pre-pivoted inputs for a single-treated-unit SRC fit."""
 
     Y_treated: np.ndarray             # (T,)
     Y_donors: np.ndarray              # (T, J)
@@ -50,8 +50,8 @@ class SMCInputs:
 
 
 @dataclass(frozen=True)
-class SMCFit:
-    """Single deterministic SMC point estimate."""
+class SRCFit:
+    """Single deterministic SRC point estimate."""
 
     att: float
     weights: np.ndarray               # (J,) combined coefficients theta * w
@@ -69,22 +69,22 @@ class SMCFit:
     donor_weights: dict = field(default_factory=dict)
 
 
-class SMCResults(BaseEstimatorResults):
-    """Top-level container returned by ``SMC.fit`` (an ``EffectResult``).
+class SRCResults(BaseEstimatorResults):
+    """Top-level container returned by ``SRC.fit`` (an ``EffectResult``).
 
     Lifts the single ``fit`` into the standardized sub-models so the flat
     accessors (``att`` / ``counterfactual`` / ``gap`` / ``donor_weights`` /
-    ``pre_rmse``) resolve through the base contract. SMC-specific detail
+    ``pre_rmse``) resolve through the base contract. SRC-specific detail
     (the ``theta`` rescalings, the box weights, ``sigma^2``) stays on ``fit``.
     """
 
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
-    inputs: SMCInputs
-    fit: SMCFit
+    inputs: SRCInputs
+    fit: SRCFit
 
     @model_validator(mode="after")
-    def _populate_standard_submodels(self) -> "SMCResults":
+    def _populate_standard_submodels(self) -> "SRCResults":
         if self.effects is not None:  # pragma: no cover - idempotency guard
             return self
         f = self.fit
@@ -108,7 +108,7 @@ class SMCResults(BaseEstimatorResults):
         object.__setattr__(self, "fit_diagnostics",
                            FitDiagnosticsResults(rmse_pre=float(f.pre_rmse)))
         object.__setattr__(self, "method_details", MethodDetailsResults(
-            method_name="SMC", is_recommended=True))
+            method_name="SRC", is_recommended=True))
         return self
 
     @property
@@ -123,4 +123,4 @@ class SMCResults(BaseEstimatorResults):
 
 
 # Resolve forward references (module uses ``from __future__ import annotations``).
-SMCResults.model_rebuild()
+SRCResults.model_rebuild()

--- a/mlsynth/utils/src_helpers/structures.py
+++ b/mlsynth/utils/src_helpers/structures.py
@@ -67,6 +67,7 @@ class SRCFit:
     v_search: str = "none"
     v: Optional[np.ndarray] = None          # predictor weights used (None => V = I)
     donor_weights: dict = field(default_factory=dict)
+    n_screened_out: int = 0                 # donors dropped by SIRS screening (0 => none)
 
 
 class SRCResults(BaseEstimatorResults):

--- a/mlsynth/utils/src_helpers/vsearch.py
+++ b/mlsynth/utils/src_helpers/vsearch.py
@@ -1,4 +1,4 @@
-"""Optional predictor-weight (V) optimisation for the covariate SMC variant.
+"""Optional predictor-weight (V) optimisation for the covariate SRC variant.
 
 Zhu (2023)'s Basque application (Algorithm 3 / Table 5) does not stop at equal
 predictor weights: it optimises a diagonal ``V`` over the matching rows to best
@@ -17,7 +17,7 @@ Cp-identified Algorithm 1 stays the default. Use it to reproduce the paper's
 covariate specification; do not read the exact weights as identified quantities.
 
 Mirrors the outer-search philosophy of the repository's MSCMT bilevel backend
-(Becker & Kloessner 2018): a log-scaled global search over ``V`` with the SMC
+(Becker & Kloessner 2018): a log-scaled global search over ``V`` with the SRC
 inner solve, differing only in the (box, Cp) inner problem.
 """
 
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from .estimation import smc_weights
+from .estimation import src_weights
 
 
 def optimize_v(
@@ -63,7 +63,7 @@ def optimize_v(
     def upper(xlog: np.ndarray) -> float:
         V = 10.0 ** xlog
         V = n * V / V.sum()
-        r = smc_weights(X, y, ridge=ridge, V=V)
+        r = src_weights(X, y, ridge=ridge, V=V)
         return float(np.sum((z - r.bias - Z @ r.combined) ** 2))
 
     res = differential_evolution(


### PR DESCRIPTION
Overhauls the estimator formerly known as SMC to match its source paper (Zhu 2023, *Synthetic Regressing Control*) and adds two donor-screening options. Five commits, each self-contained.

## 1. Notation rewritten to the canon
`docs/src.rst` (was `smc.rst`) notation converted to `agents/agents_docs.md`: units `\mathcal{N}/N_0`, time `\mathcal{T}_1/\mathcal{T}_2`, the centering projector `\mathbf{Q}`, and a bridge to Zhu's `J` / `\mathcal{T}_0`. Two things it also corrected against the implementation: the unit regression `\thetâ_j` is the *demeaned* univariate OLS (paper Eq. 16, matching the code), and the counterfactual carries its intercept (Eq. 21) — the old page had a non-demeaned, intercept-free form. Undefined symbols (`\mathbf{E}`, `\sigmâ²`, the criterion `\mathcal{C}` clashing with the feasible set) are now defined; the box program is written in the canon's loss-plus-penalty form.

## 2. Documented that the paper's σ² (Eq. 19) is a typo
Empirically, Zhu's printed Eq. 19 reduces to the residual of the equal-weight sum of all `N_0` univariate fits, which over-estimates σ² by ~100× and drives every donor weight to zero (verified in and out of the paper's regime). The author's reference `Code_SMC.R` uses the full-regression residual variance instead — which mlsynth matches to `<2e-13` — so the docs read Eq. 19 as an uncorrected typo. No code change.

## 3. Hard rename SMC → SRC
`SMC`/`SMCConfig` → `SRC`/`SRCConfig`; `smc_helpers/` → `src_helpers/`; helper structs, tests, benchmark case, and both doc pages renamed; citation title fixed to "Synthetic Regressing Control". No backward-compatible alias (breaking, by request). The author's external artifacts `Code_SMC.R` / `SMCV` are preserved. Behavior identical.

## 4. SIRS donor screening (`screen="sirs"`, Algorithm 2)
When donors are not few relative to pre-periods (`J >= T0`; recommended at `J >= 4T0/5`), the unit regression is ill-posed and `σ̂² → 0`, switching off the Cp penalty. `screen="sirs"` ranks donors by the SIRS marginal utility (Zhu, Fan, Li & Zhu 2011) and keeps the top `min(floor(T0/log(T0/2)), T0-1)` (override with `n_screen`), restoring a well-posed fit. New `src_helpers/screening.py`; `SRCFit.n_screened_out` for transparency.

## 5. FPCA donor screening (`screen="fpca"`)
A shape-based alternative that reuses ClusterSC's own routines — functional PCA (B-spline smoothing + PCA to 95% variance) then silhouette k-means (Bayani 2021) — and keeps the treated unit's cluster. So SRC and ClusterSC now screen donors by the same principle, no reimplementation. Deterministic; data-driven cluster size.

On the 1975-treated Basque panel the three rules give genuinely different pools — none: 16 donors, ATT −0.80; sirs: 8 (Aragón), ATT −1.15; fpca: 3 (Baleares/Cataluña/Madrid), ATT −0.68 — a concrete reminder that donor selection is a modelling choice. Screening is documented as a well-posedness/reproducibility device, not a route to the paper's exact Basque weight cells (those live on the non-identified V manifold).

## Tests
Test-first throughout. `test_src_screening.py` (19 tests: SIRS statistic + count + selection, FPCA cluster selection, config surface, and integration showing screening turns a degenerate wide-panel fit into a well-posed one). Full SRC + screening + result-contract: 196 passed. The full suite collects with no import errors after the rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012y2a5QT6AVGcoizpCuc8zW)_