### PR TITLE
Scale covariates before the SDID `optimized` descent

### DIFF
--- a/docs/sdid.rst
+++ b/docs/sdid.rst
@@ -790,15 +790,29 @@ logarithmic in the iteration cap, and on real panels the cap binds while
      - 10000
      - 100000
    * - fitted :math:`\beta`
-     - 0.094
-     - 0.182
-     - 0.266
-     - 0.344
-     - 0.414
+     - 0.074
+     - 0.145
+     - 0.213
+     - 0.278
+     - 0.339
+
+One consequence is worth stating on its own, because it is easy to assume the
+opposite. The exact minimiser of :math:`\ell` is scale-equivariant: multiply a
+covariate by :math:`c` and its coefficient divides by :math:`c`, leaving
+:math:`\mathbf{x}^{\top}\boldsymbol{\beta}` and the estimate untouched. A
+descent that stops early on a fixed schedule is not. The step is not scaled by
+the curvature, so a covariate whose dispersion is far from the outcome's makes
+the first step overshoot, and the iteration diverges instead of converging
+slowly. mlsynth therefore scales each covariate to unit dispersion before
+descending and undoes the scaling on the fitted coefficient. That is part of
+reproducing the reference rather than a numerical nicety layered on it: without
+it, a panel whose income covariate has seventy times the outcome's dispersion
+returns an estimate eleven orders of magnitude too large.
 
 Because :math:`\ell` is very nearly flat in :math:`\boldsymbol{\beta}` -- on the
-panel above it moves from 21.57 at :math:`\beta = 0` to 20.92 at its minimum
-near :math:`\beta = 1.05` -- this early stop is load-bearing. It acts as
+panel above it moves from 20.973 at :math:`\beta = 0` to 20.922 at its
+minimum near :math:`\beta = 1.05`, a quarter of one percent -- this early stop
+is load-bearing. It acts as
 shrinkage toward zero on a direction the data barely identify. Minimising
 :math:`\ell` properly is a different estimator: it returns :math:`\beta = 8.4`
 on one cohort of that panel and moves the ATT to 8.011, against the 8.051 every
@@ -975,8 +989,8 @@ rest of this page documents:
      - 0.004
    * - ``covariates(lngdp)``
      - 8.051
-     - 8.045
-     - 0.006
+     - 8.048
+     - 0.003
    * - ``covariates(lngdp, projected)``
      - 8.059
      - 8.054

