### PR TITLE
fix(vanillasc): make inference selection discoverable, never silent

### DIFF
--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -240,6 +240,24 @@ Inference
 
 Five inference modes are available via ``inference=``:
 
+Each mode returns one kind of output, and the fit always tells you which.
+``"placebo"``, ``"lto"`` and ``"ttest"`` are tests: they return a p-value (the
+t-test also returns an ATT confidence interval). ``"conformal"``, ``"scpi"`` and
+``"eiv"`` are prediction intervals: they return the per-period counterfactual
+bands on ``res.time_series`` (``counterfactual_lower`` / ``counterfactual_upper``)
+and the gap intervals in ``res.inference.details``. In every case
+``res.inference.method`` names the procedure that produced the numbers, so a band
+or p-value is never anonymous.
+
+Two guards keep the choice unambiguous rather than surprising. An unrecognized
+``inference=`` value raises ``MlsynthConfigError`` listing the valid ones, so a
+typo such as ``inference="scpii"`` fails loudly instead of silently disabling
+inference. And a valid mode that cannot be computed on the given panel -- for
+example ``inference="placebo"`` with a single donor, which admits no placebo
+distribution -- emits a warning and returns an ``InferenceResults`` whose
+``method`` states that it was not computed, and why, instead of a silent
+``None``. Only ``inference=False`` returns no inference object.
+
 ``"placebo"`` (default, ``inference=True``)
     Abadie's in-space placebo test: the synthetic control is refit treating
     each donor as pseudo-treated, and the treated unit's post/pre RMSPE ratio

