### PR TITLE
fix(penalized): solve the inner simplex QP exactly, in scaled residual form

### DIFF
--- a/mlsynth/tests/test_bilevel_penalized_qp.py
+++ b/mlsynth/tests/test_bilevel_penalized_qp.py
@@ -1,0 +1,243 @@
+"""Exactness of the penalized backend's inner simplex QP.
+
+``penalized_weights`` solves Abadie-L'Hour eq. (5),
+
+    min_w  ||X1 - X0 w||^2 + lambda * sum_j w_j ||X1 - X_j||^2
+    s.t.   w >= 0, sum_j w_j = 1,
+
+a convex quadratic program over the simplex. Theorem 1 says that for any
+``lambda > 0`` its solution is unique and carries at most ``K + 1`` non-zero
+weights, where ``K`` is the number of matching variables. That guarantee is the
+entire reason the backend exists -- it is what makes the estimator well defined
+when the treated unit sits inside the donor convex hull and the unpenalized
+program has a continuum of solutions.
+
+A first-order method does not deliver it at realistic iteration budgets. These
+tests pin the exact behaviour instead: the returned weights must attain the
+optimal objective value, and hence the sparsity bound.
+
+Written test-first, against an independent cvxpy reference.
+
+Two tolerances need stating, because the guarantee is exact arithmetic and the
+solver is numerical. Objective values are compared with a *relative* tolerance:
+an interior-point QP lands within ~1e-6 relative of the optimum, so demanding
+bit-agreement with another solver run would test the solver, not this module.
+And a donor is counted as carrying weight above ``_WEIGHT_FLOOR``: interior-point
+methods approach the optimal face from inside and never return exact vertices,
+so they always leave dust several orders of magnitude below any weight that
+matters (the source paper reports its own weights to three decimals). The
+substantive selection is what is asserted, and it agrees with the reference
+donor-for-donor.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.penalized import penalized_weights
+
+
+# --------------------------------------------------------------------------- #
+# reference + helpers
+# --------------------------------------------------------------------------- #
+def _reference(X1: np.ndarray, X0: np.ndarray, lam: float) -> np.ndarray:
+    """Independent exact solve of eq. (5), built from the paper's statement."""
+    import cvxpy as cp
+
+    J = X0.shape[1]
+    d2 = np.sum((X1[:, None] - X0) ** 2, axis=0)
+    w = cp.Variable(J, nonneg=True)
+    cp.Problem(cp.Minimize(cp.sum_squares(X1 - X0 @ w) + lam * (d2 @ w)),
+               [cp.sum(w) == 1]).solve(solver=cp.CLARABEL)
+    v = np.clip(np.asarray(w.value).ravel(), 0.0, None)
+    return v / v.sum()
+
+
+def _objective(X1: np.ndarray, X0: np.ndarray, lam: float, w: np.ndarray) -> float:
+    d2 = np.sum((X1[:, None] - X0) ** 2, axis=0)
+    return float(((X1 - X0 @ w) ** 2).sum() + lam * (d2 @ w))
+
+
+def _problem(J: int = 12, K: int = 4, seed: int = 0):
+    """Treated unit strictly inside the donor hull -> unpenalized non-uniqueness."""
+    rng = np.random.default_rng(seed)
+    X0 = rng.uniform(1.0, 5.0, size=(K, J))
+    w = np.zeros(J)
+    w[[0, 1, 2]] = [0.5, 0.3, 0.2]
+    return X0 @ w, X0
+
+
+LAMBDAS = (1e-6, 1e-4, 1e-2, 1e-1, 1.0)
+
+# A donor "carries weight" above this; below it is interior-point residue.
+_WEIGHT_FLOOR = 1e-4
+# Relative objective tolerance: interior-point accuracy, not solver agreement.
+_OBJ_RTOL = 1e-4
+
+
+def _nnz(w: np.ndarray) -> int:
+    return int((w > _WEIGHT_FLOOR).sum())
+
+
+# --------------------------------------------------------------------------- #
+# optimality
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("lam", LAMBDAS)
+def test_attains_the_optimal_objective(lam):
+    """The returned weights must not be beaten by an independent exact solve."""
+    X1, X0 = _problem()
+    got = _objective(X1, X0, lam, penalized_weights(X1, X0, lam))
+    ref = _objective(X1, X0, lam, _reference(X1, X0, lam))
+    assert got <= ref * (1.0 + _OBJ_RTOL) + 1e-12
+
+
+@pytest.mark.parametrize("J,K", [(12, 4), (98, 9), (38, 19), (5, 3)])
+def test_attains_the_optimum_across_shapes(J, K):
+    """Including the wide (J >> K) regime, where the unpenalized program is
+    most degenerate and the penalty matters most."""
+    X1, X0 = _problem(J=J, K=K)
+    lam = 1e-3
+    got = _objective(X1, X0, lam, penalized_weights(X1, X0, lam))
+    ref = _objective(X1, X0, lam, _reference(X1, X0, lam))
+    assert got <= ref * (1.0 + _OBJ_RTOL) + 1e-12
+
+
+# --------------------------------------------------------------------------- #
+# Theorem 1
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("lam", LAMBDAS)
+def test_sparsity_bound_holds_at_every_positive_lambda(lam):
+    """At most ``K + 1`` non-zero weights, for *any* positive lambda -- the
+    small-lambda end included, which the first-order solver could not reach."""
+    K = 4
+    X1, X0 = _problem(K=K)
+    w = penalized_weights(X1, X0, lam)
+    assert _nnz(w) <= K + 1
+
+
+def test_solution_is_unique_across_starting_conditions(lam=1e-3):
+    """Uniqueness: perturbing the problem's column order must permute the
+    solution, not change which donors are selected."""
+    X1, X0 = _problem()
+    order = np.array([7, 0, 3, 11, 2, 9, 1, 5, 8, 4, 10, 6])
+    a = penalized_weights(X1, X0, lam)
+    b = penalized_weights(X1, X0[:, order], lam)
+    assert np.allclose(a[order], b, atol=1e-6)
+
+
+def test_selection_matches_an_independent_solver(lam=1e-3):
+    """The donors carrying weight must be the same set the reference picks."""
+    for J, K in [(12, 4), (98, 9), (38, 19)]:
+        X1, X0 = _problem(J=J, K=K)
+        mine = set(np.where(penalized_weights(X1, X0, lam) > _WEIGHT_FLOOR)[0])
+        ref = set(np.where(_reference(X1, X0, lam) > _WEIGHT_FLOOR)[0])
+        assert mine == ref, f"J={J} K={K}"
+
+
+def test_residue_below_the_floor_stays_negligible(lam=1e-3):
+    """Guard on the dust itself: if it ever grows into the range where it could
+    be mistaken for a real weight, this fails."""
+    X1, X0 = _problem(J=98, K=9)
+    w = penalized_weights(X1, X0, lam)
+    assert w[w <= _WEIGHT_FLOOR].max() < 1e-5
+
+
+def test_repeated_calls_agree_exactly(lam=1e-3):
+    X1, X0 = _problem()
+    assert np.allclose(penalized_weights(X1, X0, lam),
+                       penalized_weights(X1, X0, lam), atol=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# invariants and edges
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("lam", (0.0,) + LAMBDAS)
+def test_weights_are_on_the_simplex(lam):
+    X1, X0 = _problem()
+    w = penalized_weights(X1, X0, lam)
+    assert (w >= -1e-12).all()
+    assert w.sum() == pytest.approx(1.0, abs=1e-9)
+
+
+def test_single_donor_gets_all_the_weight():
+    X1, X0 = _problem()
+    w = penalized_weights(X1, X0[:, :1], 1e-3)
+    assert w.shape == (1,)
+    assert w[0] == pytest.approx(1.0)
+
+
+def test_large_lambda_approaches_nearest_neighbour_matching():
+    """As lambda grows the penalty dominates and the solution collapses onto
+    the single closest donor (the matching estimator)."""
+    X1, X0 = _problem()
+    d2 = np.sum((X1[:, None] - X0) ** 2, axis=0)
+    w = penalized_weights(X1, X0, 1e6)
+    assert int(np.argmax(w)) == int(np.argmin(d2))
+    assert w.max() > 0.99
+
+
+def test_zero_lambda_still_fits_the_target():
+    """lambda = 0 is the unpenalized synthetic control: the fit must be exact
+    here because the treated unit is inside the hull."""
+    X1, X0 = _problem()
+    w = penalized_weights(X1, X0, 0.0)
+    assert ((X1 - X0 @ w) ** 2).sum() < 1e-12
+
+
+def test_collinear_donors_do_not_break_the_solve():
+    """A duplicated donor makes Q singular; the solve must still return a valid
+    simplex point attaining the optimum."""
+    X1, X0 = _problem()
+    X0 = np.hstack([X0, X0[:, :2]])           # exact duplicates
+    lam = 1e-3
+    w = penalized_weights(X1, X0, lam)
+    assert w.sum() == pytest.approx(1.0, abs=1e-9)
+    ref = _objective(X1, X0, lam, _reference(X1, X0, lam))
+    assert _objective(X1, X0, lam, w) <= ref * (1.0 + _OBJ_RTOL) + 1e-12
+
+
+def test_negative_lambda_is_rejected():
+    X1, X0 = _problem()
+    with pytest.raises(ValueError, match="non-negative"):
+        penalized_weights(X1, X0, -1.0)
+
+
+# --------------------------------------------------------------------------- #
+# scale invariance
+# --------------------------------------------------------------------------- #
+def _scaled_problem(scale: float, J: int = 40, K: int = 9, seed: int = 3):
+    """The same geometry at an arbitrary unit scale.
+
+    Real panels are not order-1: the motivating case for this backend is
+    campaign contributions in dollars, where the pairwise discrepancies reach
+    1e13. A solver handed those directly can fail outright.
+    """
+    rng = np.random.default_rng(seed)
+    X0 = rng.uniform(1.0, 5.0, size=(K, J)) * scale
+    w = np.zeros(J)
+    w[[0, 1, 2]] = [0.5, 0.3, 0.2]
+    return X0 @ w, X0
+
+
+@pytest.mark.parametrize("scale", [1.0, 1e3, 1e5, 1e6])
+@pytest.mark.parametrize("lam", [1e-2, 1.0, 100.0])
+def test_solve_is_invariant_to_the_unit_scale(scale, lam):
+    """Rescaling every input by a constant must not change the weights: the
+    objective is homogeneous, so the argmin is scale-free."""
+    X1_ref, X0_ref = _scaled_problem(1.0)
+    X1, X0 = _scaled_problem(scale)
+    assert np.allclose(penalized_weights(X1, X0, lam),
+                       penalized_weights(X1_ref, X0_ref, lam), atol=1e-5)
+
+
+@pytest.mark.parametrize("scale", [1e5, 1e6])
+@pytest.mark.parametrize("lam", [1.0, 100.0])
+def test_large_scale_data_still_returns_a_real_solution(scale, lam):
+    """Guard against a silent fallback: uniform weights over every donor are
+    what a failed solve looks like, and must never be returned quietly."""
+    X1, X0 = _scaled_problem(scale)
+    w = penalized_weights(X1, X0, lam)
+    assert w.sum() == pytest.approx(1.0, abs=1e-9)
+    assert not np.allclose(w, 1.0 / len(w), atol=1e-9), "silent uniform fallback"
+    assert _nnz(w) <= 9 + 1

--- a/mlsynth/tests/test_bilevel_robustness.py
+++ b/mlsynth/tests/test_bilevel_robustness.py
@@ -192,18 +192,48 @@ def test_simplex_lstsq_silent_by_default():
         simplex_lstsq(A, b, max_iter=1)               # warn=False -> no warning
 
 
-def test_simplex_qp_warns_on_nonconvergence():
+# The penalized inner QP used to be FISTA, and these two cases asserted that a
+# starved iteration budget warned about non-convergence. It is now solved
+# directly, so "non-convergence" no longer exists as a state: the solve either
+# returns the optimum or raises. What replaces those cases is the contract that
+# actually holds -- the iteration controls no longer influence the answer, and a
+# solver breakdown is raised rather than warned about and papered over.
+
+def test_simplex_qp_ignores_the_iteration_budget(recwarn):
     rng = np.random.default_rng(1)
     X0 = rng.normal(size=(3, 5)); Q = X0.T @ X0; c = rng.normal(size=5)
-    with pytest.warns(RuntimeWarning, match="did not converge"):
-        _simplex_qp(Q, c, max_iter=1, warn=True)
+    starved = _simplex_qp(Q, c, max_iter=1, warn=True)
+    generous = _simplex_qp(Q, c, max_iter=10_000, warn=True)
+    assert np.allclose(starved, generous, atol=1e-9)
+    assert not [w for w in recwarn if issubclass(w.category, RuntimeWarning)]
 
 
-def test_penalized_weights_warns_on_nonconvergence():
+def test_penalized_weights_ignores_the_iteration_budget(recwarn):
     rng = np.random.default_rng(2)
     X0 = rng.normal(size=(3, 6)); X1 = rng.normal(size=3)
-    with pytest.warns(RuntimeWarning, match="did not converge"):
-        penalized_weights(X1, X0, lam=0.1, max_iter=1, warn=True)
+    starved = penalized_weights(X1, X0, lam=0.1, max_iter=1, warn=True)
+    generous = penalized_weights(X1, X0, lam=0.1, max_iter=10_000, warn=True)
+    assert np.allclose(starved, generous, atol=1e-9)
+    assert starved.sum() == pytest.approx(1.0, abs=1e-9)
+    assert not [w for w in recwarn if issubclass(w.category, RuntimeWarning)]
+
+
+def test_penalized_weights_raises_rather_than_returning_uniform_on_breakdown():
+    """A failed solve must not be reported as a legitimate dense fit."""
+    from unittest.mock import patch
+
+    from mlsynth.exceptions import MlsynthEstimationError
+
+    rng = np.random.default_rng(3)
+    X0 = rng.normal(size=(3, 6)); X1 = rng.normal(size=3)
+
+    # A no-op solve leaves the variable unset, which is what a broken solve
+    # looks like from the caller's side.
+    import cvxpy as cp
+
+    with patch.object(cp.Problem, "solve", lambda self, **kw: None):
+        with pytest.raises(MlsynthEstimationError, match="did not solve"):
+            penalized_weights(X1, X0, lam=0.1)
 
 
 def test_mscmt_warns_on_de_nonconvergence():

--- a/mlsynth/tests/test_vanillasc_penalized_lambda.py
+++ b/mlsynth/tests/test_vanillasc_penalized_lambda.py
@@ -102,10 +102,17 @@ class TestNonePreservesCV:
 
     def test_fixed_differs_from_cv_when_far(self, df):
         # A deliberately large fixed penalty should not coincide with the
-        # CV-selected weights.
-        cv = np.array(list(_weights(_fit(df, penalized_lambda=None)).values()))
-        fixed = np.array(list(_weights(_fit(df, penalized_lambda=100.0)).values()))
-        assert not np.allclose(cv, fixed, atol=1e-6)
+        # CV-selected weights. Compared over the union of donors: the exact
+        # solver returns genuinely sparse weights and ``donor_weights`` omits
+        # zero entries, so the two dicts need not share a support (and a raw
+        # ``np.allclose`` on their values would raise on the shape mismatch
+        # rather than report a difference).
+        cv = _weights(_fit(df, penalized_lambda=None))
+        fixed = _weights(_fit(df, penalized_lambda=100.0))
+        keys = sorted(set(cv) | set(fixed))
+        a = np.array([cv.get(k, 0.0) for k in keys])
+        b = np.array([fixed.get(k, 0.0) for k in keys])
+        assert not np.allclose(a, b, atol=1e-6)
 
 
 # ----------------------------------------------------------------------

--- a/mlsynth/tests/test_vanillasc_penalized_outcome_only.py
+++ b/mlsynth/tests/test_vanillasc_penalized_outcome_only.py
@@ -141,32 +141,15 @@ def test_unpenalized_solution_is_degenerate_on_this_panel(deg):
 def test_positive_lambda_gives_at_most_K_plus_one_nonzero_weights(deg):
     """Theorem 1 sparsity bound, with the pre-period lags as matching variables.
 
-    Checked where the default solver budget attains the exact optimum; the
-    small-lambda regime is pinned separately below.
+    Covers the small-lambda end too. That regime used to be excluded here and
+    pinned separately as a solver limitation: the inner QP was a first-order
+    method that under-converged when the penalty was small relative to the fit
+    term. It is now solved exactly, so the bound holds at every positive lambda
+    as the theorem states.
     """
     T_pre = 4
-    for lam in (1e-1, 1.0):
+    for lam in (1e-4, 1e-2, 1e-1, 1.0):
         assert _nnz(_fit(deg, backend="penalized", penalized_lambda=lam)) <= T_pre + 1
-
-
-def test_small_lambda_sparsity_is_solver_limited(deg):
-    """Known limitation, pinned so a fix is noticed.
-
-    Theorem 1 guarantees at most ``K + 1`` non-zero weights for *any* positive
-    lambda, but the inner simplex QP is FISTA and under-converges when the
-    penalty is small relative to the fit term: at ``lambda = 1e-4`` on this
-    panel it returns seven donors where the exact optimum has five, at a
-    slightly higher objective. It is under-convergence rather than a wrong
-    program -- raising ``max_iter`` to ~2e5 recovers the exact solution -- so
-    the remedy is to solve the inner QP exactly rather than iterate further.
-    Tracked separately from the routing fix because it also changes the
-    with-covariates path, which carries its own benchmark.
-
-    If this assertion starts failing because the count dropped, the inner
-    solver was fixed: fold this case back into the test above.
-    """
-    T_pre = 4
-    assert _nnz(_fit(deg, backend="penalized", penalized_lambda=1e-4)) > T_pre + 1
 
 
 def test_penalized_fit_is_deterministic(deg):

--- a/mlsynth/utils/bilevel/penalized.py
+++ b/mlsynth/utils/bilevel/penalized.py
@@ -44,6 +44,7 @@ from typing import Optional, Sequence
 
 import numpy as np
 
+from ...exceptions import MlsynthEstimationError
 from .simplex import mspe, project_simplex, simplex_lstsq
 from .structure import BilevelProblem, BilevelSolution
 
@@ -76,36 +77,75 @@ def _spectral_radius(Q: np.ndarray, iters: int = 40) -> float:
 
 def _simplex_qp(Q: np.ndarray, c: np.ndarray, *, max_iter: int = 2000,
                 tol: float = 1e-9, warn: bool = False) -> np.ndarray:
-    """Minimize ``w' Q w + c' w`` over the probability simplex via FISTA.
+    """Minimize ``w' Q w + c' w`` over the probability simplex, exactly.
 
-    ``Q`` must be symmetric positive semidefinite (here ``Q = X0' X0``). If
-    ``warn`` and the iteration limit is hit before the step norm meets ``tol``,
-    a :class:`RuntimeWarning` is emitted.
+    ``Q`` must be symmetric positive semidefinite (here ``Q = X0' X0``).
+
+    Solved as a convex QP rather than by first-order iteration. The whole point
+    of this backend is Theorem 1 of Abadie & L'Hour (2021) -- a unique solution
+    with at most ``K + 1`` non-zero weights for any positive penalty -- and that
+    is a property of the *exact* optimum. FISTA approached it far too slowly to
+    deliver it at a usable iteration budget: on a 12-donor, 4-predictor problem
+    at ``lambda = 1e-4`` it returned seven donors against the true five and
+    needed ~2e5 iterations to close the gap. Solving the program directly is
+    also faster (roughly 6x on problems of this size), so there is no trade-off
+    between the two.
+
+    ``max_iter`` and ``tol`` are retained for API compatibility and forwarded to
+    the solver as its iteration cap and accuracy target. ``warn`` emits a
+    :class:`RuntimeWarning` if the solver does not reach an optimal status.
     """
     n = Q.shape[0]
     if n == 1:
         return np.array([1.0])
-    L = 2.0 * _spectral_radius(Q) + _EPS
-    step = 1.0 / L
-    w = np.full(n, 1.0 / n)
-    z = w.copy()
-    t = 1.0
-    for _ in range(max_iter):
-        grad = 2.0 * (Q @ z) + c
-        w_new = project_simplex(z - step * grad)
-        t_new = 0.5 * (1.0 + np.sqrt(1.0 + 4.0 * t * t))
-        z = w_new + ((t - 1.0) / t_new) * (w_new - w)
-        if np.linalg.norm(w_new - w) < tol:
-            return w_new
-        w, t = w_new, t_new
-    if warn:
+
+    import cvxpy as cp
+
+    # Factor Q = R'R and minimise ||R w||^2 + c'w rather than the quadratic form
+    # in Q directly: Q is a Gram matrix, so posing the problem in Q squares the
+    # condition number and costs the solver several digits on exactly the
+    # ill-conditioned, wide (J >> K) problems this backend is for. The
+    # symmetric eigendecomposition tolerates the rank deficiency that collinear
+    # donors produce, where a Cholesky would fail.
+    Qs = np.asarray(0.5 * (Q + Q.T), dtype=float)
+    evals, evecs = np.linalg.eigh(Qs)
+    # Keep only the numerically non-null directions: Q has rank K << n in the
+    # wide regime, so this hands the solver a (K, n) operator rather than an
+    # (n, n) one that is mostly zero rows.
+    keep = evals > max(float(evals.max()), 0.0) * 1e-14
+    R = (np.sqrt(evals[keep])[:, None] * evecs[:, keep].T)
+    if R.shape[0] == 0:  # pragma: no cover - Q is zero only if every donor is
+        # identical to the origin in predictor space; the objective is then
+        # linear and the simplex vertex minimising c wins.
+        out = np.zeros(n)
+        out[int(np.argmin(c))] = 1.0
+        return out
+
+    w = cp.Variable(n, nonneg=True)
+    objective = cp.Minimize(cp.sum_squares(R @ w) + c @ w)
+    problem = cp.Problem(objective, [cp.sum(w) == 1])
+    problem.solve(solver=cp.CLARABEL)
+
+    if w.value is None:  # pragma: no cover - CLARABEL returns a point for a
+        # bounded, feasible program; the simplex is compact so this cannot
+        # happen for a PSD Q, but never hand back None.
+        if warn:
+            warnings.warn(
+                f"penalized simplex QP failed to solve (status={problem.status}); "
+                "falling back to uniform weights.",
+                RuntimeWarning, stacklevel=2,
+            )
+        return np.full(n, 1.0 / n)
+    if warn and problem.status not in ("optimal", "optimal_inaccurate"):  # pragma: no cover
         warnings.warn(
-            f"penalized simplex QP did not converge within max_iter={max_iter} "
-            f"(tol={tol}); returned weights may be sub-optimal.",
-            RuntimeWarning,
-            stacklevel=2,
+            f"penalized simplex QP returned status={problem.status}; "
+            "weights may be sub-optimal.",
+            RuntimeWarning, stacklevel=2,
         )
-    return w
+
+    out = np.clip(np.asarray(w.value, dtype=float).ravel(), 0.0, None)
+    total = out.sum()
+    return out / total if total > 0 else np.full(n, 1.0 / n)
 
 
 def penalized_weights(X1: np.ndarray, X0: np.ndarray, lam: float, *,
@@ -135,10 +175,63 @@ def penalized_weights(X1: np.ndarray, X0: np.ndarray, lam: float, *,
         raise ValueError(f"penalty lambda must be non-negative, got {lam}.")
     X1 = np.asarray(X1, dtype=float)
     X0 = np.asarray(X0, dtype=float)
-    Q = X0.T @ X0
+    J = X0.shape[1]
+    if J == 1:
+        return np.array([1.0])
+
+    # Solve in normalised units. The objective is homogeneous -- dividing X1 and
+    # X0 by a constant sigma scales both the fit term and the (sigma^2-scaled)
+    # discrepancies by 1/sigma^2 -- so the argmin, and the meaning of lambda, are
+    # unchanged. Doing it matters: on the panel that motivated this backend the
+    # outcome is campaign contributions in dollars, whose pairwise discrepancies
+    # reach ~1e13, and handed those directly the conic solver reports the
+    # program "unbounded" -- impossible for a continuous objective on a compact
+    # simplex, but a plausible verdict once the numerics have broken down.
+    sigma = float(max(np.abs(X0).max(), np.abs(X1).max()))
+    if not np.isfinite(sigma) or sigma <= 0.0:  # pragma: no cover - a degenerate
+        # all-zero predictor block; nothing to match on, so stay uniform.
+        return np.full(J, 1.0 / J)
+    X1 = X1 / sigma
+    X0 = X0 / sigma
+
     d2 = np.sum((X1[:, None] - X0) ** 2, axis=0)        # pairwise discrepancies
-    c = -2.0 * (X0.T @ X1) + float(lam) * d2
-    return _simplex_qp(Q, c, max_iter=max_iter, tol=tol, warn=warn)
+
+    # Solve eq. (5) in its residual form rather than as ``w'Qw + c'w`` with
+    # ``Q = X0'X0``. The two are the same program up to the constant ``||X1||^2``,
+    # but dropping that constant is numerically ruinous in exactly the regime
+    # this backend exists for: when the treated unit is inside the donor hull the
+    # optimal value is near zero, so the (Q, c) form asks the solver to resolve a
+    # ~1e-6 quantity as the difference of two numbers of order ``||X1||^2``. On a
+    # 12-donor problem at lambda=1e-6 that cancellation cost every significant
+    # digit -- twelve donors carrying weight, and the objective 6.5 percent above
+    # the optimum -- while the residual form recovers the generating weights
+    # exactly. Keeping ``X1`` in the objective keeps the problem well scaled.
+    import cvxpy as cp
+
+    w = cp.Variable(J, nonneg=True)
+    objective = cp.Minimize(cp.sum_squares(X1 - X0 @ w) + float(lam) * (d2 @ w))
+    problem = cp.Problem(objective, [cp.sum(w) == 1])
+    problem.solve(solver=cp.CLARABEL)
+
+    if w.value is None:
+        # The feasible set is a non-empty compact simplex and the objective is
+        # convex and continuous, so a minimiser exists: no status other than
+        # optimal is meaningful here, and any such verdict means the solve broke
+        # down numerically. Raise rather than return uniform weights -- a silent
+        # fallback here is indistinguishable from a legitimate dense fit and
+        # would quietly corrupt whatever consumed it.
+        raise MlsynthEstimationError(
+            f"penalized simplex QP did not solve (solver status: "
+            f"{problem.status}). The program is a convex objective over a "
+            f"compact simplex, so this indicates numerical breakdown rather "
+            f"than an infeasible or unbounded problem. Inputs were normalised "
+            f"by {sigma:.3e} before solving; check the predictor block for "
+            f"non-finite values or extreme conditioning."
+        )
+
+    out = np.clip(np.asarray(w.value, dtype=float).ravel(), 0.0, None)
+    total = out.sum()
+    return out / total if total > 0 else np.full(J, 1.0 / J)
 
 
 def _build_block(prob: BilevelProblem, periods: slice, use_outcomes: bool,

--- a/mlsynth/utils/bilevel/penalized.py
+++ b/mlsynth/utils/bilevel/penalized.py
@@ -91,9 +91,13 @@ def _simplex_qp(Q: np.ndarray, c: np.ndarray, *, max_iter: int = 2000,
     also faster (roughly 6x on problems of this size), so there is no trade-off
     between the two.
 
-    ``max_iter`` and ``tol`` are retained for API compatibility and forwarded to
-    the solver as its iteration cap and accuracy target. ``warn`` emits a
-    :class:`RuntimeWarning` if the solver does not reach an optimal status.
+    ``max_iter`` and ``tol`` are accepted and ignored: a direct solve has no
+    iteration budget to spend or convergence tolerance to trade against. They
+    remain in the signature because callers (and ``solve_penalized``'s public
+    parameters) still pass them, and dropping them would be a breaking change
+    for no gain -- but they no longer influence the result, and saying so here
+    is better than leaving a parameter that looks live and is not. ``warn``
+    emits a :class:`RuntimeWarning` if the solver returns a non-optimal status.
     """
     n = Q.shape[0]
     if n == 1:
@@ -163,13 +167,23 @@ def penalized_weights(X1: np.ndarray, X0: np.ndarray, lam: float, *,
         Penalty ``lambda >= 0``. ``lambda > 0`` guarantees a unique, sparse
         solution; ``lambda -> 0`` is the (possibly non-unique) pure synthetic
         control; large ``lambda`` approaches nearest-neighbour matching.
+    max_iter, tol : int, float
+        Accepted and ignored -- the program is solved directly rather than
+        iteratively, so there is no budget to spend or tolerance to trade
+        against. Kept so existing callers continue to work unchanged.
     warn : bool
-        Forwarded to the inner QP: warn on non-convergence.
+        Unused here; retained for signature compatibility with the other
+        backends. A solver breakdown raises rather than warning, since uniform
+        weights are indistinguishable from a legitimate dense fit.
 
     Raises
     ------
     ValueError
         If ``lam < 0`` (a negative penalty makes the objective non-convex).
+    MlsynthEstimationError
+        If the solver fails to return a point. The feasible set is a non-empty
+        compact simplex and the objective is convex, so a minimiser always
+        exists: any such failure is numerical breakdown, not infeasibility.
     """
     if lam < 0:
         raise ValueError(f"penalty lambda must be non-negative, got {lam}.")


### PR DESCRIPTION
The penalized backend exists for one guarantee — Abadie & L'Hour (2021) Theorem 1: any positive λ yields a **unique** solution with at most `K+1` non-zero weights. That's a property of the *exact* optimum, and the inner solve was FISTA, which didn't reach it at any usable iteration budget.

This removes the limitation pinned in #281. The bound now holds at every positive λ, and the motivating panel (98 donors, 9 pre-periods) drops from **83 weighted donors to exactly 10** at λ=1e-6 — precisely the `K+1` bound.

Solving the program directly is also faster, so there was no trade-off to weigh.

## Two further problems the tests surfaced

Neither was in the original diagnosis, and both are more interesting than the FISTA swap.

**1. Catastrophic cancellation.** Posing the program as `w'Qw + c'w` with `Q = X0'X0` discards the constant `‖X1‖²`. Same argmin — but ruinous exactly where this backend is used. With the treated unit inside the donor hull the optimal value is near zero, so the solver must resolve a ~1e-6 quantity as the difference of two numbers of order `‖X1‖²`. At λ=1e-6 that cost every significant digit: twelve donors carrying weight and an objective 6.5% above the optimum, where the residual form recovers the generating weights `(0.5, 0.3, 0.2)` exactly.

**2. A false "unbounded".** On the panel that motivated this, the outcome is campaign contributions in dollars and pairwise discrepancies reach ~1e13. Handed those directly, CLARABEL reports the program **unbounded** — impossible for a continuous objective over a compact simplex, but a plausible verdict once the numerics break down. Inputs are now normalised before solving; the objective is homogeneous, so the argmin and the meaning of λ are unchanged.

That failure was being swallowed by a uniform-weights fallback — indistinguishable from a legitimate dense fit, and it would quietly corrupt whatever consumed it. That's the same silent-wrong-answer pattern #281 set out to fix, so it now raises `MlsynthEstimationError` with the solver status and the scale applied.

## Validation

`pensynth_prop99` (live against `LowRankQP`) passes, with agreement against the R reference improved ~5× and runtime 16×:

| | weight max abs diff | ATT max abs diff | runtime |
|---|---|---|---|
| before (FISTA) | 3.33e-4 | 1.98e-3 | 16s |
| exact QP | 2.76e-4 | 1.72e-3 | 4s |
| exact + scaled | **6.83e-5** | **5.42e-4** | **1s** |

45 tests in `test_bilevel_penalized_qp.py`, written test-first against an independent cvxpy reference: optimality, the `K+1` sparsity bound at every λ, uniqueness under column permutation, scale invariance across 1× to 1e6×, collinear donors, the large-λ nearest-neighbour limit, and a guard that the interior-point residue stays negligible.

Tolerances are stated explicitly in the module docstring rather than left implicit: objectives compare with a *relative* tolerance (an interior-point QP lands ~1e-6 relative of the optimum; demanding bit-agreement would test the solver, not this module), and donors count as weighted above 1e-4 (interior-point methods never return exact vertices). The selection agrees with the reference donor-for-donor.

## Second commit: obsolete tests and a stale docstring

I opened this PR quoting a regression sweep that was still running, and it went on to fail two cases in `test_bilevel_robustness.py`. Both asserted that a starved `max_iter` warns "did not converge" — intrinsic to an iterative solver, and non-convergence is no longer a state the solve can be in. Replaced with the contract that holds: the iteration controls no longer influence the answer, and a breakdown raises.

That also caught a stale claim in my own first commit — the docstring said `max_iter`/`tol` were "forwarded to the solver as its iteration cap", which stopped being true when the solve moved to the factored form. They're kept in the signature because callers still pass them, but they're now documented as accepted-and-ignored with the reason, rather than left looking live.

## Also

Repairs a latent fragility in `test_fixed_differs_from_cv_when_far`: it compared `donor_weights` dicts positionally, which only worked while the solver returned dense vectors of equal length. Genuinely sparse solutions gave it different supports, and numpy raised on the shape mismatch instead of reporting a difference.

## Known, not addressed here

On a 98-donor / 9-pre-period panel the CV selector now picks a near-matching λ, giving a poor pre-treatment fit. That's the CV criterion's behaviour on a degenerate panel rather than the QP's correctness — the benchmark's CV path agrees with R more closely than before — but a fixed λ is the sensible choice there, and the selector deserves its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TYjo4s2qMBtsJhuEqEusih