### PR TITLE
TSSC: fit a single variant, and optionally skip inference

### DIFF
--- a/docs/tssc.rst
+++ b/docs/tssc.rst
@@ -492,6 +492,54 @@ difference-in-differences; see :doc:`replications/ferman_pinto_mc`. That case's
 free-intercept requirement is what surfaced -- and fixed -- a bug in which
 ``MSCa`` had wrongly constrained its intercept to be non-negative.
 
+Fitting one variant, and skipping inference
+-------------------------------------------
+
+The default is the estimator as Li and Shankar define it: fit all four
+variants, run Step 1, report the recommended one. Two situations want less.
+
+If you already know which variant you want, ``method`` fits that one alone.
+The common case is the demeaned synthetic control, which is exactly ``MSCa``:
+
+.. code-block:: python
+
+   res = TSSC({
+       "df": df, "outcome": "y", "treat": "treated",
+       "unitid": "state", "time": "year",
+       "method": "MSCa",          # demeaned SC, no Step 1
+   }).fit()
+
+This is an override rather than a preference. Step 1 is skipped, not run and
+ignored, so ``res.selection`` is ``None`` and no recommendation is reported --
+fabricating one equal to your choice would misrepresent the test as having
+endorsed it. The variant that produced the result is still readable from
+``res.recommended_method`` and from
+``res.method_details.parameters_used["variant"]``, and
+``parameters_used["step1_run"]`` records that the test did not run.
+
+If you also do not need a confidence interval, ``inference=False`` drops the
+subsampling. That is what dominates the runtime: at the default 500 draws a fit
+of the kind used in a simulation takes on the order of ten seconds, almost all
+of it interval construction, so a thousand-replication study spends hours
+computing something it never reads.
+
+.. code-block:: python
+
+   res = TSSC({..., "method": "MSCa", "inference": False}).fit()
+
+``inference=False`` requires ``method``, because Step 1 is itself a subsampling
+procedure: with the subsampling off there is no way to recommend a variant, and
+no way to know which variant the reported summary should describe. Asking for
+one without the other raises rather than guessing.
+
+Neither option changes a number. Selecting a variant returns bit-identical
+weights, counterfactual and ATT to reading that variant off a full run, and
+turning inference off leaves the point estimate untouched -- both pinned in
+``mlsynth/tests/test_tssc_variant_select.py``. The one quantity that does move
+is the confidence interval itself: a single-variant fit draws its own
+subsampling stream rather than replaying the position the full run would have
+reached, so the interval can differ in its last digits.
+
 Core API
 --------
 

--- a/mlsynth/estimators/tssc.py
+++ b/mlsynth/estimators/tssc.py
@@ -57,9 +57,17 @@ class TSSC:
     Returns
     -------
     TSSCResults
