### PR TITLE
Add DRSC: conditional distributional treatment effects (Wied 2026)

### DIFF
--- a/benchmarks/cases/wied_nj_minwage.py
+++ b/benchmarks/cases/wied_nj_minwage.py
@@ -1,0 +1,186 @@
+"""Path A: Wied (2026), New Jersey's 1992 minimum wage, via DRSC.
+
+Reproduces the paper's empirical application on the author's own estimation
+sample: Table 1's synthetic-control weights and Table 2's conditional
+distributional treatment effects at five covariate values.
+
+What is pinned, and why at these tolerances, follows from what the replication
+measured rather than from taste.
+
+The *deterministic* quantities -- the donor weights, the integrated effect
+``f_hat``, the supremum statistics ``Tn`` -- involve no simulation and no
+eigendecomposition. They reproduce the paper's printed precision exactly, so
+they are pinned at that precision.
+
+The *simulated* quantities -- critical values and therefore p-values -- are not
+reproducible across LAPACK builds even with the seed fixed. Simulating the
+limiting Gaussian process needs a matrix square root of the estimated kernel,
+taken from ``numpy.linalg.eigh``, whose eigenvector signs are
+implementation-defined; a different build gives a different factor and hence a
+different realisation from identical draws. The distribution is unchanged, but
+individual quantiles move by 0.2-0.5 percent. So p-values are pinned loosely,
+and the qualitative pattern they carry -- which points reject on the corridor --
+is pinned as a separate boolean row that a small numerical drift cannot flip.
+
+One further property is asserted because it is load-bearing and invisible in the
+published tables. The Gram matrix has a condition number near 1e5, and the
+closed-form weight solve amplifies relative input error by roughly 1e6. A
+float32 round-trip of the same sample moves the largest donor weight by ~0.04
+(Florida 0.515 -> 0.505) while leaving the estimand almost untouched; random
+noise of the same magnitude, which does not partially cancel the way rounding
+does, moves weights by 0.12-0.17. ``weights_need_f64`` records the round-trip
+gap, which is already 40x the tolerance the weights otherwise reproduce at. It is the reason the vendored sample is float64 and the reason
+a future contributor should not "optimise" it.
+
+Reference values: the paper's Tables 1 and 2. See
+``benchmarks/reference/wied_nj_minwage/provenance.txt``. No R or Stata in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_DIR = Path(__file__).resolve().parents[1] / "reference" / "wied_nj_minwage"
+
+# Table 1: five largest synthetic control weights, by FIPS code.
+PAPER_W = {12: 0.515, 36: 0.479, 46: -0.255, 32: 0.199, 29: -0.196}
+# Table 2: f_hat x 1e3, Tn, p (full support), p (MW corridor).
+PAPER_T2 = {
+    "x0":  (0.58, 26.7, 0.294, 0.064),
+    "x10": (1.71, 73.0, 0.054, 0.012),
+    "xhl": (1.55, 37.1, 0.686, 0.150),
+    "xlh": (0.61, 28.6, 0.750, 0.060),
+    "x90": (0.21, 27.6, 0.824, 0.846),
+}
+EVAL = (("x0", 12, 10), ("x10", 10, 2), ("xhl", 16, 2),
+        ("xlh", 10, 37), ("x90", 16, 37))
+MW_LO, MW_HI = np.log(4.25), np.log(5.10)
+COVS = ["e_std", "x_std", "x_std_sq"]
+
+
+def _panel():
+    d = pd.read_parquet(_DIR / "nj_estimation_sample.parquet")
+    d["STATEFIP"] = d["STATEFIP"].astype(int)
+    d["t"] = d["t"].astype(int)
+    d["treat"] = ((d["STATEFIP"] == 34) & (d["t"] == 4)).astype(int)
+    d["x_std_sq"] = d["x_std"] ** 2
+    meta = json.loads((_DIR / "nj_meta.json").read_text())
+    return d, meta
+
+
+def _points(meta):
+    pts = {}
+    for name, ed, ex in EVAL:
+        e = (ed - meta["me"]) / meta["se"]
+        x = (ex - meta["mx"]) / meta["sx"]
+        pts[name] = {"e_std": e, "x_std": x, "x_std_sq": x ** 2}
+    return pts
+
+
+def _fit(df, points):
+    from mlsynth import DRSC
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return DRSC({
+            "df": df, "outcome": "logwage", "treat": "treat",
+            "unitid": "STATEFIP", "time": "t", "covariates": COVS,
+            "evaluation_points": points, "n_grid": 38,
+            "focus_region": (MW_LO, MW_HI), "display_graphs": False,
+        }).fit()
+
+
+def run() -> dict:
+    d, meta = _panel()
+    points = _points(meta)
+    res = _fit(d, points)
+    out: dict = {}
+
+    # --- the sample is the paper's -------------------------------------
+    out["n_total"] = float(len(d))
+    out["n_donors"] = float(len(res.weights.donor_weights))
+    out["m_active"] = float(len(res.outcome_grid))
+
+    # --- structural diagnostics ----------------------------------------
+    out["gram_condition_number"] = float(res.gram_condition_number)
+    out["n_negative_weights"] = float(res.n_negative_weights)
+    out["weights_sum_to_one"] = float(
+        sum(res.weights.donor_weights.values()))
+
+    # --- Table 1: deterministic, pinned tight --------------------------
+    w = res.weights.donor_weights
+    out["table1_max_weight_diff"] = float(max(
+        abs(w[str(f)] - target) for f, target in PAPER_W.items()))
+
+    # --- Table 2 -------------------------------------------------------
+    f_diff, tn_diff, p_diff = 0.0, 0.0, 0.0
+    for name, (pf, ptn, pp, ppc) in PAPER_T2.items():
+        e = res.conditional_effects[name]
+        f_diff = max(f_diff, abs(e.f_hat * 1e3 - pf))
+        tn_diff = max(tn_diff, abs(e.t_stat - ptn))
+        p_diff = max(p_diff, abs(e.p_value - pp),
+                     abs(e.p_value_focused - ppc))
+    out["table2_max_f_diff"] = f_diff
+    out["table2_max_Tn_diff"] = tn_diff
+    out["table2_max_p_diff"] = p_diff
+
+    # The qualitative finding, as a boolean a p-value wobble cannot flip:
+    # the corridor test rejects for low-skill young workers and for nobody
+    # whose wages sit far above the new floor.
+    ce = res.conditional_effects
+    out["corridor_pattern_holds"] = float(
+        ce["x10"].p_value_focused < 0.05 < ce["x90"].p_value_focused)
+    out["x10_is_the_largest_effect"] = float(
+        max(ce, key=lambda k: ce[k].f_hat) == "x10")
+    out["x10_lower_bound_positive"] = float(ce["x10"].lower_bound > 0.0)
+
+    # --- precision is load-bearing --------------------------------------
+    d32 = d.copy()
+    for c in ["logwage"] + COVS:
+        d32[c] = d32[c].astype("float32").astype("float64")
+    r32 = _fit(d32, points)
+    w32 = r32.weights.donor_weights
+    out["weights_need_f64"] = float(max(
+        abs(w32[k] - w[k]) for k in w))
+    out["estimand_survives_f32"] = float(max(
+        abs(r32.conditional_effects[n].f_hat - ce[n].f_hat) * 1e3
+        for n in ce))
+    return out
+
+
+#: Distances from the paper, so each row reads as "how far apart are we".
+EXPECTED = {
+    "n_total": (381953.0, 0.5),
+    "n_donors": (42.0, 0.5),
+    "m_active": (32.0, 0.5),
+
+    "gram_condition_number": (9.64e4, 5e3),
+    "n_negative_weights": (20.0, 0.5),
+    "weights_sum_to_one": (1.0, 1e-9),
+
+    # Deterministic: no simulation, no eigendecomposition.
+    "table1_max_weight_diff": (0.0, 0.001),
+    "table2_max_f_diff": (0.0, 0.01),
+    "table2_max_Tn_diff": (0.0, 0.1),
+
+    # Simulated: LAPACK eigenvector signs move critical values 0.2-0.5%,
+    # which propagates to p-values. Loose on purpose; the pattern below is
+    # what actually guards the finding.
+    "table2_max_p_diff": (0.0, 0.05),
+    "corridor_pattern_holds": (1.0, 0.5),
+    "x10_is_the_largest_effect": (1.0, 0.5),
+    "x10_lower_bound_positive": (1.0, 0.5),
+
+    # A float32 round-trip moves the weights ~0.04 -- 40x the 0.001 they
+    # otherwise reproduce at -- and the estimand by ~0.13e-3. Both halves
+    # matter: the first says "keep float64", the second says "the published
+    # effects are not hostage to it". The band is clear of zero, so a version
+    # that silently stopped caring about precision would fail here.
+    "weights_need_f64": (0.043, 0.03),
+    "estimand_survives_f32": (0.0, 0.25),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -138,6 +138,7 @@ CASES = {
     "disco_tenure": "benchmarks.cases.disco_tenure",  # cross-val vs the disco Stata Journal published weights (deterministic reference; the R package's are a Monte Carlo draw)                  # Path A: DSC distributional SC on Dube minimum-wage (Gunsilius/DiSCo vignette)
     "dtwsc_basque": "benchmarks.cases.dtwsc_basque",          # Cross-validation: DTWSC warp vs the conflictlab/dsc R package on Basque
     "ascm_kansas": "benchmarks.cases.ascm_kansas",            # cross-val vs augsynth: Kansas ridge-ASCM ladder (SCM/ridge/covariate/residualized)
+    "wied_nj_minwage": "benchmarks.cases.wied_nj_minwage",  # Path A: Wied (2026) NJ minimum wage, DRSC conditional distributional effects
     "wine_tennessee": "benchmarks.cases.wine_tennessee",  # Path A: Sun et al. (2025 AJAE) Tennessee wine reform, SCM + SDID(optimized); Study 1 unreplicable (NielsenIQ)
     "ascm_jackknife_plus": "benchmarks.cases.ascm_jackknife_plus",  # cross-val vs augsynth inf_type="jackknife+": per-period bounds on Kansas, both branches
     "augsynth_calibrated": "benchmarks.cases.augsynth_calibrated",  # Path B: ASCM near-nominal coverage + bias reduction (BMR 2021 Sec 7)

--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -86,8 +86,8 @@ At a glance
    Donor pool N ≳ T0 (overfitting)?     ─► CLUSTERSC · SparseSC · PDA · RESCM · FSCM · BVSS
    Missing cells in the panel?          ─► SNN · MCNNM · RMSI (side information)
    Interpolation across dissimilar donors? ─► MASC
-   Grouped microdata / repeated cross-sections? ─► SCD (differenced group means, √n bands) · DSC (distribution)
-   Different ESTIMAND / treatment type? ─► DSC (dist.) · CTSC (dose) · SCMO (multi-outcome) · SI (arms)
+   Grouped microdata / repeated cross-sections? ─► SCD (differenced group means, √n bands) · DSC (distribution) · DRSC (distribution | covariates)
+   Different ESTIMAND / treatment type? ─► DSC (dist.) · DRSC (cond. dist.) · CTSC (dose) · SCMO (multi-outcome) · SI (arms)
 
    PART 2 — MANY treated units   (easy ─────────────────────► hard)
    ─────────────────────────────────────────────────────────────────

--- a/docs/drsc.rst
+++ b/docs/drsc.rst
@@ -1,0 +1,256 @@
+Distribution-Regression Synthetic Control (DRSC)
+================================================
+
+.. currentmodule:: mlsynth
+
+When to Use This Estimator
+--------------------------
+
+Most synthetic control methods return one number per period: the treated unit's
+outcome minus its synthetic counterpart. That is the right summary when the
+policy shifts everyone in the same direction. It is the wrong summary when the
+policy reshapes the outcome distribution -- a minimum wage that lifts the bottom
+tail and leaves the median alone, a transfer that compresses inequality without
+moving the mean.
+
+:doc:`dsc` already answers part of that: it matches whole distributions instead
+of means, and returns quantile treatment effects. But it works on the
+*unconditional* distribution, the one you get by pooling everybody. If the
+outcome depends on individual characteristics -- and wages depend heavily on
+education and experience -- then pooling can hide the effect entirely. An
+increase that raises wages for young low-education workers and nobody else
+barely moves the overall wage distribution, because that group is a small slice
+of it.
+
+DRSC conditions. It estimates the counterfactual distribution of the outcome
+*given* covariates, so you can ask what the policy did to a 25-year-old with a
+high-school education specifically, rather than to the workforce on average.
+
+Reach for it when all of these hold: you have micro-data (many individuals per
+unit-period, not one aggregate number), one treated unit, and a reason to think
+the effect varies across people in a way you can describe with covariates.
+
+Notation
+--------
+
+There are :math:`J + 1` groups observed over :math:`T` periods. Group
+:math:`i = 1` is treated from period :math:`T_0 + 1` onward; groups
+:math:`i = 2, \ldots, J+1` are the donor pool. Within each group-period cell
+:math:`(i, t)` we observe :math:`n_{it}` individuals, each with an outcome
+:math:`Y` and a covariate vector :math:`x \in \mathbb{R}^{p}`.
+
+The conditional distribution is modelled semiparametrically as
+
+.. math::
+
+   F_{it}(y \mid x) \;=\; \Lambda\bigl(x^{\top}\theta_{it}(y)\bigr),
+
+where :math:`\Lambda` is a known link (the normal CDF by default) and
+:math:`\theta_{it} : \mathcal{Y} \to \mathbb{R}^{p}` is an unknown parameter
+function. This is the distribution regression of Foresi and Peracchi (1995).
+For a fixed :math:`y` it is just a binary regression of
+:math:`\mathbf{1}\{Y \le y\}` on :math:`x`, so estimation reduces to running one
+probit per outcome grid point per cell.
+
+The object of interest is the pointwise difference between the observed and
+counterfactual conditional distributions,
+
+.. math::
+
+   \Delta_t(y \mid x) \;=\; F_{1,t}(y \mid x) - F^{0}_{1,t}(y \mid x),
+
+and its integrated square over a region :math:`\mathcal{Y}_0`,
+
+.. math::
+
+   f_t(x, \mathcal{Y}_0) \;=\; \int_{\mathcal{Y}_0} \Delta_t(y \mid x)^2 \, dy .
+
+Setting :math:`\mathcal{Y}_0` to the whole support gives the total effect;
+restricting it to a policy-relevant window -- the corridor between the old and
+new minimum wage -- concentrates the test where the policy actually operates.
+
+Assumptions
+-----------
+
+Assumption 1 (Parallel trends in parameters). There exist weights
+:math:`w_2, \ldots, w_{J+1}` summing to one such that, for all
+:math:`y \in \mathcal{Y}_0` and all post-treatment :math:`t`,
+
+.. math::
+
+   \theta^{0}_{1,t}(y) - \theta_{1,T_0}(y)
+   \;=\; \sum_{i=2}^{J+1} w_i \bigl[\theta_{i,t}(y) - \theta_{i,T_0}(y)\bigr].
+
+Remark. This is the familiar parallel-trends idea moved into the parameter
+space of the model rather than imposed on the outcome or the CDF. That choice
+does real work. The parameter function is linear in the common factors whereas
+the CDF is not, so the weights come out constant across the whole distribution,
+and the counterfactual is guaranteed to still be a valid distribution in the
+model class. Economically it says the treated unit's exposure to aggregate
+shocks -- skill-biased technical change, the business cycle -- can be written as
+a weighted blend of the donors' exposures.
+
+Assumption 2 (Sampling). Within each cell the individuals are i.i.d., and cells
+are independent, with :math:`n_{it}/n \to r_{it} \in (0, \infty)`.
+
+Remark. The asymptotics run in :math:`n`, the number of individuals, with the
+donor count and the number of periods held fixed. This is unlike every other
+estimator in mlsynth, where precision comes from a long panel. Here one
+pre-period is enough for consistency, and extra pre-periods buy precision in the
+weights rather than in the distribution regressions. The practical consequence:
+worry about thin cells, not short panels.
+
+Assumption 3 (Pre-treatment balance). The treated unit's pre-treatment
+parameter function lies in the affine span of the donors'.
+
+Remark. The functional analogue of the usual requirement that the treated unit
+sit inside the donor hull. It is only affine, not convex -- see the note on
+negative weights below -- and it is testable, which is what the pre-trend tests
+in the next section do.
+
+Estimation
+----------
+
+The weights minimise the pre-treatment discrepancy, averaged over pre-periods
+and integrated over the outcome grid, subject only to adding up to one:
+
+.. math::
+
+   \widehat w \;=\; \operatorname*{arg\,min}_{\mathbf{1}'w = 1}
+   \frac{1}{T_0 m} \sum_{t=1}^{T_0} \sum_{l=1}^{m}
+   \bigl\| \widehat\theta_{1t}(y_l) - \sum_{i=2}^{J+1} w_i \widehat\theta_{it}(y_l)
+   \bigr\|^{2} .
+
+Because the objective is quadratic and the single constraint is linear, this has
+a closed form -- no solver, no iteration:
+
+.. math::
+
+   \widehat w \;=\; \widehat G^{-1}\widehat c
+   \;-\; \widehat G^{-1}\mathbf{1}\,
+   \frac{\mathbf{1}'\widehat G^{-1}\widehat c - 1}
+        {\mathbf{1}'\widehat G^{-1}\mathbf{1}} .
+
+Two consequences deserve stating plainly, because both look like faults and
+neither is.
+
+Negative weights are normal. Non-negativity is deliberately dropped
+(Doudchenko and Imbens), which lets the synthetic unit sit outside the donor
+hull and is what makes a good pre-treatment fit attainable when the treated unit
+is unusual. In the New Jersey application 20 of 42 donors receive negative
+weight.
+
+The Gram matrix is ill-conditioned, and that requires float64. Donors' parameter
+functions are similar to each other -- which is precisely why a weighted
+combination can track the treated unit -- so :math:`\widehat G` is nearly
+singular. On the New Jersey panel its condition number is
+:math:`9.6 \times 10^{4}`, and the solve amplifies relative input error by
+roughly :math:`10^{6}`. Passing float32 data (relative error
+:math:`\sim 6 \times 10^{-8}`) moves Florida's weight from 0.515 to 0.505, and
+the largest donor weight by about 0.04; random perturbation of the same
+magnitude, which does not partially cancel the way rounding does, moves weights
+by 0.12 to 0.17.
+The *estimand* is far more stable than the weights, so the reported effects
+barely move, but the weights themselves are what people quote. Keep the inputs
+in float64. Setting ``ridge`` to a small positive value stabilises the solve at
+the cost of shrinking the weights toward :math:`1/J`.
+
+Inference and diagnostics
+-------------------------
+
+The null of no effect, :math:`H_0 : \Delta_t(\cdot \mid x) = 0` on
+:math:`\mathcal{Y}_0`, is tested with the supremum statistic
+
+.. math::
+
+   T_n(x, t, \mathcal{Y}_0) \;=\; \sqrt{n} \,
+   \sup_{y_l \in \mathcal{Y}_0} \bigl| \widehat\Delta_t(y_l \mid x) \bigr| ,
+
+whose limit under the null is the supremum of a mean-zero Gaussian process.
+Critical values come from simulating that process using a plug-in estimate of
+its covariance kernel. The kernel carries two sources of uncertainty at the same
+:math:`\sqrt{n}` rate: the distribution-regression error in the post period, and
+the weight-estimation error inherited from the pre-periods.
+
+When the test rejects, a one-sided lower confidence bound for
+:math:`f_t(x)` is reported. It is only meaningful conditional on rejection:
+under the null the delta-method derivative vanishes, the variance degenerates,
+and the bound collapses to zero.
+
+With two or more pre-periods, parallel trends is testable directly by treating
+an earlier period as a pseudo-post period and asking whether the same machinery
+finds an effect where none can exist.
+
+One reproducibility caveat, worth knowing before comparing numbers across
+machines. The simulated critical values require a matrix square root of the
+estimated kernel, obtained from an eigendecomposition. Eigenvector *signs* are
+implementation-defined, so a different LAPACK build produces a different factor
+and hence a different realisation from identical Gaussian draws, even with the
+seed fixed. The effect is a few tenths of a percent on the critical value. The
+test statistic itself involves no eigendecomposition and is exact.
+
+Example
+-------
+
+.. code-block:: python
+
+   import numpy as np, pandas as pd
+   from mlsynth import DRSC
+
+   # micro-panel: one row per (state, policy year, worker)
+   df = pd.read_parquet("benchmarks/reference/wied_nj_minwage/"
+                        "nj_estimation_sample.parquet")
+   df["treat"] = ((df.STATEFIP == 34) & (df.t == 4)).astype(int)
+   df["x_std_sq"] = df["x_std"] ** 2
+
+   res = DRSC({
+       "df": df, "outcome": "logwage", "treat": "treat",
+       "unitid": "STATEFIP", "time": "t",
+       "covariates": ["e_std", "x_std", "x_std_sq"],
+       "evaluation_points": {
+           "low_skill_young": {"e_std": -0.98, "x_std": -1.17,
+                               "x_std_sq": 1.37},
+           "high_skill":      {"e_std":  1.64, "x_std":  1.44,
+                               "x_std_sq": 2.08},
+       },
+       "focus_region": (np.log(4.25), np.log(5.10)),   # the MW corridor
+       "display_graphs": False,
+   }).fit()
+
+   e = res.conditional_effects["low_skill_young"]
+   e.f_hat, e.p_value, e.p_value_focused     # 1.71e-3, 0.054, 0.012
+   res.gram_condition_number                  # 9.6e4 -- see the float64 note
+   res.n_negative_weights                     # 20 of 42, expected
+
+Verification
+------------
+
+Reproduced against Wied (2026), Tables 1 and 2, on the author's own CPS
+estimation sample: all five donor weights and all twenty cells of Table 2 match
+to the paper's printed precision, along with the active grid size
+(:math:`m = 32`), the Gram condition number and the negative-weight count. See
+:doc:`replications/drsc` and
+`benchmarks/reference/wied_nj_minwage/
+<https://github.com/jgreathouse9/mlsynth/tree/main/benchmarks/reference/wied_nj_minwage>`_.
+
+Not to be confused with
+-----------------------
+
+:doc:`drosc` is Distributionally *Robust* synthetic control -- robustness of a
+conventional estimate to distributional shift, a different question entirely.
+:doc:`dsc` is the unconditional distributional estimator DRSC extends.
+
+Core API
+--------
+
+.. autoclass:: DRSC
+   :members: fit
+
+.. autoclass:: mlsynth.utils.drsc_helpers.config.DRSCConfig
+   :members:
+
+.. autoclass:: mlsynth.utils.drsc_helpers.structures.DRSCResults
+   :members:
+
+.. autoclass:: mlsynth.utils.drsc_helpers.structures.ConditionalEffect
+   :members:

--- a/docs/drsc.rst
+++ b/docs/drsc.rst
@@ -131,6 +131,15 @@ a closed form -- no solver, no iteration:
    \frac{\mathbf{1}'\widehat G^{-1}\widehat c - 1}
         {\mathbf{1}'\widehat G^{-1}\mathbf{1}} .
 
+The grid :math:`\{y_l\}_{l=1}^{m}` is a set of quantiles of the pooled outcome
+between ``grid_lo`` and ``grid_hi``. One detail there is worth knowing before
+you change it: ``n_grid`` is the number of points *requested*, and ties are
+collapsed afterwards, so the active grid is generally shorter. Wages reported
+to the cent produce a lot of ties -- on the New Jersey panel the paper's 38
+requested points leave 32 active. Passing the active count instead of the
+requested one is a silent mistake rather than a loud one: asking for 32 leaves
+28 active and moves Florida's weight from 0.515 to 0.496.
+
 Two consequences deserve stating plainly, because both look like faults and
 neither is.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -245,6 +245,7 @@ headline numbers.
    compsc
    scta
    ctsc
+   drsc
    dsc
    scd
    drosc

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -50,6 +50,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    :hidden:
    :caption: Dedicated replication pages
 
+   replications/drsc
    replications/fdid
    replications/wine_tennessee
    replications/cast

--- a/docs/replications/drsc.rst
+++ b/docs/replications/drsc.rst
@@ -1,0 +1,184 @@
+.. _replication-drsc:
+
+DRSC — New Jersey's 1992 minimum wage (Wied 2026)
+==================================================
+
+:Estimator: :doc:`../drsc` — :class:`mlsynth.DRSC`
+:Source: Wied, Dominik (2026), *"A Synthetic Control Approach to Conditional
+   Distributional Treatment Effects,"* arXiv:2606.09625.
+:Replication type: Path A — the author's empirical result on the author's data.
+:Status: Fully verified — Tables 1 and 2 reproduced cell for cell.
+:Data: `benchmarks/reference/wied_nj_minwage/
+   <https://github.com/jgreathouse9/mlsynth/tree/main/benchmarks/reference/wied_nj_minwage>`_
+
+The question
+------------
+
+In April 1992 New Jersey raised its minimum wage from $4.25 to $5.05 while the
+federal floor stayed at $4.25. Card and Krueger studied the employment effects
+of the same reform; this application asks a different question, about the wage
+distribution rather than about jobs. Specifically: for which kinds of worker did
+the increase bite, and where in their wage distribution?
+
+That is a question an average cannot answer, and it is also one an
+*unconditional* distributional method answers only weakly. Low-education young
+workers are a small share of the workforce, so an effect concentrated on them
+barely registers in the pooled wage distribution. Conditioning on education and
+experience is what makes the pattern visible.
+
+Data
+----
+
+CPS Basic Monthly, 1989–1993, organised into April–March policy years aligned to
+the reform: :math:`t = 1` is Apr 1989–Mar 1990 through :math:`t = 4` is Apr
+1992–Mar 1993, the post-treatment year. That periodisation matters — it puts the
+April 1992 increase exactly at a period boundary, so no partially treated year
+has to be discarded.
+
+The estimation sample is 381,953 workers across 43 states (New Jersey plus 42
+donors) and four policy years. Eight states with their own minimum-wage changes
+during the window are excluded. New Jersey's cell sizes are 3,852 / 3,998 /
+4,031 in the pre-periods and 3,905 in the post period.
+
+The raw CPS extract is not vendored — it is roughly 145 MB compressed and 8.8
+million person-records. What is stored is the estimation sample the estimator
+actually consumes, produced by the author's own preparation code. New Jersey's
+four cell sizes matching the paper to the individual observation is what
+establishes the extract is the right one.
+
+Path A — the numbers
+--------------------
+
+Five largest synthetic control weights (Table 1):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 22 22 22
+
+   * - donor
+     - paper
+     - mlsynth
+     - difference
+   * - Florida
+     - 0.515
+     - 0.515
+     - 0.000
+   * - New York
+     - 0.479
+     - 0.479
+     - 0.000
+   * - South Dakota
+     - -0.255
+     - -0.255
+     - 0.000
+   * - Nevada
+     - 0.199
+     - 0.199
+     - 0.000
+   * - Missouri
+     - -0.196
+     - -0.196
+     - 0.000
+
+Treatment effects at five covariate values (Table 2). :math:`T_n` is the
+full-support supremum statistic, :math:`p` its p-value, and
+:math:`p_{\mathcal{Y}_0}` the p-value of the focused test restricted to the
+minimum-wage corridor :math:`[\log 4.25, \log 5.10]`:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 18 18 18 16
+
+   * - evaluation point
+     - :math:`\hat f \times 10^{3}`
+     - :math:`T_n`
+     - :math:`p`
+     - :math:`p_{\mathcal{Y}_0}`
+   * - median (ed 12, exp 10)
+     - 0.58
+     - 26.7
+     - 0.294
+     - 0.064
+   * - low-skill young (ed 10, exp 2)
+     - 1.71
+     - 73.0
+     - 0.054
+     - 0.012
+   * - high-ed young (ed 16, exp 2)
+     - 1.55
+     - 37.1
+     - 0.686
+     - 0.150
+   * - low-ed senior (ed 10, exp 37)
+     - 0.61
+     - 28.6
+     - 0.750
+     - 0.060
+   * - high-skill (ed 16, exp 37)
+     - 0.21
+     - 27.6
+     - 0.824
+     - 0.846
+
+Every cell matches the paper. Also reproduced: the active grid size
+:math:`m = 32`, the Gram condition number :math:`9.64 \times 10^{4}` against the
+paper's :math:`9.6 \times 10^{4}`, and 20 of 42 donors receiving negative
+weight.
+
+The substantive finding survives intact. The effect is sharply concentrated
+among low-education, low-experience workers and inside the wage corridor the
+policy actually operates on; for high-education, high-experience workers — whose
+wages sit far above the new floor — there is nothing, which is the falsification
+check the paper intends.
+
+What does not reproduce exactly, and why
+----------------------------------------
+
+The Gaussian-process critical values. This implementation obtains 245.5 and
+240.5 for the two pre-trend transitions where the paper reports 245.3 and 241.7,
+despite the seed being fixed in both.
+
+The cause is not the seed. Simulating the limiting process requires a matrix
+square root of the estimated covariance kernel, taken here from an
+eigendecomposition. Eigenvector signs are implementation-defined: a different
+LAPACK build returns a different set of signs for the same matrix, hence a
+different factor, hence a different realisation from identical Gaussian draws.
+The simulated distribution is unchanged; individual quantiles of it move. The
+measured effect is 0.2–0.5 percent, which covers both discrepancies.
+
+Test statistics involve no eigendecomposition and are exact — including the
+x-simultaneous pre-trend statistics, 144.9 and 209.6, which match the paper
+exactly.
+
+The rule this implies for anything built on this replication: pin
+:math:`T_n`, :math:`\hat f`, the confidence bounds and the weights tightly; pin
+critical values and p-values loosely.
+
+Precision is not optional here
+------------------------------
+
+The replication also measured what the ill-conditioned Gram matrix costs. A
+float32 round-trip of the estimation sample — relative error about
+:math:`6 \times 10^{-8}` — moves the largest donor weight by about 0.04, taking
+Florida from 0.515 to 0.505; random noise of the same magnitude, which does not
+partially cancel the way rounding does, moves them by 0.12 to 0.17. Either way
+:math:`\hat f` stays within a few percent and the corridor p-value at
+:math:`x_{10}` is unchanged at 0.012.
+
+That asymmetry is the signature of near-collinearity: the weight vector is
+poorly determined while the fitted counterfactual is well determined. It is why
+the estimator requires float64 inputs, and why a benchmark built on this should
+lean on the estimands rather than on individual weights if it ever has to choose.
+
+Reproducing it
+--------------
+
+.. code-block:: bash
+
+   python benchmarks/run_benchmarks.py --case wied_nj_minwage
+
+The author's own script output is stored alongside the data as
+``results_empirics.csv``, and an independent port written from the paper's
+equations is kept as ``independent_port.py``. Both reproduce the tables, which
+is what makes the target implementation-independent rather than a re-run of one
+author's code.

--- a/llms.txt
+++ b/llms.txt
@@ -39,6 +39,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **CounterfactualComparison** — Result of :func:`compare_counterfactuals`.
 - **DPSC** — Differentially private synthetic control estimator.  (config: DPSCConfig)
 - **DROSC** — Distributionally Robust Synthetic Control estimator.  (config: DROSCConfig)
+- **DRSC** — Distribution-regression synthetic control.
 - **DSC** — Distributional Synthetic Control estimator.  (config: DSCConfig)
 - **DSCAR** — Dynamic Synthetic Control for Auto-Regressive processes.  (config: DSCARConfig)
 - **DTWSC** — Dynamic Synthetic Control estimator.  (config: DTWSCConfig)

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -74,6 +74,7 @@ from .estimators.siv import SIV
 from .estimators.orthsc import ORTHSC
 from .estimators.beast import BEAST
 from .estimators.dpsc import DPSC
+from .estimators.drsc import DRSC
 from .estimators.dsc import DSC
 from .estimators.drosc import DROSC
 from .estimators.dscar import DSCAR
@@ -172,6 +173,7 @@ __all__ = [
     "compare_pareto",
     "from_syndes",
     "plot_compare_pareto",
+    "DRSC",
     "DSC",
     "DROSC",
     "SpSyDiD",

--- a/mlsynth/estimators/drsc.py
+++ b/mlsynth/estimators/drsc.py
@@ -1,0 +1,117 @@
+"""DRSC -- conditional distributional treatment effects (Wied 2026).
+
+Wied, D. (2026). *"A Synthetic Control Approach to Conditional Distributional
+Treatment Effects."* arXiv:2606.09625.
+
+Where :class:`mlsynth.DSC` (Gunsilius 2023) matches *unconditional* quantile
+functions, DRSC targets the conditional distribution
+:math:`F(y \\mid x)`. It models it semiparametrically as
+:math:`\\Lambda(x'\\theta(y))` -- a distribution regression -- and imposes
+parallel trends on the parameter function :math:`\\theta` rather than on the
+CDF. Two things follow from putting the assumption in parameter space: the
+counterfactual stays inside the model class, and the weight problem is a
+quadratic program with one linear constraint, hence closed-form.
+
+Why condition at all
+--------------------
+
+When the outcome depends on individual characteristics -- wages on education
+and experience -- an effect concentrated in one part of the covariate space can
+be invisible in the marginal distribution. The paper's simulation makes this
+concrete: an effect entering along a single mean-zero covariate leaves the
+marginal almost unchanged, so an unconditional method has essentially no power
+while the conditional test rejects.
+
+Data requirements
+-----------------
+
+Micro-level panel data: one row per ``(unit, time, individual)``, with
+covariates on every row. Ingestion does not use ``dataprep`` -- that pivots to
+one outcome per cell -- and follows :class:`mlsynth.DSC`'s micro-panel setup
+instead.
+
+Two properties that surprise people
+-----------------------------------
+
+The asymptotics are in the *within-cell* sample size, with the donor count and
+the number of periods fixed. One pre-period suffices for consistency; more
+pre-periods buy precision in the weights, not in the DR parameters. If your
+cells are small and your panel is long, this is the wrong estimator.
+
+Weights are constrained only to sum to one, so negative weights are ordinary
+(20 of 42 in the paper's application) and mean the treated unit sits outside
+the donor hull. The Gram matrix is correspondingly ill-conditioned, and the
+inputs must be float64 -- see :doc:`../drsc` for the measured cost of not
+doing that.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import pandas as pd
+from pydantic import ValidationError
+
+from ..exceptions import (MlsynthConfigError, MlsynthDataError,
+                          MlsynthEstimationError)
+from ..utils.drsc_helpers.config import DRSCConfig
+from ..utils.drsc_helpers.pipeline import run_drsc
+from ..utils.drsc_helpers.plotter import plot_drsc
+from ..utils.drsc_helpers.setup import prepare_drsc_inputs
+from ..utils.drsc_helpers.structures import DRSCResults
+
+
+class DRSC:
+    """Distribution-regression synthetic control.
+
+    Parameters
+    ----------
+    config : DRSCConfig or dict
+        See :class:`mlsynth.utils.drsc_helpers.config.DRSCConfig`.
+
+    Examples
+    --------
+    >>> from mlsynth import DRSC                              # doctest: +SKIP
+    >>> res = DRSC({                                          # doctest: +SKIP
+    ...     "df": micro_panel, "outcome": "logwage", "treat": "treat",
+    ...     "unitid": "state", "time": "policy_year",
+    ...     "covariates": ["educ_std", "exper_std", "exper_std_sq"],
+    ...     "evaluation_points": {
+    ...         "low_skill_young": {"educ_std": -0.98, "exper_std": -1.17,
+    ...                             "exper_std_sq": 1.37}},
+    ... }).fit()
+    >>> res.conditional_effects["low_skill_young"].p_value   # doctest: +SKIP
+    """
+
+    def __init__(self, config: Union[DRSCConfig, dict]) -> None:
+        if isinstance(config, dict):
+            try:
+                config = DRSCConfig(**config)
+            except MlsynthConfigError:
+                raise
+            except ValidationError as exc:
+                raise MlsynthConfigError(
+                    f"Invalid DRSC configuration: {exc}") from exc
+        self.config: DRSCConfig = config
+
+    def fit(self) -> DRSCResults:
+        """Estimate the conditional distributional treatment effect."""
+        cfg = self.config
+        try:
+            inputs = prepare_drsc_inputs(
+                df=cfg.df, outcome=cfg.outcome, treat=cfg.treat,
+                unitid=cfg.unitid, time=cfg.time, covariates=cfg.covariates)
+            results = run_drsc(
+                inputs=inputs, evaluation_points=cfg.evaluation_points,
+                link=cfg.link, n_grid=cfg.n_grid, grid_lo=cfg.grid_lo,
+                grid_hi=cfg.grid_hi, focus_region=cfg.focus_region,
+                ridge=cfg.ridge, alpha=cfg.alpha, n_gp_draws=cfg.n_gp_draws,
+                seed=cfg.seed)
+            if cfg.display_graphs:
+                plot_drsc(results, outcome_label=cfg.outcome,
+                          focus_region=cfg.focus_region, save=cfg.save)
+            return results
+        except (MlsynthConfigError, MlsynthDataError, MlsynthEstimationError):
+            raise
+        except Exception as exc:  # pragma: no cover - translation guard
+            raise MlsynthEstimationError(f"DRSC estimation failed: {exc}") from exc

--- a/mlsynth/guides/llms.txt
+++ b/mlsynth/guides/llms.txt
@@ -39,6 +39,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **CounterfactualComparison** — Result of :func:`compare_counterfactuals`.
 - **DPSC** — Differentially private synthetic control estimator.  (config: DPSCConfig)
 - **DROSC** — Distributionally Robust Synthetic Control estimator.  (config: DROSCConfig)
+- **DRSC** — Distribution-regression synthetic control.
 - **DSC** — Distributional Synthetic Control estimator.  (config: DSCConfig)
 - **DSCAR** — Dynamic Synthetic Control for Auto-Regressive processes.  (config: DSCARConfig)
 - **DTWSC** — Dynamic Synthetic Control estimator.  (config: DTWSCConfig)

--- a/mlsynth/tests/test_drsc.py
+++ b/mlsynth/tests/test_drsc.py
@@ -19,8 +19,9 @@ not, so the edge cases that matter are thin *cells*, not thin panels.
 
 The weights are ill-conditioned by construction. On the paper's data the Gram
 matrix has a condition number near 1e5 and the closed-form solve amplifies
-relative input error by about 1e6, so float32 inputs move donor weights by
-0.15 while barely touching the estimand. That is pinned in
+relative input error by about 1e6, so a float32 round-trip moves the largest
+donor weight by ~0.04 -- and random noise of the same magnitude by 0.12-0.17 --
+while barely touching the estimand. That is pinned in
 :class:`TestFloat64IsRequired` because it is exactly the kind of property that
 gets rediscovered painfully later.
 

--- a/mlsynth/tests/test_drsc.py
+++ b/mlsynth/tests/test_drsc.py
@@ -1,0 +1,377 @@
+"""DRSC: conditional distributional treatment effects (Wied 2026).
+
+Where :class:`mlsynth.DSC` matches *unconditional* quantile functions, DRSC
+models the conditional distribution semiparametrically as
+``F_it(y | x) = Lambda(x' theta_it(y))`` and imposes parallel trends in the
+*parameter* space rather than on the CDF. The payoff is that an effect which
+is heterogeneous across the covariate space stays visible: the paper's own
+simulation plants a shift along one covariate direction whose mean is zero, so
+the marginal distribution barely moves and an unconditional method has no
+power, while the conditional test rejects.
+
+Three things about this estimator drive the tests below and are worth stating
+because none is obvious from the model.
+
+The asymptotics are in ``n`` -- individuals within a group-time cell -- with the
+number of donors and periods fixed. One pre-period suffices for consistency.
+Every other estimator in mlsynth gets its precision from ``T``; this one does
+not, so the edge cases that matter are thin *cells*, not thin panels.
+
+The weights are ill-conditioned by construction. On the paper's data the Gram
+matrix has a condition number near 1e5 and the closed-form solve amplifies
+relative input error by about 1e6, so float32 inputs move donor weights by
+0.15 while barely touching the estimand. That is pinned in
+:class:`TestFloat64IsRequired` because it is exactly the kind of property that
+gets rediscovered painfully later.
+
+The weights are not constrained to the simplex -- only to sum to one -- so
+negative weights are normal, not a symptom. On the paper's panel 20 of 42 are
+negative.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+_REF = (Path(__file__).resolve().parents[2] / "benchmarks" / "reference"
+        / "wied_nj_minwage")
+
+
+# ---------------------------------------------------------------------------
+# synthetic panels
+# ---------------------------------------------------------------------------
+def _panel(n_per_cell=400, J=4, T=2, T0=1, delta=0.0, seed=0, p=3):
+    """Wied's own simulation design (paper Section 4).
+
+    ``J`` donors whose parameter vectors each differ from the common mean in
+    exactly one coordinate; the treated unit's parameter is the average of the
+    donors', so parallel-trends-in-parameters holds exactly with equal weights.
+    Under the alternative the treated unit's post-period outcome gains
+    ``delta * X1`` -- a shift along one covariate only, which moves the
+    conditional distribution while leaving the marginal nearly fixed.
+    """
+    rng = np.random.default_rng(seed)
+    beta_bar = np.ones(p + 1)
+    ctrl = []
+    for i in range(J):
+        b = beta_bar.copy()
+        b[i % (p + 1)] += 0.8
+        ctrl.append(b)
+    treated_beta = np.mean(ctrl, axis=0)
+    rows = []
+    for t in range(1, T + 1):
+        for i in range(J + 1):
+            beta = treated_beta if i == 0 else ctrl[i - 1]
+            X = rng.normal(size=(n_per_cell, p))
+            y = beta[0] + X @ beta[1:] + rng.normal(size=n_per_cell)
+            if i == 0 and t > T0:
+                y = y + delta * X[:, 0]
+            for k in range(n_per_cell):
+                rows.append((f"u{i}", t, y[k], *X[k],
+                             int(i == 0 and t > T0)))
+    cols = ["unit", "t", "y"] + [f"x{j+1}" for j in range(p)] + ["treat"]
+    return pd.DataFrame(rows, columns=cols)
+
+
+COVS = ["x1", "x2", "x3"]
+EVAL = {"x0": {"x1": 1.0, "x2": 0.0, "x3": 0.0}}
+
+
+def _fit(df=None, **over):
+    from mlsynth import DRSC
+
+    cfg = {"df": _panel() if df is None else df, "outcome": "y",
+           "treat": "treat", "unitid": "unit", "time": "t",
+           "covariates": COVS, "evaluation_points": EVAL,
+           "display_graphs": False}
+    cfg.update(over)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return DRSC(cfg).fit()
+
+
+# ---------------------------------------------------------------------------
+class TestSmoke:
+    """End-to-end on minimal input: right type, finite numbers."""
+
+    def test_it_fits_and_returns_the_contract_type(self):
+        from mlsynth.config_models import EffectResult
+
+        res = _fit()
+        assert isinstance(res, EffectResult)
+
+    def test_the_headline_quantities_are_finite(self):
+        res = _fit()
+        assert np.isfinite(res.effects.att)
+        w = res.weights.donor_weights
+        assert w and all(np.isfinite(v) for v in w.values())
+
+    def test_the_standard_submodels_are_populated(self):
+        res = _fit()
+        assert res.effects is not None
+        assert res.weights is not None
+        assert res.method_details is not None
+        assert "DRSC" in res.method_details.method_name
+
+
+class TestTheWeightsSolveTheStatedProgram:
+    """eq. (7): min-norm least squares subject to 1'w = 1."""
+
+    def test_weights_sum_to_one(self):
+        w = np.array(list(_fit().weights.donor_weights.values()))
+        assert w.sum() == pytest.approx(1.0, abs=1e-9)
+
+    def test_negative_weights_are_allowed(self):
+        """Not a simplex. A design outside the donor hull must still fit."""
+        df = _panel(seed=3)
+        # push the treated unit outside the affine hull of the donors
+        m = df.unit == "u0"
+        df.loc[m, "y"] = df.loc[m, "y"] * 1.8 + 4.0
+        w = np.array(list(_fit(df).weights.donor_weights.values()))
+        assert np.isfinite(w).all()
+        assert w.sum() == pytest.approx(1.0, abs=1e-9)
+
+    def test_it_recovers_equal_weights_when_the_design_says_so(self):
+        """Wied's DGP sets the treated parameter to the donors' mean, so the
+        true weights are 1/J. With one pre-period and large cells the estimate
+        should land near that."""
+        w = np.array(list(_fit(_panel(n_per_cell=1200, seed=5))
+                          .weights.donor_weights.values()))
+        assert w == pytest.approx(np.full(len(w), 1.0 / len(w)), abs=0.25)
+
+
+class TestTheConditionalTestSeesWhatTheMarginalCannot:
+    """The paper's central claim, and the reason the estimator exists."""
+
+    def test_size_is_controlled_under_the_null(self):
+        """A single draw cannot test size.
+
+        Under H0 the p-value is Uniform(0,1), so asserting ``p > alpha`` on one
+        replication fails with probability exactly alpha -- a test that is
+        broken by construction. This runs a small sweep instead and asks only
+        that the rejection rate is not wildly above nominal. With 8 draws at a
+        nominal 0.10 the expected count is 0.8, so a threshold of 4 is far into
+        the tail while still catching a grossly oversized test.
+        """
+        p = [_fit(_panel(delta=0.0, n_per_cell=300, seed=100 + s), n_grid=12)
+             .inference.p_value for s in range(8)]
+        assert sum(v < 0.10 for v in p) <= 4, f"oversized: {p}"
+
+    def test_a_covariate_heterogeneous_effect_is_detected(self):
+        """delta * X1 with E[X1] = 0: the marginal barely moves."""
+        res = _fit(_panel(delta=1.2, n_per_cell=600, seed=11))
+        assert res.inference.p_value < 0.10
+
+    def test_the_null_is_less_significant_than_the_alternative(self):
+        """The comparison a single-draw size test cannot make."""
+        null = _fit(_panel(delta=0.0, n_per_cell=600, seed=11))
+        alt = _fit(_panel(delta=1.2, n_per_cell=600, seed=11))
+        assert null.inference.p_value > alt.inference.p_value
+        assert float(null.effects.att) < float(alt.effects.att)
+
+    def test_the_effect_size_orders_correctly(self):
+        f = [float(_fit(_panel(delta=d, n_per_cell=600, seed=11)).effects.att)
+             for d in (0.0, 0.8, 1.6)]
+        assert f[0] < f[1] < f[2]
+
+
+class TestFloat64IsRequired:
+    """kappa(G) ~ 1e5 and the solve amplifies relative error by ~1e6.
+
+    Measured on the paper's data: a float32 round-trip (relative 6e-8) moves
+    donor weights by 0.12-0.17 while leaving the estimand nearly intact. The
+    estimator must therefore not silently downcast, and must say so if handed
+    a float32 outcome or covariate column.
+    """
+
+    def test_a_float32_panel_still_computes_in_float64(self):
+        df = _panel(seed=7)
+        for c in ["y"] + COVS:
+            df[c] = df[c].astype("float32")
+        res = _fit(df)
+        assert np.isfinite(res.effects.att)
+
+    def test_float32_and_float64_agree_on_the_estimand(self):
+        """The estimand is robust even where the weights are not."""
+        df64 = _panel(seed=7)
+        df32 = df64.copy()
+        for c in ["y"] + COVS:
+            df32[c] = df32[c].astype("float32")
+        assert float(_fit(df32).effects.att) == pytest.approx(
+            float(_fit(df64).effects.att), rel=0.05)
+
+
+class TestFailuresAreReported:
+    """Bad input raises a translated error, never a bare pandas/numpy one."""
+
+    def test_an_unknown_covariate_is_reported(self):
+        from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+
+        with pytest.raises((MlsynthConfigError, MlsynthDataError),
+                           match="nope"):
+            _fit(covariates=["x1", "nope"])
+
+    def test_an_empty_covariate_list_is_reported(self):
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises(MlsynthConfigError, match="empty|at least one"):
+            _fit(covariates=[])
+
+    def test_a_non_numeric_covariate_is_reported(self):
+        from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+
+        df = _panel()
+        df["label"] = "a"
+        with pytest.raises((MlsynthConfigError, MlsynthDataError),
+                           match="numeric"):
+            _fit(df, covariates=["x1", "label"],
+                 evaluation_points={"x0": {"x1": 1.0, "label": 0.0}})
+
+    def test_an_evaluation_point_naming_an_unknown_covariate_is_reported(self):
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises(MlsynthConfigError, match="nope|evaluation"):
+            _fit(evaluation_points={"bad": {"nope": 1.0}})
+
+    def test_no_evaluation_points_is_reported(self):
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises(MlsynthConfigError, match="evaluation"):
+            _fit(evaluation_points={})
+
+    def test_no_donors_is_reported(self):
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _panel(J=1)
+        df = df[df.unit == "u0"]
+        with pytest.raises(MlsynthDataError, match="donor"):
+            _fit(df)
+
+    def test_no_pre_period_is_reported(self):
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _panel(T=2, T0=0)
+        df["treat"] = (df.unit == "u0").astype(int)
+        with pytest.raises(MlsynthDataError, match="pre-treatment|pre-period"):
+            _fit(df)
+
+    def test_no_treated_unit_is_reported(self):
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _panel()
+        df["treat"] = 0
+        with pytest.raises(MlsynthDataError, match="treated"):
+            _fit(df)
+
+    def test_a_cell_too_small_to_identify_the_dr_is_reported(self):
+        """p+1 parameters need more than p+1 observations in every cell."""
+        from mlsynth.exceptions import MlsynthDataError, MlsynthEstimationError
+
+        with pytest.raises((MlsynthDataError, MlsynthEstimationError),
+                           match="observation|too few|cell"):
+            _fit(_panel(n_per_cell=3))
+
+
+class TestEdgeCases:
+    def test_a_single_donor_still_fits(self):
+        """J = 1 forces w = 1 by the adding-up constraint."""
+        res = _fit(_panel(J=1, n_per_cell=500))
+        w = list(res.weights.donor_weights.values())
+        assert len(w) == 1 and w[0] == pytest.approx(1.0, abs=1e-9)
+
+    def test_one_pre_period_is_enough(self):
+        """The paper's asymptotics are in n, not T: T0 = 1 is consistent."""
+        assert np.isfinite(_fit(_panel(T=2, T0=1)).effects.att)
+
+    def test_more_pre_periods_are_accepted(self):
+        assert np.isfinite(_fit(_panel(T=4, T0=3)).effects.att)
+
+    def test_a_collinear_covariate_is_handled(self):
+        from mlsynth.exceptions import MlsynthEstimationError
+
+        df = _panel()
+        df["x4"] = df["x1"] * 2.0            # exactly collinear
+        try:
+            res = _fit(df, covariates=COVS + ["x4"],
+                       evaluation_points={"x0": {"x1": 1.0, "x2": 0.0,
+                                                 "x3": 0.0, "x4": 2.0}})
+            assert np.isfinite(res.effects.att)
+        except MlsynthEstimationError as exc:
+            assert "collinear" in str(exc).lower() or "rank" in str(exc).lower()
+
+
+class TestPlotting:
+    def test_display_graphs_runs(self, tmp_path):
+        import matplotlib
+        matplotlib.use("Agg")
+        res = _fit(display_graphs=True, save=str(tmp_path / "drsc"))
+        assert np.isfinite(res.effects.att)
+
+
+# ---------------------------------------------------------------------------
+@pytest.mark.skipif(not (_REF / "nj_estimation_sample.parquet").exists(),
+                    reason="Wied reference sample not vendored (see #329)")
+class TestItReproducesThePaper:
+    """Path A: Wied (2026), Tables 1 and 2, on the authors' own data.
+
+    Tolerances follow the replication spike. The weights and the estimands are
+    deterministic and pinned tight; the Gaussian-process critical values are
+    not reproducible across LAPACK builds -- ``eigh`` eigenvector signs are
+    implementation-defined -- so anything downstream of the GP simulation is
+    pinned loose.
+    """
+
+    PAPER_W = {12: 0.515, 36: 0.479, 46: -0.255, 32: 0.199, 29: -0.196}
+    PAPER_F = {"x0": 0.58, "x10": 1.71, "xhl": 1.55, "xlh": 0.61, "x90": 0.21}
+
+    @pytest.fixture(scope="class")
+    def nj(self):
+        import json
+
+        d = pd.read_parquet(_REF / "nj_estimation_sample.parquet")
+        meta = json.load(open(_REF / "nj_meta.json"))
+        d["treat"] = ((d.STATEFIP == 34) & (d.t == 4)).astype(int)
+        d["x_std_sq"] = d["x_std"] ** 2
+        return d, meta
+
+    def _eval_points(self, meta):
+        pts = {}
+        for nm, ed, ex in (("x0", 12, 10), ("x10", 10, 2), ("xhl", 16, 2),
+                           ("xlh", 10, 37), ("x90", 16, 37)):
+            e = (ed - meta["me"]) / meta["se"]
+            x = (ex - meta["mx"]) / meta["sx"]
+            pts[nm] = {"e_std": e, "x_std": x, "x_std_sq": x ** 2}
+        return pts
+
+    def test_table_1_weights(self, nj):
+        d, meta = nj
+        res = _fit(d, outcome="logwage", unitid="STATEFIP", time="t",
+                   covariates=["e_std", "x_std", "x_std_sq"],
+                   evaluation_points=self._eval_points(meta))
+        w = res.weights.donor_weights
+        for fips, target in self.PAPER_W.items():
+            assert w[str(fips)] == pytest.approx(target, abs=0.01), f"FIPS {fips}"
+
+    def test_table_2_effect_sizes(self, nj):
+        d, meta = nj
+        res = _fit(d, outcome="logwage", unitid="STATEFIP", time="t",
+                   covariates=["e_std", "x_std", "x_std_sq"],
+                   evaluation_points=self._eval_points(meta))
+        for nm, target in self.PAPER_F.items():
+            got = res.conditional_effects[nm].f_hat * 1e3
+            assert got == pytest.approx(target, abs=0.05), nm
+
+    def test_the_corridor_test_rejects_only_for_low_skill_young(self, nj):
+        d, meta = nj
+        res = _fit(d, outcome="logwage", unitid="STATEFIP", time="t",
+                   covariates=["e_std", "x_std", "x_std_sq"],
+                   evaluation_points=self._eval_points(meta),
+                   focus_region=(np.log(4.25), np.log(5.10)))
+        p = {k: v.p_value_focused for k, v in res.conditional_effects.items()}
+        assert p["x10"] < 0.05
+        assert p["x90"] > 0.5

--- a/mlsynth/tests/test_drsc.py
+++ b/mlsynth/tests/test_drsc.py
@@ -349,11 +349,31 @@ class TestItReproducesThePaper:
             pts[nm] = {"e_std": e, "x_std": x, "x_std_sq": x ** 2}
         return pts
 
+    def test_the_default_grid_is_the_papers_requested_count(self):
+        """``n_grid`` counts *requested* quantile points, not active ones.
+
+        The author's ``build_grid(w, m=38, lo=0.10, hi=0.90)`` asks for 38 and
+        gets 32 after ties collapse. Defaulting to 32 would silently request the
+        active count, which on the paper's own data yields 28 active points and
+        moves Florida's weight from 0.515 to 0.496 -- a 0.06 error, sixty times
+        the tolerance the weights otherwise reproduce at.
+        """
+        from mlsynth.utils.drsc_helpers.config import DRSCConfig
+
+        assert DRSCConfig.model_fields["n_grid"].default == 38
+
+    def test_thirty_eight_requested_points_leave_thirty_two_active(self, nj):
+        d, meta = nj
+        res = _fit(d, outcome="logwage", unitid="STATEFIP", time="t",
+                   covariates=["e_std", "x_std", "x_std_sq"],
+                   evaluation_points=self._eval_points(meta), n_grid=38)
+        assert len(res.outcome_grid) == 32
+
     def test_table_1_weights(self, nj):
         d, meta = nj
         res = _fit(d, outcome="logwage", unitid="STATEFIP", time="t",
                    covariates=["e_std", "x_std", "x_std_sq"],
-                   evaluation_points=self._eval_points(meta))
+                   evaluation_points=self._eval_points(meta), n_grid=38)
         w = res.weights.donor_weights
         for fips, target in self.PAPER_W.items():
             assert w[str(fips)] == pytest.approx(target, abs=0.01), f"FIPS {fips}"
