### PR TITLE
ci: raise the suite timeout from 40 to 55 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40     # a hung suite shouldn't burn a full-length runner slot
+    # The cap exists to kill a genuinely hung suite, not to bound a healthy one.
+    # The full run has measured 30-38 min across the matrix, so 40 left under 10%
+    # headroom and ordinary runner variance was tipping jobs into a timeout that
+    # reads as 'cancelled' rather than a clear failure. 55 keeps the hang guard
+    # while leaving room for a slow runner.
+    timeout-minutes: 55
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -115,7 +120,7 @@ jobs:
   # avoid duplicating `build`.
   pyversions:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 55
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The cap exists to kill a genuinely hung suite, not to bound a healthy one — and 40 stopped doing the former without also doing the latter.

## The problem

Measured durations across the matrix are 30–38 minutes, so there was under 10% headroom. Ordinary runner variance is enough to tip a job over:

| PR | build | 3.10 | 3.12 | 3.13 |
|---|---|---|---|---|
| #277 | 37.9 | 24.0 | 34.5 | 36.5 |
| #281 | 30.0 ✅ | 35.0 ✅ | **40:00 ✗** | **40:00 ✗** |

Same tree class, same workflow — two jobs simply landed on slower runners and hit the ceiling.

The failure mode is also easy to misread: GitHub surfaces a timeout as **cancelled**, not as a red check, so a run with two jobs that never finished can look close enough to green to merge on. That nearly happened on #281.

## Why 55

A stuck job still dies well short of the six-hour platform limit, so the hang guard is intact — it just no longer fires on healthy runs. Actions minutes are free for public repositories, so the only cost of the higher ceiling is the runner slot held by a job that was going to be killed anyway. The `concurrency` group with `cancel-in-progress` already prevents superseded runs from piling up.

## The larger fix, deliberately not taken here

The suite is parallel-safe — a local `pytest -n 4` run completes **5164 passed / 283 skipped / 0 failed** — so pytest-xdist in CI would cut wall-clock substantially rather than just moving the ceiling. Left for its own branch because raising the timeout is the minimal change that stops the flake, and adding a parallel runner to CI deserves to be evaluated on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYjo4s2qMBtsJhuEqEusih

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYjo4s2qMBtsJhuEqEusih)_