### PR TITLE
fix(vanillasc): apply the Abadie-L'Hour penalty when no covariates are given

### DIFF
--- a/mlsynth/tests/test_vanillasc_penalized_lambda.py
+++ b/mlsynth/tests/test_vanillasc_penalized_lambda.py
@@ -119,15 +119,18 @@ class TestValidation:
                            time="time", covariates=["x"], backend="penalized",
                            penalized_lambda=-0.5))
 
-    def test_fixed_lambda_ignored_without_covariates(self, df):
-        # The Abadie-L'Hour pairwise penalty needs covariate predictors; with
-        # none, the engine routes backend='penalized' to the exact outcome-only
-        # simplex, so penalized_lambda has no effect and is surfaced as None.
+    def test_fixed_lambda_applies_without_covariates(self, df):
+        # Superseded. This case used to assert that penalized_lambda was
+        # ignored without covariates, on the rationale that the Abadie-L'Hour
+        # pairwise penalty "needs covariate predictors". That rationale was
+        # wrong: the penalty lives on the matching variables, which in the
+        # outcome-only specification are the pre-treatment outcome lags, and
+        # BilevelProblem documents K == 0 as supported precisely for this
+        # backend. The engine no longer routes penalized to the unpenalized
+        # simplex, so the fixed lambda is honoured and surfaced.
+        # See tests/test_vanillasc_penalized_outcome_only.py.
         base = dict(df=df, outcome="y", treat="D", unitid="unit", time="time",
                     display_graphs=False)
         res = VanillaSC({**base, "backend": "penalized", "penalized_lambda": 0.2}).fit()
-        assert res.method_details.parameters_used["penalized_lambda"] is None
-        oo = VanillaSC({**base, "backend": "outcome-only"}).fit()
-        a = np.array(list(_weights(res).values()))
-        b = np.array(list(_weights(oo).values()))
-        assert np.allclose(a, b, atol=1e-8)
+        assert res.method_details.parameters_used["penalized_lambda"] == pytest.approx(0.2)
+        assert res.method_details.parameters_used["backend"] == "penalized"

