### PR TITLE
Bring PROXIMAL into the two-family result contract

### DIFF
--- a/mlsynth/tests/test_proximal.py
+++ b/mlsynth/tests/test_proximal.py
@@ -96,6 +96,111 @@ def _validate_method_fit(fit: ProximalMethodFit, name: str, T: int) -> None:
     assert isinstance(fit.donor_weights, dict)
 
 
+# --- Two-family result contract (EffectResult conformance) ---
+
+def test_proximal_result_is_effect_result(sample_proximal_data: pd.DataFrame) -> None:
+    """PROXIMAL returns an EffectResult and lifts the headline (first-requested)
+    variant into the standardized sub-models, exactly like the TSSC dispatcher.
+    """
+    from mlsynth.config_models import (
+        BaseEstimatorResults, EffectResult, MlsynthResult,
+    )
+
+    res = PROXIMAL(_base(
+        sample_proximal_data, methods=["PI", "SPSC"],
+        vars={"donorproxies": ["DonorProxyVar1"]})).fit()
+
+    assert isinstance(res, MlsynthResult)
+    assert isinstance(res, BaseEstimatorResults)
+    assert isinstance(res, EffectResult)
+
+    # Standardized sub-models, populated from the headline variant (PI).
+    assert res.effects is not None and res.effects.att is not None
+    assert res.time_series is not None
+    assert res.time_series.counterfactual_outcome is not None
+    assert res.weights is not None
+    assert res.method_details is not None and res.method_details.method_name == "PI"
+
+    # Flat read-contract agrees with the headline fit and the lifted sub-model.
+    assert isinstance(res.att, float)
+    assert res.att == pytest.approx(res.effects.att)
+    assert res.att == pytest.approx(res.pi.att)
+    ci = res.att_ci
+    assert ci is None or (len(ci) == 2 and ci[0] <= ci[1])
+
+
+def test_proximal_sub_method_results_per_variant(sample_proximal_data: pd.DataFrame) -> None:
+    """Every run variant is promoted to its own EffectResult under
+    ``sub_method_results`` so cross-method tooling can consume any of them.
+    """
+    from mlsynth.config_models import EffectResult
+
+    res = PROXIMAL(_base(
+        sample_proximal_data, methods=["PI", "SPSC"],
+        vars={"donorproxies": ["DonorProxyVar1"]})).fit()
+
+    sub = res.sub_method_results
+    assert set(sub) == {"PI", "SPSC"}
+    for name, sr in sub.items():
+        assert isinstance(sr, EffectResult)
+        assert sr.method_details.method_name == name
+        assert sr.effects.att == pytest.approx(res.methods[name].att)
+        assert sr.att == pytest.approx(res.methods[name].att)
+
+
+def test_proximal_spsc_conformal_rides_in_inference_details(
+    sample_proximal_data: pd.DataFrame,
+) -> None:
+    """SPSC's per-period conformal (effect) band is surfaced under
+    ``inference.details``, not mis-typed as a counterfactual band.
+    """
+    res = PROXIMAL(_base(
+        sample_proximal_data, methods=["SPSC"],
+        spsc_conformal=True)).fit()
+    assert res.inference is not None
+    assert res.inference.details is not None
+    assert set(res.inference.details) >= {"periods", "lower", "upper"}
+    # It is an effect band, so it must NOT populate the counterfactual band.
+    assert not res.time_series.has_prediction_interval
+
+
+def test_proximal_pioid_band_maps_to_time_series(
+    sample_proximal_data: pd.DataFrame,
+) -> None:
+    """PIOID's genuine counterfactual band flows into the standardized
+    ``time_series`` per-period band fields.
+    """
+    res = PROXIMAL(_base(
+        sample_proximal_data, methods=["PIOID"],
+        outcome_instruments=[4, 5], pioid_band=True)).fit()
+    ts = res.time_series
+    assert ts.has_prediction_interval
+    assert ts.counterfactual_lower is not None and ts.counterfactual_upper is not None
+    assert ts.prediction_interval_kind is not None
+
+
+def test_proximal_empty_result_is_valid_effect_result() -> None:
+    """A container with no run variant stays a valid (empty) EffectResult
+    rather than fabricating sub-models.
+    """
+    from mlsynth.config_models import EffectResult
+    from mlsynth.utils.proximal_helpers.structures import PROXIMALInputs
+
+    inputs = PROXIMALInputs(
+        y=np.linspace(1.0, 3.0, 6),
+        donor_outcomes=np.zeros((6, 2)),
+        donor_proxies=None,
+        surrogate_outcomes=None,
+        surrogate_proxies=None,
+        T=6, T0=3, bandwidth=1,
+        time_labels=np.arange(6), treated_unit_name="t", donor_names=["d0", "d1"],
+    )
+    res = PROXIMALResults(inputs=inputs, pi=None, pis=None, pipost=None)
+    assert isinstance(res, EffectResult)
+    assert res.effects is None  # no primary -> nothing lifted
+    assert res.sub_method_results is None
+
+
 # --- Method selection: exactly what's asked runs ---
 
 def test_proximal_pi_only(sample_proximal_data: pd.DataFrame) -> None:

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -29,7 +29,7 @@ _HAS_NUMPYRO = importlib.util.find_spec("numpyro") is not None
 
 from mlsynth import (
     BFSC, BSCM, BVSS, CFM, CLUSTERSC, DPSC, DSCAR, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC,
-    MCNNM, MSQRT, NSC, PDA, PROPSC, RESCM, RMSI, SBC, SCMO, SCUL, SDID,
+    MCNNM, MSQRT, NSC, PDA, PROPSC, PROXIMAL, RESCM, RMSI, SBC, SCMO, SCUL, SDID,
     SequentialSDID, SHC, SNN, SparseSC, SPILLSYNTH, SPOTSYNTH, SSC, TASC, TSSC,
     VanillaSC,
 )
