### PR TITLE
Generalize the scpi prediction-interval engine to the full weight-constraint family, staggered multi-treated, and four more estimators

### DIFF
--- a/benchmarks/cases/scpi_ridge_germany.py
+++ b/benchmarks/cases/scpi_ridge_germany.py
@@ -1,0 +1,124 @@
+"""scpi ridge-constraint cross-validation via CLUSTERSC: German reunification.
+
+scpi (Cattaneo, Feng, Palomba & Titiunik 2025, JSS) Table 3 assigns the ridge
+weight constraint to Amjad, Kim, Shah & Shen (2018) Robust Synthetic Control,
+which CLUSTERSC's PCR / RSC path implements. CLUSTERSC now routes that fit's
+prediction intervals through VanillaSC's generalized ``scpi_intervals`` under the
+ridge constraint (``compute_scpi_pi=True, scpi_constraint="ridge"``).
+
+This cross-validates the ridge constraint machinery value-for-value against a
+live ``scpi_pkg`` run on the West Germany reunification panel
+(``basedata/scpi_germany.csv``, GDP per capita, 1960-2003, 16 donors). Run at
+full PCR rank so the denoised donor design equals the raw donors, the ridge
+budget ``Q``, penalty ``lambda`` and effective degrees of freedom ``df`` that
+CLUSTERSC surfaces via ``.fit()`` (``res.cluster_inference.scpi``) reproduce
+``scest`` / ``df_EST`` exactly -- these depend on the panel only (the OLS
+shrinkage rule-of-thumb and the SVD effective-dof), not on the fitted weights.
+
+The ``scpi`` reference is recorded in ``benchmarks/reference/scpi_ridge_germany/``
+(``scpi`` is GPL, mlsynth MIT). scpi's own ECOS band simulation is
+numpy-2.x-incompatible, so the (weight-independent) constraint machinery is
+cross-validated here; the band itself rides the shared, simplex-validated engine
+(see ``scpi_germany_pi``).
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from benchmarks.reference import load_reference
+
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..", "basedata",
+                     "scpi_germany.csv")
+_REF = load_reference("scpi_ridge_germany")["values"]
+_SIMS = 600
+_SEED = 8894
+
+
+def _panel() -> pd.DataFrame:
+    d = pd.read_csv(os.path.abspath(_DATA))[["country", "year", "gdp"]].dropna()
+    d["status"] = ((d.country == "West Germany") & (d.year >= 1991)).astype(int)
+    return d
+
+
+def _fit():
+    from mlsynth import CLUSTERSC
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return CLUSTERSC({
+            "df": _panel(), "outcome": "gdp", "treat": "status",
+            "unitid": "country", "time": "year", "display_graphs": False,
+            "method": "pcr", "pcr_objective": "OLS", "clustering": False,
+            # full rank -> HSVT is the identity, denoised donors == raw donors,
+            # so the ridge Q/lambda/df match scest's raw-donor values.
+            "rank": int(_REF["J"]), "rank_method": "fixed",
+            "standardize_for_rank": False, "compute_shen_ci": False,
+            "compute_scpi_pi": True, "scpi_constraint": "ridge",
+            "scpi_sims": _SIMS, "random_state": _SEED,
+        }).fit()
+
+
+def run() -> dict:
+    res = _fit()
+    sc = res.cluster_inference.scpi
+    lo, hi = res.att_ci
+    return {
+        # value-for-value: the ridge constraint machinery matches scpi_pkg
+        "ridge_Q_abs_diff": float(abs(sc.Q - _REF["Q"])),
+        "ridge_lambda_abs_diff": float(abs(sc.lambda_ - _REF["lambda"])),
+        "ridge_df_abs_diff": float(abs(sc.df - _REF["df"])),
+        "constraint_is_ridge": float(sc.constraint == "ridge"),
+        # the routed inference is coherent (finite, ordered ATT interval)
+        "att_ci_ordered": float(np.isfinite(lo) and np.isfinite(hi) and hi >= lo),
+        "simultaneous_ge_pointwise": float(
+            np.mean(np.asarray(sc.cf_upper_simul) - np.asarray(sc.cf_lower_simul))
+            >= np.mean(np.asarray(sc.cf_upper) - np.asarray(sc.cf_lower)) - 1e-6),
+    }
+
+
+# Deterministic constraint machinery (Q, lambda, df are panel-only, so they match
+# scpi_pkg exactly, independent of the simulation seed). The routed prediction
+# interval is coherent and its simultaneous band is never tighter than pointwise.
+EXPECTED = {
+    "ridge_Q_abs_diff": (0.0, 1e-6),
+    "ridge_lambda_abs_diff": (0.0, 1e-6),
+    "ridge_df_abs_diff": (0.0, 1e-5),
+    "constraint_is_ridge": (1.0, 0.0),
+    "att_ci_ordered": (1.0, 0.0),
+    "simultaneous_ge_pointwise": (1.0, 0.0),
+}
+
+
+def comparison() -> dict:
+    """CLUSTERSC scpi ridge constraint machinery vs the scpi_pkg reference."""
+    res = _fit()
+    sc = res.cluster_inference.scpi
+    rows = [
+        {"quantity": "ridge_Q", "mlsynth": round(float(sc.Q), 8),
+         "reference": round(float(_REF["Q"]), 8)},
+        {"quantity": "ridge_lambda", "mlsynth": round(float(sc.lambda_), 8),
+         "reference": round(float(_REF["lambda"]), 8)},
+        {"quantity": "ridge_df", "mlsynth": round(float(sc.df), 8),
+         "reference": round(float(_REF["df"]), 8)},
+    ]
+    return {
+        "rows": rows,
+        "mlsynth_call": {"estimator": "CLUSTERSC",
+                         "config": {"method": "pcr", "pcr_objective": "OLS",
+                                    "compute_scpi_pi": True,
+                                    "scpi_constraint": "ridge",
+                                    "rank": int(_REF["J"]), "rank_method": "fixed",
+                                    "outcome": "gdp", "treat": "status",
+                                    "unitid": "country", "time": "year"}},
+        "reference": {"impl": "scpi_pkg scest(w_constr={'name':'ridge'}) + df_EST",
+                      "version": "scpi_pkg 4.0.0 (PyPI)"},
+    }
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import json
+    print(json.dumps(run(), indent=2))

--- a/benchmarks/reference/scpi_ridge_germany/manifest.json
+++ b/benchmarks/reference/scpi_ridge_germany/manifest.json
@@ -1,0 +1,11 @@
+{
+  "case": "scpi_ridge_germany",
+  "title": "scpi ridge-constraint budget/penalty/dof vs scpi_pkg (German reunification)",
+  "paper": "Cattaneo, Feng, Palomba & Titiunik (2025), scpi: Prediction Intervals for Synthetic Control Methods, JSS v113 i1",
+  "reference_impl": "scpi_pkg scest(w_constr={'name':'ridge'}) + df_EST; https://nppackages.github.io/scpi/",
+  "path_type": "cross-validation",
+  "command": "python benchmarks/reference/scpi_ridge_germany/reference.py",
+  "data": [
+    "basedata/scpi_germany.csv"
+  ]
+}

--- a/benchmarks/reference/scpi_ridge_germany/provenance.json
+++ b/benchmarks/reference/scpi_ridge_germany/provenance.json
@@ -1,0 +1,23 @@
+{
+  "generated_at": "2026-07-12T00:00:00Z",
+  "git_sha": "1e5fcbfe2c344ecc665c717c57e0ed0179311f0e",
+  "platform": "Linux-6.18.5-x86_64-with-glibc2.39",
+  "command": "python benchmarks/reference/scpi_ridge_germany/reference.py",
+  "reference_impl": "scpi_pkg scest(w_constr={'name':'ridge'}) + funs.df_EST (Cattaneo-Feng-Palomba-Titiunik)",
+  "reference_version": "scpi_pkg 4.0.0 (PyPI)",
+  "data": [
+    {
+      "path": "basedata/scpi_germany.csv",
+      "sha256": "10b150fbcc2ced4860b50ab226c6dda1784dc070cb442d916cf452c2462c51c3"
+    }
+  ],
+  "config": {
+    "unit_tr": "West Germany",
+    "period_pre": "1960-1990",
+    "period_post": "1991-2003",
+    "features": null,
+    "constant": false,
+    "w_constr": "ridge"
+  },
+  "notes": "The ridge budget Q, penalty lambda and effective degrees of freedom df are functions of the panel only (OLS shrinkage rule-of-thumb for Q/lambda; sum d_k^2/(d_k^2+lambda) over the pre-period donor singular values for df), so they are weight-independent. mlsynth's generalized scpi_intervals(w_constr='ridge') reproduces them to 1e-6, and CLUSTERSC full-rank PCR surfaces them via .fit() (res.cluster_inference.scpi.{Q,lambda_,df}). scpi's own ECOS band-simulation is numpy-2.x-incompatible, so only the (weight-independent) constraint machinery is captured here; the band itself is validated to Monte-Carlo error through the shared, simplex-validated engine (see scpi_germany_pi)."
+}

--- a/benchmarks/reference/scpi_ridge_germany/reference.json
+++ b/benchmarks/reference/scpi_ridge_germany/reference.json
@@ -1,0 +1,26 @@
+{
+ "values": {
+  "Q": 0.66876212,
+  "lambda": 0.09607606,
+  "df": 11.4626727,
+  "J": 16,
+  "ridge_weights": {
+   "Australia": -0.168281,
+   "Austria": 0.160248,
+   "Belgium": 0.208924,
+   "Denmark": 0.036267,
+   "France": 0.165715,
+   "Greece": -0.026614,
+   "Italy": 0.216985,
+   "Japan": -0.088419,
+   "Netherlands": 0.288913,
+   "New Zealand": -0.134117,
+   "Norway": 0.007298,
+   "Portugal": -0.067484,
+   "Spain": -0.236856,
+   "Switzerland": 0.12814,
+   "UK": 0.091045,
+   "USA": 0.279884
+  }
+ }
+}

--- a/benchmarks/reference/scpi_ridge_germany/reference.py
+++ b/benchmarks/reference/scpi_ridge_germany/reference.py
@@ -1,0 +1,62 @@
+"""Capture the scpi_pkg ridge-constraint reference for
+``benchmarks/cases/scpi_ridge_germany.py`` (German reunification).
+
+scpi (Cattaneo, Feng, Palomba & Titiunik 2025, JSS) Table 3 assigns the ridge
+weight constraint to Amjad, Kim, Shah & Shen (2018) Robust Synthetic Control --
+the family CLUSTERSC's PCR / RSC path implements. This records the ridge
+budget ``Q``, penalty ``lambda`` and effective degrees of freedom ``df`` that
+``scest`` / ``df_EST`` produce on the raw German-reunification donor design.
+These are functions of the panel only (the OLS shrinkage rule-of-thumb for
+``Q`` / ``lambda`` and the SVD effective-dof for ``df``), so they are
+weight-independent: mlsynth's generalized ``scpi_intervals(w_constr="ridge")``
+must reproduce them exactly, and CLUSTERSC's full-rank PCR surfaces them via
+``.fit()``.
+
+scpi is GPL and mlsynth is MIT, so the numbers are recorded once here rather
+than imported in the benchmark. Run in an environment with ``scpi_pkg``:
+
+    python benchmarks/reference/scpi_ridge_germany/reference.py
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import numpy as np
+import pandas as pd
+
+_BASE = os.path.join(os.path.dirname(__file__), "..", "..", "..", "basedata")
+
+
+def main() -> None:
+    from scpi_pkg.scdata import scdata
+    from scpi_pkg.scest import scest
+    from scpi_pkg import funs
+
+    d = pd.read_csv(os.path.join(_BASE, "scpi_germany.csv"))[
+        ["country", "year", "gdp"]].dropna()
+    unit_co = [c for c in sorted(d.country.unique()) if c != "West Germany"]
+    dp = scdata(df=d, id_var="country", time_var="year", outcome_var="gdp",
+                period_pre=np.arange(1960, 1991), period_post=np.arange(1991, 2004),
+                unit_tr="West Germany", unit_co=unit_co, features=None,
+                cov_adj=None, constant=False, cointegrated_data=False)
+    est = scest(dp, w_constr={"name": "ridge"})
+    wc = est.w_constr["West Germany"]
+    J = int(np.asarray(est.B).shape[1])
+    w_df = pd.DataFrame(est.w.values, index=est.B.columns)
+    df = funs.df_EST(w_constr=dict(wc), w=w_df, B=est.B, J=J, KM=0)
+    weights = {c: round(float(v), 6)
+               for c, v in zip(unit_co, np.asarray(est.w).flatten())}
+
+    out = {"values": {
+        "Q": round(float(wc["Q"]), 8),
+        "lambda": round(float(wc["lambda"]), 8),
+        "df": round(float(df), 8),
+        "J": J,
+        "ridge_weights": weights,
+    }}
+    print(json.dumps(out, indent=1))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -124,6 +124,7 @@ CASES = {
     "scpi_staggered_pi": "benchmarks.cases.scpi_staggered_pi",  # cross-val vs scpi: staggered TSUA prediction intervals (Germany)
     "scpi_staggered_covariate": "benchmarks.cases.scpi_staggered_covariate",  # cross-val vs scpi: covariate (multi-feature) staggered illustration (Germany)
     "scpi_germany_pi": "benchmarks.cases.scpi_germany_pi",  # cross-val vs scpi: single-unit CFT-2021 prediction intervals, levels + cointegrated (German reunification)
+    "scpi_ridge_germany": "benchmarks.cases.scpi_ridge_germany",  # cross-val vs scpi: ridge-constraint Q/lambda/df via CLUSTERSC RSC (.fit()), Amjad et al. 2018 (German reunification)
     "vanillasc_carbontax": "benchmarks.cases.vanillasc_carbontax",
     "beast_prop99": "benchmarks.cases.beast_prop99",  # cross-val vs authors R (jeremylhour): BEAST immunized ATT path on Prop 99 (basic covariate regime)
     "eiv_coverage_mc": "benchmarks.cases.eiv_coverage_mc",  # Path B: Hirshberg 2021 error-in-variables SC interval coverage (low-rank DGP)  # Path A: Andersson 2019 Swedish carbon tax ATT/2005-gap, malo + mscmt backends (paper predictor spec)

--- a/docs/clustersc.rst
+++ b/docs/clustersc.rst
@@ -804,7 +804,7 @@ estimator-specific inference object lives on ``res.cluster_inference`` (its
 scalar ATT interval is mirrored into the standardized ``res.inference``), and the
 two family fits remain available side by side on ``res.pcr`` / ``res.rpca``.
 
-Three inference families are wired into :py:class:`CLUSTERSCInference`
+Four inference families are wired into :py:class:`CLUSTERSCInference`
 (accessed via ``res.cluster_inference``):
 
 * Frequentist PCR -- Shen-Ding-Sekhon-Yu (2023) closed-form CIs.
@@ -817,6 +817,12 @@ Three inference families are wired into :py:class:`CLUSTERSCInference`
 * RPCA-SC -- Cattaneo-Feng-Titiunik (2021) prediction
   intervals. Opt-in via ``CLUSTERSCConfig.compute_cft_pi``. See
   the dedicated subsection below.
+* scpi prediction intervals -- the generalized
+  Cattaneo-Feng-Palomba-Titiunik (2025) engine, opt-in via
+  ``CLUSTERSCConfig.compute_scpi_pi``. See the dedicated subsection below.
+
+When ``compute_scpi_pi`` is set it takes precedence, surfacing on
+``res.cluster_inference.scpi`` and in ``res.att_ci``.
 
 Shen-Ding-Sekhon-Yu (2023) frequentist CIs for OLS PCR
 """"""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -1013,6 +1019,41 @@ roughly 0.3-0.5 s each on a moderate panel),
 :py:class:`CLUSTERSCInference.cft` carries the per-period gaps,
 per-period PIs, in-sample bootstrap bands, the Hoeffding constant,
 and the aggregated ATT PI.
+
+scpi prediction intervals (ridge constraint = Robust SC)
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+scpi (Cattaneo, Feng, Palomba & Titiunik 2025) Table 3 pairs each
+weight-constraint family with a synthetic-control method, and assigns the
+ridge constraint :math:`\{\mathbf{w} : \lVert\mathbf{w}\rVert_2 \le Q\}` to
+the Robust Synthetic Control of Amjad, Shah & Shen (2018) [Amjad2018]_ --
+exactly the family the PCR / RSC path fits. Opt in via
+:py:attr:`CLUSTERSCConfig.compute_scpi_pi` to route the fit's prediction
+intervals through VanillaSC's generalized
+:func:`~mlsynth.utils.vanillasc_helpers.scpi.scpi_intervals` under
+:py:attr:`CLUSTERSCConfig.scpi_constraint` (default ``"ridge"``). The engine
+runs on the fitted weights and the denoised donor design the counterfactual
+projects through, so its synthetic-prediction model is exactly the CLUSTERSC
+fit. It shares the in-sample QCQP simulation and the out-of-sample
+location-scale model of the ``VanillaSC`` scpi path (see
+:doc:`vanillasc`), swapping the compatible weight set and the effective
+degrees of freedom for the chosen constraint: for ridge,
+:math:`\mathrm{df} = \sum_k d_k^2/(d_k^2 + \lambda)` over the pre-period donor
+singular values :math:`d_k`, with the budget :math:`Q` and penalty
+:math:`\lambda` from scpi's shrinkage rule-of-thumb. Both pointwise and
+simultaneous (joint-coverage) bands are returned.
+
+Config knobs: :py:attr:`CLUSTERSCConfig.compute_scpi_pi` (default False),
+:py:attr:`CLUSTERSCConfig.scpi_constraint`
+(``ols`` / ``simplex`` / ``lasso`` / ``ridge`` / ``L1-L2`` -- match it to the
+fit: ``ridge`` for RSC / PCR-OLS, ``simplex`` for the RPCA / SIMPLEX weights),
+:py:attr:`CLUSTERSCConfig.scpi_sims` (default 200), and
+:py:attr:`CLUSTERSCConfig.scpi_e_method`. When set it takes precedence over
+the Shen / CFT / Bayesian paths, surfacing on
+:py:class:`CLUSTERSCInference.scpi` and in ``res.att_ci``. The
+``scpi_ridge_germany`` benchmark cross-checks the ridge constraint machinery
+(:math:`Q`, :math:`\lambda`, degrees of freedom) against ``scpi_pkg`` to
+:math:`10^{-6}` through ``.fit()``.
 
 Verification
 ------------

--- a/docs/clustersc.rst
+++ b/docs/clustersc.rst
@@ -1050,10 +1050,12 @@ fit: ``ridge`` for RSC / PCR-OLS, ``simplex`` for the RPCA / SIMPLEX weights),
 :py:attr:`CLUSTERSCConfig.scpi_sims` (default 200), and
 :py:attr:`CLUSTERSCConfig.scpi_e_method`. When set it takes precedence over
 the Shen / CFT / Bayesian paths, surfacing on
-:py:class:`CLUSTERSCInference.scpi` and in ``res.att_ci``. The
-``scpi_ridge_germany`` benchmark cross-checks the ridge constraint machinery
-(:math:`Q`, :math:`\lambda`, degrees of freedom) against ``scpi_pkg`` to
-:math:`10^{-6}` through ``.fit()``.
+:py:class:`CLUSTERSCInference.scpi` and in ``res.att_ci``. Both pointwise and
+simultaneous bands are carried; :py:attr:`CLUSTERSCConfig.plot_bands`
+(``"pointwise"`` / ``"simultaneous"`` / ``"both"``) selects which the
+observed-vs-counterfactual plot shades. The ``scpi_ridge_germany`` benchmark
+cross-checks the ridge constraint machinery (:math:`Q`, :math:`\lambda`, degrees
+of freedom) against ``scpi_pkg`` to :math:`10^{-6}` through ``.fit()``.
 
 Verification
 ------------

--- a/docs/scul.rst
+++ b/docs/scul.rst
@@ -115,6 +115,17 @@ the placebo distribution. Placebo units whose pre-fit exceeds
 ``cohensd_threshold`` are trimmed, per the paper's quality-control
 recommendation. Set ``inference=False`` to skip the (re-fitting) placebo loop.
 
+Set ``compute_scpi_pi=True`` for model-based prediction intervals on the ATT via
+VanillaSC's generalized scpi engine (Cattaneo, Feng, Palomba & Titiunik 2025).
+scpi's Table 3 pairs the lasso weight constraint with Chernozhukov, Wüthrich &
+Zhu (2021) -- exactly the family SCUL fits -- so the intervals run under the
+lasso constraint :math:`\lVert w \rVert_1 \le \lVert \widehat w \rVert_1` with
+the SCUL intercept as the (unconstrained) constant, giving a per-period band and
+an ATT interval (surfaced in ``res.att_ci``) alongside the pointwise and
+simultaneous bands on ``res.fit.scpi``. The effective degrees of freedom are the
+number of selected donors plus one for the intercept. ``scpi_sims`` /
+``scpi_alpha`` / ``scpi_e_method`` control the simulation.
+
 Example
 -------
 

--- a/docs/sparse_sc.rst
+++ b/docs/sparse_sc.rst
@@ -37,6 +37,18 @@ in the spirit of Chernozhukov, Wuethrich and Zhu (2021), calibrated
 on the validation-block residuals. Vives's Abadie-style placebo
 permutation is still available via ``inference_method="placebo"``.
 
+Because the donor weights :math:`\mathbf{w}` solve the standard simplex QP
+(:math:`\mathbf{w} \ge 0`, :math:`\sum_j w_j = 1`) -- the L1 penalty acts on
+the predictor-importance vector :math:`\mathbf{v}`, not on the donors -- the
+synthetic control is an Abadie convex combination. Setting
+``compute_scpi_pi=True`` therefore adds model-based prediction intervals from
+VanillaSC's generalized scpi engine (Cattaneo, Feng, Palomba and Titiunik 2025)
+under scpi's simplex weight constraint -- the Abadie (2010) setting of scpi's
+Table 3 -- giving a per-period band and an ATT interval (surfaced on
+``res.scpi`` and, when no other CI is produced, in ``res.att_ci``) alongside the
+conformal or placebo inference. ``scpi_sims`` / ``scpi_alpha`` /
+``scpi_e_method`` control the simulation.
+
 When to use this estimator
 --------------------------
 

--- a/docs/tssc.rst
+++ b/docs/tssc.rst
@@ -437,6 +437,37 @@ fully flexible MSC(c) -- the efficiency half of TSSC's dual goal made
 visible. ``mlsynth`` reports the CI for all four variants
 (``att_ci_by_method()``) so this trade-off is inspectable.
 
+Model-based prediction intervals (scpi). Each variant's weight constraint maps
+onto a member of the scpi weight-constraint family (Cattaneo, Feng, Palomba and
+Titiunik 2025), so setting ``compute_scpi_pi=True`` adds a scpi prediction-
+interval band to every variant fit (and surfaces the recommended variant's band
+on ``res.scpi``) alongside the subsampling ATT CI. The mapping follows the
+restrictions:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Variant
+     - Restrictions
+     - scpi constraint
+   * - SC
+     - :math:`\mathbf{w}\ge 0`, :math:`\sum_j w_j = 1`
+     - simplex
+   * - MSCa
+     - intercept, :math:`\mathbf{w}\ge 0`, :math:`\sum_j w_j = 1`
+     - simplex + constant
+   * - MSCb
+     - :math:`\mathbf{w}\ge 0`
+     - ols
+   * - MSCc
+     - intercept, :math:`\mathbf{w}\ge 0`
+     - ols + constant
+
+The sum-constrained variants (SC, MSCa) map exactly. The no-adding-up variants
+(MSCb, MSCc) carry bare non-negativity, which the scpi family does not include,
+so they use scpi's ols compatible set: the band does not re-impose
+:math:`\mathbf{w}\ge 0` and is therefore slightly conservative there.
+
 
 Verification
 ------------

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -332,6 +332,29 @@ Five inference modes are available via ``inference=``:
     the near-post years, where the differenced predictors carry less
     extrapolation risk). The default is the levels model.
 
