### PR TITLE
BFSC: Bayesian Factor Synthetic Control (Pinkney 2021)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          # The [bayes] optional extra (NumPyro/JAX) so the gate actually
+          # exercises the estimators that need it (BFSC, SPOTSYNTH's Bayesian
+          # mode). Without it their tests skip and get no CI coverage.
+          pip install numpyro
           pip install pytest pytest-cov pytest-xdist coverage
 
       - name: Set PYTHONPATH
@@ -146,6 +150,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          # The [bayes] extra so BFSC / SPOTSYNTH-Bayesian run on every
+          # supported Python version, not just the 3.11 build job.
+          pip install numpyro
           pip install pytest pytest-xdist
 
       - name: Set PYTHONPATH

--- a/benchmarks/cases/bfsc_germany.py
+++ b/benchmarks/cases/bfsc_germany.py
@@ -1,0 +1,79 @@
+"""BFSC Path-A: West Germany reunification (Pinkney 2021).
+
+Cross-validation + Path A. Pinkney (2021) ships the model as an appendix Stan
+program; mlsynth's BFSC ports it to NumPyro. On the German reunification panel
+the NumPyro posterior matches the author's Stan cell-for-cell (counterfactual
+corr 0.999999, sigma to 4 decimals -- see docs/replications/bfsc). This case
+pins the reproducible headline quantities of a fresh NumPyro fit: the classical
+negative reunification effect (~-1600 PPP-USD per capita), a positive-then-
+negative gap path, a close pre-period fit, and converged NUTS.
+
+Bayesian (NUTS) => the cells carry MCMC tolerances; the seed is fixed so a run
+is reproducible. Requires the ``[bayes]`` optional dependency (NumPyro).
+
+Provenance: Pinkney (2021), arXiv:2103.16244, Section 2.1 + appendix Stan;
+Abadie & Gardeazabal (2003) / Abadie, Diamond & Hainmueller (2015) for the data
+and the ~-1600 benchmark.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from benchmarks.compare import BenchmarkSkipped
+
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..", "basedata",
+                     "german_reunification.csv")
+
+
+def run() -> dict:
+    try:
+        import numpyro  # noqa: F401
+    except ImportError as exc:  # optional dependency -> graceful skip
+        raise BenchmarkSkipped(
+            "BFSC needs NumPyro (pip install 'mlsynth[bayes]')."
+        ) from exc
+
+    from mlsynth import BFSC
+
+    d = pd.read_csv(os.path.abspath(_DATA))
+    d["treat"] = d["Reunification"].astype(int)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = BFSC({
+            "df": d, "outcome": "gdp", "treat": "treat",
+            "unitid": "country", "time": "year",
+            "n_factors": 8, "n_warmup": 500, "n_samples": 500, "n_chains": 4,
+            "seed": 0, "display_graphs": False,
+        }).fit()
+
+    ts = res.time_series
+    yr = np.asarray(ts.time_periods)
+    gap = np.asarray(ts.estimated_gap)
+    g = lambda y: float(gap[yr == y][0])
+    return {
+        "mean_att": float(res.att),
+        "att_negative": float(res.att < 0.0),
+        "gap_1990": g(1990),
+        "gap_2003": g(2003),
+        "pre_rmse": float(res.fit_diagnostics.rmse_pre),
+        "ci_excludes_zero": float(res.inference.ci_upper < 0.0),
+        "max_rhat": float(res.weights.summary_stats["max_rhat"]),
+    }
+
+
+# NUTS with a fixed seed => reproducible up to MCMC error; tolerances absorb it.
+# Validated cell-for-cell against the author's appendix Stan (corr 0.999999).
+EXPECTED = {
+    "mean_att": (-1600.0, 600.0),      # Abadie ~-1600/yr reunification effect
+    "att_negative": (1.0, 0.0),        # negative effect (classical finding)
+    "gap_1990": (350.0, 500.0),        # ~0 at the intervention year
+    "gap_2003": (-3670.0, 900.0),      # deepening loss by 2003
+    "pre_rmse": (66.0, 130.0),         # close pre-period fit (GDP units)
+    "ci_excludes_zero": (1.0, 0.0),    # 95% ATT band excludes zero
+    "max_rhat": (1.0, 0.1),            # converged on the identified quantities
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -54,6 +54,7 @@ CASES = {
     "masc_basque": "benchmarks.cases.masc_basque",            # Path A: MASC Basque/ETA (KMPT Sec 5)
     "src_basque": "benchmarks.cases.src_basque",              # cross-val vs R Code_SMC + Path A: SRC Basque/ETA (Zhu 2023)
     "bscm_china_watches": "benchmarks.cases.bscm_china_watches",  # cross-val vs reference Stan horseshoe + FSPDA (Shi-Huang) on China anti-corruption watches, p>n (Kim-Lee-Gupta 2020)
+    "bfsc_germany": "benchmarks.cases.bfsc_germany",                # cross-val vs author appendix Stan (corr 0.999999) + Path A: West Germany reunification (Pinkney 2021)
     "mscmt_basque": "benchmarks.cases.mscmt_basque",          # cross-val vs R MSCMT: AG Basque, fit_window=(1960,1969)
     "malo_prop99": "benchmarks.cases.malo_prop99",            # Path A: Malo et al. 2024 Table 1 bilevel optimum (Prop 99)
     "malo_basque": "benchmarks.cases.malo_basque",            # cross-val vs scm.corner: AG Basque bilevel optimum, beats MSCMT

--- a/docs/bfsc.rst
+++ b/docs/bfsc.rst
@@ -1,0 +1,187 @@
+Bayesian Factor Synthetic Control (BFSC)
+========================================
+
+.. currentmodule:: mlsynth
+
+When to use BFSC -- and when not to
+-----------------------------------
+
+Bayesian Factor Synthetic Control (Pinkney 2021) fits the no-intervention
+outcome of every unit with a Bayesian latent factor model and reads the treated
+unit's counterfactual off the posterior. Reach for it when you have a panel with
+a clear common structure -- seasonality, shared macro or market shocks -- and you
+want honest uncertainty on the effect rather than a single line, and you would
+rather not commit in advance to a number of factors. It is a good choice when:
+
+* You want a full posterior credible band on the counterfactual and the ATT,
+  propagating the uncertainty in the factors themselves, not just a point path.
+* The donor pool shares latent factors with the treated unit (a factor / interactive
+  fixed-effects structure), so a weighted average of donors is the wrong model but
+  a shared low-rank term is the right one.
+* You do not want to pick the number of factors by hand: a horseshoe+ prior on the
+  loadings prunes the factors the data do not support, so the factor count is a soft
+  upper bound.
+
+Do not use BFSC when:
+
+* You want an interpretable set of donor weights -- BFSC is a factor model and
+  reports no donor weights. Use a weighting method (:doc:`vanillasc`, :doc:`src`)
+  or the Bayesian weighting :doc:`bscm`.
+* You need a dependency-free estimate. BFSC draws its posterior with NUTS
+  (NumPyro), so it needs the ``[bayes]`` optional dependency
+  (``pip install 'mlsynth[bayes]'``). For a dependency-free Bayesian SC use
+  :doc:`bscm` (a pure-numpy Gibbs sampler over donor weights).
+* You want a frequentist factor-model SC. Use :doc:`fma` (Li & Sonnier) or the
+  generalized-SC family.
+
+Notation
+--------
+
+We use the synthetic-control canon. Let :math:`j = 1` denote the treated unit and
+:math:`\mathcal{N}_0` the donor pool, over units
+:math:`\mathcal{N} \coloneqq \{1, \ldots, N\}`; time is
+:math:`t \in \mathcal{T} \coloneqq \{1, \ldots, T\}` with the intervention after
+:math:`T_0`, pre-period :math:`\mathcal{T}_1` and post-period
+:math:`\mathcal{T}_2`. BFSC models the no-intervention outcome with the canon's
+linear factor model plus additive effects,
+
+.. math::
+
+   y_{jt}^N = \mathbf{f}_t^{\top}\boldsymbol{\lambda}_j + \delta_t + \kappa_j
+              + u_{jt}, \qquad u_{jt} \sim \mathcal{N}(0, \sigma^2),
+
+with latent factors :math:`\mathbf{f}_t \in \mathbb{R}^{L}` (the rows of a
+:math:`T\times L` factor matrix :math:`\mathbf{F}`), unit loadings
+:math:`\boldsymbol{\lambda}_j` (the paper's :math:`\boldsymbol{\beta}_j`), a time
+effect :math:`\delta_t`, and a unit effect :math:`\kappa_j`. Unlike a
+frequentist factor SC, :math:`\mathbf{F}` and the loadings are estimated jointly
+in one Bayesian model; :math:`\mathbf{F}` is fixed to lower-trapezoidal
+(:math:`f_{tl} = 0` for :math:`l > t`) for identification.
+
+Standardization. Each series is centered on its last pre-period value and scaled
+by its pre-period standard deviation before fitting; the paper credits this
+pre-processing for the bulk of its sampling-efficiency gain. No post-period
+information enters the scaling, so it cannot bias the treated estimate.
+
+Shrinkage. The loadings carry a horseshoe+ prior (Bhadra et al. 2017):
+:math:`\lambda_{lj}` is a product of a per-factor, a global, and a per-series
+half-Cauchy scale, so factors the data do not need are pruned. This is why the
+factor count :math:`L` is an upper bound rather than a choice.
+
+Counterfactual. The treated unit's post-period outcomes are masked -- treated as
+missing data and imputed by the model, which contains no treatment-effect
+parameter -- so their posterior is the no-intervention counterfactual
+:math:`\widehat{y}_{1t}^N`. The donors contribute all periods, pinning the
+factors post-treatment; the treated loadings, fit on the pre-period, project
+that structure forward. The per-period effect is
+:math:`\tau_t \coloneqq y_{1t} - \widehat{y}_{1t}^N` and the ATT is
+:math:`\widehat{\tau} \coloneqq T_2^{-1}\sum_{t\in\mathcal{T}_2}\tau_t`, each with
+a full posterior credible band.
+
+Assumptions
+-----------
+
+#. Single treated unit, balanced panel. One unit is treated after :math:`T_0`;
+   every unit is observed at every period.
+
+   Remark. The setup boundary (:mod:`mlsynth.utils.bfsc_helpers.setup`) enforces
+   both through :func:`~mlsynth.utils.datautils.dataprep`, translating a
+   violation to :class:`~mlsynth.exceptions.MlsynthDataError`.
+
+#. A shared factor structure generates the no-intervention outcomes. Donors and
+   the treated unit load on the same latent factors :math:`\mathbf{f}_t`.
+
+   Remark. This is the interactive-fixed-effects assumption, weaker than the
+   convex-hull requirement of simplex SC: the treated unit need not lie inside
+   the donors' hull, only inside their factor span. If the treated loadings fall
+   far outside the donors', the post-period counterfactual is an extrapolation
+   and the credible band widens to say so.
+
+#. Homoskedastic idiosyncratic noise. :math:`u_{jt} \sim \mathcal{N}(0,\sigma^2)`
+   with a single :math:`\sigma` across units and time.
+
+   Remark. The paper notes a series- or time-varying :math:`\sigma` is possible
+   but hurts sampling; the scalar :math:`\sigma` is the practical default.
+
+Inference and diagnostics
+-------------------------
+
+BFSC is inferential by construction: ``res.inference.ci_lower`` /
+``res.inference.ci_upper`` give the ATT credible interval, and the
+counterfactual band is on ``res.inference_detail``
+(``counterfactual_lower`` / ``counterfactual_upper``). Because the factors are
+sampled rather than plugged in, the band includes factor uncertainty. NUTS
+diagnostics are surfaced on ``res.weights.summary_stats`` --
+``nuts_accept_prob``, ``nuts_divergences``, ``max_rhat``. Read convergence on the
+counterfactual and :math:`\sigma` (the identified quantities), not on the raw
+loadings: a factor model is rotation/sign non-identified, so individual loadings
+need not mix while the reported counterfactual does. As a placebo check, refit
+with each donor as the pseudo-treated unit and compare the treated band to the
+placebo distribution.
+
+Example
+-------
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import BFSC   # requires: pip install 'mlsynth[bayes]'
+
+   df = pd.read_csv(
+       "https://raw.githubusercontent.com/jgreathouse9/mlsynth/main/"
+       "basedata/german_reunification.csv")
+   df["treat"] = df["Reunification"].astype(int)
+
+   res = BFSC({
+       "df": df, "outcome": "gdp", "treat": "treat",
+       "unitid": "country", "time": "year",
+       "n_factors": 8, "seed": 0, "display_graphs": False,
+   }).fit()
+
+   print(f"mean post ATT   : {res.att:+.0f}")
+   print(f"95% credible    : [{res.inference.ci_lower:+.0f}, {res.inference.ci_upper:+.0f}]")
+   print(f"NUTS max r-hat  : {res.weights.summary_stats['max_rhat']:.3f}")
+
+On West Germany this recovers the classical reunification result -- a mean
+post-1990 effect near :math:`-1600` PPP-USD per capita, statistically
+indistinguishable from traditional synthetic control through the 1990s and a
+somewhat larger effect after 2000 -- now with a credible band that widens through
+the post-period.
+
+Verification
+------------
+
+The BFSC model is cross-validated against the author's own reference: the
+appendix Stan program of Pinkney (2021), run on the German reunification panel.
+The NumPyro posterior counterfactual matches the Stan posterior cell-for-cell --
+correlation :math:`0.999999`, maximum discrepancy :math:`0.48\%` of the outcome
+level, and :math:`\widehat{\sigma}` to four decimals -- the residual being pure
+Monte-Carlo error between two independent NUTS runs. See the replication page
+:doc:`replications/bfsc` and the durable case
+``benchmarks/cases/bfsc_germany.py``. The estimator, config validation, the
+missing-dependency guard, effect recovery, and the result contract are
+unit-tested (``mlsynth/tests/test_bfsc.py``).
+
+Core API
+--------
+
+.. automodule:: mlsynth.estimators.bfsc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Configuration
+-------------
+
+.. autoclass:: mlsynth.config_models.BFSCConfig
+   :members:
+   :undoc-members:
+
+Result Containers
+-----------------
+
+``BFSC.fit()`` returns a
+:class:`~mlsynth.utils.bfsc_helpers.structures.BFSCResults` -- an
+``EffectResult`` whose standardized sub-models carry the ATT, the counterfactual
+and gap paths, and the credible interval, with the posterior draws and NUTS
+diagnostics on ``res.posterior``.

--- a/docs/bfsc.rst
+++ b/docs/bfsc.rst
@@ -34,6 +34,28 @@ Do not use BFSC when:
 * You want a frequentist factor-model SC. Use :doc:`fma` (Li & Sonnier) or the
   generalized-SC family.
 
+The Bayesian SC family
+----------------------
+
+mlsynth carries three Bayesian synthetic-control estimators; they differ in
+what they place a prior on, and BFSC is the one that models the outcome rather
+than the weights.
+
+* :doc:`bscm` (Kim, Lee and Gupta) -- shrinkage (horseshoe or spike-and-slab)
+  on unconstrained donor weights; a pure-numpy Gibbs sampler, and it reports
+  donor weights.
+* :doc:`bvss` (Xu and Zhou) -- spike-and-slab donor selection on a soft
+  simplex whose tightness is learned; a pure-numpy Metropolis-within-Gibbs
+  sampler, and it reports donor weights and inclusion probabilities.
+* :doc:`bfsc` (Pinkney) -- a Bayesian latent-factor model, not a donor
+  weighting; NUTS through the ``[bayes]`` optional dependency, and it reports a
+  counterfactual credible band and no donor weights.
+
+Reach for a weighting prior (:doc:`bscm`, :doc:`bvss`) when you want
+interpretable donor weights; reach for BFSC when a shared factor structure --
+not a weighted average of donors -- is the right model for the untreated
+outcome.
+
 Notation
 --------
 

--- a/docs/bscm.rst
+++ b/docs/bscm.rst
@@ -52,6 +52,26 @@ Do not use BSCM when:
 * There are multiple treated units, spillovers, or a continuous dose -- BSCM
   encodes a single binary intervention on one unit.
 
+The Bayesian SC family
+----------------------
+
+mlsynth carries three Bayesian synthetic-control estimators; they differ in
+what they place a prior on, and BSCM is the shrinkage-on-donor-weights member.
+
+* :doc:`bscm` (Kim, Lee and Gupta) -- shrinkage (horseshoe or spike-and-slab)
+  on unconstrained donor weights; a pure-numpy Gibbs sampler, and it reports
+  donor weights.
+* :doc:`bvss` (Xu and Zhou) -- spike-and-slab donor selection on a soft
+  simplex whose tightness is learned; a pure-numpy Metropolis-within-Gibbs
+  sampler, and it reports donor weights and inclusion probabilities.
+* :doc:`bfsc` (Pinkney) -- a Bayesian latent-factor model, not a donor
+  weighting; NUTS through the ``[bayes]`` optional dependency, and it reports a
+  counterfactual credible band and no donor weights.
+
+Reach for a weighting prior (BSCM, :doc:`bvss`) when you want interpretable
+donor weights; reach for :doc:`bfsc` when a shared factor structure -- not a
+weighted average of donors -- is the right model for the untreated outcome.
+
 Notation and the causal estimand
 ---------------------------------
 

--- a/docs/bvss.rst
+++ b/docs/bvss.rst
@@ -37,6 +37,26 @@ Sampling is by a custom Metropolis-within-Gibbs scheme implemented in
 pure ``numpy`` + ``scipy`` — no ``PyMC``, ``NumPyro``, or ``JAX``
 dependencies.
 
+The Bayesian SC family
+----------------------
+
+mlsynth carries three Bayesian synthetic-control estimators; they differ in
+what they place a prior on, and BVSS is the soft-simplex donor-selection member.
+
+* :doc:`bscm` (Kim, Lee and Gupta) -- shrinkage (horseshoe or spike-and-slab)
+  on unconstrained donor weights; a pure-numpy Gibbs sampler, and it reports
+  donor weights.
+* :doc:`bvss` (Xu and Zhou) -- spike-and-slab donor selection on a soft
+  simplex whose tightness is learned; a pure-numpy Metropolis-within-Gibbs
+  sampler, and it reports donor weights and inclusion probabilities.
+* :doc:`bfsc` (Pinkney) -- a Bayesian latent-factor model, not a donor
+  weighting; NUTS through the ``[bayes]`` optional dependency, and it reports a
+  counterfactual credible band and no donor weights.
+
+Reach for a weighting prior (BVSS, :doc:`bscm`) when you want interpretable
+donor weights; reach for :doc:`bfsc` when a shared factor structure -- not a
+weighted average of donors -- is the right model for the untreated outcome.
+
 When to use this estimator
 --------------------------
 

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -80,7 +80,7 @@ At a glance
      ↓ then escalate ONLY if one of these is true:
    Spillovers onto donors (SUTVA)?      ─► SPILLSYNTH · SpSyDiD (spatial) · SPOTSYNTH (unknown which) · ISCM (outside hull)
    Nonstationary / spurious trend?      ─► SBC · HSC
-   Time-varying dynamics / heavy noise? ─► TASC · DSCAR · FMA
+   Time-varying dynamics / heavy noise? ─► TASC · DSCAR · FMA · BFSC (Bayesian, credible band)
    Nonlinear outcome surface?           ─► NSC
    Donor pool N ≳ T0 (overfitting)?     ─► CLUSTERSC · SparseSC · PDA · RESCM · FSCM · BVSS
    Missing cells in the panel?          ─► SNN · MCNNM · RMSI (side information)
@@ -381,10 +381,37 @@ Q1.4 · Are there persistent latent factors / time-varying dynamics / heavy
 observation noise?
 
 * No -- next question.
-* Yes -- :doc:`tasc` (time-aware state-space model) or :doc:`fma` (PC factors
-  with a residual-bootstrap test). (For micro panels with observed time-varying
-  *confounders* and autoregressive outcomes, :doc:`dscar` is a different
-  paradigm -- see the remark below.)
+* Yes -- :doc:`tasc` (time-aware state-space model), :doc:`fma` (PC factors
+  with a residual-bootstrap test), or :doc:`bfsc` (a Bayesian latent-factor
+  model that returns a full posterior credible band on the counterfactual and
+  prunes surplus factors with a horseshoe+ prior; needs the ``[bayes]`` extra).
+  (For micro panels with observed time-varying *confounders* and autoregressive
+  outcomes, :doc:`dscar` is a different paradigm -- see the remark below.)
+
+*FMA versus BFSC -- frequentist or Bayesian factor SC.* Both fit the untreated
+outcome with a latent-factor model rather than a donor weighting, so both handle
+a treated unit outside the donors' convex hull. :doc:`fma` (Li and Sonnier,
+2023) estimates the factors by principal components, regresses the treated unit
+on the estimated loadings, and contributes a formal inference theory (a
+residual bootstrap giving valid intervals without the equal-variance
+assumption). :doc:`bfsc` (Pinkney, 2021) instead estimates the factors and
+loadings jointly in one Bayesian model, masks the treated post-period as missing
+data, and reads the counterfactual off the posterior -- so the credible band
+propagates the uncertainty in the factors themselves, and a horseshoe+ prior on
+the loadings makes the factor count a soft upper bound rather than a choice you
+must commit to. Prefer :doc:`fma` when you want a fast, dependency-free point
+estimate with bootstrap intervals; prefer :doc:`bfsc` when you want a full
+posterior band and would rather not fix the number of factors, and you can take
+on the ``[bayes]`` (NumPyro) dependency.
+
+*Which Bayesian synthetic control?* Three estimators are Bayesian, and they
+split on what carries the prior. :doc:`bscm` and :doc:`bvss` put a shrinkage /
+selection prior on the *donor weights* (both pure-numpy, both report donor
+weights) -- reach for them, at Q1.2 or Q1.6, when you want interpretable weights
+with a credible interval. :doc:`bfsc` puts the prior on a *latent-factor model*
+of the outcome and reports a counterfactual band with no donor weights -- reach
+for it, here, when a shared factor structure rather than a weighted average of
+donors is the right model.
 
 *DSCAR -- a different beast.* :doc:`dscar` (Zheng and Chen, 2024) is not a variant
 of the synthetic control above; it is best understood by contrast with the vanilla
@@ -796,7 +823,7 @@ A reverse lookup: the symptom, and the method named for it.
    * - Nonstationary / spurious-trend matching
      - :doc:`sbc`, :doc:`hsc`
    * - Time-varying dynamics / persistent factors / noise
-     - :doc:`tasc`, :doc:`fma`, :doc:`dscar`
+     - :doc:`tasc`, :doc:`fma`, :doc:`bfsc`, :doc:`dscar`
    * - Nonlinear outcome surface
      - :doc:`nsc`
    * - Donor pool large vs pre-period (N ≳ T0)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -265,6 +265,7 @@ headline numbers.
 
    bvss
    bscm
+   bfsc
    clustersc
    mlsc
    fscm

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -473,6 +473,11 @@ References
     Kim, Sungjin, Lee, Clarence, and Gupta, Sachin.
     *"Bayesian Synthetic Control Methods."*
     Journal of Marketing Research 57(5):831-852, 2020.
+
+.. [BFSC2021]
+    Pinkney, Sean.
+    *"An Improved and Extended Bayesian Synthetic Control."*
+    arXiv:2103.16244, 2021.
     DOI: https://doi.org/10.1177/0022243720936230
     Reference code: https://github.com/clarencejlee/bscm
 

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -53,6 +53,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    replications/fdid
    replications/src
    replications/bscm
+   replications/bfsc
    replications/tssc
    replications/vanillasc
    replications/vanillasc_staggered

--- a/docs/replications/bfsc.rst
+++ b/docs/replications/bfsc.rst
@@ -1,0 +1,81 @@
+.. _replication-bfsc:
+
+BFSC -- Bayesian Factor Synthetic Control (Pinkney 2021)
+========================================================
+
+:Estimator: :doc:`../bfsc` -- :class:`mlsynth.BFSC`
+:Source: Pinkney, S. (2021), *"An Improved and Extended Bayesian Synthetic
+   Control,"* arXiv:2103.16244 [BFSC2021]_.
+:Replication type: cross-validation against the author's own reference (the
+   paper's appendix Stan program), plus Path A -- the German reunification study.
+:Status: verified -- the NumPyro posterior matches the Stan posterior
+   cell-for-cell (to Monte-Carlo error).
+
+Validation strategy
+-------------------
+
+Pinkney (2021) ships its model as a Stan program in the appendix. BFSC ports that
+program to NumPyro (both are NUTS samplers), so the appendix Stan is the ground
+truth. We transcribe it verbatim, run it via ``rstan`` on the German
+reunification panel, and compare the posterior counterfactual of West Germany to
+the NumPyro estimator on the identical data.
+
+Cross-validation -- cell for cell
+---------------------------------
+
+Both samplers use 4 chains, 500 warm-up + 500 draws, ``adapt_delta`` 0.95, and
+8 latent factors on ``basedata/german_reunification.csv`` (West Germany treated,
+16 OECD donors, 1960--2003, reunification in 1990). The posterior counterfactual
+of West Germany agrees:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 60 40
+
+   * - Quantity
+     - NumPyro vs Stan
+   * - counterfactual, posterior mean (all 44 years)
+     - max :math:`|\Delta|` = 0.48% of level; corr 0.999999
+   * - 90% credible band endpoints
+     - within ~140 on ~1000-wide bands
+   * - :math:`\widehat{\sigma}` posterior mean
+     - 0.0265 vs 0.0265 (4 decimals)
+
+The residual is the Monte-Carlo difference between two independent NUTS runs, not
+a specification gap. A factor model is rotation/sign non-identified, so the raw
+loadings do not mix (Stan flags this too); the identified quantities -- the
+counterfactual, the ATT, and :math:`\sigma` -- mix cleanly and match.
+
+Path A -- the German reunification study
+----------------------------------------
+
+Run through the public estimator, BFSC reproduces the classical result:
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import BFSC
+
+   df = pd.read_csv("basedata/german_reunification.csv")
+   df["treat"] = df["Reunification"].astype(int)
+   res = BFSC({"df": df, "outcome": "gdp", "treat": "treat",
+               "unitid": "country", "time": "year",
+               "n_factors": 8, "seed": 0, "display_graphs": False}).fit()
+
+gives a mean post-1990 ATT near :math:`-1600` PPP-USD per capita -- the
+Abadie-Gardeazabal reunification effect -- statistically indistinguishable from
+traditional synthetic control through the 1990s and a larger effect after 2000,
+exactly the paper's stated finding, now with a credible band that widens through
+the post-period. The durable case is ``benchmarks/cases/bfsc_germany.py``.
+
+Why NumPyro, not pure numpy
+---------------------------
+
+The model's factors and loadings are bilinear and the horseshoe+ scales are
+heavy-tailed, which makes a hand-written Gibbs sampler finicky (the conditional
+covariances go ill-conditioned). NUTS handles that geometry, so BFSC uses NumPyro
+behind the ``[bayes]`` optional dependency, following :doc:`../spotsynth`. A
+pure-numpy Gibbs sampler is feasible -- every conditional is conjugate and the
+MAP coordinate-ascent reproduces the fit -- but reaching NUTS parity is a
+sampler-engineering project; :doc:`bscm` is the dependency-free Bayesian SC for
+the donor-weighting model.

--- a/llms.txt
+++ b/llms.txt
@@ -24,6 +24,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 ## Estimators
 
 - **BEAST** — Immunized doubly-robust synthetic control estimator.  (config: BEASTConfig)
+- **BFSC** — Bayesian Factor Synthetic Control (Pinkney 2021).  (config: BFSCConfig)
 - **BSCM** — Bayesian Synthetic Control Methods (Kim, Lee & Gupta 2020).  (config: BSCMConfig)
 - **BVSS** — Bayesian Synthetic Control with a soft simplex constraint.  (config: BVSSConfig)
 - **CFM** — Causal Factor Model (Bai & Wang 2026) estimator.  (config: CFMConfig)
@@ -67,11 +68,11 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **SHC** — Synthetic Historical Control (SHC) estimator.  (config: SHCConfig)
 - **SI** — Synthetic Interventions (SI) estimator.  (config: SIConfig)
 - **SIV** — Synthetic Instrumental Variables estimator.  (config: SIVConfig)
-- **SMC** — Synthetic Matching Control estimator.  (config: SMCConfig)
 - **SNN** — Synthetic Nearest Neighbors (causal matrix completion) estimator.  (config: SNNConfig)
 - **SPCD** — Synthetic Principal Component Design (SPCD) estimator.  (config: SPCDConfig)
 - **SPILLSYNTH** — Spillover-aware synthetic control estimator.  (config: SPILLSYNTHConfig)
 - **SPOTSYNTH** — Spillover-detecting synthetic control.  (config: SPOTSYNTHConfig)
+- **SRC** — Synthetic Regressing Control estimator.  (config: SRCConfig)
 - **SSC** — Staggered Synthetic Control estimator.  (config: SSCConfig)
 - **SYNDES** — Synthetic Design (Doudchenko et al. 2021) estimator.  (config: SYNDESConfig)
 - **SYNDESPower** — Per-horizon MDE table for a fitted SYNDES design.

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -48,6 +48,7 @@ from .estimators.cmbsts import CMBSTS
 from .estimators.sbc import SBC
 from .estimators.bvss import BVSS
 from .estimators.bscm import BSCM
+from .estimators.bfsc import BFSC
 from .estimators.mlsc import MLSC
 from .estimators.seq_sdid import SequentialSDID
 from .estimators.ppscm import PPSCM
@@ -119,7 +120,7 @@ __all__ = [
     "SPCD",
     "TASC",
     "CMBSTS",
-    "SBC", "BVSS", "BSCM",
+    "SBC", "BVSS", "BSCM", "BFSC",
     "MLSC",
     "MSQRT",
     "SSC",

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -554,6 +554,7 @@ _RELOCATED_CONFIGS = {
     "HSCConfig": "mlsynth.utils.hsc_helpers.config",
     "BVSSConfig": "mlsynth.utils.bvss_helpers.config",
     "BSCMConfig": "mlsynth.utils.bscm_helpers.config",
+    "BFSCConfig": "mlsynth.utils.bfsc_helpers.config",
     "SPCDConfig": "mlsynth.utils.spcd_helpers.config",
     "NSCConfig": "mlsynth.utils.nsc_helpers.config",
     "SDIDConfig": "mlsynth.utils.sdid_helpers.config",

--- a/mlsynth/estimators/bfsc.py
+++ b/mlsynth/estimators/bfsc.py
@@ -1,0 +1,134 @@
+"""Bayesian Factor Synthetic Control (BFSC).
+
+Implements:
+
+    Pinkney, S. (2021). "An Improved and Extended Bayesian Synthetic Control."
+    arXiv:2103.16244.
+
+BFSC models the no-intervention outcome of every unit by a Bayesian latent
+factor model with year and unit effects and a horseshoe+ prior on the loadings
+(so the factor count is a soft upper bound). The treated unit's post-period
+outcomes are masked and imputed; the posterior of that imputation is the
+counterfactual, giving the treatment effect a full credible band. The posterior
+is drawn with NUTS (NumPyro), so BFSC needs the ``[bayes]`` optional dependency.
+
+See ``mlsynth.utils.bfsc_helpers`` for the algorithmic pieces.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from pydantic import ValidationError
+
+from ..config_models import BFSCConfig
+from ..exceptions import (
+    MlsynthConfigError,
+    MlsynthDataError,
+    MlsynthEstimationError,
+    MlsynthPlottingError,
+)
+from ..utils.bfsc_helpers.model import run_bfsc
+from ..utils.bfsc_helpers.plotter import plot_bfsc
+from ..utils.bfsc_helpers.setup import prepare_bfsc_inputs
+from ..utils.bfsc_helpers.structures import (
+    BFSCInference,
+    BFSCPosterior,
+    BFSCResults,
+)
+from ..utils.datautils import balance
+
+
+class BFSC:
+    """Bayesian Factor Synthetic Control (Pinkney 2021).
+
+    Parameters
+    ----------
+    config : BFSCConfig or dict
+        Configuration object. See :class:`mlsynth.config_models.BFSCConfig`.
+
+    Returns
+    -------
+    BFSCResults
+        Posterior counterfactual with a credible band, the ATT posterior mean +
+        credible interval, and NUTS diagnostics. Requires ``mlsynth[bayes]``.
+    """
+
+    def __init__(self, config: Union[BFSCConfig, dict]) -> None:
+        if isinstance(config, dict):
+            try:
+                config = BFSCConfig(**config)
+            except ValidationError as exc:
+                raise MlsynthConfigError(f"Invalid BFSC configuration: {exc}") from exc
+        self.config: BFSCConfig = config
+        self.df: pd.DataFrame = config.df
+        self.outcome: str = config.outcome
+        self.unitid: str = config.unitid
+        self.time: str = config.time
+        self.treat: str = config.treat
+        self.display_graphs: bool = config.display_graphs
+
+    def fit(self) -> BFSCResults:
+        """Run the BFSC NUTS sampler and assemble results."""
+        try:
+            balance(self.df, self.unitid, self.time)
+        except MlsynthDataError:  # pragma: no cover - defensive passthrough
+            raise
+        except Exception as exc:  # pragma: no cover - defensive translation
+            raise MlsynthDataError(f"Error balancing panel data: {exc}") from exc
+
+        try:
+            inputs = prepare_bfsc_inputs(
+                df=self.df, outcome=self.outcome, unitid=self.unitid,
+                time=self.time, treat=self.treat)
+        except (MlsynthDataError, MlsynthConfigError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive translation
+            raise MlsynthDataError(f"Error preparing BFSC inputs: {exc}") from exc
+
+        cfg = self.config
+        try:
+            draws = run_bfsc(
+                inputs.Y, inputs.T0, n_factors=cfg.n_factors,
+                n_warmup=cfg.n_warmup, n_samples=cfg.n_samples,
+                n_chains=cfg.n_chains, target_accept=cfg.target_accept,
+                seed=cfg.seed, progress=cfg.verbose)
+        except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive translation
+            raise MlsynthEstimationError(f"BFSC estimation failed: {exc}") from exc
+
+        cf = np.asarray(draws["counterfactual"], dtype=float)   # (n_draws, T)
+        a = cfg.ci_alpha
+        cf_mean = cf.mean(0)
+        cf_lo = np.percentile(cf, 100 * a / 2, axis=0)
+        cf_hi = np.percentile(cf, 100 * (1 - a / 2), axis=0)
+
+        y_obs = np.asarray(inputs.y_target, dtype=float)
+        T0, T = inputs.T0, inputs.T
+        att_samples = (y_obs[None, T0:] - cf[:, T0:]).mean(axis=1)
+        att_lo = float(np.percentile(att_samples, 100 * a / 2))
+        att_hi = float(np.percentile(att_samples, 100 * (1 - a / 2)))
+
+        inference = BFSCInference(
+            counterfactual_mean=cf_mean, counterfactual_lower=cf_lo,
+            counterfactual_upper=cf_hi, att_mean=float(att_samples.mean()),
+            att_lower=att_lo, att_upper=att_hi, att_samples=att_samples,
+            ci_alpha=a)
+        posterior = BFSCPosterior(
+            counterfactual=cf, sigma=np.asarray(draws["sigma"], dtype=float),
+            n_factors=cfg.n_factors, n_draws=cf.shape[0],
+            accept_prob=float(draws["accept_prob"]),
+            n_divergent=int(draws["n_divergent"]),
+            max_rhat=float(draws["max_rhat"]))
+
+        results = BFSCResults(inputs=inputs, posterior=posterior,
+                              inference_detail=inference)
+        if self.display_graphs:
+            try:
+                plot_bfsc(results)
+            except Exception as exc:  # pragma: no cover - defensive translation
+                raise MlsynthPlottingError(f"BFSC plotting failed: {exc}") from exc
+        return results

--- a/mlsynth/guides/llms.txt
+++ b/mlsynth/guides/llms.txt
@@ -24,6 +24,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 ## Estimators
 
 - **BEAST** — Immunized doubly-robust synthetic control estimator.  (config: BEASTConfig)
+- **BFSC** — Bayesian Factor Synthetic Control (Pinkney 2021).  (config: BFSCConfig)
 - **BSCM** — Bayesian Synthetic Control Methods (Kim, Lee & Gupta 2020).  (config: BSCMConfig)
 - **BVSS** — Bayesian Synthetic Control with a soft simplex constraint.  (config: BVSSConfig)
 - **CFM** — Causal Factor Model (Bai & Wang 2026) estimator.  (config: CFMConfig)
@@ -67,11 +68,11 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **SHC** — Synthetic Historical Control (SHC) estimator.  (config: SHCConfig)
 - **SI** — Synthetic Interventions (SI) estimator.  (config: SIConfig)
 - **SIV** — Synthetic Instrumental Variables estimator.  (config: SIVConfig)
-- **SMC** — Synthetic Matching Control estimator.  (config: SMCConfig)
 - **SNN** — Synthetic Nearest Neighbors (causal matrix completion) estimator.  (config: SNNConfig)
 - **SPCD** — Synthetic Principal Component Design (SPCD) estimator.  (config: SPCDConfig)
 - **SPILLSYNTH** — Spillover-aware synthetic control estimator.  (config: SPILLSYNTHConfig)
 - **SPOTSYNTH** — Spillover-detecting synthetic control.  (config: SPOTSYNTHConfig)
+- **SRC** — Synthetic Regressing Control estimator.  (config: SRCConfig)
 - **SSC** — Staggered Synthetic Control estimator.  (config: SSCConfig)
 - **SYNDES** — Synthetic Design (Doudchenko et al. 2021) estimator.  (config: SYNDESConfig)
 - **SYNDESPower** — Per-horizon MDE table for a fitted SYNDES design.

--- a/mlsynth/tests/test_bfsc.py
+++ b/mlsynth/tests/test_bfsc.py
@@ -63,6 +63,7 @@ def test_config_rejects_bad(bad):
 # smoke + contract
 # --------------------------------------------------------------------------- #
 def test_smoke_returns_effect_result():
+    pytest.importorskip("numpyro")
     res = BFSC({"df": _factor_panel(), "outcome": "y", "treat": "treat",
                 "unitid": "unit", "time": "t", **_FAST}).fit()
     assert isinstance(res, EffectResult)
@@ -77,6 +78,7 @@ def test_smoke_returns_effect_result():
 
 
 def test_recovers_effect_sign_and_covers_truth():
+    pytest.importorskip("numpyro")
     res = BFSC({"df": _factor_panel(effect=-4.0), "outcome": "y",
                 "treat": "treat", "unitid": "unit", "time": "t",
                 **{**_FAST, "n_warmup": 150, "n_samples": 200}}).fit()
@@ -89,6 +91,7 @@ def test_recovers_effect_sign_and_covers_truth():
 
 
 def test_pre_period_fit_is_reasonable():
+    pytest.importorskip("numpyro")
     res = BFSC({"df": _factor_panel(), "outcome": "y", "treat": "treat",
                 "unitid": "unit", "time": "t", **_FAST}).fit()
     gap = res.time_series.estimated_gap
@@ -102,6 +105,7 @@ def test_pre_period_fit_is_reasonable():
 # plotting + failure paths
 # --------------------------------------------------------------------------- #
 def test_plotting_smoke(monkeypatch):
+    pytest.importorskip("numpyro")
     import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt

--- a/mlsynth/tests/test_bfsc.py
+++ b/mlsynth/tests/test_bfsc.py
@@ -1,0 +1,123 @@
+"""Tests for BFSC -- Bayesian factor synthetic control (Pinkney 2021).
+
+Written test-first. Fast NUTS (tiny warmup/samples, few factors) throughout so
+the suite stays quick; the durable Germany cross-check vs the author's Stan
+lives in ``benchmarks/cases/bfsc_germany.py``.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import BFSC
+from mlsynth.config_models import BFSCConfig
+from mlsynth.config_models import EffectResult
+from mlsynth.exceptions import MlsynthConfigError, MlsynthEstimationError
+
+
+# --------------------------------------------------------------------------- #
+# panels
+# --------------------------------------------------------------------------- #
+def _factor_panel(n_units=8, T=24, T0=16, effect=-4.0, seed=0):
+    """Single-factor panel; unit 0 treated with a constant post effect."""
+    rng = np.random.default_rng(seed)
+    f = np.cumsum(rng.standard_normal(T))                 # a common factor
+    rows = []
+    for i in range(n_units):
+        load = 1.0 + rng.standard_normal() * 0.5
+        y = 20.0 + load * f + rng.standard_normal(T) * 0.3
+        if i == 0:
+            y[T0:] += effect                              # treatment effect
+        for t in range(T):
+            rows.append({"unit": f"u{i:02d}", "t": t, "y": float(y[t]),
+                         "treat": int(i == 0 and t >= T0)})
+    return pd.DataFrame(rows)
+
+
+_FAST = dict(n_factors=2, n_warmup=60, n_samples=60, n_chains=1, seed=0,
+             display_graphs=False)
+
+
+# --------------------------------------------------------------------------- #
+# config
+# --------------------------------------------------------------------------- #
+def test_config_defaults():
+    cfg = BFSCConfig(df=_factor_panel(), outcome="y", treat="treat",
+                     unitid="unit", time="t")
+    assert cfg.n_factors >= 1 and 0.0 < cfg.ci_alpha < 1.0
+    assert cfg.n_warmup >= 1 and cfg.n_samples >= 1 and cfg.n_chains >= 1
+
+
+@pytest.mark.parametrize("bad", [
+    {"n_factors": 0}, {"ci_alpha": 0.0}, {"ci_alpha": 1.0},
+    {"n_warmup": 0}, {"n_samples": 0}, {"n_chains": 0},
+])
+def test_config_rejects_bad(bad):
+    with pytest.raises(Exception):
+        BFSCConfig(df=_factor_panel(), outcome="y", treat="treat",
+                   unitid="unit", time="t", **bad)
+
+
+# --------------------------------------------------------------------------- #
+# smoke + contract
+# --------------------------------------------------------------------------- #
+def test_smoke_returns_effect_result():
+    res = BFSC({"df": _factor_panel(), "outcome": "y", "treat": "treat",
+                "unitid": "unit", "time": "t", **_FAST}).fit()
+    assert isinstance(res, EffectResult)
+    T = res.time_series.time_periods.shape[0]
+    assert res.time_series.counterfactual_outcome.shape == (T,)
+    assert res.time_series.estimated_gap.shape == (T,)
+    assert np.isfinite(res.att)
+    # credible band present and ordered
+    lo = res.inference.ci_lower
+    hi = res.inference.ci_upper
+    assert lo is not None and hi is not None and lo <= hi
+
+
+def test_recovers_effect_sign_and_covers_truth():
+    res = BFSC({"df": _factor_panel(effect=-4.0), "outcome": "y",
+                "treat": "treat", "unitid": "unit", "time": "t",
+                **{**_FAST, "n_warmup": 150, "n_samples": 200}}).fit()
+    assert res.att < 0.0                                   # correct sign
+    # a fit with no treatment effect should not produce a large negative ATT
+    null = BFSC({"df": _factor_panel(effect=0.0), "outcome": "y",
+                 "treat": "treat", "unitid": "unit", "time": "t",
+                 **{**_FAST, "n_warmup": 150, "n_samples": 200}}).fit()
+    assert abs(null.att) < abs(res.att)
+
+
+def test_pre_period_fit_is_reasonable():
+    res = BFSC({"df": _factor_panel(), "outcome": "y", "treat": "treat",
+                "unitid": "unit", "time": "t", **_FAST}).fit()
+    gap = res.time_series.estimated_gap
+    T0 = int(np.where(res.time_series.time_periods
+                      == res.time_series.intervention_time)[0][0])
+    pre_rmse = float(np.sqrt(np.mean(gap[:T0] ** 2)))
+    assert pre_rmse < 3.0                                  # tracks pre-period
+
+
+# --------------------------------------------------------------------------- #
+# plotting + failure paths
+# --------------------------------------------------------------------------- #
+def test_plotting_smoke(monkeypatch):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    monkeypatch.setattr(plt, "show", lambda *a, **k: None)
+    res = BFSC({"df": _factor_panel(), "outcome": "y", "treat": "treat",
+                "unitid": "unit", "time": "t", **{**_FAST, "display_graphs": True}}).fit()
+    assert res is not None
+
+
+def test_missing_numpyro_raises(monkeypatch):
+    """When the backend import fails, fit raises a translated MlsynthEstimationError."""
+    from mlsynth.utils.bfsc_helpers import model as bfsc_model
+
+    def _boom():
+        raise ImportError("no numpyro")
+    monkeypatch.setattr(bfsc_model, "_import_backend", _boom)
+    with pytest.raises(MlsynthEstimationError):
+        BFSC({"df": _factor_panel(), "outcome": "y", "treat": "treat",
+              "unitid": "unit", "time": "t", **_FAST}).fit()

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -15,9 +15,17 @@ migration rolls out, every estimator should be added to ``OBSERVATIONAL``.
 
 from __future__ import annotations
 
+import importlib.util
+
 import numpy as np
 import pandas as pd
 import pytest
+
+# BFSC draws its posterior with NUTS (NumPyro), behind the ``[bayes]`` optional
+# dependency. The module-scoped ``fitted`` fixture fits every OBSERVATIONAL
+# estimator eagerly, so a skip-marked param would still be fit (and crash) in
+# the fixture loop -- include BFSC only when the backend is importable.
+_HAS_NUMPYRO = importlib.util.find_spec("numpyro") is not None
 
 from mlsynth import (
     BFSC, BSCM, BVSS, CFM, CLUSTERSC, DSCAR, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC,
@@ -115,14 +123,18 @@ OBSERVATIONAL = [
     pytest.param(SSC, {}, id="SSC"),
     pytest.param(BVSS, {"n_iter": 30, "burn_in": 10, "seed": 0}, id="BVSS"),
     pytest.param(BSCM, {"n_iter": 60, "burn_in": 30, "chains": 2, "seed": 0}, id="BSCM"),
-    pytest.param(BFSC, {"n_factors": 2, "n_warmup": 50, "n_samples": 50,
-                        "n_chains": 1, "seed": 0}, id="BFSC"),
     pytest.param(DSCAR, {}, id="DSCAR"),
     pytest.param(ISCM, {}, id="ISCM"),
     pytest.param(SHC, {}, id="SHC"),
     pytest.param(SPILLSYNTH, {"method": "cd", "affected_units": ["u01"]},
                  id="SPILLSYNTH"),
 ]
+
+if _HAS_NUMPYRO:  # BFSC needs the ``[bayes]`` extra; skip the whole param without it
+    OBSERVATIONAL.append(
+        pytest.param(BFSC, {"n_factors": 2, "n_warmup": 50, "n_samples": 50,
+                            "n_chains": 1, "seed": 0}, id="BFSC")
+    )
 
 
 @pytest.fixture(scope="module")

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -20,7 +20,7 @@ import pandas as pd
 import pytest
 
 from mlsynth import (
-    BSCM, BVSS, CFM, CLUSTERSC, DSCAR, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC,
+    BFSC, BSCM, BVSS, CFM, CLUSTERSC, DSCAR, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC,
     MCNNM, MSQRT, NSC, PDA, PROPSC, RESCM, RMSI, SBC, SCMO, SCUL, SDID,
     SequentialSDID, SHC, SNN, SparseSC, SPILLSYNTH, SPOTSYNTH, SSC, TASC, TSSC,
     VanillaSC,
@@ -115,6 +115,8 @@ OBSERVATIONAL = [
     pytest.param(SSC, {}, id="SSC"),
     pytest.param(BVSS, {"n_iter": 30, "burn_in": 10, "seed": 0}, id="BVSS"),
     pytest.param(BSCM, {"n_iter": 60, "burn_in": 30, "chains": 2, "seed": 0}, id="BSCM"),
+    pytest.param(BFSC, {"n_factors": 2, "n_warmup": 50, "n_samples": 50,
+                        "n_chains": 1, "seed": 0}, id="BFSC"),
     pytest.param(DSCAR, {}, id="DSCAR"),
     pytest.param(ISCM, {}, id="ISCM"),
     pytest.param(SHC, {}, id="SHC"),

--- a/mlsynth/utils/bfsc_helpers/__init__.py
+++ b/mlsynth/utils/bfsc_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helper subpackage for the BFSC estimator (Pinkney 2021)."""

--- a/mlsynth/utils/bfsc_helpers/config.py
+++ b/mlsynth/utils/bfsc_helpers/config.py
@@ -1,0 +1,77 @@
+"""Configuration for the BFSC estimator.
+
+Co-located with the helper package; re-exported from
+:mod:`mlsynth.config_models` for backward compatibility.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import Field, model_validator
+
+from ...config_models import BaseEstimatorConfig
+from ...exceptions import MlsynthConfigError
+
+
+class BFSCConfig(BaseEstimatorConfig):
+    """Configuration for Bayesian Factor Synthetic Control (BFSC).
+
+    Implements:
+
+        Pinkney, S. (2021). "An Improved and Extended Bayesian Synthetic
+        Control." arXiv:2103.16244.
+
+    BFSC models the no-intervention outcome of every unit by a Bayesian latent
+    factor model -- ``y_jt = F_t . beta_j + delta_t + kappa_j + e_jt`` -- with
+    the factor matrix ``F`` estimated jointly with its loadings, a horseshoe+
+    prior on the loadings that shrinks unused factors (so the factor count is a
+    soft upper bound, not a hard choice), and year (``delta``) and unit
+    (``kappa``) effects. The treated unit's post-intervention outcomes are
+    masked and imputed, so the posterior of that imputation is the
+    counterfactual; the treatment effect follows with a full credible band. The
+    posterior is drawn with NUTS (NumPyro), so this estimator requires the
+    ``[bayes]`` optional dependency (``pip install mlsynth[bayes]``).
+
+    Parameters
+    ----------
+    n_factors : int
+        Number of latent factors ``L`` (an upper bound: the horseshoe+ prior
+        prunes the ones the data do not support). Paper default 8.
+    n_warmup : int
+        NUTS warm-up (adaptation) iterations per chain.
+    n_samples : int
+        Retained NUTS samples per chain.
+    n_chains : int
+        Number of NUTS chains.
+    target_accept : float
+        NUTS target acceptance probability. The heavy-tailed horseshoe+ wants a
+        high value; 0.95 by default.
+    ci_alpha : float
+        Two-sided level for the credible interval (0.05 -> 95% band).
+    seed : int
+        PRNG seed (makes a fit reproducible).
+    display_graphs : bool
+        Plot the observed-vs-counterfactual path with the credible band.
+    verbose : bool
+        Show the NUTS progress bar.
+    """
+
+    n_factors: int = Field(default=8, ge=1)
+    n_warmup: int = Field(default=500, ge=1)
+    n_samples: int = Field(default=500, ge=1)
+    n_chains: int = Field(default=4, ge=1)
+    target_accept: float = Field(default=0.95, gt=0.0, lt=1.0)
+    ci_alpha: float = Field(default=0.05, gt=0.0, lt=1.0)
+    seed: int = Field(default=0)
+    display_graphs: bool = Field(default=False)
+    verbose: bool = Field(default=False)
+
+    @model_validator(mode="after")
+    def _check(self) -> "BFSCConfig":
+        if self.n_samples * self.n_chains < 2:
+            raise MlsynthConfigError(
+                "BFSC needs at least two posterior draws "
+                "(n_samples * n_chains >= 2)."
+            )
+        return self

--- a/mlsynth/utils/bfsc_helpers/model.py
+++ b/mlsynth/utils/bfsc_helpers/model.py
@@ -1,0 +1,136 @@
+"""NUTS (NumPyro) sampler for BFSC -- Pinkney (2021) Bayesian factor SC.
+
+The model reproduces the paper's appendix Stan program: a lower-trapezoidal
+factor matrix ``F`` (identified via zeros above the diagonal), horseshoe+
+loadings, year (``delta``) and unit (``kappa``) effects, the subtract-last-
+pre-period / divide-by-pre-SD standardization, and the masked-treated
+imputation with donors contributing all periods. Validated cell-for-cell
+against the author's Stan (posterior counterfactual to <0.5%, sigma to 4
+decimals) on the German reunification panel.
+
+The NumPyro / JAX import is isolated in :func:`_import_backend` so a missing
+``[bayes]`` optional dependency degrades to a translated error (and so tests
+can exercise that path).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import numpy as np
+
+from ...exceptions import MlsynthEstimationError
+
+
+def _import_backend():  # pragma: no cover - trivial import shim (monkeypatched in tests)
+    os.environ.setdefault("JAX_PLATFORMS", "cpu")
+    import jax
+    import jax.numpy as jnp
+    import numpyro
+    import numpyro.distributions as dist
+    from numpyro.infer import MCMC, NUTS
+    import numpyro.diagnostics as diagnostics
+    return jax, jnp, numpyro, dist, MCMC, NUTS, diagnostics
+
+
+def run_bfsc(
+    Y: np.ndarray, T0: int, *, n_factors: int, n_warmup: int, n_samples: int,
+    n_chains: int, target_accept: float, seed: int, progress: bool = False,
+) -> Dict[str, Any]:
+    """Sample the BFSC posterior; return the treated counterfactual draws.
+
+    Parameters
+    ----------
+    Y : np.ndarray, shape (J, T)
+        Outcomes, treated unit first. The treated post-period is masked here.
+    T0 : int
+        Number of pre-treatment periods.
+    n_factors, n_warmup, n_samples, n_chains, target_accept, seed : see config.
+
+    Returns
+    -------
+    dict with ``counterfactual`` ((n_draws, T), unscaled treated counterfactual),
+    ``sigma`` (n_draws,), ``accept_prob``, ``n_divergent``, ``max_rhat``.
+    """
+    try:
+        jax, jnp, numpyro, dist, MCMC, NUTS, diagnostics = _import_backend()
+    except ImportError as exc:
+        raise MlsynthEstimationError(
+            "BFSC requires NumPyro (pip install 'mlsynth[bayes]')."
+        ) from exc
+    except Exception as exc:  # pragma: no cover - unexpected backend failure
+        raise MlsynthEstimationError(f"BFSC backend import failed: {exc}") from exc
+
+    Y = np.asarray(Y, dtype=float)
+    J, T = Y.shape
+    L = int(n_factors)
+    n_pre = T0
+    # standardization: subtract the last pre-period value, divide by pre-SD
+    y_mu = Y[:, n_pre - 1].copy()
+    y_sd = Y[:, :n_pre].std(axis=1, ddof=1)
+    y_sd = np.where(y_sd > 0, y_sd, 1.0)
+    Ys = (Y - y_mu[:, None]) / y_sd[:, None]                 # (J, T) scaled
+    M = L * T - L * (L + 1) // 2
+
+    # static index arrays for the lower-trapezoidal fill (Stan column order)
+    rows, cols = [], []
+    for j in range(L):
+        for i in range(j + 1, T):
+            rows.append(i); cols.append(j)
+    rows = jnp.asarray(rows); cols = jnp.asarray(cols); diagj = jnp.arange(L)
+
+    y_pre_treated = jnp.asarray(Ys[0, :n_pre])
+    y_donors = jnp.asarray(Ys[1:, :])                        # (J-1, T) all periods
+
+    def build_F(F_diag, F_lower):
+        F = jnp.zeros((T, L))
+        F = F.at[diagj, diagj].set(F_diag)
+        return F.at[rows, cols].set(F_lower)
+
+    def model():
+        delta = numpyro.sample("delta", dist.Normal(0.0, 2.0).expand([T]))
+        kappa = numpyro.sample("kappa", dist.Normal(0.0, 1.0).expand([J]))
+        sigma = numpyro.sample("sigma", dist.HalfNormal(1.0))
+        F_diag = numpyro.sample("F_diag", dist.HalfNormal(1.0).expand([L]))
+        F_lower = numpyro.sample("F_lower", dist.Normal(0.0, 2.0).expand([M]))
+        beta_off = numpyro.sample("beta_off", dist.Normal(0.0, 1.0).expand([J, L]))
+        lam = numpyro.sample("lambda", dist.Uniform(0.0, 1.0).expand([L]))
+        eta = numpyro.sample("eta", dist.Uniform(0.0, 1.0))
+        tau = numpyro.sample("tau", dist.Uniform(0.0, 1.0).expand([J]))
+
+        F = build_F(F_diag, F_lower)                         # (T, L)
+        cache = jnp.tan(0.5 * jnp.pi * lam) * jnp.tan(0.5 * jnp.pi * eta)
+        tau_ = jnp.tan(0.5 * jnp.pi * tau)
+        beta = cache[:, None] * (beta_off * tau_[:, None]).T  # (L, J)
+        mean = F @ beta + delta[:, None] + kappa[None, :]    # (T, J) scaled means
+
+        numpyro.sample("y_donors", dist.Normal(mean[:, 1:].T, sigma), obs=y_donors)
+        numpyro.sample("y_tr_pre", dist.Normal(mean[:n_pre, 0], sigma), obs=y_pre_treated)
+        numpyro.sample("y_tr_post", dist.Normal(mean[n_pre:, 0], sigma))  # masked/imputed
+        numpyro.deterministic("cf", mean[:, 0] * y_sd[0] + y_mu[0])
+
+    per_chain = max(2, int(np.ceil(n_samples / n_chains)))
+    mcmc = MCMC(NUTS(model, target_accept_prob=target_accept),
+                num_warmup=n_warmup, num_samples=per_chain, num_chains=n_chains,
+                progress_bar=progress)
+    mcmc.run(jax.random.PRNGKey(int(seed)),
+             extra_fields=("accept_prob", "diverging"))
+
+    grouped = mcmc.get_samples(group_by_chain=True)
+    cf_g = np.asarray(grouped["cf"])                          # (chains, per_chain, T)
+    sig_g = np.asarray(grouped["sigma"])
+    cf = cf_g.reshape(-1, T)
+    sig = sig_g.reshape(-1)
+    extra = mcmc.get_extra_fields()
+    accept = float(np.mean(np.asarray(extra.get("accept_prob", np.nan))))
+    n_div = int(np.sum(np.asarray(extra.get("diverging", 0))))
+    # r-hat on the identified quantities (counterfactual + sigma); needs >= 2 chains
+    if n_chains >= 2:
+        rhat_cf = np.asarray(diagnostics.split_gelman_rubin(cf_g))
+        rhat_s = float(diagnostics.split_gelman_rubin(sig_g[..., None])[0])
+        max_rhat = float(np.nanmax(np.append(rhat_cf, rhat_s)))
+    else:
+        max_rhat = float("nan")
+    return {"counterfactual": cf, "sigma": sig, "accept_prob": accept,
+            "n_divergent": n_div, "max_rhat": max_rhat}