@@ -130,6 +130,12 @@ OBSERVATIONAL = [
                  id="SPILLSYNTH"),
     pytest.param(DPSC, {"epsilon1": 50.0, "epsilon2": 50.0, "n_draws": 20, "seed": 0},
                  id="DPSC"),
+    # PROXIMAL is a dispatcher (like TSSC): the headline variant -- the first
+    # requested method -- is lifted into the standardized sub-models. SPSC needs
+    # no proxies, so it is the cleanest headline for the generic panel.
+    pytest.param(PROXIMAL, {"methods": ["SPSC"],
+                            "donors": ["u01", "u02", "u03", "u04", "u05"]},
+                 id="PROXIMAL"),
 ]
 
 if _HAS_NUMPYRO:  # BFSC needs the ``[bayes]`` extra; skip the whole param without it

--- a/mlsynth/utils/counterfactual_compare.py
+++ b/mlsynth/utils/counterfactual_compare.py
@@ -408,8 +408,8 @@ def compare_estimators(
         res = est.fit() if hasattr(est, "fit") else est
         ts = getattr(res, "time_series", None)
         # Standard EffectResult path (canonical band on time_series) with a
-        # fallback to the flat accessors dispatcher results expose
-        # (PROXIMAL / SPILLSYNTH have no standardized time_series).
+        # fallback to the flat accessors for any result that still lacks a
+        # standardized time_series sub-model.
         if ts is not None and getattr(ts, "counterfactual_outcome", None) is not None:
             cf = ts.counterfactual_outcome
             time = getattr(ts, "time_periods", None)

--- a/mlsynth/utils/proximal_helpers/structures.py
+++ b/mlsynth/utils/proximal_helpers/structures.py
@@ -30,6 +30,14 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Sequence, Tuple
 
 import numpy as np
+from pydantic import ConfigDict, Field, model_validator
+
+from ...config_models import (
+    BaseEstimatorResults,
+    EffectResult,
+    InferenceResults,
+    WeightsResults,
+)
 
 
 # Public method names.
@@ -202,16 +210,26 @@ class ProximalMethodFit:
         return (self.att - half, self.att + half)
 
 
-@dataclass(frozen=True)
-class PROXIMALResults:
+class PROXIMALResults(BaseEstimatorResults):
     """Top-level container returned by :meth:`mlsynth.PROXIMAL.fit`.
+
+    An :class:`~mlsynth.config_models.EffectResult` (the observational
+    report). PROXIMAL is a dispatcher -- one ``fit()`` runs up to eight
+    proximal methods -- so, exactly like :class:`TSSC`, the headline variant
+    (``selected_variant``, the first requested method) is lifted into the
+    standardized sub-models (``effects``, ``time_series``, ``weights``,
+    ``inference``, ``fit_diagnostics``, ``method_details``) and every run
+    variant is additionally promoted to its own ``EffectResult`` under
+    ``sub_method_results`` so cross-method tooling can consume any of them.
+    The variant-specific fits and the flat convenience accessors below are
+    retained unchanged.
 
     Parameters
     ----------
     inputs : PROXIMALInputs
         Preprocessed panel.
     pi : ProximalMethodFit or None
-        Proximal Inference fit (always populated).
+        Proximal Inference fit.
     pis : ProximalMethodFit or None
         Proximal-with-surrogates fit (populated only when surrogates are
         configured).
@@ -220,23 +238,104 @@ class PROXIMALResults:
         configured).
     selected_variant : str
         Which fit is exposed via the convenience aliases ``att``,
-        ``att_se``, ``counterfactual``, ``gap``, ``donor_weights`` --
-        one of ``"PI"``, ``"PIS"``, ``"PIPost"``. Defaults to ``"PI"``.
+        ``att_se``, ``counterfactual``, ``gap``, ``donor_weights`` and lifted
+        into the standardized sub-models. Defaults to the first requested
+        method.
     metadata : dict
         Free-form pipeline diagnostics.
     """
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
     inputs: PROXIMALInputs
-    pi: Optional[ProximalMethodFit]
-    pis: Optional[ProximalMethodFit]
-    pipost: Optional[ProximalMethodFit]
+    pi: Optional[ProximalMethodFit] = None
+    pis: Optional[ProximalMethodFit] = None
+    pipost: Optional[ProximalMethodFit] = None
     spsc: Optional[ProximalMethodFit] = None
     dr: Optional[ProximalMethodFit] = None
     pipw: Optional[ProximalMethodFit] = None
     dr_oid: Optional[ProximalMethodFit] = None
     pioid: Optional[ProximalMethodFit] = None
     selected_variant: str = PI
-    metadata: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    def _submodels_for(self, fit: "ProximalMethodFit") -> Dict[str, Any]:
+        """Standardized sub-model bundle for one variant fit.
+
+        Maps the variant's authoritative numbers (ATT, GMM/HAC SE, donor
+        weights, pre/post RMSE, per-period band) onto the shared sub-models via
+        :func:`build_effect_submodels`, pinning the ATT / RMSE so the validated
+        values never drift from the canonical series recomputation.
+        """
+        from ..results_helpers import build_effect_submodels
+
+        se = fit.att_se if (fit.att_se is not None and np.isfinite(fit.att_se)) else None
+        ci_lower = ci_upper = None
+        if se is not None:
+            ci_lower, ci_upper = fit.ci
+        # SPSC's conformal output is a per-period band on the *effect* (a
+        # different object from the counterfactual band below), so it rides in
+        # ``inference.details`` -- its documented home -- rather than the
+        # counterfactual band fields.
+        inference = InferenceResults(
+            standard_error=se,
+            ci_lower=ci_lower,
+            ci_upper=ci_upper,
+            confidence_level=0.95 if se is not None else None,
+            method="gmm-hac",
+            details=fit.metadata.get("conformal") if fit.metadata else None,
+        )
+        # Only a genuine counterfactual band (e.g. PIOID's) maps to the
+        # standardized per-period counterfactual band fields.
+        prediction_interval = None
+        if fit.counterfactual_lower is not None:
+            prediction_interval = {
+                "lower": fit.counterfactual_lower,
+                "upper": fit.counterfactual_upper,
+                "level": fit.band_level,
+                "kind": fit.band_kind or "conformal",
+            }
+        time_labels = self.inputs.time_labels
+        intervention_time = (
+            time_labels[self.inputs.T0]
+            if time_labels is not None and self.inputs.T0 < len(time_labels)
+            else None
+        )
+        return build_effect_submodels(
+            observed_outcome=self.inputs.y,
+            counterfactual_outcome=fit.counterfactual,
+            n_pre_periods=self.inputs.T0,
+            n_post_periods=self.inputs.n_post,
+            time_periods=time_labels,
+            weights=WeightsResults(
+                donor_weights={str(k): float(v) for k, v in fit.donor_weights.items()} or None
+            ),
+            inference=inference,
+            method_name=fit.name,
+            att_std_err=se,
+            effects_overrides={"att": fit.att},
+            fit_overrides={"rmse_pre": fit.pre_rmse, "rmse_post": fit.post_rmse},
+            intervention_time=intervention_time,
+            prediction_interval=prediction_interval,
+        )
+
+    @model_validator(mode="after")
+    def _populate_standard_submodels(self) -> "PROXIMALResults":
+        """Lift the headline variant into the standardized sub-models and
+        promote every run variant to its own ``EffectResult``.
+
+        Uses ``object.__setattr__`` because the model is frozen. A no-op when
+        no method ran (all fits ``None``) -- the result stays an empty
+        EffectResult rather than fabricating sub-models.
+        """
+        primary = self._primary
+        if self.effects is None and primary is not None:
+            for key, value in self._submodels_for(primary).items():
+                object.__setattr__(self, key, value)
+            sub = {name: EffectResult(**self._submodels_for(fit))
+                   for name, fit in self.methods.items()}
+            object.__setattr__(self, "sub_method_results", sub)
+        return self
 
     @property
     def mode(self) -> str:


### PR DESCRIPTION
## Summary

`PROXIMALResults` was a frozen dataclass sitting outside the standardized `EffectResult` contract (architecture invariant #3) and absent from `test_result_contract.py`, so every consumer keyed on the contract — `counterfactual_compare`, the standard `plot()`, the shared sub-models — had to special-case it. This brings it in, mirroring the existing `TSSC` dispatcher.

## What changed

- `PROXIMALResults` now subclasses `BaseEstimatorResults` (`EffectResult`). A `model_validator` lifts the headline variant (the first requested method) into the standardized sub-models (`effects`, `time_series`, `weights`, `inference`, `fit_diagnostics`, `method_details`), and every run variant is additionally promoted to its own `EffectResult` under `sub_method_results` so cross-method tooling can consume any of them.
- All variant-specific fits, the flat accessors (`att` / `att_se` / `counterfactual` / `gap` / `donor_weights` / `pre_rmse` / `counterfactual_band`) and the helper methods (`att_by_method` / `se_by_method` / `ci_by_method`) are retained unchanged. The result now also inherits a uniform `plot()`.
- Band plumbing respects the estimand: PIOID's genuine counterfactual band maps to the standardized `time_series` band fields, while SPSC's conformal band — a band on the effect, not the counterfactual — rides in `inference.details` (its documented home).
- `counterfactual_compare` now takes the standardized `time_series` path for PROXIMAL; refreshed its now-outdated comment.

## Testing

Test-first. Added `PROXIMAL` to the result-contract conformance param list (headline `SPSC`, which needs no proxies) and added focused tests for `EffectResult` conformance, per-variant `sub_method_results` promotion, the SPSC-conformal → `inference.details` and PIOID-band → `time_series` mappings, and the empty (no-variant) no-op.

- Full proximal suite: 142 passed
- Result-contract suite: 138 passed, 4 skipped
- `counterfactual_compare` suite: green
- Reshaped `structures.py` at 94% line coverage; all new logic covered (remaining misses are pre-existing accessors, unchanged by this PR).

## Out of scope (follow-ups)

- `SIV` has the same drift (`SIVResults` dataclass) but produces a 2SLS coefficient, not a counterfactual path, so mapping it onto `EffectResult` is a genuine design question rather than a mechanical reshape.
- Benchmarks/docs left untouched, per the repo's "don't bundle migrations" convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J82EiQWA1BNatkYYhKGrw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01J82EiQWA1BNatkYYhKGrw6)_