-        Container with all four SC-class variant fits, the Step-1
-        selection record, and a standardized ``summary`` for the
-        recommended variant.
+        Container with the SC-class variant fits, the Step-1 selection
+        record, and a standardized ``summary`` for the recommended variant.
+
+    Notes
+    -----
+    By default all four variants are fit and Step 1 recommends one. Setting
+    ``config.method`` fits that variant alone and skips Step 1 entirely, so
+    ``results.selection`` is None and ``recommended_method`` names the forced
+    variant; ``config.inference=False`` additionally drops the subsampling
+    confidence intervals, which dominate the runtime. Neither option changes a
+    point estimate. See :class:`~mlsynth.utils.tssc_helpers.config.TSSCConfig`.
     """
 
     def __init__(self, config: Union[TSSCConfig, dict]) -> None:
@@ -81,6 +89,8 @@ class TSSC:
         self.alpha: float = config.alpha
         self.subsample_size = config.subsample_size
         self.draws: int = config.draws
+        self.method = config.method
+        self.inference: bool = config.inference
         self.ci: float = config.ci
         self.seed = config.seed
         self.display_graphs: bool = config.display_graphs
@@ -99,7 +109,14 @@ class TSSC:
                 time=self.time, treat=self.treat,
             )
 
+            # Only the requested variant is fit. The point estimate is a
+            # deterministic QP and does not depend on the RNG, so it matches the
+            # full run exactly; the confidence interval is a fresh subsampling
+            # draw rather than a replay of the full run's stream position, and
+            # so may differ in its last digits. Pinned in
+            # tests/test_tssc_variant_select.py.
             ci_rng = np.random.default_rng(self.seed)
+            wanted = METHODS if self.method is None else (self.method,)
             variants = {
                 method: fit_variant(
                     inputs, method, n_bootstrap=self.draws,
@@ -108,22 +125,32 @@ class TSSC:
                     scpi_sims=self.scpi_sims, scpi_alpha=self.scpi_alpha,
                     scpi_e_method=self.scpi_e_method,
                     scpi_seed=int(self.seed) if self.seed is not None else 0,
+                    compute_ci=self.inference,
                 )
-                for method in METHODS
+                for method in wanted
             }
 
-            selection = select_method(
-                inputs=inputs,
-                alpha=self.alpha,
-                subsample_size=self.subsample_size,
-                n_subsamples=self.draws,
-                seed=self.seed,
-            )
+            if self.method is None:
+                selection = select_method(
+                    inputs=inputs,
+                    alpha=self.alpha,
+                    subsample_size=self.subsample_size,
+                    n_subsamples=self.draws,
+                    seed=self.seed,
+                )
+                chosen = selection.recommended
+            else:
+                # Step 1 is skipped, not overridden: there is no recommendation
+                # to report once the caller has made the choice, and reporting
+                # one would misrepresent the test as having endorsed it.
+                selection = None
+                chosen = self.method
 
             summary = build_summary(
                 inputs=inputs,
-                variant=variants[selection.recommended],
+                variant=variants[chosen],
                 selection=selection,
+                method_name=chosen,
             )
 
             results = TSSCResults(

--- a/mlsynth/tests/test_tssc_variant_select.py
+++ b/mlsynth/tests/test_tssc_variant_select.py
@@ -1,0 +1,270 @@
+"""Choosing a single TSSC variant, and running it without inference.
+
+``TSSC`` fits all four SC-class variants (SC, MSCa, MSCb, MSCc), runs Step 1 --
+a subsampling test of the SC pretrends restriction -- to recommend one, and
+attaches a subsampling confidence interval to each variant. That is the
+estimator, and it stays the default.
+
+Two situations want less than that. A caller who wants the demeaned synthetic
+control specifically wants ``MSCa`` and nothing else (Ferman & Pinto 2021;
+``benchmarks/cases/ferman_demeaned_basque.py`` already reaches into
+``variants["MSCa"]`` for exactly this). And a Monte Carlo wants a point estimate
+many thousands of times and never reads a confidence interval. At the default
+500 draws a single fit costs about 12 s, so one 1000-replication arm is over
+three hours of subsampling that nothing consumes.
+
+Hence two knobs:
+
+``method``
+    Fit one named variant instead of all four. Step 1 is *skipped*, not
+    overridden -- there is no recommendation to make once the variant is
+    chosen -- so ``selection`` comes back as ``None``.
+``inference``
+    Skip the subsampling confidence intervals.
+
+The load-bearing property is that neither knob may move a number. Selecting
+``MSCa`` must give bit-identical estimates to reading ``variants["MSCa"]`` off a
+full run, and turning inference off must not perturb the point estimate. Both
+are asserted below rather than assumed, because a change that silently altered
+the estimate while making it faster would look like a success.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+METHODS = ("SC", "MSCa", "MSCb", "MSCc")
+
+
+@pytest.fixture(scope="module")
+def panel():
+    """A small balanced panel with one treated unit.
+
+    Deliberately modest (16 donors, 40 periods) so the full four-variant run
+    with inference stays affordable inside the suite -- several tests below
+    need a full run to compare against.
+    """
+    rng = np.random.default_rng(11)
+    rows = []
+    for j in range(17):
+        level = rng.normal(0.0, 1.0)
+        slope = rng.normal(0.05, 0.02)
+        for t in range(40):
+            rows.append({"u": f"u{j}", "t": t,
+                         "y": level + slope * t + rng.normal(0.0, 0.25)})
+    d = pd.DataFrame(rows)
+    d["treat"] = ((d.u == "u0") & (d.t >= 30)).astype(int)
+    return d
+
+
+def _fit(panel, **kw):
+    from mlsynth import TSSC
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return TSSC({"df": panel, "outcome": "y", "treat": "treat", "unitid": "u",
+                     "time": "t", "display_graphs": False, "seed": 7,
+                     "draws": 40, **kw}).fit()
+
+
+@pytest.fixture(scope="module")
+def full(panel):
+    """One full default run, reused by the equivalence tests."""
+    return _fit(panel)
+
+
+class TestTheDefaultIsUnchanged:
+    """Adding the options must not move any existing result."""
+
+    def test_all_four_variants_are_still_fit(self, full):
+        assert set(full.variants) == set(METHODS)
+
+    def test_step_one_still_runs_and_recommends(self, full):
+        assert full.selection is not None
+        assert full.selection.recommended in METHODS
+
+    def test_inference_is_still_populated(self, full):
+        ci = full.variants["MSCa"].att_ci
+        assert len(ci) == 2 and np.all(np.isfinite(ci))
+
+    def test_omitting_the_new_options_is_identical_to_passing_the_defaults(self, panel):
+        a = _fit(panel)
+        b = _fit(panel, method=None, inference=True)
+        assert a.summary.effects.att == b.summary.effects.att
+        for m in METHODS:
+            assert a.variants[m].att == b.variants[m].att
+
+
+class TestSelectingOneVariant:
+    """``method="MSCa"`` fits that variant and nothing else."""
+
+    @pytest.mark.parametrize("m", METHODS)
+    def test_only_the_requested_variant_is_fit(self, panel, m):
+        res = _fit(panel, method=m)
+        assert set(res.variants) == {m}
+
+    @pytest.mark.parametrize("m", METHODS)
+    def test_the_estimate_is_bit_identical_to_the_full_run(self, panel, full, m):
+        """The whole point: this is a cheaper route to the same number.
+
+        Bit-identical, not approximately equal -- the variant fit does not
+        depend on which other variants were fit alongside it, and if that ever
+        stops being true it is a bug worth failing on.
+        """
+        res = _fit(panel, method=m)
+        assert res.variants[m].att == full.variants[m].att
+        np.testing.assert_array_equal(
+            np.asarray(res.variants[m].counterfactual, dtype=float),
+            np.asarray(full.variants[m].counterfactual, dtype=float))
+
+    def test_the_summary_is_the_requested_variant(self, panel, full):
+        res = _fit(panel, method="MSCb")
+        assert res.summary.effects.att == full.variants["MSCb"].att
+
+    def test_step_one_is_skipped_not_overridden(self, panel):
+        """``selection`` is absent rather than pointing at the forced variant.
+
+        Stated as behaviour because fabricating a recommendation equal to the
+        forced method would be the natural shortcut, and it would misreport
+        Step 1 as having endorsed a choice the user made.
+        """
+        res = _fit(panel, method="MSCa")
+        assert res.selection is None
+
+    def test_the_forced_variant_is_recorded_somewhere_visible(self, panel):
+        """A reader of the result must be able to tell which variant produced
+        it, now that ``selection`` no longer says."""
+        res = _fit(panel, method="MSCa")
+        details = res.summary.method_details
+        assert details is not None
+        assert "MSCa" in str(details.method_name) or "MSCa" in str(details)
+
+
+class TestTheResultSurfaceStillWorks:
+    """The flat accessors must not break when Step 1 was skipped.
+
+    ``TSSCResults.att`` / ``att_ci`` / ``recommended`` all resolve through
+    ``selection.recommended`` on the default path. With a forced variant there
+    is no selection, and the obvious implementation raises ``AttributeError``
+    on ``None`` -- which would make ``method=`` unusable for anyone who reads
+    the result the normal way, or who leaves plotting on.
+    """
+
+    def test_the_flat_accessors_resolve_to_the_forced_variant(self, panel, full):
+        res = _fit(panel, method="MSCa")
+        assert res.att == full.variants["MSCa"].att
+        assert res.recommended.att == full.variants["MSCa"].att
+        assert len(res.att_ci) == 2
+
+    def test_recommended_method_names_the_forced_variant(self, panel):
+        res = _fit(panel, method="MSCb")
+        assert res.recommended_method == "MSCb"
+
+    def test_the_standard_submodels_are_populated(self, panel):
+        """A forced-variant result is still an EffectResult like any other."""
+        res = _fit(panel, method="MSCa")
+        for field in ("effects", "time_series", "weights", "method_details"):
+            assert getattr(res, field) is not None
+
+    def test_plotting_works_with_a_forced_variant(self, panel):
+        """Left broken, anyone using the default display_graphs=True with
+        method= would hit the plotter's `results.recommended`."""
+        import matplotlib
+        matplotlib.use("Agg")
+        from mlsynth.utils.tssc_helpers.plotter import plot_tssc
+        import matplotlib.pyplot as plt
+
+        res = _fit(panel, method="MSCa")
+        plot_tssc(res)
+        plt.close("all")
+
+
+class TestTurningInferenceOff:
+    """``inference=False`` drops the subsampling, and nothing else."""
+
+    def test_the_point_estimate_is_unchanged(self, panel, full):
+        res = _fit(panel, method="MSCa", inference=False)
+        assert res.variants["MSCa"].att == full.variants["MSCa"].att
+
+    def test_no_confidence_interval_is_reported(self, panel):
+        res = _fit(panel, method="MSCa", inference=False)
+        ci = res.variants["MSCa"].att_ci
+        assert ci is None or not np.any(np.isfinite(np.asarray(ci, dtype=float)))
+
+    def test_a_nan_interval_is_not_passed_off_as_an_interval(self, panel):
+        """If the CI comes back as NaN rather than None, the standardized
+        ``inference`` sub-model must not present it as a real interval."""
+        res = _fit(panel, method="MSCa", inference=False)
+        inf = res.summary.inference
+        if inf is not None and getattr(inf, "ci", None) is not None:
+            assert not np.all(np.isfinite(np.asarray(inf.ci, dtype=float)))
+
+    def test_it_is_materially_faster(self, panel):
+        """The reason the option exists, asserted so it cannot regress into a
+        no-op that merely hides the interval."""
+        import time
+
+        t0 = time.perf_counter(); _fit(panel, method="MSCa", inference=False)
+        fast = time.perf_counter() - t0
+        t0 = time.perf_counter(); _fit(panel, method="MSCa", inference=True, draws=400)
+        slow = time.perf_counter() - t0
+        assert fast < slow / 3.0
+
+    def test_the_seed_is_irrelevant_when_inference_is_off(self, panel):
+        """Nothing stochastic should remain, so two seeds must agree exactly."""
+        a = _fit(panel, method="MSCa", inference=False, seed=1)
+        b = _fit(panel, method="MSCa", inference=False, seed=999)
+        assert a.variants["MSCa"].att == b.variants["MSCa"].att
+
+
+class TestTheCombinationsAreCoherent:
+    """Which pairings are allowed, and what they mean."""
+
+    def test_inference_off_requires_a_method(self, panel):
+        """Step 1 is itself a subsampling procedure, so with inference off there
+        is no way to recommend a variant and no way to know which variant the
+        summary should describe. Refused at construction rather than resolved
+        by guessing.
+        """
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises(MlsynthConfigError, match="method"):
+            _fit(panel, inference=False)
+
+    def test_a_method_with_inference_on_still_gives_an_interval(self, panel):
+        res = _fit(panel, method="MSCa", inference=True)
+        ci = res.variants["MSCa"].att_ci
+        assert len(ci) == 2 and np.all(np.isfinite(ci))
+        assert res.selection is None      # still no Step 1
+
+
+class TestFailuresAreReported:
+    """Invalid input raises a translated error naming what was wrong."""
+
+    def test_unknown_variant_name(self, panel):
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises(MlsynthConfigError) as exc:
+            _fit(panel, method="MSCd")
+        assert "MSCd" in str(exc.value) or "MSCa" in str(exc.value)
+
+    def test_the_error_lists_the_valid_variants(self, panel):
+        """A caller who mistypes should not have to read the source."""
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises(MlsynthConfigError) as exc:
+            _fit(panel, method="msca")          # right variant, wrong case
+        assert all(m in str(exc.value) for m in METHODS)
+
+    def test_lowercase_is_not_silently_accepted(self, panel):
+        """Deciding this explicitly: the variant names are proper nouns from
+        Li & Shankar's Table 1, and quietly upcasing would make ``MSCa`` and
+        ``msca`` two spellings of one thing in some places and not others."""
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises(MlsynthConfigError):
+            _fit(panel, method="msca")