@@ -362,7 +382,7 @@ class TestItReproducesThePaper:
         d, meta = nj
         res = _fit(d, outcome="logwage", unitid="STATEFIP", time="t",
                    covariates=["e_std", "x_std", "x_std_sq"],
-                   evaluation_points=self._eval_points(meta))
+                   evaluation_points=self._eval_points(meta), n_grid=38)
         for nm, target in self.PAPER_F.items():
             got = res.conditional_effects[nm].f_hat * 1e3
             assert got == pytest.approx(target, abs=0.05), nm
@@ -371,7 +391,7 @@ class TestItReproducesThePaper:
         d, meta = nj
         res = _fit(d, outcome="logwage", unitid="STATEFIP", time="t",
                    covariates=["e_std", "x_std", "x_std_sq"],
-                   evaluation_points=self._eval_points(meta),
+                   evaluation_points=self._eval_points(meta), n_grid=38,
                    focus_region=(np.log(4.25), np.log(5.10)))
         p = {k: v.p_value_focused for k, v in res.conditional_effects.items()}
         assert p["x10"] < 0.05

--- a/mlsynth/utils/drsc_helpers/__init__.py
+++ b/mlsynth/utils/drsc_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers for DRSC (Wied 2026)."""

--- a/mlsynth/utils/drsc_helpers/config.py
+++ b/mlsynth/utils/drsc_helpers/config.py
@@ -1,0 +1,128 @@
+"""Configuration for DRSC (Wied 2026).
+
+Two inputs beyond the usual four columns, and both are intrinsic to the method
+rather than conveniences. ``covariates`` names the columns forming the design
+vector :math:`x`, because the estimand is a *conditional* distribution.
+``evaluation_points`` names the covariate values to report it at, because
+:math:`\\widehat f_t(x)` is a function of :math:`x`: unlike an ATT there is no
+single number to return, and asking the caller to say which :math:`x` they care
+about is the honest interface.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+from pydantic import Field, field_validator, model_validator
+
+from ...config_models import BaseEstimatorConfig
+from ...exceptions import MlsynthConfigError
+
+
+class DRSCConfig(BaseEstimatorConfig):
+    """Typed configuration for :class:`mlsynth.DRSC`."""
+
+    covariates: List[str] = Field(
+        ...,
+        description=(
+            "Columns forming the design vector x, in order. An intercept is "
+            "prepended automatically -- do not supply a constant column. "
+            "Derived terms are the caller's responsibility: the paper's "
+            "specification is [education, experience, experience^2], all "
+            "standardised, so the squared term is passed as its own column."),
+    )
+    evaluation_points: Dict[str, Dict[str, float]] = Field(
+        ...,
+        description=(
+            "Covariate values to report the effect at, as "
+            "{label: {covariate: value}}. Every covariate must be named in "
+            "every point. The conditional effect is a function of x, so at "
+            "least one point is required; there is no meaningful default."),
+    )
+    link: Literal["probit", "logit"] = Field(
+        default="probit",
+        description=(
+            "Link Lambda in F(y|x) = Lambda(x'theta(y)). Dette et al. (2025) "
+            "find the choice has negligible impact on estimates; probit is "
+            "the paper's default."),
+    )
+    n_grid: int = Field(
+        default=32, gt=1,
+        description=(
+            "Number of outcome grid points y_l at which the distribution "
+            "regression is run. Points are quantiles of the pooled outcome "
+            "between `grid_lo` and `grid_hi`; ties are collapsed, so the "
+            "active grid may be shorter than requested."),
+    )
+    grid_lo: float = Field(default=0.10, gt=0.0, lt=1.0,
+                           description="Lowest quantile of the outcome grid.")
+    grid_hi: float = Field(default=0.90, gt=0.0, lt=1.0,
+                           description="Highest quantile of the outcome grid.")
+    focus_region: Optional[Tuple[float, float]] = Field(
+        default=None,
+        description=(
+            "Optional (low, high) window on the outcome scale restricting the "
+            "focused supremum test -- the paper's minimum-wage corridor. The "
+            "full-support test is always reported alongside it."),
+    )
+    ridge: float = Field(
+        default=0.0, ge=0.0,
+        description=(
+            "Ridge added to the Gram matrix before the weight solve "
+            "(Remark 2.5). The Gram matrix is ill-conditioned by nature -- "
+            "kappa ~ 1e5 on the paper's panel -- so a small value stabilises "
+            "the weights at the cost of shrinking them toward 1/J. 0 (the "
+            "default) reproduces the paper."),
+    )
+    alpha: float = Field(
+        default=0.10, gt=0.0, lt=1.0,
+        description="Level of the supremum test and the one-sided lower bound.")
+    n_gp_draws: int = Field(
+        default=10_000, gt=0,
+        description=(
+            "Gaussian-process draws for the supremum test's critical value. "
+            "Note these are not reproducible across LAPACK builds even at a "
+            "fixed seed: eigenvector signs from `eigh` are "
+            "implementation-defined. The test statistic itself is exact."),
+    )
+    seed: int = Field(default=1992,
+                      description="Seed for the Gaussian-process simulation.")
+
+    @field_validator("covariates")
+    @classmethod
+    def _check_covariates(cls, v: List[str]) -> List[str]:
+        if not v:
+            raise MlsynthConfigError(
+                "covariates is empty; DRSC estimates a *conditional* "
+                "distribution and needs at least one covariate. For the "
+                "unconditional analogue use DSC.")
+        if len(set(v)) != len(v):
+            dup = sorted({c for c in v if v.count(c) > 1})
+            raise MlsynthConfigError(f"duplicate covariate column(s) {dup}.")
+        return v
+
+    @model_validator(mode="after")
+    def _check_evaluation_points(self) -> "DRSCConfig":
+        if not self.evaluation_points:
+            raise MlsynthConfigError(
+                "evaluation_points is empty; the conditional effect is a "
+                "function of x, so at least one point must be named.")
+        for label, point in self.evaluation_points.items():
+            missing = [c for c in self.covariates if c not in point]
+            extra = [c for c in point if c not in self.covariates]
+            if missing or extra:
+                raise MlsynthConfigError(
+                    f"evaluation point {label!r} does not match the "
+                    f"covariates: missing {missing}, unexpected {extra}. "
+                    "Every covariate must be given a value at every point.")
+        if self.grid_lo >= self.grid_hi:
+            raise MlsynthConfigError(
+                f"grid_lo ({self.grid_lo}) must be below grid_hi "
+                f"({self.grid_hi}).")
+        if self.focus_region is not None:
+            lo, hi = self.focus_region
+            if not lo < hi:
+                raise MlsynthConfigError(
+                    f"focus_region must be (low, high) with low < high; "
+                    f"got ({lo}, {hi}).")
+        return self

