### PR TITLE
benchmarks: differential cross-validation of SpSyDiD on the real Arizona LAWA CPS panel

### DIFF
--- a/benchmarks/cases/spsydid_lawa_diff.py
+++ b/benchmarks/cases/spsydid_lawa_diff.py
@@ -1,0 +1,202 @@
+"""Differential cross-validation: mlsynth SpSyDiD vs the authors' code on real data.
+
+A tight, real-data companion to ``spsydid_state_mc`` (which is the paper's
+Monte-Carlo simulation). Here the two implementations are run on the *same real
+panel* -- the Arizona LAWA CPS extract aggregated to state means -- and the
+mlsynth estimator is exercised end-to-end through :meth:`mlsynth.SpSyDiD.fit`
+(never its internal helpers), then compared value-for-value against the authors'
+own ``functions_ssdid`` (serenini/spatial_SDID, cloned on demand).
+
+Why this is the exact test
+--------------------------
+The SDID machinery is identical across the two codebases -- the unit-weight QP,
+the time-weight QP, and the regularisation ``zeta`` all agree to solver
+tolerance. The only thing that ever differed between them is a handful of
+*non-fitted* row-weight conventions that the paper leaves underspecified and the
+authors' notebook fills with ``join_weights`` defaults (post-period time weight
+``T_post/T``, affected-unit weight = the mean treated weight). Those depart from
+canonical SDID; mlsynth uses the canonical choices (``1/T_post`` post weights,
+``1/N_sp`` affected weights). Unifying the reference onto the canonical
+convention, the two agree to ``~1e-8``:
+
+* unit weights (``res.weights.donor_weights``)           -- to ~1e-9;
+* direct ATT (``res.att``)                               -- to ~1e-7;
+* spillover coefficient (``res.effects.additional_effects['aite']``) -- to ~1e-8.
+
+Panel and W
+-----------
+* Panel: ``basedata/cps_lawa_arizona.parquet`` aggregated to survey-weighted mean
+  log weekly earnings per state-month; Arizona treated from period 55.
+* W: ``basedata/US_no_islands_matrix.gal`` (queen contiguity), parsed directly
+  (no libpysal) and restricted/row-standardised to the 45 states common to the
+  matrix and the CPS extract. Arizona (FIPS 4) has four present neighbours (CA,
+  NV, CO, NM).
+
+Reference: serenini/spatial_SDID (cloned on demand, pinned; no licence, not
+vendored) -- its ``fit_unit_weights`` / ``fit_time_weights`` under the canonical
+final regression.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy.linalg import block_diag, lstsq
+
+from benchmarks.compare import BenchmarkSkipped
+
+_BASE = Path(__file__).resolve().parents[2] / "basedata"
+_TREATED_FIPS = 4          # Arizona
+_TSTAR = 55                # first treated period
+_KAPPA_TOL = 1e-6
+
+
+def _parse_gal(path: Path):
+    lines = [ln.strip() for ln in open(path) if ln.strip()]
+    order, adj, i = [], {}, 1
+    while i < len(lines):
+        uid, k = lines[i].split()[:2]
+        uid, k = int(uid), int(k)
+        i += 1
+        adj[uid] = [int(x) for x in lines[i].split()] if k > 0 else []
+        i += 1
+        order.append(uid)
+    return order, adj
+
+
+def _panel_and_W():
+    d = pd.read_parquet(_BASE / "cps_lawa_arizona.parquet")
+    d["wy"] = d["wklyearn"] * d["weight"]
+    p = ((d.groupby(["statefip", "period"])["wy"].sum()
+          / d.groupby(["statefip", "period"])["weight"].sum())
+         .rename("UR2").reset_index().rename(columns={"statefip": "ID", "period": "month"}))
+    order, adj = _parse_gal(_BASE / "US_no_islands_matrix.gal")
+    common = [f for f in order if f in set(p["ID"].unique())]
+    idx = {f: i for i, f in enumerate(common)}
+    A = np.zeros((len(common), len(common)))
+    for f in common:
+        for nb in adj[f]:
+            if nb in idx:
+                A[idx[f], idx[nb]] = 1.0
+    W1 = A / np.where(A.sum(1, keepdims=True) == 0, 1, A.sum(1, keepdims=True))
+    p = p[p["ID"].isin(common)].copy()
+    p["ID"] = pd.Categorical(p["ID"], categories=common, ordered=True)
+    p = p.sort_values(["month", "ID"]).reset_index(drop=True)
+    T = int(p["month"].nunique())
+    T0 = _TSTAR - 1
+    p["treatment"] = (p["ID"] == _TREATED_FIPS)
+    p["after_treatment"] = (p["month"] >= _TSTAR)
+    p["interaction"] = (p["treatment"] & p["after_treatment"]).astype(int)
+    p["spillover"] = block_diag(*[W1] * T).dot(p["interaction"].values)
+    p["ID"] = p["ID"].astype(int)
+    return p, W1, common, T, T0
+
+
+def _reference_canonical(panel, common, T, T0):
+    """Authors' fitted SDID weights + canonical convention -> (att, tau_s, unit_weights)."""
+    from benchmarks.reference.clone_spsydid import import_functions_ssdid
+
+    fns = import_functions_ssdid()
+    affected = set(panel[(panel["spillover"] > 0) & (~panel["treatment"])]["ID"].unique())
+    data1 = panel[~panel["ID"].isin(affected)].copy()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        uw = fns.fit_unit_weights(data1, "UR2", "month", "ID", "treatment", "after_treatment")
+        tw = fns.fit_time_weights(data1, "UR2", "month", "ID", "treatment", "after_treatment")
+
+    Tpost = T - T0
+    N_sp = len(affected)
+    omega = {s: (1.0 if s == _TREATED_FIPS
+                 else (1.0 / N_sp if s in affected else float(uw.get(s, 0.0))))
+             for s in common}
+    lam = np.empty(T)
+    lam[:T0] = tw.values
+    lam[T0:] = 1.0 / Tpost
+
+    wide = panel.pivot(index="ID", columns="month", values="UR2").loc[common].values
+    Dm = panel.pivot(index="ID", columns="month", values="interaction").loc[common].values
+    WDm = panel.pivot(index="ID", columns="month", values="spillover").loc[common].values
+    N = len(common)
+    wv = np.outer(np.array([omega[s] for s in common]), lam).flatten()
+    sw = np.sqrt(np.clip(wv, 0, None))
+    X = np.zeros((N * T, 1 + (N - 1) + (T - 1) + 2))
+    X[:, 0] = 1.0
+    for i in range(1, N):
+        X[i * T:(i + 1) * T, i] = 1.0
+    base = 1 + (N - 1)
+    for t in range(1, T):
+        X[np.arange(N) * T + t, base + t - 1] = 1.0
+    X[:, -2] = Dm.flatten()
+    X[:, -1] = WDm.flatten()
+    beta = lstsq(X * sw[:, None], wide.flatten() * sw, lapack_driver="gelsy")[0]
+    return float(beta[-2]), float(beta[-1]), uw
+
+
+def _mlsynth_fit(panel, W1, common):
+    from mlsynth import SpSyDiD
+
+    panel = panel.copy()
+    panel["treat_indicator"] = panel["interaction"]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = SpSyDiD({
+            "df": panel[["ID", "month", "UR2", "treat_indicator"]],
+            "outcome": "UR2", "treat": "treat_indicator", "unitid": "ID", "time": "month",
+            "spatial_matrix": W1, "unit_order": list(common),
+            "row_standardize_spatial": False, "display_graphs": False,
+        }).fit()
+    # Everything below is read from the fitted result object only.
+    att = float(res.att)
+    tau_s = float(res.effects.additional_effects["aite"])
+    donor_w = {int(k): float(v) for k, v in (res.weights.donor_weights or {}).items()}
+    return att, tau_s, donor_w
+
+
+def run() -> dict:
+    panel, W1, common, T, T0 = _panel_and_W()
+    att_ref, taus_ref, uw = _reference_canonical(panel, common, T, T0)
+    att_ml, taus_ml, donor_w = _mlsynth_fit(panel, W1, common)
+
+    uw_diff = float(np.max(np.abs(
+        uw.values - np.array([donor_w.get(int(s), np.nan) for s in uw.index]))))
+    return {
+        "lawa_unit_weight_max_abs_diff": uw_diff,
+        "lawa_att_abs_diff_vs_authors": float(abs(att_ml - att_ref)),
+        "lawa_taus_abs_diff_vs_authors": float(abs(taus_ml - taus_ref)),
+    }
+
+
+def comparison() -> dict:
+    """mlsynth SpSyDiD (.fit) vs the authors' code, on the LAWA CPS earnings panel."""
+    panel, W1, common, T, T0 = _panel_and_W()
+    att_ref, taus_ref, _ = _reference_canonical(panel, common, T, T0)
+    att_ml, taus_ml, _ = _mlsynth_fit(panel, W1, common)
+    return {
+        "rows": [
+            {"quantity": "direct ATT (LAWA on log weekly earnings)",
+             "mlsynth": round(att_ml, 8), "reference": round(att_ref, 8)},
+            {"quantity": "spillover coefficient tau_s",
+             "mlsynth": round(taus_ml, 8), "reference": round(taus_ref, 8)},
+        ],
+        "mlsynth_call": {"estimator": "SpSyDiD (.fit)",
+                         "config": {"treated": "Arizona", "outcome": "mean log weekly earnings",
+                                    "spatial_matrix": f"<queen contiguity, {len(common)} states>"}},
+        "reference": {"impl": "authors' functions_ssdid fit_unit_weights / fit_time_weights "
+                              "under the canonical SDID convention (1/T_post post weights, "
+                              "1/N_sp affected weights)",
+                      "version": "serenini/spatial_SDID (cloned on demand, pinned)"},
+    }
+
+
+# The two implementations share the SDID QPs exactly (unit weights ~1e-9), so once
+# the reference is put on mlsynth's canonical row-weight convention the direct ATT
+# and the spillover coefficient agree to solver tolerance. The mlsynth side is
+# taken entirely from SpSyDiD.fit() (res.att / res.effects.additional_effects /
+# res.weights.donor_weights).
+EXPECTED = {
+    "lawa_unit_weight_max_abs_diff": (0.0, 1e-6),
+    "lawa_att_abs_diff_vs_authors": (0.0, 1e-6),
+    "lawa_taus_abs_diff_vs_authors": (0.0, 1e-6),
+}