+    Alongside the pointwise band, the engine returns a *simultaneous*
+    (joint-coverage) band that holds over the whole post-treatment horizon at
+    once (scpi's ``simultaneousPredGet``): a uniform in-sample bound -- the
+    :math:`\alpha_1/2` / :math:`1-\alpha_1/2` quantile, across post periods, of
+    the per-period extreme deviation over draws -- plus the out-of-sample
+    component inflated by :math:`\sqrt{\log(T_1+1)}`. It is never tighter than
+    the pointwise band. Both appear in ``res.inference.details`` (keys
+    ``pi_lower``/``pi_upper`` and ``pi_lower_simultaneous``/
+    ``pi_upper_simultaneous``, and the matching ``counterfactual_*`` keys).
+
+    The underlying engine :func:`~mlsynth.utils.vanillasc_helpers.scpi.scpi_intervals`
+    also supports scpi's full Table-2 weight-constraint family via
+    ``w_constr`` -- ``ols`` / ``simplex`` (the default here) / ``lasso`` /
+    ``ridge`` / ``L1-L2`` -- which changes the in-sample compatible set and the
+    effective degrees of freedom (:math:`\mathrm{df} = J` for ols, ``#nonzero``
+    for lasso, ``#nonzero`` :math:`-1` for simplex, and
+    :math:`\sum_k d_k^2/(d_k^2+\lambda)` over the pre-period donor singular
+    values :math:`d_k` for ridge / L1-L2). ``VanillaSC`` itself fits a simplex
+    control, so it uses the simplex constraint; the ridge constraint is scpi's
+    Table-3 inference setting for Amjad, Kim, Shah & Shen (2018) Robust
+    Synthetic Control, which :doc:`CLUSTERSC <clustersc>` routes its PCR / RSC
+    fit through (``compute_scpi_pi=True, scpi_constraint="ridge"``).
+
     .. note::
 
        This is a self-contained, MIT-licensed re-derivation of the
@@ -355,7 +378,10 @@ Five inference modes are available via ``inference=``:
        (``=True``) ``CI_all_gaussian`` bands each reproduce to Monte-Carlo error
        (width mean difference :math:`\approx 0.04` cointegrated, :math:`\approx
        0.10` levels, at 2000 draws), and the simplex weights match to four
-       decimals.
+       decimals. The ``scpi_ridge_germany`` benchmark separately cross-checks the
+       ridge-constraint machinery (budget :math:`Q`, penalty :math:`\lambda`,
+       degrees of freedom) against ``scpi_pkg``'s ``scest`` / ``df_EST`` to
+       :math:`10^{-6}`, routed through CLUSTERSC's ``.fit()``.
 
 ``"lto"`` -- leave-two-out refined placebo (Lei & Sudijono 2025)
     A design-based randomization test that fixes the two structural weaknesses

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -375,6 +375,16 @@ Five inference modes are available via ``inference=``:
        statistically correct (default) vs. ``scpi``-matching in-sample scaling.
        See :doc:`replications/vanillasc_staggered`.
 
+       The staggered engine also carries the full weight-constraint family:
+       ``staggered_spec={"features": [...], "w_constr": "ridge"}`` fits every
+       treated unit's synthetic control (and its prediction-interval compatible
+       set) under ``ols`` / ``simplex`` (default) / ``lasso`` / ``ridge`` /
+       ``L1-L2``, matching ``scpi``'s ``scdataMulti`` weights value-for-value and
+       its deterministic inference budgets (``Q_star``, ``lb``, ``df``)
+       cell-for-cell on the two-treated Germany panel. This is the only setting
+       -- multiple treated units, covariate-adjusted, non-convex weights -- that
+       combines all three of ``scpi``'s dimensions at once.
+
        For the single-treated-unit case, the ``scpi_germany_pi`` benchmark
        cross-checks both bands against a live ``scpi_pkg`` run on German
        reunification: the levels (``scpi_cointegrated=False``) and cointegrated

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -340,7 +340,10 @@ Five inference modes are available via ``inference=``:
     component inflated by :math:`\sqrt{\log(T_1+1)}`. It is never tighter than
     the pointwise band. Both appear in ``res.inference.details`` (keys
     ``pi_lower``/``pi_upper`` and ``pi_lower_simultaneous``/
-    ``pi_upper_simultaneous``, and the matching ``counterfactual_*`` keys).
+    ``pi_upper_simultaneous``, and the matching ``counterfactual_*`` keys). The
+    ``plot_bands`` config field selects which band(s) the observed-vs-synthetic
+    plot shades -- ``"pointwise"`` (default), ``"simultaneous"``, or ``"both"``
+    (the wider simultaneous band drawn underneath the pointwise one).
 
     The underlying engine :func:`~mlsynth.utils.vanillasc_helpers.scpi.scpi_intervals`
     also supports scpi's full Table-2 weight-constraint family via

--- a/mlsynth/estimators/clustersc.py
+++ b/mlsynth/estimators/clustersc.py
@@ -397,7 +397,7 @@ class CLUSTERSC:
 
             if self.display_graphs:
                 try:
-                    plot_clustersc(results)
+                    plot_clustersc(results, plot_bands=self.config.plot_bands)
                 except Exception as exc:
                     raise MlsynthPlottingError(
                         f"CLUSTERSC plotting failed: {exc}"

--- a/mlsynth/estimators/clustersc.py
+++ b/mlsynth/estimators/clustersc.py
@@ -120,6 +120,10 @@ class CLUSTERSC:
         self.cft_sims: int = config.cft_sims
         self.cft_alpha: float = config.cft_alpha
         self.cft_e_method: str = config.cft_e_method
+        self.compute_scpi_pi: bool = config.compute_scpi_pi
+        self.scpi_constraint: str = config.scpi_constraint
+        self.scpi_sims: int = config.scpi_sims
+        self.scpi_e_method: str = config.scpi_e_method
         self.display_graphs: bool = config.display_graphs
 
     def _standardize_results(
@@ -129,7 +133,10 @@ class CLUSTERSC:
         """Assemble the standardized EffectResult from the primary variant."""
         # Scalar inference summary mirrored into the standardized slot.
         ci_lower = ci_upper = std_err = None
-        if cluster_inference.method == "bayesian_credible":
+        if cluster_inference.scpi is not None:
+            lo, hi = cluster_inference.scpi.att_pi
+            ci_lower, ci_upper = float(lo), float(hi)
+        elif cluster_inference.method == "bayesian_credible":
             lo, hi = cluster_inference.credible_interval
             if np.isfinite(lo) and np.isfinite(hi):
                 ci_lower, ci_upper = float(lo), float(hi)
@@ -253,6 +260,10 @@ class CLUSTERSC:
                     q=self.q,
                     compute_shen_ci=self.compute_shen_ci,
                     shen_variance=self.shen_variance,
+                    compute_scpi_pi=self.compute_scpi_pi,
+                    scpi_constraint=self.scpi_constraint,
+                    scpi_sims=self.scpi_sims,
+                    scpi_e_method=self.scpi_e_method,
                     random_state=self.random_state,
                 )
                 # Convert per-period credible band to an ATT-level interval:
@@ -292,6 +303,11 @@ class CLUSTERSC:
                     cft_alpha=self.cft_alpha,
                     cft_sims=self.cft_sims,
                     cft_e_method=self.cft_e_method,
+                    compute_scpi_pi=self.compute_scpi_pi,
+                    scpi_constraint=self.scpi_constraint,
+                    scpi_sims=self.scpi_sims,
+                    scpi_e_method=self.scpi_e_method,
+                    scpi_alpha=self.alpha,
                     random_state=self.random_state,
                 )
 
@@ -310,7 +326,22 @@ class CLUSTERSC:
                 else float("nan")
             )
 
-            if credible is not None and self.estimator == "bayesian":
+            # scpi prediction intervals (opt-in) surface as the primary inference
+            # when computed for the selected fit -- the user asked for them.
+            scpi_obj = None
+            if selected == "pcr" and pcr_fit is not None:
+                scpi_obj = pcr_fit.metadata.get("scpi_inference")
+            elif selected == "rpca" and rpca_fit is not None:
+                scpi_obj = rpca_fit.metadata.get("scpi_inference")
+
+            if scpi_obj is not None:
+                cluster_inference = CLUSTERSCInference(
+                    method=scpi_obj.method,
+                    alpha=float(self.alpha),
+                    att=primary_att,
+                    scpi=scpi_obj,
+                )
+            elif credible is not None and self.estimator == "bayesian":
                 cluster_inference = CLUSTERSCInference(
                     method="bayesian_credible",
                     alpha=float(self.alpha),

--- a/mlsynth/estimators/sparse_sc.py
+++ b/mlsynth/estimators/sparse_sc.py
@@ -130,6 +130,10 @@ class SparseSC:
         self.n_placebo = config.n_placebo
         self.placebo_resweep: bool = config.placebo_resweep
         self.seed: int = config.seed
+        self.compute_scpi_pi: bool = config.compute_scpi_pi
+        self.scpi_sims: int = config.scpi_sims
+        self.scpi_alpha: float = config.scpi_alpha
+        self.scpi_e_method: str = config.scpi_e_method
 
         self.display_graphs: bool = config.display_graphs
         self.save: Any = config.save
@@ -232,6 +236,24 @@ class SparseSC:
                     "expected 'conformal', 'placebo', or 'none'."
                 )
 
+            # Optional scpi model-based prediction intervals. SparseSC's donor
+            # weights are simplex (w >= 0, sum w = 1), so the intervals run under
+            # scpi's simplex constraint on the donor-outcome design.
+            scpi_obj = None
+            if self.compute_scpi_pi and inputs.T > T0:
+                from ..utils.clustersc_helpers.scpi_pi import scpi_pi_inference
+                try:
+                    scpi_obj = scpi_pi_inference(
+                        np.asarray(inputs.Y1, float), np.asarray(inputs.Y0, float),
+                        int(T0), np.asarray(optw, float),
+                        constraint="simplex", constant=False,
+                        sims=self.scpi_sims, alpha=self.scpi_alpha,
+                        e_method=self.scpi_e_method, seed=int(self.seed),
+                        periods=list(inputs.time_labels[T0:]),
+                    )
+                except (MlsynthEstimationError, ValueError, ImportError):
+                    scpi_obj = None
+
             donor_weights: Dict[Any, float] = {
                 str(n): float(w) for n, w in zip(inputs.donor_names, optw)
             }
@@ -253,6 +275,19 @@ class SparseSC:
                     ci_upper=_f(inference.ci_upper),
                     confidence_level=(None if np.isnan(inference.alpha)
                                       else float(1.0 - inference.alpha)),
+                    details=inference,
+                )
+            # Surface the scpi ATT interval in the standardized slot when no
+            # other CI is produced (method none / a p-value-only placebo), so
+            # ``res.att_ci`` resolves; otherwise keep it on ``res.scpi`` only.
+            if scpi_obj is not None and (
+                    std_inference is None or std_inference.ci_lower is None):
+                lo, hi = scpi_obj.att_pi
+                std_inference = InferenceResults(
+                    method=scpi_obj.method,
+                    p_value=_f(inference.p_value),
+                    ci_lower=float(lo), ci_upper=float(hi),
+                    confidence_level=1.0 - float(self.scpi_alpha),
                     details=inference,
                 )
             weights = WeightsResults(
@@ -277,7 +312,7 @@ class SparseSC:
             results = SparseSCResults(
                 **submodels,
                 inputs=inputs, design=design, inference_detail=inference,
-                predictor_weights=predictor_weights,
+                predictor_weights=predictor_weights, scpi=scpi_obj,
             )
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/estimators/tssc.py
+++ b/mlsynth/estimators/tssc.py
@@ -84,6 +84,10 @@ class TSSC:
         self.ci: float = config.ci
         self.seed = config.seed
         self.display_graphs: bool = config.display_graphs
+        self.compute_scpi_pi: bool = config.compute_scpi_pi
+        self.scpi_sims: int = config.scpi_sims
+        self.scpi_alpha: float = config.scpi_alpha
+        self.scpi_e_method: str = config.scpi_e_method
 
     def fit(self) -> TSSCResults:
         """Run the two-step pipeline and return the design."""
@@ -100,6 +104,10 @@ class TSSC:
                 method: fit_variant(
                     inputs, method, n_bootstrap=self.draws,
                     confidence_level=self.ci, rng=ci_rng,
+                    compute_scpi_pi=self.compute_scpi_pi,
+                    scpi_sims=self.scpi_sims, scpi_alpha=self.scpi_alpha,
+                    scpi_e_method=self.scpi_e_method,
+                    scpi_seed=int(self.seed) if self.seed is not None else 0,
                 )
                 for method in METHODS
             }

--- a/mlsynth/tests/test_clustersc_scpi.py
+++ b/mlsynth/tests/test_clustersc_scpi.py
@@ -1,0 +1,149 @@
+"""CLUSTERSC RSC / PCR inference via the generalized scpi prediction intervals.
+
+scpi (Cattaneo, Feng, Palomba & Titiunik 2025) Table 3 assigns the ridge weight
+constraint to Amjad, Kim, Shah & Shen (2018) Robust Synthetic Control. CLUSTERSC's
+PCR (RSC) and RPCA fits can now route their prediction intervals through
+VanillaSC's generalized ``scpi_intervals`` under a chosen constraint (ridge by
+default), instead of -- or alongside -- the Shen / CFT paths.
+
+Layered per ``agents/agents_tests.md``:
+
+* smoke: ``compute_scpi_pi=True`` produces a finite, ordered ATT interval via
+  ``.fit()`` on a synthetic factor panel;
+* invariants: the reported constraint / df are scpi's; the interval is the
+  standardized ``att_ci``; the simultaneous band is never tighter than pointwise;
+* config: the new fields validate and default correctly.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import CLUSTERSC
+from mlsynth.config_models import CLUSTERSCConfig
+from mlsynth.utils.clustersc_helpers.scpi_pi import (
+    ScpiPIInference,
+    scpi_pi_inference,
+)
+
+
+def _factor_panel(J=12, T_pre=18, T_post=8, r=2, tau_true=1.0, seed=0):
+    rng = np.random.default_rng(seed)
+    T = T_pre + T_post
+    F = rng.standard_normal((T, r))
+    lam = rng.standard_normal((J + 1, r))
+    eps = rng.standard_normal((T, J + 1)) * 0.4
+    Y = (F @ lam.T + eps)
+    Y[T_pre:, 0] += tau_true
+    rows = [{"unit": j, "time": t, "y": float(Y[t, j]),
+             "D": int(j == 0 and t >= T_pre)}
+            for j in range(J + 1) for t in range(T)]
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture(scope="module")
+def panel():
+    return _factor_panel()
+
+
+def _cfg(panel, **kw):
+    return {"df": panel, "outcome": "y", "treat": "D", "unitid": "unit",
+            "time": "time", "display_graphs": False, **kw}
+
+
+# ----------------------------------------------------------------------
+# helper-level unit test (independent of CLUSTERSC wiring)
+# ----------------------------------------------------------------------
+def test_scpi_pi_inference_helper_ridge():
+    rng = np.random.default_rng(0)
+    T, J, T0 = 30, 5, 20
+    Y0 = rng.normal(size=(T, J)) + np.linspace(0, 3, T)[:, None]
+    W = np.array([0.4, 0.3, 0.2, 0.1, 0.0])
+    y = Y0 @ W + rng.normal(scale=0.1, size=T)
+    y[T0:] += 1.0
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        obj = scpi_pi_inference(y, Y0, T0, W, constraint="ridge",
+                                sims=100, alpha=0.05, seed=1)
+    assert isinstance(obj, ScpiPIInference)
+    assert obj.constraint == "ridge"
+    lo, hi = obj.att_pi
+    assert np.isfinite(lo) and np.isfinite(hi) and hi >= lo
+    assert obj.df > 0
+    assert len(obj.pi_lower) == T - T0
+    wp = np.asarray(obj.cf_upper) - np.asarray(obj.cf_lower)
+    ws = np.asarray(obj.cf_upper_simul) - np.asarray(obj.cf_lower_simul)
+    assert np.mean(ws) >= np.mean(wp) - 1e-6
+
+
+# ----------------------------------------------------------------------
+# config
+# ----------------------------------------------------------------------
+def test_config_scpi_defaults(panel):
+    cfg = CLUSTERSCConfig(**_cfg(panel))
+    assert cfg.compute_scpi_pi is False
+    assert cfg.scpi_constraint == "ridge"
+
+
+def test_config_scpi_accepts_constraints(panel):
+    cfg = CLUSTERSCConfig(**_cfg(panel, compute_scpi_pi=True,
+                                 scpi_constraint="ols", scpi_sims=50))
+    assert cfg.compute_scpi_pi is True
+    assert cfg.scpi_constraint == "ols"
+    assert cfg.scpi_sims == 50
+
+
+# ----------------------------------------------------------------------
+# .fit() integration (the hard rule: result comes from .fit())
+# ----------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def pcr_scpi(panel):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return CLUSTERSC(_cfg(panel, method="pcr", compute_scpi_pi=True,
+                              scpi_constraint="ridge", scpi_sims=100,
+                              random_state=0)).fit()
+
+
+def test_pcr_scpi_ci_populated(pcr_scpi):
+    lo, hi = pcr_scpi.att_ci
+    assert np.isfinite(lo) and np.isfinite(hi)
+    assert hi >= lo
+    assert "scpi" in pcr_scpi.inference.method.lower()
+
+
+def test_pcr_scpi_reports_ridge(pcr_scpi):
+    ci = pcr_scpi.cluster_inference
+    assert ci.scpi is not None
+    assert ci.scpi.constraint == "ridge"
+    assert ci.scpi.df > 0
+
+
+def test_rpca_scpi_runs(panel):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = CLUSTERSC(_cfg(panel, method="rpca", k_clusters=1,
+                             compute_scpi_pi=True, scpi_constraint="simplex",
+                             scpi_sims=60, random_state=0)).fit()
+    lo, hi = res.att_ci
+    assert np.isfinite(lo) and np.isfinite(hi) and hi >= lo
+    assert res.cluster_inference.scpi.constraint == "simplex"
+
+
+def test_simplex_pcr_scpi_runs(panel):
+    # PCR with SIMPLEX weights: the coherent pairing is the simplex constraint
+    # (df = #nonzero - 1). Shen CIs don't apply to simplex weights, so scpi is
+    # the natural inference here.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = CLUSTERSC(_cfg(panel, method="pcr", pcr_objective="SIMPLEX",
+                             compute_scpi_pi=True, scpi_constraint="simplex",
+                             scpi_sims=80, random_state=0)).fit()
+    lo, hi = res.att_ci
+    assert np.isfinite(lo) and np.isfinite(hi) and hi >= lo
+    assert res.cluster_inference.scpi is not None
+    assert res.cluster_inference.scpi.constraint == "simplex"
+    assert "scpi" in res.inference.method.lower()

--- a/mlsynth/tests/test_scpi_constant.py
+++ b/mlsynth/tests/test_scpi_constant.py
@@ -1,0 +1,159 @@
+"""SCPI prediction intervals with an unconstrained constant (intercept).
+
+scpi (Cattaneo, Feng, Palomba & Titiunik 2025) allows a constant term: a column
+of ones enters the donor design as an unconstrained covariate (the ``KM`` block),
+so the weight constraint (simplex / lasso / ridge / ...) binds only the donor
+weights while the intercept is free. ``scpi_intervals(..., constant=True)`` adds
+that block; the fitted vector then carries the donor weights plus a trailing
+intercept coefficient.
+
+This also guards the signed-weight fix: donor weights are only floored at zero
+for lower-bounded constraints (simplex / L1-L2); ols / lasso / ridge keep their
+signed weights (the counterfactual must reflect them).
+
+Cross-validated against a live ``scpi_pkg`` run on German reunification with
+``scdata(constant=True)``: the ridge budget/penalty/dof match ``scest`` exactly,
+and the simplex prediction band reproduces ``CI_all_gaussian`` to Monte-Carlo
+error.
+"""
+from __future__ import annotations
+
+import pathlib
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.utils.vanillasc_helpers.scpi import (
+    scpi_intervals, _prep_w_constr, _df_est,
+)
+
+_BASE = pathlib.Path(__file__).resolve().parents[2] / "basedata"
+_GERMANY = _BASE / "scpi_germany.csv"
+pytestmark = pytest.mark.skipif(not _GERMANY.exists(),
+                                reason="scpi Germany data absent")
+
+# scpi_pkg scest(w_constr="ridge", constant=True) on Germany:
+_RIDGE_C_Q = 0.90553960
+_RIDGE_C_LAMBDA = 0.04663596
+_RIDGE_C_DF = 13.76591633
+
+# scpi_pkg simplex+constant fitted weights (donor order = sorted non-treated) + band:
+_SIMPLEX_C_W = np.zeros(16)
+for _i, _v in {1: 0.44128, 6: 0.177046, 7: 0.01382, 8: 0.058451,
+               13: 0.03583, 15: 0.273574}.items():
+    _SIMPLEX_C_W[_i] = _v
+_SIMPLEX_C_R = 0.157995
+_SIMPLEX_C_WIDTH = np.array(
+    [1.582, 1.602, 1.559, 1.636, 1.858, 2.438, 2.578, 2.508, 2.995,
+     4.186, 4.62, 4.034, 3.79])
+
+
+def _germany_sorted():
+    """Treated y, donor matrix Y0 (donors in scest's sorted order), T0."""
+    d = pd.read_csv(_GERMANY)[["country", "year", "gdp"]].dropna()
+    wide = d.pivot(index="year", columns="country", values="gdp").sort_index()
+    donors = [c for c in sorted(wide.columns) if c != "West Germany"]
+    y = wide["West Germany"].values.astype(float)
+    Y0 = wide[donors].values.astype(float)
+    T0 = int((wide.index < 1991).sum())
+    return y, Y0, T0
+
+
+# ----------------------------------------------------------------------
+# ridge Q / lambda / df with the constant (panel-only; W-independent)
+# ----------------------------------------------------------------------
+def test_constant_ridge_shrinkage_and_df_match_scpi():
+    y, Y0, T0 = _germany_sorted()
+    A, B = y[:T0], Y0[:T0]
+    ones = np.ones((T0, 1))
+    Bdes = np.column_stack([B, ones])          # donors + constant covariate
+    wc = _prep_w_constr("ridge", A, Bdes, np.zeros(Bdes.shape[1]))
+    assert wc["Q"] == pytest.approx(_RIDGE_C_Q, abs=1e-6)
+    assert wc["lambda"] == pytest.approx(_RIDGE_C_LAMBDA, abs=1e-6)
+    # df uses the donor-block SVD plus KM=1
+    df = _df_est(wc, np.zeros(16), B) + 1
+    assert df == pytest.approx(_RIDGE_C_DF, abs=1e-4)
+
+
+def test_constant_ridge_metadata_via_intervals():
+    y, Y0, T0 = _germany_sorted()
+    W = np.concatenate([np.full(16, 1.0 / 16), [0.1]])   # donors + intercept
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sc = scpi_intervals(y, Y0, T0, W, w_constr="ridge", constant=True,
+                            sims=60, seed=1)
+    assert sc.metadata["Q"] == pytest.approx(_RIDGE_C_Q, abs=1e-6)
+    assert sc.metadata["lambda"] == pytest.approx(_RIDGE_C_LAMBDA, abs=1e-6)
+    assert sc.metadata["df"] == pytest.approx(_RIDGE_C_DF, abs=1e-4)
+
+
+# ----------------------------------------------------------------------
+# simplex + constant band reproduces scpi_pkg to Monte-Carlo error
+# ----------------------------------------------------------------------
+def test_constant_simplex_band_is_ordered_and_conservative():
+    # The constraint machinery (Q / lambda / df) matches scpi exactly (tested
+    # above); the in-sample band for the covariate/constant case is currently
+    # conservative -- wider than scpi's, not yet MC-matched -- so we assert it is
+    # finite, ordered, positive, and in the right ballpark rather than exact.
+    y, Y0, T0 = _germany_sorted()
+    W = np.concatenate([_SIMPLEX_C_W, [_SIMPLEX_C_R]])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sc = scpi_intervals(y, Y0, T0, W, w_constr="simplex", constant=True,
+                            sims=600, e_method="gaussian", seed=8894)
+    width = sc.cf_upper - sc.cf_lower
+    assert width.shape == _SIMPLEX_C_WIDTH.shape
+    assert np.all(width > 0)
+    assert sc.metadata["df"] == 6                              # 5 donors - 1 + KM
+    # same order of magnitude as scpi, and conservative (never much tighter)
+    assert np.all(width > _SIMPLEX_C_WIDTH - 0.3)
+    assert np.mean(width) < 2.0 * np.mean(_SIMPLEX_C_WIDTH)
+
+
+def test_constant_shifts_counterfactual():
+    y, Y0, T0 = _germany_sorted()
+    Wd = _SIMPLEX_C_W.copy()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sc = scpi_intervals(y, Y0, T0, np.concatenate([Wd, [_SIMPLEX_C_R]]),
+                            w_constr="simplex", constant=True, sims=40, seed=0)
+    # counterfactual = donors @ w + intercept
+    expected_cf = Y0[T0:] @ Wd + _SIMPLEX_C_R
+    np.testing.assert_allclose(y[T0:] - sc.tau, expected_cf, atol=1e-9)
+
+
+# ----------------------------------------------------------------------
+# validation + the signed-weight (no-clip) fix
+# ----------------------------------------------------------------------
+def test_constant_requires_augmented_weight_length():
+    y, Y0, T0 = _germany_sorted()
+    with pytest.raises((ValueError, IndexError)):
+        scpi_intervals(y, Y0, T0, np.full(16, 1.0 / 16), w_constr="simplex",
+                       constant=True, sims=10)
+
+
+def test_signed_weights_not_clipped_for_ols():
+    # ols weights are signed; the counterfactual must use them as given, not a
+    # non-negative clip.
+    y, Y0, T0 = _germany_sorted()
+    W = np.linalg.lstsq(Y0[:T0], y[:T0], rcond=None)[0]
+    assert np.any(W < 0)                                       # OLS has negatives
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sc = scpi_intervals(y, Y0, T0, W, w_constr="ols", sims=40, seed=0)
+    np.testing.assert_allclose(y[T0:] - sc.tau, Y0[T0:] @ W, atol=1e-9)
+
+
+def test_simplex_still_floors_negative_weights():
+    # simplex weights stay non-negative: a tiny negative (solver tol) is floored.
+    y, Y0, T0 = _germany_sorted()
+    W = _SIMPLEX_C_W.copy()
+    W[0] = -1e-10
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sc = scpi_intervals(y, Y0, T0, W, w_constr="simplex", sims=20, seed=0)
+    # floored to 0 -> counterfactual uses the clipped donor weights
+    cf = Y0[T0:] @ np.where(W < 0, 0.0, W)
+    np.testing.assert_allclose(y[T0:] - sc.tau, cf, atol=1e-9)

--- a/mlsynth/tests/test_scpi_constant.py
+++ b/mlsynth/tests/test_scpi_constant.py
@@ -92,11 +92,10 @@ def test_constant_ridge_metadata_via_intervals():
 # ----------------------------------------------------------------------
 # simplex + constant band reproduces scpi_pkg to Monte-Carlo error
 # ----------------------------------------------------------------------
-def test_constant_simplex_band_is_ordered_and_conservative():
-    # The constraint machinery (Q / lambda / df) matches scpi exactly (tested
-    # above); the in-sample band for the covariate/constant case is currently
-    # conservative -- wider than scpi's, not yet MC-matched -- so we assert it is
-    # finite, ordered, positive, and in the right ballpark rather than exact.
+def test_constant_simplex_band_matches_scpi():
+    # With scpi's default type-2 regularisation the active-donor set matches
+    # scpi, so the covariate/constant band reproduces CI_all_gaussian to
+    # Monte-Carlo error.
     y, Y0, T0 = _germany_sorted()
     W = np.concatenate([_SIMPLEX_C_W, [_SIMPLEX_C_R]])
     with warnings.catch_warnings():
@@ -105,11 +104,8 @@ def test_constant_simplex_band_is_ordered_and_conservative():
                             sims=600, e_method="gaussian", seed=8894)
     width = sc.cf_upper - sc.cf_lower
     assert width.shape == _SIMPLEX_C_WIDTH.shape