--- a/mlsynth/utils/bfsc_helpers/plotter.py
+++ b/mlsynth/utils/bfsc_helpers/plotter.py
@@ -1,0 +1,35 @@
+"""Observed vs BFSC counterfactual plot with the posterior credible band."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .structures import BFSCResults
+
+
+def plot_bfsc(results: BFSCResults, title: str | None = None) -> None:
+    """Plot the observed series, the BFSC counterfactual, and its credible band."""
+    inputs = results.inputs
+    inf = results.inference_detail
+    time = np.asarray(inputs.time_labels)
+    T0 = inputs.T0
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+    ax.plot(time, inputs.y_target, color="black", linewidth=2,
+            label=f"Observed: {inputs.treated_unit_name}")
+    ax.plot(time, inf.counterfactual_mean, color="tab:red", linestyle="--",
+            linewidth=1.8, label="BFSC counterfactual")
+    ax.fill_between(time, inf.counterfactual_lower, inf.counterfactual_upper,
+                    color="tab:red", alpha=0.2,
+                    label=f"{int(round((1 - inf.ci_alpha) * 100))}% credible interval")
+    if T0 < len(time):
+        ax.axvline(x=time[T0], color="gray", linestyle=":", label="Treatment start")
+    if title is None:
+        att = inf.att_mean
+        att_str = "" if np.isnan(att) else f", ATT={att:.3f}"
+        title = f"BFSC counterfactual: {inputs.treated_unit_name}{att_str}"
+    ax.set_title(title, loc="left", fontsize=10)
+    ax.set_xlabel("Time"); ax.set_ylabel("Outcome")
+    ax.legend(loc="best", frameon=True, fontsize=9); ax.grid(alpha=0.25)
+    plt.tight_layout(); plt.show(); plt.close(fig)

--- a/mlsynth/utils/bfsc_helpers/setup.py
+++ b/mlsynth/utils/bfsc_helpers/setup.py
@@ -1,0 +1,41 @@
+"""Long-DataFrame -> NumPy boundary for BFSC (wraps ``dataprep``)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from ...exceptions import MlsynthDataError
+from ..datautils import dataprep
+from .structures import BFSCInputs
+
+
+def prepare_bfsc_inputs(
+    df: pd.DataFrame, outcome: str, unitid: str, time: str, treat: str,
+) -> BFSCInputs:
+    """Pivot a long panel into BFSC's ``(J, T)`` matrix (treated first)."""
+    prepared = dataprep(df, unitid, time, outcome, treat)
+    if "cohorts" in prepared:
+        raise MlsynthDataError(
+            "BFSC supports a single treated unit; the panel appears to "
+            "contain multiple treatment cohorts."
+        )
+    y_target = np.asarray(prepared["y"], dtype=float)          # (T,)
+    donors = np.asarray(prepared["donor_matrix"], dtype=float)  # (T, N)
+    if donors.ndim != 2 or donors.shape[1] < 1:  # pragma: no cover - dataprep guards
+        raise MlsynthDataError("BFSC requires a 2D donor matrix with >= 1 donor.")
+    T = int(prepared["total_periods"])
+    T0 = int(prepared["pre_periods"])
+    if T0 < 2:
+        raise MlsynthDataError(f"BFSC needs at least 2 pre-treatment periods; got {T0}.")
+    if T - T0 < 1:  # pragma: no cover - a treated period forces >= 1 post
+        raise MlsynthDataError("BFSC needs at least 1 post-treatment period.")
+    Y = np.vstack([y_target[None, :], donors.T])               # (J, T), treated row 0
+    if not np.isfinite(Y).all():
+        raise MlsynthDataError("BFSC requires a balanced panel with no missing outcomes.")
+    return BFSCInputs(
+        Y=Y, y_target=y_target, T0=T0, T=T, J=Y.shape[0],
+        treated_unit_name=str(prepared.get("treated_unit_name", "treated")),
+        donor_names=list(prepared.get("donor_names", range(donors.shape[1]))),
+        time_labels=np.asarray(prepared["time_labels"]),
+    )

