### PR TITLE
Run CI when benchmarks/ or basedata/ change, and pin that it does

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Decide whether this change can affect the test suite. Docs-only and
-      # benchmarks-only PRs skip the (slow) run -- the job still completes, so a
-      # required "build" check stays satisfiable. Workflow_dispatch always runs.
+      # Decide whether this change can affect the test suite. Docs-only PRs skip
+      # the (slow) run -- the job still completes, so a required "build" check
+      # stays satisfiable. Workflow_dispatch always runs.
+      #
+      # This list must cover every directory the suite READS, not only the one it
+      # lives in, because a skipped check reports success and a skipped success
+      # is indistinguishable from a real one. 'benchmarks/**' and 'basedata/**'
+      # are here for that reason: tests/test_benchmark_reference.py reads
+      # benchmarks/registry.py and benchmarks/cases/, and 75 test files load
+      # fixtures from basedata/. Benchmarks-only PRs used to skip the run
+      # legitimately; they stopped being safe to skip when the registry-coverage
+      # test was added. mlsynth/tests/test_benchmark_reference.py asserts this
+      # list against those dependencies, so narrowing it fails a test rather
+      # than silently disarming CI.
       - name: Detect code changes
         id: filter
         if: github.event_name == 'pull_request'
@@ -52,6 +63,8 @@ jobs:
           filters: |
             code:
               - 'mlsynth/**'
+              - 'benchmarks/**'
+              - 'basedata/**'
               - 'requirements.txt'
               - 'pyproject.toml'
               - '.github/workflows/build.yml'
@@ -129,6 +142,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Kept identical to the build job's filter above, including the reasoning
+      # recorded there. The test asserts every copy, so the two cannot drift.
       - name: Detect code changes
         id: filter
         if: github.event_name == 'pull_request'
@@ -137,6 +152,8 @@ jobs:
           filters: |
             code:
               - 'mlsynth/**'
+              - 'benchmarks/**'
+              - 'basedata/**'
               - 'requirements.txt'
               - 'pyproject.toml'
               - '.github/workflows/build.yml'

--- a/mlsynth/tests/test_benchmark_reference.py
+++ b/mlsynth/tests/test_benchmark_reference.py
@@ -23,6 +23,66 @@ _ROOT = Path(__file__).resolve().parents[2]
 _BUNDLE = _ROOT / "benchmarks" / "reference" / "synth_prop99"
 
 
