### PR TITLE
Let SDID's unit-weight ridge be set by the caller

### DIFF
--- a/docs/sdid.rst
+++ b/docs/sdid.rst
@@ -311,6 +311,61 @@ This is Equation 2 of Ciccia (2024). Each cohort is fit independently
 inside
 :func:`mlsynth.utils.sdid_helpers.cohort.estimate_cohort_sdid_effects`.
 
+Choosing the unit-weight penalty
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The term :math:`T_0 \zeta^2 \|\mathbf{w}\|_2^2` in the unit-weight program is
+the one free quantity in the two displays above, and it is worth being explicit
+about what sets it. Arkhangelsky et al. (2021) calibrate it to the noise the
+weights are being asked not to chase,
+
+.. math::
+
+   \zeta \;=\; \bigl(N_{tr}\, T_{post}\bigr)^{1/4}\, \widehat\sigma,
+   \qquad
+   \widehat\sigma^{\,2}
+   \;=\;
+   \frac{1}{N_{co}(T_{pre} - 1) - 1}
+   \sum_{i=1}^{N_{co}} \sum_{t=1}^{T_{pre}-1}
+     \bigl(\Delta_{it} - \overline{\Delta}\bigr)^{2},
+   \qquad
+   \Delta_{it} = y_{i,t+1} - y_{it},
+
+with :math:`\overline{\Delta}` the mean first difference over the same donor
+block. Two things follow from the shape of :math:`\zeta`. It grows with the
+volatility of the donors, so a noisy panel is pulled further toward equal
+weights; and it grows in :math:`N_{tr} T_{post}`, so a design with many treated
+units and a long post-period is regularized more strongly than a
+single-treated, short-horizon one on identical outcomes. That is the default,
+and it is what :math:`\zeta` means everywhere else on this page.
+
+It is not, however, universal. A published SDID analysis may set the penalty
+itself, and the value it sets is part of the specification rather than a
+detail: at :math:`\zeta = 0` the program is the unpenalised simplex least
+squares, which fits the pre-period more closely and tends to put weight on
+fewer donors, while as :math:`\zeta \to \infty` the objective is dominated by
+:math:`\|\mathbf{w}\|_2^2` and :math:`\mathbf{w}^\ast` approaches the uniform
+weights :math:`1/N_{co}`, i.e. plain difference-in-differences against the
+donor average. The estimate therefore moves continuously between a synthetic
+control and a DiD as the penalty rises, and reproducing someone else's number
+means using their point on that path.
+
+:py:attr:`SDIDConfig.zeta` supplies it. Left as ``None`` (the default) the
+formula above is used, recomputed per cohort from that cohort's own donors and
+horizon; given a number, that number is used for every cohort instead. Time
+weights are untouched either way -- their penalty is a separate quantity that
+SDID fixes at machine precision, for the reason given under Assumption 3.
+
+.. code-block:: python
+
+   # de Brabander, Juodis & Miyazato Szini (2025) run their Brexit study with
+   # the unit-weight penalty switched off.
+   res = SDID({
+       "df": df, "outcome": "lgdp", "treat": "brexit",
+       "unitid": "country", "time": "quarter",
+       "zeta": 0.0,
+   }).fit()
+
 Cohort-Specific Event Study (Equation 3)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/mlsynth/estimators/sdid.py
+++ b/mlsynth/estimators/sdid.py
@@ -74,6 +74,12 @@ class SDID:
     before the estimator runs. See
     :mod:`mlsynth.utils.sdid_helpers.covariates`.
 
+    Setting ``zeta`` replaces the data-driven unit-weight ridge
+    ``(N_tr * T_post)^(1/4) * sigma_hat`` with a fixed value, for reproducing a
+    published specification that set the penalty itself; ``zeta=0`` leaves the
+    unit weights unpenalised. Left as None (the default) the parameter is
+    computed per cohort as Arkhangelsky et al. (2021) prescribe.
+
     References
     ----------
     Arkhangelsky, D., Athey, S., Hirshberg, D., Imbens, G., & Wager, S. (2021).
@@ -124,6 +130,7 @@ class SDID:
         self.target_subgroup = config.target_subgroup
         self.covariates = config.covariates
         self.match_pre_periods = config.match_pre_periods