--- a/mlsynth/tests/test_sdid_covariate_scaling.py
+++ b/mlsynth/tests/test_sdid_covariate_scaling.py
@@ -1,0 +1,195 @@
+"""``optimized`` must not depend on what units a covariate is measured in.
+
+The estimator is defined by a minimisation whose exact solution is
+scale-equivariant: rescale ``X`` by ``c`` and ``beta`` scales by ``1/c``, so
+``X beta`` -- and therefore the estimate -- is unchanged. The reference does not
+solve that minimisation exactly. It descends with a fixed ``1/t`` step schedule
+and no curvature scaling, and a fixed step is not scale free: in a direction
+whose curvature goes like ``(4e4)^2`` the first step overshoots, the residual
+grows, and the next gradient is larger still.
+
+The result was an estimate eleven orders of magnitude out, returned silently:
+
+    no covariates                -46.94
+    optimized, unscaled       1.745e+11
+    Stata sdid (published)       -53.154
+
+So each covariate is scaled by its standard deviation before the descent and the
+coefficient is rescaled back afterwards. That is not a numerical nicety layered
+on top of the reference -- it is what makes the fitted coefficient reproduce the
+reference at all, on three separate published panels.
+
+These tests pin the invariant (rescaling a column changes nothing), the failure
+that motivated it (a wine-shaped panel stays finite and sane), and the degenerate
+case the scaling introduces (a constant covariate must not divide by zero).
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+
+def _panel(n_units=8, n_periods=16, first_treated=11, cov_scale=1.0, seed=0):
+    """Block panel with one covariate that genuinely drives the outcome.
+
+    ``cov_scale`` multiplies the covariate only. Because the covariate's effect
+    on the outcome is applied before scaling, every ``cov_scale`` describes the
+    same data in different units -- which is the whole point.
+    """
+    rng = np.random.default_rng(seed)
+    rows = []
+    for i in range(n_units):
+        level = 10.0 + 2.0 * i
+        for t in range(1, n_periods + 1):
+            x = rng.normal(3.0, 1.0)
+            treated = i == 0 and t >= first_treated
+            y = (level + 0.4 * t + 1.5 * x + rng.normal(0, 0.2)
+                 - (5.0 if treated else 0.0))
+            rows.append((f"u{i}", t, y, x * cov_scale, int(treated)))
+    return pd.DataFrame(rows, columns=["unit", "t", "y", "x", "treat"])
+
+
+def _att(df, covariates=None):
+    from mlsynth import SDID
+
+    cfg = {"df": df, "outcome": "y", "treat": "treat", "unitid": "unit",
+           "time": "t", "vce": "noinference", "display_graphs": False}
+    if covariates is not None:
+        cfg["covariates"] = covariates
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return float(SDID(cfg).fit().effects.att)
+
+
+class TestTheEstimateDoesNotDependOnTheCovariatesUnits:
+    """The invariant whose absence was the bug."""
+
+    @pytest.mark.parametrize("scale", [1e-3, 1.0, 1e3, 1e5])
+    def test_rescaling_a_covariate_leaves_the_estimate_alone(self, scale):
+        base = _att(_panel(cov_scale=1.0), {"optimized": ["x"]})
+        got = _att(_panel(cov_scale=scale), {"optimized": ["x"]})
+        assert got == pytest.approx(base, rel=1e-6)
+
+    def test_the_estimate_stays_finite_at_every_scale(self):
+        for scale in (1e-4, 1.0, 1e4, 1e6):
+            got = _att(_panel(cov_scale=scale), {"optimized": ["x"]})
+            assert np.isfinite(got), f"diverged at scale {scale}"
+            assert abs(got) < 1e3, f"exploded to {got} at scale {scale}"
+
+    def test_the_fitted_coefficient_is_returned_in_the_callers_units(self):
+        """beta must come back on the column's own scale, not the internal one.
+
+        The caller residualises the raw covariate with it, so a coefficient
+        left in standardised units would silently rescale the outcome.
+        """
+        from mlsynth.utils.sdid_helpers.setup import prepare_sdid_inputs
+
+        betas = {}
+        for scale in (1.0, 1000.0):
+            inputs = prepare_sdid_inputs(
+                df=_panel(cov_scale=scale), outcome="y", treat="treat",
+                unitid="unit", time="t", optimized_covariates=["x"])
+            payload = next(iter(inputs.cohorts_dict.values()))
+            betas[scale] = float(payload["optimized_beta"][0])
+        # x scaled up by 1000 -> beta scaled down by 1000
+        assert betas[1000.0] == pytest.approx(betas[1.0] / 1000.0, rel=1e-6)
+
+
+class TestTheWineShapedPanelThatFoundThis:
+    """A covariate whose dispersion is ~70x the outcome's, as in the paper."""
+
+    def _wine_shaped(self):
+        rng = np.random.default_rng(3)
+        rows = []
+        for i in range(11):
+            level = 1000.0 + 120.0 * i
+            income = 45000.0 + 4000.0 * i
+            for t in range(1, 41):
+                inc = income + rng.normal(0, 4700)
+                treated = i == 0 and t >= 31
+                y = (level + 3.0 * t + 0.004 * inc + rng.normal(0, 60)
+                     - (40.0 if treated else 0.0))
+                rows.append((f"s{i}", t, y, inc, int(treated)))
+        return pd.DataFrame(rows, columns=["unit", "t", "y", "x", "treat"])
+
+    def test_it_does_not_diverge(self):
+        df = self._wine_shaped()
+        plain = _att(df)
+        got = _att(df, {"optimized": ["x"]})
+        assert np.isfinite(got)
+        # the covariate explains part of the outcome, so the two differ -- but
+        # by an amount an effect of this size could plausibly move, not by 1e11
+        assert abs(got - plain) < 10 * abs(plain)
+
+    def test_the_coefficient_recovers_the_planted_slope(self):
+        """Sanity that scaling did not break the fit itself.
+
+        The covariate enters with slope 0.004; the reference stops early by
+        design, so this asks for the right sign and order of magnitude.
+        """
+        from mlsynth.utils.sdid_helpers.setup import prepare_sdid_inputs
+
+        inputs = prepare_sdid_inputs(
+            df=self._wine_shaped(), outcome="y", treat="treat", unitid="unit",
+            time="t", optimized_covariates=["x"])
+        beta = float(next(iter(inputs.cohorts_dict.values()))["optimized_beta"][0])
+        assert 0.0 < beta < 0.04
+
+
+class TestDegenerateCovariates:
+    """Scaling introduces a division, so the zero case needs an answer."""
+
+    def test_a_constant_covariate_does_not_divide_by_zero(self):
+        df = _panel()
+        df["const"] = 7.0
+        got = _att(df, {"optimized": ["const"]})
+        assert np.isfinite(got)
+
+    def test_a_constant_covariate_leaves_the_estimate_alone(self):
+        """It carries no information, so it must not move anything."""
+        df = _panel()
+        df["const"] = 7.0
+        assert _att(df, {"optimized": ["const"]}) == pytest.approx(
+            _att(df), rel=1e-9)
+
+    def test_a_unit_invariant_covariate_is_harmless(self):
+        """Absorbed by the unit effects, so its coefficient stays at zero."""
+        from mlsynth.utils.sdid_helpers.setup import prepare_sdid_inputs
+
+        df = _panel()
+        df["fixed"] = df["unit"].map(
+            {u: float(i) for i, u in enumerate(sorted(df["unit"].unique()))})
+        inputs = prepare_sdid_inputs(
+            df=df, outcome="y", treat="treat", unitid="unit", time="t",
+            optimized_covariates=["fixed"])
+        beta = float(next(iter(inputs.cohorts_dict.values()))["optimized_beta"][0])
+        assert abs(beta) < 1e-6
+
+
+class TestThePinnedPanelMovesToTheBetterNumber:
+    """The quota panel is the pinned case; scaling must improve it, not break it."""
+
+    def test_quota_reproduces_more_closely_than_before(self):
+        from pathlib import Path
+
+        panel = (Path(__file__).resolve().parents[2] / "benchmarks" / "reference"
+                 / "sdid_quota" / "quota_panel.csv")
+        if not panel.exists():  # pragma: no cover - the panel is committed
+            pytest.skip(f"missing {panel}")
+        from mlsynth import SDID
+
+        d = pd.read_csv(panel).dropna(subset=["lngdp"])
+        d["year"] = d["year"].astype(int)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            got = float(SDID({
+                "df": d, "outcome": "womparl", "treat": "quota",
+                "unitid": "country", "time": "year", "vce": "noinference",
+                "display_graphs": False,
+                "covariates": {"optimized": ["lngdp"]}}).fit().effects.att)
+        # Stata reports 8.051; unscaled gave 8.0446, scaled gives 8.0483.
+        assert abs(got - 8.051) < abs(8.0446 - 8.051)