--- a/benchmarks/reference/spsydid_lawa_diff/comparison.csv
+++ b/benchmarks/reference/spsydid_lawa_diff/comparison.csv
@@ -1,0 +1,10 @@
+# case: spsydid_lawa_diff
+# generated_at: 2026-07-12T12:00:11Z
+# mlsynth_version: 1.0.0
+# estimator: SpSyDiD (.fit)
+# config: {"outcome": "mean log weekly earnings", "spatial_matrix": "<queen contiguity, 45 states>", "treated": "Arizona"}
+# reference_impl: authors' functions_ssdid fit_unit_weights / fit_time_weights under the canonical SDID convention (1/T_post post weights, 1/N_sp affected weights)
+# reference_version: serenini/spatial_SDID (cloned on demand, pinned)
+quantity,mlsynth,reference,abs_diff
+direct ATT (LAWA on log weekly earnings),0.04818796,0.04818788,0.0
+spillover coefficient tau_s,0.06152929,0.0615293,0.0

--- a/benchmarks/reference/spsydid_ref.py
+++ b/benchmarks/reference/spsydid_ref.py
@@ -72,7 +72,7 @@ def reference_ssdid(panel: pd.DataFrame, WD: float):
 
     # Weighted LSDV: unit + time dummies, plus interaction and spillover.
     n = len(did2["ID"].unique())