+        self.zeta = config.zeta
 
         self.display_graphs: bool = config.display_graphs
         self.save: Any = config.save
@@ -148,6 +155,7 @@ class SDID:
                 target_subgroup=self.target_subgroup,
                 covariates=self.covariates,
                 match_pre_periods=self.match_pre_periods,
+                zeta=self.zeta,
             )
         except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
             raise

--- a/mlsynth/tests/test_sdid_zeta_override.py
+++ b/mlsynth/tests/test_sdid_zeta_override.py
@@ -1,0 +1,295 @@
+"""Overriding SDID's unit-weight ridge.
+
+SDID regularises the unit weights by :math:`T_{pre}\\zeta^2` with
+``zeta = (N_tr * T_post)^(1/4) * sigma_hat``, ``sigma_hat`` the standard
+deviation of the first-differenced control outcomes (Arkhangelsky et al. 2021;
+``synthdid``'s ``zeta.omega``). That is the right default and it stays the
+default.
+
+It is not, however, what every published SDID analysis uses. de Brabander,
+Juodis & Miyazato Szini (2025) pass ``zeta.omega = 0`` throughout their Brexit
+study, and without a way to say the same thing mlsynth cannot express their
+specification at all -- their Table 1 SDID column sits 0.06 to 0.11 percentage
+points away purely because of a penalty they switched off. Hence ``zeta``.
+
+The option is a number, not a flag, because the quantity is a number: a caller
+reproducing a paper needs whatever value that paper used, and zero is only the
+most common such value.
+
+What must not change is everything else. ``zeta=None`` computes the parameter
+from the data exactly as before, and the tests below assert that against a
+frozen reference rather than against the estimator's own output.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+_KRANZ = (Path(__file__).resolve().parents[2] / "benchmarks" / "reference"
+          / "sdid_kranz")
+_BREXIT = (Path(__file__).resolve().parents[2] / "benchmarks" / "reference"
+           / "brabander_sdid_match" / "brexit_panel.csv")
+
+
+@pytest.fixture(scope="module")
+def panel():
+    p = _KRANZ / "panel.csv"
+    if not p.exists():  # pragma: no cover - gold is committed
+        pytest.skip(f"missing {p}")
+    return pd.read_csv(p)
+
+
+@pytest.fixture(scope="module")
+def brexit():
+    if not _BREXIT.exists():  # pragma: no cover - gold is committed
+        pytest.skip(f"missing {_BREXIT}")
+    return pd.read_csv(_BREXIT)
+
+
+def _att(df, **extra):
+    from mlsynth import SDID
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return float(SDID({
+            "df": df, "outcome": "y", "treat": "treat_exp", "unitid": "i",
+            "time": "t", "vce": "noinference", "display_graphs": False,
+            **extra}).fit().effects.att)
+
+
+def _gap_at(df, t, **extra):
+    """Per-period gap on the Brexit panel, as a percentage loss.
+
+    The paper reports the effect in a named quarter rather than the post-period
+    average, so the comparison has to read the gap at that period.
+    """
+    from mlsynth import SDID
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = SDID({
+            "df": df, "outcome": "y", "treat": "treat", "unitid": "country",
+            "time": "t", "vce": "noinference", "display_graphs": False,
+            **extra}).fit()
+    ts = res.time_series
+    g = dict(zip(np.asarray(ts.time_periods).ravel().tolist(),
+                 np.asarray(ts.estimated_gap, dtype=float).ravel().tolist()))
+    return -100.0 * g[t]
+
+
+class TestTheDefaultIsUnchanged:
+    """Adding the option must not move any existing estimate."""
+
+    def test_omitting_zeta_is_identical_to_passing_none(self, panel):
+        assert _att(panel) == _att(panel, zeta=None)
+
+    def test_the_frozen_gold_still_reproduces(self, panel):
+        """Pinned against the #309 reference, not against the estimator itself."""
+        txt = (_KRANZ / "gold.txt").read_text().splitlines()
+        gold = {k.strip(): v.strip()
+                for k, v in (l.split(":", 1) for l in txt if ":" in l)}
+        assert _att(panel) == pytest.approx(
+            float(gold["tau_unadjusted_converged"]), abs=1e-6)
+
+    def test_passing_the_computed_value_reproduces_the_default(self, panel):
+        """The override is the same quantity the estimator computes, not a
+        differently-scaled one. Recomputing it by hand and passing it back must
+        return the default answer."""
+        from mlsynth.utils.sdid_helpers.weights import compute_regularization
+
+        Y = panel.pivot(index="t", columns="i", values="y")
+        treated = sorted(panel.loc[panel.treat_exp == 1, "i"].unique())
+        donors = [c for c in Y.columns if c not in treated]
+        T0 = 15
+        z = compute_regularization(Y.loc[Y.index[:T0], donors].to_numpy(),
+                                   Y.shape[0] - T0,
+                                   num_treated_units=len(treated))
+        assert _att(panel, zeta=float(z)) == pytest.approx(_att(panel), abs=1e-9)
+
+
+class TestTheOverrideTakesEffect:
+    """A different penalty gives a different answer, in the expected direction."""
+
+    def test_zero_differs_from_the_default(self, panel):
+        assert abs(_att(panel, zeta=0.0) - _att(panel)) > 1e-6
+
+    def test_a_large_penalty_drives_the_weights_toward_uniform(self, panel):
+        """The ridge's own definition, asserted rather than assumed.
+
+        With a penalty far larger than the fit, the objective is dominated by
+        ``||w||^2``, whose simplex minimiser is the uniform point.
+        """
+        from mlsynth import SDID
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = SDID({
+                "df": panel, "outcome": "y", "treat": "treat_exp", "unitid": "i",
+                "time": "t", "vce": "noinference", "display_graphs": False,
+                "zeta": 1e6}).fit()
+        w = np.array(list(res.donor_weights.values()), dtype=float)
+        np.testing.assert_allclose(w, np.full_like(w, 1.0 / w.size),
+                                   rtol=0, atol=1e-4)
+
+    def test_the_estimate_is_monotone_in_the_penalty(self, panel):
+        """Not a coincidence of one value: the estimate moves steadily from the
+        unpenalised fit toward the uniform-weight one."""
+        vals = [_att(panel, zeta=z) for z in (0.0, 50.0, 200.0, 1e6)]
+        diffs = [abs(v - vals[-1]) for v in vals]
+        assert diffs == sorted(diffs, reverse=True)
+
+    def test_weights_stay_on_the_simplex(self, panel):
+        from mlsynth import SDID
+
+        for z in (0.0, 100.0):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                res = SDID({
+                    "df": panel, "outcome": "y", "treat": "treat_exp",
+                    "unitid": "i", "time": "t", "vce": "noinference",
+                    "display_graphs": False, "zeta": z}).fit()
+            w = np.array(list(res.donor_weights.values()), dtype=float)
+            assert w.min() >= -1e-9
+            assert w.sum() == pytest.approx(1.0, abs=1e-6)
+
+
+class TestItReproducesThePublishedBrexitNumbers:
+    """The reason the option exists.
+
+    de Brabander et al. (2025) Table 1, no covariates, treatment 2016Q3, SDID
+    case (ii): 2.79 percent at 2018Q4 and 3.92 at 2019Q4. Their case (ii) fits
+    on a panel running to the evaluation period, so the panel is truncated to
+    match; with mlsynth's own ridge the estimates sit 0.11 and 0.06 above,
+    which is what motivated this.
+
+    Not gated to the published precision. ``synthdid_estimate`` stops at
+    ``min.decrease`` where mlsynth solves the weight programs exactly, a
+    difference already documented in ``sdid_helpers/weights.py`` and worth
+    roughly this much on this panel. The assertion is that ``zeta=0`` closes
+    most of the gap, which is the claim being made.
+    """
+
+    @pytest.mark.parametrize("t,published", [(236, 2.79), (240, 3.92)])
+    def test_zero_zeta_moves_the_estimate_toward_the_published_value(
+            self, brexit, t, published):
+        d = brexit[brexit.t <= t]
+        default = _gap_at(d, t)
+        zeroed = _gap_at(d, t, zeta=0.0)
+        assert abs(zeroed - published) < abs(default - published)
+
+    @pytest.mark.parametrize("t,published", [(236, 2.79), (240, 3.92)])
+    def test_it_lands_within_a_tenth_of_a_point(self, brexit, t, published):
+        d = brexit[brexit.t <= t]
+        assert _gap_at(d, t, zeta=0.0) == pytest.approx(published, abs=0.10)
+
+    def test_the_default_does_not_get_that_close(self, brexit):
+        """The contrast that makes the test above meaningful: without the
+        override the specification simply is not expressible."""
+        d = brexit[brexit.t <= 236]
+        assert abs(_gap_at(d, 236) - 2.79) > 0.05
+
+
+class TestStaggeredAdoption:
+    """Every cohort takes the override, not only the one that sets the pre/post
+    counts on the inputs object.
+
+    Worth its own test because the default is deliberately not one number: it
+    is recomputed per cohort from that cohort's donors and horizon. Overriding
+    it means asking for a single penalty across cohorts, and a loop that stops
+    at the first payload would silently give the later cohorts the data-driven
+    value instead.
+    """
+
+    @staticmethod
+    def _staggered():
+        from mlsynth.tests.test_sdid import _make_staggered_panel
+
+        return _make_staggered_panel(seed=3)
+
+    def test_the_override_reaches_every_cohort(self):
+        from mlsynth.utils.sdid_helpers.setup import prepare_sdid_inputs
+
+        inputs = prepare_sdid_inputs(
+            df=self._staggered(), outcome="y", treat="treated",
+            unitid="state", time="year", zeta=7.0)
+        assert len(inputs.cohorts_dict) > 1
+        assert all(p["zeta_override"] == 7.0
+                   for p in inputs.cohorts_dict.values())
+
+    def test_no_key_is_written_when_none_is_given(self):
+        """The payload stays exactly as it was, so nothing downstream has to
+        distinguish 'absent' from 'None'."""
+        from mlsynth.utils.sdid_helpers.setup import prepare_sdid_inputs
+
+        inputs = prepare_sdid_inputs(
+            df=self._staggered(), outcome="y", treat="treated",
+            unitid="state", time="year")
+        assert all("zeta_override" not in p
+                   for p in inputs.cohorts_dict.values())
+
+    def test_a_staggered_fit_moves_with_the_penalty(self):
+        from mlsynth import SDID
+
+        def att(**extra):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                return float(SDID({
+                    "df": self._staggered(), "outcome": "y", "treat": "treated",
+                    "unitid": "state", "time": "year", "vce": "noinference",
+                    "display_graphs": False, **extra}).fit().effects.att)
+
+        assert abs(att(zeta=0.0) - att()) > 1e-9
+        assert np.isfinite(att(zeta=0.0))
+
+
+class TestFailuresAreReported:
+    """Invalid values are rejected when the estimator is constructed.
+
+    Construction, specifically, and the tests below never call ``fit``. A
+    negative penalty is also caught downstream by ``unit_weights``, so an
+    assertion on the fitted call would pass with no config validation at all;
+    what is being pinned here is that the caller learns the value is wrong
+    before any fitting happens, and while the message can still name the option
+    they passed rather than an internal argument.
+    """
+
+    def _construct(self, df, **extra):
+        from mlsynth import SDID
+
+        return SDID({
+            "df": df, "outcome": "y", "treat": "treat_exp", "unitid": "i",
+            "time": "t", "vce": "noinference", "display_graphs": False,
+            **extra})
+
+    def test_a_valid_zeta_constructs(self, panel):
+        """The control for the two below: construction alone is what is being
+        tested, and it succeeds for a good value."""
+        assert self._construct(panel, zeta=0.0).zeta == 0.0
+
+    def test_a_negative_zeta(self, panel):
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises(MlsynthConfigError, match="non-negative"):
+            self._construct(panel, zeta=-1.0)
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_a_non_finite_zeta(self, panel, bad):
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises(MlsynthConfigError, match="finite"):
+            self._construct(panel, zeta=bad)
+
+    def test_the_message_names_the_option(self, panel):
+        """A caller who passed ``zeta=-1`` should not be told about
+        ``regularization_parameter_zeta``, which is not something they can set."""
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises(MlsynthConfigError) as exc:
+            self._construct(panel, zeta=-1.0)
+        assert "zeta" in str(exc.value)
+        assert "regularization_parameter_zeta" not in str(exc.value)