--- a/mlsynth/utils/drsc_helpers/config.py
+++ b/mlsynth/utils/drsc_helpers/config.py
@@ -47,12 +47,14 @@ class DRSCConfig(BaseEstimatorConfig):
             "the paper's default."),
     )
     n_grid: int = Field(
-        default=32, gt=1,
+        default=38, gt=1,
         description=(
-            "Number of outcome grid points y_l at which the distribution "
-            "regression is run. Points are quantiles of the pooled outcome "
-            "between `grid_lo` and `grid_hi`; ties are collapsed, so the "
-            "active grid may be shorter than requested."),
+            "Number of outcome grid points y_l *requested* for the "
+            "distribution regression. Points are quantiles of the pooled "
+            "outcome between `grid_lo` and `grid_hi`; ties are collapsed, so "
+            "the active grid is generally shorter. The default is the paper's "
+            "own request of 38, which on its data leaves 32 active points -- "
+            "pass the requested count, not the active one."),
     )
     grid_lo: float = Field(default=0.10, gt=0.0, lt=1.0,
                            description="Lowest quantile of the outcome grid.")

--- a/mlsynth/utils/drsc_helpers/dr.py
+++ b/mlsynth/utils/drsc_helpers/dr.py
@@ -1,0 +1,114 @@
+"""Distribution regression: the per-cell, per-grid-point binary regression.
+
+Wied eq. (4). For each cell and each grid point ``y``, regress ``1{Y <= y}`` on
+the design ``X`` under the link ``Lambda``. The resulting coefficient function
+``theta(y)`` is the object parallel trends is imposed on -- which is what keeps
+the counterfactual inside the model class and makes the weight program linear.
+
+Solved by Newton-Raphson with a step-halving line search on the log-likelihood,
+which is the reference implementation's method and is stable on the degenerate
+grid points (all-zero or all-one indicators) that occur at the ends of the grid.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import logistic, norm
+
+from ...exceptions import MlsynthEstimationError
+
+#: Below this the indicator is treated as degenerate and the fit short-circuits
+#: to a saturated intercept rather than diverging.
+_SATURATED = 8.0
+_EPS = 1e-12
+
+
+def link_functions(link: str):
+    """``(Lambda, lambda)`` -- the CDF and its derivative."""
+    if link == "probit":
+        return norm.cdf, norm.pdf
+    if link == "logit":
+        return logistic.cdf, logistic.pdf
+    raise MlsynthEstimationError(  # pragma: no cover - config restricts this
+        f"unknown link {link!r}; expected 'probit' or 'logit'.")
+
+
+def fit_cell(X: np.ndarray, y: np.ndarray, grid: np.ndarray, link: str = "probit",
+             max_iter: int = 50, tol: float = 1e-8, ridge: float = 1e-8):
+    """Distribution-regression coefficients for one cell.
+
+    Parameters
+    ----------
+    X : numpy.ndarray
+        Shape ``(n, k)`` design, intercept in column 0.
+    y : numpy.ndarray
+        Shape ``(n,)`` outcomes.
+    grid : numpy.ndarray
+        Shape ``(m,)`` outcome grid.
+    link : {'probit', 'logit'}
+    max_iter, tol, ridge
+        Newton controls. ``ridge`` is added to the Hessian diagonal only to
+        keep the solve well posed; it does not penalise the estimate.
+
+    Returns
+    -------
+    numpy.ndarray
+        Shape ``(m, k)`` coefficient function, one row per grid point.
+    """
+    Lam, lam = link_functions(link)
+    n, k = X.shape
+    theta = np.zeros((len(grid), k), dtype=np.float64)
+    for j, cut in enumerate(grid):
+        z = (y <= cut).astype(np.float64)
+        s = z.mean()
+        if s <= 0.0 or s >= 1.0:
+            # Degenerate indicator: the CDF is 0 or 1 for every x here, which a
+            # finite coefficient cannot express. Saturate rather than diverge.
+            theta[j, 0] = _SATURATED if s >= 1.0 else -_SATURATED
+            continue
+        beta = np.zeros(k)
+        beta[0] = norm.ppf(np.clip(s, 1e-3, 1 - 1e-3))
+        for _ in range(max_iter):
+            eta = X @ beta
+            P = np.clip(Lam(eta), _EPS, 1 - _EPS)
+            d = lam(eta)
+            grad = X.T @ (d * (z - P) / (P * (1 - P)))
+            wts = d * d / (P * (1 - P))
+            H = (X * wts[:, None]).T @ X + ridge * np.eye(k)
+            try:
+                step = np.linalg.solve(H, grad)
+            except np.linalg.LinAlgError as exc:
+                raise MlsynthEstimationError(
+                    "the distribution-regression design is rank deficient at "
+                    f"grid point {j}; drop collinear covariates.") from exc
+            ll0 = float(np.sum(z * np.log(P) + (1 - z) * np.log(1 - P)))
+            s_step, improved = 1.0, False
+            for _ in range(20):
+                cand = beta + s_step * step
+                P2 = np.clip(Lam(X @ cand), _EPS, 1 - _EPS)
+                if float(np.sum(z * np.log(P2) + (1 - z) * np.log(1 - P2))) >= ll0 - 1e-12:
+                    beta, improved = cand, True
+                    break
+                s_step *= 0.5
+            if not improved or np.max(np.abs(s_step * step)) < tol:
+                break
+        theta[j] = beta
+    return theta
+
+
+def outcome_grid(y: np.ndarray, n_grid: int, lo: float, hi: float) -> np.ndarray:
+    """Quantile grid of the pooled outcome, ties collapsed.
+
+    Collapsing ties matters: with a discrete-ish outcome (wages reported to the
+    cent) several requested quantiles land on the same value, and fitting the
+    same regression twice would double-count that point in the weight
+    objective. The paper's 38 requested points reduce to 32 active ones.
+    """
+    q = np.quantile(np.asarray(y, dtype=np.float64), np.linspace(lo, hi, n_grid))
+    grid = np.unique(np.round(q, 8))
+    if grid.size < 2:
+        raise MlsynthEstimationError(
+            "the outcome grid collapsed to fewer than two distinct points; the "
+            "outcome has almost no variation over the requested quantile "
+            "range.")
+    return grid

--- a/mlsynth/utils/drsc_helpers/inference.py
+++ b/mlsynth/utils/drsc_helpers/inference.py
@@ -1,0 +1,148 @@
+"""Variance, covariance kernel, and the supremum test (Wied eq. 10-14).
+
+Two sources of uncertainty enter the counterfactual at the same root-n rate and
+both must be carried: the distribution-regression error in the post period, and
+the weight-estimation error inherited from the pre-periods. Theorem 3.1(a)
+splits the covariance into exactly those two pieces; ``V_w`` below is the
+second, and it is why the pre-period cells are revisited during inference.
+
+A caveat that shapes what is testable. Critical values come from simulating the
+limiting Gaussian process, which requires a matrix square root of the estimated
+kernel. ``numpy.linalg.eigh`` returns eigenvectors whose *signs* are
+implementation-defined, so a different LAPACK build yields a different factor
+``L`` and hence a different realisation from identical Gaussian draws -- even
+with the seed pinned. The simulated distribution is unchanged; individual
+critical values move by a few tenths of a percent. The test statistic itself
+touches no eigendecomposition and is exact.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Tuple
+
+import numpy as np
+from scipy.stats import norm
+
+from .dr import link_functions
+
+
+def _fisher_and_scores(theta_cell: np.ndarray, X: np.ndarray, y: np.ndarray,
+                       grid: np.ndarray, link: str, eps: float = 1e-10):
+    """Inverse Fisher information and score residuals at each grid point."""
+    Lam, lam = link_functions(link)
+    n, k = X.shape
+    eta = theta_cell @ X.T                       # (m, n)
+    L = np.clip(Lam(eta), 1e-10, 1 - 1e-10)
+    d = lam(eta)
+    wts = d * d / (L * (1 - L))
+    Z = (y[None, :] <= grid[:, None]).astype(np.float64)
+    psi = d * (Z - L) / (L * (1 - L))            # (m, n)
+    Iinv = np.empty((len(grid), k, k))
+    for l in range(len(grid)):
+        info = np.einsum("n,nk,nj->kj", wts[l], X, X) / n + eps * np.eye(k)
+        Iinv[l] = np.linalg.inv(info)
+    return Iinv, psi
+
+
+def weight_variance(theta, cells, unit_names, w, G, grid, n_total, pre_periods,
+                    link: str, ridge: float = 0.0) -> np.ndarray:
+    """Plug-in ``V_w`` (eq. 13): the asymptotic variance of the weights."""
+    from .weights import projection_matrix
+
+    J = len(w)
+    m = len(grid)
+    P = projection_matrix(G, ridge)
+    Vw = np.zeros((J, J))
+    for s in pre_periods:
+        Th = np.stack([theta[(a + 1, s)] for a in range(J)], axis=1)   # (m,J,k)
+        PT = np.einsum("jk,mka->mja", P, Th)
+        for u in range(J + 1):
+            cell = cells[(unit_names[u], s)]
+            Iinv, psi = _fisher_and_scores(theta[(u, s)], cell.X, cell.y,
+                                           grid, link)
+            B = PT if u == 0 else -w[u - 1] * PT
+            C = np.einsum("mjp,mpq->mjq", B, Iinv)
+            CX = np.einsum("mjq,nq->mjn", C, cell.X)
+            D = np.einsum("mjn,mn->jn", CX, psi)
+            Vw += (n_total / cell.n ** 2) * (D @ D.T)
+    Vw /= (len(pre_periods) ** 2 * m ** 2)
+    return 0.5 * (Vw + Vw.T)
+
+
+def _cell_components(theta_cell, X, y, x, grid, link, eps: float = 1e-12):
+    Lam, lam = link_functions(link)
+    n, k = X.shape
+    eta = theta_cell @ X.T
+    L = np.clip(Lam(eta), 1e-10, 1 - 1e-10)
+    d = lam(eta)
+    wts = d * d / (L * (1 - L))
+    Z = (y[None, :] <= grid[:, None]).astype(np.float64)
+    r = d * (Z - L) / (L * (1 - L))
+    A = np.empty((len(grid), n))
+    for l in range(len(grid)):
+        Iinv = np.linalg.inv(np.einsum("n,nk,nj->kj", wts[l], X, X) / n
+                             + eps * np.eye(k))
+        A[l] = (X @ Iinv) @ x
+    return A, r
+
+
+def covariance_kernel(theta, cells, unit_names, w, th0, t, x, grid, n_total,
+                      Vw, link: str) -> np.ndarray:
+    """Sandwich estimator of the kernel ``K`` (eq. 11)."""
+    _, lam = link_functions(link)
+    J = len(w)
+    m = len(grid)
+    lam1 = lam(theta[(0, t)] @ x)
+    lam0 = lam(th0 @ x)
+    c0 = cells[(unit_names[0], t)]
+    A1, r1 = _cell_components(theta[(0, t)], c0.X, c0.y, x, grid, link)
+    G1 = A1 * r1
+    K = (lam1[:, None] * lam1[None, :]) * ((n_total / c0.n ** 2) * (G1 @ G1.T))
+    ctrl = np.zeros((m, m))
+    Tt = np.zeros((m, J))
+    for a in range(J):
+        ca = cells[(unit_names[a + 1], t)]
+        Ai, ri = _cell_components(theta[(a + 1, t)], ca.X, ca.y, x, grid, link)
+        Gi = Ai * ri
+        ctrl += (w[a] ** 2) * ((n_total / ca.n ** 2) * (Gi @ Gi.T))
+        Tt[:, a] = theta[(a + 1, t)] @ x
+    K += (lam0[:, None] * lam0[None, :]) * (ctrl + Tt @ Vw @ Tt.T)
+    return 0.5 * (K + K.T)
+
+
+def supremum_test(delta: np.ndarray, K: np.ndarray, n_total: int,
+                  idx: Optional[np.ndarray], alpha: float, seed: int,
+                  n_draws: int) -> Tuple[float, float, float]:
+    """Statistic, critical value, and p-value for ``H0: Delta = 0`` (eq. 14)."""
+    if idx is None:
+        idx = np.arange(len(delta))
+    idx = np.asarray(idx, dtype=int)
+    Ks = K[np.ix_(idx, idx)]
+    stat = float(np.sqrt(n_total) * np.max(np.abs(delta[idx])))
+    ev, V = np.linalg.eigh(0.5 * (Ks + Ks.T))
+    L = V @ np.diag(np.sqrt(np.clip(ev, 0.0, None)))
+    draws = np.random.default_rng(seed).standard_normal((len(idx), n_draws))
+    sim = np.max(np.abs(L @ draws), axis=0)
+    return stat, float(np.quantile(sim, 1 - alpha)), float(np.mean(sim >= stat))
+
+
+def integrated_effect(delta: np.ndarray, K: np.ndarray, n_total: int,
+                      idx: Optional[np.ndarray], alpha: float
+                      ) -> Tuple[float, float, float]:
+    """``f = mean(delta^2)`` with its standard error and one-sided bound (eq. 10).
+
+    The bound is reported unconditionally but is only meaningful once the
+    supremum test has rejected: under the null the delta-method derivative
+    vanishes, the variance degenerates, and the bound collapses to zero
+    (Remark 3.3).
+    """
+    if idx is None:
+        idx = np.arange(len(delta))
+    idx = np.asarray(idx, dtype=int)
+    d = delta[idx]
+    m = len(d)
+    Ks = K[np.ix_(idx, idx)]
+    f_hat = float(np.mean(d ** 2))
+    var = float((4.0 / m ** 2) * (d @ Ks @ d))
+    se = float(np.sqrt(max(var, 0.0)) / np.sqrt(n_total))
+    return f_hat, se, float(max(0.0, f_hat - norm.ppf(1 - alpha) * se))