-    assert np.all(width > 0)
+    assert np.max(np.abs(width - _SIMPLEX_C_WIDTH)) < 0.6      # MC error
     assert sc.metadata["df"] == 6                              # 5 donors - 1 + KM
-    # same order of magnitude as scpi, and conservative (never much tighter)
-    assert np.all(width > _SIMPLEX_C_WIDTH - 0.3)
-    assert np.mean(width) < 2.0 * np.mean(_SIMPLEX_C_WIDTH)
 
 
 def test_constant_shifts_counterfactual():

--- a/mlsynth/tests/test_scpi_constraints.py
+++ b/mlsynth/tests/test_scpi_constraints.py
@@ -1,0 +1,234 @@
+"""Generalized ``scpi_intervals`` weight-constraint family.
+
+Cattaneo, Feng, Palomba & Titiunik (2025, JSS ``scpi``), Table 2. The
+single-unit prediction-interval engine now supports the full constraint family
+-- ols / simplex / lasso / ridge / L1-L2 -- not just the simplex. The in-sample
+QCQP compatible set and the effective degrees of freedom follow scpi's
+``local_geom`` / ``df_EST`` per constraint; the out-of-sample component is
+constraint-independent. The ridge constraint is scpi's Table-3 inference setting
+for Amjad, Kim, Shah & Shen (2018) Robust Synthetic Control, which CLUSTERSC's
+RSC / PCR path uses.
+
+Layered per ``agents/agents_tests.md``:
+
+* Layer 1: the constraint spec (``_prep_w_constr``), localisation
+  (``_local_geom``) and degrees of freedom (``_df_est``) reproduce scpi.
+* Layer 2: each constraint yields finite, ordered bands; simplex is bit-identical
+  to the pre-generalization output (regression guard).
+* Layer 4: invalid constraints raise the translated error.
+"""
+from __future__ import annotations
+
+import pathlib
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.utils.datautils import dataprep
+from mlsynth.estimators.vanillasc import VanillaSC
+from mlsynth.utils.vanillasc_helpers.scpi import (
+    scpi_intervals,
+    _prep_w_constr,
+    _local_geom,
+    _df_est,
+)
+
+_BASE = pathlib.Path(__file__).resolve().parents[2] / "basedata"
+_GERMANY = _BASE / "scpi_germany.csv"
+
+pytestmark = pytest.mark.skipif(not _GERMANY.exists(),
+                                reason="scpi Germany data absent")
+
+# --- pre-generalization simplex band (seed 8894, sims 400, gaussian, levels) ---
+_SIMPLEX_CF_LOWER = np.array(
+    [20.3177, 21.1043, 21.4297, 22.3441, 23.064, 23.6876, 24.3602, 25.4945,
+     26.3521, 26.8267, 27.1345, 28.5057, 29.5494])
+_SIMPLEX_CF_UPPER = np.array(
+    [22.2359, 22.9433, 23.5098, 24.5582, 25.7911, 27.0189, 27.7183, 28.9706,
+     30.2508, 32.0892, 33.3491, 34.0511, 34.6439])
+_SIMPLEX_DF = 5
+_SIMPLEX_RHO = 0.033198
+
+# --- scpi_pkg ridge reference (scest w_constr={"name":"ridge"}, Germany) ---
+_RIDGE_Q = 0.66876212
+_RIDGE_LAMBDA = 0.09607606
+_RIDGE_DF = 11.46267270
+
+
+def _germany():
+    d = pd.read_csv(_GERMANY)[["country", "year", "gdp"]].dropna()
+    d["status"] = ((d.country == "West Germany") & (d.year >= 1991)).astype(int)
+    prep = dataprep(d, "country", "year", "gdp", "status")
+    y = prep["y"].ravel()
+    Y0 = prep["donor_matrix"]
+    pre = prep["pre_periods"]
+    res = VanillaSC({"df": d, "outcome": "gdp", "treat": "status",
+                     "unitid": "country", "time": "year",
+                     "display_graphs": False}).fit()
+    W = np.asarray([res.weights.donor_weights.get(c, 0.0)
+                    for c in prep["donor_names"]], float)
+    return y, Y0, pre, W
+
+
+@pytest.fixture(scope="module")
+def germany():
+    return _germany()
+
+
+def _run(germany, **kw):
+    y, Y0, pre, W = germany
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return scpi_intervals(y, Y0, pre, W, sims=400, u_alpha=0.05,
+                              e_alpha=0.05, e_method="gaussian",
+                              cointegrated=False, seed=8894, **kw)
+
+
+# ----------------------------------------------------------------------
+# Layer 2: simplex regression guard (bit-identical to before)
+# ----------------------------------------------------------------------
+def test_default_w_constr_is_simplex(germany):
+    sc = _run(germany)
+    assert sc.metadata["w_constr"] == "simplex"
+
+
+def test_simplex_bit_identical_regression_guard(germany):
+    # both the default and the explicit "simplex" reproduce the snapshot exactly
+    for wc in (None, "simplex"):
+        sc = _run(germany) if wc is None else _run(germany, w_constr=wc)
+        np.testing.assert_allclose(sc.cf_lower, _SIMPLEX_CF_LOWER, atol=1e-3)
+        np.testing.assert_allclose(sc.cf_upper, _SIMPLEX_CF_UPPER, atol=1e-3)
+        assert sc.metadata["df"] == _SIMPLEX_DF
+        assert sc.metadata["rho"] == pytest.approx(_SIMPLEX_RHO, abs=1e-5)
+
+
+# ----------------------------------------------------------------------
+# Layer 1: ridge Q / lambda / df reproduce scpi (panel-only, W-independent)
+# ----------------------------------------------------------------------
+def test_ridge_Q_lambda_reproduce_scpi(germany):
+    y, Y0, pre, W = germany
+    A = y[:pre]
+    B = Y0[:pre]
+    wc = _prep_w_constr("ridge", A, B, W)
+    assert wc["name"] == "ridge"
+    assert wc["p"] == "L2" and wc["dir"] == "<="
+    assert wc["Q"] == pytest.approx(_RIDGE_Q, abs=1e-6)
+    assert wc["lambda"] == pytest.approx(_RIDGE_LAMBDA, abs=1e-6)
+
+
+def test_ridge_df_reproduces_scpi(germany):
+    y, Y0, pre, W = germany
+    A = y[:pre]
+    B = Y0[:pre]
+    wc = _prep_w_constr("ridge", A, B, W)
+    df = _df_est(wc, W, B)
+    assert df == pytest.approx(_RIDGE_DF, abs=1e-5)
+
+
+def test_ridge_metadata_carries_constraint(germany):
+    sc = _run(germany, w_constr="ridge")
+    assert sc.metadata["w_constr"] == "ridge"
+    assert sc.metadata["Q"] == pytest.approx(_RIDGE_Q, abs=1e-6)
+    assert sc.metadata["lambda"] == pytest.approx(_RIDGE_LAMBDA, abs=1e-6)
+    assert sc.metadata["df"] == pytest.approx(_RIDGE_DF, abs=1e-5)
+
+
+# ----------------------------------------------------------------------
+# Layer 1: df_EST per constraint (ols=J, lasso=#nonzero, simplex=#nonzero-1)
+# ----------------------------------------------------------------------
+def test_df_rules_per_constraint(germany):
+    y, Y0, pre, W = germany
+    A = y[:pre]
+    B = Y0[:pre]
+    J = B.shape[1]
+    nz = int(np.sum(np.abs(W) >= 1e-6))
+    assert _df_est(_prep_w_constr("ols", A, B, W), W, B) == pytest.approx(J)
+    assert _df_est(_prep_w_constr("simplex", A, B, W), W, B) == pytest.approx(nz - 1)
+    assert _df_est(_prep_w_constr("lasso", A, B, W), W, B) == pytest.approx(nz)
+
+
+# ----------------------------------------------------------------------
+# Layer 1: localisation bounds (ridge/ols use all donors; no lb)
+# ----------------------------------------------------------------------
+def test_local_geom_active_set(germany):
+    y, Y0, pre, W = germany
+    A = y[:pre]
+    B = Y0[:pre]
+    rho = 0.03
+    lg_r = _local_geom(_prep_w_constr("ridge", A, B, W), W, rho, B)
+    assert lg_r.idxw.all()             # ridge keeps every donor active
+    assert not lg_r.use_lb             # no lower bound
+    lg_s = _local_geom(_prep_w_constr("simplex", A, B, W), W, rho, B)
+    assert lg_s.use_lb                 # simplex has the localised lb
+    assert lg_s.has_sum
+
+
+# ----------------------------------------------------------------------
+# Layer 2: constraint-family smoke (finite, ordered, sane df)
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("name", ["ols", "simplex", "lasso", "ridge", "L1-L2"])
+def test_constraint_family_smoke(germany, name):
+    sc = _run(germany, w_constr=name)
+    assert np.all(np.isfinite(sc.cf_lower))
+    assert np.all(np.isfinite(sc.cf_upper))
+    assert np.all(sc.cf_upper >= sc.cf_lower - 1e-8)
+    assert np.all(sc.upper >= sc.lower - 1e-8)
+    assert sc.metadata["att_upper"] >= sc.metadata["att_lower"] - 1e-8
+    assert 0 < sc.metadata["df"] < pre_len(germany)
+
+
+def pre_len(germany):
+    return germany[2]
+
+
+# ----------------------------------------------------------------------
+# Layer 2: simultaneous (joint-coverage) bands
+# ----------------------------------------------------------------------
+def test_simultaneous_present_and_ordered(germany):
+    sc = _run(germany)
+    for arr in (sc.cf_lower_simul, sc.cf_upper_simul,
+                sc.lower_simul, sc.upper_simul):
+        assert np.all(np.isfinite(arr))
+    assert np.all(sc.cf_upper_simul >= sc.cf_lower_simul - 1e-8)
+    assert "eps_joint" in sc.metadata
+
+
+def test_simultaneous_wider_than_pointwise(germany):
+    sc = _run(germany)
+    w_point = sc.cf_upper - sc.cf_lower
+    w_simul = sc.cf_upper_simul - sc.cf_lower_simul
+    # joint coverage over the whole horizon is never tighter than pointwise
+    assert np.all(w_simul >= w_point - 1e-6)
+    assert np.mean(w_simul) > np.mean(w_point)      # strictly wider on average
+
+
+@pytest.mark.parametrize("name", ["ols", "ridge", "lasso"])
+def test_simultaneous_wider_across_constraints(germany, name):
+    sc = _run(germany, w_constr=name)
+    w_point = sc.cf_upper - sc.cf_lower
+    w_simul = sc.cf_upper_simul - sc.cf_lower_simul
+    assert np.mean(w_simul) >= np.mean(w_point) - 1e-6
+
+
+def test_ridge_under_cointegration_runs(germany):
+    # cointegration drops the first pre-period from the Q/Sigma design; the
+    # ridge shrinkage rule-of-thumb must align the treated pre-outcome to it.
+    y, Y0, pre, W = germany
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sc = scpi_intervals(y, Y0, pre, W, w_constr="ridge", sims=200,
+                            u_alpha=0.05, e_alpha=0.05, e_method="gaussian",
+                            cointegrated=True, seed=8894)
+    assert np.all(np.isfinite(sc.cf_lower)) and np.all(np.isfinite(sc.cf_upper))
+    assert np.all(sc.cf_upper >= sc.cf_lower - 1e-8)
+
+
+# ----------------------------------------------------------------------
+# Layer 4: invalid constraints raise
+# ----------------------------------------------------------------------
+@pytest.mark.parametrize("bad", ["bogus", {"name": "nope"}, {"p": "L3"}])
+def test_invalid_w_constr_raises(germany, bad):
+    with pytest.raises((ValueError, KeyError)):
+        _run(germany, w_constr=bad)

--- a/mlsynth/tests/test_scpi_constraints.py
+++ b/mlsynth/tests/test_scpi_constraints.py
@@ -49,7 +49,7 @@ _SIMPLEX_CF_UPPER = np.array(
     [22.2359, 22.9433, 23.5098, 24.5582, 25.7911, 27.0189, 27.7183, 28.9706,
      30.2508, 32.0892, 33.3491, 34.0511, 34.6439])
 _SIMPLEX_DF = 5
-_SIMPLEX_RHO = 0.033198
+_SIMPLEX_RHO = 0.07164          # scpi's default type-2 regularisation
 
 # --- scpi_pkg ridge reference (scest w_constr={"name":"ridge"}, Germany) ---
 _RIDGE_Q = 0.66876212

--- a/mlsynth/tests/test_scpi_plot_bands.py
+++ b/mlsynth/tests/test_scpi_plot_bands.py
@@ -1,0 +1,177 @@
+"""Plotting the pointwise and/or simultaneous SCPI prediction-interval bands.
+
+Both VanillaSC (``inference="scpi"``) and CLUSTERSC (``compute_scpi_pi=True``)
+expose ``plot_bands`` in {"pointwise", "simultaneous", "both"} controlling which
+SCPI band(s) are shaded on the observed-vs-counterfactual plot. The simultaneous
+band is SCPI-only; other inference modes fall back to the pointwise band.
+
+Layered per ``agents/agents_tests.md``:
+
+* Layer 1: the pure band-selection helper resolves the right (interval,
+  interval2, label) for each choice, with fallback when no simultaneous band
+  exists.
+* Layer 2: the Plotter shades one or two bands; CLUSTERSC's plotter draws the
+  SCPI band per the choice.
+* Layer 3/4: config validates the field; ``.fit()`` renders without error.
+"""
+from __future__ import annotations
+
+import warnings
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import CLUSTERSC, VanillaSC
+from mlsynth.config_models import CLUSTERSCConfig, VanillaSCConfig
+from mlsynth.utils.plotting import Plotter, select_pi_bands
+
+
+_PW = (np.array([1.0, 2.0]), np.array([3.0, 4.0]))
+_SM = (np.array([0.5, 1.5]), np.array([3.5, 4.5]))
+
+
+# ----------------------------------------------------------------------
+# Layer 1: the pure selection helper
+# ----------------------------------------------------------------------
+def test_select_pointwise():
+    iv, iv2, label = select_pi_bands(_PW, _SM, "pointwise")
+    assert iv is _PW and iv2 is None
+    assert "Prediction" in label
+
+
+def test_select_simultaneous():
+    iv, iv2, label = select_pi_bands(_PW, _SM, "simultaneous")
+    assert iv is _SM and iv2 is None
+    assert "Simultaneous" in label
+
+
+def test_select_both():
+    iv, iv2, label = select_pi_bands(_PW, _SM, "both")
+    assert iv is _PW and iv2 is _SM
+    assert "Prediction" in label
+
+
+def test_select_falls_back_when_no_simultaneous():
+    # other inference modes have no simultaneous band -> pointwise regardless
+    for choice in ("pointwise", "simultaneous", "both"):
+        iv, iv2, label = select_pi_bands(_PW, None, choice)
+        assert iv is _PW and iv2 is None
+
+
+def test_select_none_when_no_bands():
+    iv, iv2, label = select_pi_bands(None, None, "both")
+    assert iv is None and iv2 is None
+
+
+# ----------------------------------------------------------------------
+# Layer 2: the Plotter shades two bands
+# ----------------------------------------------------------------------
+def _n_fills(ax):
+    from matplotlib.collections import PolyCollection
+    return sum(isinstance(c, PolyCollection) for c in ax.collections)
+
+
+def test_plotter_one_band():
+    p = Plotter()
+    t = np.arange(2)
+    ax = p.observed_vs_counterfactual(t, np.array([2.0, 3.0]), [np.array([2.0, 3.0])],
+                                      interval=_PW)
+    assert _n_fills(ax) == 1
+    plt.close(ax.figure)
+
+
+def test_plotter_two_bands():
+    p = Plotter()
+    t = np.arange(2)
+    ax = p.observed_vs_counterfactual(t, np.array([2.0, 3.0]), [np.array([2.0, 3.0])],
+                                      interval=_PW, interval2=_SM,
+                                      interval2_label="Simultaneous interval")
+    assert _n_fills(ax) == 2
+    labels = [t.get_text() for t in ax.get_legend().get_texts()] if ax.get_legend() else []
+    plt.close(ax.figure)
+
+
+# ----------------------------------------------------------------------
+# Layer 4: config
+# ----------------------------------------------------------------------
+def _panel():
+    rng = np.random.default_rng(0)
+    J, Tpre, Tpost, r = 10, 16, 6, 2
+    T = Tpre + Tpost
+    F = rng.standard_normal((T, r)); lam = rng.standard_normal((J + 1, r))
+    Y = F @ lam.T + rng.standard_normal((T, J + 1)) * 0.4
+    Y[Tpre:, 0] += 1.0
+    rows = [{"unit": j, "time": t, "y": float(Y[t, j]),
+             "D": int(j == 0 and t >= Tpre)}
+            for j in range(J + 1) for t in range(T)]
+    return pd.DataFrame(rows)
+
+
+def test_config_defaults_pointwise():
+    df = _panel()
+    assert VanillaSCConfig(df=df, outcome="y", treat="D", unitid="unit",
+                           time="time", display_graphs=False).plot_bands == "pointwise"
+    assert CLUSTERSCConfig(df=df, outcome="y", treat="D", unitid="unit",
+                           time="time", display_graphs=False).plot_bands == "pointwise"
+
+
+def test_config_rejects_bad_plot_bands():
+    df = _panel()
+    with pytest.raises(Exception):
+        VanillaSCConfig(df=df, outcome="y", treat="D", unitid="unit", time="time",
+                        display_graphs=False, plot_bands="nonsense")
+
+
+# ----------------------------------------------------------------------
+# Layer 3: .fit() renders without error for each choice
+# ----------------------------------------------------------------------
+def _germany():
+    import pathlib
+    base = pathlib.Path(__file__).resolve().parents[2] / "basedata"
+    d = pd.read_csv(base / "scpi_germany.csv")[["country", "year", "gdp"]].dropna()
+    d["status"] = ((d.country == "West Germany") & (d.year >= 1991)).astype(int)
+    return d
+
+
+@pytest.mark.parametrize("bands", ["pointwise", "simultaneous", "both"])
+def test_vanillasc_scpi_plot_bands_smoke(bands):
+    d = _germany()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        VanillaSC({"df": d, "outcome": "gdp", "treat": "status", "unitid": "country",
+                   "time": "year", "inference": "scpi", "scpi_sims": 40,
+                   "seed": 0, "display_graphs": True, "plot_bands": bands}).fit()
+    plt.close("all")
+
+
+@pytest.mark.parametrize("bands", ["pointwise", "simultaneous", "both"])
+def test_clustersc_scpi_plot_bands_smoke(bands):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        CLUSTERSC({"df": _panel(), "outcome": "y", "treat": "D", "unitid": "unit",
+                   "time": "time", "method": "pcr", "compute_scpi_pi": True,
+                   "scpi_constraint": "ridge", "scpi_sims": 40, "random_state": 0,
+                   "display_graphs": True, "plot_bands": bands}).fit()
+    plt.close("all")
+
+
+def test_clustersc_plot_draws_scpi_band():
+    # plot_clustersc returns the axis; the SCPI band adds a shaded region.
+    from mlsynth.utils.clustersc_helpers.plotter import plot_clustersc
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = CLUSTERSC({"df": _panel(), "outcome": "y", "treat": "D",
+                         "unitid": "unit", "time": "time", "method": "pcr",
+                         "compute_scpi_pi": True, "scpi_constraint": "ridge",
+                         "scpi_sims": 40, "random_state": 0,
+                         "display_graphs": False}).fit()
+    ax_both = plot_clustersc(res, plot_bands="both")
+    assert _n_fills(ax_both) == 2
+    plt.close("all")
+    ax_pw = plot_clustersc(res, plot_bands="pointwise")
+    assert _n_fills(ax_pw) == 1
+    plt.close("all")

--- a/mlsynth/tests/test_scul_scpi.py
+++ b/mlsynth/tests/test_scul_scpi.py
@@ -1,0 +1,97 @@
+"""SCUL prediction intervals via the generalized scpi lasso engine.
+
+scpi (Cattaneo, Feng, Palomba & Titiunik 2025) Table 3 pairs the lasso weight
+constraint with Chernozhukov, Wuthrich & Zhu (2021); SCUL (Hollingsworth & Wing
+2022) *is* a lasso synthetic control -- signed coefficients on standardized
+donors plus an intercept. SCUL can now route its prediction intervals through
+VanillaSC's generalized ``scpi_intervals`` with the lasso constraint and a
+constant (the intercept), in addition to its placebo p-value.
+
+Layered per ``agents/agents_tests.md``:
+
+* smoke: ``compute_scpi_pi=True`` yields a finite, ordered ATT interval via
+  ``.fit()`` on the California Prop 99 panel;
+* invariant: the reported constraint is lasso and the degrees of freedom equal
+  ``#nonzero + 1`` (lasso df plus the intercept ``KM``);
+* config: the new fields validate and default correctly.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SCUL
+from mlsynth.config_models import SCULConfig
+
+_PANEL = os.path.join(os.path.dirname(__file__), "..", "..", "basedata",
+                      "california_panel.csv")
+
+
+def _cfg(**kw):
+    df = pd.read_csv(_PANEL)
+    df["treat"] = ((df["state"] == "California") & (df["year"] >= 1989)).astype(int)
+    base = dict(df=df, outcome="cigsale", treat="treat", unitid="state",
+                time="year", display_graphs=False, inference=False)
+    base.update(kw)
+    return base
+
+
+# ----------------------------------------------------------------------
+# config
+# ----------------------------------------------------------------------
+def test_config_scpi_defaults():
+    cfg = SCULConfig(**_cfg())
+    assert cfg.compute_scpi_pi is False
+
+
+def test_config_scpi_accepts():
+    cfg = SCULConfig(**_cfg(compute_scpi_pi=True, scpi_sims=50))
+    assert cfg.compute_scpi_pi is True
+    assert cfg.scpi_sims == 50
+
+
+# ----------------------------------------------------------------------
+# .fit() integration (result comes from .fit())
+# ----------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def scpi_fit():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return SCUL(_cfg(compute_scpi_pi=True, scpi_sims=120)).fit()
+
+
+def test_scul_scpi_ci_populated(scpi_fit):
+    lo, hi = scpi_fit.att_ci
+    assert np.isfinite(lo) and np.isfinite(hi)
+    assert hi >= lo
+    assert "scpi" in scpi_fit.inference.method.lower()
+
+
+def test_scul_scpi_reports_lasso_and_constant(scpi_fit):
+    sc = scpi_fit.fit.scpi
+    assert sc is not None
+    assert sc.constraint == "lasso"
+    # lasso df = #nonzero donor weights + KM (the intercept)
+    nz = int(np.sum(np.abs(scpi_fit.fit.weights) > 1e-10))
+    assert sc.df == pytest.approx(nz + 1, abs=1e-9)
+
+
+def test_scul_scpi_bands_ordered(scpi_fit):
+    sc = scpi_fit.fit.scpi
+    assert np.all(np.asarray(sc.cf_upper) >= np.asarray(sc.cf_lower) - 1e-8)
+    # simultaneous band never tighter than pointwise
+    wp = np.asarray(sc.cf_upper) - np.asarray(sc.cf_lower)
+    ws = np.asarray(sc.cf_upper_simul) - np.asarray(sc.cf_lower_simul)
+    assert np.mean(ws) >= np.mean(wp) - 1e-6
+
+
+def test_placebo_still_available_without_scpi():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = SCUL(_cfg(inference=True)).fit()
+    assert res.inference is not None
+    assert res.inference.p_value is not None

--- a/mlsynth/tests/test_sparse_sc_scpi.py
+++ b/mlsynth/tests/test_sparse_sc_scpi.py
@@ -1,0 +1,99 @@
+"""SparseSC prediction intervals via the generalized scpi simplex engine.
+
+SparseSC (Vives-i-Bastida) fits simplex donor weights (``w >= 0``, ``sum w = 1``)
+-- the L1 penalty selects *predictors* (the V-weights), not donors. Its synthetic
+control is therefore an Abadie convex combination, so scpi's (Cattaneo, Feng,
+Palomba & Titiunik 2025) simplex weight-constraint prediction intervals apply
+directly. SparseSC can now route model-based prediction intervals through
+VanillaSC's generalized ``scpi_intervals`` under the simplex constraint, in
+addition to its placebo / conformal inference.
+
+Layered per ``agents/agents_tests.md``:
+
+* config: the new fields validate and default off;
+* smoke: ``compute_scpi_pi=True`` yields a finite, ordered ATT interval;
+* invariant: the reported constraint is simplex and df == ``#nonzero - 1``
+  (simplex degrees of freedom, no covariate/constant block);
+* the placebo / conformal path still works without scpi.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SparseSC
+from mlsynth.config_models import SparseSCConfig
+
+from test_sparse_sc import _factor_panel, COVS
+
+
+def _cfg(**kw):
+    df = _factor_panel()
+    base = dict(df=df, outcome="y", treat="tr", unitid="unit", time="year",
+                covariates=COVS, display_graphs=False,
+                inference_method="none", run_inference=False)
+    base.update(kw)
+    return base
+
+
+# ----------------------------------------------------------------------
+# config
+# ----------------------------------------------------------------------
+def test_config_scpi_defaults():
+    cfg = SparseSCConfig(**_cfg())
+    assert cfg.compute_scpi_pi is False
+
+
+def test_config_scpi_accepts():
+    cfg = SparseSCConfig(**_cfg(compute_scpi_pi=True, scpi_sims=50))
+    assert cfg.compute_scpi_pi is True
+    assert cfg.scpi_sims == 50
+
+
+# ----------------------------------------------------------------------
+# .fit() integration
+# ----------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def scpi_fit():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cfg = dict(df=_factor_panel(), outcome="y", treat="tr", unitid="unit",
+                   time="year", covariates=COVS, display_graphs=False,
+                   inference_method="none", run_inference=False,
+                   compute_scpi_pi=True, scpi_sims=120)
+        return SparseSC(cfg).fit()
+
+
+def test_sparsesc_scpi_ci_populated(scpi_fit):
+    lo, hi = scpi_fit.att_ci
+    assert np.isfinite(lo) and np.isfinite(hi)
+    assert hi >= lo
+    assert "scpi" in scpi_fit.inference.method.lower()
+
+
+def test_sparsesc_scpi_reports_simplex(scpi_fit):
+    sc = scpi_fit.scpi
+    assert sc is not None
+    assert sc.constraint == "simplex"
+    # simplex df = #nonzero donor weights - 1 (no covariate/constant block)
+    nz = int(np.sum(np.abs(np.asarray(scpi_fit.design.w)) > 1e-6))
+    assert sc.df == pytest.approx(nz - 1, abs=1e-9)
+
+
+def test_sparsesc_scpi_bands_ordered(scpi_fit):
+    sc = scpi_fit.scpi
+    assert np.all(np.asarray(sc.cf_upper) >= np.asarray(sc.cf_lower) - 1e-8)
+    wp = np.asarray(sc.cf_upper) - np.asarray(sc.cf_lower)
+    ws = np.asarray(sc.cf_upper_simul) - np.asarray(sc.cf_lower_simul)
+    assert np.mean(ws) >= np.mean(wp) - 1e-6
+
+
+def test_conformal_still_available_without_scpi():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = SparseSC(_cfg(run_inference=True, inference_method="conformal")).fit()
+    assert res.inference is not None
+    assert res.scpi is None

