### PR TITLE
Fix CLUSTERSC scpi band alignment on non-integer (year) time axes

### DIFF
--- a/mlsynth/estimators/clustersc.py
+++ b/mlsynth/estimators/clustersc.py
@@ -166,15 +166,24 @@ class CLUSTERSC:
         )
         ts_band: dict = {}
         if cluster_inference.scpi is not None:
-            from ..utils.results_helpers import normalize_counterfactual_band
             spec = cluster_inference.scpi.to_prediction_interval_spec()
-            axis = np.asarray(inputs.time_labels)
-            lo, hi = normalize_counterfactual_band(
-                spec["lower"], spec["upper"], time_periods=axis,
-                periods=spec["periods"])
-            lo_s, hi_s = normalize_counterfactual_band(
-                spec["lower_simultaneous"], spec["upper_simultaneous"],
-                time_periods=axis, periods=spec["periods"])
+            # The scpi band covers the post-treatment block; place it at the tail
+            # positions of the time axis. (Its ``periods`` are position indices,
+            # not the panel's time labels, so we align by position, not by label.)
+            T = int(inputs.T)
+
+            def _tail(vals):
+                if vals is None:
+                    return None
+                v = np.asarray(vals, dtype=float).reshape(-1)
+                full = np.full(T, np.nan)
+                if v.size:
+                    full[T - v.size:] = v
+                return full
+
+            lo, hi = _tail(spec["lower"]), _tail(spec["upper"])
+            lo_s, hi_s = (_tail(spec["lower_simultaneous"]),
+                          _tail(spec["upper_simultaneous"]))
             ts_band = dict(
                 counterfactual_lower=lo, counterfactual_upper=hi,
                 counterfactual_lower_simultaneous=lo_s,

--- a/mlsynth/tests/test_clustersc_scpi.py
+++ b/mlsynth/tests/test_clustersc_scpi.py
@@ -132,6 +132,25 @@ def test_pcr_scpi_populates_canonical_band(pcr_scpi):
     assert ts.prediction_interval_kind == "scpi:ridge"
 
 
+def test_scpi_band_populates_on_year_labeled_panel(panel):
+    """The band must align on a real (non-integer) time axis: the scpi post
+    periods are position indices, so the estimator places the band by position,
+    not by matching year labels."""
+    df = panel.copy()
+    df["time"] = df["time"] + 1970          # 1970, 1971, ... calendar years
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = CLUSTERSC(_cfg(df, method="pcr", compute_scpi_pi=True,
+                             scpi_constraint="ridge", scpi_sims=60,
+                             random_state=0)).fit()
+    ts = res.time_series
+    assert ts.has_prediction_interval is True
+    post = np.isfinite(ts.counterfactual_lower)
+    assert post.any() and not post.all()
+    # the finite band sits on the post-treatment tail of the axis
+    assert np.isnan(ts.counterfactual_lower[:len(ts.observed_outcome) - int(post.sum())]).all()
+
+
 def test_rpca_scpi_runs(panel):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")


### PR DESCRIPTION
## Summary

Fix-forward on #229. CLUSTERSC's PCR/RPCA pipelines report scpi `periods` as position indices (`range(T0, T)`), but the estimator was aligning the canonical band against the panel's time labels — so `compute_scpi_pi=True` raised `MlsynthConfigError: Band period N is not in the counterfactual time axis` on any year-labeled panel (Prop 99, German reunification, etc.). The existing CLUSTERSC scpi tests used integer time, which masked it.

Fix: place the post-treatment band at the tail positions of the time axis (align by position, not by label) — robust to any time labeling.

## Test
Added a regression test that fits CLUSTERSC with `compute_scpi_pi=True` on a calendar-year panel and asserts the canonical band populates on the post-treatment tail. The existing integer-time band tests still pass (9 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7bVBZsrWUPQJbnGGCG1qD)_