--- a/mlsynth/utils/drsc_helpers/pipeline.py
+++ b/mlsynth/utils/drsc_helpers/pipeline.py
@@ -1,0 +1,104 @@
+"""End-to-end DRSC: fit the DR, solve for weights, test, assemble."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+
+from .dr import fit_cell, outcome_grid
+from .inference import (covariance_kernel, integrated_effect, supremum_test,
+                        weight_variance)
+from .structures import ConditionalEffect, DRSCInputs, DRSCResults
+from .weights import counterfactual, gram_and_cross, solve_weights
+from ...config_models import MethodDetailsResults, WeightsResults
+from ...exceptions import MlsynthEstimationError
+
+
+def run_drsc(inputs: DRSCInputs, evaluation_points, link="probit", n_grid=32,
+             grid_lo=0.10, grid_hi=0.90, focus_region=None, ridge=0.0,
+             alpha=0.10, n_gp_draws=10_000, seed=1992) -> DRSCResults:
+    """Fit DRSC and return the typed results."""
+    from ...config_models import EffectsResults
+
+    Lam, _ = __import__("mlsynth.utils.drsc_helpers.dr", fromlist=["x"]).link_functions(link)
+    units = inputs.unit_names
+    periods = list(inputs.pre_periods) + list(inputs.post_periods)
+
+    pooled = np.concatenate([inputs.cells[(u, t)].y
+                             for u in units for t in periods])
+    grid = outcome_grid(pooled, n_grid, grid_lo, grid_hi)
+
+    theta = {}
+    for i, u in enumerate(units):
+        for t in periods:
+            cell = inputs.cells[(u, t)]
+            theta[(i, t)] = fit_cell(cell.X, cell.y, grid, link)
+
+    J = inputs.J
+    G, c = gram_and_cross(theta, J, inputs.pre_periods)
+    w = solve_weights(G, c, ridge)
+    Vw = weight_variance(theta, inputs.cells, units, w, G, grid,
+                         inputs.n_total, inputs.pre_periods, link, ridge)
+
+    post = inputs.post_periods[0]
+    th0 = counterfactual(theta, w, post)
+
+    corridor = None
+    if focus_region is not None:
+        lo, hi = focus_region
+        corridor = np.flatnonzero((grid >= lo) & (grid <= hi))
+        if corridor.size == 0:
+            raise MlsynthEstimationError(
+                f"focus_region ({lo}, {hi}) contains no grid points; the "
+                f"grid spans [{grid.min():.4g}, {grid.max():.4g}]. Widen the "
+                "region or the quantile range.")
+
+    effects: Dict[str, ConditionalEffect] = {}
+    for label, point in evaluation_points.items():
+        x = np.empty(len(inputs.covariates) + 1)
+        x[0] = 1.0
+        for j, name in enumerate(inputs.covariates):
+            x[j + 1] = float(point[name])
+        delta = Lam(theta[(0, post)] @ x) - Lam(th0 @ x)
+        K = covariance_kernel(theta, inputs.cells, units, w, th0, post, x,
+                              grid, inputs.n_total, Vw, link)
+        stat, crit, p = supremum_test(delta, K, inputs.n_total, None, alpha,
+                                      seed, n_gp_draws)
+        f_hat, se, lcb = integrated_effect(delta, K, inputs.n_total, None, alpha)
+        kw = {}
+        if corridor is not None:
+            sF, cF, pF = supremum_test(delta, K, inputs.n_total, corridor,
+                                       alpha, seed, n_gp_draws)
+            _, _, lF = integrated_effect(delta, K, inputs.n_total, corridor, alpha)
+            kw = dict(t_stat_focused=sF, crit_value_focused=cF,
+                      p_value_focused=pF, lower_bound_focused=lF)
+        effects[label] = ConditionalEffect(
+            label=label, x=x, delta=delta, f_hat=f_hat, std_error=se,
+            lower_bound=lcb, t_stat=stat, crit_value=crit, p_value=p, **kw)
+
+    return DRSCResults(
+        conditional_effects=effects,
+        outcome_grid=grid,
+        gram_condition_number=float(np.linalg.cond(G)),
+        n_negative_weights=int((w < 0).sum()),
+        weights=WeightsResults(
+            # the contract keys donor_weights by str; unit ids are often
+            # integers (FIPS codes), so stringify here and keep the natively
+            # typed mapping on `metadata` for callers that need to join back
+            donor_weights={str(u): float(v)
+                           for u, v in zip(inputs.donor_names, w)},
+            summary_stats={"constraint": "sum to one (negative weights allowed)",
+                           "sum": float(w.sum())}),
+        method_details=MethodDetailsResults(
+            method_name="DRSC",
+            parameters_used={"link": link, "m_active": int(len(grid)),
+                             "ridge": float(ridge), "alpha": float(alpha),
+                             "J": int(J), "n": int(inputs.n_total)}),
+        metadata={"donor_weights_native": dict(zip(inputs.donor_names,
+                                                  (float(v) for v in w))),
+                  "treated_unit": inputs.treated_unit_name,
+                  "pre_periods": list(inputs.pre_periods),
+                  "post_period": post,
+                  "covariates": list(inputs.covariates)},
+    )

--- a/mlsynth/utils/drsc_helpers/plotter.py
+++ b/mlsynth/utils/drsc_helpers/plotter.py
@@ -1,0 +1,41 @@
+"""Plot the conditional distributional treatment effect."""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+
+
+def plot_drsc(results, outcome_label: str = "outcome",
+              focus_region=None, save: Union[bool, str] = False):
+    """One panel per evaluation point: ``Delta_t(y | x)`` over the grid."""
+    import matplotlib.pyplot as plt
+
+    eff = results.conditional_effects
+    grid = np.asarray(results.outcome_grid, dtype=float)
+    n = len(eff)
+    ncol = min(3, n)
+    nrow = int(np.ceil(n / ncol))
+    fig, axes = plt.subplots(nrow, ncol, figsize=(4.4 * ncol, 3.4 * nrow),
+                             squeeze=False)
+    for ax, (label, e) in zip(axes.ravel(), eff.items()):
+        if focus_region is not None:
+            ax.axvspan(focus_region[0], focus_region[1], color="#f5d76e",
+                       alpha=0.35, lw=0)
+        ax.plot(grid, e.delta, color="#1f4e79", lw=1.8)
+        ax.axhline(0.0, color="k", lw=0.6)
+        ax.set_title(f"{label}   $\\hat f$={e.f_hat:.2e}, p={e.p_value:.3f}",
+                     fontsize=9)
+        ax.set_xlabel(outcome_label)
+        ax.set_ylabel(r"$\hat\Delta_t(y \mid x)$")
+        ax.grid(alpha=0.22)
+    for ax in axes.ravel()[n:]:
+        ax.axis("off")
+    fig.tight_layout()
+    if save:
+        fig.savefig(f"{save}.png" if isinstance(save, str) else "drsc.png",
+                    dpi=150, bbox_inches="tight")
+    else:
+        plt.show()
+    plt.close(fig)

--- a/mlsynth/utils/drsc_helpers/setup.py
+++ b/mlsynth/utils/drsc_helpers/setup.py
@@ -1,0 +1,132 @@
+"""Micro-panel ingestion for DRSC.
+
+This does not go through :func:`mlsynth.utils.datautils.dataprep`, and the
+reason is structural rather than stylistic: ``dataprep`` pivots to one outcome
+per ``(unit, time)`` and raises ``Index contains duplicate entries`` on a panel
+whose cells hold many individual records. DRSC needs the individuals -- each
+cell contributes a design matrix and an outcome vector to a distribution
+regression -- so it follows the precedent :mod:`mlsynth.utils.dsc_helpers.setup`
+already set for micro-panel estimators.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+from ...exceptions import MlsynthDataError
+from .structures import DRSCCell, DRSCInputs
+
+
+def prepare_drsc_inputs(
+    df: pd.DataFrame,
+    outcome: str,
+    treat: str,
+    unitid: str,
+    time: str,
+    covariates: Sequence[str],
+) -> DRSCInputs:
+    """Pivot a long micro-panel into per-cell design matrices.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        One row per (unit, time, individual). ``treat`` is constant within a
+        cell.
+    outcome, treat, unitid, time : str
+        Column names.
+    covariates : sequence of str
+        Design columns, in order. An intercept is prepended here.
+
+    Returns
+    -------
+    DRSCInputs
+
+    Raises
+    ------
+    MlsynthDataError
+        A column is missing or non-numeric, there is no treated unit or no
+        donor, there are no pre-treatment periods, or a cell is too small to
+        identify the distribution regression.
+    """
+    covariates = list(covariates)
+    missing = [c for c in [outcome, treat, unitid, time] + covariates
+               if c not in df.columns]
+    if missing:
+        raise MlsynthDataError(
+            f"column(s) {missing} not in the panel; available: "
+            f"{list(df.columns)}")
+
+    for c in [outcome] + covariates:
+        if not pd.api.types.is_numeric_dtype(df[c]):
+            raise MlsynthDataError(
+                f"column {c!r} is not numeric; DRSC needs a numeric outcome "
+                "and numeric covariates (encode categoricals as indicators "
+                "yourself).")
+
+    treated_rows = df[df[treat] == 1]
+    if treated_rows.empty:
+        raise MlsynthDataError(
+            "no treated rows found; DRSC needs exactly one treated unit with "
+            f"at least one post-treatment period (column {treat!r} == 1).")
+    treated_units = list(pd.unique(treated_rows[unitid]))
+    if len(treated_units) != 1:
+        raise MlsynthDataError(
+            f"DRSC supports a single treated unit; found {len(treated_units)}: "
+            f"{treated_units[:5]}. Aggregate them or fit separately.")
+    treated = treated_units[0]
+
+    times = list(pd.unique(df[time].sort_values()))
+    first_treated = treated_rows[time].min()
+    pre = [t for t in times if t < first_treated]
+    post = [t for t in times if t >= first_treated]
+    if not pre:
+        raise MlsynthDataError(
+            "no pre-treatment periods: treatment is in force from the first "
+            f"period ({first_treated!r}). DRSC needs at least one pre-period "
+            "to estimate the weights.")
+    if not post:  # pragma: no cover - implied by a non-empty treated_rows
+        raise MlsynthDataError("no post-treatment periods.")
+
+    units = [treated] + [u for u in pd.unique(df[unitid]) if u != treated]
+    if len(units) < 2:
+        raise MlsynthDataError(
+            "no donor units: DRSC needs at least one untreated unit to form "
+            "the counterfactual.")
+
+    k = len(covariates) + 1
+    cells: Dict[Tuple[Any, Any], DRSCCell] = {}
+    for (u, t), g in df.groupby([unitid, time], sort=False):
+        if u not in set(units) or t not in set(times):  # pragma: no cover
+            continue
+        X = np.empty((len(g), k), dtype=np.float64)
+        X[:, 0] = 1.0
+        for j, c in enumerate(covariates):
+            X[:, j + 1] = g[c].to_numpy(dtype=np.float64)
+        y = g[outcome].to_numpy(dtype=np.float64)
+        if len(g) <= k:
+            raise MlsynthDataError(
+                f"cell ({u!r}, {t!r}) has {len(g)} observation(s) for {k} "
+                "parameters; the distribution regression is not identified "
+                "there. DRSC's asymptotics are in the within-cell sample "
+                "size, so every cell needs to be comfortably larger than the "
+                "design.")
+        if not (np.all(np.isfinite(X)) and np.all(np.isfinite(y))):
+            raise MlsynthDataError(
+                f"cell ({u!r}, {t!r}) carries NaN/inf in the outcome or "
+                "covariates; DRSC needs complete cases.")
+        cells[(u, t)] = DRSCCell(X=X, y=y)
+
+    expected = {(u, t) for u in units for t in times}
+    absent = sorted(expected - set(cells), key=lambda p: (str(p[0]), str(p[1])))
+    if absent:
+        raise MlsynthDataError(
+            f"the panel is unbalanced: {len(absent)} (unit, time) cell(s) have "
+            f"no rows, e.g. {absent[:3]}. DRSC needs every unit observed in "
+            "every period.")
+
+    return DRSCInputs(cells=cells, unit_names=units, covariates=covariates,
+                      pre_periods=pre, post_periods=post,
+                      treated_unit_name=treated, outcome=outcome)

