### PR TITLE
DPSC: differentially private synthetic control (Rho, Cummings & Misra 2023)

### DIFF
--- a/benchmarks/cases/dpsc_prop99.py
+++ b/benchmarks/cases/dpsc_prop99.py
@@ -1,0 +1,128 @@
+"""Cross-validation benchmark: DPSC vs the authors' ``srho1/dpsc`` (Prop 99).
+
+Cross-validates ``mlsynth``'s differentially private synthetic-control mechanisms
+against the authors' own ``PrivateSC`` (Rho, Cummings & Misra 2023) on the
+Abadie-Diamond-Hainmueller Proposition 99 smoking panel
+(``basedata/smoking_data.csv``: California treated from 1989, 38 donors,
+``T0 = 19`` pre-periods).
+
+Both implementations are randomized. ``numpy.random`` seeds the authors' global
+RNG; ``numpy.random.RandomState`` seeds mlsynth's -- the two are the same
+Mersenne-Twister stream, so a shared seed makes the privatized output
+reproducible on both sides. On the identical panel, matched seed, and matched
+budget (``lambda = 10``, ``eps1 = eps2 = 50``), mlsynth reproduces the authors'
+private coefficients and private counterfactual value-for-value, for both the
+output-perturbation (Algorithm 2) and objective-perturbation (Algorithm 3)
+mechanisms. Path A / cross-validation (scenario 3). Skips gracefully when the
+authors' clone is unavailable.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_BASE = Path(__file__).resolve().parents[2] / "basedata"
+_T0, _LAMBDA, _EPS = 19, 10.0, 50.0
+_SEED = 0
+
+
+def _panel_arrays():
+    from mlsynth.utils.datautils import dataprep
+    df = pd.read_csv(_BASE / "smoking_data.csv")
+    df["treat"] = df["Proposition 99"].astype(int)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        prep = dataprep(df, "state", "year", "cigsale", "treat")
+    y = np.asarray(prep["y"], float).flatten()
+    D = np.asarray(prep["donor_matrix"], float)
+    return y, D
+
+
+def _reference(pre_donor, pre_target, donor_full, mechanism):
+    """Run the authors' PrivateSC under the global-RNG seed; return (weights, pred)."""
+    from benchmarks.reference.clone_dpsc import import_private_sc
+    psc_mod = import_private_sc()
+    method = "out" if mechanism == "output" else "obj"
+    pre_donor_df = pd.DataFrame(pre_donor)
+    pre_target_df = pd.DataFrame(pre_target.reshape(-1, 1))
+    donor_full_df = pd.DataFrame(donor_full)
+    np.random.seed(_SEED)
+    psc = psc_mod.PrivateSC()
+    psc.set_params(method=method, lmbda=_LAMBDA, eps1=_EPS, eps2=_EPS, delta=0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        psc.fit(pre_donor_df, pre_target_df, fit_intercept=False)
+        pred = psc.predict(donor_full_df).values.flatten()
+    return np.asarray(psc.weights, float).flatten(), pred
+
+
+def _mlsynth(pre_donor, pre_target, donor_full, mechanism):
+    from mlsynth.utils.dpsc_helpers.mechanisms import (
+        run_objective_perturbation, run_output_perturbation)
+    run = run_output_perturbation if mechanism == "output" else run_objective_perturbation
+    cf, w, _ = run(np.random.RandomState(_SEED), pre_donor, pre_target, donor_full,
+                   _LAMBDA, _EPS, _EPS)
+    return w, cf
+
+
+def run() -> dict:
+    y, D = _panel_arrays()
+    pre_donor, pre_target, donor_full = D[:_T0], y[:_T0], D
+    out = {"n_donors": float(D.shape[1]), "T0": float(_T0)}
+    for mech in ("output", "objective"):
+        wr, pr = _reference(pre_donor, pre_target, donor_full, mech)   # skips if no clone
+        wm, pm = _mlsynth(pre_donor, pre_target, donor_full, mech)
+        tag = "out" if mech == "output" else "obj"
+        out[f"{tag}_weights_vs_ref"] = float(np.max(np.abs(wm - wr)))
+        out[f"{tag}_pred_vs_ref"] = float(np.max(np.abs(pm - pr)))
+    return out
+
+
+def comparison() -> dict:
+    """mlsynth DPSC mechanisms vs the authors' PrivateSC on Prop 99, matched seed.
+
+    Pairs the privatized coefficient norm and the privatized counterfactual's
+    post-period mean for both mechanisms -- the quantities the mechanism actually
+    releases -- side by side.
+    """
+    y, D = _panel_arrays()
+    pre_donor, pre_target, donor_full = D[:_T0], y[:_T0], D
+    post = slice(_T0, D.shape[0])
+    rows = []
+    for mech in ("output", "objective"):
+        wr, pr = _reference(pre_donor, pre_target, donor_full, mech)
+        wm, pm = _mlsynth(pre_donor, pre_target, donor_full, mech)
+        tag = "OutputPerturb" if mech == "output" else "ObjectivePerturb"
+        rows.append({"quantity": f"{tag}: ||private weights||",
+                     "mlsynth": round(float(np.linalg.norm(wm)), 6),
+                     "reference": round(float(np.linalg.norm(wr)), 6)})
+        rows.append({"quantity": f"{tag}: private counterfactual mean (post)",
+                     "mlsynth": round(float(np.mean(pm[post])), 6),
+                     "reference": round(float(np.mean(pr[post])), 6)})
+    return {
+        "rows": rows,
+        "mlsynth_call": {"estimator": "DPSC",
+                         "config": {"mechanism": "output|objective",
+                                    "ridge_lambda": _LAMBDA,
+                                    "epsilon1": _EPS, "epsilon2": _EPS, "seed": _SEED}},
+        "reference": {"impl": "srho1/dpsc PrivateSC (differentially private SC)",
+                      "version": "@0be4eba"},
+    }
+
+
+# Validated value-for-value against srho1/dpsc @ 0be4eba on Prop 99 (lambda=10,
+# eps1=eps2=50, seed 0): under the shared Mersenne-Twister stream mlsynth
+# reproduces the authors' private coefficients and private counterfactual to
+# solver tolerance, for both mechanisms (objective solved in closed form vs the
+# authors' cvxpy).
+EXPECTED = {
+    "n_donors": (38.0, 0.0),
+    "T0": (19.0, 0.0),
+    "out_weights_vs_ref": (0.0, 1e-9),
+    "out_pred_vs_ref": (0.0, 1e-8),
+    "obj_weights_vs_ref": (0.0, 1e-5),
+    "obj_pred_vs_ref": (0.0, 1e-5),
+}

--- a/benchmarks/reference/clone_dpsc.py
+++ b/benchmarks/reference/clone_dpsc.py
@@ -1,0 +1,46 @@
+"""On-demand clone of the Rho-Cummings-Misra (2023) DP synthetic-control repo.
+
+The authors' code (https://github.com/srho1/dpsc) is cloned at a pinned commit
+into a local cache; the benchmark imports its ``PrivateSC`` and
+``SyntheticControl`` classes from there. If git and the codeload tarball are
+both unavailable the benchmark skips gracefully.
+
+Bump ``_COMMIT`` deliberately, never silently.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from benchmarks.compare import BenchmarkSkipped
+from benchmarks.reference._fetch import fetch_pinned_repo
+
+_REPO = "https://github.com/srho1/dpsc.git"
+_COMMIT = "0be4eba6a162d61fd8262ab06c4ab44d2b371817"
+_CACHE = Path(__file__).resolve().parent / ".cache" / "dpsc"
+
+
+def _ensure_clone() -> Path:
+    """Clone (or reuse) the reference repo pinned at ``_COMMIT``. Returns its path."""
+    marker = _CACHE / "src" / "private_synthetic_control.py"
+    if marker.exists():
+        return _CACHE
+    _CACHE.parent.mkdir(parents=True, exist_ok=True)
+    fetch_pinned_repo(_REPO, _COMMIT, _CACHE)
+    if not marker.exists():  # pragma: no cover - defensive
+        raise BenchmarkSkipped("reference clone missing private_synthetic_control.py")
+    return _CACHE
+
+
+def import_private_sc() -> ModuleType:
+    """Import the authors' ``src.private_synthetic_control`` from the pinned clone."""
+    path = _ensure_clone()
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+    try:
+        return importlib.import_module("src.private_synthetic_control")
+    except ImportError as exc:  # pragma: no cover - e.g. sklearn/cvxpy missing
+        raise BenchmarkSkipped(
+            f"reference src.private_synthetic_control import failed: {exc}") from exc

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -76,6 +76,7 @@ CASES = {
     "spsc_ifem_mc": "benchmarks.cases.spsc_ifem_mc",          # Path B: SPSC IFEM recovery + DT-vs-NoDT coverage (Park-Tchetgen)
     "spsc_prop99": "benchmarks.cases.spsc_prop99",            # Path A/X: SPSC California (Prop 99) linear effect path vs qkrcks0218/SPSC
     "spsc_panic": "benchmarks.cases.spsc_panic",              # Path A/X: SPSC averaged-treated Panic of 1907 vs qkrcks0218/SPSC
+    "dpsc_prop99": "benchmarks.cases.dpsc_prop99",            # cross-val vs srho1/dpsc (differentially private SC, Prop 99, bit-for-bit both mechanisms)
     "scul_prop99": "benchmarks.cases.scul_prop99",            # Path A/X: SCUL California (Prop 99) lasso SC vs hollina/scul
     "dr_proximal_mc": "benchmarks.cases.dr_proximal_mc",      # Path B: DR/PIPW recovery + double-robustness (Qiu et al. normal DGP)
     "dr_proximal_brazil": "benchmarks.cases.dr_proximal_brazil",  # cross-val vs LIVE R (authors' analysis.Rmd commit 3bcb5ec): over-identified DR-OID, Brazil vaccine/pneumonia

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -491,6 +491,17 @@ the pre-period and predict the post-period worse.
   matter -- :doc:`beast` (covariate-balancing weights under sparsity, with a
   doubly-robust, analytically-inferred ATT).
 
+*A privacy constraint on the donors.* If the donor pool is sensitive -- patient
+records in a clinical external-control arm, proprietary firm-level series in a
+data cooperative -- and the counterfactual must be released externally,
+:doc:`dpsc` (Rho, Cummings and Misra, 2023) is the only estimator here with a
+formal privacy guarantee: a ridge synthetic control fitted with differentially
+private empirical risk minimisation, so publishing the effect leaks a provably
+bounded amount about any single donor. It buys a privacy certificate, not a
+better point estimate, and it is worth its accuracy cost only when the donor
+pool is large and the pre-period long; on the usual small donor pool, and for
+public aggregates, prefer :doc:`vanillasc`.
+
 *Dense versus sparse weights -- when to relax SCM.* Standard synthetic control
 constrains the weights to the simplex, which (as Doudchenko and Imbens (2016)
 observe) tends to produce *sparse* solutions loading on a handful of donors. Two

--- a/docs/dpsc.rst
+++ b/docs/dpsc.rst
@@ -1,0 +1,294 @@
+Differentially Private Synthetic Control (DPSC)
+===============================================
+
+.. currentmodule:: mlsynth
+
+Overview
+--------
+
+``DPSC`` is a synthetic control estimator that releases its counterfactual under
+a formal privacy guarantee (Rho, Cummings & Misra 2023). It answers a question
+none of the other estimators in mlsynth address: when the donor pool is
+sensitive -- patient records in a clinical external-control arm, proprietary
+firm-level series in a data cooperative -- how do you publish the synthetic
+control, and the effect it implies, without leaking any single donor's data?
+
+The estimator is a ridge synthetic control fitted with differentially private
+empirical risk minimisation. The pre-period regression coefficients are learned
+privately, the post-intervention donor matrix is privatised, and the released
+counterfactual is formed from the two. Differential privacy then bounds, in a
+mathematically precise sense, how much an adversary who sees the released
+output can learn about any one donor.
+
+Privacy is not free. The released estimate is a single draw of a randomised
+mechanism, and the noise trades off against accuracy at a rate controlled by
+the privacy budget. ``DPSC`` reports that noise honestly as the dominant source
+of uncertainty.
+
+When to use this estimator
+--------------------------
+
+* The donor pool is sensitive or proprietary -- the donors are people or
+  entities whose individual series must be protected -- and the counterfactual
+  or the effect will be released externally (to a regulator, a publication, a
+  counterparty).
+* You need a provable, quantifiable privacy guarantee (an :math:`\varepsilon`),
+  not ad hoc de-identification.
+* The donor pool is reasonably large and the pre-period long: the privacy noise
+  averages down with panel size, so this is where differential privacy is
+  affordable.
+
+Do not reach for it for ordinary policy evaluation on public aggregates
+(Proposition 99 states, country GDP, your own first-party stores). There is no
+individual to protect, and the accuracy cost is then pure loss -- use
+:doc:`vanillasc` instead. On a small donor pool the privacy noise is large; see
+the honest caveat below.
+
+Notation
+--------
+
+Let :math:`j = 1` denote the treated unit and
+:math:`\mathcal{N}_0 \coloneqq \{2, \dots, N\}` the donor pool of cardinality
+:math:`N_0`. Time runs over :math:`t \in \{1, \dots, T\}`, 1-indexed; the
+intervention takes effect after period :math:`T_0`, splitting time into the
+pre-period :math:`\mathcal{T}_1 \coloneqq \{t : t \le T_0\}` of length
+:math:`T_0` and the post-period :math:`\mathcal{T}_2 \coloneqq \{t : t > T_0\}`.
+
+The treated series is :math:`\mathbf{y}_1 = (y_{11}, \dots, y_{1T})^\top`, and
+the donor outcomes stack into
+:math:`\mathbf{Y}_0 \coloneqq [\mathbf{y}_j]_{j \in \mathcal{N}_0} \in
+\mathbb{R}^{T \times N_0}` (one column per donor);
+:math:`\mathbf{Y}_{0,\mathcal{T}_1} \in \mathbb{R}^{T_0 \times N_0}` is its
+pre-period block. Regression weights are :math:`\mathbf{f} \in \mathbb{R}^{N_0}`
+-- unlike the canonical simplex weights :math:`\mathbf{w}` of :doc:`vanillasc`,
+these are unconstrained ridge coefficients. The synthetic counterfactual is
+:math:`\widehat{\mathbf{y}}_1 \coloneqq \mathbf{Y}_0\,\widehat{\mathbf{f}}` with
+entries :math:`\widehat{y}_{1t}`, the per-period effect is
+:math:`\tau_t \coloneqq y_{1t} - \widehat{y}_{1t}`, and the ATT is
+:math:`\widehat{\tau} \coloneqq |\mathcal{T}_2|^{-1} \sum_{t \in \mathcal{T}_2}
+\tau_t`.
+
+The privacy parameters are the budgets :math:`\varepsilon_1` (Stage 1,
+coefficients) and :math:`\varepsilon_2` (Stage 2, released donors), with total
+budget :math:`\varepsilon = \varepsilon_1 + \varepsilon_2`; the approximate-DP
+slack is :math:`\delta`; the ridge penalty is :math:`\lambda`; and
+:math:`\Delta` denotes an :math:`\ell_2` sensitivity. The significance level is
+:math:`\alpha`.
+
+Differential privacy
+--------------------
+
+A randomised mechanism :math:`\mathcal{M}` is
+:math:`(\varepsilon, \delta)`-differentially private (Dwork et al. 2006) if for
+every pair of neighbouring datasets :math:`\mathcal{D}, \mathcal{D}'` and every
+measurable set :math:`S` of outputs,
+
+.. math::
+
+   \Pr[\mathcal{M}(\mathcal{D}) \in S] \le
+   e^{\varepsilon}\, \Pr[\mathcal{M}(\mathcal{D}') \in S] + \delta.
+
+Smaller :math:`\varepsilon` is stronger privacy; :math:`\delta = 0` is pure
+:math:`\varepsilon`-DP. The crux for synthetic control is what "neighbouring"
+means. Synthetic control regresses *vertically* -- each time point is a sample,
+each donor a feature -- so changing one donor changes an entire *column* of the
+design. A neighbouring dataset therefore replaces one donor's whole series
+:math:`\mathbf{y}_j`, and the privacy guarantee protects donors, not the
+treated unit (Rho et al. 2023, Sec 3).
+
+Privacy is calibrated to sensitivity, the largest change in a statistic that
+swapping one donor can cause. For a mechanism releasing a vector :math:`g`, the
+Laplace mechanism adds noise scaled to its :math:`\ell_2` sensitivity
+:math:`\Delta_g \coloneqq \max_{\mathcal{D} \sim \mathcal{D}'} \lVert
+g(\mathcal{D}) - g(\mathcal{D}') \rVert_2`; here noise is drawn from the
+high-dimensional Laplace distribution (a magnitude :math:`\sim
+\mathrm{Lap}(\cdot)` times a uniform direction; Chaudhuri, Monteleoni & Sarwate
+2011).
+
+Identifying assumptions
+-----------------------
+
+DPSC inherits the synthetic-control identifying assumptions and adds the
+conditions differential privacy needs.
+
+1. Pre-treatment fit. There exist coefficients :math:`\mathbf{f}` under which
+   the donors reproduce the treated pre-period path,
+   :math:`y_{1t} \approx (\mathbf{Y}_0 \mathbf{f})_t` for
+   :math:`t \in \mathcal{T}_1`.
+
+   *Remark.* As in :doc:`vanillasc`, a good pre-fit is the empirical certificate
+   of a credible counterfactual. The ridge penalty :math:`\lambda` trades a
+   little pre-fit for a lower sensitivity (see below), so under privacy the fit
+   is deliberately shrunk.
+
+2. No anticipation. Treatment has no effect before :math:`T_0`, so the
+   pre-period outcomes reflect the no-intervention path.
+
+   *Remark.* Date :math:`T_0` at the first plausible response, not the nominal
+   policy date; a contaminated pre-period biases the extrapolated counterfactual.
+
+3. No interference and untreated donors (SUTVA). The treatment of unit
+   :math:`1` does not change any donor's outcome, and every donor is untreated,
+   so :math:`\mathbf{Y}_0` carries only no-intervention outcomes.
+
+4. Bounded donor data. The donor observations lie in a bounded range, so the
+   sensitivity :math:`\Delta` is finite and the noise calibration is valid.
+
+   *Remark.* This is the additional condition privacy demands. It is what makes
+   the influence of any single donor's series bounded, hence privatisable; the
+   sensitivity bound below assumes it. Unbounded or heavy-tailed donors break
+   the guarantee and must be clipped before fitting.
+
+Note that differential privacy is a property of the release *mechanism*, not of
+the data-generating process, so DPSC needs no homoskedasticity or
+exchangeability assumption for its privacy guarantee -- those enter only when
+one interprets the ATT causally, exactly as in the non-private synthetic
+control.
+
+Mathematical formulation
+------------------------
+
+The base estimator is a ridge synthetic control: on the pre-period,
+
+.. math::
+
+   \widehat{\mathbf{f}} = \operatorname*{argmin}_{\mathbf{f} \in \mathbb{R}^{N_0}}
+   \; \bigl\lVert \mathbf{y}_{1,\mathcal{T}_1} -
+   \mathbf{Y}_{0,\mathcal{T}_1} \mathbf{f} \bigr\rVert_2^2
+   + \tfrac{\lambda}{2} \lVert \mathbf{f} \rVert_2^2 ,
+
+and the counterfactual extrapolates it, :math:`\widehat{\mathbf{y}}_1 =
+\mathbf{Y}_0 \widehat{\mathbf{f}}`. Privacy is injected in two independent
+stages.
+
+Stage 1 -- private coefficients. Two mechanisms are offered.
+
+*Output perturbation* (Algorithm 2) fits :math:`\widehat{\mathbf{f}}` and adds
+high-dimensional Laplace noise calibrated to the coefficient sensitivity
+
+.. math::
+
+   \Delta = \frac{4\, T_0 \sqrt{8 + N_0}}{\lambda},
+   \qquad
+   \widetilde{\mathbf{f}} = \widehat{\mathbf{f}}
+   + \mathrm{Lap}\!\left(\tfrac{\Delta}{\varepsilon_1}\right).
+
+The sensitivity grows with the pre-period length :math:`T_0` and the donor
+count :math:`N_0` (a longer or wider design is more exposed to one donor's
+change) and shrinks with :math:`\lambda` (regularisation damps any donor's
+influence). Larger :math:`\lambda` therefore buys less noise at the cost of a
+more biased, shrunken fit.
+
+*Objective perturbation* (Algorithm 3) instead perturbs the objective with a
+random linear term :math:`\mathbf{b}` and solves exactly,
+
+.. math::
+
+   \widetilde{\mathbf{f}} = \operatorname*{argmin}_{\mathbf{f}}
+   \; \bigl\lVert \mathbf{y}_{1,\mathcal{T}_1} -
+   \mathbf{Y}_{0,\mathcal{T}_1} \mathbf{f} \bigr\rVert_2^2
+   + \tfrac{\lambda + \Delta_c}{2} \lVert \mathbf{f} \rVert_2^2
+   + \mathbf{b}^\top \mathbf{f} ,
+
+with :math:`\mathbf{b}` Laplace (pure :math:`\varepsilon`-DP, :math:`\delta =
+0`) or Gaussian (:math:`(\varepsilon, \delta)`-DP), and a curvature slack
+:math:`\Delta_c \ge 0` added when the base regularisation is too weak for the
+requested budget (Kifer, Smith & Thakurta 2012). Because the noise enters the
+objective rather than the solution, the optimiser keeps
+:math:`\widetilde{\mathbf{f}}` bounded, which is why objective perturbation is
+far more stable than output perturbation on typical panels.
+
+Stage 2 -- private release. The released donor matrix is privatised,
+:math:`\widetilde{\mathbf{Y}}_0 = \mathbf{Y}_0 +
+\mathrm{Lap}(2\sqrt{R}/\varepsilon_2)` over the :math:`R` released rows, and the
+counterfactual is :math:`\widehat{\mathbf{y}}_1 = \widetilde{\mathbf{Y}}_0\,
+\widetilde{\mathbf{f}}`.
+
+Privacy and accuracy. By the composition theorem the release is
+:math:`\varepsilon`-DP with :math:`\varepsilon = \varepsilon_1 +
+\varepsilon_2`. Relative to the non-private estimator, the root-mean-square
+error inflates by a factor :math:`O(1/\varepsilon)` -- the unavoidable price of
+privacy (Rho et al. 2023, Sec C).
+
+Inference
+---------
+
+The privatised release is one draw of a randomised mechanism, so its dominant
+uncertainty is the privacy noise itself. ``DPSC`` reports the released
+counterfactual and ATT from a single seeded draw, and quantifies the noise by
+the Monte Carlo standard deviation of the ATT over ``n_draws`` independent
+privatised draws, giving :math:`\widehat{\tau} \pm z_{1 - \alpha/2}\,
+\widehat{\mathrm{se}}`. The non-private ridge ATT (the
+:math:`\varepsilon \to \infty` target) is recorded alongside, so the privacy
+cost is visible directly.
+
+A caveat, stated plainly. Output perturbation is unusable on a small donor pool:
+the coefficient noise inflates :math:`\lVert \widetilde{\mathbf{f}} \rVert` and
+the Stage-2 term amplifies it, so a single release can be off by many multiples
+of the effect even at a nominal budget. Objective perturbation (the default) is
+the viable mechanism, but even it roughly doubles the effective uncertainty at
+weak privacy, and meaningful privacy (:math:`\varepsilon \approx 1`) on a
+few-dozen-donor panel costs a biased estimate with a wide band. The favourable
+regime is a large donor pool and a long pre-period, where the noise averages
+down.
+
+Example
+-------
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import DPSC
+
+   df = pd.read_csv(
+       "https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
+       "refs/heads/main/basedata/smoking_data.csv"
+   )
+   df["treat"] = (df["Proposition 99"]).astype(int)
+
+   res = DPSC({
+       "df":         df,
+       "outcome":    "cigsale",
+       "treat":      "treat",
+       "unitid":     "state",
+       "time":       "year",
+       "mechanism":  "objective",   # or "output"
+       "epsilon1":   1.0,           # Stage 1 budget (coefficients)
+       "epsilon2":   1.0,           # Stage 2 budget (released donors)
+       "ridge_lambda": 10.0,
+       "n_draws":    500,           # privacy-noise Monte Carlo
+       "seed":       0,
+       "display_graphs": False,
+   }).fit()
+
+   print(res.effects.att)                              # the private ATT (one release)
+   print(res.inference.standard_error)                 # the privacy noise
+   print(res.inference.details["att_non_private"])     # the epsilon -> infinity target
+
+Verification
+------------
+
+DPSC is cross-validated against the authors' own code (``srho1/dpsc``) on the
+Proposition 99 panel. Under a shared Mersenne-Twister seed, mlsynth reproduces
+the authors' private coefficients and private counterfactual value-for-value for
+both mechanisms (the objective program solved in closed form against their
+cvxpy), to solver tolerance. See the durable benchmark case
+`benchmarks/cases/dpsc_prop99.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/dpsc_prop99.py>`_
+and the :doc:`replications/dpsc` page.
+
+Core API
+--------
+
+.. automodule:: mlsynth.estimators.dpsc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Configuration
+-------------
+
+.. autoclass:: mlsynth.utils.dpsc_helpers.config.DPSCConfig
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/dpsc.rst
+++ b/docs/dpsc.rst
@@ -232,6 +232,27 @@ few-dozen-donor panel costs a biased estimate with a wide band. The favourable
 regime is a large donor pool and a long pre-period, where the noise averages
 down.
 
+Scaling with the donor pool. The two mechanisms respond oppositely to more
+donors, and the reason is instructive. The coefficient sensitivity
+:math:`\Delta = 4 T_0 \sqrt{8 + N_0} / \lambda` grows as :math:`\sqrt{N_0}`, so a
+wider donor pool raises the raw noise budget. Output perturbation injects that
+noise straight into the coefficients and the counterfactual
+:math:`\mathbf{Y}_0 \widetilde{\mathbf{f}}` amplifies it, so its error does not
+fall -- and can worsen -- as :math:`N_0` grows. Objective perturbation instead
+places the noise inside the regularised program, where the redundancy of a
+low-rank donor pool lets the solver average it out; the averaging beats the
+:math:`\sqrt{N_0}` sensitivity growth, so the privacy noise on the ATT falls with
+:math:`N_0`. In a controlled factor-model sweep (fixed :math:`T_0`,
+:math:`\varepsilon_1 = \varepsilon_2 = 1`) the objective mechanism's ATT
+standard deviation dropped roughly threefold as the pool grew from 5 to 20
+donors and continued down thereafter, while the output mechanism stayed one to
+two orders of magnitude larger. This is the concrete sense in which DPSC is a
+large-donor-pool method: prefer the objective mechanism, and add donors when you
+can. Note the pre-period length enters :math:`\Delta` *linearly*, so lengthening
+:math:`T_0` raises the noise budget faster than widening the pool -- the
+"more data helps" intuition applies cleanly to donors under the objective
+mechanism, not to the pre-period.
+
 Example
 -------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -275,6 +275,7 @@ headline numbers.
    msqrt
    sparse_sc
    beast
+   dpsc
    pda
    scul
    rescm

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -76,6 +76,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    replications/geolift
    replications/orthsc
    replications/beast
+   replications/dpsc
    replications/rolldid
    replications/ppscm
    replications/snn
@@ -393,6 +394,14 @@ High-dimensional donor pools
   :math:`-31.51` by 2000), with a valid balancing (:math:`\sum W = 1`)
   and sparse selection (durable: ``beast_prop99``). See the
   :doc:`dedicated page <replications/beast>`.
+* :doc:`dpsc` -- Rho, Cummings & Misra (2023) differentially private
+  synthetic control. Cross-validation: on California Proposition 99, under
+  a shared Mersenne-Twister seed, mlsynth reproduces the authors' own
+  ``PrivateSC`` private coefficients and private counterfactual
+  value-for-value for both mechanisms -- output perturbation and objective
+  perturbation (the latter solved in closed form against their cvxpy) -- to
+  :math:`\sim 10^{-11}` (durable: ``dpsc_prop99``). See the
+  :doc:`dedicated page <replications/dpsc>`.
 * :doc:`msqrt` -- Shen, Song & Abadie (2025) multivariate
   square-root-Lasso SC for high-dimensional disaggregated data.
   Path B: the Section-6 simulation (true ATT = 0) -- the

--- a/docs/replications/dpsc.rst
+++ b/docs/replications/dpsc.rst
@@ -1,0 +1,79 @@
+.. _replication-dpsc:
+
+DPSC -- Differentially Private Synthetic Control (Proposition 99)
+=================================================================
+
+:Estimator: :doc:`../dpsc` -- :class:`mlsynth.DPSC`
+:Source: Rho, Cummings & Misra (2023), "Differentially Private Synthetic
+   Control" (AISTATS 2023, PMLR v206), with the authors' Python reference
+   (``srho1/dpsc``).
+:Replication type: Cross-validation -- a live run of the authors' own
+   ``PrivateSC`` on the identical panel under a shared random seed.
+:Status: Done -- under the shared Mersenne-Twister stream mlsynth reproduces the
+   authors' private coefficients and private counterfactual value-for-value, for
+   both mechanisms: output perturbation to :math:`\sim 10^{-11}` and objective
+   perturbation to :math:`\sim 10^{-11}` (mlsynth's closed-form objective solve
+   versus the authors' cvxpy).
+:Durable check: ``benchmarks/cases/dpsc_prop99.py`` (``dpsc_prop99``), which
+   clones ``srho1/dpsc`` at a pinned commit on demand; plus
+   ``mlsynth/tests/test_dpsc.py``.
+
+The target
+----------
+
+The authors provide a Python implementation of two differentially private
+synthetic-control mechanisms -- output perturbation (Algorithm 2) and objective
+perturbation (Algorithm 3) -- both built on a ridge synthetic control and
+privatised through differentially private empirical risk minimisation. Their
+experiments run on synthetic random-walk panels; here the same code is exercised
+on the Abadie, Diamond & Hainmueller (2010) Proposition 99 tobacco panel
+(California treated from 1989, 38 donor states, :math:`T_0 = 19` pre-periods),
+so the cross-check runs on a canonical, inspectable design.
+
+Demonstrate-first port
+----------------------
+
+Before wiring anything into mlsynth, the two mechanisms were ported to NumPy and
+validated cell by cell against the authors' code on the identical Proposition 99
+matrices. Both mechanisms are randomised, so the validation pins the randomness:
+``numpy.random`` seeds the authors' global generator and
+``numpy.random.RandomState`` seeds mlsynth's -- the same Mersenne-Twister stream
+-- and the two mechanisms consume their draws in the same order, so a shared
+seed reproduces the private output exactly.
+
+* the non-private ridge coefficients match ``sklearn``'s to machine precision
+  (mlsynth solves the normal equations in closed form);
+* output perturbation (Algorithm 2): the private coefficients and the private
+  counterfactual match the authors' ``PrivateSC`` to :math:`\sim 10^{-11}`;
+* objective perturbation (Algorithm 3): mlsynth solves the perturbed program in
+  closed form (the perturbed normal equations) rather than through cvxpy, and
+  the private weights and counterfactual still match to :math:`\sim 10^{-11}`.
+
+The deterministic noise scales -- the coefficient sensitivity
+:math:`\Delta = 4 T_0 \sqrt{8 + N_0} / \lambda`, the objective curvature term,
+and the Stage-2 donor-noise scale -- match the authors' formulas exactly.
+
+The honest finding
+------------------
+
+The replication also mapped the method's operating envelope on a real panel. The
+private ATT is unbiased in expectation but its variance is large: on the 38-donor
+Proposition 99 panel, output perturbation is unusable -- a single release carries
+ATT noise of tens even at a negligible privacy level -- because the coefficient
+noise inflates the weight norm and the Stage-2 term amplifies it. Objective
+perturbation is the viable mechanism (the ridge term bounds the weights), and it
+is the default; even so, meaningful privacy on a few-dozen-donor panel costs a
+biased estimate with a wide band. Differential privacy is favourable when the
+donor pool is large and the pre-period long, where the noise averages down --
+which is exactly the clinical external-control and cross-party-measurement
+setting the method is built for.
+
+Reproducing
+-----------
+
+.. code-block:: bash
+
+   python benchmarks/run_benchmarks.py --only dpsc_prop99
+
+runs the case against the pinned ``srho1/dpsc`` clone (skips cleanly if the
+clone is unavailable).

--- a/llms.txt
+++ b/llms.txt
@@ -31,6 +31,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **CLUSTERSC** — Cluster-based Synthetic Control estimator.  (config: CLUSTERSCConfig)
 - **CMBSTS** — Causal Multivariate Bayesian Structural Time Series estimator.  (config: CMBSTSConfig)
 - **CTSC** — Continuous-Treatment Synthetic Control estimator.  (config: CTSCConfig)
+- **DPSC** — Differentially private synthetic control estimator.  (config: DPSCConfig)
 - **DSC** — Distributional Synthetic Control estimator.  (config: DSCConfig)
 - **DSCAR** — Dynamic Synthetic Control for Auto-Regressive processes.  (config: DSCARConfig)
 - **DesignComparison** — Result of :func:`compare_methods`.

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -57,6 +57,7 @@ from .estimators.microsynth import MicroSynth
 from .estimators.siv import SIV
 from .estimators.orthsc import ORTHSC
 from .estimators.beast import BEAST
+from .estimators.dpsc import DPSC
 from .estimators.dsc import DSC
 from .estimators.dscar import DSCAR
 from .estimators.spsydid import SpSyDiD
@@ -133,6 +134,7 @@ __all__ = [
     "SIV",
     "ORTHSC",
     "BEAST",
+    "DPSC",
     "SYNDES",
     "SYNDESPower",
     "power_analysis",

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -569,6 +569,7 @@ _RELOCATED_CONFIGS = {
     "SIVConfig": "mlsynth.utils.siv_helpers.config",
     "OrthSCConfig": "mlsynth.utils.orthsc_helpers.config",
     "BEASTConfig": "mlsynth.utils.beast_helpers.config",
+    "DPSCConfig": "mlsynth.utils.dpsc_helpers.config",
     "MAREXConfig": "mlsynth.utils.marex_helpers.config",
     "RMSIConfig": "mlsynth.utils.rmsi_helpers.config",
     "SPOTSYNTHConfig": "mlsynth.utils.spotsynth_helpers.config",

--- a/mlsynth/estimators/dpsc.py
+++ b/mlsynth/estimators/dpsc.py
@@ -1,0 +1,91 @@
+"""DPSC: differentially private synthetic control (Rho, Cummings & Misra 2023).
+
+A ridge synthetic control whose released counterfactual satisfies
+``epsilon``-differential privacy over the donor pool, via differentially private
+empirical risk minimization. The regression coefficients are learned privately
+(output perturbation, Algorithm 2, or objective perturbation, Algorithm 3), and
+the post-intervention donor matrix is privatized before the counterfactual is
+formed -- so publishing the synthetic control leaks a provably bounded amount
+about any single donor.
+
+Use it when the donor pool is sensitive (patient records, proprietary
+firm-level series) and the counterfactual must be released externally. On small
+donor pools the privacy noise is large; the method is favorable when the donor
+pool is big and the pre-period long.
+
+Reference: Rho, Cummings & Misra (2023), *"Differentially Private Synthetic
+Control"*, AISTATS. Authors' code: ``srho1/dpsc``.
+"""
+from __future__ import annotations
+
+from typing import Union
+
+from ..config_models import BaseEstimatorResults
+from ..exceptions import (
+    MlsynthConfigError,
+    MlsynthDataError,
+    MlsynthEstimationError,
+    MlsynthPlottingError,
+)
+from ..utils.dpsc_helpers.config import DPSCConfig
+from ..utils.dpsc_helpers.pipeline import run_dpsc
+from ..utils.dpsc_helpers.plotter import plot_dpsc
+
+try:  # pydantic v2 / v1 compatibility for the error type
+    from pydantic import ValidationError
+except Exception:  # pragma: no cover
+    ValidationError = Exception  # type: ignore
+
+
+class DPSC:
+    """Differentially private synthetic control estimator.
+
+    Parameters
+    ----------
+    config : DPSCConfig or dict
+        Configuration. See
+        :class:`mlsynth.utils.dpsc_helpers.config.DPSCConfig`.
+
+    Returns
+    -------
+    BaseEstimatorResults
+        The released private counterfactual and ATT, with the privacy noise
+        quantified as the standard error / interval, and the non-private ridge
+        ATT recorded for reference in ``method_details``.
+
+    Examples
+    --------
+    >>> from mlsynth import DPSC                                            # doctest: +SKIP
+    >>> res = DPSC({"df": panel, "outcome": "cigsale", "treat": "treat",
+    ...             "unitid": "state", "time": "year",
+    ...             "mechanism": "objective", "epsilon1": 1.0, "epsilon2": 1.0,
+    ...             "display_graphs": False}).fit()
+    >>> res.effects.att                                                     # doctest: +SKIP
+    """
+
+    def __init__(self, config: Union[DPSCConfig, dict]) -> None:
+        if isinstance(config, dict):
+            try:
+                config = DPSCConfig(**config)
+            except ValidationError as exc:
+                raise MlsynthConfigError(str(exc)) from exc
+        self.config: DPSCConfig = config
+
+    def fit(self) -> BaseEstimatorResults:
+        """Fit DPSC and return the standardized results container."""
+        try:
+            results = run_dpsc(self.config)
+        except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive translation
+            raise MlsynthEstimationError(f"DPSC estimation failed: {exc}") from exc
+
+        if self.config.display_graphs:
+            try:
+                plot_dpsc(self.config, results)
+            except MlsynthPlottingError:  # pragma: no cover - defensive re-raise
+                raise
+            except Exception as exc:  # pragma: no cover - defensive translation
+                raise MlsynthPlottingError(f"DPSC plotting failed: {exc}") from exc
+
+        return results

--- a/mlsynth/guides/llms.txt
+++ b/mlsynth/guides/llms.txt
@@ -31,6 +31,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **CLUSTERSC** — Cluster-based Synthetic Control estimator.  (config: CLUSTERSCConfig)
 - **CMBSTS** — Causal Multivariate Bayesian Structural Time Series estimator.  (config: CMBSTSConfig)
 - **CTSC** — Continuous-Treatment Synthetic Control estimator.  (config: CTSCConfig)
+- **DPSC** — Differentially private synthetic control estimator.  (config: DPSCConfig)
 - **DSC** — Distributional Synthetic Control estimator.  (config: DSCConfig)
 - **DSCAR** — Dynamic Synthetic Control for Auto-Regressive processes.  (config: DSCARConfig)
 - **DesignComparison** — Result of :func:`compare_methods`.

--- a/mlsynth/tests/test_dpsc.py
+++ b/mlsynth/tests/test_dpsc.py
@@ -1,0 +1,182 @@
+"""Tests for DPSC (differentially private synthetic control, Rho et al. 2023).
+
+Layered per ``agents/agents_tests.md``:
+  Layer 1 (mechanisms): closed-form ridge == sklearn; sensitivity formula;
+    high-dimensional Laplace structure + reproducibility; epsilon -> infinity
+    converges to the non-private ridge SC.
+  Layer 2 (setup): single-treated ingestion; multi-cohort rejected.
+  Layer 3 (integration): DPSC.fit on Prop 99 -- shapes, reproducibility, the
+    non-private reference, both mechanisms, plotting smoke.
+  Layer 4 (config): every validator raises the translated error.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+
+from mlsynth import DPSC  # noqa: E402
+from mlsynth.config_models import BaseEstimatorResults, DPSCConfig  # noqa: E402
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError  # noqa: E402
+from mlsynth.utils.dpsc_helpers.mechanisms import (  # noqa: E402
+    _ridge_coefficients,
+    _high_dim_laplace,
+    non_private_counterfactual,
+    output_sensitivity,
+    run_objective_perturbation,
+    run_output_perturbation,
+)
+
+_SMOKING = Path(__file__).resolve().parents[2] / "basedata" / "smoking_data.csv"
+
+
+@pytest.fixture(scope="module")
+def prop99() -> pd.DataFrame:
+    df = pd.read_csv(_SMOKING)
+    df["treat"] = df["Proposition 99"].astype(int)
+    return df[["state", "year", "cigsale", "treat"]]
+
+
+def _cfg(df, **over):
+    base = dict(df=df, outcome="cigsale", treat="treat", unitid="state", time="year",
+                n_draws=50, seed=0, display_graphs=False)
+    base.update(over)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: mechanisms
+# ---------------------------------------------------------------------------
+class TestMechanisms:
+    def test_ridge_closed_form_matches_sklearn(self):
+        from sklearn.linear_model import Ridge
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal((15, 6))
+        y = rng.standard_normal(15)
+        w = _ridge_coefficients(X, y, ridge_alpha=5.0)
+        sk = Ridge(alpha=5.0, fit_intercept=False).fit(X, y).coef_
+        assert np.max(np.abs(w - sk)) < 1e-10
+
+    def test_output_sensitivity_formula(self):
+        # Delta = 4 T0 sqrt(8 + N0) / lambda
+        assert output_sensitivity(19, 38, 10.0) == pytest.approx(4 * 19 * np.sqrt(46) / 10.0)
+
+    def test_high_dim_laplace_reproducible_and_isotropic(self):
+        a = _high_dim_laplace(np.random.RandomState(3), 10, 2.0)
+        b = _high_dim_laplace(np.random.RandomState(3), 10, 2.0)
+        assert np.array_equal(a, b)                       # seed -> identical
+        # one magnitude x unit direction: recover a unit vector
+        assert np.linalg.norm(a) > 0
+
+    def test_seeded_mechanisms_are_reproducible(self):
+        rng = np.random.default_rng(1)
+        pre_d = rng.standard_normal((10, 5)); pre_t = rng.standard_normal(10)
+        full = rng.standard_normal((13, 5))
+        for run in (run_output_perturbation, run_objective_perturbation):
+            cf1, w1, _ = run(np.random.RandomState(7), pre_d, pre_t, full, 10.0, 5.0, 5.0)
+            cf2, w2, _ = run(np.random.RandomState(7), pre_d, pre_t, full, 10.0, 5.0, 5.0)
+            assert np.array_equal(cf1, cf2) and np.array_equal(w1, w2)
+
+    def test_objective_gaussian_branch_runs(self):
+        # delta > 0 selects Gaussian ((epsilon, delta)-DP) noise for the
+        # objective mechanism; the fit must still be finite and reproducible.
+        rng = np.random.default_rng(4)
+        pre_d = rng.standard_normal((10, 5)); pre_t = rng.standard_normal(10)
+        full = rng.standard_normal((13, 5))
+        cf1, w1, _ = run_objective_perturbation(
+            np.random.RandomState(9), pre_d, pre_t, full, 10.0, 5.0, 5.0, delta=0.1)
+        cf2, w2, _ = run_objective_perturbation(
+            np.random.RandomState(9), pre_d, pre_t, full, 10.0, 5.0, 5.0, delta=0.1)
+        assert np.all(np.isfinite(cf1)) and np.array_equal(w1, w2)
+
+    def test_epsilon_to_infinity_converges_to_non_private(self):
+        rng = np.random.default_rng(2)
+        pre_d = rng.standard_normal((12, 4)); pre_t = rng.standard_normal(12)
+        full = rng.standard_normal((16, 4))
+        cf_np, _ = non_private_counterfactual(pre_d, pre_t, full, 10.0)
+        for run in (run_output_perturbation, run_objective_perturbation):
+            cf, _, _ = run(np.random.RandomState(0), pre_d, pre_t, full, 10.0, 1e7, 1e7)
+            assert np.max(np.abs(cf - cf_np)) < 1e-2  # noise ~ 1/eps -> 0
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 / 3: setup + integration on Prop 99
+# ---------------------------------------------------------------------------
+class TestProp99Integration:
+    def test_smoke_returns_contract(self, prop99):
+        res = DPSC(_cfg(prop99, epsilon1=100.0, epsilon2=100.0)).fit()
+        assert isinstance(res, BaseEstimatorResults)
+        assert np.isfinite(res.effects.att)
+        assert res.time_series.counterfactual_outcome.shape[0] == 31
+        assert res.method_details.method_name == "DPSC"
+
+    def test_non_private_reference_recorded(self, prop99):
+        res = DPSC(_cfg(prop99, epsilon1=100.0, epsilon2=100.0)).fit()
+        npv = res.inference.details["att_non_private"]
+        # Non-private ridge SC on Prop 99 lands in the canonical negative range.
+        assert -25 < npv < -8
+
+    def test_privacy_noise_reported_as_se(self, prop99):
+        res = DPSC(_cfg(prop99, epsilon1=1.0, epsilon2=1.0, n_draws=100)).fit()
+        assert res.inference.standard_error is not None and res.inference.standard_error > 0
+        lo, hi = res.inference.ci_lower, res.inference.ci_upper
+        assert lo < res.effects.att < hi
+
+    def test_output_mechanism_runs(self, prop99):
+        res = DPSC(_cfg(prop99, mechanism="output", epsilon1=50.0, epsilon2=50.0)).fit()
+        assert np.isfinite(res.effects.att)
+
+    def test_seed_reproducible_end_to_end(self, prop99):
+        a = DPSC(_cfg(prop99, epsilon1=5.0, epsilon2=5.0, seed=42)).fit()
+        b = DPSC(_cfg(prop99, epsilon1=5.0, epsilon2=5.0, seed=42)).fit()
+        assert a.effects.att == b.effects.att
+        assert np.array_equal(a.time_series.counterfactual_outcome,
+                              b.time_series.counterfactual_outcome)
+
+    def test_different_seed_gives_different_release(self, prop99):
+        a = DPSC(_cfg(prop99, epsilon1=5.0, epsilon2=5.0, seed=1)).fit()
+        b = DPSC(_cfg(prop99, epsilon1=5.0, epsilon2=5.0, seed=2)).fit()
+        assert a.effects.att != b.effects.att
+
+    def test_multi_treated_panel_rejected(self, prop99):
+        df = prop99.copy()
+        extra = {"California", "Nevada", "Utah"}
+        df["treat"] = ((df["state"].isin(extra)) & (df["year"] >= 1989)).astype(int)
+        with pytest.raises(MlsynthDataError):
+            DPSC(_cfg(df, epsilon1=5.0, epsilon2=5.0)).fit()
+
+    def test_plotting_smoke(self, prop99):
+        res = DPSC(_cfg(prop99, epsilon1=100.0, epsilon2=100.0, display_graphs=True)).fit()
+        assert res is not None
+
+
+# ---------------------------------------------------------------------------
+# Layer 4: config validation
+# ---------------------------------------------------------------------------
+class TestConfigValidation:
+    def _base(self, prop99, **over):
+        return _cfg(prop99, **over)
+
+    @pytest.mark.parametrize("field,value", [
+        ("epsilon1", 0.0), ("epsilon1", -1.0),
+        ("epsilon2", 0.0), ("epsilon2", -2.0),
+        ("ridge_lambda", 0.0), ("ridge_lambda", -1.0),
+        ("delta", -0.1), ("delta", 1.0),
+        ("n_draws", 0), ("alpha", 0.0), ("alpha", 1.0),
+        ("mechanism", "banana"),
+    ])
+    def test_invalid_config_rejected(self, prop99, field, value):
+        with pytest.raises(MlsynthConfigError):
+            DPSC(self._base(prop99, **{field: value}))
+
+    def test_extra_field_forbidden(self, prop99):
+        with pytest.raises(MlsynthConfigError):
+            DPSC(self._base(prop99, not_a_field=1))
+
+    def test_config_defaults(self, prop99):
+        cfg = DPSCConfig(**self._base(prop99))
+        assert cfg.mechanism == "objective" and cfg.delta == 0.0

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -28,7 +28,7 @@ import pytest
 _HAS_NUMPYRO = importlib.util.find_spec("numpyro") is not None
 
 from mlsynth import (
-    BFSC, BSCM, BVSS, CFM, CLUSTERSC, DSCAR, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC,
+    BFSC, BSCM, BVSS, CFM, CLUSTERSC, DPSC, DSCAR, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC,
     MCNNM, MSQRT, NSC, PDA, PROPSC, RESCM, RMSI, SBC, SCMO, SCUL, SDID,
     SequentialSDID, SHC, SNN, SparseSC, SPILLSYNTH, SPOTSYNTH, SSC, TASC, TSSC,
     VanillaSC,
@@ -128,6 +128,8 @@ OBSERVATIONAL = [
     pytest.param(SHC, {}, id="SHC"),
     pytest.param(SPILLSYNTH, {"method": "cd", "affected_units": ["u01"]},
                  id="SPILLSYNTH"),
+    pytest.param(DPSC, {"epsilon1": 50.0, "epsilon2": 50.0, "n_draws": 20, "seed": 0},
+                 id="DPSC"),
 ]
 
 if _HAS_NUMPYRO:  # BFSC needs the ``[bayes]`` extra; skip the whole param without it

--- a/mlsynth/utils/dpsc_helpers/__init__.py
+++ b/mlsynth/utils/dpsc_helpers/__init__.py
@@ -1,0 +1,5 @@
+"""Helpers for DPSC (differentially private synthetic control)."""
+from .config import DPSCConfig
+from .pipeline import run_dpsc
+
+__all__ = ["DPSCConfig", "run_dpsc"]

--- a/mlsynth/utils/dpsc_helpers/config.py
+++ b/mlsynth/utils/dpsc_helpers/config.py
@@ -1,0 +1,73 @@
+"""Configuration for the DPSC (differentially private synthetic control) estimator."""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from ...config_models import BaseEstimatorConfig
+
+
+class DPSCConfig(BaseEstimatorConfig):
+    """Configuration for :class:`mlsynth.DPSC`.
+
+    Differentially private synthetic control (Rho, Cummings & Misra 2023): a
+    ridge synthetic control whose released counterfactual satisfies
+    ``epsilon``-differential privacy over the *donor pool*. Privacy is spent in
+    two stages -- learning the regression coefficients (``epsilon1``) and
+    releasing the post-intervention prediction (``epsilon2``) -- so the total
+    budget is ``epsilon1 + epsilon2``.
+
+    The default ``mechanism="objective"`` is the objective-perturbation
+    estimator (Algorithm 3), which perturbs the ridge objective; it is far more
+    stable than output perturbation on typical panels. ``"output"`` (Algorithm
+    2) perturbs the fitted coefficients directly and is provided for
+    completeness -- its variance is large unless the donor pool is big.
+    """
+
+    mechanism: Literal["objective", "output"] = Field(
+        default="objective",
+        description="DP-ERM mechanism: 'objective' (Alg 3, perturb the ridge "
+                    "objective; stable, recommended) or 'output' (Alg 2, perturb "
+                    "the fitted coefficients; high variance on small donor pools).",
+    )
+    epsilon1: float = Field(
+        default=1.0, gt=0.0,
+        description="Privacy budget for learning the regression coefficients "
+                    "(Stage 1). Smaller is more private and noisier.",
+    )
+    epsilon2: float = Field(
+        default=1.0, gt=0.0,
+        description="Privacy budget for releasing the post-intervention "
+                    "prediction (Stage 2). The total budget is epsilon1 + epsilon2.",
+    )
+    ridge_lambda: float = Field(
+        default=10.0, gt=0.0,
+        description="Ridge penalty lambda. It regularizes the fit and, through "
+                    "the sensitivity, controls the noise scale: larger lambda "
+                    "lowers sensitivity (less noise) at the cost of a more biased "
+                    "(shrunk) synthetic control.",
+    )
+    delta: float = Field(
+        default=0.0, ge=0.0, lt=1.0,
+        description="Approximate-DP slack for the objective mechanism. delta = 0 "
+                    "(default) gives pure epsilon-DP with Laplace noise; delta > 0 "
+                    "gives (epsilon, delta)-DP with Gaussian noise.",
+    )
+    n_draws: int = Field(
+        default=500, ge=1,
+        description="Number of independent privatized draws used to quantify the "
+                    "privacy noise on the ATT (its Monte Carlo standard error and "
+                    "interval). The reported counterfactual is a single seeded "
+                    "release; n_draws only sizes the reported uncertainty.",
+    )
+    seed: int = Field(
+        default=0,
+        description="Seed for the privatized release and the noise Monte Carlo "
+                    "(reproducibility).",
+    )
+    alpha: float = Field(
+        default=0.05, gt=0.0, lt=1.0,
+        description="Two-sided level for the privacy-noise interval on the ATT "
+                    "(1 - alpha).",
+    )

--- a/mlsynth/utils/dpsc_helpers/mechanisms.py
+++ b/mlsynth/utils/dpsc_helpers/mechanisms.py
@@ -1,0 +1,158 @@
+"""Differentially private synthetic-control mechanisms (Rho, Cummings & Misra 2023).
+
+The base estimator is a ridge synthetic control -- pre-period ridge regression of
+the treated series on the donors, extrapolated to the post-period. Privacy is
+obtained through differentially private empirical risk minimization (Chaudhuri,
+Monteleoni & Sarwate 2011; Kifer, Smith & Thakurta 2012):
+
+* output perturbation (Algorithm 2): fit the ridge coefficients, then add
+  high-dimensional Laplace noise calibrated to their sensitivity;
+* objective perturbation (Algorithm 3): add a random linear term to the ridge
+  objective and solve exactly.
+
+A second, independent budget privatizes the post-intervention donor matrix
+before the counterfactual is formed. Both mechanisms are randomized; a
+``numpy.random.RandomState`` is threaded through so a fixed seed reproduces the
+release exactly (and reproduces the authors' reference stream for
+cross-validation).
+
+Sensitivity is with respect to changing one *donor's* entire series -- the
+transposed ("vertical") synthetic-control regression treats each time point, not
+each donor, as a sample, so a donor is a whole column (Rho et al. 2023, Sec 3).
+"""
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Tuple
+
+import numpy as np
+
+
+def _ridge_coefficients(design: np.ndarray, target: np.ndarray, ridge_alpha: float) -> np.ndarray:
+    """Closed-form ridge ``argmin_w ||target - design w||^2 + ridge_alpha ||w||^2``.
+
+    Matches ``sklearn.linear_model.Ridge(alpha=ridge_alpha, fit_intercept=False)``
+    to machine precision.
+    """
+    n_features = design.shape[1]
+    gram = design.T @ design + ridge_alpha * np.eye(n_features)
+    return np.linalg.solve(gram, design.T @ target)
+
+
+def _high_dim_laplace(rng: np.random.RandomState, dim: int, scale: float) -> np.ndarray:
+    """High-dimensional Laplace mechanism (Chaudhuri et al. 2011, Alg 1).
+
+    A single random vector whose magnitude is ``Lap(scale)`` and whose direction
+    is uniform on the unit ``dim``-sphere. Identical to the authors'
+    ``laplace_sample(dim, 1, scale)``; the RNG draw order (magnitude then
+    direction) is preserved so a shared seed reproduces their stream.
+    """
+    magnitude = rng.laplace(loc=0.0, scale=scale, size=1)[0]
+    direction = rng.normal(0.0, 1.0, size=dim)
+    direction = direction / np.sqrt(np.sum(direction ** 2))
+    return magnitude * direction
+
+
+def output_sensitivity(num_pre: int, num_donors: int, ridge_lambda: float) -> float:
+    """L2 sensitivity of the ridge coefficients to one donor's series (Rho et al. 2023).
+
+    ``Delta = 4 T0 sqrt(8 + N0) / lambda``.
+    """
+    return (4.0 * num_pre * math.sqrt(8.0 + num_donors)) / ridge_lambda
+
+
+def _privatize_donors(
+    rng: np.random.RandomState, donor_matrix: np.ndarray, epsilon2: float
+) -> Tuple[np.ndarray, float]:
+    """Add the Stage-2 high-dimensional Laplace noise to the donor matrix.
+
+    Scale ``b = 2 sqrt(R) / epsilon2`` where ``R`` is the number of released
+    rows (Rho et al. 2023). Mirrors the reference implementation, which
+    privatizes the whole released donor path.
+    """
+    num_rows, num_donors = donor_matrix.shape
+    scale = 2.0 * math.sqrt(num_rows) / epsilon2
+    noise = _high_dim_laplace(rng, num_rows * num_donors, scale).reshape(num_rows, num_donors)
+    return donor_matrix + noise, scale
+
+
+def run_output_perturbation(
+    rng: np.random.RandomState,
+    pre_donor: np.ndarray,
+    pre_target: np.ndarray,
+    donor_full: np.ndarray,
+    ridge_lambda: float,
+    epsilon1: float,
+    epsilon2: float,
+) -> Tuple[np.ndarray, np.ndarray, Dict[str, Any]]:
+    """Output perturbation (Algorithm 2): ridge coefficients + Laplace noise.
+
+    Returns ``(counterfactual_path, private_weights, info)`` where
+    ``counterfactual_path`` is over every row of ``donor_full``.
+    """
+    num_pre, num_donors = pre_donor.shape
+    sensitivity = output_sensitivity(num_pre, num_donors, ridge_lambda)
+    coef_scale = sensitivity / epsilon1
+    coefficients = _ridge_coefficients(pre_donor, pre_target, ridge_lambda / 2.0)
+    weights = coefficients + _high_dim_laplace(rng, num_donors, coef_scale)
+    private_donors, donor_scale = _privatize_donors(rng, donor_full, epsilon2)
+    counterfactual = private_donors @ weights
+    info = {"sensitivity": sensitivity, "coef_scale": coef_scale,
+            "donor_scale": donor_scale}
+    return counterfactual, weights, info
+
+
+def run_objective_perturbation(
+    rng: np.random.RandomState,
+    pre_donor: np.ndarray,
+    pre_target: np.ndarray,
+    donor_full: np.ndarray,
+    ridge_lambda: float,
+    epsilon1: float,
+    epsilon2: float,
+    delta: float = 0.0,
+) -> Tuple[np.ndarray, np.ndarray, Dict[str, Any]]:
+    """Objective perturbation (Algorithm 3): random linear term in the ridge objective.
+
+    Solves ``argmin_f ||y - X f||^2 + ((lambda + Delta)/2) ||f||^2 + b^T f`` in
+    closed form (the perturbed normal equations), where ``b`` is Laplace (pure
+    ``epsilon``-DP, ``delta = 0``) or Gaussian (``(epsilon, delta)``-DP). The
+    curvature slack ``Delta`` guarantees privacy when the base regularization is
+    too weak for the requested budget.
+    """
+    num_pre, num_donors = pre_donor.shape
+    curvature = (1.0 + math.sqrt(16.0 * num_donors - 15.0)) * num_pre
+    epsilon0 = epsilon1 - math.log(1.0 + (2.0 * curvature / ridge_lambda)
+                                   + (curvature ** 2 / ridge_lambda ** 2))
+    if epsilon0 > 0:
+        curvature_slack = 0.0
+    else:
+        epsilon0 = epsilon1 / 2.0
+        curvature_slack = curvature / (math.e ** (epsilon1 / 4.0) - 1.0) - ridge_lambda
+
+    if delta > 0:
+        noise_scale = (4.0 * num_pre * math.sqrt(8.0 + num_donors)
+                       * math.sqrt(2.0 * math.log(2.0 / delta) + epsilon0) / epsilon0)
+        linear = rng.multivariate_normal(np.zeros(num_donors),
+                                         noise_scale * np.eye(num_donors))
+    else:
+        scale_a = 4.0 * num_pre * math.sqrt(8.0 + num_donors) / epsilon0
+        scale_b = (curvature * math.sqrt(num_donors) + 4.0 * num_pre) / epsilon0
+        noise_scale = min(scale_a, scale_b)
+        linear = _high_dim_laplace(rng, num_donors, noise_scale)
+
+    gram = 2.0 * pre_donor.T @ pre_donor + (ridge_lambda + curvature_slack) * np.eye(num_donors)
+    weights = np.linalg.solve(gram, 2.0 * pre_donor.T @ pre_target - linear)
+    private_donors, donor_scale = _privatize_donors(rng, donor_full, epsilon2)
+    counterfactual = private_donors @ weights
+    info = {"curvature": curvature, "epsilon0": epsilon0, "curvature_slack": curvature_slack,
+            "noise_scale": noise_scale, "donor_scale": donor_scale}
+    return counterfactual, weights, info
+
+
+def non_private_counterfactual(
+    pre_donor: np.ndarray, pre_target: np.ndarray, donor_full: np.ndarray, ridge_lambda: float
+) -> Tuple[np.ndarray, np.ndarray]:
+    """The non-private ridge synthetic control (the ``epsilon -> infinity`` limit)."""
+    coefficients = _ridge_coefficients(pre_donor, pre_target, ridge_lambda / 2.0)
+    return donor_full @ coefficients, coefficients

--- a/mlsynth/utils/dpsc_helpers/pipeline.py
+++ b/mlsynth/utils/dpsc_helpers/pipeline.py
@@ -1,0 +1,129 @@
+"""Orchestration for DPSC: privatized release + privacy-noise quantification."""
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import norm
+
+from ...config_models import (
+    BaseEstimatorResults,
+    InferenceResults,
+    MethodDetailsResults,
+)
+from ..results_helpers import build_effect_submodels, make_weights_results
+from .mechanisms import (
+    non_private_counterfactual,
+    run_objective_perturbation,
+    run_output_perturbation,
+)
+from .setup import prepare_dpsc_inputs
+
+
+def _draw(config, inputs, rng):
+    """One privatized counterfactual path + weights for the configured mechanism."""
+    pre_donor = inputs.donor_matrix[: inputs.T0]
+    pre_target = inputs.y_treated[: inputs.T0]
+    donor_full = inputs.donor_matrix
+    if config.mechanism == "output":
+        return run_output_perturbation(
+            rng, pre_donor, pre_target, donor_full,
+            config.ridge_lambda, config.epsilon1, config.epsilon2)
+    return run_objective_perturbation(
+        rng, pre_donor, pre_target, donor_full,
+        config.ridge_lambda, config.epsilon1, config.epsilon2, config.delta)
+
+
+def run_dpsc(config) -> BaseEstimatorResults:
+    """Fit DPSC and return :class:`BaseEstimatorResults`.
+
+    The reported counterfactual is a single seeded differentially private
+    release. The privacy noise -- the dominant source of uncertainty -- is
+    quantified by the Monte Carlo standard deviation of the ATT over
+    ``n_draws`` independent privatized draws, and reported as the standard error
+    and interval.
+    """
+    inputs = prepare_dpsc_inputs(config)
+    y = inputs.y_treated
+    T = y.shape[0]
+    T0 = inputs.T0
+    post = slice(T0, T)
+    n_post = T - T0
+
+    # The released (seeded) private counterfactual.
+    rng = np.random.RandomState(config.seed)
+    counterfactual, weights, info = _draw(config, inputs, rng)
+    att = float(np.mean((y - counterfactual)[post]))
+
+    # Non-private ridge reference (the epsilon -> infinity target).
+    cf_np, _ = non_private_counterfactual(
+        inputs.donor_matrix[:T0], y[:T0], inputs.donor_matrix, config.ridge_lambda)
+    att_non_private = float(np.mean((y - cf_np)[post]))
+
+    # Privacy-noise Monte Carlo: the spread of the private ATT across draws.
+    mc = np.empty(config.n_draws)
+    mc_rng = np.random.RandomState(config.seed + 1)
+    for i in range(config.n_draws):
+        cf_i, _, _ = _draw(config, inputs, mc_rng)
+        mc[i] = np.mean((y - cf_i)[post])
+    att_se = float(np.std(mc, ddof=1)) if config.n_draws > 1 else float("nan")
+    z = norm.ppf(1.0 - config.alpha / 2.0)
+    att_lo = att - z * att_se if np.isfinite(att_se) else float("nan")
+    att_hi = att + z * att_se if np.isfinite(att_se) else float("nan")
+
+    donor_weights = {d: float(w) for d, w in zip(inputs.donor_names, weights)}
+    weights_res = make_weights_results(
+        donor_weights,
+        constraint="ridge regression coefficients (differentially private; "
+                   "unconstrained, may be negative)")
+
+    inference = InferenceResults(
+        standard_error=att_se if np.isfinite(att_se) else None,
+        ci_lower=att_lo if np.isfinite(att_lo) else None,
+        ci_upper=att_hi if np.isfinite(att_hi) else None,
+        confidence_level=1.0 - config.alpha,
+        method=f"differential-privacy noise ({config.mechanism} perturbation, "
+               f"Monte Carlo over {config.n_draws} draws)",
+        details={
+            "att_private": att,
+            "att_non_private": att_non_private,
+            "att_mc_mean": float(np.mean(mc)),
+            "mechanism": config.mechanism,
+            "epsilon1": config.epsilon1, "epsilon2": config.epsilon2,
+            "epsilon_total": config.epsilon1 + config.epsilon2,
+            "delta": config.delta, "ridge_lambda": config.ridge_lambda,
+            **{k: float(v) for k, v in info.items()},
+        },
+    )
+
+    submodels = build_effect_submodels(
+        observed_outcome=y,
+        counterfactual_outcome=np.asarray(counterfactual, dtype=float),
+        n_pre_periods=T0,
+        n_post_periods=n_post,
+        time_periods=inputs.time_labels,
+        weights=weights_res,
+        inference=inference,
+        att_std_err=att_se if np.isfinite(att_se) else None,
+        effects_overrides={"att": att},
+        additional_effects={"att_non_private": att_non_private},
+        intervention_time=(inputs.time_labels[T0] if T0 < T else inputs.time_labels[-1]),
+    )
+
+    return BaseEstimatorResults(
+        **submodels,
+        method_details=MethodDetailsResults(
+            method_name="DPSC",
+            is_recommended=False,
+            parameters_used={
+                "mechanism": config.mechanism,
+                "epsilon1": config.epsilon1, "epsilon2": config.epsilon2,
+                "delta": config.delta, "ridge_lambda": config.ridge_lambda,
+                "n_draws": config.n_draws, "seed": config.seed,
+            },
+        ),
+        additional_outputs={
+            "treated_name": inputs.treated_name,
+            "pre_periods": T0,
+            "att_non_private": att_non_private,
+            "noise_scales": {k: float(v) for k, v in info.items()},
+        },
+    )

--- a/mlsynth/utils/dpsc_helpers/plotter.py
+++ b/mlsynth/utils/dpsc_helpers/plotter.py
@@ -1,0 +1,33 @@
+"""Plotting for DPSC: observed treated path vs the private synthetic control."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from ..resultutils import plot_estimates
+
+
+def plot_dpsc(config, results) -> None:
+    """Observed treated path vs the differentially private synthetic counterfactual."""
+    ts = results.time_series
+    obs = np.asarray(ts.observed_outcome, float)
+    cf = np.asarray(ts.counterfactual_outcome, float)
+    time_labels = np.asarray(ts.time_periods)
+    pre = int(results.additional_outputs["pre_periods"])
+
+    processed = {"Ywide": pd.DataFrame(index=pd.Index(time_labels)), "pre_periods": pre}
+    plot_estimates(
+        processed_data_dict=processed,
+        time_axis_label=config.time,
+        unit_identifier_column_name=config.unitid,
+        outcome_variable_label=config.outcome,
+        treatment_name_label=config.treat,
+        treated_unit_name=str(results.additional_outputs["treated_name"]),
+        observed_outcome_series=obs,
+        counterfactual_series_list=[cf],
+        estimation_method_name="DPSC",
+        treated_series_color=config.treated_color,
+        counterfactual_series_colors=[config.counterfactual_color[0]],
+        counterfactual_names=["DPSC private synthetic"],
+        save_plot_config=config.save,
+    )

--- a/mlsynth/utils/dpsc_helpers/setup.py
+++ b/mlsynth/utils/dpsc_helpers/setup.py
@@ -1,0 +1,43 @@
+"""Long-panel ingestion for DPSC (via :func:`mlsynth.utils.datautils.dataprep`)."""
+from __future__ import annotations
+
+import numpy as np
+
+from ...exceptions import MlsynthDataError
+from ..datautils import dataprep
+from .structures import DPSCInputs
+
+
+def prepare_dpsc_inputs(config) -> DPSCInputs:
+    """Build :class:`DPSCInputs` from the config's long DataFrame.
+
+    Uses the canonical ``dataprep`` contract: the single treated unit's outcome
+    path ``y``, the donor matrix ``Y0`` (one column per donor), and the
+    pre-period count ``T0``.
+    """
+    prep = dataprep(config.df, config.unitid, config.time, config.outcome, config.treat)
+    if "cohorts" in prep:
+        raise MlsynthDataError(
+            "DPSC supports a single treated unit (one adoption date); the panel "
+            "has multiple treated cohorts.")
+
+    y_treated = np.asarray(prep["y"], dtype=float).flatten()
+    donor_matrix = np.asarray(prep["donor_matrix"], dtype=float)
+    T0 = int(prep["pre_periods"])
+    # Defensive guards: dataprep already guarantees a pre-period, at least one
+    # donor, and a balanced (finite) panel for a single-treated design.
+    if T0 < 1:  # pragma: no cover - dataprep guarantees a pre-period
+        raise MlsynthDataError("DPSC requires at least one pre-treatment period.")
+    if donor_matrix.shape[1] < 1:  # pragma: no cover - dataprep guarantees donors
+        raise MlsynthDataError("DPSC requires at least one donor unit.")
+    if not np.all(np.isfinite(donor_matrix)) or not np.all(np.isfinite(y_treated)):  # pragma: no cover - dataprep balances the panel
+        raise MlsynthDataError("DPSC: the outcome/donor matrix contains non-finite values.")
+
+    return DPSCInputs(
+        y_treated=y_treated,
+        donor_matrix=donor_matrix,
+        T0=T0,
+        time_labels=np.asarray(prep["time_labels"]),
+        treated_name=prep["treated_unit_name"],
+        donor_names=tuple(prep["donor_names"]),
+    )

--- a/mlsynth/utils/dpsc_helpers/structures.py
+++ b/mlsynth/utils/dpsc_helpers/structures.py
@@ -1,0 +1,26 @@
+"""Frozen input container for DPSC."""
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict
+
+
+class DPSCInputs(BaseModel):
+    """Prepared inputs for DPSC (built by ``prepare_dpsc_inputs``).
+
+    Notation follows the docs: the treated series ``y_treated`` is
+    :math:`\\mathbf{y}_1`; ``donor_matrix`` is
+    :math:`\\mathbf{Y}_0 \\in \\mathbb{R}^{T \\times N_0}`; ``T0`` is the number
+    of pre-treatment periods :math:`T_0`.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    y_treated: np.ndarray               # (T,) treated-unit outcome path
+    donor_matrix: np.ndarray            # (T, N0) donor outcomes, one column per donor
+    T0: int                             # number of pre-treatment periods
+    time_labels: np.ndarray             # (T,)
+    treated_name: Any
+    donor_names: Tuple[Any, ...]        # (N0,) donor order matching donor_matrix columns


### PR DESCRIPTION
## What

Adds `DPSC`, a ridge synthetic control whose released counterfactual satisfies `epsilon`-differential privacy over the donor pool, via differentially private empirical risk minimization. It fills a genuine gap: no other mlsynth estimator offers a formal privacy guarantee. Use it when the donor pool is sensitive (patient records in a clinical external-control arm, proprietary firm-level series) and the counterfactual must be released externally.

## How it works

Two mechanisms behind `DPSCConfig.mechanism`:

- objective perturbation (Algorithm 3, the stable default): perturbs the ridge objective with a random linear term and solves it in closed form (the perturbed normal equations);
- output perturbation (Algorithm 2): perturbs the fitted ridge coefficients directly.

A second budget privatizes the released donor matrix; the total budget is `epsilon = epsilon1 + epsilon2`. Privacy is over donors — the vertical SC regression makes a donor one whole column. The released ATT is a single seeded draw; the dominant uncertainty is the privacy noise, reported as the Monte Carlo standard error over `n_draws`, with the non-private ridge ATT recorded as the `epsilon -> infinity` target.

## Changes (repository contract)

- `utils/dpsc_helpers/{config,structures,setup,mechanisms,pipeline,plotter}.py` — dependency-free NumPy mechanisms (closed-form ridge + objective QP) using a `RandomState` so a seed reproduces the release.
- `estimators/dpsc.py` — thin `DPSC` class; exported in `mlsynth/__init__.py`; `DPSCConfig` re-registered in `config_models`; added to `test_result_contract`.
- `mlsynth/tests/test_dpsc.py` — 28 tests, 100% coverage of the new code (mechanisms, Prop 99 integration, config validation, plotting; defensive branches pragma'd).
- `docs/dpsc.rst` — the econometric theory (the `(epsilon, delta)`-DP definition, why "neighboring" means one donor's column, sensitivity, both mechanisms, the privacy/accuracy tradeoff, and a donor-pool scaling note) in the mlsynth notation canon; `docs/replications/dpsc.rst`; wired into the toctrees and the `choose.rst` decision tree; `llms.txt` regenerated.
- `benchmarks/cases/dpsc_prop99.py` (registered) + `benchmarks/reference/clone_dpsc.py` — clones `srho1/dpsc` at a pinned commit on demand.

## Verification

Demonstrate-first replication, then cross-validated bit-for-bit against the authors' own `PrivateSC` on Proposition 99 under a shared Mersenne-Twister seed:

| mechanism | private weights vs authors | private counterfactual vs authors |
|---|---:|---:|
| output perturbation (Alg 2) | 1.3e-11 | 2.9e-10 |
| objective perturbation (Alg 3) | 7.0e-12 | 5.2e-10 |

The objective program is solved in closed form against their cvxpy and still matches to ~1e-11; the non-private ridge matches sklearn to machine precision. Full DPSC, `test_result_contract`, and `test_config_models` suites green.

## Honest scope

Output perturbation is unusable on a small donor pool (single-draw ATT noise of tens even at negligible privacy); objective perturbation is the viable mechanism and the default; meaningful privacy on a few-dozen-donor panel costs a biased estimate with a wide band. A controlled factor-model sweep shows the objective mechanism's ATT noise falls with the donor pool (≈3× from 5 to 20 donors) while output perturbation does not — so this is a large-donor-pool method (clinical external-control arms, cross-party measurement), documented in the inference section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7bVBZsrWUPQJbnGGCG1qD

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7bVBZsrWUPQJbnGGCG1qD)_