### PR TITLE
Add a DiSCos provisioner that resolves its own dependency closure

### DIFF
--- a/agents/agents_discos_install.md
+++ b/agents/agents_discos_install.md
@@ -152,6 +152,25 @@ DiSCoTEA(disco, agg = "quantileDiff", graph = FALSE)
 The installer ends with exactly this fit and asserts `sum(weights) ≈ 1`, so a successful
 run of the script is itself the check.
 
+### Verified run, 2026-07-30
+
+```
+DiSCos 0.1.4 / CVXR 1.0.15 OK (real fit, sum(weights) = 1.000000 )
+```
+
+The resolver built exactly the twelve packages this file predicts, in dependency order —
+CVXR, scs, evmix, extremeStat, lmomco, Lmoments, berryFunctions, evir, ismev, extRemes,
+distillery, Renext — plus DiSCos, and nothing else. `scs` is the one worth noting: it
+appears nowhere in the script, and was pulled in automatically as a CVXR dependency.
+That is the resolver doing its job, and the reason not to go back to a hand-written list.
+
+Independently re-checked outside the installer: 652,870 rows loaded, 33 donors,
+`sum(weights)` 1.0000000000. The donor count matches what `benchmarks/cases/dsc_dube.py`
+reports, which is the first corroboration that case has had from outside mlsynth.
+
+Wall time was about 45 minutes on a container that was simultaneously running an
+unrelated R job; budget 15–25 minutes on an idle one.
+
 Pass `mixture = TRUE` to exercise the CVXR path, and `qmethod = "qkden"` /
 `qmethod = "extreme"` to exercise evmix / extremeStat. Use `copy(dube)` — DiSCos takes a
 `data.table` and modifies it by reference, so a bare `dube` mutates the bundled dataset