--- a/mlsynth/utils/tssc_helpers/config.py
+++ b/mlsynth/utils/tssc_helpers/config.py
@@ -10,9 +10,15 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from ...config_models import BaseEstimatorConfig
+from ...exceptions import MlsynthConfigError
+
+#: The SC-class variants of Li & Shankar (2023) Table 1, in the order TSSC
+#: reports them. Spelled exactly as the paper does; see ``method`` below for why
+#: the casing is not relaxed.
+TSSC_METHODS = ("SC", "MSCa", "MSCb", "MSCc")
 
 
 class TSSCConfig(BaseEstimatorConfig):
@@ -52,6 +58,32 @@ class TSSCConfig(BaseEstimatorConfig):
     subsample_size: Optional[int] = Field(default=None, ge=2,
                          description="Subsample size m; None uses T_1 (bootstrap).")
     draws: int = Field(default=500, ge=1, description="Subsampling/bootstrap replications.")
+    method: Optional[Literal["SC", "MSCa", "MSCb", "MSCc"]] = Field(
+        default=None,
+        description=(
+            "Fit one named SC-class variant instead of all four. This is an "
+            "override, not a preference: Step 1 is skipped entirely rather than "
+            "run and ignored, so no recommendation is produced and "
+            "``results.selection`` is None. Reach for it when the variant is "
+            "already decided -- 'MSCa' is the demeaned synthetic control of "
+            "Ferman & Pinto (2021) -- or when fitting all four is wasteful, as "
+            "in a simulation. None (default) runs the full two-step procedure. "
+            "Names are case-sensitive and spelled as in Li & Shankar (2023) "
+            "Table 1."
+        ),
+    )
+    inference: bool = Field(
+        default=True,
+        description=(
+            "Compute the per-variant subsampling confidence intervals. Set "
+            "False to skip them when only the point estimate is wanted; at the "
+            "default 500 draws the subsampling dominates the runtime, so a "
+            "Monte Carlo that never reads an interval pays for it many times "
+            "over. Requires ``method``, since Step 1 is itself a subsampling "
+            "procedure and cannot recommend a variant without it. The point "
+            "estimate is unaffected either way."
+        ),
+    )
     ci: float = Field(default=0.95, gt=0.0, lt=1.0, description="ATT confidence level.")
     seed: Optional[int] = Field(default=None, description="RNG seed for subsampling.")
     compute_scpi_pi: bool = Field(
@@ -81,3 +113,20 @@ class TSSCConfig(BaseEstimatorConfig):
         default="gaussian",
         description="Out-of-sample tabulation for the scpi prediction intervals.",
     )