+class TestCIRunsWhenTheSuiteCanBreak:
+    """The CI paths filter must cover every directory the test suite reads.
+
+    ``.github/workflows/build.yml`` skips the (slow) suite for changes that
+    cannot affect it. That is a sound optimisation and a dangerous one: a check
+    that is skipped reports success, and a skipped success is indistinguishable
+    from a real one on the pull request page.
+
+    The filter was originally correct. It stopped being correct when tests
+    started reading outside ``mlsynth/``: ``TestRegistryCoversEveryCase`` below
+    reads ``benchmarks/registry.py`` and ``benchmarks/cases/``, and 75 test files
+    load fixtures from ``basedata/``. A pull request touching only those
+    directories could therefore break the suite and still go green -- which is
+    exactly what happened to the pull request that added the Song benchmark: the
+    one test that validates a new case against the registry was the one CI
+    skipped.
+
+    So the coupling is asserted here rather than left to whoever next edits the
+    workflow. If the suite stops reading one of these directories, delete the
+    entry; do not narrow the filter while tests still depend on it.
+    """
+
+    @staticmethod
+    def _filter_blocks():
+        """Every ``filters:`` block in the workflow, not just the first.
+
+        ``build.yml`` gates two jobs (``build`` and the ``pyversions`` matrix)
+        and each carries its own copy of the list. Checking only the first would
+        have passed while the matrix jobs still skipped -- which is the same
+        class of partial check this whole class exists to prevent.
+        """
+        import re
+        wf = (_ROOT / ".github" / "workflows" / "build.yml").read_text()
+        blocks = re.findall(r"filters:\s*\|\n((?:\s+(?:code:|-\s*'[^']+')\n)+)", wf)
+        assert blocks, "could not locate any paths-filter block in build.yml"
+        return [set(re.findall(r"-\s*'([^']+)'", b)) for b in blocks]
+
+    def test_the_workflow_still_has_the_two_filter_copies(self):
+        """If a copy is added or removed, re-read the test below before trusting it."""
+        assert len(self._filter_blocks()) == 2
+
+    @pytest.mark.parametrize("directory", ["mlsynth", "benchmarks", "basedata"])
+    def test_directories_the_tests_read_trigger_a_run(self, directory):
+        for i, paths in enumerate(self._filter_blocks()):
+            assert f"{directory}/**" in paths, (
+                f"tests read from {directory}/ but CI filter block {i} does not "
+                "list it, so a change there skips the suite and still reports "
+                "success")
+
+    def test_the_tests_really_do_read_those_directories(self):
+        """The premise of the test above, asserted rather than assumed.
+
+        Without this, the filter entries could outlive the dependency that
+        justifies them and nobody would know it was safe to drop them.
+        """
+        srcs = [p.read_text() for p in (_ROOT / "mlsynth" / "tests").glob("*.py")]
+        assert sum("basedata" in s for s in srcs) > 10
+        assert sum("benchmarks" in s for s in srcs) > 5
+
+
 class TestRegistryCoversEveryCase:
     """Every case module is reachable from ``benchmarks/registry.py``.
 


### PR DESCRIPTION
## Related Links

- `.github/workflows/build.yml` — the filter, in both jobs
- Fixes a gap created by #300 and demonstrated by #301

## What

- Added `benchmarks/**` and `basedata/**` to the `dorny/paths-filter` list, in both copies (the `build` job and the `pyversions` matrix)
- Added `TestCIRunsWhenTheSuiteCanBreak` to `mlsynth/tests/test_benchmark_reference.py` (5 tests)

## Why

The filter gated the suite on `mlsynth/**` plus packaging files. That was correct when written, and stopped being correct once tests began reading outside `mlsynth/`:

- `mlsynth/tests/test_benchmark_reference.py` reads `benchmarks/registry.py` and `benchmarks/cases/`
- 75 test files load fixtures from `basedata/`

A skipped check reports success, and on the PR page a skipped success is indistinguishable from a real one.

#301 is the demonstration. It added a benchmark case plus its registry entry; all four checks went green in 8–11 seconds against a usual 30–40 minutes. The job set up Python and went straight to cleanup. The one test that validates a new case against the registry — the guard added in #300 for exactly that class of mistake — was the test CI skipped. Had I added the case without the registry line, CI would still have gone green.

I own this. #300 created the coupling between the suite and `benchmarks/` without widening the filter that assumed no such coupling existed. The guard and the gate were added a few hours apart and I didn't connect them.

## How

Two copies of the filter exist — the `build` job and the `pyversions` matrix each carry one. Fixing only the first would have left the three matrix jobs skipping: the same partial-check failure in miniature, which is why the test walks every `filters:` block rather than the first match.

The test asserts the path list against the dependency that justifies it. A companion test asserts the premise — that the suite really does read those directories — so if that ever stops being true the entries can be dropped honestly rather than kept out of superstition. A third pins that there are exactly two filter blocks, so adding a third job sends someone back to re-read the test instead of quietly escaping it.

## Verification

Path: not applicable — no numerical code is touched and no expected value moves.

Red before the fix on both new directories:

```
AssertionError: tests read from benchmarks/ but CI filter block 0 does not list it,
so a change there skips the suite and still reports success
AssertionError: tests read from basedata/ but CI filter block 0 does not list it, ...
```

Then verified the test catches a partial regression, which is the case that actually matters here — removing `benchmarks/**` from one block only:

```
removing it from ONE block -> DETECTED
```

`pytest mlsynth/tests/test_benchmark_reference.py -q` — 18 passed.

This PR touches `.github/workflows/build.yml`, which is in the filter, so its own CI run exercises the full suite rather than skipping it.

## Scope checks

Bug fix:

- [x] A test reproduces the defect and fails without the fix
- [x] It asserts the correct behaviour — filter coverage of every directory the suite reads — not merely the absence of a crash
- [x] No comment still states the old rationale; the "benchmarks-only PRs skip the run" comment is rewritten to say why they no longer can
- [x] No pinned value moved

## Test Steps

- [x] `pytest mlsynth/tests/test_benchmark_reference.py -q` — 18 passed
- [x] Partial-regression check: removing the entry from one block alone is detected
- [ ] Full suite — this PR's own CI, which now runs

## Other Notes

Worth stating plainly: every PR merged in this session that touched only `benchmarks/`, `basedata/` or `docs/` was merged on a green that did not run the suite. That is #301 and the benchmark-only parts of others. I ran the relevant tests locally in each case and they passed, so I do not believe anything is broken — but the CI signal behind those merges was weaker than it appeared, and that should be on the record rather than assumed away.

The daily `benchmarks.yml` workflow is unaffected; it runs on a schedule with no paths filter.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_