### PR TITLE
Compare the paper's estimator to the paper's number in the zeta tests

### DIFF
--- a/mlsynth/tests/test_sdid_zeta_override.py
+++ b/mlsynth/tests/test_sdid_zeta_override.py
@@ -9,7 +9,7 @@ default.
 It is not, however, what every published SDID analysis uses. de Brabander,
 Juodis & Miyazato Szini (2025) pass ``zeta.omega = 0`` throughout their Brexit
 study, and without a way to say the same thing mlsynth cannot express their
-specification at all -- their Table 1 SDID column sits 0.06 to 0.11 percentage
+specification at all -- their Table 1 SDID column sits 0.26 to 0.32 percentage
 points away purely because of a penalty they switched off. Hence ``zeta``.
 
 The option is a number, not a flag, because the quantity is a number: a caller
@@ -67,6 +67,15 @@ def _gap_at(df, t, **extra):
 
     The paper reports the effect in a named quarter rather than the post-period
     average, so the comparison has to read the gap at that period.
+
+    ``intercept_adjust=True`` is not a detail. The paper's estimator subtracts
+    the time-weighted pre-treatment gap,
+    ``tau = y_1T - y_0T'w - lambda'(Y_1,pre - Y_0,pre w)``, which is mlsynth's
+    intercept-adjusted counterfactual; the default un-adjusted series is a
+    different quantity and comparing it to the published number would be
+    comparing a different estimator. It is worth about 0.05 here -- small
+    enough to read as a minor disagreement rather than the wrong estimand,
+    which is exactly why it is pinned rather than assumed.
     """
     from mlsynth import SDID
 
@@ -75,7 +84,7 @@ def _gap_at(df, t, **extra):
         res = SDID({
             "df": df, "outcome": "y", "treat": "treat", "unitid": "country",
             "time": "t", "vce": "noinference", "display_graphs": False,
-            **extra}).fit()
+            "intercept_adjust": True, **extra}).fit()
     ts = res.time_series
     g = dict(zip(np.asarray(ts.time_periods).ravel().tolist(),
                  np.asarray(ts.estimated_gap, dtype=float).ravel().tolist()))
@@ -164,14 +173,21 @@ class TestItReproducesThePublishedBrexitNumbers:
     de Brabander et al. (2025) Table 1, no covariates, treatment 2016Q3, SDID
     case (ii): 2.79 percent at 2018Q4 and 3.92 at 2019Q4. Their case (ii) fits
     on a panel running to the evaluation period, so the panel is truncated to
-    match; with mlsynth's own ridge the estimates sit 0.11 and 0.06 above,
-    which is what motivated this.
+    match. With mlsynth's own ridge the estimates land at 2.53 and 3.60 --
+    0.26 and 0.32 below the published values -- which is what motivated this.
 
-    Not gated to the published precision. ``synthdid_estimate`` stops at
-    ``min.decrease`` where mlsynth solves the weight programs exactly, a
-    difference already documented in ``sdid_helpers/weights.py`` and worth
-    roughly this much on this panel. The assertion is that ``zeta=0`` closes
-    most of the gap, which is the claim being made.
+    Not gated to the paper's two printed decimals. ``synthdid_estimate`` stops
+    at ``min.decrease`` where mlsynth solves the weight programs exactly, a
+    difference already documented in ``sdid_helpers/weights.py``, and worth
+    about 0.015 on this panel. The band below is a little wider than that and
+    an order of magnitude tighter than what the default ridge produces, so it
+    separates the two specifications without claiming solver-level agreement.
+
+    The full table -- all seven estimators, both dates, and the paper's
+    in-sample placebo -- is pinned as a durable benchmark case rather than
+    here; see ``benchmarks/cases/brabander_brexit_table1.py``. What these tests
+    guard is narrower: that ``zeta`` is what makes that specification
+    reachable at all.
     """
 
     @pytest.mark.parametrize("t,published", [(236, 2.79), (240, 3.92)])
@@ -183,15 +199,17 @@ class TestItReproducesThePublishedBrexitNumbers:
         assert abs(zeroed - published) < abs(default - published)
 
     @pytest.mark.parametrize("t,published", [(236, 2.79), (240, 3.92)])
-    def test_it_lands_within_a_tenth_of_a_point(self, brexit, t, published):
+    def test_it_lands_within_a_fiftieth_of_a_point(self, brexit, t, published):
         d = brexit[brexit.t <= t]
