### PR TITLE
Add the regression-based V backend (Stata synth's default)

### DIFF
--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -168,12 +168,42 @@ polytope of :math:`\mathbf{V}` reproduces the same :math:`\mathbf{w}`).
 Backends
 --------
 
-The covariate path exposes three reliable solvers via ``backend=``:
+The covariate path exposes four reliable solvers via ``backend=``:
 
 ``"outcome-only"``
     No predictor weights; the convex simplex fit above. The well-posed
     default (also selected by ``backend="auto"`` when no covariates are
     given).
+
+``"regression"``
+    Stata ``synth``'s own default rule, and the one to reach for when the
+    goal is reproducing a published ``synth`` result. Unlike the two
+    searching backends there is no outer optimisation: the predictor
+    weights are a closed-form function of the data, so the fit is fast and
+    deterministic. Normalise every predictor by its standard deviation over
+    the pooled treated-and-donor block, regress the pre-treatment outcomes
+    of all units on the normalised predictors, and set
+    :math:`v_h \propto \beta_h^2`, scaled to sum to one. A predictor that
+    does not help explain the pre-treatment outcome is therefore
+    down-weighted, and the units a predictor happens to be measured in
+    cannot matter.
+
+    This is worth knowing before comparing numbers with a paper. Stata runs
+    the Abadie-Diamond-Hainmueller nested optimisation only when the caller
+    passes ``nested``, and wrappers such as ``allsynth`` forward that flag
+    rather than setting it. Most published ``synth`` estimates were
+    therefore produced by this rule and not by a search, so
+    ``backend="mscmt"`` or ``"malo"`` will answer a different question than
+    the paper asked.
+
+    Two details of the reference implementation are not recoverable from
+    the distributed package, whose predictor-weight subroutines ship
+    compiled: whether the regression is run once over all unit-period
+    observations or once per pre-treatment period, and whether an intercept
+    is fitted. Both are settable (``pooled``, ``fit_intercept``) rather than
+    silently fixed, because the available evidence does not favour either
+    reading. Take agreement with a Stata figure to three digits as good
+    fortune rather than as a guarantee.
 
 ``"mscmt"``
     Becker & Kloessner (2018): a global differential-evolution search over