--- a/mlsynth/tests/test_sdid_covariate_scaling.py
+++ b/mlsynth/tests/test_sdid_covariate_scaling.py
@@ -191,5 +191,9 @@ class TestThePinnedPanelMovesToTheBetterNumber:
                 "unitid": "country", "time": "year", "vce": "noinference",
                 "display_graphs": False,
                 "covariates": {"optimized": ["lngdp"]}}).fit().effects.att)
-        # Stata reports 8.051; unscaled gave 8.0446, scaled gives 8.0483.
-        assert abs(got - 8.051) < abs(8.0446 - 8.051)
+        # Stata reports 8.051. Unscaled gives 8.0446, which is 0.0064 away;
+        # scaling gives 8.0483, which is 0.0027. The threshold sits between
+        # them so this states the improvement rather than merely comparing
+        # against a rounded literal -- an earlier version did the latter and
+        # passed against the unscaled code on rounding noise alone.
+        assert abs(got - 8.051) < 0.005

--- a/mlsynth/tests/test_sdid_covariate_scaling.py
+++ b/mlsynth/tests/test_sdid_covariate_scaling.py
@@ -197,3 +197,43 @@ class TestThePinnedPanelMovesToTheBetterNumber:
         # against a rounded literal -- an earlier version did the latter and
         # passed against the unscaled code on rounding noise alone.
         assert abs(got - 8.051) < 0.005
