### PR TITLE
perf(bilevel): FISTA warm-start accelerator for large-J simplex_qp

### DIFF
--- a/mlsynth/tests/test_simplex_qp_accelerate.py
+++ b/mlsynth/tests/test_simplex_qp_accelerate.py
@@ -1,0 +1,255 @@
+"""Tests for the FISTA warm-start accelerator on ``simplex_qp``.
+
+The accelerator is a *speed-only* layer: for a large donor pool it computes a
+Gram-collapsed FISTA warm start and hands it to the exact active-set solver, so
+the active set is certified from the right support instead of built up pivot by
+pivot. It must never change the *answer* -- the exact active-set (with the cvxpy
+fallback) still determines the weights. These tests pin four things:
+
+1. the simplex projection primitive is the exact Euclidean projection;
+2. the FISTA warm start is feasible and near-optimal;
+3. ``simplex_qp`` stays KKT-optimal and matches the reference on large problems
+   (where the accelerator fires) *and* small ones (where it does not);
+4. the accelerator engages only when it should -- large ``J``, no caller warm
+   start -- and the accelerated and cold paths agree on the fitted values.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+cp = pytest.importorskip("cvxpy")
+
+from mlsynth.utils.bilevel import ridge_augment
+from mlsynth.utils.bilevel.accelerate import (
+    ACCEL_MIN_DONORS, fista_warm_start, simplex_project)
+from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+from mlsynth.utils.bilevel.ridge_augment import simplex_qp
+
+
+# --------------------------------------------------------------------------- #
+# reference oracles
+# --------------------------------------------------------------------------- #
+def _proj_ref(v):
+    """Exact Euclidean projection onto the simplex via cvxpy (oracle)."""
+    x = cp.Variable(v.shape[0])
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(x - v)), [x >= 0, cp.sum(x) == 1])
+    prob.solve(solver=cp.CLARABEL)
+    return np.clip(np.asarray(x.value, float).ravel(), 0.0, None)
+
+
+def _obj(B, A, w):
+    r = B @ np.asarray(w, float).ravel() - A
+    return float(r @ r)
+
+
+def _reference(B, A):
+    J = B.shape[1]
+    w = cp.Variable(J)
+    prob = cp.Problem(cp.Minimize(cp.sum_squares(B @ w - A)), [w >= 0, cp.sum(w) == 1])
+    try:
+        prob.solve()
+    except Exception:
+        return None
+    return None if w.value is None else np.clip(np.asarray(w.value, float).ravel(), 0, None)
+
+
+def assert_feasible(w, J, tol=1e-7):
+    w = np.asarray(w, float).ravel()
+    assert w.shape == (J,)
+    assert np.all(np.isfinite(w))
+    assert w.min() >= -tol
+    assert abs(w.sum() - 1.0) <= tol
+
+
+def assert_kkt_optimal(B, A, w, tol=1e-6):
+    w = np.asarray(w, float).ravel()
+    J = B.shape[1]
+    assert_feasible(w, J)
+    g = B.T @ (B @ w - A)
+    scale = 1.0 + float(np.max(np.abs(g)))
+    support = w > 1e-7
+    assert support.any()
+    mu = float(g[support].mean())
+    assert np.all(np.abs(g[support] - mu) <= tol * scale)
+    if (~support).any():
+        assert np.all(g[~support] >= mu - tol * scale)
+
+
+def _factor_panel(J, T0, seed=0):
+    """A factor-structure SC panel (treated + J donors on two AR(1) factors)."""
+    rng = np.random.default_rng(seed)
+    F = rng.standard_normal((T0, 2))
+    Mu = np.zeros((J + 1, 2)); h = J // 2
+    Mu[:1 + h, 0] = 1.0; Mu[1 + h:, 1] = 1.0
+    Y = F @ Mu.T + rng.standard_normal((T0, J + 1))
+    return Y[:, 0], Y[:, 1:]                      # A (T0,), B (T0, J)
+
+
+# --------------------------------------------------------------------------- #
+# 1. simplex projection primitive
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("n", [1, 2, 5, 50, 500])
+def test_simplex_project_matches_cvxpy(n):
+    # One-sided vs cvxpy: our sort-based projection is *exact*, while CLARABEL's
+    # projection QP carries ~1e-4 slack at larger n, so we assert our squared
+    # distance is no worse than cvxpy's (plus feasibility and the (v-theta)_+
+    # optimality form), not pointwise equality to CLARABEL's approximate point.
+    rng = np.random.default_rng(n)
+    for _ in range(20):
+        v = rng.standard_normal(n) * rng.uniform(0.1, 10)
+        p = simplex_project(v)
+        assert_feasible(p, n)
+        # p must have the form (v - theta)_+ for a single threshold theta
+        active = p > 0
+        if active.sum() >= 2 and (~active).any():
+            theta = float(np.mean((v - p)[active]))
+            assert np.allclose((v - p)[active], theta, atol=1e-9)
+            assert np.all(v[~active] <= theta + 1e-9)
+        ref = _proj_ref(v)
+        if ref is not None:
+            dm = float((p - v) @ (p - v))
+            dr = float((ref - v) @ (ref - v))
+            assert dm <= dr + 1e-9 * (1.0 + abs(dr))
+
+
+def test_simplex_project_idempotent_on_simplex():
+    rng = np.random.default_rng(3)
+    w = rng.random(20); w /= w.sum()
+    assert np.max(np.abs(simplex_project(w) - w)) < 1e-12
+
+
+def test_simplex_project_of_vertex_is_vertex():
+    v = np.array([10.0, -1.0, -2.0, -3.0])
+    p = simplex_project(v)
+    assert np.argmax(p) == 0 and p[0] == pytest.approx(1.0)
+
+
+# --------------------------------------------------------------------------- #
+# 2. FISTA warm start
+# --------------------------------------------------------------------------- #
+def test_fista_warm_start_feasible_and_deterministic():
+    A, B = _factor_panel(120, 240)
+    w1 = fista_warm_start(B, A)
+    w2 = fista_warm_start(B, A)
+    assert_feasible(w1, B.shape[1])
+    assert np.array_equal(w1, w2), "warm start must be deterministic"
+
+
+def test_fista_warm_start_near_optimal():
+    A, B = _factor_panel(120, 240)
+    ref = _reference(B, A)
+    o_star = _obj(B, A, ref)
+    o_fista = _obj(B, A, fista_warm_start(B, A))
+    # coarse but close: the exact polish closes the rest
+    assert o_fista <= o_star + 0.05 * (1.0 + abs(o_star))
+
+
+# --------------------------------------------------------------------------- #
+# 3. simplex_qp optimality, large and small
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("J,T0", [(100, 200), (150, 120), (200, 400)])
+def test_simplex_qp_large_is_kkt_optimal(J, T0):
+    A, B = _factor_panel(J, T0)
+    w = simplex_qp(B, A)
+    assert_kkt_optimal(B, A, w)
+    ref = _reference(B, A)
+    if ref is not None:
+        assert _obj(B, A, w) <= _obj(B, A, ref) + 1e-6 * (1 + abs(_obj(B, A, ref)))
+
+
+@pytest.mark.parametrize("J,T0", [(3, 8), (16, 30), (40, 80)])
+def test_simplex_qp_small_unaffected(J, T0):
+    A, B = _factor_panel(J, T0)
+    assert_kkt_optimal(B, A, simplex_qp(B, A))
+
+
+def test_accelerated_equals_cold_fitted_values():
+    """Accelerated simplex_qp and the cold active-set agree on the (unique)
+    fitted values B@w across shapes -- the accelerator changes speed, not answer."""
+    for J, T0 in [(100, 200), (150, 120), (250, 500), (90, 90)]:
+        A, B = _factor_panel(J, T0)
+        w_accel = simplex_qp(B, A)
+        w_cold, _ = solve_simplex_qp(B, A, return_info=True)
+        assert np.max(np.abs(B @ w_accel - B @ w_cold)) < 1e-6
+        assert _obj(B, A, w_accel) == pytest.approx(_obj(B, A, w_cold), abs=1e-6)
+
+
+def test_accelerated_matches_clarabel_value_for_value():
+    """On a large problem where the accelerator fires, the weights match a CLARABEL
+    solve (the general interior-point we are beating on speed) value-for-value."""
+    A, B = _factor_panel(200, 400)
+    w = simplex_qp(B, A)
+    x = cp.Variable(B.shape[1], nonneg=True)
+    cp.Problem(cp.Minimize(cp.sum_squares(A - B @ x)), [cp.sum(x) == 1]).solve(solver=cp.CLARABEL)
+    w_cl = np.clip(np.asarray(x.value, float).ravel(), 0.0, None)
+    assert np.max(np.abs(B @ w - B @ w_cl)) < 1e-4          # fitted values agree
+    assert _obj(B, A, w) <= _obj(B, A, w_cl) + 1e-6         # ours is (at least) as good
+
+
+def test_accelerator_faster_than_cold_on_large_J():
+    """Speed regression: the FISTA warm start makes the exact solve markedly
+    faster on a wide donor pool. Conservative 2x margin (measured ~13x at J=250)."""
+    import time
+    A, B = _factor_panel(250, 500)
+    t = time.perf_counter(); w_cold, _ = solve_simplex_qp(B, A, return_info=True); t_cold = time.perf_counter() - t
+    t = time.perf_counter(); w_acc = simplex_qp(B, A); t_acc = time.perf_counter() - t
+    assert np.max(np.abs(B @ w_acc - B @ w_cold)) < 1e-6    # same answer
+    assert t_acc < 0.5 * t_cold, f"accel {t_acc:.3f}s not < half of cold {t_cold:.3f}s"
+
+
+# --------------------------------------------------------------------------- #
+# 4. accelerator engagement gating
+# --------------------------------------------------------------------------- #
+def test_accelerator_engaged_for_large_J(monkeypatch):
+    calls = {"n": 0}
+    real = ridge_augment.fista_warm_start
+
+    def spy(B, A, **kw):
+        calls["n"] += 1
+        return real(B, A, **kw)
+
+    monkeypatch.setattr(ridge_augment, "fista_warm_start", spy)
+    A, B = _factor_panel(ACCEL_MIN_DONORS + 20, 2 * (ACCEL_MIN_DONORS + 20))
+    simplex_qp(B, A)
+    assert calls["n"] == 1
+
+
+def test_accelerator_skipped_for_small_J(monkeypatch):
+    calls = {"n": 0}
+    monkeypatch.setattr(ridge_augment, "fista_warm_start",
+                        lambda *a, **k: calls.__setitem__("n", calls["n"] + 1))
+    A, B = _factor_panel(max(2, ACCEL_MIN_DONORS - 30), 60)
+    simplex_qp(B, A)
+    assert calls["n"] == 0
+
+
+def test_accelerator_skipped_when_caller_supplies_warm_start(monkeypatch):
+    calls = {"n": 0}
+    monkeypatch.setattr(ridge_augment, "fista_warm_start",
+                        lambda *a, **k: calls.__setitem__("n", calls["n"] + 1))
+    A, B = _factor_panel(ACCEL_MIN_DONORS + 20, 2 * (ACCEL_MIN_DONORS + 20))
+    J = B.shape[1]
+    simplex_qp(B, A, warm_start=np.full(J, 1.0 / J))
+    assert calls["n"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# 5. edge cases
+# --------------------------------------------------------------------------- #
+def test_edge_single_donor():
+    B = np.array([[2.0], [3.0], [1.5]]); A = np.array([2.0, 3.0, 1.5])
+    w = simplex_qp(B, A)
+    assert w.shape == (1,) and w[0] == pytest.approx(1.0)
+
+
+def test_edge_wide_more_donors_than_periods():
+    A, B = _factor_panel(ACCEL_MIN_DONORS + 40, 30)     # J > T0, accelerator on
+    assert_kkt_optimal(B, A, simplex_qp(B, A))
+
+
+def test_edge_collinear_donors_large():
+    A, B = _factor_panel(ACCEL_MIN_DONORS + 10, 200)
+    B[:, 1] = B[:, 0]                                    # duplicate donor (degenerate)
+    w = simplex_qp(B, A)
+    assert_kkt_optimal(B, A, w)

--- a/mlsynth/utils/bilevel/accelerate.py
+++ b/mlsynth/utils/bilevel/accelerate.py
@@ -1,0 +1,108 @@
+"""Speed-only warm-start accelerator for the simplex-constrained least-squares
+solver used across the bilevel SCM engine (outcome-only SC, ridge augmentation,
+the conformal / placebo hot loops).
+
+The exact solver is the primal active-set method in :mod:`.active_set`. It builds
+the active set one pivot at a time, each pivot an ``lstsq`` on the current free
+set, so a *cold* solve on a large donor pool (hundreds of donors) can take
+seconds -- the cost is dominated by discovering *which* donors are in the support,
+not by the final small solve on that support.
+
+This module discovers the support cheaply. It collapses the pre-period (time)
+dimension into the Gram matrix ``G = B^T B`` once and runs FISTA (accelerated
+projected gradient, Beck & Teboulle 2009) with the exact Euclidean projection
+onto the probability simplex (Held, Wolfe & Crowder 1974; Duchi et al. 2008).
+FISTA converges to the neighbourhood of the optimum -- and hence the right
+support -- in a few hundred cheap iterations; the exact active-set then certifies
+from that warm start in a handful of pivots.
+
+The accelerator is *speed only*. It supplies a feasible warm start; the exact
+active-set (with the cvxpy fallback) still determines the returned weights, so
+the answer is unchanged for any warm start. Correctness therefore never depends
+on FISTA converging, the Lipschitz estimate being tight, or the problem being
+well-conditioned -- only the runtime does.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+# Engage the accelerator only for donor pools at least this wide. Below it the
+# cold active-set already solves in well under a pivot's worth of FISTA overhead
+# (measured crossover ~ J = 60-80; typical SC panels -- Prop 99 J = 38, Basque
+# J = 16 -- stay comfortably on the untouched fast path). Also skipped whenever
+# the caller already supplies a warm start (e.g. the conformal / placebo loops).
+ACCEL_MIN_DONORS = 80
+
+
+def simplex_project(v: np.ndarray) -> np.ndarray:
+    """Exact Euclidean projection of ``v`` onto ``{w >= 0, sum w = 1}``.
+
+    The sort-based method of Held, Wolfe & Crowder (1974) / Duchi et al. (2008):
+    ``O(n log n)``, returns the unique projection ``(v - theta)_+`` for the
+    threshold ``theta`` that makes the result sum to one.
+    """
+    v = np.asarray(v, dtype=float).ravel()
+    n = v.shape[0]
+    if n == 1:
+        return np.ones(1)
+    u = np.sort(v)[::-1]
+    css = np.cumsum(u) - 1.0
+    ind = np.arange(1, n + 1)
+    cond = u - css / ind > 0                 # cond[0] is always True (u[0]-(u[0]-1) = 1 > 0)
+    rho = ind[cond][-1]
+    theta = css[rho - 1] / rho
+    return np.maximum(v - theta, 0.0)
+
+
+def _spectral_bound(G: np.ndarray, iters: int = 50) -> float:
+    """An estimate of ``lambda_max(G)`` (deterministic power iteration), inflated
+    by 10% so it is, in practice, an upper bound -- FISTA's stable step is
+    ``1 / L`` with ``L >= lambda_max`` of the gradient. A loose or even invalid
+    bound only slows the warm start (the simplex projection keeps every iterate
+    bounded); it can never make the final active-set answer wrong.
+    """
+    n = G.shape[0]
+    v = np.random.default_rng(0).standard_normal(n)   # fixed seed -> deterministic
+    v /= np.linalg.norm(v)
+    lam = 0.0
+    for _ in range(iters):
+        Gv = G @ v
+        nrm = np.linalg.norm(Gv)
+        if nrm == 0.0:
+            return 0.0
+        v = Gv / nrm
+        lam = float(v @ (G @ v))
+    return lam * 1.1
+
+
+def fista_warm_start(B: np.ndarray, A: np.ndarray, *,
+                     max_iter: int = 400, tol: float = 1e-7) -> np.ndarray:
+    """A feasible, near-optimal warm start for ``min ||A - B w||^2`` on the
+    simplex, via Gram-collapsed FISTA.
+
+    Deterministic. Returns a point on the simplex; it is intended to seed the
+    exact active-set solver, not to be used as the final solution.
+    """
+    B = np.asarray(B, dtype=float)
+    A = np.asarray(A, dtype=float).ravel()
+    J = B.shape[1]
+    if J == 1:
+        return np.ones(1)
+    G = B.T @ B
+    c = B.T @ A
+    L = 2.0 * _spectral_bound(G)
+    if not np.isfinite(L) or L <= 0.0:        # degenerate (e.g. all-zero donors)
+        return np.full(J, 1.0 / J)
+    w = np.full(J, 1.0 / J)
+    y = w.copy()
+    t = 1.0
+    for _ in range(max_iter):
+        w_new = simplex_project(y - (2.0 * (G @ y - c)) / L)
+        t_new = 0.5 * (1.0 + np.sqrt(1.0 + 4.0 * t * t))
+        y = w_new + ((t - 1.0) / t_new) * (w_new - w)
+        if np.max(np.abs(w_new - w)) < tol:
+            w = w_new
+            break
+        w = w_new
+        t = t_new
+    return w