--- a/mlsynth/tests/test_bilevel_regression_v.py
+++ b/mlsynth/tests/test_bilevel_regression_v.py
@@ -1,0 +1,229 @@
+"""The regression-based predictor weights: Stata ``synth``'s default V.
+
+``synth`` only runs the nested optimisation when the caller passes ``nested``;
+otherwise (``synth2.sthlp`` lines 157-162) it uses "a data-driven regression
+based method to obtain the variable weights contained in the V-matrix". Since
+``allsynth`` forwards ``nested`` as an ordinary optional flag, most published
+``synth`` results were produced by this rule, not by the bilevel search --
+so reproducing them needs it.
+
+The Mata subroutines are shipped compiled (``l/lsynth2_mata_subr.mlib``); the
+package has no source for them. What the library's symbol table does fix:
+
+    normalize:  storemat  xtrout xcoout  quadvariance  diag  xtrmat xcomat
+    regsval:    sval  xtrout xcoout ztrout zcoout  beta  trace  diag  vmat
+
+and the only Mata builtins referenced anywhere in it are ``diag``,
+``quadvariance`` and ``trace``. Hence: scale by the pooled treated-plus-control
+standard deviation with no centring (no ``mean`` is referenced), regress the
+pre-treatment outcomes of *both* blocks on the normalised predictors, and set
+``V = diag(bb') / trace(bb')``.
+
+Two things the symbols do NOT fix, and which are therefore options rather than
+constants here: whether ``beta`` comes from one pooled regression or one per
+pre-period (the solve is an opcode, not a name), and the tie-breaking among
+equally-optimal ``V``. Both are exposed; neither is guessed silently.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------- fixtures
+def _panel(T0=6, J=8, K=4, seed=0, scale=None):
+    """Donor block, treated path and a predictor block on very different scales.
+
+    ``scale`` deliberately gives the predictors wildly different units, which is
+    what makes the normalisation step observable.
+    """
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T0, 2))
+    L = rng.normal(size=(J, 2))
+    Y0 = F @ L.T + 0.2 * rng.normal(size=(T0, J))
+    y1 = F @ rng.normal(size=2) + 0.2 * rng.normal(size=T0)
+    X0 = rng.normal(size=(K, J))
+    if scale is None:
+        scale = np.logspace(0, 4, K)          # 1 ... 10000
+    X0 = X0 * scale[:, None]
+    X1 = X0 @ rng.dirichlet(np.ones(J)) + 0.01 * rng.normal(size=K) * scale
+    return y1, Y0, X1, X0
+
+
+def _prob(**kw):
+    from mlsynth.utils.bilevel import BilevelProblem
+
+    y1, Y0, X1, X0 = _panel(**kw)
+    return BilevelProblem(y1_pre=y1, Y0_pre=Y0, X1=X1, X0=X0,
+                          predictor_names=[f"x{k}" for k in range(X0.shape[0])])
+
+
+# ---------------------------------------------------------------- smoke
+class TestSmoke:
+    def test_it_solves_and_returns_the_contract_type(self):
+        from mlsynth.utils.bilevel import BilevelSolution, solve_bilevel
+
+        sol = solve_bilevel(_prob(), method="regression")
+        assert isinstance(sol, BilevelSolution)
+        assert np.isfinite(sol.upper_loss)
+
+    def test_the_weights_are_on_both_simplices(self):
+        from mlsynth.utils.bilevel import solve_bilevel
+
+        sol = solve_bilevel(_prob(), method="regression")
+        for name, v in (("V", sol.V), ("W", sol.W)):
+            v = np.asarray(v, float)
+            assert (v >= -1e-9).all(), name
+            assert v.sum() == pytest.approx(1.0, abs=1e-8), name
+
+    def test_it_is_registered_as_a_backend(self):
+        from mlsynth.utils.bilevel.engine import _BACKENDS
+
+        assert "regression" in _BACKENDS
+
+
+# ---------------------------------------------------------------- the rule
+class TestTheRule:
+    """Properties that follow from the recovered algorithm."""
+
+    def test_normalising_before_regressing_is_not_the_same_as_after(self):
+        """The load-bearing ordering.
+
+        ``normalize`` runs on the predictors *before* ``regsval`` sees them, so
+        the coefficients come from normalised regressors. Scaling afterwards --
+        at the weighting step -- is a different estimator. On the Wiltshire
+        panel that distinction moved the reported effect from -1.43 to -1.78
+        against a target of -1.77, so it is pinned rather than left to taste.
+        """
+        from mlsynth.utils.bilevel.regression_v import regression_v
+
+        y1, Y0, X1, X0 = _panel()
+        v_before = regression_v(X1, X0, y1, Y0, normalize=True)
+        v_after = regression_v(X1, X0, y1, Y0, normalize=False)
+        assert not np.allclose(v_before, v_after, atol=1e-6)
+
+    def test_the_treated_unit_enters_the_regression(self):
+        """``regsval(Xtr_norm, Xco_norm, Ztr, Zco)`` takes both blocks."""
+        from mlsynth.utils.bilevel.regression_v import regression_v
+
+        y1, Y0, X1, X0 = _panel()
+        with_treated = regression_v(X1, X0, y1, Y0)
+        donors_only = regression_v(X1, X0, y1, Y0, include_treated=False)
+        assert not np.allclose(with_treated, donors_only, atol=1e-6)
+
+    def test_it_is_invariant_to_predictor_rescaling(self):
+        """Normalising by the pooled standard deviation means the units a
+        predictor happens to be measured in cannot change ``V``."""
+        from mlsynth.utils.bilevel.regression_v import regression_v
+
+        y1, Y0, X1, X0 = _panel()
+        v1 = regression_v(X1, X0, y1, Y0)
+        f = np.array([1.0, 1e3, 1e-2, 7.0])[: X0.shape[0]]
+        v2 = regression_v(X1 * f, X0 * f[:, None], y1, Y0)
+        np.testing.assert_allclose(v1, v2, atol=1e-8)
+
+    def test_pooled_and_per_period_are_both_reachable(self):
+        """The symbol table does not determine which one Stata runs, so the
+        choice is exposed rather than hard-coded. They must differ, else the
+        option would be vacuous."""
+        from mlsynth.utils.bilevel.regression_v import regression_v
+
+        y1, Y0, X1, X0 = _panel()
+        a = regression_v(X1, X0, y1, Y0, pooled=True)
+        b = regression_v(X1, X0, y1, Y0, pooled=False)
+        assert not np.allclose(a, b, atol=1e-6)
+
+    def test_a_predictor_uncorrelated_with_the_outcome_gets_little_weight(self):
+        """``v_h`` is proportional to a squared regression coefficient, so a
+        predictor that does not explain the pre-treatment outcome is
+        down-weighted relative to one that does."""
+        from mlsynth.utils.bilevel.regression_v import regression_v
+
+        rng = np.random.default_rng(3)
+        T0, J = 8, 10
+        signal = rng.normal(size=J)
+        Y0 = np.outer(np.ones(T0), signal) + 0.01 * rng.normal(size=(T0, J))
+        y1 = np.full(T0, signal.mean())
+        X0 = np.vstack([signal, rng.normal(size=J)])        # row 0 informative
+        X1 = np.array([signal.mean(), 0.0])
+        v = regression_v(X1, X0, y1, Y0)
+        assert v[0] > v[1]
+
+
+# ---------------------------------------------------------------- edges
+class TestEdgeCases:
+    def test_a_constant_predictor_does_not_divide_by_zero(self):
+        from mlsynth.utils.bilevel.regression_v import regression_v
+
+        y1, Y0, X1, X0 = _panel()
+        X0[1, :] = 3.0
+        X1[1] = 3.0
+        v = regression_v(X1, X0, y1, Y0)
+        assert np.isfinite(v).all()
+        assert v.sum() == pytest.approx(1.0)
+
+    def test_a_single_predictor_takes_all_the_weight(self):
+        from mlsynth.utils.bilevel.regression_v import regression_v
+
+        y1, Y0, X1, X0 = _panel(K=1)
+        v = regression_v(X1, X0, y1, Y0)
+        np.testing.assert_allclose(v, [1.0], atol=1e-12)
+
+    def test_a_single_donor_gets_all_the_donor_weight(self):
+        from mlsynth.utils.bilevel import solve_bilevel
+
+        sol = solve_bilevel(_prob(J=1), method="regression")
+        np.testing.assert_allclose(np.asarray(sol.W, float), [1.0], atol=1e-8)
+
+    def test_degenerate_coefficients_fall_back_to_uniform(self):
+        """If every coefficient is zero the normalisation is 0/0; the rule must
+        degrade to equal weights rather than emit NaN."""
+        from mlsynth.utils.bilevel.regression_v import regression_v
+
+        rng = np.random.default_rng(5)
+        T0, J, K = 5, 6, 3
+        Y0 = np.zeros((T0, J))
+        y1 = np.zeros(T0)
+        X0 = rng.normal(size=(K, J))
+        X1 = rng.normal(size=K)
+        v = regression_v(X1, X0, y1, Y0)
+        np.testing.assert_allclose(v, np.full(K, 1.0 / K), atol=1e-12)
+
+
+# ---------------------------------------------------------------- failures
+class TestFailuresAreReported:
+    def test_an_unknown_method_still_names_the_valid_ones(self):
+        from mlsynth.utils.bilevel import solve_bilevel
+
+        with pytest.raises(ValueError, match="regression"):
+            solve_bilevel(_prob(), method="not-a-backend")
+
+    def test_the_backend_requires_covariates(self):
+        """Like ``malo``/``mscmt``, a predictor-weight rule is meaningless with
+        no predictors, and must say so rather than silently degrade."""
+        from mlsynth.utils.bilevel import BilevelSCM
+
+        y1, Y0, _, _ = _panel()
+        with pytest.raises(ValueError, match="covariates"):
+            BilevelSCM(backend="regression").fit(y1, Y0)
+
+    def test_vanillasc_accepts_it_as_a_backend(self):
+        import pandas as pd
+
+        from mlsynth import VanillaSC
+
+        rng = np.random.default_rng(0)
+        rows = []
+        for u in range(6):
+            base = float(rng.normal()) * 3
+            for t in range(10):
+                rows.append({"unit": f"u{u}", "t": t,
+                             "y": float(base + 0.4 * t + rng.normal() * 0.2),
+                             "x1": float(rng.normal()),
+                             "treat": int(u == 0 and t >= 7)})
+        df = pd.DataFrame(rows)
+        res = VanillaSC({"df": df, "outcome": "y", "treat": "treat",
+                         "unitid": "unit", "time": "t", "covariates": ["x1"],
+                         "backend": "regression", "inference": False,
+                         "display_graphs": False}).fit()
+        assert np.isfinite(res.effects.att)

--- a/mlsynth/tests/test_vanillasc_v_diagnostic.py
+++ b/mlsynth/tests/test_vanillasc_v_diagnostic.py
@@ -1,0 +1,122 @@
+"""Is the reported ``V`` pinned down by the data, or one of many optima?
+
+The predictor weights are generically non-identified: a whole set of ``V`` can
+attain the same upper-level loss. ``synth``'s own help warns the nested space
+"may contain local minima" and offers restarts as a robustness check, and the
+backends bear that out -- on one county of the Wiltshire panel ``malo`` put
+weight on 1.7 of 14 predictors and ``mscmt`` on 9.0, both outer-optimal.
+
+``v_agreement`` already reports whether the two MSCMT canonicalisations agree.
+What it does not report is how *concentrated* the returned ``V`` is, which is
+the difference a user actually sees between backends. Two measures are added:
+
+``n_predictors_weighted``
+    Count above a fixed tolerance. Simple, but tolerance-dependent.
+``v_effective_count``
+    :math:`1 / \\sum_h v_h^2`, the participation ratio. No tolerance: it is
+    ``K`` for uniform weights and ``1`` for a corner, and moves continuously
+    between. This is the one to read.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _panel(n_units=8, T=12, pre=9, seed=0):
+    rng = np.random.default_rng(seed)
+    rows = []
+    for u in range(n_units):
+        base = float(rng.normal()) * 3.0
+        for t in range(T):
+            rows.append({
+                "unit": f"u{u}", "t": t,
+                "y": float(base + 0.4 * t + rng.normal() * 0.2),
+                "x1": float(rng.normal()),
+                "x2": float(rng.normal()) * 100.0,
+                "x3": float(rng.normal()) * 0.01,
+                "treat": int(u == 0 and t >= pre),
+            })
+    return pd.DataFrame(rows)
+
+
+def _fit(backend, **over):
+    from mlsynth import VanillaSC
+
+    cfg = {"df": _panel(), "outcome": "y", "treat": "treat", "unitid": "unit",
+           "time": "t", "backend": backend, "inference": False,
+           "display_graphs": False}
+    if backend != "outcome-only":
+        cfg["covariates"] = ["x1", "x2", "x3"]
+    cfg.update(over)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return VanillaSC(cfg).fit()
+
+
+class TestTheDiagnosticIsReported:
+    @pytest.mark.parametrize("backend", ["regression", "malo", "mscmt"])
+    def test_the_predictor_backends_report_concentration(self, backend):
+        res = _fit(backend)
+        extra = res.weights.summary_stats or {}
+        assert extra.get("predictor_weights") is not None
+        assert extra.get("n_predictors_weighted") is not None
+        assert extra.get("v_effective_count") is not None
+
+    @pytest.mark.parametrize("backend", ["regression", "malo", "mscmt"])
+    def test_it_reaches_the_spec_block_where_users_look(self, backend):
+        res = _fit(backend)
+        params = res.method_details.parameters_used or {}
+        assert "v_effective_count" in params
+        assert params["v_effective_count"] is not None
+
+    def test_outcome_only_reports_no_predictor_weights(self):
+        res = _fit("outcome-only")
+        extra = res.weights.summary_stats or {}
+        params = res.method_details.parameters_used or {}
+        assert extra.get("predictor_weights") is None
+        assert extra.get("v_effective_count") is None
+        assert params.get("v_effective_count") is None
+
+
+class TestItMeasuresWhatItClaims:
+    def test_the_effective_count_is_bounded_by_the_predictor_count(self):
+        for backend in ("regression", "malo", "mscmt"):
+            res = _fit(backend)
+            eff = res.weights.summary_stats["v_effective_count"]
+            assert 1.0 - 1e-9 <= eff <= 3.0 + 1e-9, backend
+
+    def test_a_corner_scores_one_and_uniform_scores_K(self):
+        from mlsynth.utils.vanillasc_helpers.pipeline import _v_concentration
+
+        n, eff = _v_concentration(np.array([1.0, 0.0, 0.0, 0.0]))
+        assert n == 1 and eff == pytest.approx(1.0)
+        n, eff = _v_concentration(np.full(4, 0.25))
+        assert n == 4 and eff == pytest.approx(4.0)
+
+    def test_it_is_continuous_between_those_ends(self):
+        from mlsynth.utils.vanillasc_helpers.pipeline import _v_concentration
+
+        # two predictors carrying almost everything, two carrying a sliver
+        _, eff = _v_concentration(np.array([0.48, 0.48, 0.02, 0.02]))
+        assert 2.0 < eff < 2.3
+
+    def test_none_in_none_out(self):
+        from mlsynth.utils.vanillasc_helpers.pipeline import _v_concentration
+
+        assert _v_concentration(None) == (None, None)
+
+    def test_it_separates_a_corner_backend_from_a_dense_one(self):
+        """The point of the diagnostic.
+
+        ``malo`` searches predictor corners, so with a lagged-outcome-like
+        predictor present it concentrates; the regression rule weights every
+        predictor by a squared coefficient and so generally does not. A user
+        comparing the two should be able to see that from the result.
+        """
+        eff = {b: _fit(b).weights.summary_stats["v_effective_count"]
+               for b in ("malo", "regression")}
+        assert eff["malo"] != pytest.approx(eff["regression"], abs=1e-6)