+
+
+class TestTheScaleIsPooledOverDonorsAndTreated:
+    """Which rows the dispersion is measured over is a real choice.
+
+    It changes the preconditioner, so it changes the descent path and the
+    fitted coefficient. The invariance tests above cannot see it: both
+    candidates are homogeneous of degree one in the column, so rescaling a
+    covariate rescales either the same way. It needs stating directly.
+
+    The choice is pooled, and the evidence is that pooling reproduces the
+    published figures more closely on both panels where the two differ
+    materially (-53.170 vs -53.304 for a published -53.154; 0.6096 vs 0.5990
+    for a published 0.610).
+    """
+
+    def test_the_treated_units_values_are_included(self):
+        from mlsynth.utils.sdid_helpers.covariates import _covariate_scale
+
+        # donors tight, treated wide: pooling must land well above the donors'
+        # own dispersion, and nowhere near it
+        donors = np.full((6, 4), 1.0)
+        donors[0, 0] = 1.001
+        treated = np.array([[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]])
+        scale = _covariate_scale(donors[None], treated)
+        donors_only = float(np.std(donors.ravel()))
+        pooled = float(np.std(np.concatenate([donors.ravel(),
+                                              treated.ravel()])))
+        assert scale[0] == pytest.approx(pooled, rel=1e-12)
+        assert scale[0] > 10 * donors_only
+
+    def test_it_is_one_scale_per_covariate(self):
+        from mlsynth.utils.sdid_helpers.covariates import _covariate_scale
+
+        donors = np.stack([np.full((5, 3), 2.0), np.arange(15.0).reshape(5, 3)])
+        treated = np.stack([np.full(5, 2.0), np.arange(5.0)])
+        scale = _covariate_scale(donors, treated)
+        assert scale.shape == (2,)
+        assert scale[0] == 1.0          # no dispersion -> guarded to one
+        assert scale[1] > 0.0

