### PR TITLE
feat(vanillasc): scpi-style plots for staggered adoption

### DIFF
--- a/mlsynth/tests/test_vanillasc_staggered_plot.py
+++ b/mlsynth/tests/test_vanillasc_staggered_plot.py
@@ -1,0 +1,183 @@
+"""Staggered-adoption VanillaSC honours ``display_graphs`` / ``save``.
+
+The staggered path (``run_vanillasc_staggered``) followed Cattaneo, Feng, Palomba
+and Titiunik but had no plotting, so ``display_graphs=True`` was silently a no-op.
+These pin scpi-``scplotMulti``-style output -- a per-unit ``series`` facet, a
+per-unit ``treatment`` (gap) facet, a per-unit ATT dot plot (``effect="unit"``),
+and the event-time aggregate effect (``effect="time"``) -- rendered through
+mlsynth's ``Plotter``, with prediction-interval bands shaded when SCPI inference
+is requested.
+"""
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")  # headless
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import VanillaSC
+
+
+def _staggered_panel(n=10, T=30, adopt=(("u00", 18), ("u01", 22)), seed=0):
+    """Factor panel with several treated units adopting at different times."""
+    rng = np.random.default_rng(seed)
+    common = np.zeros(T)
+    for t in range(1, T):
+        common[t] = 0.6 * common[t - 1] + rng.standard_normal()
+    Y = np.zeros((T, n))
+    for i in range(n):
+        Y[:, i] = 10 + rng.standard_normal() * common + rng.standard_normal(T) * 0.4
+    adopt_map = dict(adopt)
+    rows = []
+    for i in range(n):
+        name = f"u{i:02d}"
+        for t in range(T):
+            tr = int(name in adopt_map and t >= adopt_map[name])
+            rows.append({"dma": name, "start_date": t,
+                         "total_sales": Y[t, i], "treated": tr})
+    return pd.DataFrame(rows)
+
+
+def _cfg(**extra):
+    base = {"df": _staggered_panel(), "outcome": "total_sales", "treat": "treated",
+            "unitid": "dma", "time": "start_date", "display_graphs": False}
+    base.update(extra)
+    return VanillaSC(base).config
+
+
+@pytest.fixture(scope="module")
+def staggered_fit():
+    df = _staggered_panel()
+    return VanillaSC({"df": df, "outcome": "total_sales", "treat": "treated",
+                      "unitid": "dma", "time": "start_date",
+                      "display_graphs": False}).fit()
+
+
+# ── wiring: the staggered path renders when asked, and not otherwise ──────────
+
+def test_staggered_fit_writes_plot_files(tmp_path):
+    df = _staggered_panel()
+    VanillaSC({"df": df, "outcome": "total_sales", "treat": "treated",
+               "unitid": "dma", "time": "start_date",
+               "display_graphs": False, "save": str(tmp_path / "vsc")}).fit()
+    written = {p.name for p in tmp_path.glob("*.png")}
+    # one file per view (scpi scplotMulti ptype x effect coverage)
+    assert {"vsc_series.png", "vsc_treatment.png",
+            "vsc_att_by_unit.png", "vsc_event_study.png"} <= written
+
+
+def test_no_files_when_save_and_display_false(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    df = _staggered_panel()
+    VanillaSC({"df": df, "outcome": "total_sales", "treat": "treated",
+               "unitid": "dma", "time": "start_date",
+               "display_graphs": False}).fit()
+    assert not list(tmp_path.glob("*.png"))
+
+
+# ── the four scpi views ───────────────────────────────────────────────────────
+
+def _plot(staggered_fit):
+    from mlsynth.utils.vanillasc_helpers.staggered_plotter import plot_staggered
+    return plot_staggered(
+        _cfg(),
+        staggered_fit.sub_method_results,
+        staggered_fit.additional_outputs["event_study"],
+        staggered_fit.additional_outputs.get("event_study_intervals"),
+    )
+
+
+def test_all_four_views_returned(staggered_fit):
+    figs = _plot(staggered_fit)
+    assert len(figs) == 4  # series, treatment, att-by-unit, event-study
+    plt.close("all")
+
+
+def test_series_facets_one_panel_per_unit(staggered_fit):
+    n = len(staggered_fit.sub_method_results)
+    series = _plot(staggered_fit)[0]
+    visible = [ax for ax in series.axes if ax.get_visible()]
+    assert len(visible) == n
+    for ax in visible:
+        assert len(ax.get_lines()) >= 2  # observed + synthetic
+    plt.close("all")
+
+
+def test_treatment_facets_have_gap_and_zero_line(staggered_fit):
+    n = len(staggered_fit.sub_method_results)
+    treatment = _plot(staggered_fit)[1]
+    visible = [ax for ax in treatment.axes if ax.get_visible()]
+    assert len(visible) == n
+    for ax in visible:                       # gap line + a horizontal zero line
+        ys = [tuple(np.round(ln.get_ydata(), 9)) for ln in ax.get_lines()]
+        assert any(set(y) == {0.0} for y in ys), "missing zero reference line"
+    plt.close("all")
+
+
+def test_att_by_unit_has_point_per_unit(staggered_fit):
+    n = len(staggered_fit.sub_method_results)
+    att_fig = _plot(staggered_fit)[2]
+    ax = att_fig.axes[0]
+    assert len(ax.get_yticklabels()) == n
+    plt.close("all")
+
+
+def test_event_study_plots_effect_path(staggered_fit):
+    event = _plot(staggered_fit)[3]
+    assert any(ln.get_ydata().size for ln in event.axes[0].get_lines())
+    plt.close("all")
+
+
+def test_single_unit_facet_degrades_to_one_panel(staggered_fit):
+    from mlsynth.utils.vanillasc_helpers.staggered_plotter import plot_staggered
+    one_name = next(iter(staggered_fit.sub_method_results))
+    one = {one_name: staggered_fit.sub_method_results[one_name]}
+    figs = plot_staggered(_cfg(), one, {1: 0.1, 2: 0.2})
+    assert len([ax for ax in figs[0].axes if ax.get_visible()]) == 1
+    plt.close("all")
+
+
+# ── prediction intervals appear only under SCPI inference ─────────────────────
+
+def test_no_bands_without_inference(staggered_fit):
+    # Default (no inference) -> no shaded PI regions on the series facets.
+    series = _plot(staggered_fit)[0]
+    assert not any(ax.collections for ax in series.axes)
+    plt.close("all")
+
+
+def test_scpi_inference_shades_bands():
+    from mlsynth.utils.vanillasc_helpers.staggered_plotter import plot_staggered
+    df = _staggered_panel(n=8, T=22, adopt=(("u00", 13), ("u01", 16)))
+    est = VanillaSC({"df": df, "outcome": "total_sales", "treat": "treated",
+                     "unitid": "dma", "time": "start_date",
+                     "display_graphs": False, "inference": "scpi",
+                     "scpi_sims": 100})
+    res = est.fit()
+    figs = plot_staggered(est.config,
+                          res.sub_method_results,
+                          res.additional_outputs["event_study"],
+                          res.additional_outputs.get("event_study_intervals"))
+    series, treatment, _att, event = figs
+    # fill_between draws a PolyCollection -> a shaded band per panel
+    assert any(ax.collections for ax in series.axes), "no counterfactual PI band"
+    assert any(ax.collections for ax in treatment.axes), "no gap PI band"
+    assert event.axes[0].collections, "no event-study CI band"
+    plt.close("all")
+
+
+# ── the new Plotter.gap PI band ───────────────────────────────────────────────
+
+def test_plotter_gap_shades_interval_band():
+    from mlsynth.utils.plotting import Plotter
+    t = np.arange(6.0)
+    g = np.array([0.0, 0.1, -0.2, 0.5, 0.8, 1.0])
+    lo, hi = g - 0.3, g + 0.3
+    ax = Plotter().gap(t, g, interval=(lo, hi))
+    assert ax.collections, "gap() did not shade the interval band"
+    # backward compatible: no interval -> no band
+    ax2 = Plotter().gap(t, g)
+    assert not ax2.collections
+    plt.close("all")

--- a/mlsynth/utils/plotting.py
+++ b/mlsynth/utils/plotting.py
@@ -311,6 +311,8 @@ class Plotter:
         gap: np.ndarray,
         *,
         intervention: Optional[Any] = None,
+        interval: Optional[Sequence[np.ndarray]] = None,
+        interval_label: str = "Prediction interval",
         outcome: str = "",
         time: str = "",
         title: str = "Estimated gap",
@@ -321,15 +323,24 @@ class Plotter:
 
         Draws the gap series against a horizontal zero line and an optional
         vertical intervention marker -- the standard companion to the
-        observed-vs-counterfactual panel.
+        observed-vs-counterfactual panel. Pass ``interval`` as a
+        ``(lower, upper)`` pair (each shape ``(T,)``) to shade a prediction
+        interval around the gap; ``NaN`` entries are left unshaded.
         """
         import matplotlib.pyplot as plt
 
         if ax is None:
             _, ax = plt.subplots(figsize=self.figsize)
         times = np.asarray(times)
+        line_color = color or self.counterfactual_colors[0]
+        if interval is not None:
+            lower = np.asarray(interval[0], dtype=float).reshape(-1)
+            upper = np.asarray(interval[1], dtype=float).reshape(-1)
+            ax.fill_between(times, lower, upper, where=~np.isnan(lower),
+                            color=line_color, alpha=0.18, linewidth=0,
+                            label=interval_label)
         ax.plot(times, np.asarray(gap).reshape(-1),
-                color=color or self.counterfactual_colors[0],
+                color=line_color,
                 linewidth=self.counterfactual_linewidth, label="Gap")
         ax.axhline(0.0, color="black", linewidth=0.8)
         if intervention is not None:

--- a/mlsynth/utils/vanillasc_helpers/staggered.py
+++ b/mlsynth/utils/vanillasc_helpers/staggered.py
@@ -387,6 +387,13 @@ def run_vanillasc_staggered(config, prep: Dict[str, Any]) -> BaseEstimatorResult
 
     inference = _aggregate_att_interval(unit_fits, overall_att, config) if do_scpi else None
 
+    # scpi-scplotMulti-style figures (per-unit series facets + event-time
+    # aggregate effect). Honours display_graphs / save like the single-treated
+    # path; a no-op otherwise.
+    if config.display_graphs or config.save:
+        from .staggered_plotter import plot_staggered
+        plot_staggered(config, unit_fits, event_study, event_study_intervals)
+
     return BaseEstimatorResults(
         effects=EffectsResults(
             att=None if np.isnan(overall_att) else overall_att,

--- a/mlsynth/utils/vanillasc_helpers/staggered_plotter.py
+++ b/mlsynth/utils/vanillasc_helpers/staggered_plotter.py
@@ -1,0 +1,182 @@
+"""scpi-``scplotMulti``-style plots for staggered VanillaSC.
+
+Mirrors the conventions of the estimator's cousin, ``nppackages/scpi``
+(``scplotMulti``), for the multi-treated (staggered) case -- rendered through
+mlsynth's matplotlib :class:`~mlsynth.utils.plotting.Plotter` rather than
+plotnine. Four views, covering scpi's ``ptype`` x ``effect`` grid:
+
+* ``series`` facets  -- treated (observed) vs synthetic control, one panel per
+  treated unit with its adoption line (``ptype="series"``, ``effect="unit-time"``);
+* ``treatment`` facets -- the per-period gap with a zero line, one panel per unit
+  (``ptype="treatment"``, ``effect="unit-time"``);
+* a per-unit ATT dot plot -- one point per treated unit, sized by the number of
+  post-periods averaged, ordered like scpi's ``coord_flip`` (``effect="unit"``);
+* the event-time aggregate effect -- mean effect by time-to-treatment with a zero
+  line (``effect="time"``).
+
+When SCPI inference is on (``inference="scpi"``) the per-unit counterfactual and
+gap bands, the per-unit ATT credible intervals, and the event-study band are all
+shaded; otherwise the point views render on their own.
+
+Figures are saved (``config.save``) and/or shown (``config.display_graphs``) with
+the single-treated path's semantics, and returned to the caller.
+"""
+from __future__ import annotations
+
+import math
+from typing import Any, List, Tuple
+
+import numpy as np
+
+from ..plotting import Plotter, mlsynth_style
+
+
+def _save_prefix(save: Any) -> str:
+    """Treat ``config.save`` as a filename prefix (the staggered case emits
+    several figures); strip a trailing ``.png`` if the user supplied one."""
+    if isinstance(save, str) and save:
+        return save[:-4] if save.lower().endswith(".png") else save
+    return "VanillaSC_staggered"
+
+
+def _post_band_full(lower, upper, T: int):
+    """Align a post-treatment-only SCPI band ``(lower, upper)`` to the full length
+    ``T`` time axis, padding the pre-period with ``NaN`` (unshaded), tail-aligned
+    to the post-treatment periods. Returns None if either side is absent."""
+    if lower is None or upper is None:
+        return None
+    lo = np.asarray(lower, dtype=float).reshape(-1)
+    hi = np.asarray(upper, dtype=float).reshape(-1)
+    if lo.size == T:
+        return (lo, hi)
+    full_lo = np.full(T, np.nan)
+    full_hi = np.full(T, np.nan)
+    k = min(lo.size, T)
+    full_lo[T - k:] = lo[-k:]
+    full_hi[T - k:] = hi[-k:]
+    return (full_lo, full_hi)
+
+
+def _facet_grid(n: int):
+    """A (nrows x ncols) subplot grid sized like scpi's ``facet_wrap`` (ncol=3),
+    returning the figure and the flattened axes."""
+    import matplotlib.pyplot as plt
+
+    ncols = min(3, n)
+    nrows = math.ceil(n / ncols)
+    fig, axes = plt.subplots(nrows, ncols, figsize=(ncols * 5.0, nrows * 3.4),
+                             squeeze=False)
+    return fig, axes.ravel()
+
+
+def plot_staggered(config, unit_fits, event_study, event_study_intervals=None) -> List[Any]:
+    """Render the scpi-``scplotMulti``-style figures for a staggered fit.
+
+    Returns the list of matplotlib figures (also saved / shown per ``config``).
+    """
+    import matplotlib.pyplot as plt
+
+    tagged: List[Tuple[Any, str]] = []
+    with mlsynth_style():
+        plotter = Plotter.from_config(getattr(config, "plot", None))
+        n = len(unit_fits)
+
+        # 1) Per-unit series facets (ptype="series", effect="unit-time").
+        if unit_fits:
+            fig, flat = _facet_grid(n)
+            for ax, (name, uf) in zip(flat, unit_fits.items()):
+                plotter.observed_vs_counterfactual(
+                    times=uf.time_labels, observed=uf.observed,
+                    counterfactuals=[uf.counterfactual],
+                    labels=["Synthetic Control"], treated_label=name,
+                    intervention=uf.adoption_time,
+                    interval=_post_band_full(uf.cf_lower, uf.cf_upper, len(uf.observed)),
+                    outcome=config.outcome, time=config.time,
+                    title=str(name), ax=ax)
+            for ax in flat[n:]:
+                ax.set_visible(False)
+            fig.suptitle("VanillaSC (staggered): treated vs. synthetic control")
+            fig.tight_layout(rect=(0, 0, 1, 0.97))
+            tagged.append((fig, "series"))
+
+        # 2) Per-unit treatment (gap) facets (ptype="treatment", effect="unit-time").
+        if unit_fits:
+            fig, flat = _facet_grid(n)
+            for ax, (name, uf) in zip(flat, unit_fits.items()):
+                plotter.gap(
+                    times=uf.time_labels, gap=uf.gap,
+                    intervention=uf.adoption_time,
+                    interval=_post_band_full(uf.tau_lower, uf.tau_upper, len(uf.gap)),
+                    outcome=f"Effect on {config.outcome}", time=config.time,
+                    title=str(name), ax=ax)
+            for ax in flat[n:]:
+                ax.set_visible(False)
+            fig.suptitle("VanillaSC (staggered): per-period treatment effect")
+            fig.tight_layout(rect=(0, 0, 1, 0.97))
+            tagged.append((fig, "treatment"))
+
+        # 3) Per-unit ATT dot plot (effect="unit"): one point per unit, sized by
+        #    the number of post-periods averaged, with the credible interval when
+        #    SCPI inference ran. scpi flips the axes (coord_flip) -> horizontal.
+        if unit_fits:
+            names = list(unit_fits)
+            atts = np.asarray([unit_fits[k].att for k in names], float)
+            posts = np.asarray([max(unit_fits[k].post_periods, 1) for k in names], float)
+            ypos = np.arange(len(names))
+            fig, ax = plt.subplots(figsize=(6.5, 0.6 * len(names) + 1.6))
+            has_ci = any(np.isfinite(unit_fits[k].att_ci_lower) for k in names)
+            if has_ci:
+                lo = np.clip(atts - np.asarray([unit_fits[k].att_ci_lower for k in names], float), 0, None)
+                hi = np.clip(np.asarray([unit_fits[k].att_ci_upper for k in names], float) - atts, 0, None)
+                ax.errorbar(atts, ypos, xerr=np.vstack([lo, hi]), fmt="o",
+                            color=plotter.counterfactual_colors[0], capsize=3,
+                            markersize=5, label="ATT (95% PI)")
+            else:
+                ax.scatter(atts, ypos, s=20 + 6 * posts,
+                           color=plotter.counterfactual_colors[0], label="ATT")
+            ax.axvline(0.0, color="black", linestyle="--", linewidth=0.9)
+            ax.set_yticks(ypos)
+            ax.set_yticklabels(names)
+            ax.set_xlabel(f"ATT on {config.outcome}")
+            ax.set_ylabel(config.unitid)
+            ax.set_title("VanillaSC (staggered): treatment effect by unit")
+            ax.legend()
+            fig.tight_layout()
+            tagged.append((fig, "att_by_unit"))
+
+        # 4) Event-time aggregate effect (effect="time").
+        if event_study:
+            ells = sorted(event_study)
+            effects = np.asarray([event_study[e] for e in ells], float)
+            lower = upper = None
+            if event_study_intervals:
+                lo, hi = [], []
+                for e in ells:
+                    ci = (event_study_intervals.get(e) or {}).get("effect_ci")
+                    lo.append(ci[0] if ci else np.nan)
+                    hi.append(ci[1] if ci else np.nan)
+                if not np.all(np.isnan(lo)):
+                    lower, upper = np.asarray(lo, float), np.asarray(hi, float)
+            ax = plotter.event_study(
+                event_times=ells, effects=effects,
+                ci_lower=lower, ci_upper=upper,
+                outcome=f"Effect on {config.outcome}", time="Event time",
+                title="VanillaSC (staggered): event-study ATT")
+            tagged.append((ax.figure, "event_study"))
+
+        figs = [fig for fig, _ in tagged]
+
+        # Save / display with the single-treated path's semantics.
+        did_output = False
+        if getattr(config, "save", None):
+            prefix = _save_prefix(config.save)
+            for fig, tag in tagged:
+                fig.savefig(f"{prefix}_{tag}.png", bbox_inches="tight")
+            did_output = True
+        if getattr(config, "display_graphs", False):
+            plt.show()
+            did_output = True
+        if did_output:
+            for fig in figs:
+                plt.close(fig)
+    return figs


### PR DESCRIPTION
## What

For a staggered-adoption panel, VanillaSC routes to `run_vanillasc_staggered` (Cattaneo-Feng-Palomba-Titiunik), which did point estimation only and had **no plotting** — so `display_graphs=True` was silently a no-op. Only the single-treated path rendered anything.

This wires the staggered path to plot, following the conventions of the estimator's cousin, [`nppackages/scpi`](https://github.com/nppackages/scpi) (`scplotMulti`), rendered through mlsynth's matplotlib `Plotter`. Four views covering scpi's `ptype` × `effect` grid:

- **series facets** — treated vs synthetic control, one panel per treated unit with its adoption line (`ptype="series"`, `effect="unit-time"`)
- **treatment facets** — the per-period gap with a zero line, one panel per unit (`ptype="treatment"`, `effect="unit-time"`)
- **ATT-by-unit dots** — one point per treated unit, coord-flipped (`effect="unit"`)
- **event-study** — mean effect by time-to-treatment (`effect="time"`)

When `inference="scpi"`, the per-unit counterfactual/gap prediction bands, the per-unit ATT credible intervals, and the event-study band are all shaded (the post-treatment SCPI bands are tail-aligned onto the full time axis). Figures honour `display_graphs`/`save` with the single-treated path's semantics and are a no-op otherwise. `Plotter.gap` gains an optional, backward-compatible `interval` band to support the treatment facets.

## How it was verified (TDD)

- `mlsynth/tests/test_vanillasc_staggered_plot.py`, written first (watched fail — no plotting wired, plotter module absent), then green: wiring (renders when asked, no files otherwise), each of the four views, single-unit facet degradation, PI-band presence under `scpi` vs absence without, and the new `Plotter.gap` band. 11 tests pass.
- No regressions: existing VanillaSC suite green (21 passed, 1 skipped), and **all VanillaSC-backed benchmarks pass unchanged** — `vanillasc_carbontax`, `vanillasc_prop99`, `ascm_kansas`, `malo_prop99`, `malo_basque`, `pensynth_prop99`, `mscmt_basque` (numbers match references to tolerance).

## Notes

Files: new `staggered_plotter.py`, a 3-line wire-in at the end of `run_vanillasc_staggered`, the optional `Plotter.gap` band, and the test. No public API change beyond the additive `Plotter.gap` keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjyUwLsG7PsEDS4emx9dLw)_