### PR TITLE
Surface PPSCM per-period SCPI bands on per-unit fits

### DIFF
--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -179,10 +179,11 @@ class PPSCM:
             # effect path + pre-residuals. Only when inference is on; the pooled
             # inference stays unchanged.
             if self.run_inference:
-                pu_lo, pu_hi, pu_p = per_unit_intervals(M, tau_rel, alpha=self.alpha)
+                pu_lo, pu_hi, pu_p, pu_tlo, pu_thi = per_unit_intervals(
+                    M, tau_rel, alpha=self.alpha)
             else:
                 nan = np.full(len(fit["groups"]), np.nan)
-                pu_lo, pu_hi, pu_p = nan, nan, nan
+                pu_lo, pu_hi, pu_p, pu_tlo, pu_thi = nan, nan, nan, None, None
             per_unit: Dict[Any, PPSCMUnitFit] = {}
             for k, g in enumerate(fit["groups"]):
                 key = (str(inputs.time_labels[fit["adopt_of"][g]]) if self.time_cohort
@@ -201,6 +202,10 @@ class PPSCM:
                     ci_lower=(float(pu_lo[k]) if np.isfinite(pu_lo[k]) else None),
                     ci_upper=(float(pu_hi[k]) if np.isfinite(pu_hi[k]) else None),
                     p_value=(float(pu_p[k]) if np.isfinite(pu_p[k]) else None),
+                    tau_lower=(np.asarray(pu_tlo[k], dtype=float)
+                               if pu_tlo is not None else None),
+                    tau_upper=(np.asarray(pu_thi[k], dtype=float)
+                               if pu_thi is not None else None),
                 )
 
             results = PPSCMResults(

--- a/mlsynth/tests/test_ppscm_perunit_intervals.py
+++ b/mlsynth/tests/test_ppscm_perunit_intervals.py
@@ -12,6 +12,13 @@ The gate is finite-sample coverage: under a no-effect null the interval must cov
 zero at ~the nominal rate (conservative is acceptable, under-coverage is not). The
 rest pins monotonicity in ``alpha``, power against a real effect, the bracketing
 invariant, ragged-horizon handling, and the end-to-end wiring onto ``PPSCMUnitFit``.
+
+The same out-of-sample call also yields the per-period (pointwise, TSUS) band for
+each treated unit -- the pointwise counterpart of the time-averaged (TAUS) band --
+so PPSCM can report a band at every post-treatment horizon, not just the average.
+Those bands are wider than the average (the average gets the ``sqrt(L)`` shrink
+under ``time_dependence="iid"``; a single period does not) and land on
+``PPSCMUnitFit.tau_lower`` / ``tau_upper``, aligned with ``tau``.
 """
 import numpy as np
 import pytest
@@ -34,7 +41,7 @@ def test_perunit_null_coverage_is_at_least_nominal():
     alpha, reps, covered = 0.10, 400, 0
     for _ in range(reps):
         M, tau = _resid_cols(rng, n_pre=24, n_post=8, effect=0.0)
-        lo, hi, _ = per_unit_intervals(M, tau, alpha=alpha)
+        lo, hi, *_ = per_unit_intervals(M, tau, alpha=alpha)
         if lo[0] <= 0.0 <= hi[0]:
             covered += 1
     cov = covered / reps
@@ -44,15 +51,15 @@ def test_perunit_null_coverage_is_at_least_nominal():
 def test_perunit_ci_widens_as_alpha_shrinks():
     rng = np.random.default_rng(1)
     M, tau = _resid_cols(rng, n_pre=30, n_post=10, effect=0.0)
-    lo80, hi80, _ = per_unit_intervals(M, tau, alpha=0.20)
-    lo95, hi95, _ = per_unit_intervals(M, tau, alpha=0.05)
+    lo80, hi80, *_ = per_unit_intervals(M, tau, alpha=0.20)
+    lo95, hi95, *_ = per_unit_intervals(M, tau, alpha=0.05)
     assert lo95[0] <= lo80[0] and hi95[0] >= hi80[0]        # 95% contains 80%
 
 
 def test_perunit_detects_a_large_effect():
     rng = np.random.default_rng(2)
     M, tau = _resid_cols(rng, n_pre=40, n_post=12, effect=6.0)
-    lo, hi, p = per_unit_intervals(M, tau, alpha=0.10)
+    lo, hi, p, *_ = per_unit_intervals(M, tau, alpha=0.10)
     assert lo[0] > 0.0                                       # band clears zero
     assert p[0] < 0.10
 
@@ -60,7 +67,7 @@ def test_perunit_detects_a_large_effect():
 def test_perunit_ci_brackets_the_point_estimate():
     rng = np.random.default_rng(3)
     M, tau = _resid_cols(rng, n_pre=30, n_post=9, effect=1.5)
-    lo, hi, _ = per_unit_intervals(M, tau, alpha=0.10)
+    lo, hi, *_ = per_unit_intervals(M, tau, alpha=0.10)
     att = float(np.nanmean(tau))
     assert lo[0] <= att <= hi[0]
 
@@ -72,7 +79,7 @@ def test_perunit_handles_ragged_horizons_and_multiple_units():
     M = np.column_stack([rng.normal(size=24), rng.normal(size=24)])
     tau = np.vstack([np.r_[rng.normal(size=6), [np.nan, np.nan]],
                      rng.normal(size=8)])
-    lo, hi, p = per_unit_intervals(M, tau, alpha=0.10)
+    lo, hi, p, *_ = per_unit_intervals(M, tau, alpha=0.10)
     assert lo.shape == hi.shape == p.shape == (2,)
     assert np.all(np.isfinite(lo)) and np.all(np.isfinite(hi))
 
@@ -142,3 +149,103 @@ def test_ppscm_no_inference_leaves_per_unit_bands_none():
                             display_graphs=False)).fit()
     for uf in res.per_unit.values():
         assert uf.ci_lower is None and uf.ci_upper is None and uf.p_value is None
+
+
+# ---- per-period (pointwise, TSUS) bands: the same call already computes them ----
+
+def test_perunit_period_bands_shape_and_bracket_each_period():
+    # per-period bands come back aligned with tau (J, H) and bracket each period's
+    # own effect.
+    rng = np.random.default_rng(20)
+    M, tau = _resid_cols(rng, n_pre=30, n_post=9, effect=1.5)
+    lo, hi, _, tlo, thi = per_unit_intervals(M, tau, alpha=0.10)
+    assert tlo.shape == thi.shape == tau.shape
+    assert np.all(tlo[0] <= tau[0]) and np.all(tau[0] <= thi[0])
+
+
+def test_perunit_period_bands_wider_than_time_average():
+    # TSUS uses sigma; TAUS (iid) uses sigma / sqrt(L) -> per-period is wider.
+    rng = np.random.default_rng(21)
+    M, tau = _resid_cols(rng, n_pre=40, n_post=9, effect=0.0)
+    lo, hi, _, tlo, thi = per_unit_intervals(M, tau, alpha=0.10)
+    avg_hw = 0.5 * (hi[0] - lo[0])
+    period_hw = 0.5 * (thi[0] - tlo[0])                 # constant across periods
+    assert np.all(period_hw > avg_hw)
+
+
+def test_perunit_period_bands_widen_as_alpha_shrinks():
+    rng = np.random.default_rng(22)
+    M, tau = _resid_cols(rng, n_pre=30, n_post=8, effect=0.0)
+    *_, tlo80, thi80 = per_unit_intervals(M, tau, alpha=0.20)
+    *_, tlo95, thi95 = per_unit_intervals(M, tau, alpha=0.05)
+    assert np.all(tlo95[0] <= tlo80[0]) and np.all(thi95[0] >= thi80[0])
+
+
+def test_perunit_period_null_coverage_is_at_least_nominal():
+    # THE PER-PERIOD GATE: under no effect the pointwise band covers 0 at >= nominal
+    # (sub-Gaussian, conservative is fine; under-coverage is the failure mode).
+    rng = np.random.default_rng(23)
+    alpha, reps, covered, total = 0.10, 200, 0, 0
+    for _ in range(reps):
+        M, tau = _resid_cols(rng, n_pre=24, n_post=6, effect=0.0)
+        _, _, _, tlo, thi = per_unit_intervals(M, tau, alpha=alpha)
+        covered += int(np.sum((tlo[0] <= 0.0) & (0.0 <= thi[0])))
+        total += tau.shape[1]
+    assert 0.85 <= covered / total <= 1.0, covered / total
+
+
+def test_perunit_period_bands_respect_ragged_nan():
+    # NaN past a unit's horizon stays NaN in the per-period band; finite elsewhere.
+    rng = np.random.default_rng(24)
+    M = np.column_stack([rng.normal(size=24), rng.normal(size=24)])
+    tau = np.vstack([np.r_[rng.normal(size=6), [np.nan, np.nan]],
+                     rng.normal(size=8)])
+    _, _, _, tlo, thi = per_unit_intervals(M, tau, alpha=0.10)
+    assert tlo.shape == thi.shape == tau.shape
+    nanmask = ~np.isfinite(tau)
+    assert np.all(np.isnan(tlo[nanmask])) and np.all(np.isnan(thi[nanmask]))
+    assert np.all(np.isfinite(tlo[~nanmask])) and np.all(np.isfinite(thi[~nanmask]))
+
+
+def test_perunit_accepts_1d_single_unit_input():
+    # a single unit may be passed as 1-D arrays (M shape (d,), tau shape (H,));
+    # they are promoted to one column / one row and every output is single-unit.
+    rng = np.random.default_rng(25)
+    M = rng.normal(size=20)                             # 1-D pre residuals
+    tau = rng.normal(size=7) + 1.0                      # 1-D post effects
+    lo, hi, p, tlo, thi = per_unit_intervals(M, tau, alpha=0.10)
+    assert lo.shape == hi.shape == p.shape == (1,)
+    assert tlo.shape == thi.shape == (1, 7)
+    assert np.all(tlo[0] <= tau) and np.all(tau <= thi[0])
+
+
+def test_ppscm_fit_populates_per_unit_period_bands():
+    # end-to-end: tau_lower / tau_upper land on PPSCMUnitFit, aligned with tau,
+    # bracketing each period's effect and NaN past the horizon.
+    from mlsynth import PPSCM
+    from mlsynth.config_models import PPSCMConfig
+    rng = np.random.default_rng(30)
+    df = _block_panel(rng, effect=3.0)
+    res = PPSCM(PPSCMConfig(df=df, outcome="y", treat="treat", unitid="unit",
+                            time="time", run_inference=True, alpha=0.10,
+                            display_graphs=False)).fit()
+    assert res.per_unit
+    for uf in res.per_unit.values():
+        assert uf.tau_lower is not None and uf.tau_upper is not None
+        assert uf.tau_lower.shape == uf.tau_upper.shape == uf.tau.shape
+        fin = np.isfinite(uf.tau)
+        assert np.all(uf.tau_lower[fin] <= uf.tau[fin])
+        assert np.all(uf.tau[fin] <= uf.tau_upper[fin])
+        assert np.all(np.isnan(uf.tau_lower[~fin])) and np.all(np.isnan(uf.tau_upper[~fin]))
+
+
+def test_ppscm_no_inference_leaves_per_unit_period_bands_none():
+    from mlsynth import PPSCM
+    from mlsynth.config_models import PPSCMConfig
+    rng = np.random.default_rng(31)
+    df = _block_panel(rng, effect=2.0)
+    res = PPSCM(PPSCMConfig(df=df, outcome="y", treat="treat", unitid="unit",
+                            time="time", run_inference=False,
+                            display_graphs=False)).fit()
+    for uf in res.per_unit.values():
+        assert uf.tau_lower is None and uf.tau_upper is None

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -23,8 +23,8 @@ from .engine import run_multisynth, predict_tau
 def per_unit_intervals(
     M: np.ndarray, tau_rel: np.ndarray, *, alpha: float,
     time_dependence: str = "iid",
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Per-unit CFPT/SCPI prediction intervals for each unit's time-averaged ATT.
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Per-unit CFPT/SCPI prediction intervals for each unit's effect path.
 
     The pooled bootstrap / jackknife measures variability *across* units and so
     cannot give one treated unit its own interval. This builds a per-unit band from
@@ -32,7 +32,7 @@ def per_unit_intervals(
     CFPT/SCPI machinery MSQRT uses), so PPSCM's per-unit bands are methodologically
     consistent with MSQRT's.
 
-    For unit ``k`` the band comes from its post-period effect path
+    For unit ``k`` the bands come from its post-period effect path
     ``tau_rel[k, :]`` (the CFPT ``effects``) and its pre-period residuals
     ``M[:, k]`` (the CFPT ``pre_residuals``): the residual moments set the
     sub-Gaussian scale of the counterfactual prediction error, which correctly
@@ -41,6 +41,12 @@ def per_unit_intervals(
     over-reject. The engine is called per unit (one column at a time), so units
     with different post horizons (ragged ``NaN``) are handled by trimming.
 
+    A single engine call returns the full CFPT family, so both the time-averaged
+    band (``TAUS``) and the per-period pointwise bands (``TSUS``) come out of the
+    same computation: the pointwise bands are the ``TAUS`` band's per-horizon
+    counterpart and are wider (``TAUS`` shrinks by ``sqrt(L)`` under
+    ``time_dependence="iid"``; a single period does not).
+
     Parameters
     ----------
     M : numpy.ndarray
@@ -48,20 +54,24 @@ def per_unit_intervals(
         unit). ``NaN`` entries are dropped per unit.
     tau_rel : numpy.ndarray
         Post-period relative-time effect paths, shape ``(J, H)`` (a 1-D array is a
-        single unit). Trailing ``NaN`` (past a unit's horizon) is dropped.
+        single unit). ``NaN`` (past a unit's horizon) is dropped per unit.
     alpha : float
         Total miscoverage level; the interval is ``100 * (1 - alpha)`` percent.
         Keyword-only.
     time_dependence : {"iid", "general"}, default "iid"
-        Time-averaging bound passed through to the CFPT engine. Keyword-only.
+        Time-averaging bound passed through to the CFPT engine (it affects only the
+        time-averaged band, never the per-period bands). Keyword-only.
 
     Returns
     -------
     tuple of numpy.ndarray
-        ``(ci_lower, ci_upper, p_value)``, each shape ``(J,)``: the per-unit band
-        bounds on the time-averaged ATT and a band-implied two-sided p-value (the
-        house convention ``2 * (alpha/2) ** ((point/half_width) ** 2)``, clamped to
-        ``[0, 1]``). A unit with no usable residuals yields ``NaN``.
+        ``(ci_lower, ci_upper, p_value, tau_lower, tau_upper)``. The first three
+        have shape ``(J,)``: the per-unit band bounds on the time-averaged ATT and a
+        band-implied two-sided p-value (the house convention
+        ``2 * (alpha/2) ** ((point/half_width) ** 2)``, clamped to ``[0, 1]``). The
+        last two have shape ``(J, H)`` -- the per-unit, per-period band bounds,
+        aligned with ``tau_rel`` (``NaN`` where ``tau_rel`` is ``NaN``). A unit with
+        no usable residuals yields ``NaN`` throughout.
     """
     from ..scpi_helpers import out_of_sample_intervals
 
@@ -71,14 +81,17 @@ def per_unit_intervals(
         M = M[:, None]
     if tau_rel.ndim == 1:
         tau_rel = tau_rel[None, :]
-    J = tau_rel.shape[0]
+    J, H = tau_rel.shape
     lo = np.full(J, np.nan)
     hi = np.full(J, np.nan)
     pval = np.full(J, np.nan)
+    tsu_lo = np.full((J, H), np.nan)
+    tsu_hi = np.full((J, H), np.nan)
 
     for k in range(J):
+        finite = np.isfinite(tau_rel[k, :])
         pre = M[:, k][np.isfinite(M[:, k])]
-        post = tau_rel[k, :][np.isfinite(tau_rel[k, :])]
+        post = tau_rel[k, finite]
         if pre.size == 0 or post.size == 0:  # pragma: no cover - guarded upstream
             continue
         res = out_of_sample_intervals(
@@ -93,7 +106,13 @@ def per_unit_intervals(
             pval[k] = float(min(1.0, 2.0 * (alpha / 2.0) ** ((band.point / half) ** 2)))
         else:  # pragma: no cover - degenerate zero-width band
             pval[k] = 1.0
-    return lo, hi, pval
+        # Per-period (TSUS) bands -- already computed in the same call. Place each
+        # back at the horizon it came from so the output aligns with ``tau_rel``.
+        for p, col in enumerate(np.flatnonzero(finite)):
+            pband = res.tsus[(k, p)]
+            tsu_lo[k, col] = float(pband.lower)
+            tsu_hi[k, col] = float(pband.upper)
+    return lo, hi, pval, tsu_lo, tsu_hi
 
 
 # Mammen (1993) two-point wild-bootstrap multipliers (mean 0, variance 1) --

--- a/mlsynth/utils/ppscm_helpers/structures.py
+++ b/mlsynth/utils/ppscm_helpers/structures.py
@@ -158,6 +158,12 @@ class PPSCMUnitFit:
     tau : np.ndarray
         Relative-time effect path (length ``n_leads``); ``NaN`` past this unit's
         observed horizon.
+    tau_lower, tau_upper : np.ndarray or None
+        Per-period (pointwise) CFPT/SCPI prediction band for the effect path,
+        aligned with ``tau`` (length ``n_leads``, ``NaN`` past the horizon); the
+        per-horizon counterpart of ``ci_lower`` / ``ci_upper`` and wider than them
+        (the time average shrinks by ``sqrt(L)``, a single period does not).
+        ``None`` when inference is off.
     pre_imbalance : np.ndarray
         The pre-treatment imbalance vector (front-padded to the balance window)
         whose weighted RMS is ``prefit_rmspe``; the per-period in-sample residual.
@@ -181,6 +187,10 @@ class PPSCMUnitFit:
     ci_lower: Optional[float] = None
     ci_upper: Optional[float] = None
     p_value: Optional[float] = None
+    # Per-period (pointwise) CFPT/SCPI band, aligned with ``tau``. None when
+    # inference is off. See ``per_unit_intervals`` in ``inference.py``.
+    tau_lower: Optional[np.ndarray] = None
+    tau_upper: Optional[np.ndarray] = None
 
 
 class PPSCMResults(_BaseEstimatorResults):


### PR DESCRIPTION
## What

PPSCM fits a synthetic control per treated unit and already runs each one through the CFPT/SCPI out-of-sample engine. But `per_unit_intervals` kept only the time-averaged band (`TAUS`) and discarded the per-period bands (`TSUS`) computed in the very same call. This surfaces them.

- `per_unit_intervals` (`ppscm_helpers/inference.py`) now returns `(ci_lower, ci_upper, p_value, tau_lower, tau_upper)`. The last two are `(J, H)` per-unit, per-period band bounds, aligned with `tau_rel` (`NaN` past each unit's horizon).
- `PPSCMUnitFit` (`ppscm_helpers/structures.py`) carries `tau_lower` / `tau_upper` — the pointwise counterpart of `ci_lower` / `ci_upper`.
- `PPSCM.fit` (`estimators/ppscm.py`) wires them onto each per-unit fit; `None` when inference is off. Pooled inference is unchanged.

## Why

The bands were already being computed and then dropped, so a consumer had no per-period per-market interval — only the time-averaged one. Surfacing `tsus` lets a downstream table (e.g. a per-geo daily effects table) report a pointwise band at every post-treatment horizon. No extra fitting or SCPI calls.

Note on width: the per-period bands are wider than the time-averaged band by construction — the average shrinks by `sqrt(L)` under `time_dependence="iid"`, a single period does not. Same behavior as MSQRT's `tsus`.

## Testing (test-first)

Added to `test_ppscm_perunit_intervals.py`: per-period shape/bracketing, per-period null coverage (>= nominal), monotonicity in `alpha`, wider-than-average, ragged-horizon handling, 1-D single-unit input, and end-to-end wiring (fields populate on fit; `None` without inference).

- Per-unit interval file: all green (16 tests).
- Broader PPSCM + result-contract suite: 187 passed, 4 skipped — no regressions.
- New code fully covered; remaining misses in the touched files are pre-existing defensive/plotting/jackknife branches covered elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiqvLnuRPUrTskz2rqR1Mc)_