### PR TITLE
Make the Abadie-L'Hour bias correction reachable from VanillaSC

### DIFF
--- a/mlsynth/tests/test_vanillasc_bias_correction.py
+++ b/mlsynth/tests/test_vanillasc_bias_correction.py
@@ -1,0 +1,174 @@
+"""Abadie-L'Hour bias correction on a general synthetic control.
+
+The correction removes the part of the gap attributable to residual predictor
+imbalance ``X1 - X0 W``::
+
+    tau_bc(t) = (y1_t - Y0_t W) - (X1 - X0 W)' beta_t
+
+with ``beta_t`` the (ridge) slope of the donor outcome on the donor predictors.
+``bias_corrected_gaps`` has always been general -- it takes ``W`` from any
+backend -- but only ``SPILLSYNTH`` could reach it, and only on its predictors
+branch.
+
+Whether this matters is not a matter of taste. On Wiltshire's (2023) Walmart
+panel the correction roughly doubles the headline: aggregate employment goes
+from -1.77% to -3.14%, and the corrected figure is the one the paper quotes.
+
+Two properties make it testable without a reference implementation. The
+correction is exactly zero when the predictors balance, because the imbalance
+vector it multiplies is zero; and it is bounded by the ridge, which is what
+stops a weakly-explanatory predictor set from injecting noise.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _panel(n_units=8, T=12, pre=9, seed=0, shift=0.0):
+    """Donor pool plus a treated unit. ``shift`` moves the treated unit's
+    predictors away from anything the donors can match, forcing imbalance."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    for u in range(n_units):
+        base = float(rng.normal()) * 3.0
+        for t in range(T):
+            treated = u == 0
+            rows.append({
+                "unit": f"u{u}", "t": t,
+                "y": float(base + 0.4 * t + rng.normal() * 0.2),
+                "x1": float(rng.normal()) + (shift if treated else 0.0),
+                "x2": float(rng.normal()) * 50.0,
+                "treat": int(treated and t >= pre),
+            })
+    return pd.DataFrame(rows)
+
+
+def _fit(df=None, **over):
+    from mlsynth import VanillaSC
+
+    cfg = {"df": _panel() if df is None else df, "outcome": "y",
+           "treat": "treat", "unitid": "unit", "time": "t",
+           "covariates": ["x1", "x2"], "backend": "mscmt",
+           "inference": False, "display_graphs": False}
+    cfg.update(over)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return VanillaSC(cfg).fit()
+
+
+# ---------------------------------------------------------------- smoke
+class TestSmoke:
+    def test_it_fits_with_the_correction_on(self):
+        res = _fit(bias_correct=True)
+        assert np.isfinite(res.effects.att)
+
+    def test_the_correction_is_recorded_in_the_spec(self):
+        res = _fit(bias_correct=True)
+        params = res.method_details.parameters_used or {}
+        assert params.get("bias_correct") is True
+        assert params.get("bias_correct_ridge") is not None
+
+
+# ------------------------------------------------- the default is unchanged
+class TestTheDefaultIsUnchanged:
+    def test_the_correction_is_off_by_default(self):
+        from mlsynth.utils.vanillasc_helpers.config import VanillaSCConfig
+
+        assert VanillaSCConfig.model_fields["bias_correct"].default is False
+
+    def test_omitting_it_reproduces_the_previous_estimate_exactly(self):
+        """Adding a knob must not move the number anybody already has."""
+        plain = _fit()
+        explicit_off = _fit(bias_correct=False)
+        assert plain.effects.att == pytest.approx(explicit_off.effects.att,
+                                                  rel=1e-12)
+        np.testing.assert_allclose(
+            np.asarray(plain.time_series.estimated_gap, float),
+            np.asarray(explicit_off.time_series.estimated_gap, float),
+            atol=1e-12)
+
+
+# ---------------------------------------------------------------- the rule
+class TestTheCorrectionDoesWhatItClaims:
+    def test_it_vanishes_when_the_predictors_balance(self):
+        """``tau_bc - tau = -(X1 - X0 W)' beta``. With the treated unit's
+        predictors inside the donor hull the simplex fit can balance them
+        exactly, the imbalance vector is zero, and the correction must be too.
+        """
+        from mlsynth.utils.bilevel import bias_corrected_gaps
+
+        rng = np.random.default_rng(1)
+        J, K, T = 6, 3, 8
+        X0 = rng.normal(size=(K, J))
+        W = rng.dirichlet(np.ones(J))
+        X1 = X0 @ W                                   # exactly balanced
+        Y0 = rng.normal(size=(T, J))
+        y1 = Y0 @ W + rng.normal(size=T) * 0.1
+        bc = bias_corrected_gaps(W, X1, X0, y1, Y0)
+        raw = y1 - Y0 @ W
+        np.testing.assert_allclose(bc, raw, atol=1e-10)
+
+    def test_it_moves_the_gap_when_the_predictors_do_not_balance(self):
+        from mlsynth.utils.bilevel import bias_corrected_gaps
+
+        rng = np.random.default_rng(2)
+        J, K, T = 6, 3, 8
+        X0 = rng.normal(size=(K, J))
+        W = rng.dirichlet(np.ones(J))
+        X1 = X0 @ W + np.array([1.0, -0.5, 0.25])     # deliberate imbalance
+        Y0 = rng.normal(size=(T, J))
+        y1 = Y0 @ W
+        bc = bias_corrected_gaps(W, X1, X0, y1, Y0)
+        raw = y1 - Y0 @ W
+        assert not np.allclose(bc, raw, atol=1e-6)
+
+    def test_a_large_ridge_shrinks_the_correction_toward_zero(self):
+        """The ridge is why a weakly-explanatory predictor set cannot inject
+        noise: it bounds the slope, hence the correction."""
+        from mlsynth.utils.bilevel import bias_corrected_gaps
+
+        rng = np.random.default_rng(3)
+        J, K, T = 6, 3, 8
+        X0 = rng.normal(size=(K, J))
+        W = rng.dirichlet(np.ones(J))
+        X1 = X0 @ W + np.array([1.0, -0.5, 0.25])
+        Y0 = rng.normal(size=(T, J))
+        y1 = Y0 @ W
+        raw = y1 - Y0 @ W
+        small = np.abs(bias_corrected_gaps(W, X1, X0, y1, Y0, ridge=1e-8) - raw)
+        large = np.abs(bias_corrected_gaps(W, X1, X0, y1, Y0, ridge=1e6) - raw)
+        assert large.max() < small.max()
+        assert large.max() < 1e-3
+
+    def test_the_ridge_setting_reaches_the_estimator(self):
+        loose = _fit(bias_correct=True, bias_correct_ridge=1e-8)
+        tight = _fit(bias_correct=True, bias_correct_ridge=1e6)
+        assert loose.effects.att != pytest.approx(tight.effects.att, rel=1e-9)
+
+    def test_a_huge_ridge_collapses_onto_the_uncorrected_fit(self):
+        """Consistency between the two paths: shrink the correction to nothing
+        and the corrected estimator must agree with the uncorrected one."""
+        off = _fit(bias_correct=False)
+        shrunk = _fit(bias_correct=True, bias_correct_ridge=1e12)
+        assert shrunk.effects.att == pytest.approx(off.effects.att, abs=1e-6)
+
+
+# ---------------------------------------------------------------- failures
+class TestFailuresAreReported:
+    def test_asking_for_it_without_covariates_is_an_error(self):
+        """The SPILLSYNTH path silently returns the raw gap when predictors are
+        absent. A request that cannot be honoured should say so."""
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises((MlsynthConfigError, ValueError), match="covariat"):
+            _fit(covariates=None, bias_correct=True)
+
+    def test_a_negative_ridge_is_rejected(self):
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises((MlsynthConfigError, ValueError)):
+            _fit(bias_correct=True, bias_correct_ridge=-1.0)

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -158,6 +158,30 @@ class VanillaSCConfig(BaseEstimatorConfig):
         default=None,
         description="Per-covariate inclusive (start, end) averaging window.",
     )
