### PR TITLE
feat(plotting): legible date x-axes for many-period panels

### DIFF
--- a/mlsynth/tests/test_plotting_time_axis.py
+++ b/mlsynth/tests/test_plotting_time_axis.py
@@ -1,0 +1,119 @@
+"""The shared Plotter keeps date x-axes legible.
+
+Weekly ``start_date`` labels over several years arrive as strings, which
+Matplotlib plots on a *categorical* axis -- one tick per label -- producing an
+unreadable smear of ~130 overlapping dates. The Plotter parses date-like labels
+to real datetimes so a date locator auto-thins the ticks, and rotates dense
+non-date axes. These pin that behaviour.
+"""
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")  # headless
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.utils.plotting import (
+    Plotter, _coerce_time_axis, _coerce_time_scalar,
+)
+
+
+def _weekly(n_weeks=134):
+    weeks = pd.date_range("2024-01-01", periods=n_weeks, freq="W-MON")
+    return [d.strftime("%Y-%m-%d") for d in weeks]
+
+
+# ── the coercion helper ───────────────────────────────────────────────────────
+
+def test_coerce_parses_date_strings():
+    vals, is_dt = _coerce_time_axis(["2024-01-01", "2024-01-08", "2024-01-15"])
+    assert is_dt
+    assert np.issubdtype(np.asarray(vals).dtype, np.datetime64)
+
+
+def test_coerce_leaves_integer_years_alone():
+    vals, is_dt = _coerce_time_axis(np.arange(1970, 2001))
+    assert not is_dt
+    assert np.asarray(vals).dtype.kind in ("i", "u")
+
+
+def test_coerce_leaves_non_date_strings_alone():
+    vals, is_dt = _coerce_time_axis(["north", "south", "east"])
+    assert not is_dt
+
+
+def test_coerce_scalar_matches_axis():
+    dt = _coerce_time_scalar("2024-06-03", True)
+    assert np.asarray(dt).dtype.kind == "M"
+    assert _coerce_time_scalar(1990, False) == 1990          # untouched off a datetime axis
+
+
+# ── observed vs counterfactual: weekly dates -> thinned date axis ─────────────
+
+def test_weekly_dates_get_date_axis_not_134_ticks():
+    times = _weekly(134)
+    y = np.linspace(0, 1, len(times))
+    ax = Plotter().observed_vs_counterfactual(
+        times, y, [y * 0.9], intervention=times[70])
+    # a concise *date* formatter, and the plotted x-data are datetimes
+    assert isinstance(ax.xaxis.get_major_formatter(), mdates.ConciseDateFormatter)
+    xd = np.asarray(ax.get_lines()[0].get_xdata())
+    assert np.issubdtype(xd.dtype, np.datetime64)
+    # the date locator thins 134 weeks down to a legible handful
+    ax.figure.canvas.draw()
+    assert len(ax.get_xticks()) <= 12
+    plt.close("all")
+
+
+def test_integer_year_axis_stays_numeric():
+    times = np.arange(1970, 2001)
+    y = np.linspace(0, 1, len(times))
+    ax = Plotter().observed_vs_counterfactual(times, y, [y])
+    assert not isinstance(ax.xaxis.get_major_formatter(), mdates.ConciseDateFormatter)
+    xd = np.asarray(ax.get_lines()[0].get_xdata())
+    assert xd.dtype.kind in ("i", "u", "f")
+    plt.close("all")
+
+
+def test_gap_weekly_dates_thinned():
+    times = _weekly(120)
+    g = np.linspace(-1, 1, len(times))
+    ax = Plotter().gap(times, g, intervention=times[60])
+    ax.figure.canvas.draw()
+    assert isinstance(ax.xaxis.get_major_formatter(), mdates.ConciseDateFormatter)
+    assert len(ax.get_xticks()) <= 12
+    plt.close("all")
+
+
+# ── integration: the staggered facets inherit the clean date axis ─────────────
+
+def test_staggered_series_facets_have_date_axis():
+    from mlsynth import VanillaSC
+    from mlsynth.utils.vanillasc_helpers.staggered_plotter import plot_staggered
+
+    weeks = _weekly(60)
+    rng = np.random.default_rng(0)
+    rows = []
+    adopt = {"DMA_00": 35, "DMA_01": 45}
+    for i in range(6):
+        name = f"DMA_{i:02d}"
+        base = 100 + rng.standard_normal(len(weeks)).cumsum() * 0.2
+        for t, wk in enumerate(weeks):
+            tr = int(name in adopt and t >= adopt[name])
+            rows.append({"dma": name, "start_date": wk,
+                         "total_sales": base[t] + 5 * tr, "treated": tr})
+    df = pd.DataFrame(rows)
+    est = VanillaSC({"df": df, "outcome": "total_sales", "treat": "treated",
+                     "unitid": "dma", "time": "start_date", "display_graphs": False})
+    res = est.fit()
+    figs = plot_staggered(est.config, res.sub_method_results,
+                          res.additional_outputs["event_study"])
+    series = figs[0]
+    panels = [ax for ax in series.axes if ax.get_visible()]
+    assert panels and all(
+        isinstance(ax.xaxis.get_major_formatter(), mdates.ConciseDateFormatter)
+        for ax in panels)
+    plt.close("all")

--- a/mlsynth/utils/plotting.py
+++ b/mlsynth/utils/plotting.py
@@ -47,6 +47,55 @@ def select_pi_bands(pointwise, simultaneous, choice):
         return pointwise, simultaneous, "Prediction interval"
     return pointwise, None, "Prediction interval"
 
