### PR TITLE
feat(vanillasc): expose w_constr on the single-treated fit

### DIFF
--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -250,6 +250,59 @@ The covariate path exposes three reliable solvers via ``backend=``:
    the authors' own ``quadprog`` program value-for-value on the simulated panels.
    See :doc:`replications/ferman_pinto_mc`.
 
+Weight-constraint families
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The backends above choose how the *predictor* weights are found; they all leave
+the donor weights on the simplex. To change that constraint itself, set
+``w_constr`` to one of scpi's weight-constraint families (Cattaneo, Feng,
+Palomba and Titiunik):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 30 56
+
+   * - ``w_constr``
+     - constraint on :math:`\mathbf{w}`
+     - what it buys
+   * - ``"simplex"``
+     - :math:`\sum_j w_j = 1,\ w_j \ge 0`
+     - the Abadie convex hull; no extrapolation (the default behaviour)
+   * - ``"lasso"``
+     - :math:`\|\mathbf{w}\|_1 \le Q`
+     - sparsity and signed weights (Chernozhukov et al.)
+   * - ``"ridge"``
+     - :math:`\|\mathbf{w}\|_2 \le Q`
+     - shrinkage with :math:`Q` estimated from the data (Amjad et al.)
+   * - ``"ols"``
+     - none
+     - unconstrained regression; extrapolates freely
+   * - ``"L1-L2"``
+     - simplex plus :math:`\|\mathbf{w}\|_2 \le Q_2`
+     - a shrunk convex combination (Arkhangelsky et al.)
+
+.. code-block:: python
+
+   res = VanillaSC({"df": df, "outcome": "gdp", "treat": "treated",
+                    "unitid": "country", "time": "year",
+                    "w_constr": "ridge"}).fit()          # or {"name": "lasso", "Q": 0.5}
+
+Which constraint to impose is a modelling choice, not a property of the panel,
+so the same families are available whether one unit is treated or many: with
+several treated units they are reached through ``staggered_spec.w_constr``
+instead, and setting both is an error. ``w_constr`` solves scpi's constrained
+program on the pre-treatment outcomes, which is a different estimator from the
+bilevel predictor-weight engine, so it cannot be combined with ``covariates``,
+a non-default ``backend``, or ``oracle_weights`` -- those raise rather than
+silently picking one. ``res.method_details.parameters_used`` reports the family
+that ran and the budget ``Q`` it used, so a fit never leaves its specification
+ambiguous.
+
+The choice moves the estimate. Leaving the simplex relaxes the no-extrapolation
+restriction, which usually improves pre-treatment fit and may or may not improve
+the counterfactual: a better in-sample fit bought by extrapolation is not
+evidence of a better estimate. Report the family alongside the effect.
+
 The identification diagnostic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/mlsynth/tests/test_vanillasc_w_constr.py