-        assert _gap_at(d, t, zeta=0.0) == pytest.approx(published, abs=0.10)
+        assert _gap_at(d, t, zeta=0.0) == pytest.approx(published, abs=0.02)
 
-    def test_the_default_does_not_get_that_close(self, brexit):
+    @pytest.mark.parametrize("t,published", [(236, 2.79), (240, 3.92)])
+    def test_the_default_is_an_order_of_magnitude_further_away(
+            self, brexit, t, published):
         """The contrast that makes the test above meaningful: without the
         override the specification simply is not expressible."""
-        d = brexit[brexit.t <= 236]
-        assert abs(_gap_at(d, 236) - 2.79) > 0.05
+        d = brexit[brexit.t <= t]
+        assert abs(_gap_at(d, t) - published) > 0.2
 
 
 class TestStaggeredAdoption:


### PR DESCRIPTION
## Related Links

- Corrects a premise in `mlsynth/tests/test_sdid_zeta_override.py`, merged in #316.
- Found while building #317 (the durable benchmark case for this paper's Table 1), which pins the full table under the correct convention.
- Source: de Brabander, Juodis & Miyazato Szini (2025), Econometric Reviews, Table 1.

## What

- `_gap_at` now reads the intercept-adjusted counterfactual, which is the estimator the paper reports.
- Bands tightened to match: 0.02 around the published value where it was 0.10, and the contrast test requires the default to miss by more than 0.2 where it required 0.05.
- Module and class docstrings corrected — they carried the wrong figures — and the convention is written down where `_gap_at` reads it.

## Why

The tests compared mlsynth's default un-adjusted counterfactual to the paper's published Brexit figures. Those are different quantities. The paper's estimator subtracts the time-weighted pre-treatment gap,

```
tau = y_1T - y_0T'w - lambda'(Y_1,pre - Y_0,pre w)
```

which is mlsynth's `intercept_adjust=True` series.

The tests passed, and #316's conclusion is unaffected — it is in fact stronger:

| Table 1, case (ii) | published | default ridge | `zeta=0` |
|---|---|---|---|
| 2018:Q4 | 2.79 | 2.53 | 2.80 |
| 2019:Q4 | 3.92 | 3.60 | 3.94 |

Previously reported as 2.90 / 3.98 and 2.75 / 3.88. So `zeta=0` lands inside 0.02 rather than the 0.04 claimed, and the default misses by 0.26 and 0.32 rather than 0.11 and 0.06. The option matters more than the old numbers suggested. What was wrong is the quantity being pinned, not the code — no library change here.

The residual 0.015 is still `synthdid_estimate`'s `min.decrease` early stop against mlsynth's exact solve, as documented in `sdid_helpers/weights.py`.

## How

The convention is worth about 0.05 on this panel — small enough to read as a minor disagreement rather than the wrong estimand, which is why it is now stated at the point where the quantity is read rather than left implicit.

The class docstring also now points at `benchmarks/cases/brabander_brexit_table1.py` for the wider claim (all seven estimators, both dates, plus the placebo table) and keeps these tests to the narrow one: that `zeta` is what makes the paper's specification reachable at all.

## Verification

- Path: A, against de Brabander et al. (2025) Table 1, SDID case (ii).
- Compared: the per-quarter percentage loss at 2018:Q4 and 2019:Q4 to the published 2.79 and 3.92, at `abs=0.02`.
- The tightened band is what gives this teeth. With `intercept_adjust` mutated back out, the old 0.10 band still passed — it could not distinguish the two conventions — while the new one fails four tests. That mutation is the check that this fix is not cosmetic.
- Pinned durably for the full table in #317; these tests keep the narrow guard.

## Scope checks

BUG FIX

- [x] A test distinguishes the defect and fails without the fix — verified by mutation, four failures
- [x] It asserts the correct behaviour (the paper's estimand, within 0.02), not merely the absence of a crash
- [x] No docstring or comment still states the old, wrong figures
- [x] The pinned values moved because the previous ones measured the wrong quantity, not because they were re-fitted to new output

## Test Steps

- [x] `pytest mlsynth/tests/test_sdid_zeta_override.py -q` — 21 passed
- [x] `pytest mlsynth/tests/test_sdid*.py -q` — 230 passed
- [x] Mutation check: convention removed → 4 failures; restored → green

## Other Notes

`test_sdid_zeta_override.py` is the only place with this issue — `test_sdid_match_seam.py` compares weights against the R capture rather than estimates against published numbers, so it is unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_