+
+    @model_validator(mode="after")
+    def _check_variant_selection(self) -> "TSSCConfig":
+        # Pydantic's Literal already rejects unknown values, but its message
+        # does not read as an mlsynth error and buries the valid options in a
+        # type dump. The estimator translates ValidationError to
+        # MlsynthConfigError; this validator only handles the combination rule,
+        # which pydantic cannot express.
+        if not self.inference and self.method is None:
+            raise MlsynthConfigError(
+                "inference=False requires method to be set. Step 1 is itself a "
+                "subsampling procedure, so with inference off there is no way "
+                "to recommend a variant and no way to know which variant the "
+                f"summary should describe. Pass one of {list(TSSC_METHODS)}, or "
+                "leave inference=True to run the full two-step procedure."
+            )
+        return self

--- a/mlsynth/utils/tssc_helpers/estimation.py
+++ b/mlsynth/utils/tssc_helpers/estimation.py
@@ -213,8 +213,16 @@ def fit_variant(
     scpi_alpha: float = 0.05,
     scpi_e_method: str = "gaussian",
     scpi_seed: int = 0,
+    compute_ci: bool = True,
 ) -> TSSCVariantFit:
-    """Fit one SC-class variant and assemble its :class:`TSSCVariantFit`."""
+    """Fit one SC-class variant and assemble its :class:`TSSCVariantFit`.
+
+    ``compute_ci=False`` skips the subsampling confidence interval and returns
+    ``att_ci = (nan, nan)``. The weights, counterfactual and ATT are a
+    deterministic QP and are unaffected -- only the interval is dropped. The
+    subsampling dominates the runtime, so this is the difference between a fit
+    that is affordable inside a simulation loop and one that is not.
+    """
 
     if rng is None:
         rng = np.random.default_rng()