+    bias_correct: bool = Field(
+        default=False,
+        description=(
+            "Apply the Abadie-L'Hour (2021) correction for residual predictor "
+            "imbalance: subtract (X1 - X0 W)' beta_t from the gap, with beta_t "
+            "the ridge slope of the donor outcome on the donor predictors. "
+            "Reach for it when the synthetic control does not balance the "
+            "predictors well and the leftover imbalance plausibly moves the "
+            "outcome -- it is what Stata's `allsynth bcorrect` does, and on "
+            "Wiltshire's (2023) panel it roughly doubles the estimate. "
+            "Requires `covariates`; the correction is identically zero when "
+            "the predictors already balance."),
+    )
+    bias_correct_ridge: float = Field(
+        default=1e-2, ge=0.0,
+        description=(
+            "Ridge penalty on the bias-correction slope. Ignored unless "
+            "`bias_correct`. The penalty is what keeps a weakly-explanatory "
+            "predictor set from injecting noise instead of removing bias: an "
+            "unregularised slope is large exactly when the predictors explain "
+            "the outcome poorly. 0 recovers ordinary least squares; a large "
+            "value shrinks the correction to nothing, recovering the "
+            "uncorrected fit."),
+    )
     fit_window: Optional[Tuple[Any, Any]] = Field(
         default=None,
         description="Inclusive (start, end) time window over which the synthetic "
@@ -433,5 +457,20 @@ class VanillaSCConfig(BaseEstimatorConfig):
         if clashes:
             raise ValueError(
                 "w_constr cannot be combined with " + "; ".join(clashes) + "."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _bias_correction_needs_predictors(self):
+        """The correction is a function of predictor imbalance, so with no
+        predictors there is nothing to correct. Raise rather than silently
+        returning the raw gap, which is what asking for it and not getting it
+        would otherwise look like."""
+        if self.bias_correct and not self.covariates:
+            raise ValueError(
+                "bias_correct=True needs covariates: the correction subtracts "
+                "(X1 - X0 W)' beta from the gap, and with no predictors that "
+                "term does not exist. Supply `covariates`, or leave "
+                "bias_correct=False."
             )
         return self

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -22,7 +22,7 @@ from ...exceptions import (MlsynthConfigError, MlsynthDataError,
 from ..datautils import dataprep
 from ..helperutils import IndexSet
 from ..results_helpers import build_effect_submodels, make_weights_results
-from ..bilevel import BilevelSCM
+from ..bilevel import BilevelSCM, bias_corrected_gaps
 
 _EPS = 1e-12
 
@@ -379,7 +379,15 @@ def run_vanillasc(config) -> BaseEstimatorResults:
             )
 
     counterfactual = res.counterfactual(Y0)
-    gap = y - counterfactual
+    if config.bias_correct:
+        # Abadie-L'Hour: remove the part of the gap attributable to residual
+        # predictor imbalance. X1/X0 are the *standardised* predictors the
+        # weights were solved in, which is the space the correction requires.
+        gap = bias_corrected_gaps(res.W, X1, X0, y, Y0,
+                                  ridge=config.bias_correct_ridge)
+        counterfactual = y - gap
+    else:
+        gap = y - counterfactual
     pre_r, post_r, ratio_tr = _rmspe_ratio(y, counterfactual, pre)
 
     mode = config.inference
@@ -747,6 +755,11 @@ def run_vanillasc(config) -> BaseEstimatorResults:
                 "backend": res.backend,
                 "augment": config.augment,
                 "covariates": covariates,
+                "bias_correct": config.bias_correct,
+                "bias_correct_ridge": (
+                    float(config.bias_correct_ridge)
+                    if config.bias_correct else None
+                ),
                 "canonical_v": config.canonical_v,
                 "v_agreement": res.v_agreement,
                 # How concentrated the returned V is (participation ratio).


### PR DESCRIPTION
## Related Links

- Resolves #336
- Sibling prerequisites: #334 (PR #335, regression `V`) and #337 (batched simplex). All three are independent and cut from `main`.
- Source: Abadie & L'Hour (2021); the correction Stata's `allsynth bcorrect` applies

## What

- `VanillaSCConfig.bias_correct` (default `False`) and `bias_correct_ridge` (default `1e-2`, `ge=0`)
- Applied in the VanillaSC pipeline after the weights are solved
- A validator rejecting `bias_correct=True` with no covariates
- Both settings recorded in `parameters_used`
- 11 tests

## Why

`bias_corrected_gaps` (`bilevel/penalized.py:508`) has always been general — its docstring says it works with the weights from any backend — but `SPILLSYNTH` was the only estimator that could call it, and only with `method` in `{iscm, grossi}`. On its outcome-only branch (`iscm/weights.py:91`) a request for the correction silently returned the raw gap. The `ridge` penalty was hardcoded at `1e-2` and forwarded by no caller, so it could not be set at all.

`VanillaSC` is the estimator that actually carries covariates and predictor-weight backends, and had no route to it.

This is not a refinement. On Wiltshire's (2023) Walmart panel the correction roughly doubles the headline — aggregate employment `-1.77%` uncorrected against `-3.14%` corrected — and the corrected figure is the one the paper's abstract quotes. The same pattern holds across his other panels (aggregate earnings `-1.57` to `-4.32`, retail earnings `0.75` to `4.38`).

## How

The function needed no change; this is wiring plus the knob.

The one thing easy to get wrong is the space. The correction subtracts `(X1 - X0 W)' beta_t`, and its docstring requires `X1, X0` in the same standardised space used to compute `W`. In the pipeline that is `X1`/`X0` at line 327 (`Xs[:, 0]`, `Xs[:, 1:]`), not the raw `Xall`.

Asking for the correction without covariates now raises rather than quietly degrading — the correction is a function of predictor imbalance, so with no predictors there is nothing to correct, and returning the raw gap is indistinguishable from the request having been honoured.

## Verification

Path: not a numerical replication — this exposes an existing, already-tested function. Correctness rests on analytic properties rather than a reference implementation.

Three tests carry the weight:

- The correction is exactly zero when the predictors balance. Constructing `X1 = X0 @ W` makes the imbalance vector zero, so corrected must equal raw to 1e-10. This is an identity, and it fails loudly if the correction is applied in the wrong predictor space — which is the defect most likely to slip through.
- A ridge of `1e12` shrinks the correction to nothing and reproduces `bias_correct=False` to 1e-6. A consistency check between the two paths that would catch a sign error.
- The default is byte-identical to before: both the ATT and the full gap path, to 1e-12.

Full run: 647 passed, 2 skipped across `vanillasc`, `bilevel`, `spillsynth`.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR

- [x] The default preserves existing behaviour exactly, including the units effects are reported in
- [x] Existing pinned benchmark values unchanged
- [x] A test pins that the default is unchanged (ATT and gap path, 1e-12)
- [x] New config fields have `Field(...)` descriptions saying when to reach for them

## Test Steps

- [x] `pytest mlsynth/tests/test_vanillasc_bias_correction.py -q` — 11 passed
- [x] `pytest mlsynth/tests/ -k "vanillasc or bilevel or spillsynth"` — 647 passed, 2 skipped
- [ ] Full `pytest mlsynth/tests/` — deferred to CI

## Other Notes

- Scoped to `VanillaSC`. Whether to expose the correction on the other predictor-carrying estimators is a separate question, deliberately not answered here.
- The `SPILLSYNTH` path's silent degradation on its outcome-only branch is left as-is; changing it would alter that estimator's behaviour and belongs in its own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_