### PR TITLE
test(mvbbsc): assert scale invariance to MCMC error, not machine epsilon

### DIFF
--- a/mlsynth/tests/test_mvbbsc.py
+++ b/mlsynth/tests/test_mvbbsc.py
@@ -157,7 +157,18 @@ def test_pre_period_fit_is_reasonable():
 
 def test_scale_invariance_of_weights():
     """B-MV standardizes internally, so rescaling every series leaves the
-    posterior weights unchanged and scales the ATT by the same factor."""
+    posterior weights (approximately) unchanged and scales the ATT by the same
+    factor.
+
+    The invariance is exact in real arithmetic (the pre-period standardization
+    removes the scale), but NUTS is a stochastic, finite-precision sampler: the
+    float32 standardized inputs for ``y`` and ``1000*y`` are only bit-identical
+    on some JAX/NumPyro builds. On others the short ``_FAST`` chains amplify a
+    ~1e-6 float difference to ~1e-2 in the posterior-mean weights. Assert
+    invariance to MCMC / finite-precision error, not to machine epsilon, so the
+    check is robust across sampler builds rather than passing only where the
+    inputs happen to round identically.
+    """
     pytest.importorskip("numpyro")
     df = _hull_panel()
     res1 = MVBBSC(_cfg(df=df, **_FAST)).fit()
@@ -166,8 +177,8 @@ def test_scale_invariance_of_weights():
     res2 = MVBBSC(_cfg(df=df2, **_FAST)).fit()
     w1 = np.array(list(res1.weights.donor_weights.values()))
     w2 = np.array(list(res2.weights.donor_weights.values()))
-    assert np.allclose(w1, w2, atol=1e-6)
-    assert res2.att == pytest.approx(res1.att * 1000.0, rel=1e-5)
+    assert np.allclose(w1, w2, atol=0.05)                 # simplex weights, MCMC-close
+    assert res2.att == pytest.approx(res1.att * 1000.0, rel=0.05)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

`test_mvbbsc.py::test_scale_invariance_of_weights` fails intermittently in CI (e.g. [run 29945218852](https://github.com/jgreathouse9/mlsynth/actions/runs/29945218852/job/89008766618) — `1 failed, 5443 passed`), while passing locally.

The test rescales `y` by 1000 and asserts the posterior weights are unchanged to `atol=1e-6` and the ATT scales to `rel=1e-5`. That invariance is *exact in real arithmetic* — MVBBSC standardizes each series by its pre-period mean/SD, which removes the scale — but the check is against a **stochastic, finite-precision** sampler:

- JAX/NumPyro run in float32 (x64 off). The standardized inputs for `y` vs `1000*y` are only *bit-identical* on some builds. Locally they round identically, so the two NUTS runs are bit-identical (`max|w1−w2| = 0.0`, ATT ratio `1000.0` to 1e-15) and the test passes.
- On the CI build, the ~1e-6 float difference in the standardized inputs is amplified by the short `_FAST` chains (80 warmup / 80 samples) to ~1e-2 in the posterior-mean weights — so `atol=1e-6` fails.

So the tolerance, not the model, is the problem: `atol=1e-6` asserts machine-epsilon agreement between two independent stochastic fits, which isn't achievable across sampler builds.

## Change

Assert *approximate* scale invariance — weights within `atol=0.05` (simplex, MCMC-close) and the ATT scaling within `rel=0.05` — with a comment explaining why. This is robust across JAX/NumPyro builds rather than passing only where the rescaled inputs happen to round identically, and still catches a genuine invariance break (weights moving by ≫0.05). No estimator code changes.

Full `test_mvbbsc.py` passes locally (19 passed).

## Note

This is a pre-existing flake on `main` (from the MVBBSC estimator PR), not caused by any other in-flight branch — but it does red-flag the `build` check on other PRs until it lands here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjyUwLsG7PsEDS4emx9dLw)_