### PR TITLE
feat(mvbbsc): add Martinez & Vives-i-Bastida Bayesian synthetic control

### DIFF
--- a/benchmarks/R/install_bsynth.sh
+++ b/benchmarks/R/install_bsynth.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Install the authors' bsynth R package (Martinez & Vives-i-Bastida 2024,
+# github.com/ignacio82/bsynth) for the mvbbsc_bsynth_ref reference run.
+#
+# bsynth fits the Bayesian synthetic control in Stan via rstan. rstan and its
+# heavy transitive stack (StanHeaders, RcppEigen, BH, Boom-free) build slowly
+# from source, so we take the prebuilt rstan from apt (Ubuntu universe) and
+# compile only the two GitHub-only leaves: vizdraws (a Suggests bsynth loads at
+# fit time) and bsynth itself. Verified on Ubuntu + R 4.3.x in a sandbox where
+# CRAN is blocked but apt and `git clone` over HTTPS are open.
+#
+# COMMIT-PINNED (frozen 2026-07-22) so the cross-check runs the SAME reference
+# code every time. To refresh, bump the SHAs and re-pin the expected numbers in
+# benchmarks/cases/mvbbsc_germany.py and docs/replications/mvbbsc.rst.
+#
+#   bsynth     22d960f7496ba57f3d30740097ce6dfaac70d1d5  (2024-06-27, ignacio82/bsynth)
+#   vizdraws   1ca4d75fda9f8438b77ba65f47a4dc6e6aff0a3c  (ignacio82/vizdraws)
+set -euo pipefail
+
+BSYNTH_SHA=22d960f7496ba57f3d30740097ce6dfaac70d1d5
+VIZDRAWS_SHA=1ca4d75fda9f8438b77ba65f47a4dc6e6aff0a3c
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+
+# Prebuilt rstan + the CRAN deps bsynth Imports, from apt (avoids compiling the
+# whole Stan toolchain). dplyr/tidyr/ggplot2/scales/glue/tibble/purrr are pulled
+# in transitively; list the direct Imports explicitly.
+DEBIAN_FRONTEND=noninteractive apt-get update -qq
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  r-base r-base-dev build-essential gfortran git \
+  r-cran-rstan r-cran-rcpp r-cran-dplyr r-cran-tidyr r-cran-ggplot2 \
+  r-cran-scales r-cran-glue r-cran-tibble r-cran-purrr r-cran-magrittr \
+  r-cran-r6 r-cran-jsonlite r-cran-htmlwidgets r-cran-rlang
+
+clone_install() {  # $1 = owner/repo, $2 = pinned SHA
+  local repo="$1" sha="$2" name
+  name="$(basename "$repo")"
+  git clone --quiet "https://github.com/$repo.git" "$name"
+  ( cd "$name" && git checkout --quiet "$sha" )
+  R CMD INSTALL --no-help --no-docs "$name"
+}
+
+# vizdraws is a bsynth Suggests it loads when building plot data; install it
+# first so the bsynth install and the reference run both find it.
+clone_install ignacio82/vizdraws "$VIZDRAWS_SHA"
+clone_install ignacio82/bsynth   "$BSYNTH_SHA"
+
+Rscript -e 'suppressMessages(library(bsynth)); cat("bsynth", as.character(packageVersion("bsynth")), "OK\n")'

--- a/benchmarks/R/mvbbsc_bsynth_ref.R
+++ b/benchmarks/R/mvbbsc_bsynth_ref.R
@@ -1,0 +1,51 @@
+#!/usr/bin/env Rscript
+# Reference oracle for benchmarks/cases/mvbbsc_germany.py -- the authors' own
+# bsynth package (Martinez & Vives-i-Bastida 2024, arXiv:2206.01779).
+#
+# mlsynth's MVBBSC is a clean-room NumPyro port of the bsynth `model1` (outcome-
+# only, predictor_match = FALSE: uniform-Dirichlet simplex weights, HalfNormal
+# scale, Gaussian likelihood on the pre-period-standardized series). This script
+# runs the reference bsynth on the German reunification panel and dumps the
+# posterior counterfactual, credible band, ATT, and in-sample RMSE so the port
+# can be cross-checked cell-for-cell.
+#
+# Install (pinned): benchmarks/R/install_bsynth.sh. Needs R + rstan, so this is
+# NOT run in CI; it is committed so the cross-check is reproducible on demand.
+#
+#   Rscript benchmarks/R/mvbbsc_bsynth_ref.R \
+#     basedata/german_reunification.csv benchmarks/R/mvbbsc_bsynth_ref.out
+suppressMessages({library(bsynth); library(dplyr)})
+
+args   <- commandArgs(trailingOnly = TRUE)
+infile <- if (length(args) >= 1) args[1] else "basedata/german_reunification.csv"
+outfile <- if (length(args) >= 2) args[2] else "benchmarks/R/mvbbsc_bsynth_ref.out"
+
+d <- read.csv(infile)
+d$treat <- as.integer(d$Reunification)
+
+# bayesianSynth with predictor_match = FALSE is model1: outcome-only, no
+# covariates, no Gaussian-process term -- exactly the model MVBBSC ports.
+gs <- bayesianSynth$new(data = d, time = year, id = country, treated = treat,
+                        outcome = gdp, ci_width = 0.95, predictor_match = FALSE)
+gs$fit(cores = 4)
+
+pd <- as.data.frame(gs$plotData)     # year, gdp, y_synth, LB, UB, tau, tau_LB, tau_UB
+pre  <- pd$year < 1990
+post <- pd$year >= 1990
+rmse <- sqrt(mean((pd$gdp[pre] - pd$y_synth[pre])^2))
+att  <- mean(pd$gdp[post] - pd$y_synth[post])
+band_pre  <- mean((pd$UB - pd$LB)[pre])
+band_post <- mean((pd$UB - pd$LB)[post])
+
+# machine-parseable dump (key=value), plus the full path as a CSV alongside.
+lines <- c(
+  sprintf("pre_rmse=%.4f", rmse),
+  sprintf("mean_att=%.4f", att),
+  sprintf("band_width_pre=%.4f", band_pre),
+  sprintf("band_width_post=%.4f", band_post),
+  sprintf("n_periods=%d", nrow(pd))
+)
+writeLines(lines, outfile)
+write.csv(pd, sub("\\.out$", "_path.csv", outfile), row.names = FALSE)
+cat(paste(lines, collapse = "\n"), "\n")
+cat("wrote", outfile, "and", sub("\\.out$", "_path.csv", outfile), "\n")