--- a/agents/agents_discos_install.md
+++ b/agents/agents_discos_install.md
@@ -1,0 +1,174 @@
+# Installing DiSCos in this sandbox — an exact runbook
+
+A step-by-step recipe for getting a working [DiSCos](https://github.com/Davidvandijcke/DiSCos)
+(Distributional Synthetic Controls, Gunsilius 2023) into the Claude Code remote sandbox,
+so it can be used as a live R reference for cross-validating mlsynth's `DSC` / `DSCAR`
+ports — see `benchmarks/cases/dsc_dube.py`.
+
+Verified end to end on 2026-07-30, on Ubuntu 24.04 with R 4.3.3. Read
+`agents_r_environment.md` first for the general sandbox constraints; this file is the
+DiSCos-specific replay, and `benchmarks/R/install_augsynth.sh` is the same pattern at a
+third of the depth if you want the shape without the detail.
+
+## TL;DR
+
+```bash
+bash benchmarks/R/install_discos.sh
+```
+
+Budget 15–25 minutes on a cold container. Twelve packages compile from source, several
+with substantial C/C++/Fortran (CVXR, scs, evmix, the extreme-value chain).
+
+## What makes DiSCos harder than augsynth
+
+The sandbox constraints are identical to augsynth's — CRAN blocked, `codeload` blocked,
+apt and `git clone` open, so the recipe is still "apt for the prebuilt majority, clone
+`cran/<pkg>` for the rest." See `agents_r_environment.md` for that evidence table.
+
+What is different is the depth of the tree. augsynth needed three source builds with a
+hand-written list. DiSCos needs twelve, and the list is not obvious up front:
+`extremeStat` alone pulls in a chain of extreme-value packages (lmomco → Lmoments,
+berryFunctions, evir, ismev, extRemes → distillery, Renext) that apt does not carry.
+
+So `install_discos.sh` does not hand-list dependencies. It resolves the closure
+automatically with a `need <Pkg>` function that prefers the apt binary and otherwise
+clones `cran/<Pkg>`, recurses through that package's own Depends/Imports/LinkingTo, and
+then compiles. The dependency parsing is `read.dcf` in R, and base/recommended packages
+are excluded because they ship with `r-base`:
+
+```bash
+need() {
+  local pkg="$1" sha="${2:-}" deb dir
+  have "$pkg" && return 0
+  deb="r-cran-$(echo "$pkg" | tr '[:upper:]' '[:lower:]')"
+  if [ -z "$sha" ] && apt-cache show "$deb" >/dev/null 2>&1; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "$deb" \
+      && { have "$pkg" && return 0; }
+  fi
+  dir="$SRC/$pkg"; rm -rf "$dir"
+  git clone --quiet "https://github.com/cran/$pkg" "$dir"
+  [ -n "$sha" ] && git -C "$dir" checkout --quiet "$sha"
+  while read -r d; do [ -n "$d" ] && need "$d"; done < <(deps "$dir")
+  R CMD INSTALL --no-docs --no-help "$dir"
+}
+```
+
+Reuse this resolver for any other R reference package. It is the generalisation of the
+augsynth recipe and saves the manual closure-walking entirely.
+
+## The two things you have to get right by hand
+
+Everything else the resolver handles. These two it cannot.
+
+### 1. Pin CVXR to the 1.0 series
+
+DiSCos declares a bare `CVXR` with no version constraint, so an unpinned resolve grabs
+1.9.1 — and that is a wall:
+
+- CVXR >= 1.8 requires `Matrix >= 1.7` and `Rcpp >= 1.1`. Noble ships Matrix 1.6.5 and
+  Rcpp 1.0.12, so both would themselves have to be source-built.
+- It adds `clarabel`, which needs a full Rust toolchain, plus `highs`.
+
+CVXR 1.0-15 needs only `scs` beyond what apt provides. Pin it:
+
+```
+CVXR  1.0-15  871a29e5f770a8479cc1aa77cf437e20dd16dc79  (cran/CVXR)
+```
+
+This is why `need CVXR "$CVXR_SHA"` is called before the loop — so the resolver cannot
+reach a newer CVXR as a transitive dependency of anything else.
+
+### 2. Install quadprog, which is mis-declared
+
+This one will bite you. `quadprog` sits in DiSCos' `Suggests`, not `Imports`, so a
+correct Depends/Imports resolve skips it — and then `library(DiSCos)` succeeds and the
+first real fit dies:
+
+```
+Error: quadprog needed for this function to work. Please install it.
+```
+
+It is a hard runtime requirement of the weights solver on the default non-mixture path
+(`R/DiSCo_weights_reg.R:82` guards it with `requireNamespace`). apt has it as
+`r-cran-quadprog`. The script installs it explicitly with a comment saying why.
+
+The general lesson, and the same one augsynth taught: a package that imports cleanly is
+not a package that works. Suggests-but-actually-required is common in R, and the only
+thing that catches it is running a real fit.
+
+## What ends up where
+
+Pinned commits, frozen 2026-07-30:
+
+| package | version | commit                                     | source                |
+|---------|---------|--------------------------------------------|-----------------------|
+| DiSCos  | 0.1.4   | `ed2b3d948ed591ed2785e1d97acb567225432a60` | Davidvandijcke/DiSCos |
+| CVXR    | 1.0-15  | `871a29e5f770a8479cc1aa77cf437e20dd16dc79` | cran/CVXR             |
+
+Compiled from source by the resolver (12): CVXR, scs, evmix, extremeStat, lmomco,
+Lmoments, berryFunctions, evir, ismev, extRemes, distillery, Renext.
+
+Taken prebuilt from apt: data.table, ggplot2, pracma, Rdpack, MASS, quadprog, plus the
+transitive closure of each (Matrix, Rcpp, RcppEigen, bit64, gmp, Rmpfr, ECOSolveR, slam,
+cli, R6, gsl, SparseM, pbapply, RColorBrewer, evd, fExtremes, mgcv, …). The system
+libraries `libgmp-dev`, `libmpfr-dev` and `libgsl-dev` are needed for gmp/Rmpfr/gsl and
+are installed up front.
+
+`parallel` and `utils` are in DiSCos' Imports but are base R — nothing to install.
+
+## Which dependency backs which code path
+
+Worth knowing when something breaks, because the failure is usually specific to one
+option rather than to the package as a whole:
+
+| dependency  | used by                                        |
+|-------------|------------------------------------------------|
+| quadprog    | default weights solver (`simplex`/non-mixture) |
+| pracma      | `lsqlincon` constrained least-squares weights  |
+| CVXR        | `mixture = TRUE` mixture-of-distributions path |
+| evmix       | `qmethod = "qkden"` only                       |
+| extremeStat | `qmethod = "extreme"` only                     |
+
+`evmix` and `extremeStat` are each used in exactly one call site and back optional
+quantile-estimation methods. If you only need the default path and want to cut the build
+substantially, you can drop them from the `need` loop — but then `qmethod` is unavailable,
+so do not drop them for a reference install meant to cross-check arbitrary options.
+
+## Verifying
+
+`library(DiSCos)` is not a sufficient check — that is exactly what passes while quadprog
+is missing. Run a real fit against the bundled Dube panel:
+
+```r
+library(DiSCos); library(data.table)
+data(dube)                       # 652,870 x 3
+disco <- DiSCo(copy(dube), id_col.target = 2, t0 = 2003,
+               G = 100, M = 100, num.cores = 1, seed = 1,
+               simplex = TRUE, q_max = 0.9)
+sum(disco$weights)               # ~1 under simplex = TRUE
+DiSCoTEA(disco, agg = "quantileDiff", graph = FALSE)
+```
+
+The installer ends with exactly this fit and asserts `sum(weights) ≈ 1`, so a successful
+run of the script is itself the check.
+
+Pass `mixture = TRUE` to exercise the CVXR path, and `qmethod = "qkden"` /
+`qmethod = "extreme"` to exercise evmix / extremeStat. Use `copy(dube)` — DiSCos takes a
+`data.table` and modifies it by reference, so a bare `dube` mutates the bundled dataset
+for the rest of the session.
+
+Expected numbers are not pinned here yet. The vignette's own call
+(`G = 1000, boots = 1000, permutation = TRUE, CI = TRUE`) is expensive, and its published
+weight/QTE values live in figures rather than printed tables — see the note in
+`benchmarks/cases/dsc_dube.py`. Capture reference numbers into
+`benchmarks/reference/<case>/` when you pin them, per `agents_benchmarking.md`.
+
+## Gotchas
+
+- The container is ephemeral. Re-run the install once per fresh container, and never
+  write a benchmark case that assumes R is present — CI has no R.
+- `DiSCo()` is genuinely slow: it integrates over full distributions. For iteration use
+  `G = 100`, `M = 100`, `CI = FALSE`, `permutation = FALSE`; the vignette's settings are
+  a final-run configuration, not a debug loop.
+- Do not bump CVXR to 1.9.x hoping it "just works" — see the pinning section. If you do
+  need a newer CVXR, budget for Rust plus source builds of Matrix and Rcpp.

--- a/benchmarks/R/install_discos.sh
+++ b/benchmarks/R/install_discos.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Install the DiSCos reference (Distributional Synthetic Controls, Gunsilius
+# 2023) used to cross-validate mlsynth's DSC / DSCAR ports -- see
+# benchmarks/cases/dsc_dube.py.
+#
+# Same sandbox constraints as install_augsynth.sh: CRAN is blocked, codeload is
+# blocked, apt and git-over-HTTPS to github.com are open. So the recipe is again
+# "apt for the prebuilt majority, clone cran/<Pkg> for the rest".
+#
+# What is different from augsynth is the DEPTH of the tree. augsynth needed
+# three source builds and a hand-written list. DiSCos needs twelve, and the list
+# is not knowable up front: extremeStat alone pulls a chain of extreme-value
+# packages (lmomco -> Lmoments, berryFunctions, evir, ismev, extRemes ->
+# distillery, Renext) that apt does not carry. Hand-walking that closure is
+# error-prone and goes stale, so `need` below resolves it automatically:
+# prefer the apt binary, else clone cran/<Pkg>, recurse through that package's
+# own Depends/Imports/LinkingTo, then compile.
+#
+# Budget 15-25 minutes on a cold container -- CVXR, scs and the extreme-value
+# chain are substantial C/C++/Fortran builds.
+#
+# COMMIT-PINNED (frozen 2026-07-30) so the cross-check runs the SAME reference
+# every time. To refresh, bump the SHAs and re-pin the expected numbers in the
+# relevant benchmarks/cases/*.py.
+#
+#   DiSCos  0.1.4    ed2b3d948ed591ed2785e1d97acb567225432a60  (Davidvandijcke/DiSCos)
+#   CVXR    1.0-15   871a29e5f770a8479cc1aa77cf437e20dd16dc79  (cran/CVXR)
+set -euo pipefail
+
+DISCOS_SHA=ed2b3d948ed591ed2785e1d97acb567225432a60
+# CVXR MUST be pinned to the 1.0 series and MUST be resolved before anything
+# else can pull it in transitively. DiSCos declares a bare `CVXR` with no
+# version constraint, so an unpinned resolve takes 1.9.1 -- and that is a wall,
+# not an inconvenience:
+#
+#   * CVXR >= 1.8 requires Matrix >= 1.7 and Rcpp >= 1.1. Noble ships Matrix
+#     1.6.5 and Rcpp 1.0.12, so both would have to be source-built too.
+#   * it adds `clarabel`, which needs a full Rust toolchain, plus `highs`.
+#
+# 1.0-15 needs only `scs` beyond what apt provides. Do not bump this hoping it
+# "just works"; if a newer CVXR is genuinely required, budget for Rust plus
+# source builds of Matrix and Rcpp.
+CVXR_SHA=871a29e5f770a8479cc1aa77cf437e20dd16dc79
+
+SRC=/tmp/discos-src
+mkdir -p "$SRC"
+
+DEBIAN_FRONTEND=noninteractive apt-get update -qq
+# libgmp/libmpfr/libgsl are the system side of gmp, Rmpfr and gsl, which come in
+# transitively under CVXR; without them those builds fail at configure.
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  r-base r-base-dev build-essential cmake gfortran git \
+  libgmp-dev libmpfr-dev libgsl-dev \
+  r-cran-data.table r-cran-ggplot2 r-cran-pracma r-cran-rdpack r-cran-mass \
+  r-cran-matrix r-cran-rcpp r-cran-rcppeigen r-cran-bit64 r-cran-gmp \
+  r-cran-rmpfr r-cran-ecosolver r-cran-slam r-cran-cli r-cran-r6 r-cran-gsl \
+  r-cran-sparsem r-cran-pbapply r-cran-rcolorbrewer r-cran-evd r-cran-mgcv \
+  r-cran-quadprog
+
+have() { Rscript -e "quit(status = !requireNamespace('$1', quietly = TRUE))" \
+           >/dev/null 2>&1; }
+
+# A package's own Depends/Imports/LinkingTo, minus base and recommended packages
+# (those ship with r-base, so trying to build them is both wasteful and likely
+# to fail against the system copies).
+deps() {
+  Rscript -e '
+    d <- read.dcf(file.path(commandArgs(TRUE)[1], "DESCRIPTION"))
+    f <- unlist(lapply(c("Depends", "Imports", "LinkingTo"), function(k)
+      if (k %in% colnames(d)) strsplit(d[1, k], ",")[[1]] else character()))
+    f <- trimws(sub("\\(.*", "", f))
+    base <- rownames(installed.packages(priority = c("base", "recommended")))
+    cat(setdiff(f[nzchar(f)], c("R", base)), sep = "\n")' "$1" 2>/dev/null
+}
+
+# need <Pkg> [sha] -- ensure <Pkg> is importable, building it if necessary.
+# Prefers the apt binary (fast, no compile) unless a SHA is given, in which case
+# the pin is the point and apt would defeat it.
+need() {
+  local pkg="$1" sha="${2:-}" deb dir
+  have "$pkg" && return 0
+  deb="r-cran-$(echo "$pkg" | tr '[:upper:]' '[:lower:]')"
+  if [ -z "$sha" ] && apt-cache show "$deb" >/dev/null 2>&1; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      "$deb" >/dev/null 2>&1 && { have "$pkg" && return 0; }
+  fi
+  echo "  building $pkg${sha:+ @ ${sha:0:8}}"
+  dir="$SRC/$pkg"
+  rm -rf "$dir"
+  # git clone, NOT a tarball: codeload.github.com is 403 in this sandbox and
+  # github.com/<o>/<r>/archive/<sha>.tar.gz redirects to it. A full clone, not
+  # --depth 1, because a shallow clone cannot check out an arbitrary SHA.
+  git clone --quiet "https://github.com/cran/$pkg" "$dir"
+  [ -n "$sha" ] && git -C "$dir" checkout --quiet "$sha"
+  while read -r d; do [ -n "$d" ] && need "$d"; done < <(deps "$dir")
+  R CMD INSTALL --no-docs --no-help "$dir"
+}
+
+# CVXR first, so the resolver cannot reach a newer one transitively (see above).
+need CVXR "$CVXR_SHA"
+
+# quadprog is declared in DiSCos' *Suggests*, not Imports, so a correct
+# Depends/Imports resolve skips it -- and then `library(DiSCos)` succeeds while
+# the first real fit dies with "quadprog needed for this function to work".
+# It is a hard runtime requirement of the default (non-mixture) weights solver;
+# R/DiSCo_weights_reg.R guards it with requireNamespace. Installed explicitly
+# above via apt; asserted here so a change to the apt list cannot silently drop
+# it.
+need quadprog
+
+# Optional quantile-estimation backends. evmix backs qmethod = "qkden" and
+# extremeStat backs qmethod = "extreme"; each is used at exactly one call site.
+# Dropping them cuts the build substantially but makes those options unavailable,
+# which is not acceptable for a reference meant to cross-check arbitrary options.
+for p in data.table ggplot2 pracma Rdpack MASS evmix extremeStat; do
+  need "$p"
+done
+
+echo "  building DiSCos @ ${DISCOS_SHA:0:8}"
+rm -rf "$SRC/DiSCos"
+git clone --quiet https://github.com/Davidvandijcke/DiSCos "$SRC/DiSCos"
+git -C "$SRC/DiSCos" checkout --quiet "$DISCOS_SHA"
+while read -r d; do [ -n "$d" ] && need "$d"; done < <(deps "$SRC/DiSCos")
+R CMD INSTALL --no-docs --no-help "$SRC/DiSCos"
+
+# `library(DiSCos)` is NOT a sufficient check -- that is exactly what passes
+# while quadprog is missing. Run a real fit, on the default non-mixture path
+# that quadprog backs.
+Rscript -e '
+  suppressMessages({library(DiSCos); library(data.table)})
+  data(dube)
+  d <- DiSCo(copy(dube), id_col.target = 2, t0 = 2003, G = 100, M = 100,
+             num.cores = 1, seed = 1, simplex = TRUE, q_max = 0.9)
+  stopifnot(abs(sum(d$weights) - 1) < 1e-6)
+  cat("DiSCos", as.character(packageVersion("DiSCos")),
+      "/ CVXR", as.character(packageVersion("CVXR")),
+      "OK (real fit, sum(weights) =", sprintf("%.6f", sum(d$weights)), ")\n")'


### PR DESCRIPTION
## Related Links

- `benchmarks/R/install_discos.sh` — the provisioner
- `agents/agents_discos_install.md` — the runbook, including the two things the resolver cannot get right on its own
- `agents/agents_r_environment.md` — the general sandbox constraints this builds on
- Issue #304 — the first thing running this reference found
- Reference: [`Davidvandijcke/DiSCos`](https://github.com/Davidvandijcke/DiSCos) 0.1.4 @ `ed2b3d94`

## What

- Added `benchmarks/R/install_discos.sh`
- Added `agents/agents_discos_install.md`

## Why

`DiSCos` is the author's reference for mlsynth's `DSC` and `DSCAR` ports, and `benchmarks/cases/dsc_dube.py` pins five of its six rows against mlsynth's own output because no live reference was installable. The only externally anchored row is the vignette's `p > 0.05` — one bit of information, which a materially wrong DSC could still satisfy.

That gap was real, and running the reference closed it immediately: DiSCos disagrees with mlsynth on donor weights by up to 0.074 on identical data, with the two reaching pre-period objective values 4 percent apart. Filed as #304. The benchmark suite could not have found that, because nothing in it was checking against anything outside mlsynth.

## How

The sandbox constraints match augsynth's — CRAN blocked, `codeload` blocked, apt and git-over-HTTPS open. What differs is the depth of the tree. augsynth needed three source builds from a hand-written list; DiSCos needs twelve, and the list is not knowable up front: `extremeStat` alone pulls `lmomco`, `Lmoments`, `berryFunctions`, `evir`, `ismev`, `extRemes`, `distillery` and `Renext`, none of which apt carries.

So the script does not hand-list dependencies. `need <Pkg>` prefers the apt binary, otherwise clones `cran/<Pkg>`, recurses through that package's own Depends/Imports/LinkingTo (parsed with `read.dcf`, base and recommended excluded), and compiles. Worth reusing for any future R reference.

Two things the resolver cannot get right on its own, both encoded in code rather than left to comments:

**CVXR is pinned to 1.0-15 and resolved before the loop**, so nothing can reach a newer one transitively. DiSCos declares a bare `CVXR`, and 1.9.1 is a wall rather than an inconvenience: `>= 1.8` wants `Matrix >= 1.7` and `Rcpp >= 1.1`, which Noble does not ship, and adds `clarabel`, which needs a full Rust toolchain.

**`quadprog` gets its own explicit `need`** despite apt installing it above. It sits in DiSCos' `Suggests`, not `Imports`, so a correct Depends/Imports resolve skips it — and then `library(DiSCos)` succeeds while the first real fit dies in the default weights solver. Asserting it separately means a future edit to the apt list cannot silently drop it.

## Verification

The script's exit condition is a real `DiSCo()` fit asserting `sum(weights) ≈ 1`, not `library(DiSCos)` loading. That distinction is the whole `quadprog` lesson — and this session has produced three other cases where something reported success without having run: a benchmark case never registered (#300), a CI check skipped by a paths filter (#302), and my own claim that R could not read parquet here.

```
DiSCos 0.1.4 / CVXR 1.0.15 OK (real fit, sum(weights) = 1.000000 )
```

The resolver built exactly the twelve packages the runbook predicts, in dependency order, plus DiSCos and nothing else. `scs` is the one worth noting: it appears nowhere in the script and was pulled in automatically as a CVXR dependency.

Re-checked independently of the installer's own assertion: 652,870 rows, 33 donors, `sum(weights)` 1.0000000000. The donor count matches what `dsc_dube` reports, which is the first corroboration that case has had from outside mlsynth.

Path: not applicable — this adds no numerical code and moves no pinned value. It provisions the reference that later cross-validation will assert against, captured into `benchmarks/reference/` per `agents_benchmarking.md` so CI still needs no R.

## Scope checks

None of the four blocks fits: this is tooling plus its runbook. No estimator, no config, no result contract, no benchmark case, no pinned value.

## Test Steps

- [x] `bash benchmarks/R/install_discos.sh` — completes and passes its real-fit assertion
- [x] Independent re-check outside the script — 33 donors, weights sum to 1.0000000000
- [x] Both documented hand-warnings confirmed: CVXR needed the 1.0 pin; `quadprog` needed explicit installation despite `Suggests`
- [ ] Full suite — unaffected (no Python touched), but CI runs it anyway

## Other Notes

Wall time was about 45 minutes here, on a container simultaneously running an unrelated R job; budget 15–25 on an idle one.

Two things I got wrong on the way, recorded because both were failures of searching rather than of reasoning. I first concluded R could not read parquet in this sandbox after `install.packages()` hit the CRAN 403 — two benchmarks already did it via `nanoparquet` and a git clone, which a grep would have shown in seconds. And I reported the installer as still running for 45 minutes after it finished, because `pgrep -f install_discos.sh` was matching my own watcher loop.

The daily `benchmarks.yml` picks this up automatically: it runs `for s in benchmarks/R/install_*.sh`, so no workflow change is needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_