### PR TITLE
Accept numpy scalars in numeric guards

### DIFF
--- a/mlsynth/tests/test_numpy_scalar_guards.py
+++ b/mlsynth/tests/test_numpy_scalar_guards.py
@@ -1,0 +1,167 @@
+"""Numeric guards must accept numpy scalars, not just Python floats and ints.
+
+``isinstance(x, (float, int))`` looks like a test for "is this a number". It is
+not. ``np.float64`` happens to subclass Python ``float`` and passes; ``np.float32``
+does not subclass it and fails. So a guard written that way is silently
+type-width dependent, and the width is decided by whatever produced the data.
+
+That matters because pandas reads Stata ``.dta`` floats as ``float32``. A user
+loading a replication package the obvious way gets their panel rejected, with a
+message naming an internal quantity they never set:
+
+    MlsynthConfigError: regularization_parameter_zeta must be a non-negative
+    float or int.
+
+The value is fine. Only the predicate is wrong. These tests pin the predicate at
+every site that had it, and pin that the *value* checks around it still bite --
+the fix must widen what counts as a number without loosening what counts as a
+valid one.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+
+def _panel(dtype):
+    """Small block panel: 6 units, 12 periods, one treated from t=9."""
+    rng = np.random.default_rng(0)
+    rows = []
+    for i in range(6):
+        base = 10.0 + i
+        for t in range(1, 13):
+            y = base + 0.3 * t + rng.normal(0, 0.2) - (2.0 if (i == 0 and t >= 9) else 0.0)
+            rows.append((f"u{i}", t, y, int(i == 0 and t >= 9)))
+    df = pd.DataFrame(rows, columns=["unit", "t", "y", "treat"])
+    df["y"] = df["y"].astype(dtype)
+    return df
+
+
+def _fit(df):
+    import warnings
+
+    from mlsynth import SDID
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return SDID({"df": df, "outcome": "y", "treat": "treat", "unitid": "unit",
+                     "time": "t", "vce": "noinference",
+                     "display_graphs": False}).fit()
+
+
+class TestSDIDAcceptsFloat32Panels:
+    """The reachable bug: a float32 outcome column crashed the fit."""
+
+    def test_a_float32_panel_fits(self):
+        assert np.isfinite(_fit(_panel("float32")).effects.att)
+
+    def test_float32_and_float64_agree(self):
+        """Not merely 'does not crash' -- the two must be the same estimate.
+
+        float32 carries ~7 significant digits, so the tolerance is a float32
+        round-trip, not machine epsilon.
+        """
+        a = _fit(_panel("float32")).effects.att
+        b = _fit(_panel("float32").assign(
+            y=lambda d: d["y"].astype("float64"))).effects.att
+        assert a == pytest.approx(b, rel=1e-5)
+
+    @pytest.mark.parametrize("dtype", ["float32", "float64", "int64"])
+    def test_every_reasonable_dtype_fits(self, dtype):
+        df = _panel("float64")
+        if dtype == "int64":
+            df["y"] = (df["y"] * 100).round().astype("int64")
+        else:
+            df["y"] = df["y"].astype(dtype)
+        assert np.isfinite(_fit(df).effects.att)
+
+
+class TestTheZetaGuardStillBites:
+    """Widening the type must not loosen the value check."""
+
+    @pytest.mark.parametrize("bad", [np.float32(-1.0), np.float64(-1.0), -1.0])
+    def test_a_negative_zeta_is_still_rejected(self, bad):
+        from mlsynth.exceptions import MlsynthConfigError
+        from mlsynth.utils.sdid_helpers.weights import unit_weights
+
+        Y = np.random.default_rng(0).normal(size=(8, 3))
+        with pytest.raises(MlsynthConfigError, match="non-negative"):
+            unit_weights(Y, Y[:, 0], bad)
+
+    @pytest.mark.parametrize("good", [np.float32(1.5), np.float64(1.5),
+                                      np.int64(2), 1.5, 2])
+    def test_numeric_scalars_are_accepted(self, good):
+        from mlsynth.utils.sdid_helpers.weights import unit_weights
+
+        rng = np.random.default_rng(1)
+        Y = rng.normal(size=(8, 3))
+        intercept, w = unit_weights(Y, Y[:, 0], good)
+        assert np.isfinite(w).all()
+        assert w.sum() == pytest.approx(1.0, abs=1e-6)
+
+    @pytest.mark.parametrize("bad", [float("nan"), np.float32("nan"),
+                                     float("inf")])
+    def test_a_non_finite_zeta_is_rejected(self, bad):
+        """Closed while fixing the type predicate, not before it.
+
+        ``isinstance(nan, float)`` is True and ``nan < 0`` is False, so a NaN
+        penalty passed the old guard untouched and propagated silently into
+        every weight. Widening the predicate is the moment to notice that the
+        value check never covered this.
+        """
+        from mlsynth.exceptions import MlsynthConfigError
+        from mlsynth.utils.sdid_helpers.weights import unit_weights
+
+        Y = np.random.default_rng(0).normal(size=(8, 3))
+        with pytest.raises(MlsynthConfigError):
+            unit_weights(Y, Y[:, 0], bad)
+
+    @pytest.mark.parametrize("bad", ["1.0", None, [1.0]])
+    def test_non_numbers_are_still_rejected(self, bad):
+        """The predicate widens to numbers, not to anything at all."""
+        from mlsynth.exceptions import MlsynthConfigError
+        from mlsynth.utils.sdid_helpers.weights import unit_weights
+
+        Y = np.random.default_rng(0).normal(size=(8, 3))
+        with pytest.raises(MlsynthConfigError):
+            unit_weights(Y, Y[:, 0], bad)
+
+
+class TestTheOtherSitesWithTheSamePredicate:
+    """Same mistake, three other places. Fixed together so the class is closed."""
+
+    @pytest.mark.parametrize("budget", [np.float32(9.0), np.float64(9.0),
+                                        np.int64(9), 9.0])
+    def test_marex_accepts_a_numpy_budget(self, budget):
+        """``isinstance(budget, (int, float))`` is a *branch* here, so a numpy
+        scalar fell through to 'budget must be a scalar or dict' -- which it is."""
+        from mlsynth.utils.marex_helpers.formulation import validate_costs_budget
+
+        costs, per_cluster = validate_costs_budget(
+            costs=np.ones(4), budget=budget, N=4, K=2,
+            cluster_labels=["a", "b"])
+        assert costs.shape == (4,)
+        assert set(per_cluster) == {"a", "b"}
+        assert all(v == pytest.approx(4.5) for v in per_cluster.values())
+
+    @pytest.mark.parametrize("val", [np.float32(0.5), np.float64(0.5), 0.5])
+    def test_clustersc_posterior_accepts_numpy_scalars(self, val):
+        from mlsynth.utils.clustersc_helpers.pcr.bayesian.posterior import BayesSCM
+
+        rng = np.random.default_rng(3)
+        donors = rng.normal(size=(10, 3))
+        target = donors @ np.array([0.5, 0.3, 0.2])
+        w, cf, *_ = BayesSCM(donors, target, val, val)
+        assert np.isfinite(w).all()
+
+    @pytest.mark.parametrize("grid", [[np.float32(0.5), np.float32(1.0)],
+                                      np.array([0.5, 1.0], dtype="float32")])
+    def test_shc_accepts_a_numpy_bandwidth_grid(self, grid):
+        from mlsynth.utils.shc_helpers.config import SHCConfig
+
+        df = _panel("float64")
+        cfg = SHCConfig(df=df, outcome="y", treat="treat", unitid="unit",
+                        time="t", bandwidth_grid=list(grid))
+        assert len(cfg.bandwidth_grid) == 2

--- a/mlsynth/utils/clustersc_helpers/pcr/bayesian/posterior.py
+++ b/mlsynth/utils/clustersc_helpers/pcr/bayesian/posterior.py
@@ -6,6 +6,7 @@ former shared ``mlsynth.utils.bayesutils`` module: it has a single consumer
 (clustersc's PCR Bayesian path), so it lives inside that estimator's package.
 """
 