--- a/mlsynth/utils/bilevel/ridge_augment.py
+++ b/mlsynth/utils/bilevel/ridge_augment.py
@@ -43,6 +43,8 @@ from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 
+from .accelerate import ACCEL_MIN_DONORS, fista_warm_start
+
 _EPS = 1e-12
 
 # Max condition number of the ridge Gram ``B B^T + lambda I`` tolerated when
@@ -63,11 +65,19 @@ def simplex_qp(B: np.ndarray, A: np.ndarray, warm_start=None) -> np.ndarray:
     (:func:`mlsynth.utils.bilevel.active_set.solve_simplex_qp`), which avoids
     cvxpy's per-call canonicalisation overhead in the hot conformal /
     market-selection loops and is warm-startable. Augmented SCM augments an
-    *accurately solved* simplex SCM (augsynth uses quadprog), and the bilevel
-    package's FISTA primitive under-converges on long pre-periods, so the base
-    is solved exactly here. Falls back to cvxpy if the active set fails to
-    certify convergence (degenerate cycling), keeping the result no worse than
-    before.
+    *accurately solved* simplex SCM (augsynth uses quadprog), so the base is
+    solved exactly here. Falls back to cvxpy if the active set fails to certify
+    convergence (degenerate cycling), keeping the result no worse than before.
+
+    For a large donor pool (``J >= ACCEL_MIN_DONORS``) with no caller-supplied
+    warm start, a Gram-collapsed FISTA warm start
+    (:func:`mlsynth.utils.bilevel.accelerate.fista_warm_start`) is computed first
+    so the active set is certified from the right support instead of built up
+    pivot by pivot -- up to ~20x faster on a few hundred donors, and faster than a
+    general interior-point solver (CLARABEL) on the same problem. This is
+    speed-only: the exact active-set (with the cvxpy fallback) still determines
+    the weights, so the answer is unchanged; the small-``J`` hot path and any
+    caller that already warm-starts are untouched.
 
     Parameters
     ----------