--- a/mlsynth/tests/test_staggered_constraints.py
+++ b/mlsynth/tests/test_staggered_constraints.py
@@ -1,0 +1,108 @@
+"""Staggered/multi-treated scpi engine: the weight-constraint family (fit).
+
+scpi's ``scdataMulti`` + ``scest`` support the full weight-constraint family per
+treated unit (Cattaneo, Feng, Palomba & Titiunik 2025). mlsynth's clean-room
+staggered engine now generalizes its per-unit fit (``b_est``) from simplex-only
+to ols / simplex / lasso / ridge / L1-L2, matching scpi's ``scdataMulti`` weights
+value-for-value.
+
+This validates the *fit* (point-estimate) layer; the prediction-interval bands
+for non-simplex constraints follow in a separate step, so ``w_constr`` is not yet
+exposed on the public ``staggered_spec`` config.
+
+Layered per ``agents/agents_tests.md``:
+
+* invariants: per constraint the fitted weights obey the constraint set (simplex
+  sums to 1 and is non-negative; ridge sits on the L2 ball at the scpi budget Q;
+  lasso within the L1 budget; ols unconstrained matches least squares);
+* the simplex fit is unchanged (regression guard).
+"""
+from __future__ import annotations
+
+import pathlib
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.utils.vanillasc_helpers.scpi import _shrinkage_ridge
+from mlsynth.utils.vanillasc_helpers.staggered_engine import (
+    scdata_multi, scest, _normalize_spec,
+)
+
+_GERMANY = pathlib.Path(__file__).resolve().parents[2] / "basedata" / "scpi_germany.csv"
+pytestmark = pytest.mark.skipif(not _GERMANY.exists(), reason="Germany data absent")
+
+_TREATED = ["Italy", "West Germany"]
+
+
+def _md():
+    d = pd.read_csv(_GERMANY)[["country", "year", "gdp"]].dropna()
+    d["status"] = (((d.country == "West Germany") & (d.year >= 1991))
+                   | ((d.country == "Italy") & (d.year >= 1992))).astype(int)
+    feats, cadj, const, coint = _normalize_spec(
+        None, None, False, False, "gdp", _TREATED)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return scdata_multi(d, "gdp", feats, cadj, constant=const,
+                            cointegrated_data=coint, effect="unit")
+
+
+@pytest.fixture(scope="module")
+def md():
+    return _md()
+
+
+def _fit(md, name):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        est = scest(md, name)
+    w = est["w"]                                   # (ID, donor) MultiIndex
+    return {tr: np.asarray(w.loc[tr]).ravel() for tr in _TREATED}, est
+
+
+def _unit_design(md, tr):
+    A = np.asarray(md["A"].loc[(tr,)], float).ravel()
+    B = md["B"].loc[(tr,)]
+    B = np.asarray(B.loc[:, [c for c in B.columns if not np.all(B[c].values == 0)]], float)
+    return A, B
+
+
+# ----------------------------------------------------------------------
+# per-constraint invariants (each pins the fit to scpi's constraint set)
+# ----------------------------------------------------------------------
+def test_simplex_unit_weights_on_simplex(md):
+    w, _ = _fit(md, "simplex")
+    for tr in _TREATED:
+        assert w[tr].sum() == pytest.approx(1.0, abs=1e-5)
+        assert np.all(w[tr] >= -1e-6)
+
+
+def test_ridge_unit_weights_on_L2_ball_at_scpi_Q(md):
+    w, _ = _fit(md, "ridge")
+    for tr in _TREATED:
+        A, B = _unit_design(md, tr)
+        Q, _ = _shrinkage_ridge(A, B)             # equals scpi's scest Q exactly
+        assert np.linalg.norm(w[tr]) == pytest.approx(Q, abs=1e-4)
+
+
+def test_lasso_unit_weights_within_L1_budget(md):
+    w, _ = _fit(md, "lasso")
+    for tr in _TREATED:
+        assert np.sum(np.abs(w[tr])) <= 1.0 + 1e-5   # Q = 1 for lasso
+
+
+def test_ols_unit_weights_match_least_squares(md):
+    w, _ = _fit(md, "ols")
+    for tr in _TREATED:
+        A, B = _unit_design(md, tr)
+        b = np.linalg.lstsq(B, A, rcond=None)[0]
+        assert np.max(np.abs(w[tr] - b)) < 1e-4
+
+
+def test_constraint_spec_recorded(md):
+    _, est = _fit(md, "ridge")
+    for tr in _TREATED:
+        assert est["w_constr_inf"][tr]["name"] == "ridge"
+        assert est["w_constr_inf"][tr]["Q"] > 0

--- a/mlsynth/tests/test_staggered_inference_family.py
+++ b/mlsynth/tests/test_staggered_inference_family.py
@@ -1,0 +1,165 @@
+"""Staggered/multi-treated scpi engine: the weight-constraint family (inference).
+
+Task 93 generalized the *fit* (``b_est``) to scpi's ols / simplex / lasso / ridge
+/ L1-L2 family. This validates the *inference* deterministic layer that feeds the
+prediction-interval conic program:
+
+* ``df_EST`` — effective degrees of freedom per constraint;
+* ``local_geom`` + ``localgeom2step`` — the localised weight-set budget
+  (``Q_star`` / ``Q2_star``) and per-donor lower bounds (``lb``) used by the
+  in-sample conic optimisation.
+
+The reference values are captured live from ``scpi_pkg`` (Cattaneo, Feng, Palomba
+& Titiunik 2025) on the two-treated Germany panel (West Germany 1991, Italy 1992)
+via ``scdataMulti`` -> ``scest`` -> ``local_geom`` / ``localgeom2step`` /
+``df_EST``. Because mlsynth's clean-room ``scdata_multi`` + ``scest`` reproduce
+scpi's weights value-for-value (see ``test_staggered_constraints.py``), the
+residuals ``res`` and donor design ``B`` feeding these functions match too, so the
+deterministic inference pieces must match scpi cell-for-cell.
+
+The simultaneous conic bands themselves are exercised by the staggered
+benchmarks; here we pin the deterministic budgets that make those bands coherent
+for the non-simplex constraints.
+"""
+from __future__ import annotations
+
+import pathlib
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.utils.vanillasc_helpers.staggered_engine import (
+    scdata_multi, scest, _normalize_spec, local_geom, localgeom2step, df_EST,
+)
+
+_GERMANY = pathlib.Path(__file__).resolve().parents[2] / "basedata" / "scpi_germany.csv"
+pytestmark = pytest.mark.skipif(not _GERMANY.exists(), reason="Germany data absent")
+
+_TREATED = ["Italy", "West Germany"]
+
+# --- scpi_pkg reference (captured live; see module docstring) ---------------
+_REF = {
+    "simplex": {"Q_star": {"Italy": 1.0, "West Germany": 1.0}, "df": 14.0,
+                "lb_all_neg_inf": False, "lb_sum": 0.1923},
+    "ridge":   {"Q_star": {"Italy": 0.6975, "West Germany": 0.7278}, "df": 23.2549,
+                "lb_all_neg_inf": True},
+    "lasso":   {"Q_star": {"Italy": 1.0605, "West Germany": 1.0643}, "df": 13.0,
+                "lb_all_neg_inf": True},
+    "ols":     {"Q_star": {"Italy": None, "West Germany": None}, "df": 30.0,
+                "lb_all_neg_inf": True},
+}
+
+
+def _md():
+    d = pd.read_csv(_GERMANY)[["country", "year", "gdp"]].dropna()
+    d["status"] = (((d.country == "West Germany") & (d.year >= 1991))
+                   | ((d.country == "Italy") & (d.year >= 1992))).astype(int)
+    feats, cadj, const, coint = _normalize_spec(
+        None, None, False, False, "gdp", _TREATED)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return scdata_multi(d, "gdp", feats, cadj, constant=const,
+                            cointegrated_data=coint, effect="unit")
+
+
+@pytest.fixture(scope="module")
+def md():
+    return _md()
+
+
+def _inference_pieces(md, name):
+    """Run the generalized deterministic inference layer for one constraint."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        est = scest(md, name)
+    w = est["w"]
+    res = est["res"]
+    B = est["B"]
+    blocks = est["blocks"]
+    wcinf = est["w_constr_inf"]
+
+    from copy import deepcopy
+    from mlsynth.utils.vanillasc_helpers.staggered_engine import mat2dict
+
+    res_d = {tr: res.loc[pd.IndexSlice[tr, :, :]] for tr in _TREATED}
+    B_d = mat2dict(B, _TREATED, cols=True)
+    w_d = {tr: w.loc[pd.IndexSlice[tr, :]] for tr in _TREATED}
+    J = {tr: blocks[tr]["J"] for tr in _TREATED}
+    KM = {tr: blocks[tr]["KM"] for tr in _TREATED}
+    T0_M = {tr: sum(blocks[tr]["T0_features"].values()) for tr in _TREATED}
+
+    rho_dict, Qpre, Q2pre, wc_upd = {}, {}, {}, {}
+    wc_aux = {tr: deepcopy(wcinf[tr]) for tr in _TREATED}
+    for tr in _TREATED:
+        wc_upd[tr], _iw, rho_dict[tr], Qpre[tr], Q2pre[tr] = local_geom(
+            wc_aux[tr], "type-2", 0.2, res_d[tr], B_d[tr],
+            T0_M[tr], J[tr], KM[tr], w_d[tr])
+    Q = {tr: wcinf[tr]["Q"] for tr in _TREATED}
+    Q_star, lb = localgeom2step(w, rho_dict, wcinf, Q, _TREATED, J, rho_max=0.2)
+
+    Jtot = sum(J.values())
+    KMI = sum(KM.values())
+    df = df_EST(wcinf[_TREATED[-1]], w, np.asarray(B, float), Jtot, KMI)
+    return Q_star, lb, df
+
+
+@pytest.mark.parametrize("name", ["simplex", "ridge", "lasso", "ols"])
+def test_df_matches_scpi(md, name):
+    _, _, df = _inference_pieces(md, name)
+    assert df == pytest.approx(_REF[name]["df"], abs=1e-2)
+
+
+@pytest.mark.parametrize("name", ["simplex", "ridge", "lasso"])
+def test_Q_star_matches_scpi(md, name):
+    Q_star, _, _ = _inference_pieces(md, name)
+    for tr in _TREATED:
+        assert float(Q_star[tr]) == pytest.approx(_REF[name]["Q_star"][tr], abs=1e-3)
+
+
+@pytest.mark.parametrize("name", ["ridge", "lasso", "ols"])
+def test_signed_constraints_have_unbounded_lb(md, name):
+    _, lb, _ = _inference_pieces(md, name)
+    assert all(np.isneginf(x) for x in lb)
+
+
+def test_simplex_lb_pins_small_weights(md):
+    _, lb, _ = _inference_pieces(md, "simplex")
+    assert all(x >= 0.0 for x in lb)          # simplex lb floors at zero
+    assert float(np.sum(lb)) == pytest.approx(_REF["simplex"]["lb_sum"], abs=1e-3)
+
+
+# ----------------------------------------------------------------------
+# family conic bands: coherence invariants. scpi_pkg's band-simulation ECOS
+# is broken under numpy 2.x, so the bands cannot be cross-validated directly;
+# the deterministic budgets they consume are (tests above). Here we pin that
+# every constraint yields a finite, correctly-ordered band that brackets the
+# fit, and that the width ordering tracks the constraint's freedom.
+# ----------------------------------------------------------------------
+def _bands(md, name, sims=60):
+    from mlsynth.utils.vanillasc_helpers.staggered_engine import scpi
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        est = scest(md, name)
+        out = scpi(est, sims=sims, seed=8894)
+    lo = np.asarray(out["sc_l_1"], float)
+    hi = np.asarray(out["sc_r_1"], float)
+    yfit = np.asarray(out["Y_post_fit"], float)
+    return lo, hi, yfit
+
+
+@pytest.mark.parametrize("name", ["simplex", "ridge", "lasso", "ols"])
+def test_family_bands_are_finite_and_bracket_fit(md, name):
+    lo, hi, yfit = _bands(md, name)
+    assert np.all(np.isfinite(lo)) and np.all(np.isfinite(hi))
+    assert np.all(hi >= lo)
+    assert np.all(lo <= yfit + 1e-6) and np.all(hi >= yfit - 1e-6)
+
+
+def test_unconstrained_band_is_wider_than_simplex(md):
+    lo_s, hi_s, _ = _bands(md, "simplex")
+    lo_o, hi_o, _ = _bands(md, "ols")
+    # ols freely extrapolates; its in-sample compatible set (hence band) is at
+    # least as wide as the simplex-constrained one at every predictand.
+    assert np.mean(hi_o - lo_o) > np.mean(hi_s - lo_s)

--- a/mlsynth/tests/test_tssc_scpi.py
+++ b/mlsynth/tests/test_tssc_scpi.py
@@ -1,0 +1,105 @@
+"""TSSC prediction intervals via the generalized scpi engine, per variant.
+
+TSSC (Li & Shankar 2023) fits four SC-class variants distinguished by their
+weight constraints, each of which maps onto scpi's (Cattaneo, Feng, Palomba &
+Titiunik 2025) weight-constraint family:
+
+    SC    : w >= 0, sum w = 1            -> scpi simplex
+    MSCa  : intercept + w >= 0, sum w = 1 -> scpi simplex + constant
+    MSCb  : w >= 0  (no adding-up)        -> scpi ols
+    MSCc  : intercept + w >= 0            -> scpi ols + constant
+
+The sum-constrained variants (SC / MSCa) map exactly; the no-adding-up variants
+(MSCb / MSCc) carry bare non-negativity, which scpi's family does not include, so
+they map to scpi's ols compatible set -- the nonnegativity is not re-imposed on
+the PI set, giving a (slightly conservative) band. With ``compute_scpi_pi`` each
+variant fit gains a ``scpi`` band alongside its Li (2020) subsampling ATT CI.
+
+Layered per ``agents/agents_tests.md``: config validation, a per-variant
+constraint-mapping invariant, band coherence, and the recommended-variant
+surfacing; the subsampling CI is unaffected when scpi is off.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from mlsynth import TSSC
+from mlsynth.config_models import TSSCConfig
+
+from test_tssc import _make_panel
+
+_EXPECT_CONSTRAINT = {"SC": "simplex", "MSCa": "simplex",
+                      "MSCb": "ols", "MSCc": "ols"}
+
+
+def _cfg(**kw):
+    base = dict(df=_make_panel(treated_effect=3.0, seed=3), outcome="y",
+                unitid="unitid", time="time", treat="treat", display_graphs=False)
+    base.update(kw)
+    return base
+
+
+# ----------------------------------------------------------------------
+# config
+# ----------------------------------------------------------------------
+def test_config_scpi_defaults():
+    cfg = TSSCConfig(**_cfg())
+    assert cfg.compute_scpi_pi is False
+
+
+def test_config_scpi_accepts():
+    cfg = TSSCConfig(**_cfg(compute_scpi_pi=True, scpi_sims=50))
+    assert cfg.compute_scpi_pi is True
+    assert cfg.scpi_sims == 50
+
+
+# ----------------------------------------------------------------------
+# .fit() integration
+# ----------------------------------------------------------------------
+@pytest.fixture(scope="module")
+def scpi_fit():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return TSSC(dict(df=_make_panel(treated_effect=3.0, seed=3), outcome="y",
+                         unitid="unitid", time="time", treat="treat",
+                         display_graphs=False, compute_scpi_pi=True,
+                         scpi_sims=60)).fit()
+
+
+@pytest.mark.parametrize("variant", ["SC", "MSCa", "MSCb", "MSCc"])
+def test_variant_maps_to_expected_scpi_constraint(scpi_fit, variant):
+    fit = scpi_fit.variants[variant]
+    assert fit.scpi is not None
+    assert fit.scpi.constraint == _EXPECT_CONSTRAINT[variant]
+
+
+@pytest.mark.parametrize("variant", ["SC", "MSCa", "MSCb", "MSCc"])
+def test_variant_scpi_bands_are_coherent(scpi_fit, variant):
+    sc = scpi_fit.variants[variant].scpi
+    lo, hi = sc.att_pi
+    assert np.isfinite(lo) and np.isfinite(hi) and hi >= lo
+    assert np.all(np.asarray(sc.cf_upper) >= np.asarray(sc.cf_lower) - 1e-8)
+    ws = np.asarray(sc.cf_upper_simul) - np.asarray(sc.cf_lower_simul)
+    wp = np.asarray(sc.cf_upper) - np.asarray(sc.cf_lower)
+    assert np.mean(ws) >= np.mean(wp) - 1e-6
+
+
+def test_recommended_variant_scpi_surfaced(scpi_fit):
+    rec = scpi_fit.selection.recommended
+    assert scpi_fit.variants[rec].scpi is not None
+    # the recommended variant's scpi band is surfaced at top level
+    assert scpi_fit.scpi is not None
+    assert scpi_fit.scpi.constraint == _EXPECT_CONSTRAINT[rec]
+
+
+def test_subsampling_ci_intact_without_scpi():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = TSSC(_cfg()).fit()
+    for v in res.variants.values():
+        assert v.scpi is None
+        lo, hi = v.att_ci
+        assert np.isfinite(lo) and np.isfinite(hi)

--- a/mlsynth/tests/test_vanillasc_staggered.py
+++ b/mlsynth/tests/test_vanillasc_staggered.py
@@ -265,3 +265,36 @@ def test_covariate_staggered_matches_scpi_per_unit():
     assert res.inference is not None
     assert np.isfinite(res.effects.att)
     assert len(res.additional_outputs["per_cell_effects"]) == 25
+
+
+# ---------------------------------------------------------------------------
+# Weight-constraint family exposed on the staggered spec (scpi's w_constr)
+# ---------------------------------------------------------------------------
+def _fit_family(df, w_constr):
+    return VanillaSC({
+        "df": df, "outcome": "gdp", "treat": "status",
+        "unitid": "country", "time": "year", "display_graphs": False,
+        "inference": "scpi", "scpi_sims": 60, "seed": 8894,
+        "staggered_spec": {"features": ["gdp"], "w_constr": w_constr},
+    }).fit()
+
+
+@pytest.mark.parametrize("w_constr", ["ridge", "lasso", "ols"])
+def test_staggered_spec_family_bands_are_coherent(germany_staggered, w_constr):
+    """A non-simplex w_constr on the staggered spec produces finite prediction
+    intervals that bracket the point ATT (the fit routes the whole staggered
+    engine through scpi's weight-constraint family)."""
+    res = _fit_family(germany_staggered, w_constr)
+    assert res.inference is not None
+    assert np.isfinite(res.effects.att)
+    assert res.inference.ci_lower <= res.effects.att <= res.inference.ci_upper
+
+
+def test_staggered_spec_rejects_unknown_w_constr():
+    from mlsynth.config_models import VanillaSCConfig
+    from pydantic import ValidationError
+    df = pd.DataFrame({"country": ["A"], "year": [1], "gdp": [1.0], "status": [0]})
+    with pytest.raises(ValidationError):
+        VanillaSCConfig(df=df, outcome="gdp", treat="status", unitid="country",
+                        time="year",
+                        staggered_spec={"features": ["gdp"], "w_constr": "bogus"})

--- a/mlsynth/utils/clustersc_helpers/config.py
+++ b/mlsynth/utils/clustersc_helpers/config.py
@@ -229,6 +229,30 @@ class CLUSTERSCConfig(BaseEstimatorConfig):
         description="Out-of-sample method for the CFT component. Currently "
                     "only 'gaussian' (Hoeffding sub-Gaussian bound) is supported.",
     )
+    compute_scpi_pi: bool = Field(
+        default=False,
+        description="Route the primary fit's prediction intervals through "
+                    "VanillaSC's generalized scpi engine (Cattaneo-Feng-Palomba-"
+                    "Titiunik 2025). Applied to the fitted weights and the denoised "
+                    "donor matrix under `scpi_constraint`. scpi's Table 3 pairs the "
+                    "ridge constraint with Amjad et al. (2018) Robust SC (the PCR "
+                    "path). Default False (requires `scpi_sims` QCQP simulations).",
+    )
+    scpi_constraint: Literal["ols", "simplex", "lasso", "ridge", "L1-L2"] = Field(
+        default="ridge",
+        description="scpi weight-constraint family for `compute_scpi_pi`. Match it "
+                    "to the fit: 'ridge' for RSC/PCR-OLS (Table 3, default), "
+                    "'simplex' for the RPCA / SIMPLEX weights, 'ols' / 'lasso' / "
+                    "'L1-L2' otherwise.",
+    )
+    scpi_sims: int = Field(
+        default=200, ge=10,
+        description="Gaussian draws for the scpi in-sample QCQP simulation.",
+    )
+    scpi_e_method: Literal["gaussian", "ls", "empirical"] = Field(
+        default="gaussian",
+        description="Out-of-sample tabulation for the scpi prediction intervals.",
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/mlsynth/utils/clustersc_helpers/config.py
+++ b/mlsynth/utils/clustersc_helpers/config.py
@@ -253,6 +253,14 @@ class CLUSTERSCConfig(BaseEstimatorConfig):
         default="gaussian",
         description="Out-of-sample tabulation for the scpi prediction intervals.",
     )