+import numbers
 import numpy as np
 from typing import Tuple
 
@@ -96,12 +97,13 @@ def BayesSCM(
     if np.any(np.isnan(target_outcome_pre_intervention)) or np.any(np.isinf(target_outcome_pre_intervention)):
         raise MlsynthDataError("target_outcome_pre_intervention contains NaN or Inf values.")
 
-    if not isinstance(observation_noise_variance, (float, int)):
+    # numbers.Real: numpy scalars are numbers too (issue #320).
+    if not isinstance(observation_noise_variance, numbers.Real) or isinstance(observation_noise_variance, bool):
         raise MlsynthDataError("observation_noise_variance must be a float or int.")
     if observation_noise_variance <= 0:
         raise MlsynthDataError("observation_noise_variance must be positive.")
 
-    if not isinstance(weights_prior_precision, (float, int)):
+    if not isinstance(weights_prior_precision, numbers.Real) or isinstance(weights_prior_precision, bool):
         raise MlsynthDataError("weights_prior_precision must be a float or int.")
     if weights_prior_precision < 0: # Allow zero for non-informative prior if matrix is invertible
         raise MlsynthDataError("weights_prior_precision must be non-negative.")

--- a/mlsynth/utils/marex_helpers/formulation.py
+++ b/mlsynth/utils/marex_helpers/formulation.py
@@ -18,6 +18,8 @@ is selected by ``design``:
 
 from __future__ import annotations
 
+import numbers
+
 import cvxpy as cp
 import numpy as np
 import pandas as pd
@@ -71,7 +73,9 @@ def validate_costs_budget(costs, budget, N, cluster_labels, K):
         raise ValueError("costs must have length N (rows of Y).")
     if budget is None:
         raise ValueError("budget must be provided if costs are specified.")
-    if isinstance(budget, (int, float)):
+    # numbers.Real so a numpy scalar budget takes the scalar branch rather than
+    # falling through to "must be a scalar or dict" -- see issue #320.
+    if isinstance(budget, numbers.Real) and not isinstance(budget, bool):
         budget_dict = {lab: budget / K for lab in cluster_labels}
     elif isinstance(budget, dict):
         for lab in cluster_labels:

--- a/mlsynth/utils/sdid_helpers/weights.py
+++ b/mlsynth/utils/sdid_helpers/weights.py
@@ -48,6 +48,7 @@ the objective near the optimum is nearly flat. See ``TestSynthdidsEarlyStop`` in
 ``tests/test_sdid_covariates.py`` for a worked instance.
 """
 
+import numbers
 import numpy as np
 from typing import Optional, Tuple
 
@@ -344,7 +345,14 @@ def unit_weights(
         raise MlsynthDataError("mean_treated_outcome_pre_treatment must be a NumPy array.")
     if mean_treated_outcome_pre_treatment.ndim != 1: # Must be 1D: (Time,)
         raise MlsynthDataError("mean_treated_outcome_pre_treatment must be a 1D array (T0,).")
-    if not isinstance(regularization_parameter_zeta, (float, int)) or regularization_parameter_zeta < 0:
+    # numbers.Real, not (float, int): np.float64 subclasses Python float but
+    # np.float32 and np.int64 do not, so the narrow check rejected perfectly
+    # good values whenever the panel's dtype happened to be 32-bit -- which is
+    # what pandas gives you for a Stata .dta. See issue #320.
+    if (not isinstance(regularization_parameter_zeta, numbers.Real)
+            or isinstance(regularization_parameter_zeta, bool)
+            or not np.isfinite(float(regularization_parameter_zeta))
+            or regularization_parameter_zeta < 0):
         raise MlsynthConfigError("regularization_parameter_zeta must be a non-negative float or int.")
 
     # Get dimensions: number of pre-treatment periods and number of donors.

--- a/mlsynth/utils/shc_helpers/config.py
+++ b/mlsynth/utils/shc_helpers/config.py
@@ -6,6 +6,8 @@ Co-located with the helper package; re-exported from
 
 from __future__ import annotations
 
+import numbers
+
 from typing import List, Optional
 from pydantic import Field, model_validator
 from ...exceptions import MlsynthConfigError
@@ -52,7 +54,9 @@ class SHCConfig(BaseEstimatorConfig):
         if self.bandwidth_grid is not None:
             if not self.bandwidth_grid:
                 raise MlsynthConfigError("'bandwidth_grid' cannot be an empty list.")
-            if not all(isinstance(h, (int, float)) for h in self.bandwidth_grid):
+            # numbers.Real: numpy scalars are numbers too (issue #320).
+            if not all(isinstance(h, numbers.Real) and not isinstance(h, bool)
+                       for h in self.bandwidth_grid):
                 raise MlsynthConfigError("All elements in 'bandwidth_grid' must be numeric.")
             if not all(h > 0 for h in self.bandwidth_grid):
                 raise MlsynthConfigError("All bandwidth values must be strictly positive.")


### PR DESCRIPTION
## Related Links

- Closes #320.
- Found while checking mlsynth against the [`sdid` Stata package](https://github.com/Daniel-Pailanir/sdid)'s quota example, en route to the Sun et al. (2025) AJAE wine replication.

## What

- `numbers.Real` in place of `isinstance(x, (float, int))` at the five sites carrying that predicate.
- Added a finiteness check to the zeta guard, which the type fix exposed as missing.
- Added `mlsynth/tests/test_numpy_scalar_guards.py` — 28 tests, written first.

## Why

`SDID.fit()` raised on any `float32` panel:

```
MlsynthConfigError: regularization_parameter_zeta must be a non-negative float or int.
```

The value was never invalid — every cohort's zeta computes fine. `np.float64` subclasses Python `float` and passed the guard; **`np.float32` and `np.int64` do not** and were rejected. So the check was silently dtype-width dependent, and the width is decided by whatever produced the data.

That is reachable by the most ordinary route there is: **pandas reads Stata `.dta` floats as `float32`**, and replication packages in this field ship `.dta`. The error named `regularization_parameter_zeta`, an internal quantity the caller never sets and cannot see, with nothing pointing at `astype("float64")`.

Both the Stata quota panel and the wine paper's own `Replicate_Study2_Data.dta` now load and fit straight from `read_stata`, where before they raised.

## How

Five sites, same mistake:

| file | what it did |
|---|---|
| `sdid_helpers/weights.py` | the confirmed crash; internally derived, so unavoidable except by re-typing the input |
| `marex_helpers/formulation.py` | `isinstance(budget, (int, float))` is a *branch* — a numpy scalar fell through to `TypeError: budget must be a scalar or dict`, which it was |
| `clustersc.../bayesian/posterior.py` (×2) | numpy variance / precision rejected |
| `shc_helpers/config.py` | numpy values in `bandwidth_grid` rejected |

`numbers.Real` accepts every numpy scalar and still rejects `str`, `None`, `list`, `ndarray`; `bool` is excluded explicitly so the guards don't quietly accept `True` as a number.

**One thing the fix uncovered.** Widening the type predicate is the moment you notice the value check beside it never covered NaN: `isinstance(nan, float)` is True and `nan < 0` is False, so a NaN penalty passed the old guard untouched and propagated silently into every weight. The zeta guard now requires finiteness, and a test pins it. That is a behaviour change beyond the reported bug, so it's called out rather than buried.

## Verification

Against Stata on the quota panel (119 countries × 26 years, staggered, 7 cohorts), read straight from `.dta` with no casting:

| spec | mlsynth | Stata |
|---|---|---|
| no covariates | 8.038 | 8.034 |
| `covariates(lngdp, projected)` | 8.054 | 8.059 |

Both within 0.005, which is the solver tolerance already documented in `sdid_helpers/weights.py`. This PR does not add the `optimized` variant — that is its own scope.

Five mutants, all killed:

| mutant | killed by |
|---|---|
| zeta predicate back to `(float, int)` | `test_a_float32_panel_fits` |
| drop the finiteness check | `test_a_non_finite_zeta_is_rejected[nan]` |
| weaken the negative guard | `test_a_negative_zeta_is_still_rejected` |
| marex predicate back to `(int, float)` | `test_marex_accepts_a_numpy_budget` |
| clustersc predicate back to `(float, int)` | `test_clustersc_posterior_accepts_numpy_scalars` |

## Scope checks

BUG FIX

- [x] A test reproduces the defect and fails without the fix — 8 failures on the unfixed code, for the right reason
- [x] It asserts the correct behaviour, not merely the absence of a crash: float32 and float64 fits must *agree*, not just both run
- [x] No docstring or comment still states the old behaviour
- [x] No pinned value moved — this changes a type predicate, not any numeric path

## Test Steps

- [x] `pytest mlsynth/tests/test_numpy_scalar_guards.py -q` — 28 passed
- [x] `pytest` across every suite touching the five sites (sdid ×8, marex, clustersc, guards) — 384 passed, 38 skipped
- [x] Mutation-tested, 5/5 killed
- [x] End-to-end: both `.dta` files fit uncast

One note on process: a run partway through showed a spurious failure that did not reproduce in isolation. It was stale `.pyc` bytecode left by my own mutation harness, not a defect — confirmed by clearing `__pycache__` and re-running clean, which is the 384-passed result above.

## Other Notes

Follow-ups, each its own scope and issue:

1. `covariates={'optimized': [...]}` — Stata's *default* covariate method, which mlsynth cannot currently express. Validated target: 8.051 on this same panel.
2. The Sun et al. (2025) wine replication, which needs (1) for its SDID columns.


---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_