--- a/mlsynth/tests/test_vanillasc_inference_ux.py
+++ b/mlsynth/tests/test_vanillasc_inference_ux.py
@@ -1,0 +1,104 @@
+"""Discoverability / UX guards for ``VanillaSC(inference=...)``.
+
+A user should never be surprised by *what* inference they got. Two failure
+modes are pinned here:
+
+* an unknown / misspelled ``inference`` value (e.g. ``"scpii"``) must raise a
+  clear ``MlsynthConfigError`` listing the valid options -- not silently return
+  no inference;
+* a *valid* inference mode that cannot be computed on the given panel (e.g.
+  ``"placebo"`` with a single donor) must emit a warning and return an
+  ``InferenceResults`` whose ``method`` says it was not computed and why -- not a
+  silent ``None`` and not a mid-analysis crash.
+
+Valid, computable modes must keep working unchanged (regression guard).
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import VanillaSC
+from mlsynth.exceptions import MlsynthConfigError
+
+
+def _panel(n_units: int, n_periods: int = 12, t0: int = 8, seed: int = 0) -> pd.DataFrame:
+    """A small balanced panel: unit ``u0`` is treated from period ``t0``."""
+    rng = np.random.default_rng(seed)
+    donor_base = rng.normal(10.0, 1.0, size=max(n_units - 1, 1))
+    loads = rng.dirichlet(np.ones(max(n_units - 1, 1)))
+    rows = []
+    for t in range(n_periods):
+        common = 0.4 * t + rng.normal(0.0, 0.2)
+        donors = donor_base + common + rng.normal(0.0, 0.15, size=donor_base.size)
+        treated = float(loads @ donors) + (4.0 if t >= t0 else 0.0)
+        rows.append({"unit": "u0", "time": t, "y": treated,
+                     "treat": int(t >= t0)})
+        for j, dv in enumerate(donors):
+            rows.append({"unit": f"d{j}", "time": t, "y": float(dv), "treat": 0})
+    return pd.DataFrame(rows)
+
+
+_CFG = dict(outcome="y", treat="treat", unitid="unit", time="time",
+            backend="outcome-only", display_graphs=False)
+
+
+@pytest.mark.parametrize("bad", ["scpii", "conformall", "bogus", "SCPI_", "placebos"])
+def test_unknown_inference_value_raises(bad):
+    df = _panel(6)
+    with pytest.raises(MlsynthConfigError):
+        VanillaSC({"df": df, "inference": bad, **_CFG}).fit()
+
+
+def test_unknown_inference_message_lists_valid_options():
+    df = _panel(6)
+    with pytest.raises(MlsynthConfigError) as exc:
+        VanillaSC({"df": df, "inference": "scpii", **_CFG}).fit()
+    msg = str(exc.value).lower()
+    assert "scpi" in msg and "conformal" in msg and "placebo" in msg
+
+
+def test_uncomputable_placebo_warns_and_explains():
+    # One donor -> in-space placebo needs >= 2 donors, so it cannot run.
+    df = _panel(2)
+    with pytest.warns(UserWarning, match="not computed"):
+        res = VanillaSC({"df": df, "inference": "placebo", **_CFG}).fit()
+    # never a silent None: an explanatory object survives, and it says why.
+    assert res.inference is not None
+    assert res.inference.method is not None
+    assert "not computed" in res.inference.method.lower()
+    assert res.inference.p_value is None
+
+
+def test_uncomputable_lto_warns_and_explains():
+    # Two donors -> leave-two-out needs >= 3 donors.
+    df = _panel(3)
+    with pytest.warns(UserWarning, match="not computed"):
+        res = VanillaSC({"df": df, "inference": "lto", **_CFG}).fit()
+    assert res.inference is not None and "not computed" in res.inference.method.lower()
+
+
+def test_valid_inference_modes_still_produce_output():
+    df = _panel(8)
+    # bands modes
+    for mode in ("scpi", "conformal"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")           # no spurious "not computed" warning
+            res = VanillaSC({"df": df, "inference": mode, **_CFG}).fit()
+        assert res.inference is not None
+        assert res.time_series.counterfactual_lower is not None
+        assert "not computed" not in (res.inference.method or "").lower()
+    # placebo with enough donors: a real p-value, no warning
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        res = VanillaSC({"df": df, "inference": "placebo", **_CFG}).fit()
+    assert res.inference is not None and res.inference.p_value is not None
+
+
+def test_inference_false_disables_cleanly():
+    df = _panel(6)
+    res = VanillaSC({"df": df, "inference": False, **_CFG}).fit()
+    assert res.inference is None            # explicit opt-out stays None

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -15,6 +15,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ...config_models import BaseEstimatorConfig
 
+# Recognized string values for ``VanillaSCConfig.inference`` (besides the bools
+# ``True`` -> in-space placebo and ``False`` -> disabled). Kept as the single
+# source of truth so an unknown/misspelled value fails loudly at config time
+# rather than silently returning no inference.
+VALID_INFERENCE_METHODS = frozenset(
+    {"placebo", "scpi", "conformal", "lto", "ttest", "eiv", "none"}
+)
+
 
 class StaggeredSCMSpec(BaseModel):
     """Covariate (multi-feature) matching spec for staggered VanillaSC.
@@ -209,6 +217,27 @@ class VanillaSCConfig(BaseEstimatorConfig):
                     "2025 debiased SC t-test for the ATT), 'eiv' (Hirshberg 2021 "
                     "error-in-variables normal/t prediction intervals), or False.",
     )
+    @field_validator("inference")
+    @classmethod
+    def _validate_inference(cls, v):
+        """Reject unknown ``inference`` values so a typo never silently
+        disables inference; normalize strings to lower case."""
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            low = v.strip().lower()
+            if low not in VALID_INFERENCE_METHODS:
+                raise ValueError(
+                    f"inference={v!r} is not a recognized inference method. "
+                    f"Use a bool (True -> in-space placebo, False -> off) or one "
+                    f"of: {', '.join(sorted(VALID_INFERENCE_METHODS))}."
+                )
+            return low
+        raise ValueError(
+            "inference must be a bool or one of "
+            f"{', '.join(sorted(VALID_INFERENCE_METHODS))}."
+        )
+
     alpha: float = Field(
         default=0.05, gt=0.0, lt=1.0,
         description="Level (placebo confidence / SCPI alpha1 = alpha2).",

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -503,6 +503,31 @@ def run_vanillasc(config) -> BaseEstimatorResults:
             },
         )
 