+
+def _coerce_time_axis(times):
+    """Parse date-like time labels to datetimes so Matplotlib uses a *date* axis
+    (with an auto-thinning date locator) instead of a *categorical* one, which
+    draws a tick per label -- illegible for, say, weekly dates over several
+    years. Returns ``(values_for_plot, is_datetime)``; numeric labels (e.g. year
+    integers) and un-parseable strings are returned unchanged with
+    ``is_datetime=False``."""
+    arr = np.asarray(times)
+    if np.issubdtype(arr.dtype, np.datetime64):
+        return arr, True
+    if arr.dtype == object or arr.dtype.kind in ("U", "S"):
+        try:
+            import pandas as pd
+            return pd.to_datetime(arr).to_numpy(), True
+        except Exception:                       # not date-like -> leave categorical
+            return arr, False
+    return arr, False
+
+
+def _coerce_time_scalar(value, is_datetime):
+    """Coerce a single time (e.g. an intervention marker) onto the same datetime
+    axis, so vertical markers land on the right date."""
+    if not is_datetime or value is None:
+        return value
+    try:
+        import pandas as pd
+        return pd.to_datetime(value).to_numpy()
+    except Exception:                           # pragma: no cover - marker stays as-is
+        return value
+
+
+def _style_time_axis(ax, is_datetime, n_ticks):
+    """Keep the x-axis legible when there are many periods: a date locator with
+    concise labels for datetime axes, thinning for dense numeric axes, and
+    rotated labels once the tick count grows."""
+    import matplotlib.pyplot as plt
+
+    if is_datetime:
+        import matplotlib.dates as mdates
+        loc = mdates.AutoDateLocator(minticks=4, maxticks=9)
+        ax.xaxis.set_major_locator(loc)
+        ax.xaxis.set_major_formatter(mdates.ConciseDateFormatter(loc))
+    elif n_ticks > 16:
+        ax.xaxis.set_major_locator(plt.MaxNLocator(nbins=10))
+    if n_ticks > 16 and not is_datetime:
+        ax.tick_params(axis="x", labelrotation=30)
+
+
 #: Preferred display font; falls back through the ``font.sans-serif`` chain
 #: below if it is not installed. Override by reassigning before plotting.
 MLSYNTH_FONT = "Inter"
@@ -271,7 +320,8 @@ class Plotter:
         if ax is None:
             _, ax = plt.subplots(figsize=self.figsize)
 
-        times = np.asarray(times)
+        times, _is_dt = _coerce_time_axis(times)
+        intervention = _coerce_time_scalar(intervention, _is_dt)
         ax.plot(times, np.asarray(observed).reshape(-1),
                 color=self.treated_color, linewidth=self.treated_linewidth,
                 linestyle=self.treated_linestyle, label=f"Treated ({treated_label})")
@@ -303,6 +353,7 @@ class Plotter:
         ax.set_ylabel(outcome)
         ax.set_title(title)
         ax.legend()  # frame styling comes from the active rcParams
+        _style_time_axis(ax, _is_dt, len(times))
         return ax
 
     def gap(
@@ -331,7 +382,8 @@ class Plotter:
 
         if ax is None:
             _, ax = plt.subplots(figsize=self.figsize)
-        times = np.asarray(times)
+        times, _is_dt = _coerce_time_axis(times)
+        intervention = _coerce_time_scalar(intervention, _is_dt)
         line_color = color or self.counterfactual_colors[0]
         if interval is not None:
             lower = np.asarray(interval[0], dtype=float).reshape(-1)
@@ -350,6 +402,7 @@ class Plotter:
         ax.set_ylabel(outcome or "Treated - counterfactual")
         ax.set_title(title)
         ax.legend()
+        _style_time_axis(ax, _is_dt, len(times))
         return ax
 
     def event_study(


### PR DESCRIPTION
## What

Weekly (or otherwise dense) time labels arrive as strings, so Matplotlib plots them on a **categorical** axis — one tick per label — turning ~130 weekly dates into an unreadable smear with a gridline per week. This hit every plot routed through the shared `Plotter`: the single-treated path, SDID, and the new staggered VanillaSC facets.

Before → after (staggered facets, 134 weekly dates Jan-2024 → now):

| | |
|---|---|
| **before** | a black bar of 134 overlapping labels |
| **after** | `2024 · Jul · 2025 · Jul · 2026 · Jul` |

## Change

Make the `Plotter`'s time axis date-aware:

- `_coerce_time_axis` parses date-like labels to real datetimes so a date locator (`AutoDateLocator` + `ConciseDateFormatter`) auto-thins the ticks; numeric labels (year integers) and non-date strings are left unchanged.
- `_coerce_time_scalar` moves the intervention marker onto the same datetime axis so vertical lines land on the right date.
- `_style_time_axis` applies the date locator/formatter, thins dense numeric axes (`MaxNLocator`), and rotates labels once the tick count grows.

`observed_vs_counterfactual` and `gap` route through these; event studies use integer event time and are unaffected. No public API change.

## How it was verified (TDD)

- New `mlsynth/tests/test_plotting_time_axis.py` (8 tests): helper parsing (dates vs integer years vs non-date strings), weekly dates producing a thinned date axis on both `observed_vs_counterfactual` and `gap`, integer-year axes staying numeric, and the staggered facets inheriting the clean axis.
- No regressions: 108 passed / 1 skipped across the VanillaSC, SDID, and FDID plot suites (the shared `Plotter` change is safe).

Follow-up to #254 — the staggered facets pick this up automatically since they render through the `Plotter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjyUwLsG7PsEDS4emx9dLw)_