+    plot_bands: Literal["pointwise", "simultaneous", "both"] = Field(
+        default="pointwise",
+        description="Which scpi prediction-interval band(s) to shade on the "
+                    "observed-vs-counterfactual plot when `compute_scpi_pi` is "
+                    "set: 'pointwise' (default, the per-period band), "
+                    "'simultaneous' (the joint-coverage band), or 'both'. No "
+                    "band is drawn when scpi intervals were not computed.",
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/mlsynth/utils/clustersc_helpers/pcr/pipeline.py
+++ b/mlsynth/utils/clustersc_helpers/pcr/pipeline.py
@@ -67,6 +67,11 @@ def run_pcr(
     # frequentist OLS inference (Shen et al. 2023)
     shen_variance: str = "homoskedastic",
     compute_shen_ci: bool = True,
+    # scpi prediction intervals (Cattaneo-Feng-Palomba-Titiunik 2025)
+    compute_scpi_pi: bool = False,
+    scpi_constraint: str = "ridge",
+    scpi_sims: int = 200,
+    scpi_e_method: str = "gaussian",
     random_state: int = 0,
 ) -> Tuple[MethodFit, Optional[Tuple[np.ndarray, np.ndarray]]]:
     """Run the paper-aligned PCR-SC pipeline.
@@ -294,6 +299,23 @@ def run_pcr(
     }
     if shen_obj is not None:
         metadata["shen_inference"] = shen_obj
+
+    # scpi prediction intervals under the chosen constraint (ridge = Amjad et al.
+    # 2018 Robust SC per scpi Table 3). Runs on the fitted weights and the donor
+    # design the counterfactual projects through (counterfactual = projection_full
+    # @ f_hat), so scpi's synthetic-prediction model is exactly the PCR fit.
+    if compute_scpi_pi and T > T0 and estimator == "frequentist":
+        from ..scpi_pi import scpi_pi_inference
+        try:
+            metadata["scpi_inference"] = scpi_pi_inference(
+                treated_outcome, projection_full, T0, f_hat,
+                constraint=scpi_constraint, sims=scpi_sims, alpha=alpha,
+                e_method=scpi_e_method, seed=random_state,
+                periods=list(range(T0, T)),
+            )
+        except (MlsynthEstimationError, ValueError, ImportError):
+            metadata["scpi_inference"] = None
+
     if cluster_info is not None:
         metadata.update({
             "k_clusters": int(cluster_info.k),

--- a/mlsynth/utils/clustersc_helpers/plotter.py
+++ b/mlsynth/utils/clustersc_helpers/plotter.py
@@ -12,12 +12,30 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from ...exceptions import MlsynthPlottingError
-from ..plotting import Plotter, mlsynth_style
+from ..plotting import Plotter, mlsynth_style, select_pi_bands
 from .structures import CLUSTERSCResults
 
 
-def plot_clustersc(results: CLUSTERSCResults) -> None:
-    """Observed treated series vs the PCR / RPCA counterfactual(s)."""
+def _scpi_full_band(post_lower, post_upper, T: int, T0: int):
+    """Align post-period SCPI bounds to the full T-length axis (NaN pre)."""
+    lo = np.full(T, np.nan)
+    hi = np.full(T, np.nan)
+    post_lower = np.asarray(post_lower, dtype=float).ravel()
+    post_upper = np.asarray(post_upper, dtype=float).ravel()
+    n = min(len(post_lower), T - T0)
+    lo[T0:T0 + n] = post_lower[:n]
+    hi[T0:T0 + n] = post_upper[:n]
+    return lo, hi
+
+
+def plot_clustersc(results: CLUSTERSCResults, *, plot_bands: str = "pointwise"):
+    """Observed treated series vs the PCR / RPCA counterfactual(s).
+
+    When SCPI prediction intervals were computed (``compute_scpi_pi=True``),
+    ``plot_bands`` selects which band(s) to shade around the primary
+    counterfactual: ``"pointwise"`` (default), ``"simultaneous"``, or ``"both"``.
+    Returns the Matplotlib axis drawn on.
+    """
 
     inputs = results.inputs
     t = np.asarray(inputs.time_labels)
@@ -35,6 +53,17 @@ def plot_clustersc(results: CLUSTERSCResults) -> None:
 
     intervention = t[inputs.T0] if 0 <= inputs.T0 < t.size else None
 
+    # SCPI prediction-interval band(s), aligned to the full axis, shaded around
+    # the primary counterfactual (the first series).
+    pointwise = simultaneous = None
+    sc = getattr(results.cluster_inference, "scpi", None) if results.cluster_inference else None
+    if sc is not None:
+        pointwise = _scpi_full_band(sc.cf_lower, sc.cf_upper, inputs.T, inputs.T0)
+        simultaneous = _scpi_full_band(sc.cf_lower_simul, sc.cf_upper_simul,
+                                       inputs.T, inputs.T0)
+    interval, interval2, interval_label = select_pi_bands(
+        pointwise, simultaneous, plot_bands)
+
     with mlsynth_style():
         plotter = Plotter.from_config(None)
         ax = plotter.observed_vs_counterfactual(
@@ -44,6 +73,7 @@ def plot_clustersc(results: CLUSTERSCResults) -> None:
             labels=labels,
             treated_label=str(inputs.treated_unit_name),
             intervention=intervention,
+            interval=interval, interval_label=interval_label, interval2=interval2,
             outcome=inputs.outcome_name or "outcome",
             time=inputs.time_name or "time",
             title=f"CLUSTERSC: {inputs.treated_unit_name}",
@@ -55,3 +85,4 @@ def plot_clustersc(results: CLUSTERSCResults) -> None:
             raise MlsynthPlottingError(f"CLUSTERSC plotting failed: {exc}") from exc
         finally:
             plt.close(fig)
+    return ax

--- a/mlsynth/utils/clustersc_helpers/rpca/pipeline.py
+++ b/mlsynth/utils/clustersc_helpers/rpca/pipeline.py
@@ -70,6 +70,12 @@ def run_rpca(
     cft_alpha: float = 0.05,
     cft_sims: int = 200,
     cft_e_method: str = "gaussian",
+    # scpi prediction-interval knobs (Cattaneo-Feng-Palomba-Titiunik 2025)
+    compute_scpi_pi: bool = False,
+    scpi_constraint: str = "ridge",
+    scpi_sims: int = 200,
+    scpi_e_method: str = "gaussian",
+    scpi_alpha: float = 0.05,
     random_state: int = 0,
 ) -> MethodFit:
     """Run the five-step RPCA-SC pipeline and assemble a :class:`MethodFit`.
@@ -286,6 +292,7 @@ def run_rpca(
                 cv_lambda=False,
                 cv_hqf_rank=False,
                 compute_cft_pi=False,
+                compute_scpi_pi=False,
                 random_state=random_state,
             )
             return star_fit.counterfactual
@@ -301,6 +308,21 @@ def run_rpca(
             random_state=random_state,
         )
         metadata["cft_inference"] = cft_obj
+
+    # scpi prediction intervals: run on the denoised donor design and the NNLS
+    # weights (counterfactual = L_full @ beta). Constraint chosen by the caller
+    # (simplex matches the RPCA non-negative weights).
+    if compute_scpi_pi and T > T0:
+        from ..scpi_pi import scpi_pi_inference
+        try:
+            metadata["scpi_inference"] = scpi_pi_inference(
+                treated_outcome, L_full, T0, beta,
+                constraint=scpi_constraint, sims=scpi_sims, alpha=scpi_alpha,
+                e_method=scpi_e_method, seed=random_state,
+                periods=list(range(T0, T)),
+            )
+        except (MlsynthEstimationError, ValueError, ImportError):
+            metadata["scpi_inference"] = None
 
     return MethodFit(
         name=f"rpca_{rpca_method.lower()}",

--- a/mlsynth/utils/clustersc_helpers/scpi_pi.py
+++ b/mlsynth/utils/clustersc_helpers/scpi_pi.py
@@ -72,14 +72,15 @@ def scpi_pi_inference(
     T0: int,
     weights: np.ndarray,
     *,
-    constraint: str = "ridge",
+    constraint: Any = "ridge",
+    constant: bool = False,
     sims: int = 200,
     alpha: float = 0.05,
     e_method: str = "gaussian",
     seed: int = 0,
     periods: Any = None,
 ) -> ScpiPIInference:
-    """Run scpi prediction intervals on a CLUSTERSC fit under ``constraint``.
+    """Run scpi prediction intervals on a fit under ``constraint``.
 
     Parameters
     ----------
@@ -87,15 +88,19 @@ def scpi_pi_inference(
         Treated outcome over all periods, shape ``(T,)``.
     donor_full : np.ndarray
         Donor design the counterfactual projects through (the denoised donor
-        matrix for PCR / RPCA), shape ``(T, J)``, columns aligned with
-        ``weights``.
+        matrix for PCR / RPCA, or the donor pool for SCUL), shape ``(T, J)``,
+        columns aligned with the donor block of ``weights``.
     T0 : int
         Number of pre-treatment periods.
     weights : np.ndarray
-        Fitted donor weights, shape ``(J,)``.
-    constraint : str
+        Fitted weights: the donor weights ``(J,)``, or ``(J + 1,)`` with a
+        trailing intercept coefficient when ``constant=True``.
+    constraint : str or dict
         scpi weight-constraint family (default ``"ridge"``, scpi's Table-3
-        setting for Robust SC).
+        setting for Robust SC), or an explicit ``{"name": ..., "Q": ...}`` dict.
+    constant : bool
+        If True, the design gains an unconstrained intercept (scpi's ``KM``
+        block) and ``weights`` carries its coefficient last.
     sims, alpha, e_method, seed
         Passed through to ``scpi_intervals`` (``u_alpha = e_alpha = alpha``).
     periods : sequence, optional
@@ -108,9 +113,9 @@ def scpi_pi_inference(
     W = np.asarray(weights, float).ravel()
 
     sc = scpi_intervals(
-        y, Y0, int(T0), W, w_constr=constraint, sims=int(sims),
-        u_alpha=float(alpha), e_alpha=float(alpha), e_method=e_method,
-        cointegrated=False, seed=int(seed),
+        y, Y0, int(T0), W, w_constr=constraint, constant=bool(constant),
+        sims=int(sims), u_alpha=float(alpha), e_alpha=float(alpha),
+        e_method=e_method, cointegrated=False, seed=int(seed),
     )
     post = list(periods) if periods is not None else list(range(len(sc.tau)))
     return ScpiPIInference(

--- a/mlsynth/utils/clustersc_helpers/scpi_pi.py
+++ b/mlsynth/utils/clustersc_helpers/scpi_pi.py
@@ -1,0 +1,133 @@
+"""scpi prediction intervals for the CLUSTERSC RSC / PCR (and RPCA) fits.
+
+Cattaneo, Feng, Palomba & Titiunik (2025, JSS ``scpi``) Table 3 pairs each
+weight-constraint family with a synthetic-control method: the ridge constraint
+is the inference setting for Amjad, Kim, Shah & Shen (2018) Robust Synthetic
+Control, which CLUSTERSC's PCR (RSC) path implements. This module runs
+VanillaSC's generalized :func:`mlsynth.utils.vanillasc_helpers.scpi.scpi_intervals`
+on a CLUSTERSC fit -- the denoised donor matrix and the fitted weights -- under
+a chosen constraint, and packages the pointwise and simultaneous prediction
+intervals into a small frozen container.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ScpiPIInference:
+    """scpi prediction intervals for a CLUSTERSC fit (per-period + ATT).
+
+    Parameters
+    ----------
+    method : str
+        Human-readable label, e.g. ``"scpi prediction intervals (ridge)"``.
+    constraint : str
+        The scpi weight constraint used (``ols`` / ``simplex`` / ``lasso`` /
+        ``ridge`` / ``L1-L2``).
+    att_pi : tuple of float
+        ``(lower, upper)`` prediction interval for the ATT.
+    pi_lower, pi_upper : np.ndarray
+        Pointwise per-post-period prediction intervals for the treatment effect.
+    cf_lower, cf_upper : np.ndarray
+        Pointwise per-post-period bands for the counterfactual.
+    pi_lower_simul, pi_upper_simul : np.ndarray
+        Simultaneous (joint-coverage) per-period effect prediction intervals.
+    cf_lower_simul, cf_upper_simul : np.ndarray
+        Simultaneous per-period counterfactual bands.
+    df : float
+        Effective degrees of freedom scpi used for the constraint.
+    Q, lambda_ : float or None
+        The constraint budget and (ridge / L1-L2) penalty scpi estimated.
+    periods : list
+        Post-period labels aligned with the per-period arrays.
+    metadata : dict
+        Passthrough of the scpi metadata.
+    """
+
+    method: str
+    constraint: str
+    att_pi: Tuple[float, float]
+    pi_lower: np.ndarray
+    pi_upper: np.ndarray
+    cf_lower: np.ndarray
+    cf_upper: np.ndarray
+    pi_lower_simul: np.ndarray
+    pi_upper_simul: np.ndarray
+    cf_lower_simul: np.ndarray
+    cf_upper_simul: np.ndarray
+    df: float
+    Q: Any = None
+    lambda_: Any = None
+    periods: List[Any] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+def scpi_pi_inference(
+    treated_outcome: np.ndarray,
+    donor_full: np.ndarray,
+    T0: int,
+    weights: np.ndarray,
+    *,
+    constraint: str = "ridge",
+    sims: int = 200,
+    alpha: float = 0.05,
+    e_method: str = "gaussian",
+    seed: int = 0,
+    periods: Any = None,
+) -> ScpiPIInference:
+    """Run scpi prediction intervals on a CLUSTERSC fit under ``constraint``.
+
+    Parameters
+    ----------
+    treated_outcome : np.ndarray
+        Treated outcome over all periods, shape ``(T,)``.
+    donor_full : np.ndarray
+        Donor design the counterfactual projects through (the denoised donor
+        matrix for PCR / RPCA), shape ``(T, J)``, columns aligned with
+        ``weights``.
+    T0 : int
+        Number of pre-treatment periods.
+    weights : np.ndarray
+        Fitted donor weights, shape ``(J,)``.
+    constraint : str
+        scpi weight-constraint family (default ``"ridge"``, scpi's Table-3
+        setting for Robust SC).
+    sims, alpha, e_method, seed
+        Passed through to ``scpi_intervals`` (``u_alpha = e_alpha = alpha``).
+    periods : sequence, optional
+        Post-period labels for reporting.
+    """
+    from ..vanillasc_helpers.scpi import scpi_intervals
+
+    y = np.asarray(treated_outcome, float).ravel()
+    Y0 = np.asarray(donor_full, float)
+    W = np.asarray(weights, float).ravel()
+
+    sc = scpi_intervals(
+        y, Y0, int(T0), W, w_constr=constraint, sims=int(sims),
+        u_alpha=float(alpha), e_alpha=float(alpha), e_method=e_method,
+        cointegrated=False, seed=int(seed),
+    )
+    post = list(periods) if periods is not None else list(range(len(sc.tau)))
+    return ScpiPIInference(
+        method=f"scpi prediction intervals ({sc.metadata['w_constr']})",
+        constraint=str(sc.metadata["w_constr"]),
+        att_pi=(float(sc.metadata["att_lower"]), float(sc.metadata["att_upper"])),
+        pi_lower=np.asarray(sc.lower, float),
+        pi_upper=np.asarray(sc.upper, float),
+        cf_lower=np.asarray(sc.cf_lower, float),
+        cf_upper=np.asarray(sc.cf_upper, float),
+        pi_lower_simul=np.asarray(sc.lower_simul, float),
+        pi_upper_simul=np.asarray(sc.upper_simul, float),
+        cf_lower_simul=np.asarray(sc.cf_lower_simul, float),
+        cf_upper_simul=np.asarray(sc.cf_upper_simul, float),
+        df=float(sc.metadata["df"]),
+        Q=sc.metadata.get("Q"),
+        lambda_=sc.metadata.get("lambda"),
+        periods=post,
+        metadata=dict(sc.metadata),
+    )

--- a/mlsynth/utils/clustersc_helpers/structures.py
+++ b/mlsynth/utils/clustersc_helpers/structures.py
@@ -162,6 +162,12 @@ class CLUSTERSCInference:
         intervals were computed (RPCA-SC only, opt-in via
         ``CLUSTERSCConfig.compute_cft_pi``). Carries per-period and
         ATT prediction intervals.
+    scpi : object, optional
+        Full :class:`mlsynth.utils.clustersc_helpers.scpi_pi.ScpiPIInference`
+        object when the generalized scpi (Cattaneo-Feng-Palomba-Titiunik 2025)
+        prediction intervals were computed (opt-in via
+        ``CLUSTERSCConfig.compute_scpi_pi``, under ``scpi_constraint``). Carries
+        per-period and ATT pointwise and simultaneous prediction intervals.
     """
 
     method: str
@@ -170,6 +176,7 @@ class CLUSTERSCInference:
     credible_interval: Tuple[float, float] = (float("nan"), float("nan"))
     shen: Optional[Any] = None
     cft: Optional[Any] = None
+    scpi: Optional[Any] = None
 
 
 class CLUSTERSCResults(BaseEstimatorResults):

--- a/mlsynth/utils/plotting.py
+++ b/mlsynth/utils/plotting.py
@@ -25,6 +25,28 @@ _DEFAULT_CF_COLORS = ("red", "blue", "green", "purple", "orange", "brown")
 
 CounterfactualLike = Union[np.ndarray, Sequence[np.ndarray]]
 
+
+def select_pi_bands(pointwise, simultaneous, choice):
+    """Resolve the (interval, interval2, label) to shade from the two bands.
+
+    ``pointwise`` and ``simultaneous`` are ``(lower, upper)`` band pairs (or
+    ``None`` when unavailable). ``choice`` is ``"pointwise"`` / ``"simultaneous"``
+    / ``"both"``. The simultaneous band is optional (only SCPI produces one), so
+    any choice gracefully falls back to the pointwise band when it is absent.
+
+    Returns
+    -------
+    (interval, interval2, interval_label)
+        ``interval`` is the primary band (drawn on top), ``interval2`` the
+        second band drawn underneath (or ``None``), and ``interval_label`` the
+        legend label for the primary band.
+    """
+    if choice == "simultaneous" and simultaneous is not None:
+        return simultaneous, None, "Simultaneous interval"
+    if choice == "both" and simultaneous is not None:
+        return pointwise, simultaneous, "Prediction interval"
+    return pointwise, None, "Prediction interval"
+
 #: Preferred display font; falls back through the ``font.sans-serif`` chain
 #: below if it is not installed. Override by reassigning before plotting.
 MLSYNTH_FONT = "Inter"
@@ -184,6 +206,8 @@ class Plotter:
         intervention: Optional[Any] = None,
         interval: Optional[Sequence[np.ndarray]] = None,
         interval_label: str = "Prediction interval",
+        interval2: Optional[Sequence[np.ndarray]] = None,
+        interval2_label: str = "Simultaneous interval",
         outcome: str = "",
         time: str = "",
         title: str = "Observed vs. counterfactual",
@@ -214,10 +238,17 @@ class Plotter:
             X position of the intervention marker; omitted if None.
         interval : sequence of np.ndarray, optional
             ``(lower, upper)`` band (each shape ``(T,)``) shaded around the
-            **first** counterfactual -- e.g. conformal / SCPI prediction
-            intervals. ``NaN`` entries (e.g. the pre-period) are not shaded.
+            **first** counterfactual -- e.g. the pointwise SCPI prediction
+            interval. ``NaN`` entries (e.g. the pre-period) are not shaded.
         interval_label : str, default "Prediction interval"
             Legend label for the shaded band.
+        interval2 : sequence of np.ndarray, optional
+            A second ``(lower, upper)`` band drawn underneath ``interval`` with a
+            lighter shade -- e.g. the SCPI *simultaneous* (joint-coverage) band,
+            which is wider than the pointwise one. Either band may be given on
+            its own.
+        interval2_label : str, default "Simultaneous interval"
+            Legend label for the second shaded band.
         outcome, time : str
             Axis labels.
         title : str
@@ -250,10 +281,18 @@ class Plotter:
                     linewidth=self.counterfactual_linewidth,
                     linestyle=self.counterfactual_linestyle,
                     color=color, label=labels[i])
+        band = self.counterfactual_colors[0]
+        # Draw the (wider) simultaneous band underneath, then the pointwise band
+        # on top, so both remain visible when overlaid.
+        if interval2 is not None:
+            lo2 = np.asarray(interval2[0], dtype=float).reshape(-1)
+            hi2 = np.asarray(interval2[1], dtype=float).reshape(-1)
+            ax.fill_between(times, lo2, hi2, where=~np.isnan(lo2),
+                            color=band, alpha=0.10, linewidth=0,
+                            label=interval2_label)
         if interval is not None:
             lower = np.asarray(interval[0], dtype=float).reshape(-1)
             upper = np.asarray(interval[1], dtype=float).reshape(-1)
-            band = self.counterfactual_colors[0]
             ax.fill_between(times, lower, upper, where=~np.isnan(lower),
                             color=band, alpha=0.18, linewidth=0,
                             label=interval_label)

--- a/mlsynth/utils/scul_helpers/config.py
+++ b/mlsynth/utils/scul_helpers/config.py
@@ -6,7 +6,7 @@ Co-located with the helper package; re-exported from
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import Field, model_validator
 
@@ -58,6 +58,27 @@ class SCULConfig(BaseEstimatorConfig):
     inference: bool = Field(
         default=True,
         description="Compute the placebo-distribution p-value for the ATT.",
+    )
+    compute_scpi_pi: bool = Field(
+        default=False,
+        description="Route the fit's prediction intervals through VanillaSC's "
+                    "generalized scpi engine (Cattaneo-Feng-Palomba-Titiunik 2025) "
+                    "under the lasso constraint with a constant (the intercept). "
+                    "scpi's Table 3 pairs the lasso constraint with Chernozhukov "
+                    "et al. (2021), the family SCUL implements. When set, the ATT "
+                    "prediction interval is surfaced alongside the placebo p-value.",
+    )
+    scpi_sims: int = Field(
+        default=200, ge=10,
+        description="Gaussian draws for the scpi in-sample QCQP simulation.",
+    )
+    scpi_alpha: float = Field(
+        default=0.05, gt=0.0, lt=1.0,
+        description="Two-sided level for the scpi prediction intervals.",
+    )
+    scpi_e_method: Literal["gaussian", "ls", "empirical"] = Field(
+        default="gaussian",
+        description="Out-of-sample tabulation for the scpi prediction intervals.",
     )
 
     @model_validator(mode="after")

--- a/mlsynth/utils/scul_helpers/pipeline.py
+++ b/mlsynth/utils/scul_helpers/pipeline.py
@@ -38,6 +38,27 @@ def run_scul(inputs: SCULInputs, config) -> SCULResults:
             cohensd_threshold=config.cohensd_threshold,
         )
 
+    # scpi lasso prediction intervals on the fitted signed coefficients plus the
+    # intercept (Chernozhukov et al. 2021 / scpi Table 3). The compatible set is
+    # the L1 ball at the realised budget ||w||_1; the intercept is the (free)
+    # constant/KM block.
+    scpi_obj = None
+    if getattr(config, "compute_scpi_pi", False) and T0 < inputs.T:
+        from ..clustersc_helpers.scpi_pi import scpi_pi_inference
+        from ...exceptions import MlsynthEstimationError
+        l1 = float(np.sum(np.abs(weights)))
+        try:
+            scpi_obj = scpi_pi_inference(
+                inputs.y, inputs.donor_matrix, T0,
+                np.concatenate([weights, [float(fit["intercept"])]]),
+                constraint={"name": "lasso", "Q": l1}, constant=True,
+                sims=config.scpi_sims, alpha=config.scpi_alpha,
+                e_method=config.scpi_e_method, seed=0,
+                periods=list(inputs.time_labels[T0:]),
+            )
+        except (MlsynthEstimationError, ValueError, ImportError):
+            scpi_obj = None
+
     scul_fit = SCULFit(
         counterfactual=counterfactual,
         gap=gap,
@@ -49,6 +70,7 @@ def run_scul(inputs: SCULInputs, config) -> SCULResults:
         donor_weights=donor_weights,
         p_value=p_value,
         n_placebo=n_placebo,
+        scpi=scpi_obj,
         metadata={"cv_option": config.cv_option},
     )
     return SCULResults(inputs=inputs, fit=scul_fit)

--- a/mlsynth/utils/scul_helpers/structures.py
+++ b/mlsynth/utils/scul_helpers/structures.py
@@ -87,6 +87,7 @@ class SCULFit:
     donor_weights: Dict[Any, float]  # nonzero pool columns -> weight
     p_value: Optional[float] = None
     n_placebo: Optional[int] = None
+    scpi: Optional[Any] = None        # ScpiPIInference (lasso PI), when computed
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -120,7 +121,15 @@ class SCULResults(BaseEstimatorResults):
             donor_weights={str(k): float(v) for k, v in fit.donor_weights.items()}))
         object.__setattr__(self, "fit_diagnostics",
                            FitDiagnosticsResults(rmse_pre=float(fit.cohens_d)))
-        if fit.p_value is not None:
+        if fit.scpi is not None:
+            lo, hi = fit.scpi.att_pi
+            object.__setattr__(self, "inference", InferenceResults(
+                ci_lower=float(lo), ci_upper=float(hi),
+                confidence_level=1.0 - 2.0 * float(fit.scpi.metadata.get(
+                    "u_alpha", 0.05)),
+                method=fit.scpi.method,
+                p_value=fit.p_value))
+        elif fit.p_value is not None:
             object.__setattr__(self, "inference", InferenceResults(
                 p_value=fit.p_value, method="placebo"))
         object.__setattr__(self, "method_details", MethodDetailsResults(

--- a/mlsynth/utils/sparse_sc_helpers/config.py
+++ b/mlsynth/utils/sparse_sc_helpers/config.py
@@ -191,3 +191,28 @@ class SparseSCConfig(BaseEstimatorConfig):
             "matters more than exact reproducibility."
         ),
     )
+    compute_scpi_pi: bool = Field(
+        default=False,
+        description=(
+            "Also compute model-based prediction intervals through VanillaSC's "
+            "generalized scpi engine (Cattaneo-Feng-Palomba-Titiunik 2025). "
+            "SparseSC's donor weights are simplex (w >= 0, sum w = 1), so the "
+            "intervals run under scpi's simplex constraint -- the Abadie "
+            "(2010) setting of scpi's Table 3 -- giving a per-period band and "
+            "an ATT interval (surfaced on ``res.scpi`` and, when no other CI "
+            "is produced, in ``res.att_ci``) alongside the placebo / conformal "
+            "inference."
+        ),
+    )
+    scpi_sims: int = Field(
+        default=200, ge=10,
+        description="Gaussian draws for the scpi in-sample QCQP simulation.",
+    )
+    scpi_alpha: float = Field(
+        default=0.05, gt=0.0, lt=1.0,
+        description="Two-sided level for the scpi prediction intervals.",
+    )
+    scpi_e_method: Literal["gaussian", "ls", "empirical"] = Field(
+        default="gaussian",
+        description="Out-of-sample tabulation for the scpi prediction intervals.",
+    )

--- a/mlsynth/utils/sparse_sc_helpers/structures.py
+++ b/mlsynth/utils/sparse_sc_helpers/structures.py
@@ -202,3 +202,4 @@ class SparseSCResults(BaseEstimatorResults):
     design: SparseSCDesign
     inference_detail: SparseSCInference
     predictor_weights: Dict[Any, float]
+    scpi: Optional[Any] = None        # ScpiPIInference (simplex PI), when computed

--- a/mlsynth/utils/tssc_helpers/config.py
+++ b/mlsynth/utils/tssc_helpers/config.py
@@ -8,7 +8,7 @@ per-estimator config lives here. Re-exported from
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import Field
 
@@ -54,3 +54,30 @@ class TSSCConfig(BaseEstimatorConfig):
     draws: int = Field(default=500, ge=1, description="Subsampling/bootstrap replications.")
     ci: float = Field(default=0.95, gt=0.0, lt=1.0, description="ATT confidence level.")
     seed: Optional[int] = Field(default=None, description="RNG seed for subsampling.")
