### PR TITLE
Fix canonical band normalizer for full-length EIV/conformal prediction bands

### DIFF
--- a/mlsynth/tests/test_prediction_interval_contract.py
+++ b/mlsynth/tests/test_prediction_interval_contract.py
@@ -69,6 +69,23 @@ def test_post_only_band_aligns_onto_axis():
     assert np.allclose(hi[3:], [2.0, 2.5])
 
 
+def test_full_length_band_with_redundant_periods_uses_bounds():
+    # The EIV / conformal inference paths stash a full-length (NaN-padded) band
+    # *and* a post-only ``periods`` label list. That pairing must be accepted:
+    # the bounds are already aligned, so ``periods`` is redundant, not a
+    # length-mismatch error. (Regression for the PR #229 band-lift, which only
+    # handled the scpi convention of post-only bounds keyed by ``periods``.)
+    t = np.array([2000, 2001, 2002, 2003, 2004])          # T0 = 3
+    full_lo = [np.nan, np.nan, np.nan, 1.0, 1.5]
+    full_hi = [np.nan, np.nan, np.nan, 2.0, 2.5]
+    lo, hi = normalize_counterfactual_band(
+        lower=full_lo, upper=full_hi,
+        periods=[2003, 2004], time_periods=t)             # post-only periods
+    assert np.isnan(lo[:3]).all() and np.isnan(hi[:3]).all()
+    assert np.allclose(lo[3:], [1.0, 1.5])
+    assert np.allclose(hi[3:], [2.0, 2.5])
+
+
 def test_one_sided_band_rejected():
     with pytest.raises(MlsynthConfigError):
         normalize_counterfactual_band(lower=[1, 2], upper=None,
@@ -183,3 +200,36 @@ def test_vanillasc_scpi_populates_canonical_band():
     post = np.isfinite(ts.counterfactual_lower)
     assert post.any() and not post.all()
     assert str(ts.prediction_interval_kind).startswith("scpi:")
+
+
+def _factor_panel_df(T=20, T0=14, n=6, seed=0):
+    import pandas as pd
+    rng = np.random.default_rng(seed)
+    F = rng.standard_normal((T, 3)); L = rng.standard_normal((n + 1, 3))
+    Y = F @ L.T + 0.2 * rng.standard_normal((T, n + 1)); Y[T0:, 0] -= 3.0
+    rows = [{"unit": f"u{u}", "year": 2000 + t, "y": float(Y[t, u]),
+             "tr": int(u == 0 and t >= T0)}
+            for u in range(n + 1) for t in range(T)]
+    return pd.DataFrame(rows), T, T0
+
+
+@pytest.mark.parametrize("mode", ["eiv", "conformal"])
+def test_vanillasc_full_length_inference_populates_canonical_band(mode):
+    # EIV and conformal stash a full-length band + post-only periods in
+    # inference.details; the canonical band must populate on the post-tail
+    # rather than raising a length mismatch (regression for PR #229).
+    import warnings
+    from mlsynth import VanillaSC
+
+    df, T, T0 = _factor_panel_df()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = VanillaSC({"df": df, "outcome": "y", "treat": "tr",
+                         "unitid": "unit", "time": "year",
+                         "display_graphs": False, "inference": mode}).fit()
+    ts = res.time_series
+    assert ts.has_prediction_interval is True
+    assert len(ts.counterfactual_lower) == T
+    post = np.isfinite(ts.counterfactual_lower)
+    assert post.any() and not post.all()
+    assert np.all(ts.counterfactual_upper[post] >= ts.counterfactual_lower[post])

--- a/mlsynth/utils/results_helpers.py
+++ b/mlsynth/utils/results_helpers.py
@@ -62,12 +62,9 @@ def normalize_counterfactual_band(
     n = axis.size
     full_lo = np.full(n, np.nan)
     full_hi = np.full(n, np.nan)
-    if periods is not None:
-        band_p = np.asarray(periods).reshape(-1)
-        if band_p.size != lo.size:
-            raise MlsynthConfigError(
-                f"Band 'periods' length ({band_p.size}) does not match the "
-                f"bounds ({lo.size}).")
+    band_p = None if periods is None else np.asarray(periods).reshape(-1)
+    if band_p is not None and band_p.size == lo.size:
+        # Post-only bounds keyed by period labels: scatter onto the axis.
         index = {p: i for i, p in enumerate(axis.tolist())}
         for p, l, u in zip(band_p.tolist(), lo, hi):
             if p not in index:
@@ -76,12 +73,14 @@ def normalize_counterfactual_band(
             full_lo[index[p]] = l
             full_hi[index[p]] = u
     elif lo.size == n:
+        # Already full-length (possibly NaN-padded, as the EIV / conformal
+        # inference paths produce); any accompanying 'periods' list is redundant.
         full_lo[:] = lo
         full_hi[:] = hi
     else:
         raise MlsynthConfigError(
             f"Prediction interval has length {lo.size} but the counterfactual "
-            f"has length {n}; pass 'periods' to align a post-only band.")
+            f"has length {n}; pass a matching 'periods' to align a post-only band.")
     return full_lo, full_hi
 
 


### PR DESCRIPTION
## Problem

The nightly full-suite "Daily coverage badge" run on `main` is red with 5 failures, all the same error:

```
MlsynthConfigError: Band 'periods' length (N) does not match the bounds (M)
```

- `test_vanillasc_ascm.py::test_conformal_inference_bands_contain_counterfactual`
- `test_vanillasc_ascm.py::test_plot_saved_with_conformal_band`
- `test_vanillasc_eiv.py::test_eiv_runs_through_vanillasc`
- `test_vanillasc_eiv.py::test_eiv_does_not_change_weights`
- `test_vanillasc_eiv.py::test_eiv_basque_significant_negative`

## Root cause

`normalize_counterfactual_band` (added in #229) assumed the scpi convention: a *post-only* band (`counterfactual_lower/upper` of length = post-periods) keyed by a *matching* post-only `periods` list, which it scatters onto the full time axis by label.

VanillaSC's EIV and conformal inference paths (predating #229) instead stash a *full-length, NaN-padded* band in `inference.details` together with a *post-only* `periods` label list. The generic band-lift `_prediction_interval_from_inference` passed both straight through, so the normalizer received full-length bounds (e.g. 24) + post-only periods (e.g. 6) and tripped its length guard. scpi worked only because its two pieces are the same length.

The failing files are byte-identical between #229 and `HEAD`, so these have been red since #229 merged; the nightly full-suite job is simply where it surfaced.

## Fix

Make the normalizer accept the older format: when a `periods` list is supplied but the bounds are already full-length (`len == axis`), treat the bounds as aligned and ignore the redundant labels; only scatter by label when the bounds are genuinely post-only. The scpi post-only path is unchanged, and a band that is neither post-matching nor full-length still raises.

## Tests (test-first, red → green)

- New normalizer unit test: full-length bounds + a redundant post-only `periods` list is accepted (not a length error).
- New VanillaSC integration test parametrized over `inference="eiv"` and `inference="conformal"`, asserting the canonical band populates on the post-tail.

Both were confirmed red before the fix and green after. The 5 originally-failing tests now pass, and a regression sweep across every band consumer (clustersc scpi, sparsesc, tssc/scul, proximal PIOID bands, comparison, result contract, PDA intervals, staggered) is 206 passed / 4 skipped / 0 failures.

Turns the nightly coverage job green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7bVBZsrWUPQJbnGGCG1qD)_