@@ -82,6 +92,10 @@ def simplex_qp(B: np.ndarray, A: np.ndarray, warm_start=None) -> np.ndarray:
     """
     from .active_set import solve_simplex_qp
 
+    B = np.asarray(B, dtype=float)
+    A = np.asarray(A, dtype=float).ravel()
+    if warm_start is None and B.shape[1] >= ACCEL_MIN_DONORS:
+        warm_start = fista_warm_start(B, A)
     w, info = solve_simplex_qp(B, A, warm_start=warm_start, return_info=True)
     if info["converged"]:
         return w


### PR DESCRIPTION
## What

The exact simplex-least-squares solver behind outcome-only SC, ridge augmentation, and the conformal/placebo loops (`simplex_qp` → active-set) builds the support one pivot at a time, each an `lstsq` on the free set. On a wide donor pool (hundreds of donors) the cold solve is dominated by *discovering* the support and can take seconds — slower even than a general interior-point solver (CLARABEL).

This adds a **speed-only** accelerator: collapse the pre-period dimension into the Gram `G = B'B` once, run **FISTA** (accelerated projected gradient with an exact simplex projection) to identify the support cheaply, then hand that as a warm start to the existing exact active-set, which certifies from the right support in a handful of pivots.

## Numbers

Factor-structure panels, all returning the **identical** optimum (gap 0 vs the cold solve):

| J | cold active-set | accelerated | speedup |
|---|---|---|---|
| 150 | 370 ms | 32 ms | 11× |
| 400 | 4.6 s | 208 ms | 22× |
| 600 | 17.0 s | 256 ms | 66× |

Against CLARABEL on the same problems the accelerated path is ~6–23× faster and exact (a textbook Frank–Wolfe, by contrast, stalls at ~1% precision at every scale).

## Why it's safe

Correctness is structural, not incidental: FISTA only supplies a feasible warm start; the proven active-set (with the cvxpy fallback) still determines the weights. So the answer is unchanged for *any* warm start — it never depends on FISTA converging, the Lipschitz estimate being tight, or the problem being well-conditioned. Only the runtime does.

Gated at `J >= 80` (`ACCEL_MIN_DONORS`), so the typical small-`J` hot path (Prop 99 `J=38`, Basque `J=16`) and any caller that already warm-starts (the conformal/placebo loops) are **untouched** — they hit the exact same code as before.

## Changes

- New `mlsynth/utils/bilevel/accelerate.py`: exact sort-based simplex projection (Held–Wolfe–Crowder / Duchi) + deterministic Gram-collapsed FISTA warm start.
- `simplex_qp` computes the warm start for large `J` only; everything else is unchanged.

## Tests (TDD, test-first)

`mlsynth/tests/test_simplex_qp_accelerate.py` (24 tests): projection exactness vs cvxpy (one-sided — ours is the exact one, CLARABEL carries ~1e-4 slack); warm-start feasibility/determinism/near-optimality; KKT-optimality and value-for-value match to both the cold active-set and CLARABEL on large problems; engagement gating (engaged for large `J`, skipped for small `J` and when a warm start is supplied); a conservative speed regression; edge cases (single donor, `J>T0`, collinear donors). Full local suite: **4935 passed, 283 skipped**.

Note: kept to the test suite rather than a `benchmarks/` registry case, since a solver speed/exactness check isn't a paper replication and per repo convention benchmark cases aren't bundled into a refactor PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdcyUtZVE263on5BYhgzSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdcyUtZVE263on5BYhgzSw)_