-    t = 36
+    t = int(did2["month"].nunique())   # window length from the data (was hardcoded 36)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         new = pd.concat([pd.get_dummies(did2["ID"], prefix="ID"),

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -18,6 +18,7 @@ CASES = {
     "sdid_prop99": "benchmarks.cases.sdid_prop99",      # cross-val vs authors' synthdid R (Prop 99)
     "mcnnm_prop99": "benchmarks.cases.mcnnm_prop99",    # cross-val vs authors' MCPanel R (Prop 99)
     "spsydid_state_mc": "benchmarks.cases.spsydid_state_mc",  # cross-val vs authors' repo
+    "spsydid_lawa_diff": "benchmarks.cases.spsydid_lawa_diff",  # differential cross-val vs authors' functions_ssdid on the real Arizona LAWA CPS panel (SpSyDiD.fit() ATT + spillover agree to solver tolerance under canonical convention)
     "seq_sdid_mc": "benchmarks.cases.seq_sdid_mc",            # Path B: SSDiD vs DiD coverage/RMSE
     "clustersc_subgroups": "benchmarks.cases.clustersc_subgroups",      # Path B: ClusterSC vs RSC
     "clustersc_subgroups_ref": "benchmarks.cases.clustersc_subgroups_ref",  # cross-val vs authors' repo

--- a/docs/spsydid.rst
+++ b/docs/spsydid.rst
@@ -440,6 +440,28 @@ runs both ``SpSyDiD`` and the authors' own algorithm on each panel and
 asserts per-rep agreement; see the dedicated page
 :doc:`replications/spsydid`.
 
+A real-data differential cross-check complements the two simulations.
+The paper's Section-4 outcome (the noncitizen-Hispanic share) is not
+reconstructible from public in-repo data, but the SpSyDiD machinery can still be
+exercised on the genuine LAWA setting: ``benchmarks/cases/spsydid_lawa_diff.py``
+aggregates the Arizona LAWA CPS extract (``basedata/cps_lawa_arizona.parquet``,
+shared with :doc:`scd`) to state-mean log weekly earnings, treats Arizona from
+period 55 with the queen-contiguity ``W`` restricted to the 45 common states, and
+compares ``SpSyDiD(config).fit()`` against the authors' own ``fit_unit_weights``
+/ ``fit_time_weights``. The SDID quadratic programs are shared exactly -- the
+unit weights agree to :math:`\sim 10^{-9}` -- so once the reference is placed on
+mlsynth's canonical row-weight convention the direct ATT and the spillover
+coefficient agree to :math:`\sim 10^{-8}`.
+
+The only substantive difference between the two codebases is a convention the
+paper leaves underspecified. The authors' ``join_weights`` fills the post-period
+time weight with :math:`T_{post}/T` and the affected-unit weight with the mean
+treated weight, whereas mlsynth uses the canonical synthetic-DiD choices
+(:math:`1/T_{post}` for the post-period time weights, :math:`1/N_{sp}` for the
+affected units). With the large injected effect of the simulation the two are
+indistinguishable; on a small real effect they can differ at the third decimal,
+so mlsynth follows the canonical convention.
+
 The reference panels and adjacency matrices ship with mlsynth in
 ``basedata/``:
 

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -9,8 +9,8 @@ test suite asserts against, so the numbers here cannot drift from what CI
 enforces. Each row links to the reference implementation, the dataset (with
 checksum), and the mlsynth case that runs the check.
 
-Coverage: **59 cross-validation checks** against original
-implementations across **35 estimators** -- 26 reproduce the reference to display precision, 21 to
+Coverage: **60 cross-validation checks** against original
+implementations across **35 estimators** -- 27 reproduce the reference to display precision, 21 to
 within two percent. A further 1 are captured on the next daily run (see `Pending capture`_). Per-estimator paper replications (Path A / Path B) are catalogued in :doc:`replications`.
 
 Legend: **exact** (agreement to display precision), **tight** (worst
@@ -158,8 +158,8 @@ Summary
      - 1 tight
      - 0.001
    * - :ref:`SpSyDiD <val-spsydid>`
-     - 1
-     - 1 close
+     - 2
+     - 1 exact · 1 close
      - 0.094
    * - :ref:`TASC <val-tasc>`
      - 1
@@ -979,6 +979,12 @@ SpSyDiD
      - max \|Δ\|
      - Verdict
      - Case
+   * - authors' functions_ssdid fit_unit_weights / fit_time_weights under the canonical SDID convention (1/T_post post weights, 1/N_sp affected weights)
+     - —
+     - 2
+     - 0
+     - exact — matches to display precision
+     - `spsydid_lawa_diff <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/spsydid_lawa_diff.py>`__
    * - authors' SDID weight functions (serenini/spatial_SDID functions_ssdid) + the notebook's spatial WLS, via benchmarks.reference.spsydid_ref
      - —
      - 20


### PR DESCRIPTION
## Summary

Adds a real-data differential cross-validation of `SpSyDiD` against the authors' own code (Serenini & Masek 2024, `serenini/spatial_SDID`), on the same Arizona LAWA CPS panel used by the newly-added `SCD` estimator — establishing that the two implementations agree to solver tolerance, and pinning the one place they ever differed.

## What it does

`benchmarks/cases/spsydid_lawa_diff.py` is a real-data companion to the Monte-Carlo `spsydid_state_mc`. It aggregates `basedata/cps_lawa_arizona.parquet` (shared with SCD) to state-mean log weekly earnings, treats Arizona from period 55 with the queen-contiguity `W` (`US_no_islands_matrix.gal`, parsed directly — no libpysal) restricted to the 45 states common to the matrix and the CPS extract, and runs both implementations on it.

The mlsynth side is taken entirely from `SpSyDiD(config).fit()` — `res.att`, `res.effects.additional_effects["aite"]`, `res.weights.donor_weights` — never its internal helpers. The reference is the authors' own `fit_unit_weights` / `fit_time_weights` (cloned on demand) under the canonical final regression.

## Result

| Quantity (from `.fit()`) | mlsynth vs authors |
|---|---|
| unit weights (`res.weights.donor_weights`) | 1.65e-9 |
| direct ATT (`res.att`) | 7.76e-8 |
| spillover coefficient (`res.effects.additional_effects["aite"]`) | 1.11e-8 |

The SDID quadratic programs are shared exactly, so the only prior difference was a set of non-fitted-row conventions the paper leaves underspecified: the authors' `join_weights` fills post-period time weights with `T_post/T` and affected-unit weights with the mean treated weight, whereas mlsynth uses the canonical synthetic-DiD `1/T_post` and `1/N_sp`. Immaterial under the simulation's large injected effect; visible on a small real effect — so mlsynth follows the canonical convention.

## Also in this PR

- Fixes a latent bug in `benchmarks/reference/spsydid_ref.py`: the LSDV dummy slicing hardcoded `t = 36` (the simulation window length), which mis-slices dummies on panels of any other length. `t` is now derived from the data. Harmless to the existing 36-month `spsydid_state_mc`.
- A Verification note on `docs/spsydid.rst` documenting the real-data differential and the canonical-vs-notebook convention.
- Validation dashboard refreshed.

## Verification

`python benchmarks/run_benchmarks.py --case spsydid_lawa_diff` passes (agreement to ~1e-8); `spsydid_state_mc` unchanged (skips without libpysal); SpSyDiD test suite green (105 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7bVBZsrWUPQJbnGGCG1qD)_