+++ b/mlsynth/tests/test_vanillasc_w_constr.py
@@ -1,0 +1,190 @@
+"""Weight-constraint families for the single-treated VanillaSC.
+
+``w_constr`` -- scpi's weight-constraint family (Cattaneo, Feng, Palomba and
+Titiunik) -- was reachable only through ``staggered_spec``, so it applied only
+to panels with two or more treated units. Which constraint the estimator uses
+is a modelling choice, not a property of how many units were treated, so it is
+exposed at the top level and honoured on the single-treated path.
+
+The families are genuinely different estimators: ``simplex`` pins the weights
+to the unit simplex (no extrapolation), ``lasso`` bounds their L1 norm,
+``ridge`` their L2 norm, and ``ols`` leaves them free. The regression these
+tests exist to prevent is all four silently collapsing to one.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import VanillaSC
+from mlsynth.config_models import VanillaSCConfig
+from mlsynth.exceptions import MlsynthConfigError
+from pydantic import ValidationError
+
+FAMILIES = ["simplex", "lasso", "ridge", "ols", "L1-L2"]
+
+
+def _panel(n_donors: int = 5, n_periods: int = 24, treated_offset: float = 0.0,
+           seed: int = 3) -> pd.DataFrame:
+    """Balanced single-treated panel; ``treated_offset`` lifts the treated unit
+    off the donors' convex hull, which is where the families separate."""
+    rng = np.random.default_rng(seed)
+    t = np.arange(1, n_periods + 1)
+    base = 50 + 2.0 * t
+    rows = []
+    donor_paths = []
+    for j in range(n_donors):
+        y = base * (0.8 + 0.1 * j) + rng.normal(0, 0.6, n_periods)
+        donor_paths.append(y)
+        rows.append(pd.DataFrame({"unit": f"d{j}", "period": t, "y": y,
+                                  "x": y * 0.4 + rng.normal(0, 0.3, n_periods),
+                                  "treated": 0}))
+    y1 = np.mean(donor_paths, axis=0) + treated_offset + rng.normal(0, 0.6, n_periods)
+    treat = (t >= 18).astype(int)
+    y1 = y1 + treat * 9.0
+    rows.append(pd.DataFrame({"unit": "T", "period": t, "y": y1,
+                              "x": y1 * 0.4 + rng.normal(0, 0.3, n_periods),
+                              "treated": treat}))
+    return pd.concat(rows, ignore_index=True)
+
+
+def _fit(df: pd.DataFrame, **extra):
+    cfg = {"df": df, "outcome": "y", "treat": "treated", "unitid": "unit",
+           "time": "period", "display_graphs": False, "inference": False}
+    cfg.update(extra)
+    return VanillaSC(cfg).fit()
+
+
+def _w(res, df: pd.DataFrame) -> np.ndarray:
+    """Weights in donor-label order, zeros for donors the fit dropped."""
+    d = {str(k): float(v) for k, v in res.weights.donor_weights.items()}
+    names = sorted(u for u in df.unit.unique() if u != "T")
+    return np.array([d.get(n, 0.0) for n in names], dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("family", FAMILIES)
+def test_each_family_fits(family):
+    res = _fit(_panel(), w_constr=family)
+    assert np.isfinite(res.effects.att)
+    assert res.weights.donor_weights
+    assert np.all(np.isfinite(np.asarray(res.time_series.counterfactual_outcome,
+                                         dtype=float)))
+
+
+# ---------------------------------------------------------------------------
+# The families must actually differ -- this is the regression under test
+# ---------------------------------------------------------------------------
+def test_families_are_not_all_the_same_fit():
+    df = _panel(treated_offset=14.0)          # treated sits above the donor hull
+    ws = {f: _w(_fit(df, w_constr=f), df) for f in FAMILIES}
+    assert not np.allclose(ws["simplex"], ws["ols"], atol=1e-6)
+    assert not np.allclose(ws["simplex"], ws["ridge"], atol=1e-6)
+    atts = {f: float(_fit(df, w_constr=f).effects.att) for f in FAMILIES}
+    assert len({round(a, 6) for a in atts.values()}) > 1
+
+
+def test_simplex_reproduces_the_default_fit():
+    """The default path already solves the simplex program; naming it must not
+    change the answer."""
+    df = _panel()
+    assert _w(_fit(df, w_constr="simplex"), df) == pytest.approx(
+        _w(_fit(df), df), abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Each family's defining invariant
+# ---------------------------------------------------------------------------
+def test_simplex_weights_are_on_the_simplex():
+    w = _w(_fit(_panel(treated_offset=14.0), w_constr="simplex"), _panel())
+    assert w.min() >= -1e-8
+    assert w.sum() == pytest.approx(1.0, abs=1e-6)
+
+
+def test_lasso_bounds_the_l1_norm():
+    df = _panel(treated_offset=14.0)
+    w = _w(_fit(df, w_constr="lasso"), df)
+    assert np.abs(w).sum() <= 1.0 + 1e-6
+
+
+def test_ols_is_not_confined_to_the_simplex():
+    """Free weights: on a treated unit off the hull, OLS leaves the simplex."""
+    df = _panel(treated_offset=14.0)
+    w = _w(_fit(df, w_constr="ols"), df)
+    assert (w.min() < -1e-6) or (abs(w.sum() - 1.0) > 1e-3)
+
+
+def test_ridge_bounds_the_l2_norm():
+    df = _panel(treated_offset=14.0)
+    res = _fit(df, w_constr="ridge")
+    q = res.method_details.parameters_used["w_constr_Q"]
+    assert np.linalg.norm(_w(res, df)) <= float(q) + 1e-6
+
+
+def test_explicit_budget_is_honoured():
+    """A dict spec passes Q straight through, as in scpi's w_constr."""
+    df = _panel(treated_offset=14.0)
+    w = _w(_fit(df, w_constr={"name": "lasso", "Q": 0.4}), df)
+    assert np.abs(w).sum() <= 0.4 + 1e-6
+
+
+def test_method_details_record_the_constraint():
+    res = _fit(_panel(), w_constr="ridge")
+    assert res.method_details.parameters_used["w_constr"] == "ridge"
+
+
+# ---------------------------------------------------------------------------
+# Failures -- reported, never silently resolved
+# ---------------------------------------------------------------------------
+def test_unknown_family_rejected_at_config_time():
+    df = _panel()
+    with pytest.raises(ValidationError):
+        VanillaSCConfig(df=df, outcome="y", treat="treated", unitid="unit",
+                        time="period", w_constr="bogus")
+
+
+def test_unknown_family_in_dict_rejected():
+    df = _panel()
+    with pytest.raises(ValidationError):
+        VanillaSCConfig(df=df, outcome="y", treat="treated", unitid="unit",
+                        time="period", w_constr={"name": "bogus"})
+
+
+@pytest.mark.parametrize("clash,message", [
+    ({"covariates": ["x"]}, "covariates"),
+    ({"backend": "mscmt"}, "backend"),
+    ({"oracle_weights": {"d0": 1.0}}, "oracle_weights"),
+])
+def test_incompatible_combinations_raise(clash, message):
+    """The constraint families are solved by the scpi program, not the bilevel
+    predictor-weight engine; combining them would silently pick one."""
+    df = _panel()
+    with pytest.raises((MlsynthConfigError, ValidationError)) as exc:
+        _fit(df, w_constr="lasso", **clash)
+    assert message in str(exc.value)
+
+
+def test_w_constr_and_staggered_spec_conflict():
+    df = _panel()
+    with pytest.raises((MlsynthConfigError, ValidationError)):
+        _fit(df, w_constr="lasso",
+             staggered_spec={"features": ["y"], "w_constr": "ridge"})
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+def test_single_donor():
+    df = _panel(n_donors=1)
+    res = _fit(df, w_constr="lasso")
+    assert np.isfinite(res.effects.att)
+    assert len(res.weights.donor_weights) == 1
+
+
+def test_default_is_unchanged_when_w_constr_is_absent():
+    res = _fit(_panel())
+    assert res.method_details.parameters_used.get("w_constr") is None

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import (BaseModel, ConfigDict, Field, field_validator,
+                      model_validator)
 
 from ...config_models import BaseEstimatorConfig
 
@@ -270,6 +271,20 @@ class VanillaSCConfig(BaseEstimatorConfig):
                     "inference='scpi'; other inference modes always show the "
                     "pointwise band.",
     )
+    w_constr: Optional[Union[str, Dict[str, Any]]] = Field(
+        default=None,
+        description="Donor weight-constraint family for the SINGLE-treated fit "
+                    "(scpi's w_constr): 'simplex' (the Abadie sum-to-one convex "
+                    "hull), 'ols' (unconstrained), 'lasso' (L1 <= Q), 'ridge' "
+                    "(L2 <= Q, budget estimated from the data) or 'L1-L2'. A "
+                    "dict passes the family plus an explicit budget, e.g. "
+                    "{'name': 'lasso', 'Q': 0.5}. None (default) keeps the "
+                    "bilevel engine's simplex fit, so behaviour is unchanged "
+                    "unless the option is set. Which constraint is used is a "
+                    "modelling choice, not a property of the panel: on a "
+                    "multi-treated panel the same families are reached through "
+                    "staggered_spec.w_constr, and setting both is an error.",
+    )
     staggered_spec: Optional[StaggeredSCMSpec] = Field(
         default=None,
         description="Staggered adoption only. Covariate (multi-feature) matching "
@@ -347,3 +362,56 @@ class VanillaSCConfig(BaseEstimatorConfig):
                     "lambda relative to the fit term, so Abadie-L'Hour's "
                     "at-most-K+1 sparsity bound may not be attained there.",
     )
+
+    # Recognized scpi weight-constraint families, shared with StaggeredSCMSpec.
+    _W_CONSTR_NAMES = ("simplex", "ols", "lasso", "ridge", "L1-L2")
+
+    @field_validator("w_constr")
+    @classmethod
+    def _validate_w_constr(cls, v):
+        if v is None:
+            return v
+        if isinstance(v, str):
+            name = v
+        elif isinstance(v, dict):
+            name = v.get("name", "simplex")
+        else:
+            raise ValueError(
+                "w_constr must be a family name or a dict carrying one; got "
+                f"{type(v).__name__}."
+            )
+        valid = ("simplex", "ols", "lasso", "ridge", "L1-L2")
+        if name not in valid:
+            raise ValueError(
+                f"w_constr name must be one of {valid}; got {name!r}."
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _w_constr_is_exclusive(self):
+        """``w_constr`` routes the fit through scpi's constrained program, which
+        is a different estimator from the bilevel predictor-weight engine and
+        from user-supplied weights. Silently preferring one over the other is
+        the failure mode this option exists to remove, so the clashes raise."""
+        if self.w_constr is None:
+            return self
+        clashes = []
+        if self.covariates:
+            clashes.append(
+                "covariates (the scpi constrained program matches on the "
+                "outcome; for predictor matching use a bilevel `backend`)")
+        if self.backend != "auto":
+            clashes.append(
+                f"backend={self.backend!r} (a predictor-weight backend; "
+                "w_constr constrains the donor weights instead)")
+        if self.oracle_weights is not None:
+            clashes.append(
+                "oracle_weights (weights supplied, so no program is solved)")
+        if self.staggered_spec is not None:
+            clashes.append(
+                "staggered_spec, which carries its own w_constr")
+        if clashes:
+            raise ValueError(
+                "w_constr cannot be combined with " + "; ".join(clashes) + "."
+            )
+        return self

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -48,6 +48,42 @@ class _OracleFit:
         return np.asarray(Y0, dtype=float) @ self.W
 
 
+class _ConstrainedFit:
+    """Drop-in for the bilevel fit when a ``w_constr`` family is requested.
+
+    Solves scpi's constrained weight program (Cattaneo, Feng, Palomba and
+    Titiunik) on the pre-treatment outcomes instead of the bilevel simplex QP,
+    and exposes the same surface ``run_vanillasc`` reads off a fitted engine.
+    ``wc`` carries the normalised constraint, including the budget ``Q`` that
+    ridge and L1-L2 estimate from the data.
+    """
+
+    def __init__(self, y_pre: np.ndarray, Y0_pre: np.ndarray,
+                 donor_names: List[str], w_constr: Any):
+        from .staggered_engine import b_est
+
+        J = Y0_pre.shape[1]
+        x, wc = b_est(np.asarray(y_pre, dtype=float).reshape(-1, 1),
+                      np.asarray(Y0_pre, dtype=float), J, 0, w_constr)
+        self.W = np.asarray(x, dtype=float).ravel()[:J]
+        self.wc = wc
+        self.donor_weights = {n: float(v) for n, v in zip(donor_names, self.W)}
+        self.backend = f"w_constr:{wc['name']}"
+        self.V = None
+        self.v_agreement = None
+        self.predictor_names: List[str] = []
+        self.diagnostics: Dict[str, Any] = {
+            "backend": self.backend,
+            "w_constr": wc["name"],
+            "w_constr_Q": wc.get("Q"),
+            "w_constr_Q2": wc.get("Q2"),
+            "w_constr_lambda": wc.get("lambda"),
+        }
+
+    def counterfactual(self, Y0: np.ndarray) -> np.ndarray:
+        return np.asarray(Y0, dtype=float) @ self.W
+
+
 def _align_oracle(oracle_weights: Dict[Any, float],
                   donor_names: List[str]) -> np.ndarray:
     """Align a ``{donor_id: weight}`` map to the Y0 column order (missing -> 0)."""
@@ -243,6 +279,14 @@ def run_vanillasc(config) -> BaseEstimatorResults:
         oracle_w = _align_oracle(config.oracle_weights, donor_names)
         engine = None
         res = _OracleFit(oracle_w, donor_names)
+    elif getattr(config, "w_constr", None) is not None:
+        # Named weight-constraint family: solve scpi's constrained program on
+        # the pre-treatment outcomes. The config forbids combining this with
+        # covariates / a predictor-weight backend, so there is no ambiguity
+        # about which estimator ran.
+        engine = None
+        res = _ConstrainedFit(y[fit_pos], Y0[fit_pos], donor_names,
+                              config.w_constr)
     else:
         # Build predictor matrices (treated + donors, donor order matches Y0 cols).
         if covariates:
@@ -604,6 +648,11 @@ def run_vanillasc(config) -> BaseEstimatorResults:
                     and res.diagnostics.get("lambda") is not None
                     else None
                 ),
+                # Which weight-constraint family ran, and the budget it used
+                # (estimated from the data for ridge / L1-L2). None on the
+                # default path, so the reported spec is never ambiguous.
+                "w_constr": res.diagnostics.get("w_constr"),
+                "w_constr_Q": res.diagnostics.get("w_constr_Q"),
             },
         ),
         additional_outputs={


### PR DESCRIPTION
## The gap

The scpi weight-constraint families (Cattaneo, Feng, Palomba & Titiunik) were reachable only through `staggered_spec`, which the single-treated code path never reads. So which constraint the donor weights obey — convex hull, L1 ball, L2 ball, unconstrained — was decided by an unrelated property of the panel: how many units happened to be treated. A single-case study could not ask for a lasso- or ridge-constrained synthetic control at all.

That is a config-surface misalignment. `cov_adj`, `constant` and `cointegrated` genuinely belong to the staggered spec; `w_constr` does not.

## The change

`w_constr` becomes a top-level `VanillaSCConfig` option, honoured on the single-treated path. It solves scpi's constrained program via `staggered_engine.b_est` — the same solver the staggered covariate engine already uses — on the pre-treatment outcomes, instead of the bilevel simplex QP.

Default `None` keeps the existing fit, so behaviour is unchanged unless the option is set. On a multi-treated panel the families are still reached through `staggered_spec.w_constr`.

On the German reunification panel the families now genuinely differ:

```
simplex   n= 7  L1=1.00  preRMSE= 60.8  ATT=-1297
lasso     n= 8  L1=1.00  preRMSE= 60.8  ATT=-1285
ridge     n=16  L1=1.76  preRMSE= 33.4  ATT=-1432
ols       n=16  L1=2.09  preRMSE= 28.3  ATT=-1353
L1-L2     n= 7  L1=1.00  preRMSE= 60.8  ATT=-1297
```

## Failing loudly

`w_constr` cannot be combined with `covariates`, a non-default `backend`, `oracle_weights` or `staggered_spec` — each raises with the reason, because each would leave two estimators claiming the same fit. Quietly preferring one is the failure mode this option exists to remove.

`method_details.parameters_used` reports the family that ran and the budget `Q` (data-estimated for ridge / L1-L2), so a fit never leaves its specification ambiguous.

## Tests

21 tests, written first and confirmed red. Each family's defining invariant is asserted — simplex on the simplex, lasso's L1 bound, ridge's L2 bound against the estimated `Q`, ols leaving the simplex — plus an explicit-budget dict, the config failures, the single-donor edge case, and the regression that motivated the change: the families must not all collapse to one fit.

New code is fully covered; the only uncovered line nearby is pre-existing in `_align_oracle`.

## Verification

`test_vanillasc`, `test_vanillasc_staggered`, `test_staggered_constraints`, `test_vanillasc_oracle`, `test_vanillasc_fit_window`, `test_vanillasc_replications`, `test_result_contract` and the new file: **251 passed, 5 skipped**. The replication tests passing is the load-bearing part — those pin VanillaSC against published paper results, so the default path is provably unmoved.

## Docs

A `Weight-constraint families` section in `docs/vanillasc.rst` with the constraint table, the exclusivity rules, and a caution that a better pre-treatment fit bought by extrapolation is not evidence of a better estimate.

## Follow-up

Independent of #287, but once both land the guard's message there should also point at `w_constr` — it currently sends single-treated users to `covariates`, which solves only the `features` half. Kept out of both branches to preserve their independence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYjo4s2qMBtsJhuEqEusih)_