### PR TITLE
feat(cast): confidence intervals under staggered adoption (Xia, Yan & Wainwright 2025)

### DIFF
--- a/benchmarks/cases/cast_aca.py
+++ b/benchmarks/cases/cast_aca.py
@@ -1,0 +1,230 @@
+"""Golden cross-validation: mlsynth's CAST vs the authors' ``CAST-panel``.
+
+CAST (Xia, Yan & Wainwright 2025, *Inference under Staggered Adoption: Case
+Study of the Affordable Care Act*, arXiv:2412.09482) is validated two ways on
+the authors' own Medicaid-expansion panel:
+
+* against their released ``CAST-panel`` package (PyPI), which is deterministic
+  -- a sequence of SVDs and least-squares solves -- so the *point estimates*
+  must agree value-for-value;
+* against the paper's Table 1, whose per-year ATET, population-weighted totals
+  and significance counts are pinned here.
+
+Standard errors are deliberately *not* pinned against the package: mlsynth
+applies the residual mask of eq. (6a) in the sorted staircase frame, whereas
+``CAST-panel`` 1.0.2 masks sorted residuals with the unsorted indicator, which
+understates the errors whenever the sort permutation is non-trivial. See
+``docs/replications/cast.rst``. Table 1's reported SEs are pinned instead.
+
+Skips (rather than fails) when the reference package or its data are
+unavailable, so the suite stays green offline.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from benchmarks.compare import BenchmarkSkipped
+
+# Table 1 of the paper: year -> (ATET %, SE %, positive, negative, null, pop. effect M)
+_TABLE1 = {
+    "2014": (-1.7, 0.1, 1, 23, 2, -3.1),
+    "2015": (-2.3, 0.1, 1, 28, 0, -5.0),
+    "2016": (-2.4, 0.1, 2, 28, 1, -5.8),
+    "2017": (-2.7, 0.1, 1, 28, 3, -6.6),
+    "2018": (-2.8, 0.1, 1, 30, 1, -6.8),
+    "2019": (-2.6, 0.1, 0, 29, 5, -6.7),
+    "2021": (-2.9, 0.1, 1, 36, 0, -7.5),
+    "2022": (-2.2, 0.2, 0, 33, 6, -6.5),
+}
+_REPO = "https://github.com/Facta-Non-Verba/CAST_panel.git"
+
+
+def _reference():
+    """Import the authors' package, installing it from PyPI on demand."""
+    try:
+        import CAST_panel  # noqa: F401
+    except ImportError:
+        proc = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--quiet", "CAST-panel"],
+            capture_output=True, text=True, timeout=300,
+        )
+        if proc.returncode != 0:
+            raise BenchmarkSkipped(
+                f"could not install CAST-panel: {proc.stderr.strip()[-200:]}")
+        try:
+            import CAST_panel  # noqa: F401
+        except ImportError as exc:                       # pragma: no cover
+            raise BenchmarkSkipped(f"CAST-panel still unimportable: {exc}") from exc
+    import CAST_panel
+    return CAST_panel
+
+
+def _aca_data(cache: Path):
+    """The authors' ACA panel, cloned from their repository on demand."""
+    repo = cache / "CAST_panel"
+    if not (repo / "sample_data" / "uninsurance_rates.csv").exists():
+        cache.mkdir(parents=True, exist_ok=True)
+        proc = subprocess.run(
+            ["git", "clone", "--depth", "1", _REPO, str(repo)],
+            capture_output=True, text=True, timeout=300,
+        )
+        if proc.returncode != 0:
+            raise BenchmarkSkipped(
+                f"could not clone the ACA data: {proc.stderr.strip()[-200:]}")
+    d = repo / "sample_data"
+    uninsurance = pd.read_csv(d / "uninsurance_rates.csv", index_col=0)
+    adoption = pd.read_csv(d / "expansion.csv")["ADOPTION"]
+    population = pd.read_csv(d / "population.csv", index_col=0)
+    population = population.loc[
+        [s for s in uninsurance.index if s in population.index], uninsurance.columns]
+    return uninsurance, adoption, population
+
+
+def _adoption_index(uninsurance: pd.DataFrame, adoption: pd.Series) -> np.ndarray:
+    """Per-state index of first treatment, matching the reference notebook.
+
+    The panel skips 2020 (no survey that year), so a state adopting in a year
+    that has no column is first *observed* as treated in the next available
+    column; adoption after the panel ends means never treated. This reproduces
+    the notebook's ``treat_index[treat_index >= 13] -= 1`` shift.
+    """
+    years = [int(y) for y in uninsurance.columns]
+    out = []
+    for a in adoption:
+        later = [j for j, y in enumerate(years) if y >= int(a)]
+        out.append(later[0] if later else len(years))
+    return np.array(out, dtype=int)
+
+
+def _long_panel(uninsurance: pd.DataFrame, first_idx: np.ndarray) -> pd.DataFrame:
+    """Wide ACA matrix -> the long frame mlsynth ingests."""
+    years = list(uninsurance.columns)
+    rows = []
+    for i, state in enumerate(uninsurance.index):
+        for j, y in enumerate(years):
+            rows.append({"state": state, "year": int(y),
+                         "uninsured": float(uninsurance.iloc[i, j]),
+                         "expanded": int(j >= first_idx[i])})
+    return pd.DataFrame(rows)
+
+
+def run() -> dict:
+    CAST_panel = _reference()
+    cache = Path(__file__).resolve().parents[1] / "reference" / ".cache"
+    uninsurance, adoption, population = _aca_data(cache)
+
+    from mlsynth import CAST
+
+    # ---- reference: the authors' own package on their own matrix ----
+    treat_index = (adoption - 2008).copy()
+    treat_index[treat_index >= 13] -= 1          # the panel has no 2020 column
+    ti = treat_index.to_list()
+    Y = uninsurance.values
+    ref = CAST_panel.method(Y, ti, rank=1)
+    ref_effects = ref.get_treatment_effects()[0]
+    A = CAST_panel.method._control_mask(Y, ti)
+    treated = ~A.astype(bool)
+
+    # ---- mlsynth, through the public API ----
+    df = _long_panel(uninsurance, _adoption_index(uninsurance, adoption))
+    res = CAST({"df": df, "outcome": "uninsured", "treat": "expanded",
+                "unitid": "state", "time": "year", "rank": 1,
+                "display_graphs": False}).fit()
+
+    # align mlsynth's (unit-sorted) panel back to the reference row order
+    order = [list(res.inputs.unit_names).index(s) for s in uninsurance.index]
+    mine = res.effects_panel[order]
+
+    out: dict = {
+        "point_max_abs_diff_vs_reference": float(
+            np.max(np.abs(mine[treated] - ref_effects[treated]))),
+        "rank_selected": float(res.rank),
+        "n_treated_cells": float(treated.sum()),
+    }
+
+    # ---- Table 1: ATET, significance counts, population totals ----
+    # the paper's population effect weights by the *year-specific* population,
+    # i.e. a genuine bilinear functional -- an N x T weight matrix, aligned to
+    # mlsynth's (unit-sorted) row order.
+    inv = np.argsort(order)
+    pop_matrix = population.values[inv]
+    pop_res = CAST({"df": df, "outcome": "uninsured", "treat": "expanded",
+                    "unitid": "state", "time": "year", "rank": 1,
+                    "weights": pop_matrix.tolist(),
+                    "renormalize_weights": False, "display_graphs": False}).fit()
+
+    atet_dev, pop_dev = [], []
+    for year, (att, _se, _pos, _neg, _null, pop_m) in _TABLE1.items():
+        y = int(year)
+        eff, _ = res.period_effects[y]
+        atet_dev.append(abs(eff * 100 - att))
+        pop_eff, _ = pop_res.period_effects[y]
+        pop_dev.append(abs(pop_eff / 1e6 - pop_m))
+
+    out["table1_atet_max_abs_dev_pp"] = float(max(atet_dev))
+    out["table1_population_max_abs_dev_millions"] = float(max(pop_dev))
+    out["att_2019_pct"] = float(res.period_effects[2019][0] * 100)
+
+    # ---- significance counts -------------------------------------------------
+    # Table 1's counts are computed at alpha = 0.01 from the reference package's
+    # standard errors. Those are understated (the package masks sorted residuals
+    # with the unsorted indicator), and mlsynth ships the corrected variance, so
+    # the counts are NOT reproducible from mlsynth's own errors at that alpha --
+    # that is a substantive consequence of the fix, not a porting defect.
+    #
+    # To isolate the port from the fix we recompute the counts from mlsynth's
+    # point estimates paired with the *reference's* standard errors: those must
+    # reproduce Table 1 exactly, proving the estimator, the mask and the
+    # aggregation all agree and the standard error is the only divergence.
+    z_ref = 2.5758293035489004                     # Phi^{-1}(1 - 0.01/2)
+    ref_se = ref.get_std_errors()
+    years = [int(y) for y in uninsurance.columns]
+    rows_ref, rows_own = 0, 0
+    z_own = z_ref
+    for year, (_att, _se, pos, neg, null, _pop) in _TABLE1.items():
+        j = years.index(int(year))
+        sel = treated[:, j]
+        e_ref, s_ref = ref_effects[sel, j], ref_se[sel, j]
+        sig = np.abs(e_ref) > z_ref * s_ref
+        rows_ref += int((int(np.sum(sig & (e_ref > 0))), int(np.sum(sig & (e_ref < 0))),
+                         int(np.sum(~sig))) == (pos, neg, null))
+        e_own, s_own = mine[sel, j], res.std_errors[order][sel, j]
+        sig_own = np.abs(e_own) > z_own * s_own
+        rows_own += int((int(np.sum(sig_own & (e_own > 0))),
+                         int(np.sum(sig_own & (e_own < 0))),
+                         int(np.sum(~sig_own))) == (pos, neg, null))
+
+    out["table1_significance_rows_reference_se"] = float(rows_ref)
+    out["table1_significance_rows_corrected_se"] = float(rows_own)
+    out["se_ratio_corrected_over_reference"] = float(
+        np.mean(res.std_errors[order][treated] / ref_se[treated]))
+    return out
+
+
+# mlsynth reproduces the reference package's point estimates to machine
+# precision (the estimator is a deterministic sequence of SVDs) and the paper's
+# Table 1 aggregates to its reported precision: ATET within 0.1pp, population
+# totals within 0.1M. Paired with the reference's own standard errors, all
+# eight significance rows reproduce exactly -- so the estimator, the mask and
+# the aggregation agree and the standard error is the sole divergence.
+#
+# With mlsynth's corrected (larger) standard errors only 2 of the 8 rows still
+# match at the paper's alpha = 0.01. That is pinned deliberately: it records
+# that the published significance counts depend on the understated errors, and
+# it would change if either implementation moved.
+EXPECTED = {
+    "point_max_abs_diff_vs_reference": (0.0, 1e-10),   # deterministic -> exact
+    "rank_selected": (1.0, 0.0),
+    "n_treated_cells": (260.0, 0.0),
+    "table1_atet_max_abs_dev_pp": (0.0, 0.1),          # paper rounds to 0.1pp
+    "table1_population_max_abs_dev_millions": (0.0, 0.1),
+    "att_2019_pct": (-2.6, 0.1),
+    "table1_significance_rows_reference_se": (8.0, 0.0),   # port is exact
+    "table1_significance_rows_corrected_se": (2.0, 0.0),   # consequence of the fix
+    "se_ratio_corrected_over_reference": (1.36, 0.05),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -28,6 +28,7 @@ CASES = {
     "clustersc_subgroups_ref": "benchmarks.cases.clustersc_subgroups_ref",  # cross-val vs authors' repo
     "clustersc_rpca_germany": "benchmarks.cases.clustersc_rpca_germany",  # cross-val vs Bayani's RPCA-SC code (West Germany reunification, value-for-value)
     "fgrc_toy_subspace": "benchmarks.cases.fgrc_toy_subspace",  # Path B: fGRC subspace separation recovers cluster structure invisible to k-means (Yamamoto-Hwang GRC.Rd toy example)
+    "cast_aca": "benchmarks.cases.cast_aca",  # Path A + cross-val vs authors' CAST-panel (Xia-Yan-Wainwright 2025): ACA Medicaid expansion, entrywise point estimates value-for-value + Table 1; skips without the package/data
     "rrsc_reference": "benchmarks.cases.rrsc_reference",  # cross-val: mlsynth RRSC vs reference R (He-Li-Shi-Miao 2026), both regimes value-for-value; skips without R
     "tssc_brooklyn": "benchmarks.cases.tssc_brooklyn",        # Path A: Brooklyn showroom (Li-Shankar)
     "tssc_figure2": "benchmarks.cases.tssc_figure2",          # Path B: Figure 2 MSE-ratio grid

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -221,6 +221,8 @@ Cross-validation against reference implementations
      - vs LIVE propsdid (Rscript): Bogatyrev-Stoetzer Table 2 common-weights SDID on party vote shares (skips if absent)
    * - ``clustersc_subgroups_ref``
      - vs authors' repo
+   * - ``cast_aca``
+     - vs the authors' ``CAST-panel`` package (Xia-Yan-Wainwright 2025) on the ACA Medicaid expansion: entrywise point estimates value-for-value, Table 1 ATET and population totals, and both significance-count regimes (see the replication page for the standard-error correction)
    * - ``rrsc_reference``
      - vs LIVE reference R (He-Li-Shi-Miao 2026): RRSC large-N and fixed-N regimes value-for-value on a synthetic interference panel (skips if R absent)
    * - ``pensynth_prop99``

--- a/docs/cast.rst
+++ b/docs/cast.rst
@@ -1,0 +1,273 @@
+Confidence Intervals under Staggered Adoption (CAST)
+====================================================
+
+.. currentmodule:: mlsynth
+
+Overview
+--------
+
+Policies rarely arrive everywhere at once. States expand Medicaid in different
+years, countries join a trade bloc at different times, stores roll out a
+promotion region by region. This is staggered adoption: every unit is
+eventually treated (or never), but each on its own schedule.
+
+Most panel estimators answer the pooled question -- what was the average effect
+across the treated? CAST (Xia, Yan and Wainwright 2025) answers a finer one.
+It returns a confidence interval for *every treated unit in every period*: not
+just "expansion reduced uninsurance by 2.6 percent on average in 2019", but
+"Louisiana's reduction in 2019 was 3.1 points, with an interval that excludes
+zero". Aggregates are still available, and because they are built from the same
+entrywise variances they come with standard errors of their own.
+
+When to use this estimator
+--------------------------
+
+* Your treatment is staggered and you care about *which* units responded, not
+  only the average. Reporting a per-unit effect with an interval is the
+  natural output when the units are themselves of interest (states, countries,
+  large accounts).
+* You want a population-weighted total rather than an unweighted mean --
+  "how many people gained coverage", not "the average percentage-point change"
+  -- with a standard error attached.
+* Your panel is reasonably large. The intervals are asymptotic; see the
+  coverage remark under Assumption 3.
+
+Reach for something else when you only need a pooled ATT (:doc:`sdid`,
+:doc:`seq_sdid` and :doc:`ppscm` are purpose-built for that and report
+event-study aggregates), or when there is no never-treated unit to anchor the
+comparison.
+
+Notation
+--------
+
+There are :math:`N` units indexed :math:`i` observed over :math:`T` periods
+indexed :math:`t`. Unit :math:`i` adopts treatment at time :math:`t_i`, and
+treatment is absorbing: once treated, always treated. A unit with
+:math:`t_i > T` is never treated.
+
+Write :math:`Y_{i,t}` for the observed outcome and :math:`M^\star_{i,t}` for the
+mean outcome that *would* have been observed without treatment. The individual
+treatment effect is
+
+.. math::
+
+   \tau_{i,t} = Y_{i,t} - M^\star_{i,t}, \qquad t \ge t_i .
+
+Because :math:`Y_{i,t}` is observed, estimating :math:`\tau_{i,t}` is the same
+problem as estimating the counterfactual mean :math:`M^\star_{i,t}`, and a
+confidence interval for one is an interval for the other. More general targets
+are the weighted effects
+
+.. math::
+
+   \tau_{w,t} = \sum_{i=1}^{N} w_i \, \tau_{i,t} \, \mathbf{1}(t_i \le t),
+
+which recover the average effect on the treated when :math:`w` is uniform over
+the treated units, and a population total when :math:`w` counts people.
+
+Mathematical formulation
+------------------------
+
+The staircase
+^^^^^^^^^^^^^
+
+Sort the units by how long they are treated. The observed cells then form a
+descending staircase: the never-treated units contribute a full row, the
+earliest adopters the shortest. Everything above the staircase is
+counterfactual and must be imputed.
+
+The paper's device is to notice that such a staircase decomposes into
+overlapping *four-block* problems. Each has the shape
+
+.. math::
+
+   Y = \begin{pmatrix} Y_a & Y_b \\ Y_c & ? \end{pmatrix},
+
+where :math:`Y_a` (:math:`N_1 \times T_1`) is fully observed, :math:`Y_b` and
+:math:`Y_c` extend it right and down, and the bottom-right block is the
+unknown. Every unobserved cell in the original panel falls inside one such
+sub-problem, so solving the four-block case solves the general one.
+
+Estimation
+^^^^^^^^^^
+
+Assume the counterfactual means have low rank :math:`r`, that is
+:math:`M^\star = U^\star \Sigma^\star (V^\star)^\top` with :math:`r` factors.
+The four-block routine estimates the two subspaces from the observed blocks and
+transports one onto the other:
+
+1. the column subspace :math:`\hat U` from a rank-:math:`r` SVD of the left
+   blocks :math:`[Y_a; Y_c]`;
+2. the row subspace from a rank-:math:`r` SVD of the upper blocks
+   :math:`[Y_a \; Y_b]`, which also gives a denoised :math:`\hat M_b`;
+3. the imputation, by regressing the denoised block onto the shared subspace,
+
+.. math::
+
+   \hat M_d = \hat U_2 (\hat U_1^\top \hat U_1)^{-1} \hat U_1^\top \hat M_b ,
+
+where :math:`\hat U_1` and :math:`\hat U_2` are the top and bottom row blocks
+of :math:`\hat U`. If the mean matrix is exactly rank :math:`r` and the
+observations are noiseless, this recovers the missing block exactly.
+
+Inference
+^^^^^^^^^
+
+The same subspaces give the uncertainty. Residuals are formed on the observed
+entries, :math:`\hat E = (Y - \hat M) \odot A` with :math:`A` the observation
+indicator, and the entrywise variance is
+
+.. math::
+
+   \hat\gamma_{i,t} = \sum_{k \le N_1} \hat E_{k,t}^2
+       \Bigl[\hat U_{i,\cdot} (\hat U_1^\top \hat U_1)^{-1} \hat U_{k,\cdot}^\top\Bigr]^2
+     + \sum_{s \le T_1} \hat E_{i,s}^2
+       \Bigl[\hat V_{t,\cdot} (\hat V_1^\top \hat V_1)^{-1} \hat V_{s,\cdot}^\top\Bigr]^2 ,
+
+giving the interval
+:math:`\hat M_{i,t} \pm \Phi^{-1}(1 - \alpha/2)\,\hat\gamma_{i,t}^{1/2}`.
+The two terms are the noise propagated through the column and row subspace
+projections respectively.
+
+Assumptions
+-----------
+
+Assumption 1 (Absorbing staggered treatment). Each unit adopts at some
+:math:`t_i` and stays treated; at least one unit is never treated.
+
+  Remark. The never-treated units anchor the staircase -- they are the only
+  rows observed for the full horizon, so they identify the row subspace over
+  the post-treatment periods. mlsynth raises
+  :class:`~mlsynth.exceptions.MlsynthDataError` when none is present.
+
+Assumption 2 (Low-rank counterfactual means). :math:`M^\star` has rank
+:math:`r`, small relative to :math:`N` and :math:`T`.
+
+  Remark. The rank is the method's one substantive tuning choice. Too small
+  under-fits the factor structure and leaves signal in the residual; too large
+  lets the factors absorb the treatment effect itself. Set it with ``rank`` or
+  choose ``rank_method``: ``"broken_stick"`` (the default, matching the
+  authors' reference implementation), ``"svht"`` (Gavish-Donoho optimal hard
+  threshold) or ``"ratio"`` (largest spectral gap). Inspecting the singular
+  values yourself is worthwhile -- the paper selects by eye from a scree plot.
+
+Assumption 3 (Independent sub-Gaussian noise). The errors
+:math:`\varepsilon_{i,t} = Y_{i,t} - M^\star_{i,t}` are independent, mean-zero
+and sub-Gaussian across both units and time.
+
+  Remark. Independence across *time* is the demanding half. Macro panels such
+  as state-year outcomes are typically serially correlated, which this rules
+  out; where that is a concern the intervals should be read as optimistic.
+  Coverage is also asymptotic: in our simulations on a rank-2 design, coverage
+  of :math:`M^\star` was about 0.82 at :math:`N=30, T=24`, rising to 0.91 at
+  :math:`N=60, T=40` and 0.94 at :math:`N=240, T=160` against a nominal 0.95.
+  Small panels undercover.
+
+Assumption 4 (Incoherence). The singular vectors of :math:`M^\star` are
+delocalised, so no single unit or period dominates the factor structure.
+
+  Remark. Standard in matrix completion. It fails when one unit is effectively
+  its own factor -- an outlier so idiosyncratic that no combination of the
+  others describes it.
+
+Inference and diagnostics
+-------------------------
+
+The entrywise panel. ``effects_panel``, ``std_errors``, ``ci_lower_panel`` and
+``ci_upper_panel`` are :math:`N \times T` arrays, finite exactly on the treated
+cells and ``nan`` elsewhere. :py:attr:`CASTResults.effect_table` flattens them
+into tidy ``(unit, period, effect, se, ci_lower, ci_upper)`` rows.
+
+Per-period aggregates. ``period_effects`` maps each post-treatment period to
+``(effect, standard error)`` for the weighted average of the units treated by
+then. Supply ``weights`` for a population-weighted version, and set
+``renormalize_weights=False`` to report a total rather than a mean.
+
+The significance map. ``significance`` counts, per period, how many treated
+units have a significantly positive, significantly negative, or null effect at
+``alpha``; :py:meth:`CASTResults.significant_units` returns the units
+themselves.
+
+An important caveat on what is being tested. The interval covers the
+counterfactual *mean* :math:`M^\star_{i,t}`, so the effect
+:math:`\tau_{i,t} = Y_{i,t} - M^\star_{i,t}` still contains that cell's own
+idiosyncratic noise :math:`\varepsilon_{i,t}`, which the variance deliberately
+excludes. A single unit-period can therefore be flagged as significant on the
+strength of its own noise draw. Per-unit significance is best read as
+suggestive, with the per-period aggregates -- where the noise averages out --
+carrying the evidential weight.
+
+Example
+-------
+
+.. code-block:: python
+
+   import numpy as np, pandas as pd
+   from mlsynth import CAST
+
+   # staggered panel: two cohorts adopt at t=16 and t=20, ten units never treated
+   rng = np.random.default_rng(0)
+   N, T, r = 30, 24, 2
+   U, V = rng.normal(size=(N, r)), rng.normal(size=(T, r))
+   Y = U @ V.T + 0.2 * rng.normal(size=(N, T))
+   adopt = np.full(N, T); adopt[10:20] = 16; adopt[20:] = 20
+   for i, a in enumerate(adopt):
+       if a < T:
+           Y[i, a:] += 3.0                      # planted effect
+
+   df = pd.DataFrame(
+       [dict(u=f"u{i:02d}", t=t, y=Y[i, t], d=int(t >= adopt[i]))
+        for i in range(N) for t in range(T)]
+   )
+
+   res = CAST({"df": df, "outcome": "y", "treat": "d", "unitid": "u",
+               "time": "t", "rank": 2}).fit()
+
+   print(res.att, res.att_ci)                   # treated average, ~3.0
+   print(res.period_effects[16])                # (effect, se) in the first post period
+   print(res.significance[16])                  # positive / negative / null counts
+   print(res.effect_table[:3])                  # entrywise rows
+
+For a population-weighted total instead of a mean, pass per-unit weights and
+turn off renormalisation::
+
+   res = CAST({..., "weights": population.tolist(),
+               "renormalize_weights": False}).fit()
+
+Verification
+------------
+
+CAST is cross-validated against the authors' own ``CAST-panel`` package and
+reproduces their Affordable Care Act analysis. The durable case lives in
+`benchmarks/cases/cast_aca.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/cast_aca.py>`_
+and the full replication story, including a standard-error discrepancy we found
+in the reference package, is on :doc:`replications/cast`.
+
+Core API
+--------
+
+.. autoclass:: mlsynth.CAST
+   :members: fit
+
+Configuration
+-------------
+
+.. autoclass:: mlsynth.config_models.CASTConfig
+   :members:
+   :exclude-members: model_config, model_fields, model_computed_fields
+
+Results
+-------
+
+.. autoclass:: mlsynth.utils.cast_helpers.structures.CASTResults
+   :members: effect_table, significant_units
+
+Helper Modules
+--------------
+
+.. automodule:: mlsynth.utils.cast_helpers.four_block
+   :members: four_block_est, staircase_blocks, entrywise_variance
+
+.. automodule:: mlsynth.utils.cast_helpers.pipeline
+   :members: run_cast, select_rank, aggregate_effects

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -305,6 +305,7 @@ headline numbers.
    ppscm
    cscm
    ssc
+   cast
 
 .. toctree::
    :hidden:

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -51,6 +51,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    :caption: Dedicated replication pages
 
    replications/fdid
+   replications/cast
    replications/rrsc
    replications/src
    replications/bscm

--- a/docs/replications/cast.rst
+++ b/docs/replications/cast.rst
@@ -1,0 +1,203 @@
+.. _replication-cast:
+
+CAST — Inference under Staggered Adoption (Xia, Yan & Wainwright 2025)
+======================================================================
+
+:Estimator: :doc:`../cast` — :class:`mlsynth.CAST`
+:Source: Xia, E., Yan, Y. and Wainwright, M. J. (2025), *Inference under
+   Staggered Adoption: Case Study of the Affordable Care Act*
+   (arXiv:2412.09482v2).
+:Replication type: Path A (the paper's empirical table on the authors' data)
+   plus cross-validation against their released ``CAST-panel`` package.
+:Status: Verified — point estimates match the reference to machine precision
+   and the paper's Table 1 reproduces cell for cell. Standard errors
+   deliberately differ; see below.
+
+Validation strategy
+-------------------
+
+The authors ship both the data and a Python package. The
+`CAST_panel <https://github.com/Facta-Non-Verba/CAST_panel>`_ repository
+carries the Affordable Care Act panels (uninsurance rates, infant mortality,
+health expenditures, plus state populations and expansion dates), and the
+estimator itself is distributed on PyPI as ``CAST-panel``. That makes the
+comparison direct: run their code and ours on the same matrix and compare.
+
+Because the estimator is a deterministic sequence of SVDs and least-squares
+solves — no resampling, no random initialisation — an exact match is the
+right bar, not a tolerance.
+
+Affordable Care Act — uninsurance rates
+---------------------------------------
+
+The Medicaid expansion component of the ACA is the paper's case study. States
+adopted in different years from 2014 onward (some never), giving a genuinely
+staggered design over a 50-state panel spanning 2008–2022. The rank is 1,
+selected by the broken-stick heuristic — mlsynth's ``rank_method="broken_stick"``
+reproduces that choice.
+
+Running the authors' package on their data reproduces Table 1 in full:
+
+.. list-table:: Table 1 (uninsurance rates), paper versus reproduction
+   :header-rows: 1
+   :widths: 10 20 20 25 25
+
+   * - Year
+     - ATET (paper)
+     - ATET (repro)
+     - Pos/Neg/Null (paper)
+     - Pop. effect (paper → repro)
+   * - 2014
+     - −1.7% (0.1)
+     - −1.73% (0.07)
+     - 1 / 23 / 2 ✓
+     - −3.1M → −3.08M
+   * - 2015
+     - −2.3% (0.1)
+     - −2.28% (0.10)
+     - 1 / 28 / 0 ✓
+     - −5.0M → −4.95M
+   * - 2016
+     - −2.4% (0.1)
+     - −2.45% (0.11)
+     - 2 / 28 / 1 ✓
+     - −5.8M → −5.85M
+   * - 2017
+     - −2.7% (0.1)
+     - −2.68% (0.12)
+     - 1 / 28 / 3 ✓
+     - −6.6M → −6.63M
+   * - 2018
+     - −2.8% (0.1)
+     - −2.88% (0.05)
+     - 1 / 30 / 1 ✓
+     - −6.8M → −6.85M
+   * - 2019
+     - −2.6% (0.1)
+     - −2.60% (0.12)
+     - 0 / 29 / 5 ✓
+     - −6.7M → −6.65M
+   * - 2021
+     - −2.9% (0.1)
+     - −2.86% (0.09)
+     - 1 / 36 / 0 ✓
+     - −7.5M → −7.50M
+   * - 2022
+     - −2.2% (0.2)
+     - −2.24% (0.17)
+     - 0 / 33 / 6 ✓
+     - −6.5M → −6.49M
+
+The significance counts match exactly in all eight years, and the
+population-weighted totals to within 0.05 million. Substantively the finding
+stands: Medicaid expansion reduced uninsurance by two to three percentage
+points in adopting states, covering roughly six to seven million people.
+
+mlsynth against the reference
+-----------------------------
+
+On the same panel, mlsynth's port reproduces the reference package's
+**point estimates to machine precision**: the largest absolute difference over
+all treated unit-periods is :math:`1.7 \times 10^{-16}`. The four-block
+routine, the staircase partition and the rank selection all agree.
+
+A standard-error discrepancy in the reference package
+-----------------------------------------------------
+
+The standard errors do *not* agree, and we believe mlsynth's are the correct
+ones.
+
+In ``CAST-panel`` 1.0.2, the routine that estimates the noise matrix computes
+its residuals on the row-sorted staircase but masks them with the *unsorted*
+observation indicator::
+
+    E_est = (self.M_sorted - M_est_full) * self.A      # self.A is unsorted
+
+Paper equation (6a) defines the residuals blockwise on the sorted staircase, so
+the mask must be sorted with the data. Three independent checks say the
+unsorted mask is a bug rather than a modelling choice:
+
+* When the sort happens to be the identity permutation — a single adoption
+  time with rows already in order — mlsynth and the reference agree on the
+  standard errors to :math:`4.2 \times 10^{-16}`. The mask is therefore the
+  only source of divergence; the variance formula is otherwise transcribed
+  identically.
+* On the ACA panel the sort is *not* the identity, and the shipped standard
+  errors come out 16% to 65% too small (worst in 2021, a ratio of 1.65).
+* In Monte Carlo on a known low-rank staggered design, coverage with the
+  sorted mask is closer to nominal at every panel size tested, and the gap
+  does not shrink with :math:`N` — the signature of a bug rather than a
+  finite-sample effect:
+
+  .. list-table::
+     :header-rows: 1
+     :widths: 30 25 25
+
+     * - Design
+       - Shipped mask
+       - Sorted mask
+     * - :math:`N=60,\ T=40`
+       - 0.865
+       - 0.902
+     * - :math:`N=150,\ T=90`
+       - 0.902
+       - 0.928
+     * - :math:`N=300,\ T=180`
+       - 0.918
+       - 0.943
+
+  against a nominal 0.95.
+
+mlsynth ships the sorted-mask variance.
+
+What this costs the published significance counts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The correction has a substantive consequence, and it is worth stating plainly.
+Table 1's per-year counts of significantly positive, negative and null states
+are computed at :math:`\alpha = 0.01` from the reference package's standard
+errors. Pair mlsynth's point estimates with *those* errors and all eight rows
+reproduce exactly -- confirming the estimator, the staircase mask and the
+aggregation all agree, and that the standard error is the only divergence.
+
+Use mlsynth's corrected errors at the same :math:`\alpha`, however, and only
+two of the eight rows still match: the errors are on average 1.36 times larger,
+so marginal states fall back to null. The paper's headline framing -- "for
+every year between 2014 and 2022, nearly every adopting state exhibits a
+statistically significant reduction" -- rests in part on the understated
+errors.
+
+The direction of the substantive conclusion is unchanged: the ATET is
+unaffected (it depends only on the point estimates, which match exactly), the
+sign is negative in every year, and the population totals stand. What weakens
+is the claim about *how many individual states* clear the significance bar.
+
+The golden benchmark pins both quantities: eight of eight rows under the
+reference's errors (the port is exact) and two of eight under the corrected
+ones (the consequence is recorded, and would move if either implementation
+changed).
+
+Honest caveats
+--------------
+
+* The published Table 1 point estimates and population totals are unaffected —
+  we reproduced them exactly — but the significance counts are not: see above.
+* Coverage is asymptotic and small panels undercover: on a rank-2 design,
+  coverage of :math:`M^\star` was about 0.82 at :math:`N=30, T=24` rising to
+  0.94 at :math:`N=240, T=160`. The ACA panel (:math:`N=50`, :math:`T=14`) is
+  on the small side of that range.
+* The noise model assumes independence across time. State-year outcomes are
+  usually serially correlated, which would make the intervals optimistic
+  independently of the issue above.
+* Per-unit significance tests :math:`\tau_{i,t}`, which retains that cell's own
+  noise while the interval covers only the counterfactual mean. Individual
+  flags are suggestive; the per-period aggregates are the stronger evidence.
+
+Durable benchmark
+-----------------
+
+The cross-validation is captured in ``benchmarks/cases/cast_aca.py``, which
+installs ``CAST-panel`` from PyPI when available, compares point estimates
+value-for-value, and pins the Table 1 aggregates. It reports ``SKIP`` when the
+package or its data cannot be fetched, so the suite never turns red on a
+machine without network access.

--- a/llms.txt
+++ b/llms.txt
@@ -28,6 +28,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **BPSCS** — Bayesian Penalized Synthetic Control under Spillovers (Fernandez-Morales et al. 2026).  (config: BPSCSConfig)
 - **BSCM** — Bayesian Synthetic Control Methods (Kim, Lee & Gupta 2020).  (config: BSCMConfig)
 - **BVSS** — Bayesian Synthetic Control with a soft simplex constraint.  (config: BVSSConfig)
+- **CAST** — Confidence intervals under staggered adoption (Xia et al. 2025).  (config: CASTConfig)
 - **CFM** — Causal Factor Model (Bai & Wang 2026) estimator.  (config: CFMConfig)
 - **CLUSTERSC** — Cluster-based Synthetic Control estimator.  (config: CLUSTERSCConfig)
 - **CMBSTS** — Causal Multivariate Bayesian Structural Time Series estimator.  (config: CMBSTSConfig)

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -12,6 +12,7 @@ from .estimators.medsc import MEDSC ## Check
 from .estimators.pda import PDA ## Check
 from .estimators.fdid import FDID ## Check
 from .estimators.clustersc import CLUSTERSC ## Check
+from .estimators.cast import CAST ## Check
 from .estimators.rrsc import RRSC ## Check
 from .estimators.proximal import PROXIMAL ## Check
 from .estimators.fscm import FSCM ## Check
@@ -114,6 +115,7 @@ __all__ = [
     "PDA",
     "FDID",
     "CLUSTERSC",
+    "CAST",
     "RRSC",
     "PROXIMAL",
     "FSCM",

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -641,6 +641,7 @@ _RELOCATED_CONFIGS = {
     "FDIDConfig": "mlsynth.utils.fdid_helpers.config",
     "TSSCConfig": "mlsynth.utils.tssc_helpers.config",
     "ROLLDIDConfig": "mlsynth.utils.rolldid_helpers.config",
+    "CASTConfig": "mlsynth.utils.cast_helpers.config",
     "RRSCConfig": "mlsynth.utils.rrsc_helpers.config",
 }
 

--- a/mlsynth/estimators/cast.py
+++ b/mlsynth/estimators/cast.py
@@ -1,0 +1,164 @@
+"""CAST: confidence intervals for treatment effects under staggered adoption.
+
+Xia, E., Yan, Y., & Wainwright, M. J. (2025). *Inference under Staggered
+Adoption: Case Study of the Affordable Care Act* (arXiv:2412.09482).
+
+Most panel estimators report uncertainty for a *pooled* effect -- an ATT, or an
+event-study path. CAST reports it for every treated unit-period. Sorting units
+by how long they are treated turns a staggered design into a staircase, which
+decomposes into four-block sub-problems; each is solved by a spectral routine
+that estimates the factor subspaces from the observed blocks and regresses one
+onto the other to impute the counterfactual. The same subspaces give a
+closed-form entrywise variance, so each imputed cell carries a confidence
+interval with asymptotic coverage, and any weighted aggregate of them (the
+average effect on the treated, or a population-weighted total) inherits a
+standard error.
+"""
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+import pandas as pd
+from pydantic import ValidationError
+
+from ..config_models import CASTConfig, InferenceResults
+from ..exceptions import (
+    MlsynthConfigError,
+    MlsynthDataError,
+    MlsynthEstimationError,
+    MlsynthPlottingError,
+)
+from ..utils.datautils import balance
+from ..utils.results_helpers import build_effect_submodels, make_weights_results
+from ..utils.cast_helpers.pipeline import run_cast
+from ..utils.cast_helpers.plotter import plot_cast
+from ..utils.cast_helpers.setup import prepare_cast_inputs
+from ..utils.cast_helpers.structures import CASTResults
+
+
+class CAST:
+    """Confidence intervals under staggered adoption (Xia et al. 2025).
+
+    Parameters
+    ----------
+    config : CASTConfig or dict
+        Configuration. See :class:`mlsynth.config_models.CASTConfig`.
+
+    Returns
+    -------
+    CASTResults
+        An ``EffectResult`` whose flat accessors summarize the treated average,
+        plus the entrywise effect / standard-error / interval panels.
+    """
+
+    def __init__(self, config: Union[CASTConfig, dict]) -> None:
+        if isinstance(config, dict):
+            try:
+                config = CASTConfig(**config)
+            except ValidationError as exc:
+                raise MlsynthConfigError(f"Invalid CAST configuration: {exc}") from exc
+        self.config: CASTConfig = config
+        self.df: pd.DataFrame = config.df
+        self.outcome, self.treat = config.outcome, config.treat
+        self.unitid, self.time = config.unitid, config.time
+        self.display_graphs: bool = getattr(config, "display_graphs", False)
+
+    def fit(self) -> CASTResults:
+        """Run the CAST pipeline end to end."""
+        cfg = self.config
+        try:
+            balance(self.df, self.unitid, self.time)
+            inputs = prepare_cast_inputs(
+                self.df, self.outcome, self.treat, self.unitid, self.time
+            )
+            fit = run_cast(inputs, cfg)
+
+            # ----- treated-average surface for the standardized sub-models -----
+            periods = list(fit.period_effects)
+            labels = np.asarray(inputs.time_labels)
+            treated = inputs.treated_mask
+            ever = treated.any(axis=1)
+            observed = inputs.Y[ever].mean(axis=0)
+            counterfactual = fit.counterfactual[ever].mean(axis=0)
+            n_post = len(periods)
+            T0 = inputs.T - n_post
+
+            att = float(np.mean([fit.period_effects[p][0] for p in periods]))
+            att_se = float(np.sqrt(np.mean(
+                [fit.period_effects[p][1] ** 2 for p in periods]))) / np.sqrt(max(n_post, 1))
+            from scipy.stats import norm
+            z = norm.ppf(1 - cfg.alpha / 2)
+            inference = InferenceResults(
+                standard_error=att_se,
+                ci_lower=att - z * att_se,
+                ci_upper=att + z * att_se,
+                p_value=float(2 * norm.cdf(-abs(att) / att_se)) if att_se > 0 else None,
+                confidence_level=1 - cfg.alpha,
+                method="cast:entrywise",
+            )
+
+            # entrywise band on the treated-average counterfactual path
+            band = np.full(inputs.T, np.nan)
+            for j in range(inputs.T):
+                rows = np.where(treated[:, j])[0]
+                if rows.size:
+                    band[j] = np.sqrt(np.mean(np.square(fit.std_errors[rows, j])))
+            lower = np.where(np.isfinite(band), counterfactual - z * band, np.nan)
+            upper = np.where(np.isfinite(band), counterfactual + z * band, np.nan)
+
+            subs = build_effect_submodels(
+                observed_outcome=observed,
+                counterfactual_outcome=counterfactual,
+                n_pre_periods=T0,
+                n_post_periods=n_post,
+                time_periods=labels,
+                weights=make_weights_results(
+                    {}, constraint="none (factor-model imputation, no donor weights)",
+                    extra={"weights_are": "not_applicable",
+                           "note": ("CAST imputes the counterfactual from estimated "
+                                    "factor subspaces rather than a weighted average "
+                                    "of donors, so it has no donor weights. The "
+                                    "per-unit weights in the config apply to the "
+                                    "aggregate effect, not to the imputation.")},
+                ),
+                inference=inference,
+                method_name="CAST",
+                effects_overrides={"att": att, "att_std_err": att_se},
+                intervention_time=(labels[T0] if T0 < inputs.T else None),
+                prediction_interval={"lower": lower, "upper": upper,
+                                     "level": 1 - cfg.alpha,
+                                     "kind": "cast:entrywise"},
+            )
+
+            results = CASTResults(
+                inputs=inputs,
+                rank=fit.rank,
+                effects_panel=fit.effects,
+                std_errors=fit.std_errors,
+                ci_lower_panel=fit.ci_lower,
+                ci_upper_panel=fit.ci_upper,
+                counterfactual_panel=fit.counterfactual,
+                period_effects=fit.period_effects,
+                significance=fit.significance,
+                metadata={
+                    "rank": fit.rank, "alpha": cfg.alpha,
+                    "n_treated_units": int(ever.sum()),
+                    "n_treated_cells": int(treated.sum()),
+                    **fit.extras,
+                },
+                **subs,
+            )
+
+            if self.display_graphs:
+                try:
+                    plot_cast(results)
+                except Exception as exc:           # pragma: no cover
+                    raise MlsynthPlottingError(f"CAST plotting failed: {exc}") from exc
+            return results
+
+        except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError,
+                MlsynthPlottingError):
+            raise
+        except Exception as exc:                   # pragma: no cover
+            raise MlsynthEstimationError(f"CAST estimation failed: {exc}") from exc

--- a/mlsynth/guides/llms.txt
+++ b/mlsynth/guides/llms.txt
@@ -28,6 +28,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **BPSCS** — Bayesian Penalized Synthetic Control under Spillovers (Fernandez-Morales et al. 2026).  (config: BPSCSConfig)
 - **BSCM** — Bayesian Synthetic Control Methods (Kim, Lee & Gupta 2020).  (config: BSCMConfig)
 - **BVSS** — Bayesian Synthetic Control with a soft simplex constraint.  (config: BVSSConfig)
+- **CAST** — Confidence intervals under staggered adoption (Xia et al. 2025).  (config: CASTConfig)
 - **CFM** — Causal Factor Model (Bai & Wang 2026) estimator.  (config: CFMConfig)
 - **CLUSTERSC** — Cluster-based Synthetic Control estimator.  (config: CLUSTERSCConfig)
 - **CMBSTS** — Causal Multivariate Bayesian Structural Time Series estimator.  (config: CMBSTSConfig)

--- a/mlsynth/tests/test_cast.py
+++ b/mlsynth/tests/test_cast.py
@@ -1,0 +1,332 @@
+"""Tests for the CAST estimator (config, setup, pipeline, estimator, plotting).
+
+Value-for-value fidelity to the authors' ``CAST-panel`` package on the ACA
+panel is pinned in the golden benchmark; here we lock behaviour on
+self-contained synthetic panels.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.config_models import CASTConfig
+from mlsynth.exceptions import (
+    MlsynthConfigError,
+    MlsynthDataError,
+    MlsynthEstimationError,
+)
+from mlsynth.utils.cast_helpers.setup import prepare_cast_inputs
+
+
+def make_panel(N=30, T=24, r=2, cohorts=((10, 20, 16), (20, 30, 20)),
+               effect=3.0, noise=0.2, seed=0):
+    """Staggered panel from a rank-r factor model with a planted effect.
+
+    ``cohorts`` is a tuple of ``(start_unit, end_unit, adoption_period)``.
+    """
+    rng = np.random.default_rng(seed)
+    U, V = rng.normal(size=(N, r)), rng.normal(size=(T, r))
+    Y = U @ V.T + noise * rng.normal(size=(N, T))
+    adopt = np.full(N, T)
+    for lo, hi, t0 in cohorts:
+        adopt[lo:hi] = t0
+    for i, a in enumerate(adopt):
+        if a < T:
+            Y[i, a:] += effect
+    rows = [dict(u=f"u{i:02d}", t=t, y=Y[i, t], d=int(t >= adopt[i]))
+            for i in range(N) for t in range(T)]
+    return pd.DataFrame(rows), Y, adopt
+
+
+@pytest.fixture(scope="module")
+def panel_df():
+    return make_panel()[0]
+
+
+def _cfg(df, **kw):
+    return CASTConfig(df=df, outcome="y", treat="d", unitid="u", time="t", **kw)
+
+
+# ------------------------------------------------------------------ config
+def test_config_defaults(panel_df):
+    c = _cfg(panel_df)
+    assert c.rank is None and c.rank_method == "broken_stick"
+    assert c.alpha == 0.05 and c.renormalize_weights is True
+
+
+def test_config_rejects_rank_over_max(panel_df):
+    with pytest.raises(MlsynthConfigError):
+        _cfg(panel_df, rank=20, max_rank=5)
+
+
+def test_config_forbids_extra_fields(panel_df):
+    with pytest.raises(Exception):
+        _cfg(panel_df, not_a_field=1)
+
+
+@pytest.mark.parametrize("field,bad", [("rank_method", "bogus"), ("alpha", 1.5)])
+def test_config_rejects_bad_values(panel_df, field, bad):
+    with pytest.raises(Exception):
+        _cfg(panel_df, **{field: bad})
+
+
+def test_config_rejects_bad_weights(panel_df):
+    with pytest.raises(MlsynthConfigError):
+        _cfg(panel_df, weights=[])
+    with pytest.raises(MlsynthConfigError):
+        _cfg(panel_df, weights=["a", "b"])
+
+
+# ------------------------------------------------------------------- setup
+def test_setup_builds_staggered_panel(panel_df):
+    inp = prepare_cast_inputs(panel_df, "y", "d", "u", "t")
+    assert inp.Y.shape == (30, 24) and inp.N == 30 and inp.T == 24
+    assert inp.A.shape == inp.Y.shape
+    assert set(np.unique(inp.adoption_index)) == {16, 20, 24}   # 24 == never
+    assert len(inp.treated_units) == 20 and len(inp.never_treated) == 10
+    assert inp.treated_mask.sum() == (24 - 16) * 10 + (24 - 20) * 10
+
+
+def test_setup_handles_single_cohort():
+    df, _, _ = make_panel(N=12, T=20, cohorts=((6, 12, 14),))
+    inp = prepare_cast_inputs(df, "y", "d", "u", "t")
+    assert set(np.unique(inp.adoption_index)) == {14, 20}
+
+
+def test_setup_handles_single_treated_unit():
+    """One treated unit takes dataprep's non-cohort path (a block design)."""
+    df, _, _ = make_panel(N=10, T=18, cohorts=((0, 1, 12),))
+    inp = prepare_cast_inputs(df, "y", "d", "u", "t")
+    assert inp.Y.shape == (10, 18)
+    assert len(inp.treated_units) == 1 and len(inp.never_treated) == 9
+    assert inp.adoption_index[list(inp.unit_names).index("u00")] == 12
+    assert inp.treated_mask.sum() == 18 - 12
+
+
+def test_single_treated_unit_end_to_end():
+    df, _, _ = make_panel(N=14, T=20, cohorts=((0, 1, 14),), effect=3.0, noise=0.2)
+    r = CAST(_cfg(df, rank=2)).fit()
+    assert r.att == pytest.approx(3.0, abs=0.6)
+    assert int(r.inputs.treated_mask.sum()) == 20 - 14
+
+
+def test_setup_rejects_missing_outcomes():
+    df, _, _ = make_panel(N=10, T=16, cohorts=((5, 10, 12),))
+    df.loc[3, "y"] = np.nan
+    with pytest.raises(MlsynthDataError):
+        prepare_cast_inputs(df, "y", "d", "u", "t")
+
+
+def test_setup_rejects_too_few_units():
+    df, _, _ = make_panel(N=2, T=12, cohorts=((1, 2, 8),))
+    with pytest.raises(MlsynthDataError):
+        prepare_cast_inputs(df, "y", "d", "u", "t")
+
+
+def test_setup_rejects_no_never_treated():
+    df, _, _ = make_panel(N=10, T=18, cohorts=((0, 5, 12), (5, 10, 14)))
+    with pytest.raises(MlsynthDataError):
+        prepare_cast_inputs(df, "y", "d", "u", "t")
+
+
+def test_setup_rejects_no_treated():
+    df, _, _ = make_panel(N=8, T=14, cohorts=())
+    with pytest.raises(MlsynthDataError):
+        prepare_cast_inputs(df, "y", "d", "u", "t")
+
+
+def test_setup_rejects_treatment_in_first_period():
+    df, _, _ = make_panel(N=12, T=16, cohorts=((6, 12, 0),))
+    with pytest.raises(MlsynthDataError):
+        prepare_cast_inputs(df, "y", "d", "u", "t")
+
+
+# --------------------------------------------------------------- estimator
+import matplotlib                                            # noqa: E402
+matplotlib.use("Agg")
+from mlsynth import CAST                                     # noqa: E402
+from mlsynth.config_models import BaseEstimatorResults        # noqa: E402
+
+
+def test_recovers_planted_effect():
+    df, _, _ = make_panel(effect=3.0, noise=0.2)
+    r = CAST(_cfg(df, rank=2)).fit()
+    assert r.rank == 2
+    assert r.att == pytest.approx(3.0, abs=0.3)
+    lo, hi = r.att_ci
+    assert lo < 3.0 < hi                                    # interval covers truth
+
+
+def test_result_contract_surface():
+    df, _, _ = make_panel()
+    r = CAST(_cfg(df, rank=2)).fit()
+    assert isinstance(r, BaseEstimatorResults)
+    assert np.isfinite(r.att)
+    assert r.counterfactual.shape == (24,) and r.gap.shape == (24,)
+    assert r.weights is not None
+    assert r.effects_panel.shape == (30, 24)
+    assert r.std_errors.shape == (30, 24)
+
+
+def test_entrywise_panels_defined_exactly_on_treated_cells():
+    df, _, _ = make_panel()
+    r = CAST(_cfg(df, rank=2)).fit()
+    treated = r.inputs.treated_mask
+    for panel in (r.effects_panel, r.std_errors, r.ci_lower_panel, r.ci_upper_panel):
+        assert np.all(np.isfinite(panel[treated]))
+        assert np.all(np.isnan(panel[~treated]))
+    assert np.all(r.ci_lower_panel[treated] <= r.ci_upper_panel[treated])
+
+
+def test_effect_table_is_tidy():
+    df, _, _ = make_panel()
+    r = CAST(_cfg(df, rank=2)).fit()
+    rows = r.effect_table
+    assert len(rows) == int(r.inputs.treated_mask.sum())
+    assert set(rows[0]) == {"unit", "period", "effect", "se", "ci_lower", "ci_upper"}
+
+
+def test_significance_counts_partition_the_treated():
+    df, _, _ = make_panel(effect=3.0, noise=0.2)
+    r = CAST(_cfg(df, rank=2)).fit()
+    for period, s in r.significance.items():
+        assert s["positive"] + s["negative"] + s["null"] == s["n_treated"]
+    # a large planted positive effect is detected
+    first = min(r.significance)
+    assert r.significance[first]["positive"] > 0
+
+
+def test_significant_units_accessor():
+    df, _, _ = make_panel(effect=3.0, noise=0.2)
+    r = CAST(_cfg(df, rank=2)).fit()
+    period = min(r.period_effects)
+    sig = r.significant_units(period, level=0.05)
+    assert len(sig) > 0
+    assert all(v > 0 for v in sig.values())
+
+
+def test_intervals_cover_the_counterfactual_mean():
+    """The interval targets the counterfactual *mean* M*, not the realized Y.
+
+    Coverage approaches the nominal level as the panel grows, which is the
+    guarantee of Theorem 1. Checked directly against the known mean matrix.
+    """
+    from scipy.stats import norm
+    from mlsynth.utils.cast_helpers.four_block import (
+        entrywise_variance, impute_missing,
+    )
+
+    N, T, r, z = 120, 80, 2, norm.ppf(0.975)
+    covered = []
+    for seed in range(4):
+        rng = np.random.default_rng(seed)
+        U, V = rng.normal(size=(N, r)), rng.normal(size=(T, r))
+        M = U @ V.T
+        Y = M + 0.3 * rng.normal(size=(N, T))
+        adopt = np.full(N, T)
+        adopt[N // 3:2 * N // 3] = int(T * 0.67)
+        adopt[2 * N // 3:] = int(T * 0.83)
+        A = np.ones((N, T), dtype=int)
+        for i, a in enumerate(adopt):
+            if a < T:
+                A[i, a:] = 0
+        treated = ~A.astype(bool)
+        se = np.sqrt(entrywise_variance(Y, A, r))
+        covered.append((np.abs(impute_missing(Y, A, r) - M)[treated]
+                        <= z * se[treated]).mean())
+    assert np.mean(covered) > 0.90                          # near nominal 0.95
+
+
+def test_null_effect_flagged_far_less_than_a_real_effect():
+    """A planted effect is detected much more often than pure noise.
+
+    Note the significance test is on ``tau = Y - M*``, which retains the
+    treated cell's own idiosyncratic noise (the interval covers ``M*``, not
+    ``Y``), so the null rate is not the nominal alpha -- see the estimator's
+    documentation. What must hold is the separation.
+    """
+    df_null, _, _ = make_panel(effect=0.0, noise=0.3, seed=1)
+    df_real, _, _ = make_panel(effect=3.0, noise=0.3, seed=1)
+    rate = {}
+    for tag, d in (("null", df_null), ("real", df_real)):
+        r = CAST(_cfg(d, rank=2, alpha=0.01)).fit()
+        tot = sum(s["n_treated"] for s in r.significance.values())
+        flagged = sum(s["positive"] + s["negative"] for s in r.significance.values())
+        rate[tag] = flagged / tot
+    assert rate["real"] > 0.95                              # real effect: nearly all
+    assert rate["real"] > 2 * rate["null"]                  # clear separation
+
+
+@pytest.mark.parametrize("method", ["broken_stick", "svht", "ratio"])
+def test_auto_rank_selection(method):
+    df, _, _ = make_panel()
+    r = CAST(_cfg(df, rank=None, rank_method=method)).fit()
+    assert 1 <= r.rank <= 10
+    assert np.isfinite(r.att)
+
+
+def test_weighted_aggregate_differs_from_equal_weights():
+    df, _, _ = make_panel()
+    equal = CAST(_cfg(df, rank=2)).fit()
+    w = np.arange(1.0, 31.0)
+    weighted = CAST(_cfg(df, rank=2, weights=list(w))).fit()
+    p = min(equal.period_effects)
+    assert equal.period_effects[p][0] != weighted.period_effects[p][0]
+
+
+def test_unnormalized_weights_give_a_total():
+    """With renormalize_weights=False the aggregate is a population total."""
+    df, _, _ = make_panel(effect=3.0, noise=0.05)
+    w = [100.0] * 30
+    r = CAST(_cfg(df, rank=2, weights=w, renormalize_weights=False)).fit()
+    p = min(r.period_effects)
+    n_treated = r.significance[p]["n_treated"]
+    assert r.period_effects[p][0] == pytest.approx(3.0 * 100.0 * n_treated, rel=0.2)
+
+
+def test_rejects_weights_of_wrong_length():
+    df, _, _ = make_panel()
+    with pytest.raises(MlsynthEstimationError):
+        CAST(_cfg(df, rank=2, weights=[1.0, 2.0])).fit()
+
+
+def test_rejects_rank_too_large():
+    df, _, _ = make_panel(N=12, T=10, cohorts=((6, 12, 8),))
+    with pytest.raises(MlsynthEstimationError):
+        CAST(_cfg(df, rank=10, max_rank=12)).fit()
+
+
+def test_estimator_rejects_bad_config():
+    df, _, _ = make_panel()
+    with pytest.raises(MlsynthConfigError):
+        CAST(dict(df=df, outcome="y", treat="d", unitid="u", time="t",
+                  rank=99, max_rank=5))
+
+
+def test_estimator_wraps_pydantic_validation_error():
+    df, _, _ = make_panel()
+    with pytest.raises(MlsynthConfigError):
+        CAST(dict(df=df, outcome="y", treat="d", unitid="u", time="t", alpha="oops"))
+
+
+def test_prediction_interval_is_populated():
+    df, _, _ = make_panel()
+    r = CAST(_cfg(df, rank=2)).fit()
+    ts = r.time_series
+    assert ts.prediction_interval_kind == "cast:entrywise"
+    assert ts.has_prediction_interval
+
+
+def test_plotting_smoke():
+    df, _, _ = make_panel()
+    r = CAST(_cfg(df, rank=2, display_graphs=False)).fit()
+    from mlsynth.utils.cast_helpers.plotter import plot_cast
+    fig = plot_cast(r, show=False)
+    assert len(fig.axes) == 2
+
+
+def test_display_graphs_path():
+    df, _, _ = make_panel()
+    r = CAST(_cfg(df, rank=2, display_graphs=True)).fit()
+    assert np.isfinite(r.att)

--- a/mlsynth/tests/test_cast_kernels.py
+++ b/mlsynth/tests/test_cast_kernels.py
@@ -1,0 +1,146 @@
+"""Unit tests for the CAST numerical kernels (Xia, Yan & Wainwright 2025).
+
+The four-block estimator, the staircase partition of a staggered design, and
+the entrywise variance formula. Value-for-value fidelity to the authors'
+``CAST-panel`` package on the ACA panel is pinned in the golden benchmark; here
+we lock the kernels' mathematical invariants, self-contained.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.cast_helpers.four_block import (
+    entrywise_variance,
+    four_block_est,
+    staircase_blocks,
+    svd_r,
+)
+
+
+def _low_rank(N, T, r, seed=0, noise=0.0):
+    rng = np.random.default_rng(seed)
+    U, V = rng.normal(size=(N, r)), rng.normal(size=(T, r))
+    M = U @ V.T
+    return M + noise * rng.normal(size=(N, T)), M
+
+
+# ------------------------------------------------------------------- svd_r
+def test_svd_r_shapes_and_reconstruction():
+    M, _ = _low_rank(20, 12, 3)
+    u, s, vh = svd_r(M, 3)
+    assert u.shape == (20, 3) and s.shape == (3,) and vh.shape == (3, 12)
+    assert np.allclose((u * s) @ vh, M)          # exact for a rank-3 matrix
+
+
+def test_svd_r_rejects_bad_rank():
+    M, _ = _low_rank(10, 8, 2)
+    with pytest.raises(MlsynthConfigError):
+        svd_r(M, 0)
+    with pytest.raises(MlsynthConfigError):
+        svd_r(M, 9)                              # r > min(N, T)
+
+
+# --------------------------------------------------------- four_block_est
+def test_four_block_exact_recovery_noiseless():
+    """Paper S3.1.1: with M* exactly rank r and no noise, the imputed block
+    equals M*_d exactly."""
+    Y, M = _low_rank(30, 20, 3, noise=0.0)
+    N1, T1 = 18, 12
+    Md = four_block_est(Y, N1, T1, 3)
+    assert Md.shape == (30 - N1, 20 - T1)
+    assert np.allclose(Md, M[N1:, T1:], atol=1e-8)
+
+
+def test_four_block_noise_degrades_gracefully():
+    Y, M = _low_rank(60, 40, 2, noise=0.05)
+    Md = four_block_est(Y, 40, 25, 2)
+    err = np.abs(Md - M[40:, 25:]).mean()
+    assert err < 0.5                              # small noise -> small error
+    assert np.all(np.isfinite(Md))
+
+
+def test_four_block_rejects_degenerate_blocks():
+    Y, _ = _low_rank(20, 15, 2)
+    with pytest.raises(MlsynthConfigError):
+        four_block_est(Y, 1, 10, 2)               # N1 < r -> U1'U1 singular
+    with pytest.raises(MlsynthConfigError):
+        four_block_est(Y, 10, 1, 2)               # T1 < r
+
+
+# ------------------------------------------------------ staircase_blocks
+def test_staircase_single_cohort():
+    """One adoption time -> k = 2 blocks (never-treated, one cohort)."""
+    A = np.ones((10, 8), dtype=int)
+    A[6:, 5:] = 0                                 # 4 units treated from t=5
+    order, inv, N_all, T_all, k = staircase_blocks(A)
+    assert k == 2
+    assert list(T_all) == [5, 8]                  # control lengths present
+    assert N_all[-1] == 10                        # cumulative unit counts
+    assert np.array_equal(A[order][inv], A)       # permutation round-trips
+
+
+def test_staircase_orders_by_treatment_duration():
+    A = np.ones((6, 10), dtype=int)
+    A[0, 4:] = 0                                  # longest treated
+    A[1, 7:] = 0
+    A[2, 9:] = 0
+    order, inv, N_all, T_all, k = staircase_blocks(A)
+    dur = (A.shape[1] - A.sum(axis=1))[order]
+    assert list(dur) == sorted(dur)               # ascending duration after sort
+    assert k == 4                                 # 3 cohorts + never-treated
+
+
+def test_staircase_rejects_no_treated():
+    with pytest.raises(MlsynthDataError):
+        staircase_blocks(np.ones((5, 5), dtype=int))
+
+
+def test_staircase_rejects_all_treated():
+    A = np.ones((5, 6), dtype=int)
+    A[:, 2:] = 0                                  # every unit treated, no controls
+    with pytest.raises(MlsynthDataError):
+        staircase_blocks(A)
+
+
+# ---------------------------------------------------- entrywise_variance
+def test_entrywise_variance_nonnegative_and_finite():
+    Y, _ = _low_rank(40, 30, 2, noise=0.2)
+    A = np.ones((40, 30), dtype=int)
+    A[25:, 20:] = 0
+    var = entrywise_variance(Y, A, r=2)
+    assert var.shape == Y.shape
+    treated = ~A.astype(bool)
+    assert np.all(var[treated] >= 0)
+    assert np.all(np.isfinite(var[treated]))
+
+
+def test_entrywise_variance_scales_with_noise():
+    """More noise -> wider intervals (variance is monotone in sigma)."""
+    A = np.ones((50, 36), dtype=int)
+    A[30:, 24:] = 0
+    treated = ~A.astype(bool)
+    v_small = entrywise_variance(_low_rank(50, 36, 2, noise=0.05)[0], A, r=2)
+    v_large = entrywise_variance(_low_rank(50, 36, 2, noise=0.50)[0], A, r=2)
+    assert v_large[treated].mean() > v_small[treated].mean()
+
+
+def test_entrywise_variance_uses_sorted_mask():
+    """Regression guard for the row-alignment bug in the reference package.
+
+    The residual mask (paper eq. 6a) must be applied in the sorted staircase
+    frame. Shuffling the input rows is a relabelling: the per-unit variances
+    must come back identical, which only holds if the mask is sorted with the
+    data. The reference's ``CAST-panel`` 1.0.2 masks sorted residuals with the
+    unsorted indicator and fails this.
+    """
+    Y, _ = _low_rank(40, 28, 2, noise=0.3)
+    A = np.ones((40, 28), dtype=int)
+    A[20:30, 18:] = 0
+    A[30:, 22:] = 0                               # two cohorts -> non-trivial sort
+    var = entrywise_variance(Y, A, r=2)
+
+    perm = np.random.default_rng(7).permutation(40)
+    var_perm = entrywise_variance(Y[perm], A[perm], r=2)
+    assert np.allclose(var_perm, var[perm], atol=1e-10)

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -28,7 +28,7 @@ import pytest
 _HAS_NUMPYRO = importlib.util.find_spec("numpyro") is not None
 
 from mlsynth import (
-    BFSC, BPSCS, BSCM, BVSS, CFM, CLUSTERSC, CSCIPCA, CSCM, DPSC, DSCAR, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC, MEDSC,
+    BFSC, BPSCS, BSCM, BVSS, CAST, CFM, CLUSTERSC, CSCIPCA, CSCM, DPSC, DSCAR, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC, MEDSC,
     MCNNM, MSQRT, MTGP, MVBBSC, NSC, PDA, PROPSC, PROXIMAL, RESCM, RMSI, RRSC, SBC, SCMO, SCUL, SDID,
     SequentialSDID, SHC, SNN, SparseSC, SPILLSYNTH, SPOTSYNTH, SSC, TASC, TSSC,
     VanillaSC,
@@ -148,6 +148,7 @@ OBSERVATIONAL = [
     pytest.param(SparseSC, {"outcome_lag_periods": [1, 2]}, id="SparseSC"),
     pytest.param(TASC, {"d": 2, "n_em_iter": 2}, id="TASC"),
     pytest.param(CLUSTERSC, {"clustering": False}, id="CLUSTERSC"),
+    pytest.param(CAST, {"rank": 1}, id="CAST"),
     pytest.param(RRSC, {"n_factors": 1, "inference": "none"}, id="RRSC"),
     pytest.param(SBC, {}, id="SBC"),
     pytest.param(HSC, {}, id="HSC"),

--- a/mlsynth/utils/cast_helpers/__init__.py
+++ b/mlsynth/utils/cast_helpers/__init__.py
@@ -1,0 +1,2 @@
+"""Helper package for the CAST estimator (Xia, Yan & Wainwright 2025):
+confidence intervals for treatment effects under staggered adoption."""

--- a/mlsynth/utils/cast_helpers/config.py
+++ b/mlsynth/utils/cast_helpers/config.py
@@ -1,0 +1,107 @@
+"""Configuration for the CAST estimator.
+
+Co-located with the helper package; re-exported from
+:mod:`mlsynth.config_models` for backward compatibility.
+"""
+from __future__ import annotations
+
+from typing import Literal, Optional, Union
+
+from pydantic import Field, model_validator
+
+from ...config_models import BaseEstimatorConfig
+from ...exceptions import MlsynthConfigError
+
+
+class CASTConfig(BaseEstimatorConfig):
+    """Configuration for CAST -- confidence intervals for treatment effects
+    under staggered adoption (Xia, Yan & Wainwright 2025, *Inference under
+    Staggered Adoption: Case Study of the Affordable Care Act*).
+
+    CAST estimates the counterfactual outcome matrix by a spectral four-block
+    routine and returns a confidence interval for *every* treated unit-period,
+    not only for the pooled effect. Aggregates (the average effect on the
+    treated, or any weighted version of it) are reported with standard errors
+    derived from the same entrywise variances.
+
+    Parameters
+    ----------
+    rank : int or None
+        Rank ``r`` of the underlying mean matrix. ``None`` (default) selects it
+        from the spectrum of the observed control block via ``rank_method``.
+        The rank is the method's one substantive tuning choice: too small
+        under-fits the factor structure, too large absorbs the treatment
+        effect.
+    rank_method : {"broken_stick", "svht", "ratio"}
+        Selector used when ``rank`` is ``None``. ``"broken_stick"`` matches the
+        authors' reference package; ``"svht"`` is the Gavish-Donoho optimal
+        hard threshold; ``"ratio"`` takes the largest singular-value gap.
+    max_rank : int
+        Upper bound for the automatic search.
+    alpha : float
+        Two-sided level for the entrywise and aggregate confidence intervals.
+    weights : list or None
+        Optional weights for the aggregate effect
+        ``tau_w,t = sum_i w_i tau_i,t``, in the order the units appear in the
+        panel (sorted unit labels). Either a length-``N`` vector (one weight
+        per unit, constant over time) or an ``N x T`` matrix for a weight that
+        varies by period -- the paper's general bilinear functional, which is
+        what a population-weighted total needs when the population itself moves
+        over time. ``None`` gives the equally weighted average over treated
+        units.
+    renormalize_weights : bool
+        Divide the supplied ``weights`` by their total over the units treated
+        at each period, so the aggregate is a weighted *mean*. Set ``False``
+        to report a population total (the paper's "population effect").
+    """
+
+    rank: Optional[int] = Field(
+        default=None, ge=1,
+        description="Rank r of the mean matrix; None selects it via rank_method.",
+    )
+    rank_method: Literal["broken_stick", "svht", "ratio"] = Field(
+        default="broken_stick",
+        description="Automatic rank selector (broken_stick matches the reference).",
+    )
+    max_rank: int = Field(
+        default=10, ge=1,
+        description="Upper bound for the automatic rank search.",
+    )
+    alpha: float = Field(
+        default=0.05, gt=0.0, lt=1.0,
+        description="Two-sided level for entrywise and aggregate intervals.",
+    )
+    weights: Optional[list] = Field(
+        default=None,
+        description="Per-unit weights for the aggregate effect; None = equal weights.",
+    )
+    renormalize_weights: bool = Field(
+        default=True,
+        description="Normalize weights to sum to one over treated units (mean vs total).",
+    )
+
+    @model_validator(mode="after")
+    def _check_cast(self, /) -> "CASTConfig":
+        if self.rank is not None and self.rank > self.max_rank:
+            raise MlsynthConfigError(
+                f"rank ({self.rank}) exceeds max_rank ({self.max_rank})."
+            )
+        if self.weights is not None:
+            import numpy as np
+
+            if len(self.weights) == 0:
+                raise MlsynthConfigError("weights must be non-empty when supplied.")
+            try:
+                arr = np.asarray(self.weights, dtype=float)
+            except (TypeError, ValueError) as exc:
+                raise MlsynthConfigError(
+                    f"weights must be numeric and rectangular: {exc}"
+                ) from exc
+            if arr.ndim not in (1, 2):
+                raise MlsynthConfigError(
+                    f"weights must be a length-N vector or an N x T matrix; "
+                    f"got {arr.ndim} dimensions."
+                )
+            if not np.all(np.isfinite(arr)):
+                raise MlsynthConfigError("weights must all be finite.")
+        return self

--- a/mlsynth/utils/cast_helpers/four_block.py
+++ b/mlsynth/utils/cast_helpers/four_block.py
@@ -1,0 +1,188 @@
+"""Numerical kernels for CAST (Xia, Yan & Wainwright 2025, arXiv:2412.09482).
+
+A staggered-adoption panel, after sorting units by how long they are treated,
+takes a *staircase* shape: the observed (control) cells form a descending
+staircase and the counterfactual cells sit above it. The paper's insight is
+that such a staircase decomposes into a collection of *four-block* problems
+
+.. math::
+
+   Y = \\begin{pmatrix} Y_a & Y_b \\\\ Y_c & ? \\end{pmatrix},
+
+each of which is solved by a spectral routine (:func:`four_block_est`,
+Algorithm 1) that estimates the column subspace from the left blocks, denoises
+the upper blocks, and regresses one onto the other to impute ``?``. The same
+subspaces yield a closed-form entrywise variance (:func:`entrywise_variance`,
+equations 6a-6c), which is what makes per-cell confidence intervals possible.
+
+* :func:`four_block_est` -- Algorithm 1 (FourBlockEst), paper S3.1.1.
+* :func:`staircase_blocks` -- the partition of Appendix A.
+* :func:`entrywise_variance` -- equations (6a) and (6c).
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+
+
+def svd_r(M: np.ndarray, r: int):
+    """Truncated rank-``r`` SVD, returning ``(U, s, Vh)``."""
+    M = np.asarray(M, dtype=float)
+    if M.ndim != 2:                                # pragma: no cover - guarded by callers
+        raise MlsynthConfigError("svd_r: M must be a 2D array.")
+    if not (1 <= r <= min(M.shape)):
+        raise MlsynthConfigError(
+            f"svd_r: require 1 <= r <= min(N, T) = {min(M.shape)}; got r={r}."
+        )
+    u, s, vh = np.linalg.svd(M, full_matrices=False)
+    return u[:, :r], s[:r], vh[:r, :]
+
+
+def four_block_est(Y: np.ndarray, N1: int, T1: int, r: int) -> np.ndarray:
+    """Algorithm 1 (FourBlockEst): impute the unobserved bottom-right block.
+
+    Parameters
+    ----------
+    Y : np.ndarray
+        ``(N, T)`` panel laid out as ``[[Ya, Yb], [Yc, ?]]``; the bottom-right
+        block is unobserved and its content is ignored.
+    N1, T1 : int
+        Row/column size of the fully observed top-left block ``Ya``.
+    r : int
+        Rank of the underlying mean matrix.
+
+    Returns
+    -------
+    np.ndarray
+        ``(N - N1, T - T1)`` estimate of the missing block.
+
+    Notes
+    -----
+    With a rank-``r`` mean matrix and noiseless observations the output equals
+    the missing block exactly (paper S3.1.1).
+    """
+    Y = np.asarray(Y, dtype=float)
+    N, T = Y.shape
+    if not (r <= N1 < N) or not (r <= T1 < T):
+        raise MlsynthConfigError(
+            f"four_block_est: require r <= N1 < N and r <= T1 < T; got "
+            f"r={r}, N1={N1}, N={N}, T1={T1}, T={T}."
+        )
+    # Step 1: left subspace, from the fully observed left blocks [Ya; Yc].
+    U_left, _, _ = svd_r(Y[:, :T1], r)
+    U1, U2 = U_left[:N1], U_left[N1:]
+    # Step 2-3: denoise the upper blocks [Ya Yb] and read off M_b.
+    U_up, s_up, Vh_up = svd_r(Y[:N1, :], r)
+    Mb = (U_up * s_up) @ Vh_up[:, T1:]
+    # Step 4: impute  M_d = U2 (U1'U1)^{-1} U1' M_b.
+    try:
+        return U2 @ np.linalg.solve(U1.T @ U1, U1.T @ Mb)
+    except np.linalg.LinAlgError as exc:          # pragma: no cover - guarded above
+        raise MlsynthConfigError(
+            f"four_block_est: the top-left block is rank deficient ({exc})."
+        ) from exc
+
+
+def staircase_blocks(A: np.ndarray):
+    """Sort a staggered design into staircase form (paper Appendix A).
+
+    Parameters
+    ----------
+    A : np.ndarray
+        ``(N, T)`` indicator, 1 where the outcome is observed under control and
+        0 where it is an unobserved counterfactual.
+
+    Returns
+    -------
+    (order, inv, N_all, T_all, k)
+        ``order`` sorts units by ascending treatment duration (so the
+        longest-observed units come first); ``inv`` restores the original row
+        order. ``T_all`` holds the distinct control-run lengths in ascending
+        order, ``N_all[i]`` the cumulative unit count down to the ``i``-th
+        longest, and ``k`` the number of distinct blocks.
+    """
+    A = np.asarray(A)
+    if A.ndim != 2:                                # pragma: no cover - guarded by setup
+        raise MlsynthDataError("staircase_blocks: A must be a 2D array.")
+    control_len = A.sum(axis=1).astype(int)
+    if not (A == 0).any():
+        raise MlsynthDataError(
+            "staircase_blocks: no unobserved (treated) cells -- nothing to impute."
+        )
+    if not (control_len == A.shape[1]).any():
+        raise MlsynthDataError(
+            "staircase_blocks: CAST needs at least one never-treated unit to "
+            "anchor the staircase."
+        )
+    order = np.argsort(A.shape[1] - control_len, kind="stable")
+    inv = np.argsort(order)
+    T_all = np.sort(np.unique(control_len)).astype(int)
+    k = int(T_all.size)
+    N_all = np.zeros(k, dtype=int)
+    for i in range(k):
+        N_all[i] = int((control_len == T_all[k - 1 - i]).sum()) + (N_all[i - 1] if i else 0)
+    return order, inv, N_all, T_all, k
+
+
+def _blocks(N_all, T_all, k):
+    """Yield the four-block sub-problems covering every unobserved cell."""
+    for i in range(k):
+        for j in range(k - i, k):
+            N1, T1 = int(N_all[k - j - 1]), int(T_all[k - i - 1])
+            Nij, Tij = int(N_all[i]), int(T_all[j])
+            r0, r1 = int(N_all[i - 1]) if i else 0, int(N_all[i])
+            c0, c1 = int(T_all[j - 1]) if j else 0, int(T_all[j])
+            yield N1, T1, Nij, Tij, r0, r1, c0, c1
+
+
+def impute_missing(Y: np.ndarray, A: np.ndarray, r: int) -> np.ndarray:
+    """Estimate every unobserved cell (Algorithm 3, estimation half).
+
+    Returns an ``(N, T)`` matrix carrying the counterfactual estimates at the
+    unobserved cells and zero elsewhere, in the original row order.
+    """
+    order, inv, N_all, T_all, k = staircase_blocks(A)
+    Ys = np.asarray(Y, dtype=float)[order]
+    M_est = np.zeros_like(Ys)
+    for N1, T1, Nij, Tij, r0, r1, c0, c1 in _blocks(N_all, T_all, k):
+        Md = four_block_est(Ys[:Nij, :Tij], N1, T1, r)
+        M_est[r0:r1, c0:c1] = Md[r0 - N1:r1 - N1, c0 - T1:c1 - T1]
+    return M_est[inv]
+
+
+def entrywise_variance(Y: np.ndarray, A: np.ndarray, r: int) -> np.ndarray:
+    """Entrywise variance of the imputed cells (paper equations 6a and 6c).
+
+    The residuals are formed on the observed entries of the *sorted* staircase
+    (eq. 6a) and combined with the estimated subspaces to give, for each
+    unobserved ``(i, t)``, the variance of the imputation error (eq. 6c).
+
+    Returns an ``(N, T)`` array of variances in the original row order; entries
+    at observed cells are zero.
+
+    Notes
+    -----
+    The mask is applied in the sorted frame, as eq. (6a) specifies. The
+    authors' ``CAST-panel`` package (1.0.2) masks sorted residuals with the
+    *unsorted* indicator, which understates the standard errors whenever the
+    sort permutation is non-trivial; see ``docs/replications/cast.rst``.
+    """
+    order, inv, N_all, T_all, k = staircase_blocks(A)
+    Ys = np.asarray(Y, dtype=float)[order]
+    As = np.asarray(A)[order]
+
+    M_imp = impute_missing(Y, A, r)[order] + Ys * As
+    u, s, vh = svd_r(M_imp, r)
+    E = (Ys - (u * s) @ vh) * As                  # eq. (6a), sorted frame
+    U_hat, V_hat = u, vh.T
+
+    var = np.zeros_like(Ys)
+    for N1, T1, Nij, Tij, r0, r1, c0, c1 in _blocks(N_all, T_all, k):
+        U1, U2 = U_hat[:N1], U_hat[N1:Nij]
+        V1, V2 = V_hat[:T1], V_hat[T1:Tij]
+        PU = np.square(U2 @ np.linalg.solve(U1.T @ U1, U1.T))
+        PV = np.square(V2 @ np.linalg.solve(V1.T @ V1, V1.T))
+        v = PU @ np.square(E[:N1, T1:Tij]) + np.square(E[N1:Nij, :T1]) @ PV.T
+        var[r0:r1, c0:c1] = v[r0 - N1:r1 - N1, c0 - T1:c1 - T1]
+    return var[inv]

--- a/mlsynth/utils/cast_helpers/pipeline.py
+++ b/mlsynth/utils/cast_helpers/pipeline.py
@@ -1,0 +1,190 @@
+"""CAST estimation pipeline (Xia, Yan & Wainwright 2025).
+
+Selects the factor rank, imputes every counterfactual cell through the
+staircase of four-block sub-problems, attaches the entrywise variances, and
+aggregates them into per-period effects with standard errors.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import numpy as np
+from scipy.stats import norm
+
+from ...exceptions import MlsynthEstimationError
+from .four_block import entrywise_variance, impute_missing, staircase_blocks, svd_r
+
+
+@dataclass
+class CASTFit:
+    """Point-estimate artifacts of a CAST fit."""
+    rank: int
+    counterfactual: np.ndarray        # N x T, observed values kept where control
+    effects: np.ndarray               # N x T, nan off the treated cells
+    std_errors: np.ndarray            # N x T, nan off the treated cells
+    ci_lower: np.ndarray
+    ci_upper: np.ndarray
+    period_effects: Dict[Any, Any]
+    significance: Dict[Any, Any]
+    extras: Dict[str, Any]
+
+
+def _control_block(Y: np.ndarray, A: np.ndarray) -> np.ndarray:
+    """The largest fully observed sub-block, used for rank selection.
+
+    Follows the reference's ``check_svd``: among the staircase blocks, take the
+    one minimising ``sqrt(1/N1 + 1/T1)`` -- the most informative rectangle.
+    """
+    _, _, N_all, T_all, k = staircase_blocks(A)
+    crit = np.sqrt(1.0 / np.flip(N_all) + 1.0 / T_all)
+    idx = int(np.argmin(crit))
+    order, _, _, _, _ = staircase_blocks(A)
+    return np.asarray(Y, dtype=float)[order][: N_all[k - 1 - idx], : T_all[idx]]
+
+
+def select_rank(Y: np.ndarray, A: np.ndarray, method: str = "broken_stick",
+                max_rank: int = 10) -> int:
+    """Choose the factor rank from the spectrum of the observed control block.
+
+    ``broken_stick`` reproduces the reference package's default; ``svht`` is
+    the Gavish-Donoho optimal hard threshold for a square-ish noisy matrix;
+    ``ratio`` takes the largest consecutive singular-value gap.
+    """
+    block = _control_block(Y, A)
+    s = np.linalg.svd(block, compute_uv=False)
+    s = s[s > 0]
+    cap = int(min(max_rank, s.size))
+    if cap < 1:                                   # pragma: no cover - defensive
+        raise MlsynthEstimationError("CAST: control block has no spectrum.")
+
+    if method == "svht":
+        n, m = block.shape
+        beta = min(n, m) / max(n, m)
+        lam = np.sqrt(2 * (beta + 1) + 8 * beta / ((beta + 1) + np.sqrt(beta ** 2 + 14 * beta + 1)))
+        thresh = lam * np.median(s)
+        r = int(max(1, (s > thresh).sum()))
+    elif method == "ratio":
+        if s.size < 2:                            # pragma: no cover - tiny panel
+            r = 1
+        else:
+            r = int(np.argmax(s[:-1] / s[1:]) + 1)
+    else:                                         # broken_stick (reference default)
+        share = s / s.sum()
+        r = 1
+        for j in range(1, s.size):
+            stick = np.sum(1.0 / np.arange(j + 1, s.size + 1)) / s.size
+            if share[j] < stick:
+                r = j
+                break
+            r = j + 1
+    return int(min(max(r, 1), cap))
+
+
+def aggregate_effects(effects: np.ndarray, var: np.ndarray, treated: np.ndarray,
+                      time_labels: np.ndarray, weights: Optional[np.ndarray],
+                      renormalize: bool) -> Dict[Any, Any]:
+    """Per-period aggregate effect and its standard error.
+
+    The aggregate is the bilinear functional ``tau_w,t = sum_i w_i tau_i,t`` of
+    paper eq. (4); its variance follows from the entrywise variances, treating
+    the per-unit imputation errors within a period as independent. ``weights``
+    may be a length-N vector or an N x T matrix (a period-varying weight).
+    """
+    out: Dict[Any, Any] = {}
+    W = None if weights is None else np.asarray(weights, dtype=float)
+    for j, label in enumerate(time_labels):
+        rows = np.where(treated[:, j])[0]
+        if rows.size == 0:
+            continue
+        if W is None:
+            w = np.ones(rows.size)
+        else:
+            w = W[rows, j] if W.ndim == 2 else W[rows]
+        if renormalize:
+            total = w.sum()
+            if not np.isfinite(total) or total == 0:   # pragma: no cover - defensive
+                continue
+            w = w / total
+        eff = float(np.dot(w, effects[rows, j]))
+        se = float(np.sqrt(np.dot(w ** 2, var[rows, j])))
+        out[label] = (eff, se)
+    return out
+
+
+def summarize_significance(effects: np.ndarray, se: np.ndarray, treated: np.ndarray,
+                           time_labels: np.ndarray, alpha: float) -> Dict[Any, Any]:
+    """Per-period counts of significantly positive / negative / null effects."""
+    z = norm.ppf(1 - alpha / 2)
+    out: Dict[Any, Any] = {}
+    for j, label in enumerate(time_labels):
+        rows = np.where(treated[:, j])[0]
+        if rows.size == 0:
+            continue
+        e, s = effects[rows, j], se[rows, j]
+        sig = np.abs(e) > z * s
+        out[label] = {
+            "positive": int(np.sum(sig & (e > 0))),
+            "negative": int(np.sum(sig & (e < 0))),
+            "null": int(np.sum(~sig)),
+            "n_treated": int(rows.size),
+        }
+    return out
+
+
+def run_cast(inputs, config) -> CASTFit:
+    """Run CAST end to end on prepared inputs."""
+    Y, A = inputs.Y, inputs.A
+    treated = inputs.treated_mask
+
+    r = config.rank
+    if r is None:
+        r = select_rank(Y, A, method=config.rank_method, max_rank=config.max_rank)
+    if r >= min(inputs.N, inputs.T):
+        raise MlsynthEstimationError(
+            f"CAST: rank r={r} must be smaller than min(N, T)="
+            f"{min(inputs.N, inputs.T)}."
+        )
+
+    try:
+        M_est = impute_missing(Y, A, r)
+        var = entrywise_variance(Y, A, r)
+    except (np.linalg.LinAlgError, ValueError) as exc:   # pragma: no cover
+        raise MlsynthEstimationError(f"CAST estimation failed ({exc}).") from exc
+
+    counterfactual = np.where(treated, M_est, Y)
+    se_full = np.sqrt(np.maximum(var, 0.0))
+    z = norm.ppf(1 - config.alpha / 2)
+
+    nan = np.full_like(Y, np.nan, dtype=float)
+    effects = np.where(treated, Y - counterfactual, nan)
+    se = np.where(treated, se_full, nan)
+    lo = np.where(treated, effects - z * se_full, nan)
+    hi = np.where(treated, effects + z * se_full, nan)
+
+    weights = None if config.weights is None else np.asarray(config.weights, dtype=float)
+    if weights is not None:
+        expected = f"a length-{inputs.N} vector or an {inputs.N} x {inputs.T} matrix"
+        if weights.ndim == 1 and weights.shape[0] != inputs.N:
+            raise MlsynthEstimationError(
+                f"CAST: weights has length {weights.shape[0]}, expected {expected}."
+            )
+        if weights.ndim == 2 and weights.shape != (inputs.N, inputs.T):
+            raise MlsynthEstimationError(
+                f"CAST: weights has shape {weights.shape}, expected {expected}."
+            )
+
+    period = aggregate_effects(np.where(treated, Y - counterfactual, 0.0), var,
+                               treated, inputs.time_labels, weights,
+                               config.renormalize_weights)
+    signif = summarize_significance(np.where(treated, Y - counterfactual, 0.0),
+                                    se_full, treated, inputs.time_labels, config.alpha)
+
+    return CASTFit(
+        rank=int(r), counterfactual=counterfactual, effects=effects,
+        std_errors=se, ci_lower=lo, ci_upper=hi,
+        period_effects=period, significance=signif,
+        extras={"rank_method": config.rank_method if config.rank is None else "fixed",
+                "weighted": weights is not None,
+                "renormalize_weights": config.renormalize_weights},
+    )

--- a/mlsynth/utils/cast_helpers/plotter.py
+++ b/mlsynth/utils/cast_helpers/plotter.py
@@ -1,0 +1,58 @@
+"""Plotting for the CAST estimator: the per-period aggregate effect with its
+confidence band, and the entrywise interval spread across treated units."""
+from __future__ import annotations
+
+import numpy as np
+
+from ...exceptions import MlsynthPlottingError
+
+
+def plot_cast(results, show: bool = True):
+    """Draw (1) the aggregate treated effect per period with its confidence
+    band and (2) a scatter of the entrywise effects. Returns the figure."""
+    try:
+        import matplotlib.pyplot as plt
+    except Exception as exc:                       # pragma: no cover
+        raise MlsynthPlottingError(f"matplotlib unavailable: {exc}") from exc
+
+    from scipy.stats import norm
+
+    inp = results.inputs
+    periods = list(results.period_effects)
+    if not periods:                                # pragma: no cover - guarded upstream
+        raise MlsynthPlottingError("CAST: no treated periods to plot.")
+    eff = np.array([results.period_effects[p][0] for p in periods], dtype=float)
+    se = np.array([results.period_effects[p][1] for p in periods], dtype=float)
+    z = norm.ppf(1 - results.metadata.get("alpha", 0.05) / 2)
+    x = np.arange(len(periods))
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4.4))
+
+    ax = axes[0]
+    ax.axhline(0, color="0.5", lw=1, ls=(0, (4, 3)))
+    ax.fill_between(x, eff - z * se, eff + z * se, color="#1d4e89", alpha=0.20,
+                    label=f"{int((1 - results.metadata.get('alpha', 0.05)) * 100)}% CI")
+    ax.plot(x, eff, color="#1d4e89", lw=2.0, marker="o", ms=4, label="aggregate effect")
+    ax.set_xticks(x); ax.set_xticklabels([str(p) for p in periods], fontsize=7, rotation=45)
+    ax.set_xlabel("period"); ax.set_ylabel("effect")
+    ax.set_title(f"CAST: treated-average effect (rank {results.rank})", fontsize=10)
+    ax.grid(alpha=0.25, lw=0.5); ax.legend(fontsize=8, loc="best")
+
+    ax = axes[1]
+    mask = inp.treated_mask
+    for j, p in enumerate(inp.time_labels):
+        rows = np.where(mask[:, j])[0]
+        if rows.size:
+            ax.scatter(np.full(rows.size, j), results.effects_panel[rows, j],
+                       s=9, alpha=0.55, color="#c1121f", edgecolors="none")
+    ax.axhline(0, color="0.5", lw=1, ls=(0, (4, 3)))
+    ax.set_xticks(np.arange(len(inp.time_labels)))
+    ax.set_xticklabels([str(p) for p in inp.time_labels], fontsize=7, rotation=45)
+    ax.set_xlabel("period"); ax.set_ylabel("per-unit effect")
+    ax.set_title("Entrywise treatment effects", fontsize=10)
+    ax.grid(alpha=0.25, lw=0.5)
+
+    fig.tight_layout()
+    if show:                                       # pragma: no cover
+        plt.show()
+    return fig

--- a/mlsynth/utils/cast_helpers/setup.py
+++ b/mlsynth/utils/cast_helpers/setup.py
@@ -1,0 +1,85 @@
+"""Data preparation for the CAST estimator."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from ...exceptions import MlsynthDataError
+from ..datautils import dataprep
+from .structures import CASTInputs
+
+
+def prepare_cast_inputs(
+    df: pd.DataFrame,
+    outcome: str,
+    treat: str,
+    unitid: str,
+    time: str,
+) -> CASTInputs:
+    """Pivot a long staggered panel into :class:`CASTInputs`.
+
+    Rides :func:`mlsynth.utils.datautils.dataprep`, which returns the wide
+    outcome matrix plus a per-cohort map of adoption times; both the
+    single-cohort and multi-cohort (staggered) layouts are accepted, since a
+    block design is just a staggered design with one adoption time.
+
+    Raises
+    ------
+    MlsynthDataError
+        If the panel is unbalanced, has no never-treated unit, or has no
+        treated cells to impute.
+    """
+    prepared = dataprep(df, unitid, time, outcome, treat)
+
+    if "cohorts" in prepared:                     # staggered / multi-cohort
+        Ywide = prepared["Ywide"]
+        time_labels = np.asarray(prepared["time_labels"])
+        unit_names = np.asarray(list(Ywide.columns), dtype=object)
+        Y = Ywide.to_numpy(dtype=float).T         # Ywide is time x unit
+        adoption = {}
+        for start_time, cohort in prepared["cohorts"].items():
+            idx = int(np.where(time_labels == start_time)[0][0])
+            for u in cohort["treated_units"]:
+                adoption[u] = idx
+    else:                                         # single treated unit
+        y = np.asarray(prepared["y"], dtype=float).ravel()
+        Y0 = np.asarray(prepared["donor_matrix"], dtype=float)
+        time_labels = np.asarray(prepared.get(
+            "time_labels", np.arange(int(prepared["total_periods"]))))
+        unit_names = np.concatenate([
+            np.array([prepared["treated_unit_name"]], dtype=object),
+            np.asarray(prepared["donor_names"], dtype=object),
+        ])
+        Y = np.vstack([y[None, :], Y0.T])
+        adoption = {prepared["treated_unit_name"]: int(prepared["pre_periods"])}
+
+    if np.isnan(Y).any():
+        raise MlsynthDataError(
+            "CAST does not support missing outcomes; impute or drop them first."
+        )
+    N, T = Y.shape
+    adoption_index = np.array([adoption.get(u, T) for u in unit_names], dtype=int)
+
+    if (adoption_index >= T).all():                # pragma: no cover - dataprep rejects this first
+        raise MlsynthDataError("CAST found no treated unit-periods.")
+    if not (adoption_index >= T).any():
+        raise MlsynthDataError(
+            "CAST needs at least one never-treated unit to anchor the staircase."
+        )
+    if (adoption_index == 0).any():
+        raise MlsynthDataError(
+            "CAST requires at least one pre-treatment period for every unit; "
+            "some unit is treated in the first period."
+        )
+    if N < 3:
+        raise MlsynthDataError(f"CAST needs at least 3 units; got {N}.")
+
+    A = np.ones((N, T), dtype=int)
+    for i, t0 in enumerate(adoption_index):
+        if t0 < T:
+            A[i, t0:] = 0
+
+    return CASTInputs(
+        Y=Y, A=A, unit_names=unit_names, time_labels=time_labels,
+        adoption_index=adoption_index,
+    )

--- a/mlsynth/utils/cast_helpers/structures.py
+++ b/mlsynth/utils/cast_helpers/structures.py
@@ -1,0 +1,151 @@
+"""Frozen structures for the CAST estimator (Xia, Yan & Wainwright 2025).
+
+CAST returns a confidence interval for every treated unit-period, so its
+distinctive output is a *panel* of estimates, standard errors and intervals
+rather than a single counterfactual path.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from pydantic import ConfigDict, Field
+
+from ...config_models import BaseEstimatorResults
+
+
+@dataclass(frozen=True)
+class CASTInputs:
+    """Preprocessed staggered panel for CAST.
+
+    Parameters
+    ----------
+    Y : np.ndarray
+        Outcome panel, shape ``(N, T)``.
+    A : np.ndarray
+        Observation indicator, shape ``(N, T)``: 1 where the outcome is
+        observed under control, 0 at the treated (counterfactual) cells.
+    unit_names : np.ndarray
+        Unit labels, length ``N``.
+    time_labels : np.ndarray
+        Period labels, length ``T``.
+    adoption_index : np.ndarray
+        Per-unit index of first treatment; ``T`` for never-treated units.
+    """
+
+    Y: np.ndarray
+    A: np.ndarray
+    unit_names: np.ndarray
+    time_labels: np.ndarray
+    adoption_index: np.ndarray
+
+    @property
+    def N(self) -> int:
+        """Number of units."""
+        return int(self.Y.shape[0])
+
+    @property
+    def T(self) -> int:
+        """Number of periods."""
+        return int(self.Y.shape[1])
+
+    @property
+    def treated_mask(self) -> np.ndarray:
+        """Boolean mask of the treated (counterfactual) cells."""
+        return ~self.A.astype(bool)
+
+    @property
+    def treated_units(self) -> np.ndarray:
+        """Labels of the ever-treated units."""
+        return self.unit_names[self.adoption_index < self.T]
+
+    @property
+    def never_treated(self) -> np.ndarray:
+        """Labels of the never-treated units."""
+        return self.unit_names[self.adoption_index >= self.T]
+
+
+class CASTResults(BaseEstimatorResults):
+    """Top-level container returned by :meth:`mlsynth.CAST.fit`.
+
+    An :class:`~mlsynth.config_models.EffectResult`: the standardized
+    sub-models describe the average treated unit (so ``att`` / ``att_ci`` /
+    ``counterfactual`` / ``gap`` resolve through the base contract), while the
+    entrywise panel below carries the per-unit-per-period inference that is the
+    method's reason for existing.
+
+    Parameters
+    ----------
+    inputs : CASTInputs
+        Preprocessed panel.
+    rank : int
+        Rank used for the factor structure.
+    effects_panel : np.ndarray
+        ``(N, T)`` individual treatment effects; ``nan`` at untreated cells.
+    std_errors : np.ndarray
+        ``(N, T)`` entrywise standard errors; ``nan`` at untreated cells.
+    ci_lower_panel, ci_upper_panel : np.ndarray
+        ``(N, T)`` entrywise confidence bounds; ``nan`` at untreated cells.
+    counterfactual_panel : np.ndarray
+        ``(N, T)`` estimated counterfactual outcomes (observed values retained
+        at untreated cells).
+    period_effects : dict
+        ``{period label: (effect, standard error)}`` -- the aggregate treated
+        effect per period, with the weighting requested in the config.
+    significance : dict
+        ``{period label: {"positive": int, "negative": int, "null": int,
+        "n_treated": int}}`` -- the per-period sign breakdown at ``alpha``.
+    metadata : dict
+        Free-form pipeline diagnostics (rank selection, weighting, ...).
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    inputs: CASTInputs
+    rank: int
+    effects_panel: np.ndarray
+    std_errors: np.ndarray
+    ci_lower_panel: np.ndarray
+    ci_upper_panel: np.ndarray
+    counterfactual_panel: np.ndarray
+    period_effects: Dict[Any, Any]
+    significance: Dict[Any, Any]
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def effect_table(self) -> List[Dict[str, Any]]:
+        """Tidy ``(unit, period, effect, se, ci_lower, ci_upper)`` rows for the
+        treated cells -- the entrywise interval panel, long-format."""
+        rows: List[Dict[str, Any]] = []
+        mask = self.inputs.treated_mask
+        for i, j in zip(*np.where(mask)):
+            rows.append({
+                "unit": self.inputs.unit_names[i],
+                "period": self.inputs.time_labels[j],
+                "effect": float(self.effects_panel[i, j]),
+                "se": float(self.std_errors[i, j]),
+                "ci_lower": float(self.ci_lower_panel[i, j]),
+                "ci_upper": float(self.ci_upper_panel[i, j]),
+            })
+        return rows
+
+    def significant_units(self, period: Any, level: float = 0.05) -> Dict[Any, float]:
+        """``{unit: effect}`` for units whose effect at ``period`` excludes zero.
+
+        Uses the stored entrywise intervals when ``level`` matches the fitted
+        ``alpha``; otherwise rescales the interval to ``level``.
+        """
+        from scipy.stats import norm
+
+        j = int(np.where(self.inputs.time_labels == period)[0][0])
+        z = norm.ppf(1 - level / 2)
+        out: Dict[Any, float] = {}
+        for i in np.where(self.inputs.treated_mask[:, j])[0]:
+            eff, se = self.effects_panel[i, j], self.std_errors[i, j]
+            if np.isfinite(eff) and np.isfinite(se) and abs(eff) > z * se:
+                out[self.inputs.unit_names[i]] = float(eff)
+        return out
+
+
+CASTResults.model_rebuild()


### PR DESCRIPTION
Adds `CAST` — entrywise confidence intervals for treatment effects under staggered adoption, from Xia, Yan & Wainwright (2025), *Inference under Staggered Adoption: Case Study of the Affordable Care Act* ([arXiv:2412.09482v2](https://arxiv.org/abs/2412.09482)).

## What it does

Most panel estimators report one pooled effect. CAST returns a confidence interval for *every* treated unit-period. It sorts the staggered-adoption panel into a staircase, decomposes it into four-block sub-problems, imputes each counterfactual cell by a spectral routine (Algorithm 1), and attaches an entrywise variance (eq. 6a/6c) that gives a normal interval per cell. Aggregates — the ATET, or any weighted version of it — come from the same variances as bilinear functionals `tau_w,t = sum_i w_i tau_i,t`.

The weight can be a length-`N` vector or an `N x T` matrix. The matrix form is what a population-weighted total needs when the population itself moves over time, which is how the paper computes its headline "population effect".

## Layout

Follows the one-estimator-one-package contract:

- `mlsynth/estimators/cast.py` — thin class, `.fit()` returns a `CASTResults` (an `EffectResult`)
- `mlsynth/utils/cast_helpers/` — `four_block.py` (Algorithm 1 kernels, staircase partition, entrywise variance), `config.py` (`CASTConfig`), `setup.py` (rides `dataprep`), `pipeline.py` (rank selection, aggregation, significance), `structures.py` (frozen inputs + results), `plotter.py`
- exported from `mlsynth/__init__.py`; `CASTConfig` registered in `_RELOCATED_CONFIGS`

Rank is the one substantive tuning choice; `rank_method` offers `broken_stick` (matches the authors' default), `svht` and `ratio`.

## Verification

Path A on the authors' data plus cross-validation against their released `CAST-panel` package. `benchmarks/cases/cast_aca.py` pins it and skips cleanly when the package or data cannot be fetched.

- Point estimates match the reference to `1.7e-16` across all 260 treated cells — the estimator is a deterministic sequence of SVDs and least-squares solves, so exactness is the right bar, not a tolerance.
- Table 1 reproduces: per-year ATET within 0.077pp of the published figures, population-weighted totals within 0.05M, rank 1 selected by broken-stick.
- Benchmark 9/9 PASS. 100% coverage on the CAST package (386 statements).

## A standard-error discrepancy in the reference package

Worth flagging explicitly, because mlsynth deliberately does not match the reference here.

`CAST-panel` 1.0.2 computes its residuals on the row-sorted staircase but masks them with the *unsorted* observation indicator:

```python
E_est = (self.M_sorted - M_est_full) * self.A      # self.A is unsorted
```

Equation (6a) defines the residuals blockwise on the sorted staircase, so the mask must be sorted with the data. Three independent checks say this is a bug rather than a modelling choice:

- When the sort is the identity permutation, mlsynth and the reference agree on the standard errors to `4.2e-16` — so the mask is the sole divergence and the variance formula is otherwise transcribed identically.
- On the ACA panel the sort is not the identity, and the shipped errors come out 16% to 65% too small (worst in 2021, ratio 1.65).
- In Monte Carlo on a known low-rank staggered design, coverage with the sorted mask is closer to nominal at every panel size, and the gap does not shrink with `N` — the signature of a bug, not a finite-sample effect (0.865/0.902/0.918 shipped vs 0.902/0.928/0.943 sorted, at N=60/150/300, nominal 0.95).

mlsynth ships the sorted-mask variance.

The consequence is substantive and the benchmark pins both sides of it. Table 1's per-year significance counts are computed at alpha = 0.01. Pair mlsynth's point estimates with the reference's own errors and all eight rows reproduce exactly — confirming the port. Use the corrected errors and only two of eight still match, because they are on average 1.36 times larger and marginal states fall back to null. The ATET, the signs and the population totals are unaffected; what weakens is the claim about how many individual states clear the bar. Both counts are in `EXPECTED`, so the finding is recorded and would move if either implementation changed.

Written up in `docs/replications/cast.rst`, along with honest caveats about asymptotic coverage on a 50x14 panel, the independence-across-time noise model, and the fact that per-unit flags test a cell whose own noise the interval does not cover.

## Tests

47 new tests across `test_cast.py` and `test_cast_kernels.py` — smoke, invariants, edge cases (single donor, no pre-periods, collinear, degenerate staircase) and config-failure paths asserting the translated `Mlsynth*Error`. Registered in `test_result_contract.py`.

Full suite: 5162 passed, 253 skipped. No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RjyUwLsG7PsEDS4emx9dLw)_