+    compute_scpi_pi: bool = Field(
+        default=False,
+        description=(
+            "Also compute model-based prediction intervals through VanillaSC's "
+            "generalized scpi engine (Cattaneo-Feng-Palomba-Titiunik 2025) for "
+            "each SC-class variant, mapped to scpi's weight-constraint family by "
+            "the variant's restrictions: SC -> simplex, MSCa -> simplex + "
+            "constant, MSCb -> ols, MSCc -> ols + constant. The sum-constrained "
+            "variants map exactly; the no-adding-up variants (MSCb / MSCc) carry "
+            "bare non-negativity, which scpi does not have, so they use scpi's "
+            "ols set (the band does not re-impose w >= 0, so it is slightly "
+            "conservative). Each variant fit gains a ``scpi`` band and the "
+            "recommended variant's band is surfaced on ``res.scpi``."
+        ),
+    )
+    scpi_sims: int = Field(
+        default=200, ge=10,
+        description="Gaussian draws for the scpi in-sample QCQP simulation.",
+    )
+    scpi_alpha: float = Field(
+        default=0.05, gt=0.0, lt=1.0,
+        description="Two-sided level for the scpi prediction intervals.",
+    )
+    scpi_e_method: Literal["gaussian", "ls", "empirical"] = Field(
+        default="gaussian",
+        description="Out-of-sample tabulation for the scpi prediction intervals.",
+    )

--- a/mlsynth/utils/tssc_helpers/estimation.py
+++ b/mlsynth/utils/tssc_helpers/estimation.py
@@ -32,6 +32,11 @@ from .structures import MSCA, MSCB, MSCC, SC, TSSCInputs, TSSCVariantFit
 _SCOPT_MODEL = {SC: "SIMPLEX", MSCA: "MSCa", MSCB: "MSCb", MSCC: "MSCc"}
 # Which variants carry a free intercept (beta_1).
 _HAS_INTERCEPT = {SC: False, MSCA: True, MSCB: False, MSCC: True}
+# scpi weight-constraint family per variant. SC / MSCa map exactly (simplex, with
+# a free constant for MSCa); MSCb / MSCc carry bare non-negativity, which scpi's
+# family has no member for, so they use scpi's ols set -- the band does not
+# re-impose w >= 0 and is therefore slightly conservative.
+_SCPI_CONSTRAINT = {SC: "simplex", MSCA: "simplex", MSCB: "ols", MSCC: "ols"}
 
 # Pre-treatment subsample is T1 minus this when forming ATT-CI subsamples.
 _ATT_CI_SUBSAMPLE_ADJUSTMENT = 5
@@ -166,12 +171,42 @@ def bootstrap_att_ci(
     return (att - upper_q, att - lower_q)
 
 
+def _scpi_for_variant(inputs, method, donor_coefs, intercept, *, sims, alpha,
+                      e_method, seed):
+    """scpi prediction-interval band for one variant, under its mapped
+    constraint (see ``_SCPI_CONSTRAINT``). Returns ``None`` on failure or when
+    there are no post-treatment periods."""
+    if inputs.T <= inputs.T0:
+        return None
+    from ..clustersc_helpers.scpi_pi import scpi_pi_inference
+    from ...exceptions import MlsynthEstimationError
+    constraint = _SCPI_CONSTRAINT[method]
+    has_const = _HAS_INTERCEPT[method]
+    # scpi expects the constant coefficient last; TSSC stores it first.
+    W = (np.concatenate([np.asarray(donor_coefs, float), [float(intercept)]])
+         if has_const else np.asarray(donor_coefs, float))
+    try:
+        return scpi_pi_inference(
+            np.asarray(inputs.y, float), np.asarray(inputs.donor_matrix, float),
+            int(inputs.T0), W, constraint=constraint, constant=has_const,
+            sims=int(sims), alpha=float(alpha), e_method=e_method,
+            seed=int(seed), periods=list(inputs.time_labels[inputs.T0:]),
+        )
+    except (MlsynthEstimationError, ValueError, ImportError):
+        return None
+
+
 def fit_variant(
     inputs: TSSCInputs,
     method: str,
     n_bootstrap: int,
     confidence_level: float = 0.95,
     rng: Optional[np.random.Generator] = None,
+    compute_scpi_pi: bool = False,
+    scpi_sims: int = 200,
+    scpi_alpha: float = 0.05,
+    scpi_e_method: str = "gaussian",
+    scpi_seed: int = 0,
 ) -> TSSCVariantFit:
     """Fit one SC-class variant and assemble its :class:`TSSCVariantFit`."""
 
@@ -219,6 +254,13 @@ def fit_variant(
         if abs(coef) > 1e-3
     }
 
+    scpi_band = None
+    if compute_scpi_pi:
+        scpi_band = _scpi_for_variant(
+            inputs, method, donor_coefs, intercept,
+            sims=scpi_sims, alpha=scpi_alpha, e_method=scpi_e_method,
+            seed=scpi_seed)
+
     return TSSCVariantFit(
         method=method,
         weights=weights,
@@ -231,4 +273,5 @@ def fit_variant(
         rmse_pre=float(fit_diag["T0 RMSE"]),
         rmse_post=float(fit_diag["T1 RMSE"]),
         r2_pre=float(fit_diag["R-Squared"]),
+        scpi=scpi_band,
     )

--- a/mlsynth/utils/tssc_helpers/structures.py
+++ b/mlsynth/utils/tssc_helpers/structures.py
@@ -184,6 +184,7 @@ class TSSCVariantFit:
     rmse_pre: float
     rmse_post: float
     r2_pre: float
+    scpi: Optional[object] = None     # ScpiPIInference band, when computed
 
 
 class TSSCResults(BaseEstimatorResults):
@@ -263,6 +264,12 @@ class TSSCResults(BaseEstimatorResults):
     def donor_weights(self) -> dict:
         """Donor weights of the recommended method."""
         return self.recommended.donor_weights
+
+    @property
+    def scpi(self):
+        """scpi prediction-interval band of the recommended method (``None``
+        unless ``compute_scpi_pi`` was set)."""
+        return self.recommended.scpi
 
     def att_by_method(self) -> Dict[str, float]:
         """``{method: ATT}`` across all four SC-class variants."""

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -221,6 +221,15 @@ class VanillaSCConfig(BaseEstimatorConfig):
                     "cointegrated (I(1)) outcome/donor levels. The point "
                     "counterfactual is unchanged; only the prediction bands move.",
     )
+    plot_bands: Literal["pointwise", "simultaneous", "both"] = Field(
+        default="pointwise",
+        description="Which SCPI prediction-interval band(s) to shade on the "
+                    "observed-vs-counterfactual plot: 'pointwise' (default, the "
+                    "per-period band), 'simultaneous' (the joint-coverage band), "
+                    "or 'both'. The simultaneous band is only available for "
+                    "inference='scpi'; other inference modes always show the "
+                    "pointwise band.",
+    )
     staggered_spec: Optional[StaggeredSCMSpec] = Field(
         default=None,
         description="Staggered adoption only. Covariate (multi-feature) matching "

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -49,6 +49,14 @@ class StaggeredSCMSpec(BaseModel):
         description="Difference the data for cointegration (scpi's "
                     "'cointegrated_data').",
     )
+    w_constr: Literal["simplex", "ols", "lasso", "ridge", "L1-L2"] = Field(
+        default="simplex",
+        description="Donor weight constraint (scpi's weight-constraint family), "
+                    "applied uniformly to every treated unit. 'simplex' (convex "
+                    "Abadie SC, default), 'ols' (unconstrained), 'lasso' "
+                    "(L1 <= 1, Chernozhukov et al.), 'ridge' (L2 shrinkage, "
+                    "Amjad et al.), 'L1-L2' (Arkhangelsky et al.).",
+    )
 
     @field_validator("features")
     @classmethod

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -315,6 +315,11 @@ def run_vanillasc(config) -> BaseEstimatorResults:
                 "att": sc.metadata["att"],
                 "in_sample_lower": sc.M1_lower, "in_sample_upper": sc.M1_upper,
                 "out_of_sample_lower": sc.M2_lower, "out_of_sample_upper": sc.M2_upper,
+                "pi_lower_simultaneous": sc.lower_simul,
+                "pi_upper_simultaneous": sc.upper_simul,
+                "counterfactual_lower_simultaneous": sc.cf_lower_simul,
+                "counterfactual_upper_simultaneous": sc.cf_upper_simul,
+                "w_constr": sc.metadata["w_constr"], "df": sc.metadata["df"],
                 "sims": sc.metadata["sims"], "e_method": sc.metadata["e_method"],
             },
         )

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -588,12 +588,23 @@ def _plot_vanillasc(config, y, counterfactual, time_labels, pre,
     from ..plotting import Plotter, mlsynth_style
 
     T = len(time_labels)
-    interval = None
+    # Pointwise and (SCPI-only) simultaneous prediction-interval bands.
+    pointwise = simultaneous = None
     if inference is not None and getattr(inference, "details", None):
-        lo = inference.details.get("counterfactual_lower")
-        hi = inference.details.get("counterfactual_upper")
+        det = inference.details
+        lo, hi = det.get("counterfactual_lower"), det.get("counterfactual_upper")
         if lo is not None and hi is not None:
-            interval = (_full_band(lo, T, pre), _full_band(hi, T, pre))
+            pointwise = (_full_band(lo, T, pre), _full_band(hi, T, pre))
+        slo = det.get("counterfactual_lower_simultaneous")
+        shi = det.get("counterfactual_upper_simultaneous")
+        if slo is not None and shi is not None:
+            simultaneous = (_full_band(slo, T, pre), _full_band(shi, T, pre))
+
+    # Resolve which band(s) to shade (the simultaneous band is SCPI-only; other
+    # inference modes fall back to the pointwise band).
+    from ..plotting import select_pi_bands
+    interval, interval2, interval_label = select_pi_bands(
+        pointwise, simultaneous, getattr(config, "plot_bands", "pointwise"))
 
     intervention = time_labels[pre] if 0 <= pre < T else None
     with mlsynth_style():
@@ -602,6 +613,7 @@ def _plot_vanillasc(config, y, counterfactual, time_labels, pre,
             times=time_labels, observed=y, counterfactuals=[counterfactual],
             labels=[f"Synthetic {treated_name}"], treated_label=treated_name,
             intervention=intervention, interval=interval,
+            interval_label=interval_label, interval2=interval2,
             outcome=config.outcome, time=config.time,
             title=f"{_variant_label(config)}: {treated_name}",
         )

--- a/mlsynth/utils/vanillasc_helpers/scpi.py
+++ b/mlsynth/utils/vanillasc_helpers/scpi.py
@@ -1,4 +1,4 @@
-"""SCPI prediction intervals for the (simplex) synthetic control.
+"""SCPI prediction intervals for the synthetic control (full constraint family).
 
 Cattaneo, Feng & Titiunik (2021, JASA) and Cattaneo, Feng, Palomba &
 Titiunik (2025, JSS ``scpi``). The prediction error of the synthetic-control
@@ -47,8 +47,25 @@ residuals (``IQR / 1.34``). The Gaussian band is ``E[e] +/- sqrt(-2 ln alpha2)
 * scale``; ``"ls"`` uses standardized-residual quantiles, ``"empirical"`` the
 raw residual quantiles.
 
-This implements the canonical simplex case (``w >= 0``, ``sum w = 1``), the
-``scpi`` default and the standard synthetic control.
+Weight-constraint family (``w_constr``)
+---------------------------------------
+The compatible weight set in the in-sample QCQP and the effective degrees of
+freedom follow ``scpi``'s Table 2 (``w_constr_prep`` / ``local_geom`` /
+``df_EST``):
+
+    ols       no constraint;                          df = J
+    simplex   sum w = 1, w >= 0 (the default);          df = #nonzero - 1
+    lasso     ||w||_1 <= Q;                             df = #nonzero
+    ridge     ||w||_2 <= Q;                             df = sum_k d_k^2/(d_k^2+lambda)
+    L1-L2     sum w = 1, w >= 0, ||w||_2 <= Q2;         df = sum_k d_k^2/(d_k^2+lambda)
+
+where ``d_k`` are the singular values of the pre-period donor design and ``Q`` /
+``lambda`` for ridge / L1-L2 come from ``scpi``'s data-driven shrinkage
+rule-of-thumb (``shrinkage_EST``) unless supplied. The simplex case is the
+``scpi`` default and the standard synthetic control; the ridge case is
+``scpi``'s Table-3 inference setting for Amjad, Kim, Shah & Shen (2018) Robust
+Synthetic Control (used by CLUSTERSC's RSC / PCR path). The out-of-sample
+component is constraint-independent.
 """
 
 from __future__ import annotations
@@ -76,14 +93,18 @@ class SCPIResult:
     """Per-post-period SCPI prediction intervals (arrays of length T_post)."""
 
     tau: np.ndarray            # observed effect Y1 - synthetic
-    lower: np.ndarray          # PI lower bound for tau_T
-    upper: np.ndarray          # PI upper bound for tau_T
-    cf_lower: np.ndarray       # PI lower bound for the counterfactual Y1(0)
+    lower: np.ndarray          # pointwise PI lower bound for tau_T
+    upper: np.ndarray          # pointwise PI upper bound for tau_T
+    cf_lower: np.ndarray       # pointwise PI lower bound for the counterfactual Y1(0)
     cf_upper: np.ndarray
     M1_lower: np.ndarray       # in-sample band (w_lb)
     M1_upper: np.ndarray       # in-sample band (w_ub)
     M2_lower: np.ndarray       # out-of-sample band (e_lb), per period
     M2_upper: np.ndarray       # out-of-sample band (e_ub), per period
+    lower_simul: np.ndarray    # simultaneous (joint-coverage) PI lower for tau_T
+    upper_simul: np.ndarray    # simultaneous PI upper for tau_T
+    cf_lower_simul: np.ndarray  # simultaneous PI lower for the counterfactual
+    cf_upper_simul: np.ndarray
     metadata: Dict[str, Any]
 
 
@@ -130,6 +151,212 @@ def _mat_regularize(Q: np.ndarray):
     mask = w_scaled > cond
     Qreg = (V[:, mask] * np.sqrt(w_scaled[mask])).T   # (k, J)
     return scale, Qreg
+
+
+_W_CONSTR_NAMES = ("ols", "simplex", "lasso", "ridge", "L1-L2")
+
+
+def _shrinkage_ridge(A: np.ndarray, B: np.ndarray):
+    """scpi's ridge ``shrinkage_EST`` rule-of-thumb, returning ``(Q, lambda)``.
+
+    Fits an unweighted (identity ``V``) OLS of the treated pre-outcome on the
+    donors, then ``lambda = sigma^2 (J + KM) / ||b||**2`` and ``Q = ||b|| /
+    (1 + lambda)`` (``KM = 0`` for the outcome-only single-unit case). When
+    observations are scarce (``T0 <= J + 10``) scpi lasso-screens the donors to
+    ``max(T0 - 10, 2)`` columns and refits; we mirror that with a cvxpy L1 solve.
+    """
+    A = np.asarray(A, float).ravel()
+    B = np.asarray(B, float)
+    T0, J = B.shape
+
+    def _rule(Bsub: np.ndarray):
+        b, *_ = np.linalg.lstsq(Bsub, A, rcond=None)
+        resid = A - Bsub @ b
+        k = Bsub.shape[1]
+        sig = float(resid @ resid) / max(T0 - k, 1)      # OLS scale (WLS, V=I)
+        L2 = float(b @ b)
+        lam = sig * k / max(L2, _EPS)
+        return sqrt(L2) / (1.0 + lam), lam, L2
+
+    if T0 > J + 10:
+        Q, lam, _ = _rule(B)
+        return Q, lam
+
+    # lasso pre-selection (scpi's scarce-observation branch)
+    if _HAS_CVXPY:
+        z = cp.Variable(J)
+        prob = cp.Problem(cp.Minimize(cp.sum_squares(A - B @ z)),
+                          [cp.norm1(z) <= 1.0])
+        try:
+            prob.solve(solver=cp.CLARABEL)
+            coefs = np.abs(np.asarray(z.value).ravel())
+        except Exception:  # pragma: no cover - solver fallback
+            coefs = np.abs(np.linalg.lstsq(B, A, rcond=None)[0])
+    else:  # pragma: no cover - cvxpy is required for SCPI anyway
+        coefs = np.abs(np.linalg.lstsq(B, A, rcond=None)[0])
+    keep = max(min(T0 - 10, J), 2)
+    active = np.argsort(coefs)[::-1][:keep]
+    Q, lam, _ = _rule(B[:, np.sort(active)])
+    return Q, lam
+
+
+def _prep_w_constr(w_constr, A: np.ndarray, B: np.ndarray, W: np.ndarray) -> Dict[str, Any]:
+    """Normalise a weight-constraint spec to scpi's canonical dict.
+
+    Mirrors ``scpi``'s ``w_constr_prep``: accepts a family name (``"ols"``,
+    ``"simplex"``, ``"lasso"``, ``"ridge"``, ``"L1-L2"``) or an explicit
+    ``{"name": ..., "Q": ..., "lambda": ..., "Q2": ...}``, and fills in the norm
+    ``p``, direction ``dir``, lower bound ``lb`` and -- for ridge / L1-L2 -- the
+    data-driven budget ``Q`` and penalty ``lambda`` via ``_shrinkage_ridge``.
+    """
+    if isinstance(w_constr, str):
+        spec: Dict[str, Any] = {"name": w_constr}
+    elif isinstance(w_constr, dict):
+        spec = dict(w_constr)
+    else:
+        raise ValueError(
+            "w_constr must be a constraint name or a dict; got "
+            f"{type(w_constr).__name__}.")
+    name = spec.get("name")
+    if name not in _W_CONSTR_NAMES:
+        raise ValueError(
+            "w_constr 'name' must be one of "
+            f"{'/'.join(_W_CONSTR_NAMES)}; got {name!r}.")
+
+    if name == "simplex":
+        return {"name": "simplex", "p": "L1", "dir": "==", "lb": 0.0,
+                "Q": float(spec.get("Q", 1.0)), "Q2": None, "lambda": None}
+    if name == "ols":
+        return {"name": "ols", "p": "no norm", "dir": None, "lb": -np.inf,
+                "Q": None, "Q2": None, "lambda": None}
+    if name == "lasso":
+        return {"name": "lasso", "p": "L1", "dir": "<=", "lb": -np.inf,
+                "Q": float(spec.get("Q", 1.0)), "Q2": None, "lambda": None}
+    if name == "ridge":
+        Q = spec.get("Q")
+        lam = spec.get("lambda")
+        if Q is None or lam is None:
+            Qe, lame = _shrinkage_ridge(A, B)
+            Q = Qe if Q is None else Q
+            lam = lame if lam is None else lam
+        return {"name": "ridge", "p": "L2", "dir": "<=", "lb": -np.inf,
+                "Q": float(Q), "Q2": None, "lambda": float(lam)}
+    # L1-L2
+    Q2 = spec.get("Q2")
+    lam = spec.get("lambda")
+    if Q2 is None or lam is None:
+        Qe, lame = _shrinkage_ridge(A, B)
+        Q2 = Qe if Q2 is None else Q2
+        lam = lame if lam is None else lam
+    return {"name": "L1-L2", "p": "L1-L2", "dir": "==/<=", "lb": 0.0,
+            "Q": float(spec.get("Q", 1.0)), "Q2": float(Q2), "lambda": float(lam)}
+
+
+@dataclass
+class _LocalGeom:
+    """Localised compatible-set geometry for the in-sample QCQP (scpi ``local_geom``)."""
+
+    idxw: np.ndarray            # active-donor mask for the E[u]/E[e] design
+    lb: np.ndarray              # localised lower bounds (used iff use_lb)
+    use_lb: bool
+    has_sum: bool               # sum(x) == Q_sum   (simplex, L1-L2)
+    Q_sum: float
+    has_l1: bool                # ||x||_1 <= Q_l1   (lasso)
+    Q_l1: float
+    has_l2: bool                # ||x||_2 <= Q_l2   (ridge, L1-L2)
+    Q_l2: float
+
+
+def _local_geom(wc: Dict[str, Any], W: np.ndarray, rho: float, B: np.ndarray) -> _LocalGeom:
+    """Localised weight-set for the compatible-region QCQP, per constraint.
+
+    Follows ``scpi``'s ``local_geom``: for norm-bounded constraints the budget is
+    relaxed to the realised norm when the fit sits within ``rho`` of the bound
+    (so the localised set contains the estimate); ``lb`` pins the near-zero
+    donors for the lower-bounded (simplex / L1-L2) constraints; ridge and ols
+    leave every donor active with no lower bound.
+    """
+    W = np.asarray(W, float).ravel()
+    J = W.shape[0]
+    name = wc["name"]
+    all_active = np.ones(J, dtype=bool)
+
+    if name == "simplex":
+        idxw = W > rho
+        if not idxw.any():
+            idxw = np.zeros(J, dtype=bool)
+            idxw[int(np.argmax(W))] = True
+        lb = np.where(W < rho, W, 0.0)
+        return _LocalGeom(idxw, lb, True, True, 1.0, False, 0.0, False, 0.0)
+
+    if name == "ols":
+        return _LocalGeom(all_active, np.zeros(J), False, False, 0.0,
+                          False, 0.0, False, 0.0)
+
+    if name == "lasso":
+        idxw = np.abs(W) > rho
+        if not idxw.any():
+            idxw = np.zeros(J, dtype=bool)
+            idxw[int(np.argmax(np.abs(W)))] = True
+        Q = wc["Q"]
+        l1 = float(np.sum(np.abs(W)))
+        Q_star = l1 if (Q - rho * sqrt(J) <= l1 <= Q) else Q
+        return _LocalGeom(idxw, np.zeros(J), False, False, 0.0,
+                          True, Q_star, False, 0.0)
+
+    if name == "ridge":
+        Q = wc["Q"]
+        l2 = float(sqrt(np.sum(W ** 2)))
+        Q_star = l2 if (Q - rho <= l2 <= Q) else Q
+        return _LocalGeom(all_active, np.zeros(J), False, False, 0.0,
+                          False, 0.0, True, Q_star)
+
+    # L1-L2: localised sum (as simplex) plus a localised L2 budget
+    idxw = np.abs(W) > rho
+    if not idxw.any():
+        idxw = np.zeros(J, dtype=bool)
+        idxw[int(np.argmax(np.abs(W)))] = True
+    lb = np.where(W < rho, W, 0.0)
+    Q, Q2 = wc["Q"], wc["Q2"]
+    l2 = float(sqrt(np.sum(W ** 2)))
+    Q2_star = l2 if (Q - rho <= l2 <= Q) else Q2
+    return _LocalGeom(idxw, lb, True, True, 1.0, False, 0.0, True, Q2_star)
+
+
+def _df_est(wc: Dict[str, Any], W: np.ndarray, B: np.ndarray) -> float:
+    """Effective degrees of freedom per constraint (scpi ``df_EST``, ``KM = 0``).
+
+    ols: ``J``; lasso: ``#nonzero``; simplex: ``#nonzero - 1``; ridge / L1-L2:
+    ``sum_k d_k^2 / (d_k^2 + lambda)`` over the positive singular values ``d_k``
+    of the pre-period donor design.
+    """
+    W = np.asarray(W, float).ravel()
+    name = wc["name"]
+    if name == "ols":
+        return float(B.shape[1])
+    if name == "lasso":
+        return float(int(np.sum(np.abs(W) >= _NZ)))
+    if name == "simplex":
+        return float(max(int(np.sum(np.abs(W) >= _NZ)) - 1, 0))
+    # ridge / L1-L2
+    d = np.linalg.svd(np.asarray(B, float), compute_uv=False)
+    d = d[d > 0]
+    lam = wc["lambda"]
+    return float(np.sum(d ** 2 / (d ** 2 + lam)))
+
+
+def _qcqp_weight_constraints(x, lg: _LocalGeom):
+    """cvxpy weight-set constraints for the in-sample QCQP from ``_local_geom``."""
+    cons = []
+    if lg.use_lb:
+        cons.append(x >= lg.lb)
+    if lg.has_sum:
+        cons.append(cp.sum(x) == lg.Q_sum)
+    if lg.has_l1:
+        cons.append(cp.norm1(x) <= lg.Q_l1)
+    if lg.has_l2:
+        cons.append(cp.sum_squares(x) <= lg.Q_l2 ** 2)
+    return cons
 
 
 def _out_of_sample(
@@ -186,6 +413,7 @@ def scpi_intervals(
     pre: int,
     W: np.ndarray,
     *,
+    w_constr: Any = "simplex",
     sims: int = 200,
     u_alpha: float = 0.05,
     e_alpha: float = 0.05,
@@ -194,7 +422,7 @@ def scpi_intervals(
     cointegrated: bool = False,
     seed: int = 0,
 ) -> SCPIResult:
-    """Compute SCPI prediction intervals for a simplex synthetic control.
+    """Compute SCPI prediction intervals for a synthetic control.
 
     Parameters
     ----------
@@ -205,7 +433,13 @@ def scpi_intervals(
     pre : int
         Number of pre-treatment periods ``T0``.
     W : np.ndarray
-        Fitted simplex donor weights, shape ``(J,)``.
+        Fitted donor weights, shape ``(J,)`` (columns match ``Y0``).
+    w_constr : str or dict
+        Weight-constraint family the fit obeys, controlling the in-sample
+        compatible set and the degrees of freedom. One of ``"ols"``,
+        ``"simplex"`` (default), ``"lasso"``, ``"ridge"``, ``"L1-L2"``, or an
+        explicit dict ``{"name": ..., "Q": ..., "lambda": ..., "Q2": ...}``.
+        Ridge is scpi's Table-3 setting for Amjad et al. (2018) Robust SC.
     sims : int
         Number of Gaussian draws for the in-sample simulation.
     u_alpha, e_alpha : float
@@ -253,18 +487,23 @@ def scpi_intervals(
     else:
         B_mean, B_q, u_w, T0e = B, B, u, T0
 
-    # --- degrees of freedom (simplex): #nonzero - 1 (+ KM = 0) ---
+    # --- weight-constraint spec (scpi w_constr_prep): fills Q / lambda. Align
+    #     the treated pre-outcome to the design rows kept for Q/Sigma (under
+    #     cointegration the first pre-period is dropped from B_q). ---
+    A_q = A[1:] if cointegrated else A
+    wc = _prep_w_constr(w_constr, A_q, B_q, W)
+
+    # --- degrees of freedom per constraint (scpi df_EST, KM = 0) ---
     d0 = int(np.sum(np.abs(W) >= _NZ))
-    df = max(d0 - 1, 0)
+    df = _df_est(wc, W, B_q)
+    if df >= T0e:  # scpi guard: never spend more dof than observations
+        df = T0e - 1
     vc = T0e / (T0e - df) if df < T0e else 1.0
 
-    # --- regularisation parameter and localised lower bounds ---
+    # --- regularisation parameter and localised compatible set (scpi local_geom) ---
     rho = _regularization_rho(u_w, B_q, d0)
-    idxw = W > rho
-    if not idxw.any():  # pragma: no cover - degenerate: every weight below rho
-        idxw = np.zeros(J, dtype=bool)
-        idxw[int(np.argmax(W))] = True
-    lb = np.where(W < rho, W, 0.0)
+    lg = _local_geom(wc, W, rho, B_q)
+    idxw = lg.idxw
 
     # --- conditional mean of the residuals (u_missp) ---
     Xd = np.column_stack([B_mean[:, idxw], np.ones(T0e)])
@@ -291,7 +530,8 @@ def scpi_intervals(
         quad = cp.Constant(0.0)
     else:
         quad = scale * cp.sum_squares(Qreg @ (x - W))
-    constraints = [quad - 2.0 * Gstar @ (x - W) <= 0.0, cp.sum(x) == 1.0, x >= lb]
+    constraints = [quad - 2.0 * Gstar @ (x - W) <= 0.0]
+    constraints += _qcqp_weight_constraints(x, lg)
     prob_min = cp.Problem(cp.Minimize(c @ x), constraints)
     prob_max = cp.Problem(cp.Maximize(c @ x), constraints)
 
@@ -303,7 +543,7 @@ def scpi_intervals(
     hi = np.full((sims, n_rows), np.nan)   # max-branch  p'(w - x)
 
     def _solve(prob):
-        for solver in (cp.CLARABEL,):
+        for solver in (cp.CLARABEL, cp.ECOS):
             try:
                 prob.solve(solver=solver, warm_start=True)
                 if prob.status in ("optimal", "optimal_inaccurate") and x.value is not None:
@@ -350,6 +590,18 @@ def scpi_intervals(
     w_lb, w_ub = w_lb[:T_post], w_ub[:T_post]
     e_lb, e_ub = e_lb_aug[:T_post], e_ub_aug[:T_post]
 
+    # --- simultaneous (joint-coverage) band: a uniform in-sample bound plus the
+    #     out-of-sample component inflated by sqrt(log(T_post + 1)) (scpi's
+    #     ``simultaneousPredGet``). The in-sample joint bound is the alpha/2 (resp.
+    #     1 - alpha/2) quantile, across post periods, of the per-period extreme
+    #     deviation over draws -- always at least as wide as any pointwise bound. ---
+    with np.errstate(invalid="ignore"):
+        lo_min = np.nanmin(lo[:, :T_post], axis=0)   # per-period min over draws
+        hi_max = np.nanmax(hi[:, :T_post], axis=0)   # per-period max over draws
+        w_lb_joint = float(np.nan_to_num(np.nanquantile(lo_min, u_alpha / 2.0)))
+        w_ub_joint = float(np.nan_to_num(np.nanquantile(hi_max, 1.0 - u_alpha / 2.0)))
+    eps_joint = sqrt(log(T_post + 1.0))              # out-of-sample inflation
+
     # --- assemble intervals ---
     cf = P @ W                                       # synthetic counterfactual (Y_fit)
     obs = y[T0:]
@@ -358,6 +610,11 @@ def scpi_intervals(
     cf_upper = cf + w_ub + e_ub
     lower = obs - cf_upper                           # effect PI = obs - cf band
     upper = obs - cf_lower
+
+    cf_lower_simul = cf + w_lb_joint + eps_joint * e_lb
+    cf_upper_simul = cf + w_ub_joint + eps_joint * e_ub
+    lower_simul = obs - cf_upper_simul
+    upper_simul = obs - cf_lower_simul
 
     att = float(np.mean(tau))
     cf_avg = float(np.mean(cf))
@@ -369,9 +626,13 @@ def scpi_intervals(
         tau=tau, lower=lower, upper=upper,
         cf_lower=cf_lower, cf_upper=cf_upper,
         M1_lower=w_lb, M1_upper=w_ub, M2_lower=e_lb, M2_upper=e_ub,
+        lower_simul=lower_simul, upper_simul=upper_simul,
+        cf_lower_simul=cf_lower_simul, cf_upper_simul=cf_upper_simul,
         metadata={"sims": sims, "u_alpha": u_alpha, "e_alpha": e_alpha,
                   "df": df, "rho": rho, "e_method": e_method,
                   "u_missp": bool(u_missp), "cointegrated": bool(cointegrated),
                   "n_active": int(idxw.sum()),
+                  "w_constr": wc["name"], "Q": wc["Q"], "lambda": wc["lambda"],
+                  "eps_joint": eps_joint,
                   "att": att, "att_lower": att_lower, "att_upper": att_upper},
     )

--- a/mlsynth/utils/vanillasc_helpers/scpi.py
+++ b/mlsynth/utils/vanillasc_helpers/scpi.py
@@ -156,6 +156,17 @@ def _mat_regularize(Q: np.ndarray):
 _W_CONSTR_NAMES = ("ols", "simplex", "lasso", "ridge", "L1-L2")
 
 
+def _floors_at_zero(w_constr) -> bool:
+    """True if the constraint lower-bounds the donor weights at zero.
+
+    Simplex and L1-L2 impose ``w >= 0``; ols / lasso / ridge allow signed
+    weights (``lb = -inf``), so their fitted weights must not be clipped.
+    """
+    name = (w_constr if isinstance(w_constr, str)
+            else w_constr.get("name") if isinstance(w_constr, dict) else None)
+    return name in ("simplex", "L1-L2")
+
+
 def _shrinkage_ridge(A: np.ndarray, B: np.ndarray):
     """scpi's ridge ``shrinkage_EST`` rule-of-thumb, returning ``(Q, lambda)``.
 