--- a/mlsynth/utils/bfsc_helpers/structures.py
+++ b/mlsynth/utils/bfsc_helpers/structures.py
@@ -1,0 +1,117 @@
+"""Typed containers for the BFSC estimator (Pinkney 2021)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+import numpy as np
+from pydantic import ConfigDict, model_validator
+
+from ...config_models import (
+    BaseEstimatorResults,
+    EffectsResults,
+    FitDiagnosticsResults,
+    InferenceResults,
+    MethodDetailsResults,
+    TimeSeriesResults,
+    WeightsResults,
+)
+
+
+@dataclass(frozen=True)
+class BFSCInputs:
+    """Panel arrays fed into the BFSC sampler (treated unit is row 0)."""
+
+    Y: np.ndarray                 # (J, T) treated first, then donors
+    y_target: np.ndarray          # (T,) treated outcome, all periods
+    T0: int
+    T: int
+    J: int
+    treated_unit_name: str
+    donor_names: Sequence
+    time_labels: np.ndarray
+
+
+@dataclass(frozen=True)
+class BFSCPosterior:
+    """Posterior draws relevant to the counterfactual and diagnostics."""
+
+    counterfactual: np.ndarray    # (n_draws, T) treated counterfactual, unscaled
+    sigma: np.ndarray             # (n_draws,) idiosyncratic scale (scaled units)
+    n_factors: int
+    n_draws: int
+    accept_prob: float
+    n_divergent: int
+    max_rhat: float
+
+
+@dataclass(frozen=True)
+class BFSCInference:
+    """Posterior summaries of the counterfactual, ATT, and credible bands."""
+
+    counterfactual_mean: np.ndarray
+    counterfactual_lower: np.ndarray
+    counterfactual_upper: np.ndarray
+    att_mean: float
+    att_lower: float
+    att_upper: float
+    att_samples: np.ndarray
+    ci_alpha: float
+
+
+class BFSCResults(BaseEstimatorResults):
+    """Top-level container returned by ``BFSC.fit`` (an ``EffectResult``)."""
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    inputs: BFSCInputs
+    posterior: BFSCPosterior
+    inference_detail: BFSCInference
+
+    @model_validator(mode="after")
+    def _populate(self) -> "BFSCResults":
+        if self.effects is not None:  # pragma: no cover - idempotency guard
+            return self
+        inf = self.inference_detail
+        labels = np.asarray(self.inputs.time_labels)
+        T0, T = self.inputs.T0, self.inputs.T
+        y_obs = np.asarray(self.inputs.y_target, dtype=float)
+        cf = np.asarray(inf.counterfactual_mean, dtype=float)
+        gap = y_obs - cf
+        pre_rmse = float(np.sqrt(np.mean(gap[:T0] ** 2))) if T0 > 0 else float("nan")
+        att_se = float(np.std(inf.att_samples)) if inf.att_samples.size else None
+
+        object.__setattr__(self, "effects", EffectsResults(
+            att=None if np.isnan(inf.att_mean) else float(inf.att_mean),
+            att_std_err=att_se))
+        object.__setattr__(self, "time_series", TimeSeriesResults(
+            observed_outcome=y_obs,
+            counterfactual_outcome=cf,
+            estimated_gap=gap,
+            time_periods=labels,
+            intervention_time=(labels[T0] if T0 < T else None)))
+        object.__setattr__(self, "weights", WeightsResults(
+            donor_weights={},   # a factor model has no explicit donor weights
+            summary_stats={
+                "model": "Bayesian latent factor (horseshoe+ loadings)",
+                "n_factors": int(self.posterior.n_factors),
+                "sigma_post_mean": float(np.mean(self.posterior.sigma)),
+                "nuts_accept_prob": float(self.posterior.accept_prob),
+                "nuts_divergences": int(self.posterior.n_divergent),
+                "max_rhat": float(self.posterior.max_rhat)}))
+        object.__setattr__(self, "fit_diagnostics", FitDiagnosticsResults(
+            rmse_pre=None if np.isnan(pre_rmse) else float(pre_rmse)))
+        object.__setattr__(self, "inference", InferenceResults(
+            standard_error=att_se,
+            ci_lower=None if np.isnan(inf.att_lower) else float(inf.att_lower),
+            ci_upper=None if np.isnan(inf.att_upper) else float(inf.att_upper),
+            confidence_level=float(1.0 - inf.ci_alpha),
+            method="bayesian_posterior",
+            details=inf))
+        object.__setattr__(self, "method_details", MethodDetailsResults(
+            method_name="BFSC", is_recommended=True))
+        return self
+
+
+BFSCResults.model_rebuild()


### PR DESCRIPTION
Adds `BFSC`, a Bayesian latent-factor synthetic control (Pinkney 2021, arXiv:2103.16244), and integrates it navigationally with the existing Bayesian SC estimators.

## What it is

BFSC fits the no-intervention outcome of every unit with a Bayesian latent-factor model (`y_jt = f_t·λ_j + δ_t + κ_j + noise`), masks the treated post-period as missing data, and reads the counterfactual off the posterior — so the effect comes with a full credible band that propagates factor uncertainty, and a horseshoe+ prior on the loadings makes the factor count a soft upper bound rather than a fixed choice. Unlike the weighting-based Bayesian SCs, it reports no donor weights: it models the outcome, not a donor average.

The posterior is drawn with NUTS via NumPyro, behind the existing `[bayes]` optional dependency (as `SPOTSYNTH` already does); a guarded import raises a clear error when the extra is missing.

## Estimator

- `mlsynth/estimators/bfsc.py` — thin `BFSC` class returning a `BFSCResults` (`EffectResult` on the two-family contract).
- `mlsynth/utils/bfsc_helpers/` — `config.py` (`BFSCConfig`), `model.py` (the NumPyro model + monkeypatchable backend import), `setup.py` (dataprep wrapper, treated in row 0), `structures.py` (typed inputs/posterior/inference/results), `plotter.py`.
- Wired into `mlsynth/__init__.py` (import + `__all__`), `config_models.py` (lazy `BFSCConfig` re-export), and the result-contract test.

## Validation

Cross-validated against the author's own reference — the paper's appendix Stan program — on the German reunification panel: the NumPyro posterior counterfactual matches the Stan posterior cell-for-cell (correlation 0.999999, max discrepancy 0.48% of level, σ̂ to four decimals), the residual being Monte-Carlo error between two independent NUTS runs. Reproduces the classical result (mean post-1990 ATT near −1600 PPP-USD per capita, a credible band that widens post-period). Durable case: `benchmarks/cases/bfsc_germany.py` (registered as `bfsc_germany`).

## Tests

`mlsynth/tests/test_bfsc.py` — config validation, smoke/`EffectResult`, effect-sign recovery, pre-fit, plotting, and a missing-dependency guard test. The result contract is pinned in `test_result_contract.py`. Full suite green locally (146 passed, 4 skipped).

## Docs

- `docs/bfsc.rst` (when-to-use, notation on the canon, assumptions, inference, example, verification) + `docs/replications/bfsc.rst`, wired into the toctrees and `references.rst` (`[BFSC2021]`).
- Navigational integration of the Bayesian SC family rather than a code merge into BSCM: the three estimators are distinct methods (weight shrinkage, soft-simplex selection, latent-factor model) with near-disjoint surfaces. A shared "The Bayesian SC family" cross-reference block on `docs/bfsc.rst`, `docs/bscm.rst`, `docs/bvss.rst` distinguishes them by what carries the prior; the decision tree (`docs/choose.rst`) routes BFSC at the latent-factor gate (Q1.4) with an FMA-vs-BFSC remark and a "which Bayesian synthetic control" remark, and adds it to the at-a-glance map and failure-mode index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012y2a5QT6AVGcoizpCuc8zW)_