+    # Never leave a requested-but-uncomputable inference as a silent ``None``: a
+    # valid mode whose preconditions were not met (too few donors, no
+    # post-periods) returns an explanatory ``InferenceResults`` plus a warning,
+    # so the caller is never surprised by a missing band or p-value. ``"none"``
+    # (``inference=False``) is an explicit opt-out and stays ``None``.
+    if inference is None and mode != "none":
+        if not gap[pre:].size:
+            reason = "there are no post-treatment periods"
+        elif mode == "placebo":
+            reason = f"in-space placebo needs >=2 donors (this panel has {J})"
+        elif mode == "lto":
+            reason = f"leave-two-out needs >=3 donors (this panel has {J})"
+        else:  # pragma: no cover - band/ttest modes only skip on empty post window
+            reason = "its preconditions were not met on this panel"
+        warnings.warn(
+            f"VanillaSC inference={mode!r} was requested but not computed: "
+            f"{reason}. No band or p-value is available.",
+            UserWarning, stacklevel=2,
+        )
+        inference = InferenceResults(
+            confidence_level=1.0 - config.alpha,
+            method=f"{mode} (requested but not computed: {reason})",
+            details={"requested": mode, "computed": False, "reason": reason},
+        )
+
     weights = make_weights_results(
         res.donor_weights,
         constraint=("simplex (non-negative, sum to 1)"),


### PR DESCRIPTION
## Problem

Two ways a `VanillaSC` user could be surprised by *what* inference they got:

- An unknown / misspelled `inference` value silently disabled inference. `inference="scpii"` returned `res.inference = None` with no error — the typo just quietly dropped the analysis.
- A *valid* mode that couldn't be computed on the panel returned a silent `None`. `inference="placebo"` with a single donor (no placebo distribution) gave back nothing, no explanation.

In both cases the caller is left with a missing band or p-value and no idea why.

## Change

- `VanillaSCConfig` now validates `inference`: an unrecognized value raises `MlsynthConfigError` listing the valid options; strings are case/whitespace-normalized (`"SCPI "` → `"scpi"`). Single source of truth: `VALID_INFERENCE_METHODS`.
- The pipeline no longer returns a silent `None` for a valid-but-uncomputable mode. It emits a warning and returns an `InferenceResults` whose `method` states it was not computed, and why (too few donors, no post-periods). `inference=False` stays `None` — the one explicit opt-out.
- Docs (`docs/vanillasc.rst`): the Inference section now says which output each mode returns (test → p-value vs prediction interval → counterfactual bands) and documents both guards, so `res.inference.method` is never anonymous.

No behavior change for a valid, computable mode — those paths are untouched.

## Tests

Test-first: `mlsynth/tests/test_vanillasc_inference_ux.py` (10 tests, red → green) — unknown value raises with a helpful message; uncomputable `placebo`/`lto` warn and return an explanatory object; valid modes still produce output with no spurious warning; `inference=False` stays `None`. `test_spec.py` + `test_inference_accessors.py` + the prediction-interval contract all still pass.

## Context

Surfaced while comparing `VanillaSC` to the R `Synth` package (j-hai/Synth) on Prop 99: the empty bands I first saw were the default `inference=True` (in-space placebo, no bands), not a backend limitation — every backend already returns SCPI bands or CWZ conformal intervals on request. This PR makes that impossible to mistake. A follow-up PR adds the split-conformal band to match j-hai/Synth's `synth_inference()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdcyUtZVE263on5BYhgzSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdcyUtZVE263on5BYhgzSw)_