### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: An estimator crashes, raises the wrong error, or returns a result you believe is incorrect
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If the concern is that mlsynth's numbers disagree with a paper or another
+        implementation, use the Replication discrepancy form instead — the
+        resolution there is often to document a known difference rather than to
+        change code.
+  - type: input
+    id: estimator
+    attributes:
+      label: Estimator
+      placeholder: e.g. DTWSC, FDID, MCNNM
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: How does it misbehave?
+      description: The first one matters most. A wrong number that runs cleanly is the hardest kind to catch, so it is worth separating.
+      options:
+        - Runs, but returns a result I believe is wrong
+        - Raises an exception
+        - Raises the wrong error type, or an unclear message
+        - Hangs, or is unreasonably slow
+        - Something else
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: The smallest script that shows it. If the data cannot be shared, a generator that reproduces the shape of the panel is just as useful.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected, and what you got
+      description: For a numerical disagreement, please give both numbers and how far apart they are.
+    validations:
+      required: true
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Full traceback
+      description: If it raised. Please paste the whole thing rather than the last line.
+      render: shell
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      placeholder: mlsynth 0.0.0, Python 3.12, numpy 2.1, macOS 15
+    validations:
+      required: true
+  - type: textarea
+    id: panel
+    attributes:
+      label: Panel shape
+      description: Units, periods, pre-periods, donors, and anything degenerate about it — a single donor, collinear donors, unbalanced panel, treatment in the first period.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Which estimator should I use?
+    url: https://mlsynth.readthedocs.io/en/latest/choose.html
+    about: The decision tree covers most of these without needing an issue.
+  - name: How an estimator was validated
+    url: https://mlsynth.readthedocs.io/en/latest/replications.html
+    about: Replication pages record what each estimator was checked against, including known and deliberate differences.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,32 @@
+name: Documentation
+description: Something in the docs is wrong, unclear, or missing
+title: "[Docs] "
+labels: ["documentation"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page
+      placeholder: docs/dtwsc.rst, or the URL
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What kind of problem?
+      options:
+        - Factually wrong — it states something untrue about the method or the code
+        - An example does not run, or does not produce what it claims
+        - Unclear, or assumes knowledge a newcomer would not have
+        - Missing — an assumption, diagnostic, or caveat that should be stated
+        - Notation is inconsistent with the rest of the docs
+        - Typo or formatting
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: What it says, and what it should say
+      description: Quoting the passage helps. If a stated number looks wrong, please say what you think it should be.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: A new option, backend, or diagnostic on an estimator that already exists
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For a method that is not implemented at all, use the Paper candidate form.
+  - type: input
+    id: estimator
+    attributes:
+      label: Estimator
+      placeholder: e.g. VanillaSC, DTWSC
+    validations:
+      required: true
+  - type: textarea
+    id: request
+    attributes:
+      label: What should it be able to do?
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: What is not possible without it?
+      description: If it mirrors something a paper or a reference implementation does, say which — that is the strongest case, since it means a published result is currently out of reach.
+    validations:
+      required: true
+  - type: dropdown
+    id: compat
+    attributes:
+      label: Would this change existing behaviour?
+      description: New options are expected to default to what the estimator already does, so existing results do not move silently.
+      options:
+        - "No — purely additive, off by default"
+        - "Yes — it would change what a default configuration returns"
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: sketch
+    attributes:
+      label: How you would expect to call it
+      render: python

--- a/.github/ISSUE_TEMPLATE/paper_candidate.yml
+++ b/.github/ISSUE_TEMPLATE/paper_candidate.yml
@@ -1,0 +1,73 @@
+name: Paper candidate
+description: Propose a method for implementation as a new estimator
+title: "[Paper] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Candidates are assessed on four questions: is the method genuinely new
+        relative to what mlsynth already has, is it implementable from what the
+        authors published, is there a credible route to validating it, and is the
+        build cost proportionate. This form asks for what is needed to answer
+        them. A partial answer is fine — an assessment is the point of filing.
+  - type: input
+    id: citation
+    attributes:
+      label: Paper
+      description: Full citation with DOI or link.
+    validations:
+      required: true
+  - type: textarea
+    id: method
+    attributes:
+      label: What the method does
+      description: In a few sentences, and in plain terms — what it estimates and what makes it different.
+    validations:
+      required: true
+  - type: textarea
+    id: regime
+    attributes:
+      label: What regime does it cover that mlsynth does not?
+      description: The most important question. Which existing estimator would someone otherwise misapply, and why would it mislead them? See `docs/choose.rst` for what is already covered.
+    validations:
+      required: true
+  - type: dropdown
+    id: reference
+    attributes:
+      label: Is there a reference implementation?
+      options:
+        - Yes, a maintained package
+        - Yes, replication code with the paper
+        - Code exists but only as excerpts in an appendix
+        - No, the paper alone
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: reference_link
+    attributes:
+      label: Where
+      description: Repository, archive DOI, or supplement link. Note the licence if you know it.
+  - type: dropdown
+    id: validation
+    attributes:
+      label: What could validate it?
+      description: Every estimator needs one of these before it ships.
+      options:
+        - The paper's empirical result on data the authors provide
+        - The paper's Monte Carlo or simulation table
+        - A match against a reference implementation
+        - Not obvious — needs assessing
+    validations:
+      required: true
+  - type: textarea
+    id: data
+    attributes:
+      label: Data availability
+      description: Is the authors' data public, and is it already in `basedata/`?
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: Known difficulties, dependencies the method would pull in, or parts of the paper that look under-specified.

--- a/.github/ISSUE_TEMPLATE/replication_discrepancy.yml
+++ b/.github/ISSUE_TEMPLATE/replication_discrepancy.yml
@@ -1,0 +1,66 @@
+name: Replication discrepancy
+description: mlsynth's output disagrees with a published result or another implementation
+title: "[Replication] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Every estimator here is validated against a paper or a reference
+        implementation, so a disagreement is worth knowing about even when it
+        turns out to be expected. Some differences are documented and
+        deliberate — see the estimator's page under `docs/replications/`.
+
+        Before filing, one thing is worth ruling out: that both sides are
+        reporting the same quantity in the same units. Rescaling, differing
+        pre-treatment windows, and differing donor pools have all produced
+        apparent disagreements that were really two different numbers.
+  - type: input
+    id: estimator
+    attributes:
+      label: Estimator
+      placeholder: e.g. DTWSC
+    validations:
+      required: true
+  - type: input
+    id: source
+    attributes:
+      label: What you compared against
+      description: Paper with DOI, or the reference implementation and its version or commit.
+      placeholder: Cao & Chadefaux (2025), 10.1017/pan.2024.14 — or conflictlab/dsc @ b1cd241
+    validations:
+      required: true
+  - type: dropdown
+    id: path
+    attributes:
+      label: Kind of comparison
+      options:
+        - A published number in the paper
+        - A table or figure in the paper
+        - Output I generated from the authors' code
+        - Output from an unrelated implementation
+    validations:
+      required: true
+  - type: textarea
+    id: numbers
+    attributes:
+      label: The quantities, side by side
+      description: Which statistic, the reference value, mlsynth's value, and the gap. Pointwise paths are more informative than summary statistics, since averaging hides sign-cancelling error.
+    validations:
+      required: true
+  - type: textarea
+    id: setup
+    attributes:
+      label: How each side was configured
+      description: Data source, donor pool and any exclusions, treatment date, pre-treatment window, predictors, and the units the outcome is in on each side.
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Reproducer
+      render: python
+  - type: input
+    id: versions
+    attributes:
+      label: Versions
+      placeholder: mlsynth 0.0.0, Python 3.12 — and the reference's language and version


### PR DESCRIPTION
## Related Links

- `.github/ISSUE_TEMPLATE/` — five forms plus `config.yml`
- Companion to #290, which adds the PR templates these map onto
- `docs/choose.rst` and `docs/replications.rst` are linked from the chooser as contact links

## What

- Added `bug_report.yml`, `replication_discrepancy.yml`, `paper_candidate.yml`, `feature_request.yml`, `docs.yml`, and `config.yml`.

Nothing outside `.github/ISSUE_TEMPLATE/`.

## Why

The repository has zero issues, open or closed, so this starts a practice rather than tidying one. Each form maps onto a PR template from #290, so an issue arrives with an obvious resolution shape:

| issue form | resolved by |
|---|---|
| `bug_report` | `bugfix.md` |
| `replication_discrepancy` | `bugfix.md` or `benchmark.md` |
| `paper_candidate` | `new-estimator.md` |
| `feature_request` | `estimator-feature.md` |
| `docs` | the default template |

## How

Issue forms rather than markdown templates, so fields can be required and dropdowns can steer a report toward the information that is actually needed. Unlike PR templates, these get a real picker UI when someone clicks New issue.

Three decisions worth surfacing, since they are judgment calls rather than transcription:

Bug and replication discrepancy are deliberately separate forms. For this library the distinction is substantive, not cosmetic: a disagreement with a paper is frequently not a defect, and several are documented as deliberate — the DTWSC Savitzky–Golay edge treatment being the current example. Collapsing them into one form would either bury genuine bugs among expected differences or invite changing code to chase a gap that was already understood. The replication form asks for the units and the pre-treatment window on both sides before anything else, because apparent disagreements have turned out to be two different quantities reported on two different scales.

The bug form asks how the estimator misbehaves and lists "runs, but returns a result I believe is wrong" first, above crashes. That is the failure mode that does not announce itself, and the one least likely to be reported without prompting.

The paper candidate form asks the four questions a candidate is actually assessed on — is the method new relative to `docs/choose.rst`, is it implementable from what was published, is there a route to validating it, and is the build cost proportionate — rather than asking for a general description and hoping the rest follows.

## Verification

Not applicable — no code. All six files parse as YAML; field and required-field counts:

```
bug_report.yml                fields=8 required=5
replication_discrepancy.yml   fields=8 required=5
paper_candidate.yml           fields=9 required=5
feature_request.yml           fields=6 required=4
docs.yml                      fields=3 required=3
config.yml                    (chooser config)
```

## Designs

None. The forms render on GitHub once merged; they cannot be previewed from a branch.

## Test Steps

- [ ] After merge, click New issue and confirm all five appear in the picker with sensible descriptions
- [ ] Open one and confirm required fields block submission when empty
- [ ] Confirm the two contact links resolve
- [ ] Confirm labels apply: `bug`, `enhancement`, `documentation`

## Other Notes

- Labels are limited to the three that exist in this repository (`bug`, `documentation`, `enhancement`). Issue forms silently drop labels that have not been created, so `replication_discrepancy` carries none. A `replication` label — and possibly `paper-candidate` — would triage better, but they have to be created first and I do not have a tool that creates labels. Worth doing by hand if you want them.
- `blank_issues_enabled` is left `true`, on the theory that a blocked blank issue is usually an unfiled one. One-line change to `false` if you would rather require a form.
- The contact links point at `mlsynth.readthedocs.io`. If that is not the canonical docs host, they need correcting.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_