@@ -248,10 +256,14 @@ def fit_variant(
     )
     att = float(att_results["ATT"])
 
-    att_ci = bootstrap_att_ci(
-        inputs=inputs, method=method, weights=weights,
-        counterfactual=counterfactual, att=att, n_bootstrap=n_bootstrap,
-        confidence_level=confidence_level, rng=rng,
+    att_ci = (
+        bootstrap_att_ci(
+            inputs=inputs, method=method, weights=weights,
+            counterfactual=counterfactual, att=att, n_bootstrap=n_bootstrap,
+            confidence_level=confidence_level, rng=rng,
+        )
+        if compute_ci
+        else (float("nan"), float("nan"))
     )
 
     donor_weights = {

--- a/mlsynth/utils/tssc_helpers/results_assembly.py
+++ b/mlsynth/utils/tssc_helpers/results_assembly.py
@@ -7,6 +7,8 @@ into the project's standardized result models, so TSSC's public
 
 from __future__ import annotations
 
+from typing import Optional
+
 import numpy as np
 
 from ...config_models import (
@@ -24,9 +26,23 @@ from .structures import TSSCInputs, TSSCSelection, TSSCVariantFit
 def build_summary(
     inputs: TSSCInputs,
     variant: TSSCVariantFit,
-    selection: TSSCSelection,
+    selection: Optional[TSSCSelection] = None,
+    method_name: Optional[str] = None,
 ) -> BaseEstimatorResults:
-    """Standardized bundle for the Step-1-recommended TSSC variant."""
+    """Standardized bundle for one TSSC variant.
+
+    ``selection`` is None when the caller forced a variant via
+    ``TSSCConfig.method``: Step 1 is skipped in that case, so there is no
+    recommendation and no restriction tests to report. The Step-1 fields are
+    then omitted from ``method_details`` rather than filled with the forced
+    choice, which would misreport the test as having endorsed it.
+    ``method_name`` names the variant actually fit, and is required when
+    ``selection`` is absent.
+    """
+
+    if selection is None and method_name is None:  # pragma: no cover - guarded
+        raise ValueError("build_summary needs method_name when selection is None")
+    chosen = selection.recommended if selection is not None else method_name
 
     ci_lower, ci_upper = variant.att_ci
     half_width = (ci_upper - ci_lower) / 2.0
@@ -40,7 +56,7 @@ def build_summary(
             "ci_upper": t.ci_upper,
             "rejected": t.rejected,
         }
-        for name, t in selection.tests.items()
+        for name, t in (selection.tests.items() if selection is not None else ())
     }
 
     return BaseEstimatorResults(
@@ -68,18 +84,23 @@ def build_summary(
             ci_lower=ci_lower,
             ci_upper=ci_upper,
             standard_error=standard_error,
-            method="bootstrap",
-            details={"selection_alpha": selection.alpha},
+            method="bootstrap" if np.isfinite(half_width) else "none",
+            details=({"selection_alpha": selection.alpha}
+                     if selection is not None else {}),
         ),
         method_details=MethodDetailsResults(
-            method_name=f"TSSC ({selection.recommended})",
+            method_name=f"TSSC ({chosen})",
             parameters_used={
-                "recommended_method": selection.recommended,
-                "selection_alpha": selection.alpha,
-                "subsample_size": selection.subsample_size,
-                "n_subsamples": selection.n_subsamples,
-                "decision_path": list(selection.decision_path),
-                "restriction_tests": test_summary,
+                "variant": chosen,
+                "step1_run": selection is not None,
+                **({
+                    "recommended_method": selection.recommended,
+                    "selection_alpha": selection.alpha,
+                    "subsample_size": selection.subsample_size,
+                    "n_subsamples": selection.n_subsamples,
+                    "decision_path": list(selection.decision_path),
+                    "restriction_tests": test_summary,
+                } if selection is not None else {}),
             },
         ),
     )

--- a/mlsynth/utils/tssc_helpers/structures.py
+++ b/mlsynth/utils/tssc_helpers/structures.py
@@ -203,9 +203,13 @@ class TSSCResults(BaseEstimatorResults):
     inputs : TSSCInputs
         Preprocessed panel data.
     variants : dict
-        ``method_name -> TSSCVariantFit`` for all four SC-class methods.
-    selection : TSSCSelection
-        The Step-1 recommendation and its underlying tests.
+        ``method_name -> TSSCVariantFit``. All four SC-class methods by
+        default; a single entry when the caller forced one via
+        ``TSSCConfig.method``.
+    selection : TSSCSelection or None
+        The Step-1 recommendation and its underlying tests. None when the
+        caller forced a variant via ``TSSCConfig.method``, in which case Step 1
+        was skipped rather than run and overridden.
     summary : BaseEstimatorResults, optional
         Standardized result bundle for the recommended variant.
     """
@@ -214,7 +218,7 @@ class TSSCResults(BaseEstimatorResults):
 
     inputs: TSSCInputs
     variants: Dict[str, TSSCVariantFit]
-    selection: TSSCSelection
+    selection: Optional[TSSCSelection] = None
     summary: Optional[BaseEstimatorResults] = None
 
     @model_validator(mode="after")
@@ -242,13 +246,24 @@ class TSSCResults(BaseEstimatorResults):
 
     @property
     def recommended_method(self) -> str:
-        """Name of the method recommended by Step 1."""
-        return self.selection.recommended
+        """Name of the variant this result describes.
+
+        The Step-1 recommendation on the default path. When the caller forced a
+        variant via ``TSSCConfig.method`` there is no Step 1, and this names the
+        forced variant instead -- the only one fit. The name is kept for the
+        flat accessors below, which every EffectResult consumer relies on;
+        whether Step 1 actually ran is recorded on
+        ``method_details.parameters_used["step1_run"]`` and by ``selection``
+        being None.
+        """
+        if self.selection is not None:
+            return self.selection.recommended
+        return next(iter(self.variants))
 
     @property
     def recommended(self) -> TSSCVariantFit:
-        """The :class:`TSSCVariantFit` for the recommended method."""
-        return self.variants[self.selection.recommended]
+        """The :class:`TSSCVariantFit` this result describes."""
+        return self.variants[self.recommended_method]
 
     @property
     def att(self) -> float:


### PR DESCRIPTION
## Related Links

- Task 1 of #313; prerequisite for #312 (de Brabander, Juodis & Miyazato Szini 2025 replication)
- Docs: new "Fitting one variant, and skipping inference" section in `docs/tssc.rst`
- Existing consumer this unblocks: `benchmarks/cases/ferman_demeaned_basque.py`, which already reaches into `variants["MSCa"]`
- Source: Li, K. T., & Shankar, V. (2023), "A Two-Step Synthetic Control Approach for Estimating Causal Effects of Marketing Events", *Management Science*

## What

- Added `TSSCConfig.method` — fit one named SC-class variant (`SC` / `MSCa` / `MSCb` / `MSCc`) instead of all four
- Added `TSSCConfig.inference` — skip the per-variant subsampling confidence intervals
- `TSSCResults.selection` is now `Optional`; `build_summary` and `fit_variant` take the corresponding arguments
- Fixed the flat accessors (`att`, `att_ci`, `recommended`, `recommended_method`) to work when Step 1 was skipped
- Added `mlsynth/tests/test_tssc_variant_select.py` (29 tests) and a docs section

## Why

The demeaned synthetic control of Ferman & Pinto (2021) is exactly TSSC's `MSCa`, and `ferman_demeaned_basque` already reaches into `variants["MSCa"]` to get it — so the estimator is reachable, just not cheaply. Every call fits all four variants and runs 500 subsampling draws for each, and #312's Monte Carlo needs the point estimate a thousand times per arm with no interval at all.

Measured on a 21-unit, 60-period panel:

| `draws` | one `fit()` | × 1000 replications |
|---|---|---|
| 500 (default) | 12.34 s | 3.4 hours |
| 50 | 1.22 s | 20 min |
| 5 | 0.15 s | 2.5 min |

Almost all of that is interval construction. The Monte Carlo is `γ ∈ {0, 0.25, 1, 1.5}` × `σ ∈ {0.25, 1}` — eight arms — so roughly 27 hours computing something the simulation never reads. Setting `draws=5` is not the fix: it abuses an inference parameter to mean "skip inference", still fits four variants, and leaves a meaningless interval on the result.

## How

Two design calls worth reviewing, since neither is forced by the requirement.

`method` skips Step 1 rather than overriding it. `selection` comes back `None`, and no recommendation is reported. Fabricating one equal to the user's own choice would misrepresent the subsampling test as having endorsed it. Which variant ran stays readable from `recommended_method` and from `method_details.parameters_used`, which now carries `"variant"` and `"step1_run"`.

`inference=False` requires `method`. Step 1 is itself a subsampling procedure, so with the subsampling off there is neither a recommendation nor a way to know which variant the summary should describe. Refused at construction with an error naming the valid variants, rather than resolved by guessing.

## Verification

- Path: not applicable — this adds options to an existing estimator and changes no numerical code. The relevant check is that nothing moves.

| Quantity | Tolerance |
|---|---|
| default run vs explicitly passing the defaults | bit-identical |
| `method="X"` weights / counterfactual / ATT vs `variants["X"]` from a full run | bit-identical |
| point estimate with `inference=False` vs `inference=True` | bit-identical |
| `inference=False` under two different seeds | bit-identical |

- Full suite: 5665 passed, 331 skipped, 0 failed
- `python benchmarks/run_benchmarks.py --case ferman_demeaned_basque` — 1/1 passed, unchanged
- Docs build clean (the two `TSSCSample` autosummary warnings are pre-existing)

One behaviour does change, and it is stated in the code and the docs rather than left to be discovered: a single-variant fit draws its own subsampling stream instead of replaying the position a full run would have reached, so its confidence interval can differ in the last digits. Point estimates are unaffected, which is what the bit-identical pins above cover.

### A defect the tests caught

Writing them first paid for itself. `TSSCResults.att`, `att_ci`, `recommended` and `recommended_method` all resolve through `selection.recommended`, so with Step 1 skipped they raised `AttributeError` on `None`. That would have made `method=` unusable for anyone reading the result the ordinary way, or leaving `display_graphs` at its default — the plotter goes through `results.recommended` too. The accessors now fall back to the single fitted variant, and a test plots a forced-variant result so the path stays exercised.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR

- [x] The default preserves existing behaviour exactly — asserted bit-identical, not merely "still runs"
- [x] Existing pinned benchmark values unchanged; `ferman_demeaned_basque` re-run and unchanged
- [x] A test pins that the default is unchanged (`TestTheDefaultIsUnchanged`)
- [x] Both new config fields have `Field(...)` descriptions saying when to reach for them, and `method`'s says plainly that Step 1 is skipped

## Designs

No plotting changes, but plotting is newly exercised on a forced-variant result — previously `plot_tssc` would have raised on `selection is None`.

## Test Steps

- [x] `pytest mlsynth/tests/test_tssc_variant_select.py -q` — 29 passed
- [x] `pytest mlsynth/tests/ -k "tssc or result_contract" -q` — 258 passed, 5 skipped
- [x] `pytest mlsynth/tests/` — 5665 passed, 331 skipped, 0 failed
- [x] `python benchmarks/run_benchmarks.py --case ferman_demeaned_basque` — 1/1 passed
- [x] Docs build, section underlines checked

## Other Notes

- Variant names are case-sensitive; `"msca"` raises rather than being upcast. They are proper nouns from Li & Shankar's Table 1, and quietly accepting both spellings would make them equivalent in some places and not others. Pinned as a test so the decision is visible rather than incidental.
- Task 2 of #313 (SDID covariate handling) is the substantial one and is next. The adopted design is the dict form, `covariates={"adjust": [...], "match": [...]}` — see the comment on #313 for why that beats a separate selector field.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_