--- a/mlsynth/utils/sdid_helpers/cohort.py
+++ b/mlsynth/utils/sdid_helpers/cohort.py
@@ -243,11 +243,18 @@ def estimate_cohort_sdid_effects(
         # synthdid's zeta.omega = (N_tr * T_post)^(1/4) * sigma. A single treated
         # unit leaves zeta unchanged; multiple treated units regularize omega
         # more strongly.
-        regularization_parameter_zeta = compute_regularization(
-            donor_outcomes_pre_treatment_cohort,
-            num_post_treatment_periods_cohort,
-            num_treated_units=cohort_treated_outcomes_matrix.shape[1],
-        )
+        # A caller-supplied zeta replaces that quantity outright rather than
+        # scaling it, so reproducing a published specification means passing the
+        # number that paper used (commonly 0, which switches the ridge off).
+        zeta_override = cohort_data_dict.get("zeta_override")
+        if zeta_override is not None:
+            regularization_parameter_zeta = float(zeta_override)
+        else:
+            regularization_parameter_zeta = compute_regularization(
+                donor_outcomes_pre_treatment_cohort,
+                num_post_treatment_periods_cohort,
+                num_treated_units=cohort_treated_outcomes_matrix.shape[1],
+            )
         # Estimate unit weights (omega) and intercept. When the caller asked for
         # covariates={"match": ...} the cohort payload carries per-unit
         # covariate summaries, and the weights come from the stacked program of

--- a/mlsynth/utils/sdid_helpers/config.py
+++ b/mlsynth/utils/sdid_helpers/config.py
@@ -6,6 +6,7 @@ Co-located with the helper package; re-exported from
 
 from __future__ import annotations
 
+import math
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import Field, field_validator, model_validator
@@ -53,6 +54,26 @@ class SDIDConfig(BaseEstimatorConfig):
     seed: int = Field(
         default=1400,
         description="Random seed used for the placebo / bootstrap resampling.",
+    )
+    zeta: Optional[float] = Field(
+        default=None,
+        description=(
+            "Ridge penalty on the unit weights, ``synthdid``'s ``zeta.omega``: "
+            "the unit-weight objective carries the term "
+            "``T_pre * zeta^2 * ||omega||^2``. None (the default) computes it "
+            "from the data as Arkhangelsky et al. (2021) prescribe, "
+            "``(N_tr * T_post)^(1/4) * sigma_hat`` with ``sigma_hat`` the "
+            "standard deviation of the first-differenced control outcomes; "
+            "that is the recommended value and nothing changes unless this is "
+            "set. Give a number to override it -- published SDID analyses do "
+            "not all use the default, and de Brabander, Juodis & Miyazato "
+            "Szini (2025) set it to 0 throughout their Brexit study, a "
+            "specification that is otherwise not expressible. A number rather "
+            "than a flag because the quantity is a number; 0 is only the most "
+            "common override. Time weights are unaffected -- their penalty is "
+            "``zeta.lambda``, which SDID sets from the machine epsilon and "
+            "which this does not touch."
+        ),
     )
     intercept_adjust: bool = Field(
         default=False,
@@ -146,6 +167,26 @@ class SDIDConfig(BaseEstimatorConfig):
                 "for covariate matching in the unit-weight problem. Both keys "
                 "may be given together."
             )
+        return v
+
+    @field_validator("zeta")
+    @classmethod
+    def _check_zeta(cls, v):
+        # A bad penalty does not fail loudly downstream: a negative one makes
+        # the weight objective non-convex and a NaN one propagates silently
+        # into every weight, so both are caught here rather than surfacing as
+        # an unexplained fit.
+        if v is None:
+            return v
+        if not math.isfinite(v):
+            raise MlsynthConfigError(
+                f"zeta must be finite; got {v}. Leave it as None (the default) "
+                "to compute the penalty from the data.")
+        if v < 0:
+            raise MlsynthConfigError(
+                f"zeta must be non-negative; got {v}. It is the coefficient on "
+                "a squared-norm penalty, so a negative value would reward "
+                "large weights. Pass 0 to switch the penalty off.")
         return v
 
     @model_validator(mode="after")

--- a/mlsynth/utils/sdid_helpers/orchestration.py
+++ b/mlsynth/utils/sdid_helpers/orchestration.py
@@ -239,6 +239,7 @@ def run_sdid(
     target_subgroup=None,
     covariates=None,
     match_pre_periods=None,
+    zeta=None,
 ) -> SDIDResults:
     """End-to-end SDID pipeline producing a typed ``SDIDResults`` object.
 
@@ -251,6 +252,11 @@ def run_sdid(
     (2022) two-step projection (:func:`adjust_outcome_for_covariates`) and
     ordinary SDID runs on the adjusted outcome. The two options are mutually
     exclusive; ``SDIDConfig`` rejects the combination.
+
+    ``zeta`` overrides the unit-weight ridge penalty, which is otherwise
+    computed per cohort from that cohort's own donor outcomes and horizon. It
+    is carried on the cohort payloads rather than passed down the call chain so
+    that the placebo resampler, which deep-copies those payloads, keeps it.
     """
 
     method_name = "SDID"
@@ -282,6 +288,7 @@ def run_sdid(
         df=df, outcome=outcome, treat=treat, unitid=unitid, time=time,
         match_covariates=match_cols or None,
         match_pre_periods=match_pre_periods,
+        zeta=zeta,
     )
     raw = estimate_event_study_sdid(
         prepped_event_study_data={"cohorts": inputs.cohorts_dict},

--- a/mlsynth/utils/sdid_helpers/setup.py
+++ b/mlsynth/utils/sdid_helpers/setup.py
@@ -137,6 +137,7 @@ def prepare_sdid_inputs(
     time: str,
     match_covariates=None,
     match_pre_periods=None,
+    zeta=None,
 ) -> SDIDInputs:
     """Prepare panel data for the SDID pipeline.
 
@@ -147,6 +148,11 @@ def prepare_sdid_inputs(
     outcome, treat, unitid, time : str
         Column names identifying the outcome, treatment indicator, units,
         and time periods.
+    zeta : float, optional
+        Unit-weight ridge penalty to use in place of the data-driven one. When
+        given it is written onto every cohort payload, so each cohort uses the
+        same penalty rather than one scaled to its own donors and horizon --
+        which is the point of overriding it.
 
     Returns
     -------
@@ -245,6 +251,10 @@ def prepare_sdid_inputs(
         n_post = int(post)
         treated_unit_name = prep["treated_unit_name"]
         donor_names = list(prep["donor_names"])
+
+    if zeta is not None:
+        for payload in cohorts_dict.values():
+            payload["zeta_override"] = float(zeta)
 
     Ywide = prep["Ywide"]
     time_labels = np.asarray(prep["time_labels"])


### PR DESCRIPTION
## Related Links

- Unblocks the SDID column of #312 (de Brabander, Juodis & Miyazato Szini 2025, Table 1). Follows #314 (TSSC variant/inference selection) and #315 (SDID covariate dict and ADH-style matching), which closed the other two gaps in that replication.
- Docs page: `docs/sdid.rst`, new subsection "Choosing the unit-weight penalty"
- Source papers: Arkhangelsky, Athey, Hirshberg, Imbens & Wager (2021), "Synthetic Difference-in-Differences", AER 111(12), [doi:10.1257/aer.20190159](https://doi.org/10.1257/aer.20190159), for the default; de Brabander, Juodis & Miyazato Szini (2025) for the specification that motivated the option
- Reference implementation the default matches: `synthdid`'s `zeta.omega`

## What

- Added `SDIDConfig.zeta`, an optional override for the unit-weight ridge penalty.
- Added `mlsynth/tests/test_sdid_zeta_override.py` — 20 tests.
- Added a docs subsection deriving the default and stating what the two limits of the penalty mean.
- Threaded the value from the config to the per-cohort weight solve.

## Why

SDID regularises the unit weights by `T_pre * zeta^2 * ||w||^2` with

    zeta = (N_tr * T_post)^(1/4) * sigma_hat

and `sigma_hat` the standard deviation of the first-differenced control outcomes. That is the right default and it stays the default.

It is not what every published SDID analysis uses. de Brabander et al. (2025) pass `zeta.omega = 0` throughout their Brexit study, and with no way to say the same thing their specification was not expressible at all. On their Table 1, case (ii), 2016Q3 treatment, no covariates:

| | published | mlsynth default | mlsynth `zeta=0` |
|---|---|---|---|
| 2018Q4 | 2.79 | 2.90 | 2.75 |
| 2019Q4 | 3.92 | 3.98 | 3.88 |

So the discrepancy was a penalty they had switched off, not a disagreement about the estimator. The residual 0.04 is the exact weight solve against `synthdid_estimate`'s `min.decrease` early stop, already documented in `sdid_helpers/weights.py` and left as is.

A number rather than a flag, because the quantity is a number: a caller reproducing a paper needs whatever value that paper used, and zero is only the most common such value.

## How

- `zeta: Optional[float] = None` on `SDIDConfig`, with a `field_validator` rejecting negative and non-finite values at construction. `unit_weights` already rejects a negative penalty, but by then the caller is told about `regularization_parameter_zeta`, an internal argument they cannot set, and only after a fit has been attempted.
- The value rides on the cohort payloads (`zeta_override`) rather than the call chain, the same way `match_pre_periods` does. The placebo resampler deep-copies those payloads, so the override survives into inference without touching the inference code.
- It is written to every cohort. The default is deliberately not one number — it is recomputed per cohort from that cohort's own donors and horizon — so asking for a fixed penalty is exactly asking not to have one scaled per cohort.
- `cohort.py` reads the key and skips `compute_regularization` when it is present; time weights are untouched, their penalty being a separate quantity SDID fixes at machine precision.

## Verification

- Path: A, on the SDID column of de Brabander et al. (2025) Table 1, plus a default-preservation check against the frozen #309 reference.
- Quantities compared: the per-period percentage loss at 2018Q4 and 2019Q4 against the published 2.79 and 3.92, pinned at `abs=0.10`. Not gated tighter, for the `min.decrease` reason above. A companion test pins that the default does not get within 0.05, so the assertion is a real contrast rather than one that would pass either way.
- Default preservation is pinned against `benchmarks/reference/sdid_kranz/gold.txt` at `abs=1e-6`, not against the estimator's own output, and separately by recomputing `compute_regularization` by hand and asserting that passing it back reproduces the default exactly.
- The ridge's own definition is asserted rather than assumed: a penalty far larger than the fit drives the weights to uniform (`atol=1e-4`), and the estimate is monotone in the penalty across `0, 50, 200, 1e6`.
- Nothing that does not match. The full de Brabander benchmark case is deliberately not in this PR — benchmark authoring is a separate workstream, and it is the next piece of #312.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR

- [x] The default preserves existing behaviour exactly — `zeta=None` computes the parameter as before, and `test_omitting_zeta_is_identical_to_passing_none` asserts bit equality
- [x] Existing pinned benchmark values unchanged; none moved
- [x] A test pins that the default is unchanged, against the frozen gold rather than against the estimator
- [x] New config field has a `Field(...)` description saying when to reach for it

## Designs

No plotting change. The counterfactual path moves only when the option is set, and by the amount in the table above.

## Test Steps

- [x] `pytest mlsynth/tests/test_sdid_zeta_override.py -q` — 20 passed
- [x] `pytest mlsynth/tests/test_sdid*.py -q` — 209 passed
- [ ] `pytest mlsynth/tests/` — full suite still running locally at the time of opening; will report here
- [x] `coverage run --timid -m pytest mlsynth/tests/test_sdid_zeta_override.py` — every new line covered, no new `# pragma: no cover`
- [x] Mutation-tested: seven mutants, all killed — dropping the override, ignoring a falsy `0.0`, rescaling it, applying it to the first cohort only, and weakening either guard

On the mutants, one is worth recording. The negative-guard mutant survived the first pass because `unit_weights` raises the same exception type with the same word "non-negative", so a test asserting on the fitted call proved nothing about config validation. The tests now construct the estimator without calling `fit`, which is the claim actually being made.

## Other Notes

- The remaining ~0.04pp on the Brexit numbers is the exact solve against `synthdid`'s early stop. Recorded, not chased.
- Next on #312: the durable benchmark case covering Tables 1 and 7 and the Monte Carlo error decomposition, on its own branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_