--- a/mlsynth/utils/bilevel/__init__.py
+++ b/mlsynth/utils/bilevel/__init__.py
@@ -20,6 +20,7 @@ from .structure import BilevelProblem, BilevelSolution
 from .simplex import project_simplex, simplex_lstsq, mspe
 from .solver import solve_bilevel, lower_level_weights
 from .mscmt import solve_mscmt
+from .regression_v import regression_v, solve_regression
 from .penalized import bias_corrected_gaps, penalized_weights, solve_penalized
 from .determine_v import (
     canonical_v,
@@ -46,6 +47,8 @@ from .ridge_inference import (
 )
 
 __all__ = [
+    "regression_v",
+    "solve_regression",
     "BilevelProblem",
     "BilevelSolution",
     "BilevelSCM",

--- a/mlsynth/utils/bilevel/engine.py
+++ b/mlsynth/utils/bilevel/engine.py
@@ -30,13 +30,16 @@ from .determine_v import canonical_v_diagnostics
 from .solver import solve_bilevel
 from .ridge_augment import simplex_qp
 
-_BACKENDS = ("auto", "outcome-only", "malo", "mscmt", "penalized")
+_BACKENDS = ("auto", "outcome-only", "malo", "mscmt", "regression",
+             "penalized")
 # Keyword arguments each bilevel backend accepts (others are filtered out so a
 # single ``solver_kwargs`` blob can be passed regardless of backend).
 _SOLVER_KWARGS = {
     "mscmt": {"lb", "maxiter", "popsize", "tol", "seed", "polish", "feas_tol",
               "prune_shady"},
     "malo": {"feas_tol", "eps_corner", "refine", "refine_gap_tol"},
+    "regression": {"normalize", "include_treated", "pooled", "fit_intercept",
+                   "max_iter", "tol"},
     "penalized": {"lam", "cv", "lam_grid", "max_iter", "tol"},
 }
 _EPS = 1e-10
@@ -225,7 +228,7 @@ class BilevelSCM:
             # backend's predictor-weight search is neither needed nor used; keep
             # the base cheap. Covariates still flow to the ridge layer below.
             backend = "outcome-only"
-        if backend in ("malo", "mscmt") and not has_cov:
+        if backend in ("malo", "mscmt", "regression") and not has_cov:
             raise ValueError(
                 f"backend {backend!r} needs covariates (X1/X0); for outcome-only "
                 "matching use backend='outcome-only' or 'penalized'."

--- a/mlsynth/utils/bilevel/regression_v.py
+++ b/mlsynth/utils/bilevel/regression_v.py
@@ -1,0 +1,201 @@
+"""Regression-based predictor weights ``V`` -- Stata ``synth``'s default rule.
+
+``synth`` runs the Abadie-Diamond-Hainmueller nested optimisation only when the
+caller passes ``nested``. Its default is cheaper and different (``synth2.sthlp``
+lines 157-162):
+
+    by default ``synth2`` uses a data-driven regression based method to obtain
+    the variable weights contained in the V-matrix
+
+``allsynth`` forwards ``nested`` as an ordinary optional flag, so published
+results that did not request it -- which is most of them -- were produced by
+this rule. Reproducing them needs it; the bilevel backends solve a different
+program.
+
+The algorithm
+-------------
+``synth2.ado`` calls two Mata subroutines in sequence::
+
+    mata: normalize("Xtr", "Xco")                        // predictors first
+    mata: regsval("Xtr_norm", "Xco_norm", "Ztr", "Zco")  // then outcome on them
+
+Both ship compiled, inside ``l/lsynth2_mata_subr.mlib``; the package contains no
+source for either. What the library's symbol table fixes::
+
+    normalize:  storemat  xtrout xcoout  quadvariance  diag  xtrmat xcomat
+    regsval:    sval  xtrout xcoout ztrout zcoout  beta  trace  diag  vmat
+
+and the only Mata builtins referenced anywhere in it are ``diag``,
+``quadvariance`` and ``trace``. So:
+
+* ``normalize`` divides each predictor by its standard deviation over the
+  pooled treated-plus-control block. No ``mean`` is referenced anywhere in the
+  library, so it is scale-only, not centring.
+* ``regsval`` receives both predictor blocks and both outcome blocks, so the
+  treated unit is included in the regression.
+* ``V = diag(bb') / trace(bb')`` -- squared coefficients, trace-normalised.
+
+Two choices the symbols do *not* determine, because the regression solve
+compiles to an opcode rather than a name lookup: whether ``beta`` comes from one
+pooled regression over all ``(unit, period)`` observations or one per
+pre-period, and whether an intercept is fitted. Both are exposed as arguments
+and neither is guessed silently -- on the Wiltshire (2023) panel the two
+readings tie (total absolute error 1.854 vs 1.768 over eight reported cells),
+so the repository has no basis for picking one. See issue #334.
+
+Ordering is load-bearing. Normalising the predictors *before* the regression,
+rather than scaling afterwards at the weighting step, moved Wiltshire's Panel A
+from -1.43 to -1.78 against a target of -1.77, and repaired a sign flip on his
+Panel D.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from .simplex import simplex_lstsq
+from .structure import BilevelProblem, BilevelSolution
+
+__all__ = ["regression_v", "solve_regression"]
+
+_EPS = 1e-12
+
+
+def _pooled_scale(X: np.ndarray) -> np.ndarray:
+    """``normalize``: per-predictor standard deviation, no centring.
+
+    Mata's ``quadvariance`` is a quad-precision variance; the transformation
+    applied is a division by its square root. A predictor with no variation is
+    left alone rather than divided by zero -- it carries no information for the
+    regression either way, and its coefficient will be zero.
+    """
+    sd = X.std(axis=1, ddof=1) if X.shape[1] > 1 else np.zeros(X.shape[0])
+    return np.where(sd < _EPS, 1.0, sd)
+
+
+def regression_v(
+    X1: np.ndarray,
+    X0: np.ndarray,
+    y1_pre: np.ndarray,
+    Y0_pre: np.ndarray,
+    *,
+    normalize: bool = True,
+    include_treated: bool = True,
+    pooled: bool = False,
+    fit_intercept: bool = True,
+) -> np.ndarray:
+    """Predictor weights ``v_h`` on the simplex.
+
+    Parameters
+    ----------
+    X1, X0 : np.ndarray
+        Treated predictor vector ``(K,)`` and donor predictor matrix ``(K, J)``.
+    y1_pre, Y0_pre : np.ndarray
+        Treated ``(T0,)`` and donor ``(T0, J)`` pre-treatment outcomes.
+    normalize : bool
+        Scale predictors by the pooled standard deviation before regressing.
+        ``True`` reproduces ``normalize`` running ahead of ``regsval``. Setting
+        it ``False`` regresses on raw predictors, which is a *different*
+        estimator, not a formatting choice -- see the module docstring.
+    include_treated : bool
+        Pool the treated unit into the regression, as ``regsval``'s signature
+        implies. ``False`` regresses on donors alone.
+    pooled : bool
+        One regression stacking every ``(unit, period)`` observation, versus one
+        per pre-period with the squared coefficients summed. Not determined by
+        the reference; see the module docstring.
+    fit_intercept : bool
+        Include a constant. With ``normalize=True`` the regressors are scaled
+        but not centred, so this is not a no-op.
+
+    Returns
+    -------
+    np.ndarray
+        ``(K,)`` non-negative weights summing to one. Falls back to uniform
+        weights when every coefficient vanishes.
+    """
+    X1 = np.asarray(X1, dtype=float).ravel()
+    X0 = np.asarray(X0, dtype=float)
+    y1_pre = np.asarray(y1_pre, dtype=float).ravel()
+    Y0_pre = np.asarray(Y0_pre, dtype=float)
+    K = X1.shape[0]
+    if K == 0:
+        return np.zeros(0)
+
+    # Pool the blocks -- treated first, matching regsval(Xtr, Xco, Ztr, Zco).
+    if include_treated:
+        X_all = np.column_stack([X1, X0])            # (K, 1 + J)
+        Z_all = np.column_stack([y1_pre, Y0_pre])    # (T0, 1 + J)
+    else:
+        X_all, Z_all = X0, Y0_pre
+
+    if normalize:
+        X_all = X_all / _pooled_scale(X_all)[:, None]
+
+    D = X_all.T                                      # (N, K)
+    if fit_intercept:
+        D = np.column_stack([np.ones(D.shape[0]), D])
+
+    if pooled:
+        big_D = np.tile(D, (Z_all.shape[0], 1))
+        beta, *_ = np.linalg.lstsq(big_D, Z_all.reshape(-1), rcond=None)
+        b = beta[1:] if fit_intercept else beta
+        sq = b ** 2
+    else:
+        beta, *_ = np.linalg.lstsq(D, Z_all.T, rcond=None)     # (K[+1], T0)
+        b = beta[1:] if fit_intercept else beta
+        sq = np.sum(b ** 2, axis=1)                  # diag(b b')
+
+    total = sq.sum()                                 # trace(b b')
+    if not np.isfinite(total) or total <= _EPS:
+        return np.full(K, 1.0 / K)
+    return sq / total
+
+
+def solve_regression(
+    prob: BilevelProblem,
+    *,
+    normalize: bool = True,
+    include_treated: bool = True,
+    pooled: bool = False,
+    fit_intercept: bool = True,
+    max_iter: int = 20000,
+    tol: float = 1e-11,
+) -> BilevelSolution:
+    """Backend entry point: regression ``V``, then the lower-level simplex fit.
+
+    Unlike ``malo``/``mscmt`` there is no outer search -- ``V`` is a closed-form
+    function of the data, and only the lower level is solved. ``lower_bound`` is
+    reported for comparability with the searching backends: it is the
+    unconstrained outcome fit, so ``upper_loss - lower_bound`` still reads as
+    the price paid for matching on predictors rather than on the outcome.
+    """
+    V = regression_v(
+        prob.X1, prob.X0, prob.y1_pre, prob.Y0_pre,
+        normalize=normalize, include_treated=include_treated,
+        pooled=pooled, fit_intercept=fit_intercept,
+    )
+    root = np.sqrt(V)
+    W = np.asarray(
+        simplex_lstsq(prob.X0 * root[:, None], prob.X1 * root,
+                      max_iter=max_iter, tol=tol), dtype=float).ravel()
+
+    resid = prob.y1_pre - prob.Y0_pre @ W
+    upper = float(resid @ resid)
+    pres = prob.X1 - prob.X0 @ W
+    lower = float(np.sum(V * pres ** 2))
+    W_star = np.asarray(
+        simplex_lstsq(prob.Y0_pre, prob.y1_pre, max_iter=max_iter, tol=tol),
+        dtype=float).ravel()
+    r_star = prob.y1_pre - prob.Y0_pre @ W_star
+    return BilevelSolution(
+        V=V, W=W, upper_loss=upper, lower_loss=lower,
+        lower_bound=float(r_star @ r_star), stage="regression",
+        iterations=0,
+        metadata={"rule": "regression", "normalize": normalize,
+                  "include_treated": include_treated, "pooled": pooled,
+                  "fit_intercept": fit_intercept,
+                  "n_predictors_weighted": int((V > 1e-6).sum())},
+    )

--- a/mlsynth/utils/bilevel/solver.py
+++ b/mlsynth/utils/bilevel/solver.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import numpy as np
 
 from .mscmt import solve_mscmt
+from .regression_v import solve_regression
 from .penalized import solve_penalized
 from .simplex import mspe
 from .stages import (
@@ -55,10 +56,12 @@ def solve_bilevel(
     ----------
     prob : BilevelProblem
         Outcome and predictor matrices.
-    method : {"malo", "mscmt", "penalized"}
+    method : {"malo", "mscmt", "regression", "penalized"}
         Which backend to use. ``"malo"`` (default) runs the staged corner
         search; ``"mscmt"`` runs the global differential-evolution outer
-        search; ``"penalized"`` runs the Abadie-L'Hour penalized estimator
+        search; ``"regression"`` uses Stata ``synth``'s default closed-form
+        regression rule (no outer search); ``"penalized"`` runs the
+        Abadie-L'Hour penalized estimator
         with leave-one-out ``lambda`` selection. The default preserves the
         historical behaviour of every existing caller.
     **kwargs
@@ -74,6 +77,8 @@ def solve_bilevel(
     BilevelSolution
     """
     method = str(method).lower()
+    if method == "regression":
+        return solve_regression(prob, **kwargs)
     if method == "mscmt":
         return solve_mscmt(prob, **kwargs)
     if method == "penalized":
@@ -81,7 +86,8 @@ def solve_bilevel(
     if method == "malo":
         return _solve_malo(prob, **kwargs)
     raise ValueError(
-        f"Unknown bilevel method {method!r}; expected 'malo', 'mscmt' or 'penalized'."
+        f"Unknown bilevel method {method!r}; expected 'malo', 'mscmt', "
+        f"'regression' or 'penalized'."
     )
 
 

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -92,7 +92,7 @@ class VanillaSCConfig(BaseEstimatorConfig):
 
     Parameters
     ----------
-    backend : {"auto", "outcome-only", "malo", "mscmt", "penalized"}
+    backend : {"auto", "outcome-only", "malo", "mscmt", "regression", "penalized"}
         Predictor-weight backend. ``"auto"`` (default) uses ``"outcome-only"``
         (convex simplex fit on pre-treatment outcomes) when no covariates are
         given, and ``"mscmt"`` (global differential-evolution ``V`` search)
@@ -145,7 +145,8 @@ class VanillaSCConfig(BaseEstimatorConfig):
         slow backends.
     """
 
-    backend: Literal["auto", "outcome-only", "malo", "mscmt", "penalized"] = Field(
+    backend: Literal["auto", "outcome-only", "malo", "mscmt", "regression",
+                     "penalized"] = Field(
         default="auto",
         description="Predictor-weight backend (see class docstring).",
     )

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -212,6 +212,30 @@ def _covariate_balance(
     }
 
 
+def _v_concentration(V) -> Tuple[Optional[int], Optional[float]]:
+    """How concentrated are the predictor weights, and is ``V`` pinned down?
+
+    ``V`` is generically non-identified -- several predictor-weight vectors can
+    attain the same upper-level loss -- and backends differ in which member of
+    that set they return: a corner search lands on a sparse one, a global search
+    on a dense one, a closed-form rule on whatever the data imply. The returned
+    weights alone do not make that visible, so two numbers are reported.
+
+    ``n_weighted`` counts the predictors above a fixed tolerance, which is easy
+    to read but depends on the tolerance. ``effective`` is the participation
+    ratio :math:`1 / \sum_h v_h^2`: no tolerance, equal to ``K`` for uniform
+    weights and ``1`` for a corner, moving continuously in between. Prefer it.
+    """
+    if V is None:
+        return None, None
+    v = np.asarray(V, dtype=float).ravel()
+    if v.size == 0:
+        return None, None
+    ss = float(np.sum(v ** 2))
+    effective = float(1.0 / ss) if ss > 1e-12 else None
+    return int(np.sum(v > 1e-6)), effective
+
+
 def _rmspe_ratio(y: np.ndarray, cf: np.ndarray, pre: int) -> Tuple[float, float, float]:
     """(pre_rmspe, post_rmspe, ratio) for an outcome/counterfactual pair."""
     gap = y - cf
@@ -702,6 +726,8 @@ def run_vanillasc(config) -> BaseEstimatorResults:
                 {n: float(v) for n, v in zip(res.predictor_names, res.V)}
                 if res.V is not None else None
             ),
+            "n_predictors_weighted": _v_concentration(res.V)[0],
+            "v_effective_count": _v_concentration(res.V)[1],
             "v_agreement": res.v_agreement,
         },
     )
@@ -723,6 +749,11 @@ def run_vanillasc(config) -> BaseEstimatorResults:
                 "covariates": covariates,
                 "canonical_v": config.canonical_v,
                 "v_agreement": res.v_agreement,
+                # How concentrated the returned V is (participation ratio).
+                # Near 1 means the fit rests on a single predictor, which under
+                # V's non-identification is a property of the backend's search
+                # as much as of the data -- see _v_concentration.
+                "v_effective_count": _v_concentration(res.V)[1],
                 "penalized_lambda": (
                     float(res.diagnostics["lambda"])
                     if res.backend == "penalized"


### PR DESCRIPTION
## Related Links

- Resolves #334
- Docs: `docs/vanillasc.rst`, Backends section
- Reference: Hainmueller's `synth` (`synth2.ado`, `synth2.sthlp`, `synth2_ll.ado` in [bquistorff/Stata-modules](https://github.com/bquistorff/Stata-modules/tree/master/s))
- First of three prerequisites for a stacked bias-corrected SCM (Wiltshire 2023)

## What

- `mlsynth/utils/bilevel/regression_v.py` — `regression_v()` (the rule) and `solve_regression()` (the backend)
- Registered in `solver.py`'s dispatch, `_BACKENDS` and `_SOLVER_KWARGS`; exported from `bilevel/__init__.py`; `VanillaSCConfig.backend` widened to accept `"regression"`
- `_v_concentration()` in the VanillaSC pipeline, reporting how concentrated the returned `V` is
- 27 tests across two files; a Backends entry on the docs page

## Why

None of the five existing backends is what Stata `synth` actually runs by default. `synth` performs the Abadie-Diamond-Hainmueller nested optimisation only when the caller passes `nested` (`synth2.sthlp` 157-162, `synth2.ado` 426), and wrappers such as `allsynth` forward that flag rather than setting it (`allsynth.ado` 69, 1489). Most published `synth` estimates were therefore produced by the regression rule and not by a search, and mlsynth had no way to reproduce them.

The converse matters too and is now documented: R's `Synth::synth()` optimises `V` numerically, so an R-lineage result wants a searching backend. These are different estimators, not different tunings.

## How

The rule is not published — `normalize` and `regsval` ship compiled inside `l/lsynth2_mata_subr.mlib`, and the package manifest carries no source for either. The library's symbol table constrains it:

```
normalize:  storemat  xtrout xcoout  quadvariance  diag  xtrmat xcomat
regsval:    sval  xtrout xcoout ztrout zcoout  beta  trace  diag  vmat
```

The only Mata builtins referenced anywhere in the library are `diag`, `quadvariance` and `trace`. Hence: scale each predictor by its standard deviation over the pooled treated-and-donor block (no `mean` is referenced anywhere, so scale-only rather than centring), regress the pre-treatment outcomes of both blocks on the normalised predictors, and set `V = diag(bb') / trace(bb')`.

Two details are genuinely unrecoverable, because the regression solve compiles to an opcode rather than a name lookup: whether `beta` comes from one pooled regression or one per pre-period, and whether an intercept is fitted. Both are arguments (`pooled`, `fit_intercept`) rather than silent constants — on the Wiltshire panel the two readings tie at 1.854 vs 1.768 total absolute error over eight reported cells, so there is no basis for choosing.

Operator ordering turned out to be the load-bearing detail and has its own test. `normalize` runs before `regsval`, so the coefficients come from normalised regressors; scaling afterwards at the weighting step is a different estimator. That single fix moved Wiltshire's Panel A from -1.43 to -1.78 against a target of -1.77, and repaired a sign flip on his Panel D (-0.655 to +0.620, target +1.112).

## Verification

Path: cross-validation against the reference implementation's documented behaviour, plus behavioural tests. Not a numerical replication — see the caveat below.

On the canonical Prop 99 specification (four covariates plus cigsale lags for 1975, 1980, 1988):

| backend | ATT | pre-RMSE | v_eff | max abs weight error vs ADH Table 2 |
|---|---|---|---|---|
| outcome-only | -19.51 | 1.656 | — | 0.149 |
| regression | -17.97 | 2.039 | 2.25 | 0.199 |
| malo | -19.48 | 1.657 | 1.00 | 0.149 |
| mscmt | -18.98 | 1.754 | 2.00 | **0.004** |

`mscmt` reproduces ADH's published donor weights to 0.004; this backend does not, and should not — ADH's table came from R, which optimises `V`. Recorded rather than fixed, and stated on the docs page, because a reader would otherwise reasonably expect the new backend to be the one that matches.

`malo`'s effective count of exactly 1.00 is the corner collapse the docs already warned about in prose, now measurable: with all weight on one lagged outcome the inner match degenerates to outcome-fitting, which is why its donor weights come out nearly identical to the outcome-only fit.

Durably pinned by `test_bilevel_regression_v.py` (the ordering, the treated unit's inclusion, scale invariance) and `test_vanillasc_v_diagnostic.py` (the concentration endpoints). A benchmark case for the Prop 99 comparison belongs to the separate benchmark workstream and is not in this branch.

## Scope checks

Shared-helper addition plus a diagnostic — none of the four blocks fits. The change is additive: a new dispatch branch, a widened tuple and Literal, and two new keys in existing dicts. No existing backend path is altered, and 954 passed / 3 skipped across everything touching `bilevel` confirms it.

## Test Steps

- [x] `pytest mlsynth/tests/test_bilevel_regression_v.py -q` — 15 passed
- [x] `pytest mlsynth/tests/test_vanillasc_v_diagnostic.py -q` — 12 passed
- [x] `pytest mlsynth/tests/ -k "vanillasc or bilevel"` — 414 passed, 2 skipped
- [x] `pytest mlsynth/tests/ -k "bilevel or vanillasc or simplex or determine_v or fscm or spillsynth or scta or scmo"` — 954 passed, 3 skipped
- [ ] Full `pytest mlsynth/tests/` — deferred to CI
- [x] RST underlines checked; no bold in the added prose

## Other Notes

- `v_agreement` returns 0.216 for `regression` against 0.999 and 1.000 for the two searches, which reads as the closed-form rule being the best identified of the three. Plausible — it is a deterministic function of the data rather than one member of an optimal set — but that metric was designed for a bilevel optimum and its interpretation for a non-optimising rule deserves a look before anyone quotes it.
- Two sibling prerequisites remain for the stacked estimator, each its own branch: rewiring the Abadie-L'Hour correction in `bilevel/penalized.py:508` so a general SCM can reach it (currently `SPILLSYNTH`-only, and only on its predictors branch), and promoting the batched multi-RHS simplex primitives next to `bilevel/simplex.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_