### PR TITLE
fix(results): add se/ci convenience accessors to InferenceResults

### DIFF
--- a/docs/replications/sdid.rst
+++ b/docs/replications/sdid.rst
@@ -40,7 +40,7 @@ The panel ships as ``basedata/smoking_data.csv`` with a ready-made
                "outcome": "cigsale", "treat": "treat",
                "unitid": "state", "time": "year",
                "display_graphs": False}).fit()
-   res.inference.att        # -15.605
+   res.att                  # -15.605
 
 mlsynth returns :math:`\widehat{\mathrm{ATT}} = -15.605`, matching the
 AER headline (-15.6) and the ``synthdid`` value (-15.604).

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any, Dict, Union, Literal
+from typing import List, Optional, Any, Dict, Tuple, Union, Literal
 import pandas as pd
 import numpy as np
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -320,6 +320,18 @@ class InferenceResults(BaseModel):
     confidence_level: Optional[float] = Field(default=None, description="Confidence level used for the CI (e.g., 0.95 for 95%).")
     method: Optional[str] = Field(default=None, description="Method used for inference (e.g., 'placebo', 'conformal', 'asymptotic').")
     details: Optional[Any] = Field(default=None, description="More detailed inference results, e.g., full prediction interval arrays for conformal methods.")
+
+    @property
+    def se(self) -> Optional[float]:
+        """Short read-only alias for :attr:`standard_error` (the documented
+        ``res.inference.se`` accessor)."""
+        return self.standard_error
+
+    @property
+    def ci(self) -> Tuple[Optional[float], Optional[float]]:
+        """Read-only ``(lower, upper)`` view of :attr:`ci_lower` /
+        :attr:`ci_upper`, so ``res.inference.ci[0]`` / ``[1]`` resolve."""
+        return (self.ci_lower, self.ci_upper)
 
     class Config:
         arbitrary_types_allowed = True

--- a/mlsynth/estimators/sdid.py
+++ b/mlsynth/estimators/sdid.py
@@ -16,7 +16,7 @@ Proposition 99) and staggered-adoption designs with multiple cohorts.
 Output is a typed :class:`mlsynth.utils.sdid_helpers.structures.SDIDResults`
 object that exposes:
 
-    * ``inference.att`` / ``inference.se`` / ``inference.ci`` / ``inference.p_value``
+    * ``effects.att`` / ``inference.se`` / ``inference.ci`` / ``inference.p_value``
         the overall ATT and its placebo-based inference (Ciccia 2024 Eq. 7);
     * ``event_study.tau`` / ``event_study.se`` / ``event_study.ci`` / ``event_study.event_times``
         the pooled event-study estimator (Ciccia 2024 Eq. 6);
@@ -89,7 +89,7 @@ class SDID:
     ...     "unitid": "state", "time": "year", "B": 200,
     ...     "display_graphs": False,
     ... }).fit()
-    >>> res.inference.att                                                   # doctest: +SKIP
+    >>> res.att                                                             # doctest: +SKIP
     -14.485...
     """
 

--- a/mlsynth/tests/test_inference_accessors.py
+++ b/mlsynth/tests/test_inference_accessors.py
@@ -1,0 +1,55 @@
+"""Convenience accessors on the standardized :class:`InferenceResults`.
+
+The estimator docs advertise short inference accessors -- ``res.inference.se``
+(docs/ppscm.rst) and ``res.inference.ci`` (docs/microsynth.rst) -- but the model
+only stored ``standard_error`` / ``ci_lower`` / ``ci_upper``, so those documented
+examples raised ``AttributeError``. These pin the read-only ``se`` and ``ci``
+views that back the documented surface.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mlsynth.config_models import InferenceResults
+
+
+# -- se: alias of standard_error -------------------------------------------------
+
+def test_se_aliases_standard_error():
+    inf = InferenceResults(standard_error=1.2345)
+    assert inf.se == pytest.approx(1.2345)
+    assert inf.se == inf.standard_error
+
+
+def test_se_none_when_standard_error_unset():
+    # No SE reported -> se is None, never an AttributeError (edge case).
+    assert InferenceResults().se is None
+
+
+def test_se_is_a_view_not_a_stored_field():
+    # `se` must be computed from standard_error, never a separate field that
+    # could drift out of sync.
+    assert "se" not in InferenceResults.model_fields
+    assert InferenceResults(standard_error=0.5).se == 0.5
+
+
+# -- ci: (lower, upper) view -----------------------------------------------------
+
+def test_ci_is_lower_upper_tuple():
+    inf = InferenceResults(ci_lower=-2.0, ci_upper=3.5)
+    assert inf.ci == (-2.0, 3.5)
+    # subscriptable exactly as docs/microsynth.rst uses it: res.inference.ci[0/1]
+    assert inf.ci[0] == -2.0
+    assert inf.ci[1] == 3.5
+
+
+def test_ci_tuple_when_bounds_unset():
+    assert InferenceResults().ci == (None, None)
+
+
+# -- the documented ppscm.rst usage now resolves ---------------------------------
+
+def test_documented_ppscm_line_formats():
+    # docs/ppscm.rst: f"Average ATT : {res.att:.3f}  (SE {res.inference.se:.3f})"
+    inf = InferenceResults(standard_error=0.4210)
+    assert f"SE {inf.se:.3f}" == "SE 0.421"


### PR DESCRIPTION
## What

The estimator docs advertise short inference accessors that don't exist on the standardized `InferenceResults` model, so following the documented examples raises `AttributeError`:

```python
res = PPSCM({...}).fit()
print(f"Average ATT : {res.att:.3f}  (SE {res.inference.se:.3f})")
#                                          ^^^^^^^^^^^^^^^^
# AttributeError: 'InferenceResults' object has no attribute 'se'
```

The value was always populated (PPSCM sets `standard_error`); only the accessor was missing. This adds two read-only properties so the documented surface resolves and can't drift from the underlying fields:

- `se` → `standard_error` (docs/ppscm.rst)
- `ci` → `(ci_lower, ci_upper)` (docs/microsynth.rst, e.g. `res.inference.ci[0]`)

It also corrects three stale references to `res.inference.att`. `att` is an effect, not an inference statistic — it lives on `res.att` / `res.effects.att`, and SDiD's `InferenceResults` never carried it. Fixed in `docs/replications/sdid.rst` and the `sdid.py` docstring/doctest.

## How it was verified (TDD)

- New `mlsynth/tests/test_inference_accessors.py` (smoke / unit / edge) written first, watched fail with the exact `AttributeError`, then green after adding the properties.
- End-to-end on the PPSCM augsynth example (`basedata/Teachingaugsynth.scv`): prints `nu 0.2607, Average ATT -0.011, SE 0.020`, matching the documented output; `res.inference.ci` → `(-0.049, 0.028)`.
- No regressions: `test_result_contract.py` + `test_resultutils.py` → 188 passed, 4 skipped.

Backward-compatible: `standard_error` / `ci_lower` / `ci_upper` are unchanged; `se` / `ci` are computed views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjyUwLsG7PsEDS4emx9dLw)_