--- a/mlsynth/utils/sdid_helpers/covariates.py
+++ b/mlsynth/utils/sdid_helpers/covariates.py
@@ -267,14 +267,15 @@ def adjust_outcome_for_covariates(
 # The two weight programs are strictly convex, so "the optimum" is a well-posed
 # target and solving it exactly is unambiguously better. The beta block is not.
 # Holding the weights at their optima, the objective is very nearly flat in
-# beta: on the quota panel below, cohort 1 runs from 21.57 at ``beta = 0`` to a
-# minimum of 20.92 near ``beta = 1.05``, and the reference never gets there.
+# beta: on the quota panel below, cohort 1 runs from 20.973 at ``beta = 0`` to a
+# minimum of 20.922 near ``beta = 1.05`` -- a quarter of one percent -- and the
+# reference never gets there.
 # ``synthdid`` steps beta by ``1/t`` along the gradient, so its total step budget
 # grows like ``log(max.iter)``; the iteration hits its cap rather than its
 # convergence test, and beta is still drifting when it stops:
 #
 #     max_iter      10     100    1000   10000  100000
-#     beta        0.094   0.182   0.266   0.344   0.414
+#     beta        0.074   0.145   0.213   0.278   0.339
 #
 # The stopping rule is therefore load-bearing, not incidental -- it acts as
 # shrinkage toward zero on a direction the data barely identify. Solving the
@@ -374,6 +375,28 @@ def _validate_block(donor_outcomes, treated_outcome, donor_covariates,
                 f"the 'optimized' covariate fit needs a {name} block free of "
                 "NaN/inf; check the covariate columns for missing values.")
     return Y0, y1, X0, x1, t0, n_post
+
+
+def _covariate_scale(donor_covariates: np.ndarray,
+                     treated_covariates: np.ndarray) -> np.ndarray:
+    """Per-covariate dispersion used to precondition the beta descent.
+
+    The standard deviation over every value the covariate takes in the block,
+    donors and treated together, so the scaling does not depend on which unit
+    happens to be treated.
+
+    A covariate with no dispersion carries no information -- it is absorbed by
+    the unit and time effects and its coefficient stays at zero -- so its scale
+    is set to one rather than dividing by zero.
+    """
+    k = donor_covariates.shape[0]
+    scale = np.empty(k, dtype=float)
+    for j in range(k):
+        pooled = np.concatenate([donor_covariates[j].ravel(),
+                                 treated_covariates[j].ravel()])
+        s = float(np.std(pooled))
+        scale[j] = s if s > 0.0 and np.isfinite(s) else 1.0
+    return scale
 
 
 def _noise_level(donor_outcomes: np.ndarray, pre_periods: int) -> float:
@@ -504,6 +527,21 @@ def optimized_covariate_beta(
     zeta_lambda = _ZETA_LAMBDA * noise
     min_decrease = _FW_MIN_DECREASE * noise
 
+    # Scale each covariate to unit dispersion before descending, and undo it on
+    # the way out. The exact minimiser would not need this -- rescale a column
+    # by c and its coefficient scales by 1/c, leaving the fit unchanged -- but
+    # the beta block is gradient descent on a fixed 1/t schedule with no
+    # curvature scaling, and a fixed step is not scale free. A column whose
+    # dispersion is far from the outcome's makes the first step overshoot, and
+    # the iteration diverges rather than converging slowly: on the Sun et al.
+    # (2025) employment panel an income covariate reached 5.5e8 and the estimate
+    # came back as 1.7e11. Scaling is therefore part of reproducing the
+    # reference, not a numerical nicety on top of it -- it is what makes the
+    # coefficient match Stata on all three published panels tested.
+    scale = _covariate_scale(X0, x1)
+    X0 = X0 / scale[:, None, None]
+    x1 = x1 / scale[:, None]
+
     Yc = _collapse(Y0, y1, t0)
     Xc = np.stack([_collapse(X0[k], x1[k], t0) for k in range(X0.shape[0])])
     n0 = Yc.shape[0] - 1
@@ -546,4 +584,6 @@ def optimized_covariate_beta(
         value, lam, omega, err_l, err_o = update(block, lam, omega)
         if t >= 2 and previous - value <= min_decrease ** 2:
             break
-    return beta
+    # Back to the caller's units, so the returned coefficient multiplies the
+    # raw covariate column rather than the internally scaled one.
+    return beta / scale

--- a/mlsynth/utils/sdid_helpers/covariates.py
+++ b/mlsynth/utils/sdid_helpers/covariates.py
@@ -385,6 +385,13 @@ def _covariate_scale(donor_covariates: np.ndarray,
     donors and treated together, so the scaling does not depend on which unit
     happens to be treated.
 
+    Pooling rather than using the donors alone is a real choice, not a
+    formality: it changes the preconditioner, hence the descent path, hence the
+    coefficient. Both reproduce the published quota figure (8.0482 against
+    8.0481), but on the two Sun et al. (2025) panels pooling is closer on both
+    -- -53.170 against -53.304 for a published -53.154, and 0.6096 against
+    0.5990 for a published 0.610.
+
     A covariate with no dispersion carries no information -- it is absorbed by
     the unit and time effects and its coefficient stays at zero -- so its scale
     is set to one rather than dividing by zero.


### PR DESCRIPTION
## Related Links

- Resolves #325
- Fixes a defect introduced in #323
- Found while starting #324 (Sun et al. 2025 replication)
- Docs: `docs/sdid.rst`, "Optimising jointly with the weights"

## What

- Each covariate is divided by its dispersion before the beta iteration, and the fitted coefficient multiplied back, so callers still receive a coefficient in their own units
- `_covariate_scale` added, pooling donors and the treated unit, guarding a zero-variance column
- Two figures in the #323 docs corrected (see below)

## Why

`covariates={'optimized': [...]}` returned nonsense on a panel whose covariates are on a scale unlike the outcome's:

| specification | ATT |
|---|---|
| no covariates | `-46.94` |
| `optimized`, as merged in #323 | `1.745e+11` |
| Stata `sdid` (published) | `-53.154` |

Eleven orders of magnitude out, returned without a warning.

The cause is in the beta block. On the Sun et al. employment panel `incomepc` has a within-unit standard deviation of 4739 against the outcome's 66, and the fitted coefficients came out as:

```
popdense2010   -2.94e-07     <- time-invariant, correctly ~0
incomepc        5.54e+08     <- diverged
unemploy       -1.01e+04
```

The beta block is gradient descent on a fixed `1/t` schedule with no curvature scaling. In a direction whose curvature goes like `(4e4)^2` the first step overshoots, the residual grows, and the next gradient is larger still.

Worth stating plainly because it is easy to assume otherwise: the exact minimiser of this objective *is* scale-equivariant — rescale a column by `c` and its coefficient scales by `1/c`, leaving the fit untouched. An early-stopped fixed-schedule descent is not. So the covariate scale is part of this estimator, and scaling is part of reproducing the reference rather than a numerical nicety layered on top of it. This is the same non-convergence that #323 documented as making the stopping rule load-bearing; the scale-dependence is its other consequence.

## Verification

- Path: A — published results on the authors' data, on every panel available

| panel | published | before | after |
|---|---|---|---|
| Clarke et al. quota | 8.051 | 8.0446 | 8.0482 |
| Sun et al. Study 2, employment | -53.154 | 1.745e+11 | -53.170 |
| Sun et al. Study 3, tax revenue | 0.610 | -6.336e+10 | 0.6096 |

The quota panel is the one already pinned in the test suite, and it moves *closer* — from 0.0064 off to 0.0028. So this is not a trade of one panel against another. It survived unscaled only because `lngdp` has a standard deviation of 1.14 against the outcome's 10.96, so the curvature was mild.

Centring makes no difference (SDID absorbs a constant shift): scale-only and full z-scoring agree to four decimals on both wine panels. So the fix is scaling, not standardisation.

The two wine panels are not in the repo yet — they arrive with #324 — so they are cited here as the evidence that motivated the change, and the tests in this PR use a synthetic panel of the same shape (covariate dispersion ~70x the outcome's) plus the committed quota panel.

## Scope checks

BUG FIX

- [x] Tests reproduce the defect and fail without the fix — committed red first (`46cce81`), then green
- [x] They assert the correct behaviour, not the absence of a crash: the invariant is that rescaling a covariate leaves the estimate unchanged
- [x] No docs, docstring or comment still states the old behaviour — and two stale figures from #323 are corrected
- [x] The pinned quota value moved, and is justified as the better number: it is closer to Stata than before, not re-fitted to output

## Test Steps

- [x] `pytest mlsynth/tests/test_sdid_covariate_scaling.py -q` — 14 passed
- [x] `pytest mlsynth/tests/ -k sdid` — 386 passed, 1 skipped, no regressions
- [x] Mutation-checked: 7 mutants, 7 killed

## Other Notes

Two figures stated in the #323 docs were wrong and are corrected here. The objective at `beta = 0` is 20.973, not 21.57 — that number was the solver's running value after ten iterations, not the reduced objective. The corrected range (20.973 down to 20.922 at the minimum, a quarter of one percent) is flatter than claimed, which strengthens the argument for why the early stop is load-bearing rather than weakening it. The beta drift table is also restated on the scaled solver.

One mutant survived the first sweep: computing the dispersion from the donors alone rather than pooling with the treated unit. The invariance tests structurally could not see it, since both candidates are homogeneous of degree one in the column. Rather than assume it equivalent, I measured — pooling is closer on both panels where the two differ materially (-53.170 against -53.304; 0.6096 against 0.5990) — so the choice is now pinned directly and the evidence recorded in the docstring.

This is the argument for doing replications: the defect shipped in #323 with a green suite, full coverage and 12/12 mutants killed, and was caught within the hour by the next paper that used the feature in earnest. No test written against the quota panel alone would have found it, because that panel's covariate happens to be mild enough not to diverge.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_