--- a/mlsynth/utils/drsc_helpers/structures.py
+++ b/mlsynth/utils/drsc_helpers/structures.py
@@ -1,0 +1,151 @@
+"""Typed containers for DRSC."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+from pydantic import ConfigDict, Field, model_validator
+
+from ...config_models import (
+    BaseEstimatorResults,
+    EffectsResults,
+    InferenceResults,
+    MethodDetailsResults,
+    WeightsResults,
+)
+
+
+@dataclass(frozen=True)
+class DRSCCell:
+    """One (unit, time) cell: an intercept-prepended design and its outcomes."""
+
+    X: np.ndarray          # (n_it, k)
+    y: np.ndarray          # (n_it,)
+
+    @property
+    def n(self) -> int:
+        return int(self.y.shape[0])
+
+
+@dataclass(frozen=True)
+class DRSCInputs:
+    """Preprocessed micro-panel."""
+
+    cells: Dict[Tuple[Any, Any], DRSCCell]
+    unit_names: List[Any]           # index 0 is the treated unit
+    covariates: List[str]
+    pre_periods: List[Any]
+    post_periods: List[Any]
+    treated_unit_name: Any
+    outcome: str
+
+    @property
+    def J(self) -> int:
+        """Number of donors."""
+        return len(self.unit_names) - 1
+
+    @property
+    def donor_names(self) -> List[Any]:
+        return self.unit_names[1:]
+
+    @property
+    def n_total(self) -> int:
+        return int(sum(c.n for c in self.cells.values()))
+
+
+@dataclass(frozen=True)
+class ConditionalEffect:
+    """The estimate at one evaluation point, for one post-treatment period.
+
+    Attributes
+    ----------
+    label : str
+        The caller's name for the evaluation point.
+    x : np.ndarray
+        The design vector, intercept first.
+    delta : np.ndarray
+        Pointwise CDF difference over the outcome grid (eq. 3).
+    f_hat : float
+        Integrated squared effect (eq. 2), the scalar summary.
+    std_error : float
+        Standard error of ``f_hat``.
+    lower_bound : float
+        One-sided lower confidence bound (eq. 10); 0 when uninformative.
+    t_stat : float
+        Supremum statistic on the full grid (eq. 14).
+    crit_value : float
+        Simulated critical value at the configured level.
+    p_value : float
+        Full-support p-value.
+    t_stat_focused, crit_value_focused, p_value_focused, lower_bound_focused
+        The same quantities restricted to ``focus_region``; NaN when no
+        focus region was given.
+    """
+
+    label: str
+    x: np.ndarray
+    delta: np.ndarray
+    f_hat: float
+    std_error: float
+    lower_bound: float
+    t_stat: float
+    crit_value: float
+    p_value: float
+    t_stat_focused: float = float("nan")
+    crit_value_focused: float = float("nan")
+    p_value_focused: float = float("nan")
+    lower_bound_focused: float = float("nan")
+
+
+class DRSCResults(BaseEstimatorResults):
+    """Container returned by :meth:`mlsynth.DRSC.fit`.
+
+    An :class:`~mlsynth.config_models.EffectResult`: the headline scalar is
+    lifted into the standardized sub-models so the flat accessors resolve
+    through the base contract, while the conditional objects -- which have no
+    analogue in a scalar-ATT estimator -- stay on
+    :attr:`conditional_effects`.
+
+    ``effects.att`` is the integrated squared effect at the *first* evaluation
+    point. That is a summary of convenience: this estimator's output is a
+    function of the covariate value, and reading only ``att`` discards what it
+    was built to show.
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    conditional_effects: Dict[str, ConditionalEffect] = Field(
+        default_factory=dict,
+        description="Per-evaluation-point estimates, keyed by the caller's label.")
+    outcome_grid: Optional[np.ndarray] = Field(
+        default=None, description="Outcome grid y_l the DR was fitted on.")
+    gram_condition_number: Optional[float] = Field(
+        default=None,
+        description=("Condition number of the Gram matrix. Large values (~1e5 "
+                     "on the paper's panel) are normal and mean the weights "
+                     "need float64; see the docs."))
+    n_negative_weights: Optional[int] = Field(
+        default=None,
+        description="Donors receiving negative weight; expected, not a fault.")
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _populate(self) -> "DRSCResults":
+        if self.effects is not None or not self.conditional_effects:
+            return self
+        first = next(iter(self.conditional_effects.values()))
+        object.__setattr__(self, "effects", EffectsResults(
+            att=float(first.f_hat), att_std_err=float(first.std_error),
+            additional_effects={k: float(v.f_hat)
+                                for k, v in self.conditional_effects.items()}))
+        object.__setattr__(self, "inference", InferenceResults(
+            p_value=float(first.p_value), ci_lower=float(first.lower_bound),
+            ci_upper=float("inf"), standard_error=float(first.std_error),
+            method="supremum test (Gaussian process)",
+            details={k: {"p_value": float(v.p_value),
+                         "p_value_focused": float(v.p_value_focused),
+                         "t_stat": float(v.t_stat)}
+                     for k, v in self.conditional_effects.items()}))
+        return self

