### PR TITLE
fix(vanillasc): reject staggered_spec on a single-treated panel

### DIFF
--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -1168,6 +1168,13 @@ effects match scpi's ``scest`` (West Germany :math:`-1.75`, Italy
 :math:`-0.89`) and the event-time prediction intervals match its
 ``CI_all_gaussian`` (durable benchmark ``scpi_staggered_covariate``).
 
+The spec belongs to the staggered engine, so it needs at least two treated
+units. Passing it on a single-treated panel raises ``MlsynthConfigError``
+rather than being quietly dropped -- otherwise every field on the spec,
+``w_constr`` included, would be discarded while the fit returned the ordinary
+outcome-only result. With one treated unit, match on several series through
+``covariates`` and ``covariate_windows`` with a predictor-weight ``backend``.
+
 .. note::
 
    scpi's multi-feature design produces duplicate donor-column names that recent

--- a/mlsynth/tests/test_vanillasc_staggered_spec_guard.py
+++ b/mlsynth/tests/test_vanillasc_staggered_spec_guard.py
@@ -1,0 +1,112 @@
+"""``staggered_spec`` must not be silently ignored on a single-treated panel.
+
+``run_vanillasc`` routes to the staggered engine only when ``dataprep`` returns
+cohorts, i.e. when the panel has more than one treated unit. A single-treated
+panel falls through to the ordinary path, which never reads
+``config.staggered_spec`` -- so every field on the spec, including
+``w_constr``, was accepted and discarded. Silent acceptance is the failure
+mode the repo's fail-early contract exists to prevent: the caller believes a
+constraint family is in force when the fit is the plain outcome-only one.
+
+The single-treated route to covariate matching is ``covariates`` /
+``covariate_windows`` with a predictor-weight ``backend``, so the guard raises
+and says so rather than trying to honour the spec.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import VanillaSC
+from mlsynth.exceptions import MlsynthConfigError
+
+
+def _panel(n_units: int = 6, n_periods: int = 20, n_treated: int = 1,
+           seed: int = 0) -> pd.DataFrame:
+    """Balanced panel; the first ``n_treated`` units adopt at period 15."""
+    rng = np.random.default_rng(seed)
+    t = np.arange(1, n_periods + 1)
+    rows = []
+    for i in range(n_units):
+        y = 100 + 3.0 * t + rng.normal(0, 1.0, n_periods) + 5 * i
+        treated = np.zeros(n_periods, dtype=int)
+        if i < n_treated:
+            treated[t >= 15] = 1
+            y = y + treated * 6.0
+        rows.append(pd.DataFrame({"unit": f"u{i}", "period": t, "y": y,
+                                  "x": y * 0.5 + rng.normal(0, 0.5, n_periods),
+                                  "treated": treated}))
+    return pd.concat(rows, ignore_index=True)
+
+
+def _fit(df: pd.DataFrame, **extra):
+    cfg = {"df": df, "outcome": "y", "treat": "treated", "unitid": "unit",
+           "time": "period", "display_graphs": False, "inference": False}
+    cfg.update(extra)
+    return VanillaSC(cfg).fit()
+
+
+SPEC = {"features": ["y"], "w_constr": "lasso"}
+
+
+# ---------------------------------------------------------------------------
+# The guard itself
+# ---------------------------------------------------------------------------
+def test_single_treated_with_staggered_spec_raises():
+    """One treated unit plus a staggered_spec is a contradiction, not a no-op."""
+    with pytest.raises(MlsynthConfigError):
+        _fit(_panel(n_treated=1), staggered_spec=SPEC)
+
+
+def test_guard_message_names_the_cause_and_the_fix():
+    """The error has to be actionable: say the panel is single-treated, and
+    point at the knob that does work there."""
+    with pytest.raises(MlsynthConfigError) as exc:
+        _fit(_panel(n_treated=1), staggered_spec=SPEC)
+    msg = str(exc.value)
+    assert "staggered_spec" in msg
+    assert "1 treated unit" in msg
+    assert "covariates" in msg
+
+
+def test_guard_fires_before_any_fitting():
+    """The failure is reported, not swallowed and papered over with a result.
+
+    A degenerate spec on a single-treated panel must still raise the config
+    error rather than falling through to a plain fit that happens to succeed.
+    """
+    with pytest.raises(MlsynthConfigError):
+        _fit(_panel(n_treated=1), staggered_spec={"features": ["y", "x"],
+                                                  "constant": True})
+
+
+@pytest.mark.parametrize("w_constr", ["simplex", "lasso", "ols", "ridge"])
+def test_guard_is_independent_of_the_constraint_family(w_constr):
+    """Every w_constr was equally ignored, so every one must be caught."""
+    with pytest.raises(MlsynthConfigError):
+        _fit(_panel(n_treated=1),
+             staggered_spec={"features": ["y"], "w_constr": w_constr})
+
+
+# ---------------------------------------------------------------------------
+# No collateral damage
+# ---------------------------------------------------------------------------
+def test_single_treated_without_the_spec_is_unaffected():
+    res = _fit(_panel(n_treated=1))
+    assert np.isfinite(res.effects.att)
+    assert res.weights is not None
+
+
+def test_multi_treated_with_the_spec_still_fits():
+    """The guard must key on the panel, not on the presence of the spec."""
+    res = _fit(_panel(n_treated=2), staggered_spec=SPEC)
+    assert np.isfinite(res.effects.att)
+
+
+def test_single_treated_covariate_route_still_works():
+    """The alternative the message recommends has to actually run."""
+    res = _fit(_panel(n_treated=1), covariates=["x"], backend="mscmt",
+               mscmt_maxiter=5, mscmt_popsize=4, seed=0)
+    assert np.isfinite(res.effects.att)

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -188,6 +188,20 @@ def run_vanillasc(config) -> BaseEstimatorResults:
         # fit one synthetic control per treated unit on the never-treated donors.
         from .staggered import run_vanillasc_staggered
         return run_vanillasc_staggered(config, prep)
+    if getattr(config, "staggered_spec", None) is not None:
+        # Only the staggered engine reads ``staggered_spec``; the single-treated
+        # path below never looks at it. Accepting it here would discard every
+        # field on the spec -- including ``w_constr`` -- while returning a plain
+        # outcome-only fit that looks like it honoured the constraint.
+        raise MlsynthConfigError(
+            "staggered_spec was given, but this panel has 1 treated unit and "
+            "the staggered engine needs at least 2. On a single-treated panel "
+            "the spec would be silently ignored, so it is rejected instead. "
+            "For multi-feature matching with one treated unit use `covariates` "
+            "(with `covariate_windows` and a predictor-weight `backend`); to "
+            "use the staggered spec, mark the other treated units in "
+            f"'{config.treat}'."
+        )
     if "y" not in prep or "donor_matrix" not in prep:
         raise MlsynthDataError(
             "VanillaSC could not prepare the data (dataprep returned neither a "


### PR DESCRIPTION
## The bug

`run_vanillasc` routes to the staggered engine only when `dataprep` returns cohorts, which requires two or more treated units. A single-treated panel falls through to the ordinary path, and that path never reads `config.staggered_spec` — so the spec was accepted and discarded.

Everything on it went with it, `w_constr` included. On the German reunification panel (one treated unit), `simplex`, `lasso`, `ols` and `ridge` all returned byte-identical results equal to the plain outcome-only fit:

```
simplex  n=7 sum=1.000 preRMSE=60.8 ATT=-1297
lasso    n=7 sum=1.000 preRMSE=60.8 ATT=-1297
ols      n=7 sum=1.000 preRMSE=60.8 ATT=-1297
ridge    n=7 sum=1.000 preRMSE=60.8 ATT=-1297
```

That is how the bug surfaced. The failure is silent and the fallback is a perfectly good fit — weights, counterfactual, ATT, sensible diagnostics — just from a different estimator than the one requested. The substitution is econometrically substantive: simplex forbids extrapolation and forces sum-to-one, while lasso, ridge and ols permit extrapolation and shrinkage.

The worst case is the one that looks best. Run the standard robustness table across constraint families and every column agrees to the last digit, which reads as an admirably insensitive result and is actually the signature of four identical fits.

## The fix

Raise `MlsynthConfigError` rather than trying to honour the spec. `extra="forbid"` catches keys that do not exist; it cannot catch a key that exists and does nothing on the code path taken.

The single-treated route to multi-feature matching already exists as `covariates` / `covariate_windows` with a predictor-weight `backend`, so the message points there rather than duplicating machinery.

## Tests

Ten tests in `test_vanillasc_staggered_spec_guard.py`, written before the fix and confirmed red on `Failed: DID NOT RAISE MlsynthConfigError`:

- the guard fires, and its message names the treated-unit count and the alternative;
- it fires for every `w_constr` value, since every one was equally ignored;
- it fires on a spec carrying no `w_constr` at all, so the failure is reported rather than papered over by a fit that happens to succeed;
- single-treated without the spec, multi-treated with it, and the recommended `covariates` route are all unaffected.

New code is fully covered — the only uncovered line in that region is the pre-existing `MlsynthDataError` below it.

## Verification

`test_vanillasc`, `test_vanillasc_staggered`, `test_staggered_constraints`, `test_vanillasc_staggered_plot`, `test_result_contract` and the new file: **233 passed, 5 skipped**.

## Note for release notes

This is a behaviour change, not purely additive. Code currently passing `staggered_spec` on a single-treated panel gets an exception where it used to get a fit. That fit was never the requested one, so the break is the point — but it should be called out.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYjo4s2qMBtsJhuEqEusih)_