### PR TITLE
Register ascm_jackknife_plus, and guard the registry against the next omission

### DIFF
--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -133,6 +133,7 @@ CASES = {
     "dsc_dube": "benchmarks.cases.dsc_dube",                  # Path A: DSC distributional SC on Dube minimum-wage (Gunsilius/DiSCo vignette)
     "dtwsc_basque": "benchmarks.cases.dtwsc_basque",          # Cross-validation: DTWSC warp vs the conflictlab/dsc R package on Basque
     "ascm_kansas": "benchmarks.cases.ascm_kansas",            # cross-val vs augsynth: Kansas ridge-ASCM ladder (SCM/ridge/covariate/residualized)
+    "ascm_jackknife_plus": "benchmarks.cases.ascm_jackknife_plus",  # cross-val vs augsynth inf_type="jackknife+": per-period bounds on Kansas, both branches
     "augsynth_calibrated": "benchmarks.cases.augsynth_calibrated",  # Path B: ASCM near-nominal coverage + bias reduction (BMR 2021 Sec 7)
     "pensynth_prop99": "benchmarks.cases.pensynth_prop99",  # cross-val vs LIVE pensynth wsoll1 (Rscript+LowRankQP) on Prop 99 penalized SC (skips if absent)
     "microsynth_seattle": "benchmarks.cases.microsynth_seattle",  # cross-val vs R microsynth panel method (Seattle DMI)

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -215,6 +215,8 @@ Cross-validation against reference implementations
      - Validates
    * - ``ascm_kansas``
      - vs augsynth: Kansas ridge-ASCM ladder (SCM/ridge/covariate/residualized)
+   * - ``ascm_jackknife_plus``
+     - vs augsynth ``inf_type="jackknife+"`` on Kansas: the per-drop held-out errors and counterfactuals, the pointwise bounds under both the default and conservative branches, and the post-period average interval
    * - ``drosc_basque``
      - DROSC vs authors' R ``DRoSC`` (Koo & Guo 2026, ``limSolve::lsei``) on Basque: worst-case estimand τ(λ) and λ=0 weights value-for-value across the robustness sweep
    * - ``propsc_spain``

--- a/mlsynth/tests/test_benchmark_reference.py
+++ b/mlsynth/tests/test_benchmark_reference.py
@@ -23,6 +23,53 @@ _ROOT = Path(__file__).resolve().parents[2]
 _BUNDLE = _ROOT / "benchmarks" / "reference" / "synth_prop99"
 
 
+class TestRegistryCoversEveryCase:
+    """Every case module is reachable from ``benchmarks/registry.py``.
+
+    A case that is written, committed and reviewed but never added to ``CASES``
+    is invisible to ``run_benchmarks.py --all``: it does not run in the routine
+    sweep, so it can rot indefinitely without a single check going red. That is
+    a worse failure than a case that fails, because nothing announces it -- and
+    it is easy to do, since the case file and the registry are separate edits
+    and only the case file is the interesting one to write.
+    """
+
+    @staticmethod
+    def _modules():
+        d = _ROOT / "benchmarks" / "cases"
+        return {p.stem for p in d.glob("*.py") if p.stem != "__init__"}
+
+    @staticmethod
+    def _registered():
+        from benchmarks import registry
+        return {v.rsplit(".", 1)[1] for v in registry.CASES.values()}
+
+    def test_every_case_module_is_registered(self):
+        missing = sorted(self._modules() - self._registered())
+        assert not missing, (
+            "case module(s) not in benchmarks/registry.py CASES, so they never "
+            f"run under --all: {missing}")
+
+    def test_every_registered_case_module_exists(self):
+        """The other direction: a rename that misses the registry."""
+        stale = sorted(self._registered() - self._modules())
+        assert not stale, f"CASES names a module that does not exist: {stale}"
+
+    def test_registry_keys_match_their_module_names(self):
+        """The short name and the module stem are the same word.
+
+        ``run_benchmarks.py --case <name>`` takes the key while every other
+        reference to a case -- docs, the reference bundle directory, this test --
+        uses the module name. Letting them drift apart makes a case findable by
+        one name and not the other.
+        """
+        from benchmarks import registry
+        mismatched = sorted(
+            (k, v) for k, v in registry.CASES.items()
+            if v.rsplit(".", 1)[1] != k)
+        assert not mismatched, f"key != module stem: {mismatched}"
+
+
 def test_loader_returns_values_and_weights():
     ref = load_reference("synth_prop99")
     assert set(ref) >= {"values", "weights"}


### PR DESCRIPTION
## Related Links

- `benchmarks/cases/ascm_jackknife_plus.py` — the case that was never reachable
- `benchmarks/registry.py` — where it should have been
- `docs/replications/ascm_jackknife_plus.rst` — the replication page, which already linked the case
- Fixes an omission in #296

## What

- Registered `ascm_jackknife_plus` in `benchmarks/registry.py`
- Added `TestRegistryCoversEveryCase` to `mlsynth/tests/test_benchmark_reference.py` (3 tests)
- Added the case to the cross-validation table in `docs/benchmarks.rst`, which had the same gap

## Why

`benchmarks/cases/ascm_jackknife_plus.py` shipped in #296 and was never added to `CASES`, so it has never run under `python benchmarks/run_benchmarks.py --all`.

The case itself is fine. Registered and run:

```
[PASS] ascm_jackknife_plus   (12s)
  PASS  n_drops: got 89  exp 89
  PASS  bounds_ordered: got 1  exp 1
  PASS  appended_entry_is_the_mean: got 1  exp 1
  PASS  conservative_width_matches_construction: 1.409e-15 (tol 1e-09)
  PASS  perdrop_err_max_diff: 3.508e-08 (tol 1e-06)
  PASS  perdrop_est_max_diff: 1.742e-07 (tol 1e-06)
  PASS  bounds_max_diff: 3.845e-09 (tol 1e-07)
  PASS  bounds_max_diff_conservative: 1.791e-07 (tol 1e-06)
  PASS  average_att_lower_diff: 6.385e-10 (tol 1e-07)
  PASS  average_att_upper_diff: 3.203e-09 (tol 1e-07)
```

That is what makes the omission worth fixing carefully rather than quietly. A case that fails goes red and someone looks at it. A case that is never reached says nothing at all, so it can rot indefinitely while `--all` reports success — and the replication page links it as durable validation the whole time.

## How

The mistake is easy to repeat, because writing the case and registering it are separate edits and only the first one is interesting to write. A convention would not have caught it; the convention was already there and I was the one who broke it.

So the registry gets a test instead. `TestRegistryCoversEveryCase` asserts three things:

- every module in `benchmarks/cases/` appears in `CASES` — the failure that happened
- every `CASES` entry names a module that exists — the other direction, for a rename that misses the registry
- each key equals its module stem — `--case <name>` takes the key while docs, reference bundle directories and tests all use the module name, and letting those drift makes a case findable by one name and not the other

Written first. It was red on `ascm_jackknife_plus`, which is how the omission surfaced at all — I went to run a different case through the runner, hit a `KeyError`, and audited the registry rather than just fixing the one name.

## Verification

Path: not applicable to the registry change itself — no numerical code is touched, and no expected value moves.

What the change buys is that `ascm_jackknife_plus`'s existing cross-validation against live augsynth 0.2.0 now actually runs in the routine sweep. Its ten rows compare the per-drop held-out errors and counterfactuals, the pointwise bounds under both the default and conservative branches, and the post-period average interval; the tightest agrees at 6.4e-10.

The guard is pinned by its own tests, which fail on a missing registration rather than on a downstream symptom.

## Scope checks

Bug fix:

- [x] A test reproduces the defect and fails without the fix — `test_every_case_module_is_registered`, red on `ascm_jackknife_plus`
- [x] It asserts the correct behaviour, not merely the absence of a crash — the assertion is registry coverage, and the message names the unreachable module
- [x] No docs page, docstring or comment still states the old behaviour — `docs/benchmarks.rst` now lists the case it was silently omitting
- [x] No pinned value moved

## Test Steps

- [x] `pytest mlsynth/tests/test_benchmark_reference.py -q` — 13 passed
- [x] `python benchmarks/run_benchmarks.py --case ascm_jackknife_plus` — all 10 rows pass, 12s
- [ ] Full suite — CI
- [ ] Docs build (underline lengths checked; Sphinx not run in this environment)

## Other Notes

The audit found exactly one other unregistered case, `song_ml_ascm`, which is not on `main` yet — it sits on `claude/song-ml-ascm-benchmark` and will carry its own registry line in its own PR. After that the registry is complete and the new test keeps it so.

Worth recording how this was found, since the near-miss is the useful part: I had previously reported that case as passing, having exercised it by importing the module directly. That is the one way of running a case that cannot detect an unregistered one.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_