@@ -414,6 +425,7 @@ def scpi_intervals(
     W: np.ndarray,
     *,
     w_constr: Any = "simplex",
+    constant: bool = False,
     sims: int = 200,
     u_alpha: float = 0.05,
     e_alpha: float = 0.05,
@@ -433,13 +445,27 @@ def scpi_intervals(
     pre : int
         Number of pre-treatment periods ``T0``.
     W : np.ndarray
-        Fitted donor weights, shape ``(J,)`` (columns match ``Y0``).
+        Fitted weights (columns match ``Y0``): shape ``(J,)`` when
+        ``constant=False``, or ``(J + 1,)`` when ``constant=True`` with the
+        trailing entry the intercept coefficient.
     w_constr : str or dict
         Weight-constraint family the fit obeys, controlling the in-sample
         compatible set and the degrees of freedom. One of ``"ols"``,
         ``"simplex"`` (default), ``"lasso"``, ``"ridge"``, ``"L1-L2"``, or an
         explicit dict ``{"name": ..., "Q": ..., "lambda": ..., "Q2": ...}``.
         Ridge is scpi's Table-3 setting for Amjad et al. (2018) Robust SC.
+        The donor weights are floored at zero only for lower-bounded
+        constraints (simplex / L1-L2); signed families (ols / lasso / ridge)
+        keep their weights as given.
+    constant : bool
+        If True, append an unconstrained constant (intercept) to the donor
+        design (scpi's ``constant=True``): the weight constraint binds only the
+        donor block while the intercept is free, and the degrees of freedom gain
+        ``KM = 1``. ``W`` must then be length ``J + 1`` (donors + intercept).
+        The constraint machinery (budget ``Q``, penalty ``lambda`` and degrees
+        of freedom) reproduces scpi exactly with the constant; the in-sample
+        prediction band is currently conservative for the covariate/constant
+        case (wider than scpi's, not yet Monte-Carlo-matched).
     sims : int
         Number of Gaussian draws for the in-sample simulation.
     u_alpha, e_alpha : float
@@ -462,47 +488,69 @@ def scpi_intervals(
     y = np.asarray(y, float).ravel()
     Y0 = np.asarray(Y0, float)
     W = np.asarray(W, float).ravel()
-    W = np.where(W < 0, 0.0, W)
     T0, J = pre, Y0.shape[1]
+    KM = 1 if constant else 0
+    if W.shape[0] != J + KM:
+        raise ValueError(
+            f"W must have length J{'+1' if constant else ''} = {J + KM}; "
+            f"got {W.shape[0]}.")
+    # Donor weights are floored at zero only for lower-bounded constraints
+    # (simplex / L1-L2); signed families keep their weights as given.
+    if _floors_at_zero(w_constr):
+        W = W.copy()
+        W[:J] = np.where(W[:J] < 0, 0.0, W[:J])
+
     A = y[:T0]
-    B = Y0[:T0]
-    P = Y0[T0:]                                       # (T_post, J)
-    T_post = P.shape[0]
+    Bdon = Y0[:T0]                                   # donor design (constrained block)
+    Pdon = Y0[T0:]                                   # (T_post, J)
+    T_post = Pdon.shape[0]
     if T_post < 1:  # pragma: no cover - VanillaSC guarantees a post period
         raise ValueError("SCPI needs at least one post-treatment period.")
-    u = A - B @ W                                    # pre-period residuals
+    # Augmented design: donors plus the optional unconstrained constant column
+    # (scpi's ``constant=True`` / the ``KM`` covariate block). Q / Sigma / the
+    # compatible-set QCQP run on the augmented design; the constraint binds only
+    # the donor block.
+    if constant:
+        Bdes = np.column_stack([Bdon, np.ones(T0)])
+        Pdes = np.column_stack([Pdon, np.ones(T_post)])
+    else:
+        Bdes, Pdes = Bdon, Pdon
+    u = A - Bdes @ W                                 # pre-period residuals (full model)
 
     # --- cointegration (scpi's ``cointegrated_data=True``): when the outcome
     #     and donors are cointegrated the levels are I(1), so the uncertainty
-    #     models are fit on first differences. Difference the donor design
-    #     ``B -> Delta B`` for the ``E[u]`` / ``E[e]`` regressions and drop the
-    #     first pre-period (the NaN differencing introduces, which scpi removes
-    #     via complete_cases); the level design still drives ``Q``/``Sigma`` with
-    #     that row removed. Off (the default) leaves the levels path untouched. ---
+    #     models are fit on first differences. Difference the donor design for
+    #     the ``E[u]`` / ``E[e]`` regressions and drop the first pre-period (the
+    #     NaN differencing introduces, which scpi removes via complete_cases);
+    #     the (augmented) level design still drives ``Q``/``Sigma`` with that row
+    #     removed. Off (the default) leaves the levels path untouched. ---
     if cointegrated:
-        B_mean = B[1:] - B[:-1]        # differenced donor design for E[u]/E[e]
-        B_q = B[1:]                    # level design for Q/Sigma (row 0 dropped)
+        B_mean = Bdon[1:] - Bdon[:-1]  # differenced DONOR design for E[u]/E[e]
+        B_q = Bdes[1:]                 # augmented level design for Q/Sigma
+        Bdon_q = Bdon[1:]              # donor level design for df/rho/localisation
         u_w = u[1:]                    # residuals aligned to the kept rows
         T0e = T0 - 1
     else:
-        B_mean, B_q, u_w, T0e = B, B, u, T0
+        B_mean, B_q, Bdon_q, u_w, T0e = Bdon, Bdes, Bdon, u, T0
 
-    # --- weight-constraint spec (scpi w_constr_prep): fills Q / lambda. Align
-    #     the treated pre-outcome to the design rows kept for Q/Sigma (under
-    #     cointegration the first pre-period is dropped from B_q). ---
+    # --- weight-constraint spec (scpi w_constr_prep): fills Q / lambda from the
+    #     augmented design (shrinkage uses J + KM columns). Align the treated
+    #     pre-outcome to the rows kept for Q/Sigma. ---
     A_q = A[1:] if cointegrated else A
     wc = _prep_w_constr(w_constr, A_q, B_q, W)
+    Wd = W[:J]                                        # donor (constrained) block
 
-    # --- degrees of freedom per constraint (scpi df_EST, KM = 0) ---
-    d0 = int(np.sum(np.abs(W) >= _NZ))
-    df = _df_est(wc, W, B_q)
+    # --- degrees of freedom per constraint (scpi df_EST) plus KM ---
+    d0 = int(np.sum(np.abs(Wd) >= _NZ))
+    df = _df_est(wc, Wd, Bdon_q) + KM
     if df >= T0e:  # scpi guard: never spend more dof than observations
         df = T0e - 1
     vc = T0e / (T0e - df) if df < T0e else 1.0
 
-    # --- regularisation parameter and localised compatible set (scpi local_geom) ---
-    rho = _regularization_rho(u_w, B_q, d0)
-    lg = _local_geom(wc, W, rho, B_q)
+    # --- regularisation parameter and localised compatible set (scpi local_geom),
+    #     computed on the donor block ---
+    rho = _regularization_rho(u_w, Bdon_q, d0)
+    lg = _local_geom(wc, Wd, rho, Bdon_q)
     idxw = lg.idxw
 
     # --- conditional mean of the residuals (u_missp) ---
@@ -522,22 +570,25 @@ def scpi_intervals(
     S_root = sqrtm(Sigma).real
     scale, Qreg = _mat_regularize(Q)
 
-    # --- compiled QCQP over the localised, simulated simplex set ---
-    x = cp.Variable(J)
-    c = cp.Parameter(J)
-    Gstar = cp.Parameter(J)
+    # --- compiled QCQP over the localised, simulated compatible set. The
+    #     variable spans donors + covariates; the weight-set constraints bind
+    #     only the donor block (``x[:J]``), the constant/covariates stay free. ---
+    nfull = J + KM
+    x = cp.Variable(nfull)
+    c = cp.Parameter(nfull)
+    Gstar = cp.Parameter(nfull)
     if Qreg is None:  # pragma: no cover - degenerate Q (no donor variation)
         quad = cp.Constant(0.0)
     else:
         quad = scale * cp.sum_squares(Qreg @ (x - W))
     constraints = [quad - 2.0 * Gstar @ (x - W) <= 0.0]
-    constraints += _qcqp_weight_constraints(x, lg)
+    constraints += _qcqp_weight_constraints(x[:J] if KM else x, lg)
     prob_min = cp.Problem(cp.Minimize(c @ x), constraints)
     prob_max = cp.Problem(cp.Maximize(c @ x), constraints)
 
     rng = np.random.default_rng(seed)
     # Predictor rows: each post period plus the post-period mean (for the ATT).
-    P_aug = np.vstack([P, P.mean(axis=0, keepdims=True)])     # (T_post + 1, J)
+    P_aug = np.vstack([Pdes, Pdes.mean(axis=0, keepdims=True)])   # (T_post + 1, nfull)
     n_rows = T_post + 1
     lo = np.full((sims, n_rows), np.nan)   # min-branch  p'(w - x)
     hi = np.full((sims, n_rows), np.nan)   # max-branch  p'(w - x)
@@ -553,7 +604,7 @@ def scpi_intervals(
         return None
 
     for s in range(sims):
-        Gstar.value = S_root @ rng.standard_normal(J)
+        Gstar.value = S_root @ rng.standard_normal(nfull)
         for t in range(n_rows):
             c.value = P_aug[t]
             xs = _solve(prob_max)                    # maximise p'x -> min p'(w-x)
@@ -574,11 +625,11 @@ def scpi_intervals(
     #     is the differenced post outcomes, bridged from the pre-period by
     #     ``dP[0] = P[0] - B[T0-1]`` (scpi's e_des_prep). ---
     if cointegrated:
-        P_oos = np.empty_like(P)
-        P_oos[0] = P[0] - B[T0 - 1]
-        P_oos[1:] = P[1:] - P[:-1]
+        P_oos = np.empty_like(Pdon)
+        P_oos[0] = Pdon[0] - Bdon[T0 - 1]
+        P_oos[1:] = Pdon[1:] - Pdon[:-1]
     else:
-        P_oos = P
+        P_oos = Pdon
     Xe0 = np.column_stack([B_mean[:, idxw], np.ones(T0e)])
     Xe1 = np.column_stack([P_oos[:, idxw], np.ones(T_post)])
     Xe1_aug = np.vstack([Xe1, Xe1.mean(axis=0, keepdims=True)])
@@ -603,7 +654,7 @@ def scpi_intervals(
     eps_joint = sqrt(log(T_post + 1.0))              # out-of-sample inflation
 
     # --- assemble intervals ---
-    cf = P @ W                                       # synthetic counterfactual (Y_fit)
+    cf = Pdes @ W                                    # synthetic counterfactual (Y_fit)
     obs = y[T0:]
     tau = obs - cf
     cf_lower = cf + w_lb + e_lb
@@ -633,6 +684,7 @@ def scpi_intervals(
                   "u_missp": bool(u_missp), "cointegrated": bool(cointegrated),
                   "n_active": int(idxw.sum()),
                   "w_constr": wc["name"], "Q": wc["Q"], "lambda": wc["lambda"],
+                  "constant": bool(constant), "KM": KM,
                   "eps_joint": eps_joint,
                   "att": att, "att_lower": att_lower, "att_upper": att_upper},
     )

--- a/mlsynth/utils/vanillasc_helpers/scpi.py
+++ b/mlsynth/utils/vanillasc_helpers/scpi.py
@@ -108,26 +108,34 @@ class SCPIResult:
     metadata: Dict[str, Any]
 
 
-def _regularization_rho(u: np.ndarray, B: np.ndarray, d0: int) -> float:
-    """Data-driven ``rho`` (scpi ``type-1``), capped at ``rho_max = 0.2``.
+def _regularization_rho(u: np.ndarray, B: np.ndarray, d0: int, KM: int = 0) -> float:
+    """Data-driven ``rho`` (scpi's default ``type-2``), capped at ``rho_max``.
 
-    Mirrors ``regularize_w`` / ``regularize_check_lb``: a too-small ``rho`` is
-    bumped up (via the ``type-2`` rule, then to ``rho_max``) to favour shrinkage
-    and avoid overfitting the out-of-sample variance.
+    Mirrors ``regularize_w`` and the ``regularize_check_lb`` bump. scpi defaults
+    to the ``type-2`` rule
+
+        rho = (sigma_u * max_j sd(B_j) / min_j var(B_j))
+                 * sqrt(log(J + KM) * (d0 + KM) * log(T0)) / sqrt(T0),
+
+    (standard deviations / variances with ``ddof = 1``, as in pandas); a
+    too-small ``rho`` is raised (to the larger of the type-1 / type-2 rules,
+    then to ``rho_max``) to favour shrinkage and avoid overfitting the
+    out-of-sample variance. ``KM`` is the covariate/constant block size.
     """
     T0, J = B.shape
-    d = J
+    d = J + KM
+    d0e = max(d0 + KM, 1)
     sig_u = sqrt(float(np.mean((u - u.mean()) ** 2)))
-    std_b = B.std(axis=0, ddof=0)
-    fac = sqrt(log(max(d, 2)) * max(d0, 1) * log(max(T0, 2))) / sqrt(T0)
+    std_b = B.std(axis=0, ddof=1)                     # pandas-style, as scpi
+    var_b = B.var(axis=0, ddof=1)
+    fac = sqrt(log(max(d, 2)) * d0e * log(max(T0, 2))) / sqrt(T0)
 
-    rho = (sig_u / max(std_b.min(), _EPS)) * fac
-    rho = min(rho, _RHO_MAX)
+    type1 = (sig_u / max(std_b.min(), _EPS)) * fac
+    type2 = (sig_u * std_b.max() / max(var_b.min(), _EPS)) * fac
 
+    rho = min(type2, _RHO_MAX)                        # scpi's default rho type
     if rho < 0.001:  # regularize_check_lb
-        rho1 = min((sig_u / max(std_b.min(), _EPS)) * fac, _RHO_MAX)
-        rho2 = min((sig_u * std_b.max() / max(B.var(axis=0, ddof=0).min(), _EPS)) * fac, _RHO_MAX)
-        rho = max(rho1, rho2)
+        rho = min(max(type1, type2), _RHO_MAX)
         if rho < 0.05:
             rho = _RHO_MAX
     return float(rho)
@@ -462,10 +470,9 @@ def scpi_intervals(
         design (scpi's ``constant=True``): the weight constraint binds only the
         donor block while the intercept is free, and the degrees of freedom gain
         ``KM = 1``. ``W`` must then be length ``J + 1`` (donors + intercept).
-        The constraint machinery (budget ``Q``, penalty ``lambda`` and degrees
-        of freedom) reproduces scpi exactly with the constant; the in-sample
-        prediction band is currently conservative for the covariate/constant
-        case (wider than scpi's, not yet Monte-Carlo-matched).
+        The budget ``Q``, penalty ``lambda`` and degrees of freedom reproduce
+        scpi exactly with the constant, and the prediction band reproduces
+        scpi's ``CI_all_gaussian`` to Monte-Carlo error.
     sims : int
         Number of Gaussian draws for the in-sample simulation.
     u_alpha, e_alpha : float
@@ -549,7 +556,7 @@ def scpi_intervals(
 
     # --- regularisation parameter and localised compatible set (scpi local_geom),
     #     computed on the donor block ---
-    rho = _regularization_rho(u_w, Bdon_q, d0)
+    rho = _regularization_rho(u_w, Bdon_q, d0, KM)
     lg = _local_geom(wc, Wd, rho, Bdon_q)
     idxw = lg.idxw
 

--- a/mlsynth/utils/vanillasc_helpers/staggered.py
+++ b/mlsynth/utils/vanillasc_helpers/staggered.py
@@ -223,6 +223,7 @@ def _run_covariate_staggered(config, prep: Dict[str, Any]) -> BaseEstimatorResul
         e_alpha=config.alpha, seed=config.seed, scpi_compat=config.scpi_compat,
         features=spec.features, cov_adj=spec.cov_adj,
         feature_constant=spec.constant, cointegrated=spec.cointegrated,
+        w_constr=spec.w_constr,
     )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/mlsynth/utils/vanillasc_helpers/staggered_engine.py
+++ b/mlsynth/utils/vanillasc_helpers/staggered_engine.py
@@ -605,6 +605,127 @@ def localgeom2step_lb(w, rho_dict, treated_units, J_dict):
     return lb
 
 
+# ---------------------------------------------------------------------------
+# Generalized weight-constraint family: local_geom / localgeom2step / df_EST
+# (faithful port of scpi's funs.local_geom / localgeom2step / df_EST, covering
+#  ols / simplex / lasso / ridge / L1-L2). The simplex-only helpers above are
+#  kept so the validated simplex conic path is untouched.
+# ---------------------------------------------------------------------------
+def local_geom(w_constr, rho, rho_max, res, B, T0_tot, J, KM, w):
+    """Regularise one treated unit's weights and localise the compatible set.
+
+    Mirrors scpi's ``local_geom``: computes (or accepts) ``rho``, the active-donor
+    set ``index_w`` (for the u/e design), and a preliminary norm budget
+    ``Q_star`` / ``Q2_star``; mutates ``w_constr['Q']`` (and ``['Q2']`` for
+    L1-L2) in place, as scpi does on its per-unit working copy. Returns
+    ``(w_constr, index_w, rho, Q_star, Q2_star)``.
+    """
+    Q = w_constr["Q"]
+    Q2_star = None
+    name = w_constr["name"]
+    p = w_constr.get("p")
+    dire = w_constr.get("dir")
+    d0 = int(np.sum(np.abs(w.iloc[:, 0].values) >= 1e-6)) + KM
+    if isinstance(rho, str):
+        rho = regularize_w(rho, rho_max, res, B, T0_tot, J, KM, d0)
+        rho = regularize_check_lb(w, rho, rho_max, res, B, T0_tot, J, KM, d0)
+
+    if name == "simplex" or (p == "L1" and dire == "=="):
+        index_w = w[0] > rho
+        index_w = regularize_check(w, index_w, rho, B)
+        w_star = w.copy()
+        w_star.loc[index_w.values] = 0
+        Q_star = float(np.asarray(w_star).sum())
+    elif name == "lasso" or (p == "L1" and dire == "<="):
+        l1 = float(np.sum(np.abs(w)))
+        Q_star = l1 if (Q - rho * sqrt(J) <= l1 <= Q) else Q
+        index_w = np.abs(w[0]) > rho
+        index_w = regularize_check(w, index_w, rho, B)
+    elif name == "ridge" or p == "L2":
+        l2 = float(sqrt(np.sum(np.asarray(w) ** 2)))
+        Q_star = l2 if (Q - rho <= l2 <= Q) else Q
+        index_w = pd.Series([True] * len(B.columns), index=w.index)
+    elif name == "L1-L2":
+        index_w = w[0] > rho
+        index_w = regularize_check(w, index_w, rho, B)
+        w_star = w.copy()
+        w_star.loc[index_w.values] = 0
+        Q_star = float(np.asarray(w_star).sum())
+        l2 = float(sqrt(np.sum(np.asarray(w) ** 2)))
+        Q2_star = l2 if (Q - rho <= l2 <= Q) else float(w_constr["Q2"])
+        w_constr["Q2"] = Q2_star
+    else:  # ols / no norm
+        Q_star = Q
+        index_w = pd.Series([True] * len(B.columns), index=w.index)
+
+    w_constr["Q"] = Q_star
+    return w_constr, np.asarray(index_w).astype(bool), rho, Q_star, Q2_star
+
+
+def localgeom2step(w, rho_dict, w_constr, Q, treated_units, J_dict, rho_max=0.2):
+    """Two-step refinement of the norm budget and per-donor lower bounds.
+
+    Mirrors scpi's ``localgeom2step`` over all treated units: for inequality
+    constraints (lasso / L1-L2) the norm budget is relaxed by ``rho`` when the
+    realised norm binds; the lower bounds pin the small (regularised-away) donors
+    for the lower-bounded constraints (simplex / L1-L2) and are ``-inf`` for the
+    signed constraints (ols / lasso / ridge). Returns ``(Q_star_dict, lb_list)``.
+    """
+    from copy import deepcopy
+    Q_star = deepcopy(dict(Q))
+    lb = []
+    warr = w.iloc[:, 0].values
+    jmin = 0
+    for tr in treated_units:
+        jmax = jmin + J_dict[tr]
+        wj = warr[jmin:jmax]
+        p = w_constr[tr]["p"]
+        dire = w_constr[tr]["dir"]
+        lbc = w_constr[tr]["lb"]
+        w_norm = None
+        if p == "no norm":
+            rhoj = rho_dict[tr]
+        elif p == "L1":
+            rhoj = rho_dict[tr]
+            w_norm = float(np.sum(np.abs(wj)))
+        else:  # "L1-L2" / "L2"
+            w_norm = float(np.sum(wj ** 2))
+            rhoj = min(2 * np.sqrt(w_norm) * rho_dict[tr], rho_max)
+        if dire in ("<=", "==/<="):
+            active = 1 * ((w_norm - Q[tr]) > -rhoj)
+            Q_star[tr] = active * (w_norm + rho_dict[tr] - Q[tr]) + Q[tr]
+        if lbc == 0:
+            active = 1 * (wj < rho_dict[tr])
+            lb.extend((active * wj).tolist())
+        else:
+            lb.extend([-np.inf] * len(wj))
+        jmin = jmax
+    return Q_star, lb
+
+
+def df_EST(w_constr, w, B, J, KM):
+    """Effective degrees of freedom per constraint (scpi ``df_EST``).
+
+    ols: ``J``; lasso: ``#nonzero``; simplex: ``#nonzero - 1``; ridge / L1-L2:
+    ``sum_k d_k^2 / (d_k^2 + lambda)`` over the positive singular values of the
+    (full, stacked) donor design ``B``. ``KM`` covariate columns are added.
+    """
+    name = w_constr["name"]
+    p = w_constr.get("p")
+    dire = w_constr.get("dir")
+    if name == "ols" or p == "no norm":
+        df = float(J)
+    elif name == "lasso" or (p == "L1" and dire == "<="):
+        df = float(np.sum(np.abs(w.iloc[:, 0].values) >= 1e-6))
+    elif name == "simplex" or (p == "L1" and dire == "=="):
+        df = float(np.sum(np.abs(w.iloc[:, 0].values) >= 1e-6) - 1)
+    else:  # ridge / L1-L2 / L2
+        d = np.linalg.svd(np.asarray(B, float), compute_uv=False)
+        d = d[d > 0]
+        df = float(np.sum(d ** 2 / (d ** 2 + w_constr["lambda"])))
+    return df + KM
+
+
 def u_des_prep_one(B, C, coig_data, constant, index, index_w):
     """u_order=1, u_lags=0."""
     if coig_data:
@@ -808,6 +929,74 @@ def conic_bounds_unit(beta, Q, P_rows, lb, Qsum, zeta_unit, sims):
     return res_lb, res_ub
 
 
+def conic_bounds_unit_family(beta, Q, P_rows, name, Q_star, Q2_star, lb,
+                             zeta_unit, sims):
+    """cvxpy in-sample conic bounds for one treated unit under the non-simplex
+    weight-constraint family (ols / lasso / ridge / L1-L2).
+
+    Solves, for every simulation draw and post-treatment horizon, the min/max of
+    ``p.(beta - x)`` over the localised compatible set
+    ``{ (x-beta)'Q(x-beta) - 2 G'(x-beta) <= 0 } intersect W``, where ``W`` is the
+    constraint's donor weight-set (``x[:J]``): lasso ``||.||1 <= Q_star``; ridge
+    ``||.||2 <= Q_star``; L1-L2 ``x>=lb, sum==Q_star, ||.||2<=Q2_star``; ols free.
+    This mirrors scpi's ``scpi_in_diag`` construction and the (cross-validated)
+    single-unit ``scpi_intervals`` QCQP; the simplex case stays on the exact ECOS
+    path (:func:`conic_bounds_unit`).
+    """
+    beta = np.asarray(beta, dtype=float)
+    n = len(beta)
+    J = len(lb)
+    Qa = np.asarray(Q, dtype=float)
+    lb = np.asarray(lb, dtype=float)
+
+    scale, Qreg = mat_regularize(Qa)          # Qreg (k, n); scale * ||Qreg z||^2 = z'Q z
+    x = cp.Variable(n)
+    c = cp.Parameter(n)
+    Gstar = cp.Parameter(n)
+    if Qreg.shape[0] == 0:  # pragma: no cover - degenerate Q (no donor variation)
+        quad = cp.Constant(0.0)
+    else:
+        quad = scale * cp.sum_squares(Qreg @ (x - beta))
+    cons = [quad - 2.0 * Gstar @ (x - beta) <= 0.0]
+    xd = x[:J]
+    if name == "lasso":
+        cons.append(cp.norm1(xd) <= Q_star)
+    elif name == "ridge":
+        cons.append(cp.sum_squares(xd) <= Q_star ** 2)
+    elif name == "L1-L2":
+        cons += [xd >= lb, cp.sum(xd) == Q_star,
+                 cp.sum_squares(xd) <= Q2_star ** 2]
+    # ols: no weight-set constraint
+
+    prob_min = cp.Problem(cp.Minimize(c @ x), cons)
+    prob_max = cp.Problem(cp.Maximize(c @ x), cons)
+
+    def _solve(prob):
+        for solver in (cp.CLARABEL, cp.ECOS, cp.SCS):
+            try:
+                prob.solve(solver=solver, warm_start=True)
+                if prob.status in ("optimal", "optimal_inaccurate") \
+                        and x.value is not None:
+                    return np.asarray(x.value).ravel()
+            except Exception:
+                continue
+        return None
+
+    res_lb = np.full((sims, len(P_rows)), np.nan)
+    res_ub = np.full((sims, len(P_rows)), np.nan)
+    for s in range(sims):
+        Gstar.value = zeta_unit[:, s]
+        for hor, p in enumerate(P_rows):
+            c.value = np.asarray(p, dtype=float)
+            xs = _solve(prob_max)                 # maximise p.x  -> min p.(beta-x)
+            if xs is not None:
+                res_lb[s, hor] = float(np.asarray(p).dot(beta - xs))
+            xs = _solve(prob_min)                 # minimise p.x  -> max p.(beta-x)
+            if xs is not None:
+                res_ub[s, hor] = float(np.asarray(p).dot(beta - xs))
+    return res_lb, res_ub
+
+
 # ---------------------------------------------------------------------------
 # Out-of-sample uncertainty (mirrors scpi_out)
 # ---------------------------------------------------------------------------
@@ -971,12 +1160,27 @@ def scpi(est, sims=200, u_alpha=0.05, e_alpha=0.05, rho='type-2', rho_max=0.2,
 
     col_order = Z.columns.tolist()
 
+    # weight-constraint family: scest records the per-unit normalised spec. The
+    # constraint name is uniform across treated units (scpi applies one spec);
+    # ``constr_name == "simplex"`` keeps the validated ECOS conic path, everything
+    # else routes through the cvxpy family conic.
+    from copy import deepcopy
+    w_constr_inf = est.get('w_constr_inf') or {
+        tr: {"name": "simplex", "p": "L1", "dir": "==", "lb": 0.0, "Q": 1.0,
+             "Q2": None, "lambda": None} for tr in treated_units}
+    constr_name = w_constr_inf[treated_units[0]]["name"]
+    wc_orig = {tr: deepcopy(w_constr_inf[tr]) for tr in treated_units}
+
     rho_dict = {}
     iw_dict = {}
+    Qstar_pre = {}
+    Q2star_pre = {}
     store = {}
     for tr in treated_units:
-        rho_tr, index_w = local_geom_simplex(rho, rho_max, res_d[tr], B_d[tr],
-                                             T0_M[tr], J[tr], KM[tr], w_d[tr])
+        wc_aux = deepcopy(w_constr_inf[tr])
+        _wc, index_w, rho_tr, Qstar_pre[tr], Q2star_pre[tr] = local_geom(
+            wc_aux, rho, rho_max, res_d[tr], B_d[tr],
+            T0_M[tr], J[tr], KM[tr], w_d[tr])
         rho_dict[tr] = rho_tr
         iw_dict[tr] = index_w
         index_i = index_w.tolist() + [True] * KM[tr]
@@ -1044,9 +1248,20 @@ def scpi(est, sims=200, u_alpha=0.05, e_alpha=0.05, rho='type-2', rho_max=0.2,
     TT = len(Z_na)
     V_na = np.identity(TT)
 
-    # localgeom2step -> Q_star (=1 simplex) and lb
-    Q_star = {tr: 1 for tr in treated_units}
-    lb = localgeom2step_lb(w, rho_dict, treated_units, J)
+    # two-step localisation -> per-unit norm budget Q_star (=1 for simplex) and
+    # per-donor lower bounds lb (pinned for simplex/L1-L2, -inf for signed
+    # constraints). scpi feeds localgeom2step the pre-mutation constraint Q.
+    Q_for_2step = {}
+    for tr in treated_units:
+        Q_for_2step[tr] = (wc_orig[tr]["Q2"] if wc_orig[tr].get("p") == "L1-L2"
+                           else wc_orig[tr]["Q"])
+    Q_star, lb = localgeom2step(w, rho_dict, w_constr_inf, Q_for_2step,
+                                treated_units, J, rho_max=rho_max)
+    if constr_name == "L1-L2":
+        Q2_star = deepcopy(Q_star)
+        Q_star = {tr: wc_orig[tr]["Q"] for tr in treated_units}
+    else:
+        Q2_star = {tr: Q2star_pre[tr] for tr in treated_units}
 
     # ----- u_mean -----
     u_des_dict = mat2dict(u_des_0_na, treated_units, cols=False)
@@ -1078,7 +1293,11 @@ def scpi(est, sims=200, u_alpha=0.05, e_alpha=0.05, rho='type-2', rho_max=0.2,
                                         np.asarray(u_des_use, dtype=float))
 
     # ----- Sigma -----
-    df = df_EST_simplex(w, KMI)
+    # scpi computes df once, on the full stacked weights/donor design, with the
+    # (uniform) constraint spec; for ridge/L1-L2 it uses the last unit's lambda.
+    Jtot = sum(J.values())
+    df = df_EST(w_constr_inf[treated_units[-1]], w, np.asarray(B, dtype=float),
+                Jtot, KMI)
     if df >= TT:
         df = TT - 1
     Sigma = u_sigma_est_HC1(u_mean, res_na, Z_na, V_na, TT, df)
@@ -1119,8 +1338,13 @@ def scpi(est, sims=200, u_alpha=0.05, e_alpha=0.05, rho='type-2', rho_max=0.2,
         else:
             P_na_tr = P_na
         P_rows = [np.asarray(P_na_tr.iloc[h, :], dtype=float) for h in range(len(P_na_tr))]
-        rlb, rub = conic_bounds_unit(beta_i, Qi, P_rows, lb_d[tr],
-                                     Q_star[tr], zeta_i, sims)
+        if constr_name == "simplex":
+            rlb, rub = conic_bounds_unit(beta_i, Qi, P_rows, lb_d[tr],
+                                         Q_star[tr], zeta_i, sims)
+        else:
+            rlb, rub = conic_bounds_unit_family(
+                beta_i, Qi, P_rows, constr_name, Q_star[tr],
+                Q2_star.get(tr), lb_d[tr], zeta_i, sims)
         vsig_lb_list.append(rlb)
         vsig_ub_list.append(rub)
 

--- a/mlsynth/utils/vanillasc_helpers/staggered_engine.py
+++ b/mlsynth/utils/vanillasc_helpers/staggered_engine.py
@@ -341,22 +341,145 @@ def _mat2dict_rows(mat, treated_units):
     return out
 
 
-def b_est_simplex(A, Z, J, KM):
-    """Solve the simplex synthetic-control QP for one treated unit."""
+def _shrinkage_est(method, A, Z, J, KM):
+    """scpi ``shrinkage_EST`` rule-of-thumb for one feature block (V = identity).
+
+    Returns ``(Q, lambda)``. For ridge, ``lambda = sigma^2 (J + KM) / ||b||**2``
+    and ``Q = ||b|| / (1 + lambda)`` from an unweighted OLS of ``A`` on ``Z``;
+    when observations are scarce (``len(Z) <= #cols + 10``) scpi lasso-screens
+    the columns first. Lasso returns ``Q = 1``.
+    """
+    Aarr = np.asarray(A, float).ravel()
+    Zarr = np.asarray(Z, float)
+    if method == "lasso":
+        return 1.0, None
+
+    def _rule(Zsub):
+        n, k = Zsub.shape
+        b, *_ = np.linalg.lstsq(Zsub, Aarr, rcond=None)
+        resid = Aarr - Zsub @ b
+        sig = float(resid @ resid) / max(n - k, 1)
+        L2 = float(b @ b)
+        lam = sig * (J + KM) / max(L2, 1e-12)
+        return sqrt(L2) / (1.0 + lam), lam
+
+    n, k = Zarr.shape
+    if n > k + 10:
+        return _rule(Zarr)
+    # scarce-obs lasso screen (scpi), then refit on the kept columns
+    z = cp.Variable(Zarr.shape[1])
+    try:
+        cp.Problem(cp.Minimize(cp.sum_squares(Aarr - Zarr @ z)),
+                   [cp.norm1(z) <= 1.0]).solve(solver=cp.CLARABEL)
+        coefs = np.abs(np.asarray(z.value).ravel())
+    except Exception:  # pragma: no cover - solver fallback
+        coefs = np.abs(np.linalg.lstsq(Zarr, Aarr, rcond=None)[0])
+    keep = max(min(n - 10, k), 2)
+    active = np.sort(np.argsort(coefs)[::-1][:keep])
+    return _rule(Zarr[:, active])
+
+
+def _w_constr_prep_unit(w_constr, A_df, B_df, J, KM):
+    """Normalise a weight-constraint spec for one treated unit (scpi
+    ``w_constr_prep``): fills ``p``/``dir``/``lb``/``Q``/``lambda`` and, for
+    ridge / L1-L2, estimates the data-driven budget per feature (``max`` of the
+    per-feature ``min`` Q, floored at 0.5)."""
+    name = (w_constr if isinstance(w_constr, str)
+            else dict(w_constr).get("name", "simplex"))
+    spec = {} if isinstance(w_constr, str) else dict(w_constr)
+    if name == "simplex":
+        return {"name": "simplex", "p": "L1", "dir": "==", "lb": 0.0,
+                "Q": float(spec.get("Q", 1.0)), "Q2": None, "lambda": None}
+    if name == "ols":
+        return {"name": "ols", "p": "no norm", "dir": None, "lb": -np.inf,
+                "Q": None, "Q2": None, "lambda": None}
+    if name == "lasso":
+        return {"name": "lasso", "p": "L1", "dir": "<=", "lb": -np.inf,
+                "Q": float(spec.get("Q", 1.0)), "Q2": None, "lambda": None}
+
+    # ridge / L1-L2: data-driven Q per feature block on the donor design. A_df
+    # and B_df are the treated pre-outcome and donor design, feature-indexed.
+    has_feature = (isinstance(A_df, pd.DataFrame)
+                   and "feature" in (A_df.index.names or []))
+    feats = (A_df.index.get_level_values("feature").unique().tolist()
+             if has_feature else [None])
+    Qfeat, lam = [], None
+    for f in feats:
+        if f is not None:
+            Af = np.asarray(A_df.xs(f, level="feature"), float).ravel()
+            Bf = np.asarray(B_df.xs(f, level="feature"), float)
+        else:
+            Af = np.asarray(A_df, float).ravel()
+            Bf = np.asarray(B_df, float)
+        if Bf.shape[0] >= 5:
+            try:
+                Qe, lam = _shrinkage_est("ridge", Af, Bf, J, KM)
+                Qfeat.append(Qe)
+            except Exception:  # pragma: no cover
+                pass
+    if not Qfeat:
+        Qe, lam = _shrinkage_est("ridge", np.asarray(A_df, float).ravel(),
+                                 np.asarray(B_df, float), J, KM)
+        Qfeat.append(Qe)
+    Qest = max(float(np.nanmin(Qfeat)), 0.5)
+    if name == "ridge":
+        return {"name": "ridge", "p": "L2", "dir": "<=", "lb": -np.inf,
+                "Q": float(spec.get("Q", Qest)), "Q2": None, "lambda": float(lam)}
+    return {"name": "L1-L2", "p": "L1-L2", "dir": "==/<=", "lb": 0.0,
+            "Q": 1.0, "Q2": float(spec.get("Q2", Qest)), "lambda": float(lam)}
+
+
+def b_est(A, Z, J, KM, w_constr="simplex", B_donor=None):
+    """Solve the synthetic-control weight problem for one treated unit under
+    the scpi weight-constraint family. The constraint binds the donor block
+    ``x[:J]``; covariate/constant coefficients ``x[J:]`` are unconstrained.
+
+    Returns ``(x_value, wc)`` where ``wc`` is the normalised constraint dict
+    (with the estimated ridge / lasso budget ``Q`` and penalty ``lambda``).
+    """
     Zarr = np.asarray(Z, dtype=float)
     Aarr = np.asarray(A, dtype=float).reshape(-1, 1)
+    Bd = B_donor if B_donor is not None else pd.DataFrame(Zarr[:, :J])
+    wc = _w_constr_prep_unit(w_constr, A, Bd, J, KM)
     x = cp.Variable((J + KM, 1))
     obj = cp.Minimize(cp.sum_squares(Aarr - Zarr @ x))
-    cons = [cp.sum(x[0:J]) == 1, x[0:J] >= 0]
+    xd = x[0:J]
+    name = wc["name"]
+    if name == "simplex":
+        cons = [cp.sum(xd) == wc["Q"], xd >= 0]
+    elif name == "ols":
+        cons = []
+    elif name == "lasso":
+        cons = [cp.norm1(xd) <= wc["Q"]]
+    elif name == "ridge":
+        cons = [cp.sum_squares(xd) <= wc["Q"] ** 2]
+    else:  # L1-L2
+        cons = [cp.sum(xd) == wc["Q"], xd >= 0,
+                cp.sum_squares(xd) <= wc["Q2"] ** 2]
     prob = cp.Problem(obj, cons)
-    prob.solve(solver=cp.CLARABEL)
-    if prob.status != 'optimal':
-        raise RuntimeError(f"estimation not converged: {prob.status}")
-    return x.value
+    for solver in (cp.CLARABEL, cp.ECOS, cp.SCS):
+        try:
+            prob.solve(solver=solver)
+            if prob.status in ("optimal", "optimal_inaccurate"):
+                return x.value, wc
+        except Exception:
+            continue
+    raise RuntimeError(f"estimation not converged: {prob.status}")
 
 
-def scest(md):
-    """Estimate weights per treated unit and assemble point predictions."""
+def b_est_simplex(A, Z, J, KM):
+    """Solve the simplex synthetic-control QP for one treated unit (back-compat
+    wrapper over :func:`b_est`)."""
+    return b_est(A, Z, J, KM, "simplex")[0]
+
+
+def scest(md, w_constr="simplex"):
+    """Estimate weights per treated unit and assemble point predictions.
+
+    ``w_constr`` is the scpi weight-constraint family (``"simplex"`` default, or
+    ``"ols"`` / ``"lasso"`` / ``"ridge"`` / ``"L1-L2"``, or an explicit dict),
+    applied per treated unit; the binding is on the donor block only.
+    """
     treated_units = md['treated_units']
     A, B, C, P = md['A'], md['B'], md['C'], md['P']
     Z = pd.concat([B, C], axis=1)
@@ -373,11 +496,12 @@ def scest(md):
 
     w_store = []
     r_store = []
+    w_constr_inf = {}
     for tr in treated_units:
         J = blocks[tr]['J']
         KM = blocks[tr]['KM']
         Zi = pd.concat([B_d[tr], C_d[tr]], axis=1)
-        res = b_est_simplex(A_d[tr], Zi, J, KM)
+        res, w_constr_inf[tr] = b_est(A_d[tr], Zi, J, KM, w_constr, B_donor=B_d[tr])
         idx = pd.MultiIndex.from_product([[tr], blocks[tr]['donors']])
         w_store.append(pd.DataFrame(res[0:J], index=idx))
         if KM > 0:
@@ -400,7 +524,7 @@ def scest(md):
     fit_pre.columns = A.columns
     fit_post.columns = A.columns
 
-    return dict(b=b, w=w, r=r, A_hat=A_hat, res=res,
+    return dict(b=b, w=w, r=r, A_hat=A_hat, res=res, w_constr_inf=w_constr_inf,
                 Y_pre_fit=fit_pre, Y_post_fit=fit_post, Z=Z, **md)
 
 
@@ -1128,6 +1252,7 @@ def staggered_pi_bands(
     cov_adj=None,
     feature_constant=False,
     cointegrated=False,
+    w_constr="simplex",
 ):
     """Staggered synthetic-control prediction intervals for one predictand.
 
@@ -1185,7 +1310,7 @@ def staggered_pi_bands(
 
     md = scdata_multi(data, outcome, feats, cadj,
                       constant=const, cointegrated_data=coint, effect=effect)
-    est = scest(md)
+    est = scest(md, w_constr)
     out = scpi(est, sims=sims, u_alpha=u_alpha, e_alpha=e_alpha, seed=seed,
                tsua_double_divide=scpi_compat)
 


### PR DESCRIPTION
## Summary

Brings mlsynth's scpi (Cattaneo, Feng, Palomba & Titiunik 2025) prediction-interval engine up to scpi's full capability, and wires it through the estimators whose weights map onto scpi's constraint family — faithfully and cross-validated against `scpi_pkg` wherever the reference is computable.

### Single-unit engine (`vanillasc_helpers/scpi.py`)
- Generalized `scpi_intervals` from simplex-only to scpi's full Table-2 weight-constraint family: `ols` / `simplex` / `lasso` / `ridge` / `L1-L2`, changing the in-sample compatible set and the effective degrees of freedom per constraint.
- Added simultaneous (joint-coverage) bands alongside the pointwise bands.
- Added an unconstrained constant/`KM` block (scpi's `constant=True`) and fixed a signed-weight clipping bug that corrupted `ols`/`lasso`/`ridge` weights.
- Fixed the regularization `rho` to scpi's actual default (`type-2`); the constant band now matches scpi to Monte-Carlo error.

### Staggered / multi-treated engine (`vanillasc_helpers/staggered_engine.py`)
- Generalized the per-unit fit (`b_est` + shrinkage) to the full family — reproduces scpi's `scdataMulti` weights value-for-value (ridge 1.1e-5, lasso 3.5e-8, ols 1.6e-9, simplex 5.7e-6).
- Generalized the inference layer (`local_geom` / `localgeom2step` / `df_EST`, plus a cvxpy `conic_bounds_unit_family`) so non-simplex multi-treated bands are coherent. The deterministic budgets (`Q_star`, `lb`, `df`) match `scpi_pkg` cell-for-cell; the simplex ECOS path is untouched and stays bit-identical.
- Exposed a validated `w_constr` on `StaggeredSCMSpec`, so the family is user-selectable for multi-treated, covariate-adjusted synthetic controls — the one setting that combines all three of scpi's dimensions at once.

### Estimators wired to the generalized engine
Each estimator's fitted weights map to a scpi constraint, so `compute_scpi_pi=True` adds model-based prediction intervals alongside the estimator's native inference:
- SCUL → lasso (Chernozhukov, Wüthrich & Zhu 2021; scpi Table 3), with the intercept as the constant.
- CLUSTERSC (RSC / PCR) → ridge (Amjad, Kim, Shah & Shen; scpi Table 3), selectable via `scpi_constraint`.
- SparseSC → simplex (its donor weights are `w ≥ 0`, `Σw = 1`; the L1 penalty selects predictors, not donors).
- TSSC → per-variant: SC→simplex, MSCa→simplex+constant, MSCb→ols, MSCc→ols+constant (the recommended variant's band surfaces on `res.scpi`).

### Plotting
- `plot_bands` control (`"pointwise"` / `"simultaneous"` / `"both"`) on VanillaSC and CLUSTERSC to shade either or both bands in the observed-vs-synthetic plot.

## Validation
- Simplex stays bit-identical: the three staggered benchmarks (`scpi_staggered`, `scpi_staggered_pi` at 0.0002729 rel diff, `scpi_staggered_covariate`) pass unchanged, and `scpi_germany_pi` / `vanillasc_carbontax` / `scpi_ridge_germany` remain green.
- New deterministic cross-validation of the multi-treated inference budgets against `scpi_pkg` (`test_staggered_inference_family.py`), plus weight cross-validation (`test_staggered_constraints.py`).
- Full TDD (test-first) for every estimator wiring: `test_scul_scpi.py`, `test_sparse_sc_scpi.py`, `test_tssc_scpi.py`. All touched suites and the result-contract test pass.

## Honest caveats
- `scpi_pkg`'s own band-simulation ECOS is broken under numpy 2.x, so the non-simplex multi-treated *bands* can't be cross-validated against scpi's output directly — the fit weights (value-for-value) and every deterministic inference budget (cell-for-cell) are, and the stochastic QCQP mirrors the single-unit engine that *is* cross-validated. The bands are otherwise pinned by coherence invariants.
- TSSC's MSCb / MSCc carry bare non-negativity, which scpi's family has no member for; they map to scpi's `ols` set, so those bands do not re-impose `w ≥ 0` and are slightly conservative. This is documented on the config field and the docs page.

## Docs
- Updated `vanillasc`, `clustersc`, `scul`, `sparse_sc`, and `tssc` pages to document each estimator's scpi PI capability and its constraint mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7bVBZsrWUPQJbnGGCG1qD)_