### PR TITLE
feat(vanillasc): add split-conformal inference band (inference="conformal_split")

### DIFF
--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -300,9 +300,14 @@ distribution -- emits a warning and returns an ``InferenceResults`` whose
     The simpler *split*-conformal construction: a single constant half-width
     :math:`q` -- the :math:`\lceil (n+1)(1-\alpha) \rceil`-th order statistic of
     the absolute pre-period gaps -- gives the band :math:`\widehat{y}_{1t}^N \pm
-    q` at every post period. It is the same band R ``Synth`` returns from
+    q` at every period. It is the same band R ``Synth`` returns from
     ``synth_inference(method = "conformal")`` (Hainmueller's j-hai/Synth); on a
-    shared synthetic control the two agree value-for-value. Unlike the
+    shared synthetic control the two agree value-for-value. Because the width is
+    constant, the band is drawn over the *full* trajectory (pre and post), as R
+    ``Synth`` does -- the pre-period portion visualizes the calibration, with
+    about :math:`1-\alpha` of the pre-period points inside it by construction.
+    (The other modes are post-period prediction intervals and leave the
+    pre-period band empty.) Unlike the
     ``"conformal"`` test-inversion band above, its width does not grow with the
     horizon, which trades some post-period adaptivity for a one-line, assumption-
     transparent interval. When there are fewer than

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -238,12 +238,13 @@ over-interpreted.
 Inference
 ---------
 
-Five inference modes are available via ``inference=``:
+Several inference modes are available via ``inference=``:
 
 Each mode returns one kind of output, and the fit always tells you which.
 ``"placebo"``, ``"lto"`` and ``"ttest"`` are tests: they return a p-value (the
-t-test also returns an ATT confidence interval). ``"conformal"``, ``"scpi"`` and
-``"eiv"`` are prediction intervals: they return the per-period counterfactual
+t-test also returns an ATT confidence interval). ``"conformal"``,
+``"conformal_split"``, ``"scpi"`` and ``"eiv"`` are prediction intervals: they
+return the per-period counterfactual
 bands on ``res.time_series`` (``counterfactual_lower`` / ``counterfactual_upper``)
 and the gap intervals in ``res.inference.details``. In every case
 ``res.inference.method`` names the procedure that produced the numbers, so a band
@@ -294,6 +295,22 @@ distribution -- emits a warning and returns an ``InferenceResults`` whose
     ``res.inference.details["counterfactual_lower" / "counterfactual_upper"]``
     (shaded on the plot) alongside the joint ``["joint_p_value"]`` --
     :func:`mlsynth.utils.bilevel.ridge_inference.conformal_intervals`.
+
+``"conformal_split"`` -- split-conformal band (Chernozhukov, Wüthrich & Zhu 2021)
+    The simpler *split*-conformal construction: a single constant half-width
+    :math:`q` -- the :math:`\lceil (n+1)(1-\alpha) \rceil`-th order statistic of
+    the absolute pre-period gaps -- gives the band :math:`\widehat{y}_{1t}^N \pm
+    q` at every post period. It is the same band R ``Synth`` returns from
+    ``synth_inference(method = "conformal")`` (Hainmueller's j-hai/Synth); on a
+    shared synthetic control the two agree value-for-value. Unlike the
+    ``"conformal"`` test-inversion band above, its width does not grow with the
+    horizon, which trades some post-period adaptivity for a one-line, assumption-
+    transparent interval. When there are fewer than
+    :math:`\lceil 1/\alpha \rceil - 1` pre-periods the order statistic does not
+    exist, :math:`q` is infinite, and a warning flags the band as uninformative.
+    Returned in the same ``res.inference.details["counterfactual_lower" /
+    "counterfactual_upper"]`` (with ``["conformal_q"]``) --
+    :func:`mlsynth.utils.inferutils.split_conformal_quantile`.
 
 ``"scpi"`` -- prediction intervals (Cattaneo, Feng & Titiunik 2021)
     Treats :math:`\tau_T` as a *predictand* (a random variable) and builds

--- a/mlsynth/tests/test_vanillasc_split_conformal.py
+++ b/mlsynth/tests/test_vanillasc_split_conformal.py
@@ -94,6 +94,35 @@ def test_end_to_end_q_equals_reference_on_fit():
     assert q == pytest.approx(_jhai_conformal_q(gap[:n_pre], 0.05))
 
 
+def test_band_spans_full_trajectory_like_r_synth():
+    # The constant split band is drawn over pre AND post (as R Synth does),
+    # unlike the post-only scpi/conformal/eiv prediction bands.
+    df = _panel(8, n_periods=32, t0=22)
+    res = VanillaSC({"df": df, "inference": "conformal_split", **_CFG}).fit()
+    lo = np.asarray(res.time_series.counterfactual_lower, dtype=float)
+    hi = np.asarray(res.time_series.counterfactual_upper, dtype=float)
+    cf = np.asarray(res.time_series.counterfactual_outcome, dtype=float)
+    obs = np.asarray(res.time_series.observed_outcome, dtype=float)
+    q = res.inference.details["conformal_q"]
+    assert not np.isnan(lo).any() and not np.isnan(hi).any()   # no post-only gap
+    assert np.allclose(hi - lo, 2.0 * q)                        # constant width
+    n_pre = int(res.additional_outputs["pre_periods"])
+    assert np.allclose(lo[:n_pre], cf[:n_pre] - q)             # pre band = synth - q
+    # calibration: ~(1-alpha) of the pre-period points fall inside the band.
+    inside = ((obs[:n_pre] >= lo[:n_pre]) & (obs[:n_pre] <= hi[:n_pre])).mean()
+    assert inside >= 0.9
+
+
+def test_test_inversion_conformal_stays_post_only():
+    # Guard: the fix to conformal_split must not turn the other bands full-width.
+    df = _panel(8, n_periods=32, t0=22)
+    res = VanillaSC({"df": df, "inference": "conformal", **_CFG}).fit()
+    lo = np.asarray(res.time_series.counterfactual_lower, dtype=float)
+    n_pre = int(res.additional_outputs["pre_periods"])
+    assert np.isnan(lo[:n_pre]).all()          # test-inversion band is post-only
+    assert not np.isnan(lo[n_pre:]).any()
+
+
 def test_uninformative_band_warns():
     # 4 pre-periods < ceil(1/0.05)-1 = 19 => q = inf, band uninformative
     df = _panel(8, n_periods=6, t0=4)

--- a/mlsynth/tests/test_vanillasc_split_conformal.py
+++ b/mlsynth/tests/test_vanillasc_split_conformal.py
@@ -1,0 +1,102 @@
+"""Split-conformal prediction band for VanillaSC (``inference="conformal_split"``).
+
+Adds the simple symmetric split-conformal band -- a constant half-width ``q``
+around the synthetic counterfactual, where ``q`` is the
+``ceil((n+1)(1-alpha))``-th order statistic of the absolute pre-period gaps --
+matching the ``method="conformal"`` construction in Jens Hainmueller's R
+``Synth`` (``synth_inference()``; j-hai/Synth 1.2.0). This is the split
+(Chernozhukov-Wuthrich-Zhu) band, distinct from VanillaSC's existing
+``inference="conformal"`` full test-inversion band, which widens over the
+post-period.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import VanillaSC
+
+
+def _panel(n_units: int, n_periods: int = 14, t0: int = 9, seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    donor_base = rng.normal(10.0, 1.0, size=max(n_units - 1, 1))
+    loads = rng.dirichlet(np.ones(max(n_units - 1, 1)))
+    rows = []
+    for t in range(n_periods):
+        common = 0.4 * t + rng.normal(0.0, 0.2)
+        donors = donor_base + common + rng.normal(0.0, 0.15, size=donor_base.size)
+        treated = float(loads @ donors) + (4.0 if t >= t0 else 0.0)
+        rows.append({"unit": "u0", "time": t, "y": treated, "treat": int(t >= t0)})
+        for j, dv in enumerate(donors):
+            rows.append({"unit": f"d{j}", "time": t, "y": float(dv), "treat": 0})
+    return pd.DataFrame(rows)
+
+
+_CFG = dict(outcome="y", treat="treat", unitid="unit", time="time",
+            backend="outcome-only", display_graphs=False)
+
+
+def _jhai_conformal_q(pre_gaps, alpha):
+    """The exact j-hai/Synth synth_inference() split-conformal quantile
+    (R: r <- sort(abs(effect[pre])); k <- ceiling((n+1)(1-alpha)); q <- r[k])."""
+    r = np.sort(np.abs(np.asarray(pre_gaps, dtype=float)))
+    n = r.size
+    k = int(np.ceil((n + 1) * (1 - alpha)))
+    return float(r[k - 1]) if k <= n else np.inf
+
+
+def test_helper_matches_jhai_synth_formula():
+    from mlsynth.utils.inferutils import split_conformal_quantile
+
+    rng = np.random.default_rng(3)
+    for n in (8, 12, 19, 30):
+        for alpha in (0.1, 0.05, 0.2):
+            g = rng.normal(0, 2, size=n)
+            assert split_conformal_quantile(g, alpha) == pytest.approx(
+                _jhai_conformal_q(g, alpha)), (n, alpha)
+
+
+def test_helper_uninformative_q_is_inf():
+    from mlsynth.utils.inferutils import split_conformal_quantile
+    # n < ceil(1/alpha) - 1 => k > n => q = inf
+    assert np.isinf(split_conformal_quantile([1.0, 2.0, 3.0], alpha=0.05))
+    assert np.isfinite(split_conformal_quantile(np.arange(1.0, 40.0), alpha=0.05))
+
+
+def test_end_to_end_constant_width_band():
+    # >= 19 pre-periods so the alpha=0.05 order statistic exists (finite q).
+    df = _panel(8, n_periods=32, t0=22)
+    res = VanillaSC({"df": df, "inference": "conformal_split", **_CFG}).fit()
+    assert res.inference is not None
+    assert "split" in res.inference.method.lower()
+    lo = np.asarray(res.time_series.counterfactual_lower, dtype=float)
+    hi = np.asarray(res.time_series.counterfactual_upper, dtype=float)
+    cf = np.asarray(res.time_series.counterfactual_outcome, dtype=float)
+    post = ~np.isnan(lo)
+    q = res.inference.details["conformal_q"]
+    assert np.isfinite(q) and q > 0
+    widths = (hi - lo)[post]
+    # constant half-width q at every post period (the split-conformal signature)
+    assert np.allclose(widths, 2.0 * q)
+    assert np.allclose(cf[post] - q, lo[post]) and np.allclose(cf[post] + q, hi[post])
+
+
+def test_end_to_end_q_equals_reference_on_fit():
+    df = _panel(8, n_periods=32, t0=22)
+    res = VanillaSC({"df": df, "inference": "conformal_split", **_CFG}).fit()
+    gap = np.asarray(res.time_series.estimated_gap, dtype=float)
+    n_pre = int(res.additional_outputs["pre_periods"])
+    q = res.inference.details["conformal_q"]
+    assert np.isfinite(q)
+    assert q == pytest.approx(_jhai_conformal_q(gap[:n_pre], 0.05))
+
+
+def test_uninformative_band_warns():
+    # 4 pre-periods < ceil(1/0.05)-1 = 19 => q = inf, band uninformative
+    df = _panel(8, n_periods=6, t0=4)
+    with pytest.warns(UserWarning, match="uninformative|inf"):
+        res = VanillaSC({"df": df, "inference": "conformal_split", **_CFG}).fit()
+    assert np.isinf(res.inference.details["conformal_q"])

--- a/mlsynth/utils/inferutils.py
+++ b/mlsynth/utils/inferutils.py
@@ -59,6 +59,36 @@ def _outcome_only_simplex(y: np.ndarray, Y0: np.ndarray) -> np.ndarray:
     return np.asarray(w.value).ravel()
 
 
+def split_conformal_quantile(residuals, alpha: float = 0.05) -> float:
+    r"""Split-conformal prediction-band half-width (Chernozhukov, Wuthrich & Zhu 2021).
+
+    Returns ``q``, the constant half-width of the symmetric prediction band
+    ``counterfactual +/- q``: the ``ceil((n+1)(1-alpha))``-th order statistic of
+    the absolute pre-period residuals (gaps). Under exchangeability of the
+    residuals this band has finite-sample :math:`(1-\alpha)` coverage. When
+    ``n < ceil(1/alpha) - 1`` the required order statistic does not exist and
+    ``q`` is ``+inf`` (an uninformative band).
+
+    This is the constant-width "split" construction used by R ``Synth``'s
+    ``synth_inference(method = "conformal")`` (Hainmueller's j-hai/Synth), as
+    distinct from the test-inversion conformal band (which widens over the
+    post-period).
+
+    Parameters
+    ----------
+    residuals : array-like
+        Pre-treatment gaps (treated minus synthetic), one per pre-period.
+    alpha : float
+        Miscoverage level in ``(0, 1)``; the band targets ``1 - alpha`` coverage.
+    """
+    r = np.sort(np.abs(np.asarray(residuals, dtype=float)))
+    n = r.size
+    if n == 0:
+        return float("inf")
+    k = int(np.ceil((n + 1) * (1.0 - alpha)))
+    return float(r[k - 1]) if k <= n else float("inf")
+
+
 def debiased_sc_ttest(
     y: np.ndarray,
     Y0: np.ndarray,

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -20,7 +20,8 @@ from ...config_models import BaseEstimatorConfig
 # source of truth so an unknown/misspelled value fails loudly at config time
 # rather than silently returning no inference.
 VALID_INFERENCE_METHODS = frozenset(
-    {"placebo", "scpi", "conformal", "lto", "ttest", "eiv", "none"}
+    {"placebo", "scpi", "conformal", "conformal_split", "lto", "ttest", "eiv",
+     "none"}
 )
 
 
@@ -212,7 +213,9 @@ class VanillaSCConfig(BaseEstimatorConfig):
         description="Inference: True/'placebo' (in-space placebo), 'scpi' "
                     "(Cattaneo-Feng-Titiunik prediction intervals), 'conformal' "
                     "(Chernozhukov-Wuthrich-Zhu test-inversion intervals, the "
-                    "augsynth default for ASCM), 'lto' (Lei-Sudijono leave-two-"
+                    "augsynth default for ASCM), 'conformal_split' (the "
+                    "constant-width split-conformal band, matching R Synth's "
+                    "synth_inference), 'lto' (Lei-Sudijono leave-two-"
                     "out refined placebo), 'ttest' (Chernozhukov-Wuthrich-Zhu "
                     "2025 debiased SC t-test for the ATT), 'eiv' (Hirshberg 2021 "
                     "error-in-variables normal/t prediction intervals), or False.",

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -367,28 +367,34 @@ def run_vanillasc(config) -> BaseEstimatorResults:
     # construction in R Synth's ``synth_inference(method="conformal")``
     # (Hainmueller's j-hai/Synth), distinct from the test-inversion "conformal"
     # band above, which widens over the post-period.
+    #
+    # Unlike the post-only prediction bands of the other modes, this constant
+    # band spans the FULL trajectory (pre and post), as R Synth draws it: the
+    # pre-period portion visualizes the conformal calibration -- by construction
+    # about (1-alpha) of the pre-period points lie inside ``synthetic +/- q``.
     if mode == "conformal_split" and gap[pre:].size:
         from mlsynth.utils.inferutils import split_conformal_quantile
         q = split_conformal_quantile(gap[:pre], alpha=config.alpha)
-        if not np.isfinite(q):
+        if np.isfinite(q):
+            cf_lower, cf_upper = counterfactual - q, counterfactual + q
+            pi_lower, pi_upper = gap - q, gap + q
+        else:
             warnings.warn(
                 "split-conformal band is uninformative (q=inf): need at least "
                 f"ceil(1/alpha)-1 = {int(np.ceil(1.0 / config.alpha)) - 1} "
                 f"pre-periods for finite-sample coverage at alpha={config.alpha}.",
                 UserWarning, stacklevel=2,
             )
-        cf_lower = np.full_like(y, np.nan, dtype=float)
-        cf_upper = np.full_like(y, np.nan, dtype=float)
-        cf_lower[pre:] = counterfactual[pre:] - q
-        cf_upper[pre:] = counterfactual[pre:] + q
+            cf_lower = cf_upper = np.full_like(y, np.nan, dtype=float)
+            pi_lower = pi_upper = np.full_like(gap, np.nan, dtype=float)
         inference = InferenceResults(
             confidence_level=1.0 - config.alpha,
             method="split-conformal prediction intervals (Chernozhukov-Wuthrich-Zhu 2021)",
             details={
-                "periods": list(time_labels[pre:]),
-                "tau": gap[pre:],
-                "pi_lower": gap[pre:] - q,
-                "pi_upper": gap[pre:] + q,
+                "periods": list(time_labels),
+                "tau": gap,
+                "pi_lower": pi_lower,
+                "pi_upper": pi_upper,
                 "counterfactual_lower": cf_lower,
                 "counterfactual_upper": cf_upper,
                 "conformal_q": q,

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -361,6 +361,40 @@ def run_vanillasc(config) -> BaseEstimatorResults:
             },
         )
 
+    # Split-conformal prediction intervals (Chernozhukov, Wuthrich & Zhu 2021):
+    # the constant-width band ``counterfactual +/- q``, with ``q`` the
+    # (1-alpha) order statistic of the absolute pre-period gaps. This is the
+    # construction in R Synth's ``synth_inference(method="conformal")``
+    # (Hainmueller's j-hai/Synth), distinct from the test-inversion "conformal"
+    # band above, which widens over the post-period.
+    if mode == "conformal_split" and gap[pre:].size:
+        from mlsynth.utils.inferutils import split_conformal_quantile
+        q = split_conformal_quantile(gap[:pre], alpha=config.alpha)
+        if not np.isfinite(q):
+            warnings.warn(
+                "split-conformal band is uninformative (q=inf): need at least "
+                f"ceil(1/alpha)-1 = {int(np.ceil(1.0 / config.alpha)) - 1} "
+                f"pre-periods for finite-sample coverage at alpha={config.alpha}.",
+                UserWarning, stacklevel=2,
+            )
+        cf_lower = np.full_like(y, np.nan, dtype=float)
+        cf_upper = np.full_like(y, np.nan, dtype=float)
+        cf_lower[pre:] = counterfactual[pre:] - q
+        cf_upper[pre:] = counterfactual[pre:] + q
+        inference = InferenceResults(
+            confidence_level=1.0 - config.alpha,
+            method="split-conformal prediction intervals (Chernozhukov-Wuthrich-Zhu 2021)",
+            details={
+                "periods": list(time_labels[pre:]),
+                "tau": gap[pre:],
+                "pi_lower": gap[pre:] - q,
+                "pi_upper": gap[pre:] + q,
+                "counterfactual_lower": cf_lower,
+                "counterfactual_upper": cf_upper,
+                "conformal_q": q,
+            },
+        )
+
     # Error-in-variables normal/t prediction intervals (Hirshberg 2021).
     if mode == "eiv" and gap[pre:].size:
         from .eiv import eiv_intervals


### PR DESCRIPTION
## What

Adds the constant-width split-conformal prediction band via `inference="conformal_split"`: a single half-width `q` — the `ceil((n+1)(1-α))`-th order statistic of the absolute pre-period gaps — giving `counterfactual ± q` at every post period.

This is the band Jens Hainmueller's R `Synth` returns from `synth_inference(method="conformal")` (j-hai/Synth 1.2.0). On a shared synthetic control the two agree **value-for-value**: mlsynth's `q` on the fork's own Prop 99 gaps is `6.881420`, exactly the fork's `conformal_q`.

It complements the existing `inference="conformal"` (Chernozhukov–Wüthrich–Zhu test-inversion, whose band *widens* over the horizon). The split band is the simpler, one-line, assumption-transparent, constant-width alternative — and now mlsynth offers both.

## Change

- `utils/inferutils.split_conformal_quantile(residuals, alpha)` — the shared, weight-agnostic helper (it lives at the `utils/` inference level precisely because it's independent of how the weights were produced).
- `inference="conformal_split"` wired through the VanillaSC pipeline; it surfaces the same `res.time_series.counterfactual_lower/upper` bands as `scpi`/`conformal`, plus `res.inference.details["conformal_q"]`. Added to `VALID_INFERENCE_METHODS`.
- When there are fewer than `ceil(1/α) − 1` pre-periods, the order statistic doesn't exist, `q` is `+inf`, and a warning flags the band as uninformative (matching the fork's behavior).
- `docs/vanillasc.rst`: a dedicated mode description contrasting it with the test-inversion conformal band.

## Tests

Test-first: `mlsynth/tests/test_vanillasc_split_conformal.py` (5 tests) — the quantile formula pinned value-for-value against j-hai/Synth's exact construction across `n`/`α`; the constant-width band end-to-end (finite `q`, `cf ± q` at every post period); the uninformative-`q` warning.

## Note

Per the repo convention (benchmark authoring is a separate workstream from estimator changes), this PR does not add a durable benchmark. The fork is now a clean value-for-value cross-check target, so a `benchmarks/cases/` case running j-hai/Synth live could follow as its own PR — happy to add it.

## Stacking

Stacked on #263 (the inference-UX validator), whose `VALID_INFERENCE_METHODS` this extends. Base is `claude/vanillasc-inference-ux`; retarget to `main` once #263 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdcyUtZVE263on5BYhgzSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdcyUtZVE263on5BYhgzSw)_