--- a/mlsynth/tests/test_vanillasc_penalized_outcome_only.py
+++ b/mlsynth/tests/test_vanillasc_penalized_outcome_only.py
@@ -1,0 +1,228 @@
+"""Abadie-L'Hour penalization without covariates (outcome-lag matching).
+
+The pairwise penalty is defined on the *matching variables*. In the canonical
+outcome-only specification those are the pre-treatment outcome lags, so
+``backend="penalized"`` is well defined with no covariates at all -- and that is
+exactly the configuration where it matters most. When the donor pool is large
+relative to the pre-period, the treated unit lies inside the donors' convex hull
+and the unpenalized program has a *continuum* of solutions that all reproduce
+the pre-treatment path perfectly; which one a solver returns is an artifact of
+its path, not a feature of the data. Abadie & L'Hour (2021) Theorem 1 says any
+``lambda > 0`` restores a unique solution with at most ``K + 1`` non-zero
+weights, selecting the one with the least interpolation bias.
+
+Written test-first: before the fix, ``backend="penalized"`` silently fell
+through to the unpenalized outcome-only simplex whenever covariates were absent
+and discarded ``penalized_lambda`` without warning.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import VanillaSC
+from mlsynth.exceptions import MlsynthConfigError
+
+
+# --------------------------------------------------------------------------- #
+# fixtures
+# --------------------------------------------------------------------------- #
+def _degenerate_panel(J: int = 12, T_pre: int = 4, T_post: int = 4, seed: int = 0):
+    """Panel where the unpenalized solution is *not* unique.
+
+    ``J`` donors against ``T_pre`` pre-periods with the treated unit built as an
+    exact convex combination of donors, so it sits strictly inside the hull and
+    the interpolation polytope has dimension ``J - T_pre - 1 > 0``.
+    """
+    rng = np.random.default_rng(seed)
+    T = T_pre + T_post
+    Y0 = rng.uniform(1.0, 5.0, size=(T, J))
+    w = np.zeros(J)
+    w[[0, 1, 2]] = [0.5, 0.3, 0.2]          # treated is inside the hull
+    y1 = Y0 @ w
+    y1[T_pre:] += 3.0                        # a post-treatment effect
+    rows = []
+    for t in range(T):
+        rows.append({"unit": "treated", "time": t, "y": float(y1[t]),
+                     "D": int(t >= T_pre)})
+        for j in range(J):
+            rows.append({"unit": f"d{j:02d}", "time": t, "y": float(Y0[t, j]),
+                         "D": 0})
+    return pd.DataFrame(rows)
+
+
+def _covariate_panel(J: int = 8, T_pre: int = 15, T_post: int = 6, seed: int = 0):
+    """Ordinary panel carrying a unit-level covariate (non-regression guard)."""
+    rng = np.random.default_rng(seed)
+    T = T_pre + T_post
+    F = rng.standard_normal((T, 2))
+    lam = rng.standard_normal((J + 1, 2))
+    Y = F @ lam.T + 0.2 * rng.standard_normal((T, J + 1))
+    x = lam[:, 0] * 3.0 + rng.standard_normal(J + 1) * 0.1
+    return pd.DataFrame([
+        {"unit": j, "time": t, "y": float(Y[t, j]), "x": float(x[j]),
+         "D": int(j == 0 and t >= T_pre)}
+        for j in range(J + 1) for t in range(T)
+    ])
+
+
+@pytest.fixture
+def deg():
+    return _degenerate_panel()
+
+
+@pytest.fixture
+def cov_df():
+    return _covariate_panel()
+
+
+def _fit(df, **over):
+    cfg = dict(df=df, outcome="y", treat="D", unitid="unit", time="time",
+               inference=False, display_graphs=False)
+    cfg.update(over)
+    return VanillaSC(cfg).fit()
+
+
+def _w(res, keys=None) -> np.ndarray:
+    """Weight vector aligned to ``keys`` (``donor_weights`` drops zero entries,
+    so two fits with different support are not directly comparable)."""
+    d = res.weights.donor_weights or {}
+    if keys is None:
+        keys = sorted(d)
+    return np.array([float(d.get(k, 0.0)) for k in keys], dtype=float)
+
+
+def _nnz(res, tol: float = 1e-6) -> int:
+    return int((_w(res) > tol).sum())
+
+
+# --------------------------------------------------------------------------- #
+# the penalty is actually applied
+# --------------------------------------------------------------------------- #
+def test_penalized_without_covariates_differs_from_unpenalized(deg):
+    """The whole point: penalizing must change the selected weights."""
+    pen = _fit(deg, backend="penalized", penalized_lambda=1e-3)
+    plain = _fit(deg, backend="outcome-only")
+    keys = sorted(set(pen.weights.donor_weights) | set(plain.weights.donor_weights))
+    assert not np.allclose(_w(pen, keys), _w(plain, keys), atol=1e-8)
+
+
+def test_explicit_lambda_is_honoured_and_reported(deg):
+    res = _fit(deg, backend="penalized", penalized_lambda=1e-3)
+    assert res.method_details.parameters_used["penalized_lambda"] == pytest.approx(1e-3)
+
+
+def test_reports_the_penalized_backend(deg):
+    res = _fit(deg, backend="penalized", penalized_lambda=1e-3)
+    assert "penalized" in res.method_details.method_name.lower()
+    assert res.method_details.parameters_used["backend"] == "penalized"
+
+
+def test_cv_selects_a_lambda_without_covariates(deg):
+    """With no fixed lambda the CV path must still run and surface its choice."""
+    res = _fit(deg, backend="penalized")
+    lam = res.method_details.parameters_used["penalized_lambda"]
+    assert lam is not None and lam >= 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Abadie-L'Hour Theorem 1: uniqueness and sparsity
+# --------------------------------------------------------------------------- #
+def test_unpenalized_solution_is_degenerate_on_this_panel(deg):
+    """Guard on the fixture: without a penalty the fit is perfect and dense,
+    which is the signature of a non-unique optimum."""
+    plain = _fit(deg, backend="outcome-only")
+    assert plain.fit_diagnostics.rmse_pre < 1e-6
+    assert _nnz(plain) > 5          # weight smeared across the polytope
+
+
+def test_positive_lambda_gives_at_most_K_plus_one_nonzero_weights(deg):
+    """Theorem 1 sparsity bound, with the pre-period lags as matching variables.
+
+    Checked where the default solver budget attains the exact optimum; the
+    small-lambda regime is pinned separately below.
+    """
+    T_pre = 4
+    for lam in (1e-1, 1.0):
+        assert _nnz(_fit(deg, backend="penalized", penalized_lambda=lam)) <= T_pre + 1
+
+
+def test_small_lambda_sparsity_is_solver_limited(deg):
+    """Known limitation, pinned so a fix is noticed.
+
+    Theorem 1 guarantees at most ``K + 1`` non-zero weights for *any* positive
+    lambda, but the inner simplex QP is FISTA and under-converges when the
+    penalty is small relative to the fit term: at ``lambda = 1e-4`` on this
+    panel it returns seven donors where the exact optimum has five, at a
+    slightly higher objective. It is under-convergence rather than a wrong
+    program -- raising ``max_iter`` to ~2e5 recovers the exact solution -- so
+    the remedy is to solve the inner QP exactly rather than iterate further.
+    Tracked separately from the routing fix because it also changes the
+    with-covariates path, which carries its own benchmark.
+
+    If this assertion starts failing because the count dropped, the inner
+    solver was fixed: fold this case back into the test above.
+    """
+    T_pre = 4
+    assert _nnz(_fit(deg, backend="penalized", penalized_lambda=1e-4)) > T_pre + 1
+
+
+def test_penalized_fit_is_deterministic(deg):
+    """Uniqueness implies repeated fits agree exactly."""
+    a = _w(_fit(deg, backend="penalized", penalized_lambda=1e-3))
+    b = _w(_fit(deg, backend="penalized", penalized_lambda=1e-3))
+    assert np.allclose(a, b, atol=1e-12)
+
+
+def test_larger_lambda_is_weakly_sparser(deg):
+    counts = [_nnz(_fit(deg, backend="penalized", penalized_lambda=lam))
+              for lam in (1e-4, 1e-2, 1.0)]
+    assert counts[-1] <= counts[0]
+
+
+def test_small_lambda_keeps_the_pre_treatment_fit(deg):
+    """lambda -> 0 selects *among* the best synthetic controls, so a tiny
+    penalty must not meaningfully degrade the pre-period fit."""
+    plain = _fit(deg, backend="outcome-only")
+    pen = _fit(deg, backend="penalized", penalized_lambda=1e-8)
+    assert pen.fit_diagnostics.rmse_pre <= plain.fit_diagnostics.rmse_pre + 1e-4
+
+
+def test_weights_remain_a_valid_simplex(deg):
+    w = _w(_fit(deg, backend="penalized", penalized_lambda=1e-2))
+    assert (w >= -1e-12).all()
+    assert w.sum() == pytest.approx(1.0, abs=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# failures
+# --------------------------------------------------------------------------- #
+def test_negative_lambda_rejected_without_covariates(deg):
+    with pytest.raises(MlsynthConfigError):
+        VanillaSC(dict(df=deg, outcome="y", treat="D", unitid="unit",
+                       time="time", backend="penalized", penalized_lambda=-1.0))
+
+
+# --------------------------------------------------------------------------- #
+# non-regression
+# --------------------------------------------------------------------------- #
+def test_outcome_only_backend_is_unchanged(deg):
+    """The fix must not perturb the plain outcome-only path."""
+    res = _fit(deg, backend="outcome-only")
+    assert res.method_details.parameters_used["backend"] == "outcome-only"
+    assert res.fit_diagnostics.rmse_pre < 1e-6
+
+
+def test_penalized_with_covariates_still_works(cov_df):
+    res = _fit(cov_df, covariates=["x"], backend="penalized", penalized_lambda=0.2)
+    assert res.method_details.parameters_used["penalized_lambda"] == pytest.approx(0.2)
+    w = _w(res)
+    assert w.sum() == pytest.approx(1.0, abs=1e-9)
+
+
+def test_auto_backend_without_covariates_stays_outcome_only(cov_df):
+    """``auto`` must keep routing to outcome-only, not to penalized."""
+    res = _fit(cov_df, backend="auto")
+    assert res.method_details.parameters_used["backend"] == "outcome-only"

--- a/mlsynth/utils/bilevel/engine.py
+++ b/mlsynth/utils/bilevel/engine.py
@@ -236,7 +236,17 @@ class BilevelSCM:
         pred_names: List[str] = []
         diagnostics: Dict[str, Any] = {}
 
-        if backend == "outcome-only" or not has_cov:
+        # ``penalized`` is well defined without covariates: Abadie-L'Hour's
+        # pairwise penalty lives on the *matching variables*, which in the
+        # outcome-only specification are the pre-treatment outcome lags. That is
+        # also the case where it matters most -- a donor pool large relative to
+        # the pre-period puts the treated unit inside the hull, so the
+        # unpenalized program has a continuum of perfect-fitting solutions and
+        # the returned one is a solver artifact. So only fall through to the
+        # plain simplex for the genuinely predictor-free backends; ``penalized``
+        # continues below with an empty (K=0) predictor block, which
+        # :class:`BilevelProblem` and the penalized solver both accept.
+        if backend == "outcome-only" or (not has_cov and backend != "penalized"):
             backend = "outcome-only"
             # Exact simplex QP (cvxpy). The FISTA primitive ``simplex_lstsq``
             # under-converges on long, ill-conditioned pre-windows (e.g. the
@@ -245,6 +255,10 @@ class BilevelSCM:
             # exactly, matching augsynth's quadprog.
             W = simplex_qp(Y0_pre, y_pre)
         else:
+            if not has_cov:
+                # Predictor-free penalized fit: match on the outcome lags alone.
+                X1 = np.empty(0, dtype=float)
+                X0 = np.empty((0, J), dtype=float)
             X1 = np.asarray(X1, dtype=float).ravel()
             X0 = np.asarray(X0, dtype=float)
             if X0.shape != (X1.shape[0], J):

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -337,5 +337,13 @@ class VanillaSCConfig(BaseEstimatorConfig):
                     "nearest-neighbour matching, an infinitesimal value gives "
                     "the lexicographic (fit-preserving) tie-break, and 0 is the "
                     "unpenalized synthetic control. 'None' (default) selects "
-                    "lambda by cross-validation. Ignored for other backends.",
+                    "lambda by cross-validation. Ignored for other backends. "
+                    "Covariates are not required: with none supplied the "
+                    "pre-treatment outcome lags are the matching variables, "
+                    "which is the case where the penalty matters most (a donor "
+                    "pool large relative to the pre-period makes the "
+                    "unpenalized optimum non-unique). Note the inner QP is a "
+                    "first-order method that under-converges for very small "
+                    "lambda relative to the fit term, so Abadie-L'Hour's "
+                    "at-most-K+1 sparsity bound may not be attained there.",
     )


### PR DESCRIPTION
`VanillaSC(backend="penalized")` **silently did nothing without covariates.** The engine routed every predictor-free fit to the plain outcome-only simplex before the penalized solver was reached, and discarded an explicit `penalized_lambda` without warning:

```
requested: backend="penalized", penalized_lambda=1e-6
reported:  VanillaSC[outcome-only],  penalized_lambda: None
```

## Why that's backwards

Abadie–L'Hour's pairwise penalty lives on the **matching variables**, which in the canonical outcome-only specification are the pre-treatment outcome lags. No covariates are required — and that is precisely the configuration where the penalty matters most. When the donor pool is large relative to the pre-period, the treated unit sits inside the donors' convex hull and the *unpenalized* program has a continuum of solutions that all reproduce the pre-treatment path perfectly. Which one comes back is an artifact of the solver's path, not a feature of the data. Theorem 1 (any λ > 0 ⇒ unique, ≤ K+1 nonzero weights) is the fix for exactly that.

The capability already existed — `structure.py:49` documents `K == 0` as permitted *"only [by] the predictor-free penalized backend"*, `_build_block` guards `n_predictors > 0`, and the default `cv="holdout"` needs no covariates. The routing was blocking it.

## The change

Confined to `engine.py`: only genuinely predictor-free backends fall through to the plain simplex; `penalized` continues with an empty `(K=0)` predictor block.

## Motivating case

Found auditing the replication package for Van Parys (2026, *AJPS*), which fits **98 donors on 9 pre-periods**. There the unpenalized estimate isn't identified at all — weight vectors achieving identical, machine-zero pre-treatment fit imply four-month effects anywhere in **\$36,572–\$180,773**. With the penalty actually applied:

| Specification | nonzero | pre-RMSE | effect (4-mo) |
|---|---|---|---|
| outcome-only (the paper's spec) | 98 | 0.0000 | \$126,770 |
| penalized, λ = 1e-2 | **9** | 998 | \$122,734 |
| penalized, λ by CV | 27 | 138 | \$123,589 |

The estimate concentrates in \$117k–\$124k instead of spanning a 5× interval.

## A second defect, pinned but not fixed

The tests exposed that the penalized inner QP is FISTA and under-converges when λ is small relative to the fit term, so Theorem 1's ≤ K+1 sparsity bound isn't attained there — 7 donors against the exact 5 on the fixture, 83 against ~10 on the real data at λ=1e-6. It's under-convergence, not a wrong program (~2×10⁵ iterations recovers the exact solution), so the remedy is an exact inner solve.

Left to its own branch because it also changes the with-covariates path, which carries the `pensynth_prop99` benchmark. Asserted in `test_small_lambda_sparsity_is_solver_limited` (with instructions to fold it back when fixed) and documented on the config field, so it's tracked rather than hidden.

## One existing test overturned

`test_fixed_lambda_ignored_without_covariates` asserted the old behaviour on the rationale that the penalty *"needs covariate predictors."* That rationale was wrong. I rewrote it to assert the lambda is honoured, keeping the history in the docstring rather than deleting the case.

## Testing

Written test-first — 5 of the 15 new tests failed for the right reason before the change, 9 guard/non-regression tests passed throughout.

- 15 new tests in `test_vanillasc_penalized_outcome_only.py` (penalty applied, lambda honoured and reported, Theorem 1 sparsity, determinism, monotone sparsification, simplex validity, negative-lambda rejection, and non-regression on `outcome-only` / with-covariates / `auto`)
- **`pensynth_prop99` re-run live** against `LowRankQP` (installed from the CRAN GitHub mirror rather than accepting the usual skip) — passes, so the with-covariates path is unchanged
- **1401 passed, 84 skipped, 0 failed** across all VanillaSC / bilevel / penalized / MASC / MAREX / LEXSCM / FSCM / MLSC / CV tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYjo4s2qMBtsJhuEqEusih

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYjo4s2qMBtsJhuEqEusih)_