--- a/mlsynth/utils/drsc_helpers/weights.py
+++ b/mlsynth/utils/drsc_helpers/weights.py
@@ -1,0 +1,96 @@
+"""The weight program: eq. (5)-(7).
+
+The weights minimise the pre-treatment discrepancy between the treated unit's
+DR parameter function and a weighted combination of the donors', averaged over
+pre-periods and integrated over the outcome grid, subject only to adding up to
+one. Because the objective is quadratic and the single constraint is linear,
+the solution is closed-form -- no solver, no simplex projection.
+
+Dropping non-negativity is deliberate (Doudchenko-Imbens): it lets the
+synthetic unit sit outside the donor hull, which is what makes the pre-period
+fit attainable when the treated unit is extreme. The price is a Gram matrix
+that can be badly conditioned, so see :func:`solve_weights` on float64.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence, Tuple
+
+import numpy as np
+
+from ...exceptions import MlsynthEstimationError
+
+
+def gram_and_cross(theta: Dict[Tuple[int, object], np.ndarray], J: int,
+                   pre_periods: Sequence[object]) -> Tuple[np.ndarray, np.ndarray]:
+    """Time-and-grid-averaged Gram matrix ``G`` and cross-vector ``c``.
+
+    ``theta[(i, t)]`` is the ``(m, k)`` coefficient function for unit index
+    ``i`` (0 = treated) in period ``t``.
+    """
+    m = next(iter(theta.values())).shape[0]
+    G = np.zeros((J, J), dtype=np.float64)
+    c = np.zeros(J, dtype=np.float64)
+    for t in pre_periods:
+        for a in range(J):
+            c[a] += float(np.sum(theta[(0, t)] * theta[(a + 1, t)]))
+            for b in range(a, J):
+                v = float(np.sum(theta[(a + 1, t)] * theta[(b + 1, t)]))
+                G[a, b] += v
+                if b != a:
+                    G[b, a] += v
+    denom = len(pre_periods) * m
+    return G / denom, c / denom
+
+
+def solve_weights(G: np.ndarray, c: np.ndarray, ridge: float = 0.0) -> np.ndarray:
+    """Closed-form min-norm weights under ``1'w = 1`` (eq. 7).
+
+    The Gram matrix is ill-conditioned by construction -- donors' DR parameter
+    functions are similar, which is exactly why a weighted combination can
+    track the treated unit -- so the inverse amplifies input error sharply. On
+    the paper's panel ``kappa(G) ~ 1e5`` and a relative input perturbation of
+    1e-7 moves the weights by ~0.15. The estimand is far more stable than the
+    weights, but the weights are what get reported, so the inputs must be
+    float64 end to end.
+    """
+    J = G.shape[0]
+    A = G + ridge * np.eye(J) if ridge > 0 else G
+    one = np.ones(J)
+    try:
+        Ai = np.linalg.inv(A)
+    except np.linalg.LinAlgError as exc:
+        raise MlsynthEstimationError(
+            "the Gram matrix is singular; donor DR parameter functions are "
+            "linearly dependent. Drop duplicate donors or set `ridge` > 0."
+        ) from exc
+    Aic, Ai1 = Ai @ c, Ai @ one
+    denom = float(one @ Ai1)
+    if not np.isfinite(denom) or abs(denom) < 1e-300:  # pragma: no cover
+        raise MlsynthEstimationError(
+            "the adding-up constraint is degenerate for this Gram matrix.")
+    w = Aic - Ai1 * ((float(one @ Aic) - 1.0) / denom)
+    if not np.all(np.isfinite(w)):  # pragma: no cover - defensive
+        raise MlsynthEstimationError(
+            "the weight solve produced non-finite values; check for duplicate "
+            "donor units or set `ridge` > 0.")
+    return w
+
+
+def projection_matrix(G: np.ndarray, ridge: float = 0.0) -> np.ndarray:
+    """``P = dw/dc``, the derivative of the weights in the cross-vector."""
+    J = G.shape[0]
+    A = G + ridge * np.eye(J) if ridge > 0 else G
+    one = np.ones(J)
+    Ai = np.linalg.inv(A)
+    Ai1 = Ai @ one
+    return Ai - np.outer(Ai1, Ai1) / float(one @ Ai1)
+
+
+def counterfactual(theta: Dict[Tuple[int, object], np.ndarray], w: np.ndarray,
+                   t: object) -> np.ndarray:
+    """Counterfactual DR parameter, eq. (9)."""
+    out = np.zeros_like(theta[(1, t)])
+    for a in range(len(w)):
+        out = out + w[a] * theta[(a + 1, t)]
+    return out


### PR DESCRIPTION
## Related Links

- Resolves #328
- Builds on #329 (merged) — the replication evidence this validates against
- Paper: Wied (2026), [arXiv:2606.09625v1](https://arxiv.org/abs/2606.09625)

## What

DRSC — conditional distributional treatment effects via distribution-regression synthetic control.

Where `DSC` matches unconditional quantile functions, DRSC models the conditional distribution semiparametrically as `F_it(y | x) = Λ(x'θ_it(y))` and imposes parallel trends in the parameter space rather than on the CDF. An effect concentrated on a small subgroup stays visible instead of being washed out by pooling.

- `mlsynth/utils/drsc_helpers/` — `config`, `setup`, `dr`, `weights`, `inference`, `structures`, `pipeline`, `plotter`
- `mlsynth/estimators/drsc.py`, exported from `mlsynth/__init__.py`
- `mlsynth/tests/test_drsc.py` — 31 tests
- `docs/drsc.rst`, `docs/replications/drsc.rst`, `docs/choose.rst` entry
- `benchmarks/cases/wied_nj_minwage.py`

## Verification

Path A, on the author's own CPS estimation sample. All five Table 1 weights and all twenty cells of Table 2 match to the paper's printed precision, along with the active grid size (m = 32), the Gram condition number (9.64e4 vs 9.6e4) and the negative-weight count (20 of 42).

Not reproducible exactly, by design: the Gaussian-process critical values. `eigh` eigenvector signs are implementation-defined, so a different LAPACK build gives a different matrix square root and hence a different realisation from identical draws. Measured at 0.2–0.5%. Test statistics touch no eigendecomposition and are exact. Tolerances follow that split — weights, `f_hat`, `Tn` and the bounds pinned tight; critical values and p-values pinned loose, with the qualitative corridor pattern pinned as a separate boolean.

## A defect this branch found and fixes

Once #329 landed and the three replication tests stopped skipping, two of them failed.

`DRSCConfig.n_grid` defaulted to 32. That is the paper's *active* grid size, but the field is the number of points *requested* — the author's `build_grid(w, m=38, lo=0.10, hi=0.90)` asks for 38 quantile points and collapses ties down to 32. Requesting 32 leaves 28 active:

| `n_grid` | active m | κ(Ĝ) | neg | Florida | max weight err | max `f_hat`×10³ err |
|---|---|---|---|---|---|---|
| 32 (old default) | 28 | 9.53e4 | 17 | 0.4962 | 0.0604 | 0.234 |
| 38 (author's, new default) | 32 | 9.64e4 | 20 | 0.5155 | 0.0005 | 0.005 |

A 0.06 weight error is sixty times the tolerance the weights otherwise reproduce at. The benchmark case already passed `n_grid=38` and was unaffected, which is precisely why the default slipped through — the validated path never exercised it.

Fixed by defaulting to 38, rewording the field description to say requested rather than active, and adding two tests: one pinning the default, one pinning the 38 → 32 collapse on the paper's data. The replication tests now pass `n_grid=38` explicitly rather than leaning on a default. The docs page gained a paragraph on the distinction.

## Test Steps

- [x] `pytest mlsynth/tests/test_drsc.py` — 31 passed, including the three replication tests that activate now that #329 is on `main`
- [x] Red→green confirmed on the new default test before changing the config
- [ ] Full `pytest mlsynth/tests/` — deferred to CI, which runs it on 3.10/3.12/3.13

## Scope checks

One estimator, one branch: config, estimator, helpers, tests, docs page, replication page, `__init__` export, `choose.rst` entry, and the benchmark case. The only change outside DRSC's own files is none.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_