--- a/benchmarks/cases/mvbbsc_germany.py
+++ b/benchmarks/cases/mvbbsc_germany.py
@@ -1,0 +1,85 @@
+"""MVBBSC Path-A: West Germany reunification (Martinez & Vives-i-Bastida 2024).
+
+Cross-validation + Path A. Martinez and Vives-i-Bastida (2024) ship their method
+as the ``bsynth`` R package (Stan via rstan); mlsynth's MVBBSC is a clean-room
+NumPyro port of the same generative model (uniform-Dirichlet simplex weights,
+HalfNormal scale, Gaussian likelihood on the pre-period-standardized series). On
+the German reunification panel a fresh NumPyro fit matches the bsynth posterior
+to MCMC error -- pre-RMSE 62.2 vs 62.2, mean post-ATT -2078 vs -2075, and the
+95% credible-band widths agree year-by-year to within a few percent (see
+docs/replications/mvbbsc; reference produced by benchmarks/R/mvbbsc_bsynth_ref.R).
+
+This case pins the reproducible headline quantities of a fresh NumPyro fit: the
+negative reunification effect near the paper's own ~7.5% magnitude, a positive-
+then-negative gap path, a close pre-period fit, an ATT band that excludes zero,
+and converged NUTS.
+
+Bayesian (NUTS) => the cells carry MCMC tolerances; the seed is fixed so a run
+is reproducible. Requires the ``[bayes]`` optional dependency (NumPyro).
+
+Provenance: Martinez & Vives-i-Bastida (2024), arXiv:2206.01779, Sections 2--3
+and the bsynth package; Abadie, Diamond & Hainmueller (2015) for the data and
+the reunification benchmark.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import numpy as np
+import pandas as pd
+
+from benchmarks.compare import BenchmarkSkipped
+
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..", "basedata",
+                     "german_reunification.csv")
+
+
+def run() -> dict:
+    try:
+        import numpyro  # noqa: F401
+    except ImportError as exc:  # optional dependency -> graceful skip
+        raise BenchmarkSkipped(
+            "MVBBSC needs NumPyro (pip install 'mlsynth[bayes]')."
+        ) from exc
+
+    from mlsynth import MVBBSC
+
+    d = pd.read_csv(os.path.abspath(_DATA))
+    d["treat"] = d["Reunification"].astype(int)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = MVBBSC({
+            "df": d, "outcome": "gdp", "treat": "treat",
+            "unitid": "country", "time": "year",
+            "n_warmup": 500, "n_samples": 500, "n_chains": 4,
+            "seed": 0, "display_graphs": False,
+        }).fit()
+
+    ts = res.time_series
+    yr = np.asarray(ts.time_periods)
+    gap = np.asarray(ts.estimated_gap)
+    g = lambda y: float(gap[yr == y][0])
+    return {
+        "mean_att": float(res.att),
+        "att_negative": float(res.att < 0.0),
+        "gap_1990": g(1990),
+        "gap_2003": g(2003),
+        "pre_rmse": float(res.fit_diagnostics.rmse_pre),
+        "ci_excludes_zero": float(res.inference.ci_upper < 0.0),
+        "max_rhat": float(res.weights.summary_stats["max_rhat"]),
+    }
+
+
+# NUTS with a fixed seed => reproducible up to MCMC error; tolerances absorb it.
+# Cross-validated against the authors' bsynth package (pre-RMSE 62.2, ATT -2075).
+EXPECTED = {
+    "mean_att": (-2080.0, 500.0),      # ~7.5% decline (the paper's own magnitude)
+    "att_negative": (1.0, 0.0),        # negative effect (classical finding)
+    "gap_1990": (426.0, 500.0),        # near the intervention year
+    "gap_2003": (-4989.0, 1200.0),     # deepening loss by 2003
+    "pre_rmse": (62.2, 20.0),          # close pre-period fit (GDP units)
+    "ci_excludes_zero": (1.0, 0.0),    # 95% ATT band excludes zero
+    "max_rhat": (1.0, 0.1),            # converged simplex weights + sigma
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -65,6 +65,7 @@ CASES = {
     "bvss_watches": "benchmarks.cases.bvss_watches",              # cross-val vs authors' own two-coordinate Gibbs (Xu-Zhou 2025) on China anti-corruption watches, p>n: engine exact + posterior ATT within MC error
     "bfsc_germany": "benchmarks.cases.bfsc_germany",                # cross-val vs author appendix Stan (corr 0.999999) + Path A: West Germany reunification (Pinkney 2021)
     "bfsc_prop99": "benchmarks.cases.bfsc_prop99",                  # cross-val vs author appendix Stan run LIVE via rstan (Prop 99, California 1989) -- needs [bayes] + rstan
+    "mvbbsc_germany": "benchmarks.cases.mvbbsc_germany",            # cross-val vs authors' bsynth package (rstan) + Path A: West Germany reunification (Martinez & Vives-i-Bastida 2024)
     "mtgp_california": "benchmarks.cases.mtgp_california",          # cross-val vs replication-package Stan run LIVE via rstan (California APPS, homicide rates 1997-2018, treated 2007) -- needs [bayes] + rstan
     "bpscs_synthetic": "benchmarks.cases.bpscs_synthetic",           # self-contained: BPSCS effect recovery + distance-based shrinkage on a simulated spatial-spillover panel (GPL reference not shipped) -- needs [bayes]
     "mscmt_basque": "benchmarks.cases.mscmt_basque",          # cross-val vs R MSCMT: AG Basque, fit_window=(1960,1969)

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -227,6 +227,8 @@ Cross-validation against reference implementations
      - vs R microsynth panel method (Seattle DMI)
    * - ``mlsc_bottmer``
      - vs Bottmer's mlSC_estimator (skips if absent)
+   * - ``mvbbsc_germany``
+     - vs authors' bsynth R package (rstan): posterior counterfactual + credible bands + ATT, West Germany reunification (Martinez & Vives-i-Bastida)
    * - ``nsc_prop99``
      - vs Tian's NSC.R (Prop 99 Table 2)
    * - ``ppscm_paglayan``

--- a/docs/bfsc.rst
+++ b/docs/bfsc.rst
@@ -37,10 +37,14 @@ Do not use BFSC when:
 The Bayesian SC family
 ----------------------
 
-mlsynth carries three Bayesian synthetic-control estimators; they differ in
+mlsynth carries several Bayesian synthetic-control estimators; they differ in
 what they place a prior on, and BFSC is the one that models the outcome rather
 than the weights.
 
+* :doc:`mvbbsc` (Martinez and Vives-i-Bastida) -- a uniform prior over the hard
+  simplex, standardized internally, with a Bernstein-von Mises guarantee that
+  makes the credible interval a valid confidence interval; NUTS through the
+  ``[bayes]`` optional dependency, and it reports donor weights.
 * :doc:`bscm` (Kim, Lee and Gupta) -- shrinkage (horseshoe or spike-and-slab)
   on unconstrained donor weights; a pure-numpy Gibbs sampler, and it reports
   donor weights.
@@ -51,9 +55,9 @@ than the weights.
   weighting; NUTS through the ``[bayes]`` optional dependency, and it reports a
   counterfactual credible band and no donor weights.
 
-Reach for a weighting prior (:doc:`bscm`, :doc:`bvss`) when you want
-interpretable donor weights; reach for BFSC when a shared factor structure --
-not a weighted average of donors -- is the right model for the untreated
+Reach for a weighting prior (:doc:`mvbbsc`, :doc:`bscm`, :doc:`bvss`) when you
+want interpretable donor weights; reach for BFSC when a shared factor structure
+-- not a weighted average of donors -- is the right model for the untreated
 outcome.
 
 Notation

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -458,24 +458,31 @@ already in hand. It needs at least as many covariates as factors and a
 pre-period longer than covariates-times-factors, and reports a per-period
 moving-block conformal band. With no covariates, use :doc:`fma` or :doc:`cfm`.
 
-*Which Bayesian synthetic control?* Five estimators are Bayesian, and they
-split on what carries the prior. :doc:`bscm` and :doc:`bvss` put a shrinkage /
-selection prior on the *donor weights* (both pure-numpy, both report donor
-weights) -- reach for them, at Q1.2 or Q1.6, when you want interpretable weights
-with a credible interval. :doc:`bfsc` and :doc:`mtgp` put the prior on a
-*latent-factor model* of the outcome and report a counterfactual band with no
-donor weights -- reach for them when a shared factor structure rather than a
-weighted average of donors is the right model. The two factor models differ in
-one thing: :doc:`bfsc` leaves the factors unconstrained over time, while
-:doc:`mtgp` puts a Gaussian-process (squared-exponential) prior on them, so its
-factor paths are smooth and its post-period band grows with extrapolation
-distance. Prefer :doc:`mtgp` when the untreated series are smooth trends and you
-want that widening band; prefer :doc:`bfsc` when the shared structure is best
-left unconstrained. The fifth, :doc:`bpscs`, puts the prior on *donor
-coefficients* but scales it by an external covariate-and-distance utility --
-reach for it, at Q1.1, when the concern is spatial spillover contaminating the
-donor pool and you want close-by donors down-weighted rather than trusted or
-dropped.
+*Which Bayesian synthetic control?* Six estimators are Bayesian, and they
+split on what carries the prior. :doc:`mvbbsc`, :doc:`bscm`, and :doc:`bvss`
+put a prior on the *donor weights* and all report donor weights -- reach for
+them, at Q1.2 or Q1.6, when you want interpretable weights with a credible
+interval. They differ in the constraint: :doc:`mvbbsc` (Martinez and
+Vives-i-Bastida) keeps the *hard simplex* with a uniform prior, standardizes
+internally so the fit is unit-free, and carries a Bernstein-von Mises guarantee
+that makes its credible interval a valid confidence interval -- the choice when
+the treated unit is inside the donors' hull and you want principled inference on
+the classical convex-combination model; :doc:`bscm` drops the simplex for
+shrinkage (horseshoe or spike-and-slab) on *unconstrained* weights; :doc:`bvss`
+keeps a *soft* simplex and adds spike-and-slab donor selection with inclusion
+probabilities. :doc:`bfsc` and :doc:`mtgp` put the prior on a *latent-factor
+model* of the outcome and report a counterfactual band with no donor weights --
+reach for them when a shared factor structure rather than a weighted average of
+donors is the right model. The two factor models differ in one thing:
+:doc:`bfsc` leaves the factors unconstrained over time, while :doc:`mtgp` puts a
+Gaussian-process (squared-exponential) prior on them, so its factor paths are
+smooth and its post-period band grows with extrapolation distance. Prefer
+:doc:`mtgp` when the untreated series are smooth trends and you want that
+widening band; prefer :doc:`bfsc` when the shared structure is best left
+unconstrained. The sixth, :doc:`bpscs`, puts the prior on *donor coefficients*
+but scales it by an external covariate-and-distance utility -- reach for it, at
+Q1.1, when the concern is spatial spillover contaminating the donor pool and you
+want close-by donors down-weighted rather than trusted or dropped.
 
 *DSCAR -- a different beast.* :doc:`dscar` (Zheng and Chen, 2024) is not a variant
 of the synthetic control above; it is best understood by contrast with the vanilla

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -269,6 +269,7 @@ headline numbers.
    bvss
    bscm
    bfsc
+   mvbbsc
    mtgp
    bpscs
    clustersc

--- a/docs/mvbbsc.rst
+++ b/docs/mvbbsc.rst
@@ -1,0 +1,208 @@
+Bayesian Synthetic Control of Martinez & Vives-i-Bastida (MVBBSC)
+=================================================================
+
+.. currentmodule:: mlsynth
+
+When to use MVBBSC -- and when not to
+-------------------------------------
+
+MVBBSC is the Bayesian synthetic control of Martinez and Vives-i-Bastida (2024).
+It keeps the standard synthetic-control model -- the untreated outcome of the
+treated unit is a simplex-weighted average of the donor pool -- but replaces the
+single optimized weight vector with a posterior over weights, so every quantity
+it reports (the counterfactual, the per-period effect, the ATT) arrives with a
+credible band rather than a point. Reach for it when you want the interpretable,
+non-extrapolating fit of a classical synthetic control and honest uncertainty on
+the effect, drawn from one coherent Bayesian model. It is a good choice when:
+
+* You want donor weights that are non-negative and sum to one -- the same
+  convex-combination the classical method reports -- but with a full posterior,
+  not a single solve.
+* You want a principled interval. Under the paper's conditions the Bayesian
+  credible interval is also a valid frequentist confidence interval (a
+  Bernstein-von Mises result), so the band is usable inference, not just a
+  visual aid.
+* The treated unit lies inside (or near) the donors' convex hull, so a weighted
+  average is the right model and a good pre-period fit is attainable.
+
+Do not use MVBBSC when:
+
+* The treated unit is outside the donor hull. A hard simplex cannot reach it and
+  the pre-period fit will be poor; a factor model (:doc:`bfsc`, :doc:`fma`) or an
+  unconstrained-weight method (:doc:`bscm`) is the better model there.
+* You need a dependency-free estimate. MVBBSC draws its posterior with NUTS
+  (NumPyro), so it needs the ``[bayes]`` optional dependency
+  (``pip install 'mlsynth[bayes]'``). For a dependency-free Bayesian SC use
+  :doc:`bscm` (a pure-numpy Gibbs sampler).
+
+The Bayesian SC family
+----------------------
+
+mlsynth carries four Bayesian synthetic-control estimators; they differ in what
+they place a prior on and whether the weights are constrained to the simplex.
+
+* :doc:`bscm` (Kim, Lee and Gupta) -- shrinkage (horseshoe or spike-and-slab)
+  on unconstrained donor weights; a pure-numpy Gibbs sampler.
+* :doc:`bvss` (Xu and Zhou) -- spike-and-slab donor selection on a soft simplex
+  whose tightness is learned; reports inclusion probabilities.
+* :doc:`bfsc` (Pinkney) -- a Bayesian latent-factor model, not a donor
+  weighting; reports a counterfactual band and no donor weights.
+* :doc:`mvbbsc` (Martinez and Vives-i-Bastida) -- a uniform prior over the
+  hard simplex, standardized internally, with the frequentist-inference
+  (Bernstein-von Mises) guarantee.
+
+Reach for MVBBSC when you want the classical convex-combination model with a
+principled interval; reach for :doc:`bvss` when you additionally want the model
+to select which donors enter; reach for :doc:`bscm` when you are willing to drop
+the simplex for shrinkage on unconstrained weights; reach for :doc:`bfsc` when a
+shared factor structure, not a weighted average, is the right model.
+
+Notation
+--------
+
+We use the synthetic-control canon. Let :math:`j = 1` denote the treated unit and
+:math:`\mathcal{N}_0 \coloneqq \{2, \ldots, J+1\}` the donor pool; time is
+:math:`t \in \mathcal{T} \coloneqq \{1, \ldots, T\}` with the intervention after
+:math:`T_0`, pre-period :math:`\mathcal{T}_1` and post-period
+:math:`\mathcal{T}_2`. Write :math:`y_{1t}` for the treated outcome and
+:math:`\mathbf{y}_{0t} = (y_{2t}, \ldots, y_{J+1,t})^{\top}` for the donor
+outcomes at :math:`t`. MVBBSC models the no-intervention outcome as a
+simplex-weighted average of the donors,
+
+.. math::
+
+   y_{1t}^N = \mathbf{y}_{0t}^{\top}\mathbf{w} + \varepsilon_t,
+   \qquad \varepsilon_t \sim \mathcal{N}(0, \sigma^2),
+   \qquad \mathbf{w} \in \Delta^{J},
+
+where :math:`\Delta^{J}` is the unit simplex
+(:math:`w_j \ge 0,\ \sum_j w_j = 1`).
+
+Prior. The paper's characterization of when the risk minimizer is a synthetic
+control motivates placing the weights in the simplex; MVBBSC does so with a
+uniform Dirichlet prior and a weakly-informative scale,
+
+.. math::
+
+   \mathbf{w} \sim \mathrm{Dirichlet}(\mathbf{1}_J),
+   \qquad \sigma \sim \mathrm{HalfNormal}(1).
+
+Standardization. Before fitting, the treated series and every donor series are
+centered on their pre-period mean and scaled by their pre-period standard
+deviation; the counterfactual is transformed back to the outcome scale
+afterwards. No post-period information enters the scaling, so it cannot bias the
+treated estimate, and because the fit happens on standardized data the estimate
+is invariant to the units of the outcome.
+
+Counterfactual. The posterior is drawn with NUTS. The counterfactual is the
+posterior-predictive draw of the untreated outcome,
+:math:`\widehat{y}_{1t}^{N,(m)} = \mathbf{y}_{0t}^{\top}\mathbf{w}^{(m)} +
+\eta_t^{(m)}` with :math:`\eta_t^{(m)} \sim \mathcal{N}(0, \sigma^{(m)2})` for
+each posterior draw :math:`m`, so its pointwise quantiles are a credible band.
+The per-period effect is :math:`\tau_t \coloneqq y_{1t} - \widehat{y}_{1t}^N` and
+the ATT is
+:math:`\widehat{\tau} \coloneqq T_2^{-1}\sum_{t\in\mathcal{T}_2}\tau_t`, each with
+a full posterior credible band.
+
+Assumptions
+-----------
+
+#. Single treated unit, balanced panel. One unit is treated after :math:`T_0`;
+   every unit is observed at every period.
+
+   Remark. The setup boundary (:mod:`mlsynth.utils.mvbbsc_helpers.setup`)
+   enforces both through :func:`~mlsynth.utils.datautils.dataprep`, translating a
+   violation (including a second treated cohort) to
+   :class:`~mlsynth.exceptions.MlsynthDataError`.
+
+#. The treated unit is a convex combination of the donors. There exist simplex
+   weights under which the donors reproduce the treated unit's pre-period path.
+
+   Remark. This is the classical synthetic-control design assumption. When it
+   fails -- the treated unit outside the donors' hull -- the hard simplex cannot
+   track the pre-period, the fit is poor, and (as the paper stresses) the
+   estimate is likely biased. A poor pre-period fit is the diagnostic; read it
+   before trusting the effect.
+
+#. Gaussian idiosyncratic noise. :math:`\varepsilon_t \sim \mathcal{N}(0,
+   \sigma^2)` with a single :math:`\sigma`.
+
+   Remark. The Gaussian likelihood is what the paper's Bernstein-von Mises
+   argument uses to link the Bayesian posterior predictive to the frequentist
+   sampling distribution as :math:`T_0, J \to \infty`.
+
+Inference and diagnostics
+-------------------------
+
+MVBBSC is inferential by construction. ``res.inference.ci_lower`` /
+``res.inference.ci_upper`` give the ATT credible interval, and the counterfactual
+band is on ``res.inference_detail`` (``counterfactual_lower`` /
+``counterfactual_upper``). Under the paper's conditions this credible interval is
+also a valid confidence interval, so it can be read as frequentist inference.
+NUTS diagnostics are surfaced on ``res.weights.summary_stats`` --
+``nuts_accept_prob``, ``nuts_divergences``, ``max_rhat`` -- alongside
+``sigma_post_mean``. The posterior-mean simplex weights are on
+``res.weights.donor_weights``. Read the pre-period fit
+(``res.fit_diagnostics.rmse_pre``) first: a large value means the treated unit is
+not in the donors' hull and the effect should not be trusted.
+
+Example
+-------
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import MVBBSC   # requires: pip install 'mlsynth[bayes]'
+
+   df = pd.read_csv(
+       "https://raw.githubusercontent.com/jgreathouse9/mlsynth/main/"
+       "basedata/german_reunification.csv")
+   df["treat"] = df["Reunification"].astype(int)
+
+   res = MVBBSC({
+       "df": df, "outcome": "gdp", "treat": "treat",
+       "unitid": "country", "time": "year",
+       "seed": 0, "display_graphs": False,
+   }).fit()
+
+   print(f"pre-period RMSE : {res.fit_diagnostics.rmse_pre:.1f}")
+   print(f"mean post ATT   : {res.att:+.0f}")
+   print(f"95% credible    : [{res.inference.ci_lower:+.0f}, {res.inference.ci_upper:+.0f}]")
+   print(f"NUTS max r-hat  : {res.weights.summary_stats['max_rhat']:.3f}")
+
+On West Germany this fits the pre-1990 path to an RMSE near :math:`62` (in
+PPP-USD per capita) and estimates a mean post-1990 effect near :math:`-2080` --
+about a :math:`7.5\%` decline in per-capita GDP -- with a 95% credible band of
+roughly :math:`[-2600, -1600]` that widens through the post-period as the
+counterfactual extrapolates. The posterior weight is spread across Norway, Italy,
+Austria, and the USA.
+
+Verification
+------------
+
+The MVBBSC model is cross-validated against the reference ``bsynth`` R package
+(Martinez and Vives-i-Bastida's own implementation). On the German reunification
+panel a fresh NumPyro fit matches the ``bsynth`` posterior to Monte-Carlo error:
+pre-period RMSE :math:`62.2` vs :math:`62.2`, mean post-ATT :math:`-2078` vs
+:math:`-2075`, and the 95% credible band agrees year-by-year to within a few
+percent (ratios :math:`0.95`--:math:`1.07`), with in-sample coverage of the
+observed series at :math:`96.7\%` against the nominal :math:`95\%`. See the
+replication page :doc:`replications/mvbbsc` and the durable case
+``benchmarks/cases/mvbbsc_germany.py``. The estimator, config validation, the
+missing-dependency guard, effect recovery, scale invariance, and the result
+contract are unit-tested (``mlsynth/tests/test_mvbbsc.py``).
+
+Core API
+--------
+
+.. automodule:: mlsynth.estimators.mvbbsc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Configuration
+-------------
+
+.. autoclass:: mlsynth.config_models.MVBBSCConfig
+   :members:
+   :undoc-members:

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -500,6 +500,12 @@ References
     DOI: https://doi.org/10.1177/0022243720936230
     Reference code: https://github.com/clarencejlee/bscm
 
+.. [MVBBSC2024]
+    Martinez, Ignacio, and Vives-i-Bastida, Jaume.
+    *"Bayesian and Frequentist Inference for Synthetic Controls."*
+    arXiv:2206.01779, 2024.
+    Reference code: https://github.com/ignacio82/bsynth
+
 .. [MTGP2023]
     Ben-Michael, Eli, Arbour, David, Feller, Avi, Franks, Alexander, and Raphael, Steven.
     *"Estimating the effects of a California gun control program with multitask Gaussian processes."*

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -54,6 +54,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    replications/src
    replications/bscm
    replications/bfsc
+   replications/mvbbsc
    replications/mtgp
    replications/bpscs
    replications/tssc

--- a/docs/replications/mvbbsc.rst
+++ b/docs/replications/mvbbsc.rst
@@ -1,0 +1,86 @@
+.. _replication-mvbbsc:
+
+MVBBSC -- Bayesian Synthetic Control (Martinez & Vives-i-Bastida 2024)
+======================================================================
+
+:Estimator: :doc:`../mvbbsc` -- :class:`mlsynth.MVBBSC`
+:Source: Martinez, I. and Vives-i-Bastida, J. (2024), *"Bayesian and
+   Frequentist Inference for Synthetic Controls,"* arXiv:2206.01779
+   [MVBBSC2024]_.
+:Replication type: cross-validation against the authors' own reference
+   implementation, the ``bsynth`` R package, on the German reunification panel;
+   plus Path A, the German reunification study.
+:Status: verified -- the NumPyro posterior matches the ``bsynth`` (Stan/rstan)
+   posterior to Monte-Carlo error, in both the point estimates and the credible
+   bands.
+
+Validation strategy
+-------------------
+
+Martinez and Vives-i-Bastida (2024) ship their method as the ``bsynth`` R
+package, which fits the model in Stan via ``rstan``. mlsynth's MVBBSC is a
+clean-room port of the method -- the same generative model (uniform-Dirichlet
+simplex weights, ``HalfNormal`` scale, Gaussian likelihood on the
+pre-period-standardized series) sampled with NUTS in NumPyro -- so ``bsynth`` is
+the ground truth. We fit both on the identical panel and compare the posterior
+counterfactual, the ATT, and the credible bands.
+
+The reference is the ``bsynth`` model ``bayesianSynth`` with
+``predictor_match = FALSE`` (outcome-only, no covariates, no Gaussian-process
+term), ``ci_width = 0.95``, and four chains of 1000 warm-up + 1000 draws. The
+mlsynth fit uses the same chain configuration and seed on
+``basedata/german_reunification.csv`` (West Germany treated, 16 OECD donors,
+1960--2003, reunification in 1990).
+
+Cross-validation -- point estimates and bands
+---------------------------------------------
+
+Both samplers agree to Monte-Carlo error:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 46 27 27
+
+   * - Quantity
+     - MVBBSC (NumPyro)
+     - bsynth (rstan)
+   * - pre-1990 in-sample RMSE
+     - 62.2
+     - 62.2
+   * - mean post-1990 ATT
+     - :math:`-2078`
+     - :math:`-2075`
+   * - mean 95% band width, pre-1990
+     - 300.4
+     - 300.9
+   * - mean 95% band width, post-1990
+     - 1162
+     - 1155
+
+Year by year the 95% credible-band widths agree to within a few percent (ratios
+:math:`0.95`--:math:`1.07`), the residual being pure Monte-Carlo error between
+two independent NUTS runs. The band is well calibrated: in-sample coverage of the
+observed West Germany series is :math:`96.7\%` against the nominal :math:`95\%`,
+and it has the right shape -- tight in the pre-period where the donors pin the
+fit (:math:`\sim 300`), fanning out through the post-period as the counterfactual
+extrapolates (to :math:`\sim 2400` by 2003).
+
+Path A -- the reunification result
+----------------------------------
+
+On its own terms MVBBSC recovers the classical reunification finding. The mean
+post-1990 effect near :math:`-2080` PPP-USD per capita is about a :math:`7.5\%`
+decline in West German per-capita GDP -- the magnitude the authors themselves
+report in the text -- with the effect widening after 2000 and a credible band
+that grows with the horizon.
+
+Reproducing
+-----------
+
+The durable case ``benchmarks/cases/mvbbsc_germany.py`` pins the reproducible
+headline quantities of a fresh NumPyro fit (the negative effect near the
+:math:`7.5\%` magnitude, a close pre-period fit, an ordered credible band, and
+converged NUTS). The reference ``bsynth`` numbers were produced with the R script
+under ``benchmarks/R/mvbbsc_bsynth_ref.R`` (install pinned via
+``benchmarks/R/install_bsynth.sh``); because it needs R and rstan it is not run
+in CI, but the script is committed so the cross-check is reproducible.

--- a/llms.txt
+++ b/llms.txt
@@ -55,6 +55,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **MTGP** — Multitask Gaussian Process synthetic control (Ben-Michael et al. 2023).  (config: MTGPConfig)
 - **MULTICELLGEOLIFT** — Multi-cell GeoLift: measure several treatment cells at once.
 - **MUSC** — Modified Unbiased Synthetic Control estimator.  (config: MUSCConfig)
+- **MVBBSC** — Bayesian synthetic control of Martinez & Vives-i-Bastida (2024).  (config: MVBBSCConfig)
 - **MicroSynth** — User-level balancing synthetic control estimator.  (config: MicroSynthConfig)
 - **NSC** — Nonlinear Synthetic Control (Tian 2023) estimator.  (config: NSCConfig)
 - **ORTHSC** — Orthogonalized Synthetic Control estimator.

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -58,6 +58,7 @@ from .estimators.sbc import SBC
 from .estimators.bvss import BVSS
 from .estimators.bscm import BSCM
 from .estimators.bfsc import BFSC
+from .estimators.mvbbsc import MVBBSC
 from .estimators.mtgp import MTGP
 from .estimators.bpscs import BPSCS
 from .estimators.mlsc import MLSC
@@ -135,7 +136,7 @@ __all__ = [
     "SPCD",
     "TASC",
     "CMBSTS",
-    "SBC", "BVSS", "BSCM", "BFSC", "MTGP", "BPSCS",
+    "SBC", "BVSS", "BSCM", "BFSC", "MVBBSC", "MTGP", "BPSCS",
     "MLSC",
     "MSQRT",
     "SSC",

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -576,6 +576,7 @@ _RELOCATED_CONFIGS = {
     "BVSSConfig": "mlsynth.utils.bvss_helpers.config",
     "BSCMConfig": "mlsynth.utils.bscm_helpers.config",
     "BFSCConfig": "mlsynth.utils.bfsc_helpers.config",
+    "MVBBSCConfig": "mlsynth.utils.mvbbsc_helpers.config",
     "MTGPConfig": "mlsynth.utils.mtgp_helpers.config",
     "BPSCSConfig": "mlsynth.utils.bpscs_helpers.config",
     "SPCDConfig": "mlsynth.utils.spcd_helpers.config",

--- a/mlsynth/estimators/mvbbsc.py
+++ b/mlsynth/estimators/mvbbsc.py
@@ -1,0 +1,153 @@
+"""Bayesian synthetic control of Martinez & Vives-i-Bastida (MVBBSC).
+
+Implements:
+
+    Martinez, I. & Vives-i-Bastida, J. (2024). "Bayesian and Frequentist
+    Inference for Synthetic Controls." arXiv:2206.01779.
+
+MVBBSC models the treated unit's no-intervention outcome as a simplex-weighted
+average of the donor pool with a uniform Dirichlet prior on the weights, a
+``HalfNormal`` idiosyncratic scale, and a Gaussian likelihood on the
+pre-treatment window. Both the treated and donor series are standardized by
+their pre-period moments before fitting and the counterfactual is transformed
+back to the outcome scale, so the fit is invariant to the units of the outcome.
+The posterior is drawn with NUTS (NumPyro); the counterfactual is the
+posterior-predictive draw of the untreated outcome, giving a full credible band
+and an ATT credible interval. MVBBSC therefore needs the ``[bayes]`` optional
+dependency.
+
+See ``mlsynth.utils.mvbbsc_helpers`` for the algorithmic pieces.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from pydantic import ValidationError
+
+from ..config_models import MVBBSCConfig
+from ..exceptions import (
+    MlsynthConfigError,
+    MlsynthDataError,
+    MlsynthEstimationError,
+    MlsynthPlottingError,
+)
+from ..utils.datautils import balance
+from ..utils.mvbbsc_helpers.model import run_mvbbsc
+from ..utils.mvbbsc_helpers.plotter import plot_mvbbsc
+from ..utils.mvbbsc_helpers.setup import prepare_mvbbsc_inputs
+from ..utils.mvbbsc_helpers.structures import (
+    MVBBSCInference,
+    MVBBSCPosterior,
+    MVBBSCResults,
+)
+
+
+class MVBBSC:
+    """Bayesian synthetic control of Martinez & Vives-i-Bastida (2024).
+
+    Parameters
+    ----------
+    config : MVBBSCConfig or dict
+        Configuration object. See :class:`mlsynth.config_models.MVBBSCConfig`.
+
+    Returns
+    -------
+    MVBBSCResults
+        Posterior counterfactual with a credible band, the ATT posterior mean +
+        credible interval, the posterior-mean simplex donor weights, and NUTS
+        diagnostics. Requires ``mlsynth[bayes]``.
+    """
+
+    def __init__(self, config: Union[MVBBSCConfig, dict]) -> None:
+        if isinstance(config, dict):
+            try:
+                config = MVBBSCConfig(**config)
+            except ValidationError as exc:
+                raise MlsynthConfigError(
+                    f"Invalid MVBBSC configuration: {exc}"
+                ) from exc
+        self.config: MVBBSCConfig = config
+        self.df: pd.DataFrame = config.df
+        self.outcome: str = config.outcome
+        self.unitid: str = config.unitid
+        self.time: str = config.time
+        self.treat: str = config.treat
+        self.display_graphs: bool = config.display_graphs
+
+    def fit(self) -> MVBBSCResults:
+        """Run the MVBBSC NUTS sampler and assemble results."""
+        try:
+            balance(self.df, self.unitid, self.time)
+        except MlsynthDataError:  # pragma: no cover - defensive passthrough
+            raise
+        except Exception as exc:  # pragma: no cover - defensive translation
+            raise MlsynthDataError(f"Error balancing panel data: {exc}") from exc
+
+        try:
+            inputs = prepare_mvbbsc_inputs(
+                df=self.df, outcome=self.outcome, unitid=self.unitid,
+                time=self.time, treat=self.treat)
+        except (MlsynthDataError, MlsynthConfigError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive translation
+            raise MlsynthDataError(f"Error preparing MVBBSC inputs: {exc}") from exc
+
+        cfg = self.config
+        try:
+            draws = run_mvbbsc(
+                inputs.y_target, inputs.X_all, inputs.T0,
+                n_warmup=cfg.n_warmup, n_samples=cfg.n_samples,
+                n_chains=cfg.n_chains, target_accept=cfg.target_accept,
+                seed=cfg.seed, progress=cfg.verbose)
+        except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive translation
+            raise MlsynthEstimationError(f"MVBBSC estimation failed: {exc}") from exc
+
+        cf = np.asarray(draws["counterfactual"], dtype=float)   # (n_draws, T)
+        a = cfg.ci_alpha
+        cf_mean = cf.mean(0)
+        cf_lo = np.percentile(cf, 100 * a / 2, axis=0)
+        cf_hi = np.percentile(cf, 100 * (1 - a / 2), axis=0)
+
+        y_obs = np.asarray(inputs.y_target, dtype=float)
+        T0, T = inputs.T0, inputs.T
+        if T0 < T:
+            att_samples = (y_obs[None, T0:] - cf[:, T0:]).mean(axis=1)
+            att_mean = float(att_samples.mean())
+            att_lo = float(np.percentile(att_samples, 100 * a / 2))
+            att_hi = float(np.percentile(att_samples, 100 * (1 - a / 2)))
+        else:  # pragma: no cover - dataprep guarantees a post window here
+            att_samples = np.array([])
+            att_mean = att_lo = att_hi = float("nan")
+
+        inference = MVBBSCInference(
+            counterfactual_mean=cf_mean, counterfactual_lower=cf_lo,
+            counterfactual_upper=cf_hi, att_mean=att_mean,
+            att_lower=att_lo, att_upper=att_hi, att_samples=att_samples,
+            ci_alpha=a)
+
+        W = np.asarray(draws["weights"], dtype=float)           # (n_draws, N)
+        weight_means = {
+            str(inputs.donor_names[i]): float(W[:, i].mean())
+            for i in range(inputs.N)
+        }
+        posterior = MVBBSCPosterior(
+            counterfactual=cf, weights=W,
+            sigma=np.asarray(draws["sigma"], dtype=float),
+            n_draws=cf.shape[0], accept_prob=float(draws["accept_prob"]),
+            n_divergent=int(draws["n_divergent"]),
+            max_rhat=float(draws["max_rhat"]))
+
+        results = MVBBSCResults(inputs=inputs, posterior=posterior,
+                                inference_detail=inference,
+                                weight_means=weight_means)
+        if self.display_graphs:
+            try:
+                plot_mvbbsc(results)
+            except Exception as exc:  # pragma: no cover - defensive translation
+                raise MlsynthPlottingError(f"MVBBSC plotting failed: {exc}") from exc
+        return results

--- a/mlsynth/guides/llms.txt
+++ b/mlsynth/guides/llms.txt
@@ -55,6 +55,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **MTGP** — Multitask Gaussian Process synthetic control (Ben-Michael et al. 2023).  (config: MTGPConfig)
 - **MULTICELLGEOLIFT** — Multi-cell GeoLift: measure several treatment cells at once.
 - **MUSC** — Modified Unbiased Synthetic Control estimator.  (config: MUSCConfig)
+- **MVBBSC** — Bayesian synthetic control of Martinez & Vives-i-Bastida (2024).  (config: MVBBSCConfig)
 - **MicroSynth** — User-level balancing synthetic control estimator.  (config: MicroSynthConfig)
 - **NSC** — Nonlinear Synthetic Control (Tian 2023) estimator.  (config: NSCConfig)
 - **ORTHSC** — Orthogonalized Synthetic Control estimator.

--- a/mlsynth/tests/test_mvbbsc.py
+++ b/mlsynth/tests/test_mvbbsc.py
@@ -1,0 +1,210 @@
+"""Tests for MVBBSC -- Martinez & Vives-i-Bastida (2024) Bayesian synthetic control.
+
+Written test-first. The model is the outcome-only Bayesian SC of Martinez &
+Vives-i-Bastida (arXiv:2206.01779): uniform-Dirichlet simplex weights, a
+``HalfNormal`` idiosyncratic scale, a Gaussian likelihood on the pre-period,
+and pre-period standardization of the treated and donor series. NUTS is run
+tiny (few warmup/samples) so the suite stays fast; the durable Germany
+cross-check vs the ``bsynth`` reference package lives in
+``benchmarks/cases/mvbbsc_germany.py``.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import MVBBSC
+from mlsynth.config_models import EffectResult, MVBBSCConfig
+from mlsynth.exceptions import MlsynthEstimationError
+
+
+# --------------------------------------------------------------------------- #
+# panels
+# --------------------------------------------------------------------------- #
+def _hull_panel(n_units=8, T=24, T0=16, effect=-4.0, seed=0):
+    """Panel where the treated unit is a convex combination of two donors.
+
+    Because the treated series lives inside the donor convex hull, the
+    simplex-constrained B-MV weights can track it well in the pre-period.
+    Unit 0 is treated with a constant post-treatment effect.
+    """
+    rng = np.random.default_rng(seed)
+    f1 = 100.0 + np.cumsum(rng.standard_normal(T))
+    f2 = 120.0 + np.cumsum(rng.standard_normal(T))
+    donors = []
+    for i in range(n_units - 1):
+        a = rng.uniform(0.2, 1.0)
+        donors.append(a * f1 + (1 - a) * f2 + rng.standard_normal(T) * 0.4)
+    # treated = 0.6 * donor0 + 0.4 * donor1 (inside the hull) + tiny noise
+    treated = 0.6 * donors[0] + 0.4 * donors[1] + rng.standard_normal(T) * 0.3
+    treated = treated.copy()
+    treated[T0:] += effect
+
+    rows = []
+    for t in range(T):
+        rows.append({"unit": "u00", "t": t, "y": float(treated[t]),
+                     "treat": int(t >= T0)})
+    for i, d in enumerate(donors):
+        for t in range(T):
+            rows.append({"unit": f"d{i:02d}", "t": t, "y": float(d[t]),
+                         "treat": 0})
+    return pd.DataFrame(rows)
+
+
+_FAST = dict(n_warmup=80, n_samples=80, n_chains=1, seed=0, display_graphs=False)
+
+
+def _cfg(df=None, **kw):
+    if df is None:
+        df = _hull_panel()
+    base = dict(df=df, outcome="y", treat="treat", unitid="unit", time="t")
+    base.update(kw)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# config
+# --------------------------------------------------------------------------- #
+def test_config_defaults():
+    cfg = MVBBSCConfig(**_cfg())
+    assert cfg.n_warmup >= 1 and cfg.n_samples >= 1 and cfg.n_chains >= 1
+    assert 0.0 < cfg.ci_alpha < 1.0
+
+
+@pytest.mark.parametrize("bad", [
+    {"n_warmup": 0}, {"n_samples": 0}, {"n_chains": 0},
+    {"ci_alpha": 0.0}, {"ci_alpha": 1.0},
+])
+def test_config_rejects_bad(bad):
+    with pytest.raises(Exception):
+        MVBBSCConfig(**_cfg(**bad))
+
+
+def test_config_rejects_extra_field():
+    with pytest.raises(Exception):
+        MVBBSCConfig(**_cfg(not_a_field=1))
+
+
+def test_config_rejects_too_few_draws():
+    """A single posterior draw (n_samples * n_chains < 2) is rejected."""
+    from mlsynth.exceptions import MlsynthConfigError
+    with pytest.raises(MlsynthConfigError):
+        MVBBSCConfig(**_cfg(n_samples=1, n_chains=1))
+
+
+# --------------------------------------------------------------------------- #
+# smoke + contract
+# --------------------------------------------------------------------------- #
+def test_smoke_returns_effect_result():
+    pytest.importorskip("numpyro")
+    res = MVBBSC(_cfg(**_FAST)).fit()
+    assert isinstance(res, EffectResult)
+    T = res.time_series.time_periods.shape[0]
+    assert res.time_series.counterfactual_outcome.shape == (T,)
+    assert res.time_series.estimated_gap.shape == (T,)
+    assert np.isfinite(res.att)
+    lo, hi = res.inference.ci_lower, res.inference.ci_upper
+    assert lo is not None and hi is not None and lo <= hi
+
+
+def test_weights_are_a_simplex():
+    pytest.importorskip("numpyro")
+    res = MVBBSC(_cfg(**_FAST)).fit()
+    w = np.array(list(res.weights.donor_weights.values()))
+    assert np.all(w >= -1e-8)                       # non-negative
+    assert abs(w.sum() - 1.0) < 1e-6                # sums to one
+
+
+def test_recovers_effect_sign_and_covers_truth():
+    pytest.importorskip("numpyro")
+    slow = {**_FAST, "n_warmup": 200, "n_samples": 300}
+    res = MVBBSC(_cfg(df=_hull_panel(effect=-4.0), **slow)).fit()
+    assert res.att < 0.0                            # correct sign
+    null = MVBBSC(_cfg(df=_hull_panel(effect=0.0), **slow)).fit()
+    assert abs(null.att) < abs(res.att)
+
+
+def test_multichain_reports_rhat():
+    """Two chains populate the split-R-hat convergence diagnostic."""
+    pytest.importorskip("numpyro")
+    import os
+    os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=2")
+    res = MVBBSC(_cfg(**{**_FAST, "n_chains": 2})).fit()
+    max_rhat = res.weights.summary_stats["max_rhat"]
+    assert np.isfinite(max_rhat) and max_rhat > 0.0
+
+
+def test_multi_cohort_raises():
+    """A panel with a second treated cohort is rejected in setup."""
+    from mlsynth.exceptions import MlsynthDataError
+    df = _hull_panel()
+    # inject a second treated cohort adopting at a different time
+    df.loc[(df["unit"] == "d00") & (df["t"] >= 10), "treat"] = 1
+    with pytest.raises(MlsynthDataError):
+        MVBBSC(_cfg(df=df, **_FAST)).fit()
+
+
+def test_pre_period_fit_is_reasonable():
+    pytest.importorskip("numpyro")
+    res = MVBBSC(_cfg(**_FAST)).fit()
+    gap = res.time_series.estimated_gap
+    T0 = int(np.where(res.time_series.time_periods
+                      == res.time_series.intervention_time)[0][0])
+    pre_rmse = float(np.sqrt(np.mean(gap[:T0] ** 2)))
+    assert pre_rmse < 5.0                           # tracks the pre-period
+
+
+def test_scale_invariance_of_weights():
+    """B-MV standardizes internally, so rescaling every series leaves the
+    posterior weights unchanged and scales the ATT by the same factor."""
+    pytest.importorskip("numpyro")
+    df = _hull_panel()
+    res1 = MVBBSC(_cfg(df=df, **_FAST)).fit()
+    df2 = df.copy()
+    df2["y"] = df2["y"] * 1000.0
+    res2 = MVBBSC(_cfg(df=df2, **_FAST)).fit()
+    w1 = np.array(list(res1.weights.donor_weights.values()))
+    w2 = np.array(list(res2.weights.donor_weights.values()))
+    assert np.allclose(w1, w2, atol=1e-6)
+    assert res2.att == pytest.approx(res1.att * 1000.0, rel=1e-5)
+
+
+# --------------------------------------------------------------------------- #
+# plotting + failure paths
+# --------------------------------------------------------------------------- #
+def test_plotting_smoke(monkeypatch):
+    pytest.importorskip("numpyro")
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    monkeypatch.setattr(plt, "show", lambda *a, **k: None)
+    res = MVBBSC(_cfg(**{**_FAST, "display_graphs": True})).fit()
+    assert res is not None
+
+
+def test_invalid_config_dict_raises():
+    """A bad dict config is translated to MlsynthConfigError at construction."""
+    from mlsynth.exceptions import MlsynthConfigError
+    with pytest.raises(MlsynthConfigError):
+        MVBBSC(_cfg(ci_alpha=2.0))
+
+
+def test_too_few_pre_periods_raises():
+    """A panel with a single pre-period fails in setup with MlsynthDataError."""
+    from mlsynth.exceptions import MlsynthDataError
+    # treatment starts at t=1, leaving only one pre-period.
+    df = _hull_panel(T=6, T0=1)
+    with pytest.raises(MlsynthDataError):
+        MVBBSC(_cfg(df=df, **_FAST)).fit()
+
+
+def test_missing_numpyro_raises(monkeypatch):
+    """When the backend import fails, fit raises a translated error."""
+    from mlsynth.utils.mvbbsc_helpers import model as mvbbsc_model
+
+    def _boom():
+        raise ImportError("no numpyro")
+    monkeypatch.setattr(mvbbsc_model, "_import_backend", _boom)
+    with pytest.raises(MlsynthEstimationError):
+        MVBBSC(_cfg(**_FAST)).fit()

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -29,7 +29,7 @@ _HAS_NUMPYRO = importlib.util.find_spec("numpyro") is not None
 
 from mlsynth import (
     BFSC, BPSCS, BSCM, BVSS, CFM, CLUSTERSC, CSCIPCA, DPSC, DSCAR, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC, MEDSC,
-    MCNNM, MSQRT, MTGP, NSC, PDA, PROPSC, PROXIMAL, RESCM, RMSI, SBC, SCMO, SCUL, SDID,
+    MCNNM, MSQRT, MTGP, MVBBSC, NSC, PDA, PROPSC, PROXIMAL, RESCM, RMSI, SBC, SCMO, SCUL, SDID,
     SequentialSDID, SHC, SNN, SparseSC, SPILLSYNTH, SPOTSYNTH, SSC, TASC, TSSC,
     VanillaSC,
 )
@@ -195,6 +195,10 @@ if _HAS_NUMPYRO:  # BFSC/MTGP need the ``[bayes]`` extra; skip the params withou
     OBSERVATIONAL.append(
         pytest.param(MTGP, {"n_factors": 2, "n_warmup": 50, "n_samples": 50,
                             "n_chains": 1, "seed": 0}, id="MTGP")
+    )
+    OBSERVATIONAL.append(
+        pytest.param(MVBBSC, {"n_warmup": 50, "n_samples": 50,
+                              "n_chains": 1, "seed": 0}, id="MVBBSC")
     )
     OBSERVATIONAL.append(
         pytest.param(BPSCS, {"covariates": ["cov1"], "coords": ["lat", "lon"],

--- a/mlsynth/utils/mvbbsc_helpers/__init__.py
+++ b/mlsynth/utils/mvbbsc_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helper subpackage for the MVBBSC estimator (Martinez & Vives-i-Bastida 2024)."""

--- a/mlsynth/utils/mvbbsc_helpers/config.py
+++ b/mlsynth/utils/mvbbsc_helpers/config.py
@@ -1,0 +1,75 @@
+"""Configuration for the MVBBSC estimator.
+
+Co-located with the helper package; re-exported from
+:mod:`mlsynth.config_models` for backward compatibility.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import Field, model_validator
+
+from ...config_models import BaseEstimatorConfig
+from ...exceptions import MlsynthConfigError
+
+
+class MVBBSCConfig(BaseEstimatorConfig):
+    """Configuration for the Martinez--Vives-i-Bastida Bayesian synthetic control.
+
+    Implements the outcome-only Bayesian synthetic control of
+
+        Martinez, I. & Vives-i-Bastida, J. (2024). "Bayesian and Frequentist
+        Inference for Synthetic Controls." arXiv:2206.01779.
+
+    The no-intervention outcome of the treated unit is modelled as a
+    simplex-weighted average of the donor pool with a uniform Dirichlet prior on
+    the weights (``w ~ Dir(1)``), a ``HalfNormal`` idiosyncratic scale
+    (``sigma``), and a Gaussian likelihood on the pre-treatment window. Both the
+    treated and donor series are standardized by their pre-period mean and
+    standard deviation before fitting and the counterfactual is transformed
+    back to the outcome scale, so the fit is invariant to the units of the
+    outcome. The posterior is drawn with NUTS (NumPyro) and the counterfactual
+    is the posterior-predictive draw of the treated outcome in absence of
+    treatment, giving a full credible band and an ATT credible interval. This
+    estimator therefore requires the ``[bayes]`` optional dependency
+    (``pip install mlsynth[bayes]``).
+
+    Parameters
+    ----------
+    n_warmup : int
+        NUTS warm-up (adaptation) iterations per chain.
+    n_samples : int
+        Retained NUTS samples per chain.
+    n_chains : int
+        Number of NUTS chains.
+    target_accept : float
+        NUTS target acceptance probability.
+    ci_alpha : float
+        Two-sided level for the credible interval (0.05 -> 95% band).
+    seed : int
+        PRNG seed (makes a fit reproducible, including the posterior-predictive
+        draw used for the bands).
+    display_graphs : bool
+        Plot the observed-vs-counterfactual path with the credible band.
+    verbose : bool
+        Show the NUTS progress bar.
+    """
+
+    n_warmup: int = Field(default=1000, ge=1)
+    n_samples: int = Field(default=1000, ge=1)
+    n_chains: int = Field(default=4, ge=1)
+    target_accept: float = Field(default=0.8, gt=0.0, lt=1.0)
+    ci_alpha: float = Field(default=0.05, gt=0.0, lt=1.0)
+    seed: int = Field(default=0)
+    display_graphs: bool = Field(default=False)
+    verbose: bool = Field(default=False)
+
+    @model_validator(mode="after")
+    def _check(self) -> "MVBBSCConfig":
+        if self.n_samples * self.n_chains < 2:
+            raise MlsynthConfigError(
+                "MVBBSC needs at least two posterior draws "
+                "(n_samples * n_chains >= 2)."
+            )
+        return self

--- a/mlsynth/utils/mvbbsc_helpers/model.py
+++ b/mlsynth/utils/mvbbsc_helpers/model.py
@@ -1,0 +1,154 @@
+"""NUTS (NumPyro) sampler for MVBBSC -- Martinez & Vives-i-Bastida (2024).
+
+The model is the outcome-only Bayesian synthetic control of arXiv:2206.01779
+(the ``bsynth`` package's ``model1`` with ``predictor_match = FALSE``):
+
+    w      ~ Dirichlet(1_N)                 # uniform prior over the simplex
+    sigma  ~ HalfNormal(1)
+    y_z    ~ Normal(X_z w, sigma)           # Gaussian likelihood, pre-period
+
+Both the treated series ``y`` and the donor matrix ``X`` are standardized by
+their pre-period mean and standard deviation (``ddof = 1``, matching the
+reference ``sd()``) before fitting, and the counterfactual is transformed back
+to the outcome scale. The counterfactual returned here is the posterior
+predictive draw of the treated outcome in absence of treatment -- the
+noiseless mean ``X_z w`` plus an idiosyncratic ``Normal(0, sigma)`` shock, as in
+the reference ``generated quantities`` block -- so its pointwise quantiles are a
+credible band. Cross-validated against the ``bsynth`` R package on the German
+reunification panel (see ``benchmarks/cases/mvbbsc_germany.py``).
+
+The NumPyro / JAX import is isolated in :func:`_import_backend` so a missing
+``[bayes]`` optional dependency degrades to a translated error (and so tests can
+exercise that path).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import numpy as np
+
+from ...exceptions import MlsynthEstimationError
+
+
+def _import_backend():  # pragma: no cover - trivial import shim (monkeypatched in tests)
+    os.environ.setdefault("JAX_PLATFORMS", "cpu")
+    import jax
+    import jax.numpy as jnp
+    import numpyro
+    import numpyro.distributions as dist
+    from numpyro.infer import MCMC, NUTS
+    import numpyro.diagnostics as diagnostics
+    return jax, jnp, numpyro, dist, MCMC, NUTS, diagnostics
+
+
+def run_mvbbsc(
+    y: np.ndarray,
+    X: np.ndarray,
+    T0: int,
+    *,
+    n_warmup: int,
+    n_samples: int,
+    n_chains: int,
+    target_accept: float,
+    seed: int,
+    progress: bool = False,
+) -> Dict[str, Any]:
+    """Sample the MVBBSC posterior; return counterfactual and weight draws.
+
+    Parameters
+    ----------
+    y : np.ndarray, shape (T,)
+        Treated outcome over all periods.
+    X : np.ndarray, shape (T, N)
+        Donor matrix over all periods.
+    T0 : int
+        Number of pre-treatment periods.
+    n_warmup, n_samples, n_chains, target_accept, seed : see config.
+    progress : bool
+        Show the NUTS progress bar.
+
+    Returns
+    -------
+    dict with ``counterfactual`` ((n_draws, T) posterior-predictive draws on the
+    outcome scale), ``weights`` ((n_draws, N) simplex draws), ``sigma``
+    ((n_draws,) standardized scale), ``accept_prob``, ``n_divergent``,
+    ``max_rhat``.
+    """
+    try:
+        jax, jnp, numpyro, dist, MCMC, NUTS, diagnostics = _import_backend()
+    except ImportError as exc:
+        raise MlsynthEstimationError(
+            "MVBBSC requires NumPyro (pip install 'mlsynth[bayes]')."
+        ) from exc
+    except Exception as exc:  # pragma: no cover - unexpected backend failure
+        raise MlsynthEstimationError(
+            f"MVBBSC backend import failed: {exc}"
+        ) from exc
+
+    y = np.asarray(y, dtype=float)
+    X = np.asarray(X, dtype=float)
+    T, N = X.shape
+
+    # Standardize by pre-period moments (ddof=1 to match the reference sd()).
+    my = float(y[:T0].mean())
+    sy = float(y[:T0].std(ddof=1))
+    sy = sy if sy > 0 else 1.0
+    mX = X[:T0].mean(axis=0)
+    sX = X[:T0].std(axis=0, ddof=1)
+    sX = np.where(sX > 0, sX, 1.0)
+
+    yz_pre = (y[:T0] - my) / sy
+    Xz_pre = (X[:T0] - mX) / sX
+    Xz_all = (X - mX) / sX
+
+    Xz_pre_j = jnp.asarray(Xz_pre)
+    yz_pre_j = jnp.asarray(yz_pre)
+
+    def model():
+        w = numpyro.sample("w", dist.Dirichlet(jnp.ones(N)))
+        sigma = numpyro.sample("sigma", dist.HalfNormal(1.0))
+        numpyro.sample("y", dist.Normal(Xz_pre_j @ w, sigma), obs=yz_pre_j)
+
+    per_chain = max(2, int(np.ceil(n_samples)))
+    mcmc = MCMC(
+        NUTS(model, target_accept_prob=target_accept),
+        num_warmup=n_warmup, num_samples=per_chain, num_chains=n_chains,
+        progress_bar=progress,
+    )
+    mcmc.run(jax.random.PRNGKey(int(seed)),
+             extra_fields=("accept_prob", "diverging"))
+
+    grouped = mcmc.get_samples(group_by_chain=True)
+    w_g = np.asarray(grouped["w"])                 # (chains, per_chain, N)
+    s_g = np.asarray(grouped["sigma"])             # (chains, per_chain)
+    W = w_g.reshape(-1, N)                          # (n_draws, N)
+    S = s_g.reshape(-1)                             # (n_draws,)
+    n_draws = W.shape[0]
+
+    # Posterior-predictive counterfactual (matches the reference normal_rng):
+    # noiseless mean X_z w plus a Normal(0, sigma) shock, then back-transformed.
+    mu_z = W @ Xz_all.T                             # (n_draws, T) standardized mean
+    rng = np.random.default_rng(int(seed))
+    noise = rng.standard_normal((n_draws, T)) * S[:, None]
+    cf = (mu_z + noise) * sy + my                   # (n_draws, T) outcome scale
+
+    extra = mcmc.get_extra_fields()
+    accept = float(np.mean(np.asarray(extra.get("accept_prob", np.nan))))
+    n_div = int(np.sum(np.asarray(extra.get("diverging", 0))))
+    if n_chains >= 2:
+        rhat_w = np.asarray(diagnostics.split_gelman_rubin(w_g))
+        rhat_s = float(diagnostics.split_gelman_rubin(s_g[..., None])[0])
+        max_rhat = float(np.nanmax(np.append(rhat_w, rhat_s)))
+    else:
+        max_rhat = float("nan")
+
+    return {
+        "counterfactual": cf,
+        "weights": W,
+        "sigma": S,
+        "accept_prob": accept,
+        "n_divergent": n_div,
+        "max_rhat": max_rhat,
+    }

--- a/mlsynth/utils/mvbbsc_helpers/plotter.py
+++ b/mlsynth/utils/mvbbsc_helpers/plotter.py
@@ -1,0 +1,58 @@
+"""Observed vs counterfactual plot for MVBBSC, with posterior credible band."""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .structures import MVBBSCResults
+
+
+def plot_mvbbsc(results: MVBBSCResults, title: str | None = None) -> None:
+    """Plot observed series, MVBBSC counterfactual, and pointwise credible band.
+
+    One solid black series for the observed outcome, a dashed blue
+    posterior-mean counterfactual, a shaded credible band, and a vertical line
+    at ``T_0``.
+    """
+
+    inputs = results.inputs
+    inference = results.inference_detail
+
+    time = inputs.time_labels
+    T0 = inputs.T0
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    ax.plot(
+        time, inputs.y_target,
+        color="black", linewidth=2, label=f"Observed: {inputs.treated_unit_name}",
+    )
+    ax.plot(
+        time, inference.counterfactual_mean,
+        color="tab:blue", linestyle="--", linewidth=1.8,
+        label="MVBBSC counterfactual",
+    )
+    ax.fill_between(
+        time,
+        inference.counterfactual_lower,
+        inference.counterfactual_upper,
+        color="tab:blue", alpha=0.2,
+        label=f"{int(round((1 - inference.ci_alpha) * 100))}% credible interval",
+    )
+    if T0 < len(time):
+        ax.axvline(x=time[T0], color="red", linestyle=":", label="Treatment start")
+
+    if title is None:
+        att_str = ("" if np.isnan(inference.att_mean)
+                   else f", ATT={inference.att_mean:.3f}")
+        title = f"MVBBSC counterfactual: {inputs.treated_unit_name}{att_str}"
+    ax.set_title(title, loc="left", fontsize=10)
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Outcome")
+    ax.legend(loc="best", frameon=True, fontsize=9)
+    ax.grid(alpha=0.25)
+
+    plt.tight_layout()
+    plt.show()
+    plt.close(fig)

--- a/mlsynth/utils/mvbbsc_helpers/setup.py
+++ b/mlsynth/utils/mvbbsc_helpers/setup.py
@@ -1,0 +1,75 @@
+"""Data preparation for MVBBSC.
+
+Wraps :func:`mlsynth.utils.datautils.dataprep`. The sampler standardizes the
+treated and donor series internally by their pre-period moments, so the donor
+blocks are passed through here on their original scale.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from ...exceptions import MlsynthDataError
+from ..datautils import dataprep
+from .structures import MVBBSCInputs
+
+
+def prepare_mvbbsc_inputs(
+    df: pd.DataFrame,
+    outcome: str,
+    unitid: str,
+    time: str,
+    treat: str,
+) -> MVBBSCInputs:
+    """Pivot panel data into the arrays the MVBBSC sampler consumes.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Long balanced panel data.
+    outcome, unitid, time, treat : str
+        Column names identifying the outcome, units, time periods, and the
+        binary treatment indicator.
+
+    Returns
+    -------
+    MVBBSCInputs
+    """
+
+    prepared = dataprep(df, unitid, time, outcome, treat)
+    if "cohorts" in prepared:
+        raise MlsynthDataError(
+            "MVBBSC currently supports a single treated unit; the input "
+            "panel appears to contain multiple treatment cohorts."
+        )
+
+    y_target = np.asarray(prepared["y"], dtype=float)
+    donor_matrix_tn = np.asarray(prepared["donor_matrix"], dtype=float)
+    if donor_matrix_tn.ndim != 2:  # pragma: no cover - dataprep guarantees 2D
+        raise MlsynthDataError(
+            "MVBBSC requires a 2D donor matrix; got shape "
+            f"{donor_matrix_tn.shape}."
+        )
+
+    T = int(prepared["total_periods"])
+    T0 = int(prepared["pre_periods"])
+    n_donors = donor_matrix_tn.shape[1]
+
+    if n_donors < 1:  # pragma: no cover - dataprep guarantees >= 1 donor
+        raise MlsynthDataError("MVBBSC requires at least one donor unit.")
+    if T0 < 2:
+        raise MlsynthDataError(
+            "MVBBSC requires at least two pre-treatment periods."
+        )
+
+    return MVBBSCInputs(
+        y_target=y_target,
+        X_all=donor_matrix_tn,
+        T0=T0,
+        T=T,
+        N=n_donors,
+        treated_unit_name=prepared["treated_unit_name"],
+        donor_names=list(prepared["donor_names"]),
+        time_labels=np.asarray(prepared["time_labels"]),
+    )

--- a/mlsynth/utils/mvbbsc_helpers/structures.py
+++ b/mlsynth/utils/mvbbsc_helpers/structures.py
@@ -1,0 +1,166 @@
+"""Typed containers for the MVBBSC estimator (Martinez & Vives-i-Bastida 2024)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+from pydantic import ConfigDict, model_validator
+
+from ...config_models import (
+    BaseEstimatorResults,
+    EffectsResults,
+    FitDiagnosticsResults,
+    InferenceResults,
+    MethodDetailsResults,
+    TimeSeriesResults,
+    WeightsResults,
+)
+
+
+@dataclass(frozen=True)
+class MVBBSCInputs:
+    """Panel arrays fed into the MVBBSC sampler.
+
+    Parameters
+    ----------
+    y_target : np.ndarray
+        Length-``T`` treated outcome over all periods.
+    X_all : np.ndarray
+        Shape ``(T, N)`` donor matrix over all periods.
+    T0 : int
+        Number of pre-treatment periods.
+    T : int
+        Total number of periods.
+    N : int
+        Number of donor units.
+    treated_unit_name : str
+    donor_names : Sequence
+    time_labels : np.ndarray
+    """
+
+    y_target: np.ndarray
+    X_all: np.ndarray
+    T0: int
+    T: int
+    N: int
+    treated_unit_name: str
+    donor_names: Sequence
+    time_labels: np.ndarray
+
+
+@dataclass(frozen=True)
+class MVBBSCPosterior:
+    """Posterior draws relevant to the counterfactual, weights, and diagnostics.
+
+    Parameters
+    ----------
+    counterfactual : np.ndarray
+        Shape ``(n_draws, T)`` posterior-predictive counterfactual draws on the
+        outcome scale (back-transformed from the standardized fit).
+    weights : np.ndarray
+        Shape ``(n_draws, N)`` simplex donor-weight draws.
+    sigma : np.ndarray
+        Length-``n_draws`` idiosyncratic scale (in standardized units).
+    n_draws : int
+    accept_prob : float
+    n_divergent : int
+    max_rhat : float
+    """
+
+    counterfactual: np.ndarray
+    weights: np.ndarray
+    sigma: np.ndarray
+    n_draws: int
+    accept_prob: float
+    n_divergent: int
+    max_rhat: float
+
+
+@dataclass(frozen=True)
+class MVBBSCInference:
+    """Posterior summaries of the counterfactual, ATT, and credible bands."""
+
+    counterfactual_mean: np.ndarray
+    counterfactual_lower: np.ndarray
+    counterfactual_upper: np.ndarray
+    att_mean: float
+    att_lower: float
+    att_upper: float
+    att_samples: np.ndarray
+    ci_alpha: float
+
+
+class MVBBSCResults(BaseEstimatorResults):
+    """Top-level container returned by ``MVBBSC.fit`` (an ``EffectResult``).
+
+    Populates the standardized sub-models so the flat accessors (``att`` /
+    ``att_ci`` / ``counterfactual`` / ``gap`` / ``donor_weights`` /
+    ``pre_rmse``) resolve through the base contract. ``att`` is the posterior
+    mean ATT and ``att_ci`` its credible interval; ``donor_weights`` are the
+    posterior-mean simplex weights. The Bayesian detail -- the posterior draws,
+    the per-draw ATT samples, and the pointwise counterfactual bands -- stays in
+    the typed fields below.
+
+    Parameters
+    ----------
+    inputs : MVBBSCInputs
+    posterior : MVBBSCPosterior
+    inference_detail : MVBBSCInference
+    weight_means : dict
+        ``donor_label -> E[w_i | y]`` posterior-mean simplex weights.
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    inputs: MVBBSCInputs
+    posterior: MVBBSCPosterior
+    inference_detail: MVBBSCInference
+    weight_means: dict
+
+    @model_validator(mode="after")
+    def _populate(self) -> "MVBBSCResults":
+        if self.effects is not None:  # pragma: no cover - idempotency guard
+            return self
+        inf = self.inference_detail
+        labels = np.asarray(self.inputs.time_labels)
+        T0, T = self.inputs.T0, self.inputs.T
+        y_obs = np.asarray(self.inputs.y_target, dtype=float)
+        cf = np.asarray(inf.counterfactual_mean, dtype=float)
+        gap = y_obs - cf
+        pre_rmse = float(np.sqrt(np.mean(gap[:T0] ** 2))) if T0 > 0 else float("nan")
+        att_se = float(np.std(inf.att_samples)) if inf.att_samples.size else None
+
+        object.__setattr__(self, "effects", EffectsResults(
+            att=None if np.isnan(inf.att_mean) else float(inf.att_mean),
+            att_std_err=att_se))
+        object.__setattr__(self, "time_series", TimeSeriesResults(
+            observed_outcome=y_obs,
+            counterfactual_outcome=cf,
+            estimated_gap=gap,
+            time_periods=labels,
+            intervention_time=(labels[T0] if T0 < T else None)))
+        object.__setattr__(self, "weights", WeightsResults(
+            donor_weights={str(k): float(v) for k, v in self.weight_means.items()},
+            summary_stats={
+                "constraint": "Bayesian simplex (uniform Dirichlet), posterior mean",
+                "sigma_post_mean": float(np.mean(self.posterior.sigma)),
+                "nuts_accept_prob": float(self.posterior.accept_prob),
+                "nuts_divergences": int(self.posterior.n_divergent),
+                "max_rhat": float(self.posterior.max_rhat)}))
+        object.__setattr__(self, "fit_diagnostics", FitDiagnosticsResults(
+            rmse_pre=None if np.isnan(pre_rmse) else float(pre_rmse)))
+        object.__setattr__(self, "inference", InferenceResults(
+            standard_error=att_se,
+            ci_lower=None if np.isnan(inf.att_lower) else float(inf.att_lower),
+            ci_upper=None if np.isnan(inf.att_upper) else float(inf.att_upper),
+            confidence_level=float(1.0 - inf.ci_alpha),
+            method="bayesian_posterior",
+            details=inf))
+        object.__setattr__(self, "method_details", MethodDetailsResults(
+            method_name="MVBBSC", is_recommended=True))
+        return self
+
+
+MVBBSCResults.model_rebuild()


### PR DESCRIPTION
## What

Adds `MVBBSC`, a native mlsynth estimator: the outcome-only Bayesian synthetic control of Martinez & Vives-i-Bastida (2024, arXiv:2206.01779) — the `bsynth` package's `model1` with `predictor_match=FALSE`. The untreated outcome is a simplex-weighted average of the donors with a uniform Dirichlet prior on the weights, a HalfNormal scale, and a Gaussian likelihood on the pre-period-standardized series. The posterior is drawn with NUTS (NumPyro) and the counterfactual is the posterior-predictive draw, giving a full credible band and an ATT credible interval. Because the fit happens on standardized data, the estimate is invariant to the units of the outcome. Under the paper's conditions the credible interval is a valid confidence interval (a Bernstein-von Mises result).

## Clean-room / licensing

Ported from the method (uncopyrightable math from the paper), not from `bsynth`'s Apache-2.0 code. `bsynth` is used only as a black-box numerical oracle, matching the repo's existing augsynth/mscmt precedent, so mlsynth stays MIT. Ships zero `bsynth` code.

## Changes

- Config `MVBBSCConfig` (`utils/mvbbsc_helpers/config.py`), re-exported from `config_models`; validators raise `MlsynthConfigError`.
- Helpers `mvbbsc_helpers/{setup,model,structures,plotter}`; `model.py` isolates the NumPyro import so a missing `[bayes]` extra degrades to a translated `MlsynthEstimationError`.
- Estimator `MVBBSC` + export in `__init__`; returns an `EffectResult` with credible bands, posterior-mean simplex weights, and NUTS diagnostics.
- Tests `test_mvbbsc.py` (test-first, 19 tests, 100% coverage of the new modules): smoke/contract, weights-are-a-simplex, effect recovery, scale invariance, multi-chain r-hat, and the multi-cohort / too-few-pre-periods / missing-numpyro failure paths. Registered in the result contract.
- Docs `docs/mvbbsc.rst` + `docs/replications/mvbbsc.rst`; toctrees, `choose.rst`, `bfsc.rst` family blurb, benchmarks index, references.
- Benchmark `benchmarks/cases/mvbbsc_germany.py` (Path A + cross-validation) with the pinned R oracle `benchmarks/R/{install_bsynth.sh,mvbbsc_bsynth_ref.R}`.

## Validation

Cross-validated against `bsynth` on West Germany reunification, to Monte-Carlo error:

| Quantity | MVBBSC (NumPyro) | bsynth (rstan) |
| --- | --- | --- |
| pre-1990 in-sample RMSE | 62.2 | 62.2 |
| mean post-1990 ATT | −2078 | −2075 |
| mean 95% band width, pre-1990 | 300.4 | 300.9 |
| mean 95% band width, post-1990 | 1162 | 1155 |

The 95% credible-band widths agree year-by-year to within a few percent (ratios 0.95–1.07); in-sample coverage of the observed series is 96.7% against the nominal 95%. NUTS converges (max r-hat 1.002, 0 divergences). The ATT of ≈−2078 is a ~7.5% GDP decline, matching the magnitude the authors report in their own text.

## Tests

- `pytest mlsynth/tests/test_mvbbsc.py` — 19 passed, 100% coverage of the new modules.
- `pytest mlsynth/tests/test_result_contract.py` — 162 passed, 4 skipped (`[bayes]`-optional cases).
- `benchmarks/run_benchmarks.py --case mvbbsc_germany` — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwokeUva19jJph7ynKYpq1

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwokeUva19jJph7ynKYpq1)_