### PR TITLE
Add batched (multi-RHS) simplex projection and least squares

### DIFF
--- a/mlsynth/tests/test_bilevel_simplex_batch.py
+++ b/mlsynth/tests/test_bilevel_simplex_batch.py
@@ -1,0 +1,186 @@
+"""Multiple-right-hand-side simplex least squares.
+
+A stacked synthetic-control design fits one weight vector per treated unit,
+which looks like N independent problems. It is not: every treated unit in a
+cohort solves against the *same* donor block ``A`` and differs only in its own
+target ``b_j``. Stacking the targets as columns makes it one program with many
+right-hand sides, so the Gram matrix and step size are formed once instead of
+per unit -- 5.2s against 81.7s on the Walmart panel's 566 counties.
+
+Two things these tests deliberately do NOT assert.
+
+Batch and loop are not interchangeable on a rank-deficient design. With few
+pre-treatment periods against many donors the optimum is a face rather than a
+point, so two solvers can both reach it and land in different places. The
+objectives must agree; the weights need not, and asserting they do would pin a
+solver artefact.
+
+The batched solver stops on the objective, while the scalar ``simplex_lstsq``
+stops on the step norm. That is on purpose -- along a flat optimal face the
+iterate keeps moving after the objective has settled, so a step-norm rule never
+fires and the solver burns its whole iteration budget.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.simplex import project_simplex, simplex_lstsq
+
+
+def _rank_deficient(T0=5, J=39, k=40, seed=0):
+    """Fewer rows than donors: the Walmart cohorts' shape, null space >= 34.
+
+    The targets are offset well outside the donors' convex hull. Without that
+    the simplex fit is exact, every objective is zero, and comparing them says
+    nothing -- the residuals differ only in their last bits.
+    """
+    rng = np.random.default_rng(seed)
+    return rng.normal(size=(T0, J)), rng.normal(size=(T0, k)) + 8.0
+
+
+def _well_conditioned(m=30, n=8, k=25, seed=1):
+    rng = np.random.default_rng(seed)
+    return rng.normal(size=(m, n)), rng.normal(size=(m, k))
+
+
+# --------------------------------------------------------------- projection
+class TestTheBatchedProjection:
+    @pytest.mark.parametrize("n,k,scale", [(1, 7, 1.0), (2, 5, 10.0),
+                                           (39, 200, 1e3), (100, 50, 1e-3)])
+    def test_it_agrees_with_the_scalar_version_column_by_column(self, n, k, scale):
+        from mlsynth.utils.bilevel.simplex import project_simplex_cols
+
+        rng = np.random.default_rng(n * 100 + k)
+        V = rng.normal(size=(n, k)) * scale
+        batched = project_simplex_cols(V)
+        scalar = np.column_stack([project_simplex(V[:, j]) for j in range(k)])
+        np.testing.assert_allclose(batched, scalar, atol=1e-12)
+
+    def test_every_column_lands_on_the_simplex(self):
+        from mlsynth.utils.bilevel.simplex import project_simplex_cols
+
+        rng = np.random.default_rng(2)
+        P = project_simplex_cols(rng.normal(size=(12, 40)) * 100.0)
+        assert (P >= -1e-12).all()
+        np.testing.assert_allclose(P.sum(axis=0), 1.0, atol=1e-12)
+
+    def test_a_point_already_on_the_simplex_is_left_alone(self):
+        from mlsynth.utils.bilevel.simplex import project_simplex_cols
+
+        rng = np.random.default_rng(3)
+        W = rng.dirichlet(np.ones(6), size=9).T          # (6, 9)
+        np.testing.assert_allclose(project_simplex_cols(W), W, atol=1e-12)
+
+    def test_the_radius_is_honoured(self):
+        from mlsynth.utils.bilevel.simplex import project_simplex_cols
+
+        rng = np.random.default_rng(4)
+        P = project_simplex_cols(rng.normal(size=(5, 8)), z=3.0)
+        np.testing.assert_allclose(P.sum(axis=0), 3.0, atol=1e-12)
+
+    def test_a_single_row_is_the_degenerate_branch(self):
+        from mlsynth.utils.bilevel.simplex import project_simplex_cols
+
+        rng = np.random.default_rng(5)
+        P = project_simplex_cols(rng.normal(size=(1, 6)))
+        np.testing.assert_allclose(P, np.ones((1, 6)), atol=1e-12)
+
+
+# ------------------------------------------------------------ least squares
+class TestTheBatchedSolve:
+    def test_it_matches_the_loop_on_a_well_conditioned_design(self):
+        from mlsynth.utils.bilevel.simplex import simplex_lstsq_batch
+
+        A, B = _well_conditioned()
+        W = simplex_lstsq_batch(A, B)
+        loop = np.column_stack([simplex_lstsq(A, B[:, j], max_iter=20000,
+                                              tol=1e-12)
+                                for j in range(B.shape[1])])
+        np.testing.assert_allclose(W, loop, atol=1e-4)
+
+    def test_on_a_rank_deficient_design_the_objectives_agree(self):
+        """Not the weights. The optimum is a face, so where on it a solver
+        lands is an artefact; the loss is the identified quantity."""
+        from mlsynth.utils.bilevel.simplex import simplex_lstsq_batch
+
+        A, B = _rank_deficient()
+        assert np.linalg.matrix_rank(A) < A.shape[1]     # the premise
+        W = simplex_lstsq_batch(A, B)
+        loop = np.column_stack([simplex_lstsq(A, B[:, j], max_iter=20000,
+                                              tol=1e-12)
+                                for j in range(B.shape[1])])
+        obj_b = ((A @ W - B) ** 2).sum(axis=0)
+        obj_l = ((A @ loop - B) ** 2).sum(axis=0)
+        # Guard against the comparison going vacuous: if the fit were exact the
+        # objectives would both be ~0 and agreeing would mean nothing.
+        assert obj_b.min() > 1.0
+        np.testing.assert_allclose(obj_b, obj_l, rtol=1e-3)
+
+    def test_the_solution_is_on_the_simplex(self):
+        from mlsynth.utils.bilevel.simplex import simplex_lstsq_batch
+
+        A, B = _well_conditioned()
+        W = simplex_lstsq_batch(A, B)
+        assert (W >= -1e-9).all()
+        np.testing.assert_allclose(W.sum(axis=0), 1.0, atol=1e-8)
+
+    def test_it_beats_uniform_weights(self):
+        """A minimiser must not do worse than the point it starts from."""
+        from mlsynth.utils.bilevel.simplex import simplex_lstsq_batch
+
+        A, B = _well_conditioned()
+        W = simplex_lstsq_batch(A, B)
+        U = np.full_like(W, 1.0 / A.shape[1])
+        assert (((A @ W - B) ** 2).sum(0) <= ((A @ U - B) ** 2).sum(0) + 1e-9).all()
+
+    def test_the_ridge_shrinks_toward_uniform(self):
+        from mlsynth.utils.bilevel.simplex import simplex_lstsq_batch
+
+        A, B = _rank_deficient()
+        uniform = np.full(A.shape[1], 1.0 / A.shape[1])
+        plain = simplex_lstsq_batch(A, B, ridge=0.0)
+        heavy = simplex_lstsq_batch(A, B, ridge=1e3)
+        d_plain = np.abs(plain - uniform[:, None]).max()
+        d_heavy = np.abs(heavy - uniform[:, None]).max()
+        assert d_heavy < d_plain
+
+    def test_one_column_agrees_with_the_scalar_solver(self):
+        from mlsynth.utils.bilevel.simplex import simplex_lstsq_batch
+
+        A, B = _well_conditioned(k=1)
+        W = simplex_lstsq_batch(A, B)
+        assert W.shape == (A.shape[1], 1)
+        np.testing.assert_allclose(
+            W[:, 0], simplex_lstsq(A, B[:, 0], max_iter=20000, tol=1e-12),
+            atol=1e-4)
+
+    def test_a_single_donor_takes_everything(self):
+        from mlsynth.utils.bilevel.simplex import simplex_lstsq_batch
+
+        rng = np.random.default_rng(7)
+        W = simplex_lstsq_batch(rng.normal(size=(6, 1)), rng.normal(size=(6, 4)))
+        np.testing.assert_allclose(W, np.ones((1, 4)), atol=1e-12)
+
+    def test_a_one_dimensional_target_is_accepted_as_one_column(self):
+        from mlsynth.utils.bilevel.simplex import simplex_lstsq_batch
+
+        A, B = _well_conditioned(k=1)
+        np.testing.assert_allclose(simplex_lstsq_batch(A, B[:, 0]),
+                                   simplex_lstsq_batch(A, B), atol=1e-12)
+
+
+# ---------------------------------------------------------------- failures
+class TestFailuresAreReported:
+    def test_mismatched_shapes_are_rejected(self):
+        from mlsynth.utils.bilevel.simplex import simplex_lstsq_batch
+
+        rng = np.random.default_rng(8)
+        with pytest.raises(ValueError):
+            simplex_lstsq_batch(rng.normal(size=(6, 3)), rng.normal(size=(5, 4)))
+
+    def test_a_negative_radius_is_rejected(self):
+        from mlsynth.utils.bilevel.simplex import project_simplex_cols
+
+        with pytest.raises(ValueError):
+            project_simplex_cols(np.zeros((3, 2)), z=-1.0)

--- a/mlsynth/utils/bilevel/__init__.py
+++ b/mlsynth/utils/bilevel/__init__.py
@@ -17,7 +17,8 @@ Two interchangeable backends are available via ``solve_bilevel(..., method=)``:
 """
 
 from .structure import BilevelProblem, BilevelSolution
-from .simplex import project_simplex, simplex_lstsq, mspe
+from .simplex import (project_simplex, project_simplex_cols,
+                      simplex_lstsq, simplex_lstsq_batch, mspe)
 from .solver import solve_bilevel, lower_level_weights
 from .mscmt import solve_mscmt
 from .regression_v import regression_v, solve_regression
@@ -49,6 +50,8 @@ from .ridge_inference import (
 __all__ = [
     "regression_v",
     "solve_regression",
+    "project_simplex_cols",
+    "simplex_lstsq_batch",
     "BilevelProblem",
     "BilevelSolution",
     "BilevelSCM",

--- a/mlsynth/utils/bilevel/simplex.py
+++ b/mlsynth/utils/bilevel/simplex.py
@@ -121,6 +121,129 @@ def simplex_lstsq(
     return w
 
 
+def project_simplex_cols(V: np.ndarray, z: float = 1.0) -> np.ndarray:
+    """Project every COLUMN of ``V`` onto ``{w >= 0, sum(w) = z}``.
+
+    The column-wise form of :func:`project_simplex`, and exact in the same
+    sense: same sort-based algorithm (Held, Wolfe & Crowder 1974; Duchi et al.
+    2008), just carried out along ``axis=0`` with the per-column threshold
+    located by a single ``argmax`` over the reversed condition array instead of
+    a Python loop over columns.
+
+    Parameters
+    ----------
+    V : np.ndarray
+        Points to project, shape ``(n, k)`` -- one column per problem.
+    z : float
+        Simplex radius; each column sums to this.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(n, k)``, every column on the simplex.
+    """
+    if z <= 0:
+        raise ValueError(f"simplex radius z must be positive, got {z}.")
+    V = np.asarray(V, dtype=float)
+    if V.ndim != 2:
+        raise ValueError(f"V must be 2-D (n, k); got shape {V.shape}.")
+    n, k = V.shape
+    if n == 1:
+        return np.full((1, k), z)
+    U = -np.sort(-V, axis=0)                       # descending within column
+    cssv = np.cumsum(U, axis=0) - z
+    ind = np.arange(1, n + 1)[:, None]
+    cond = (U - cssv / ind) > 0                    # a True block, then False
+    rho = n - 1 - np.argmax(cond[::-1], axis=0)    # index of the last True
+    theta = cssv[rho, np.arange(k)] / (rho + 1.0)
+    return np.maximum(V - theta, 0.0)
+
+
+def simplex_lstsq_batch(
+    A: np.ndarray,
+    B: np.ndarray,
+    *,
+    ridge: float = 0.0,
+    max_iter: int = 20000,
+    tol: float = 1e-11,
+    check_every: int = 25,
+) -> np.ndarray:
+    """``min_W ||A W - B||_F^2`` with every column of ``W`` on the simplex.
+
+    One program with many right-hand sides, not many programs. ``A`` is shared,
+    so the Gram matrix, the ridge and the step size are formed once and
+    amortised over ``B``'s columns; each FISTA iteration is then a single
+    ``(n, n) @ (n, k)`` matmul plus a column-wise projection. This is the shape
+    a stacked synthetic-control design has whenever the treated units in a
+    cohort share a donor pool.
+
+    Parameters
+    ----------
+    A : np.ndarray
+        Shared design matrix, shape ``(m, n)``.
+    B : np.ndarray
+        Targets, shape ``(m, k)``; a 1-D array is treated as a single column.
+    ridge : float
+        L2 penalty added to the Gram diagonal. Not a solver tolerance -- it
+        changes the estimand, shrinking the weights toward uniform.
+    max_iter, tol, check_every : int, float, int
+        Stopping controls; the objective is tested every ``check_every`` steps.
+
+    Returns
+    -------
+    np.ndarray
+        Shape ``(n, k)``, every column on the simplex.
+
+    Notes
+    -----
+    Convergence is judged on the objective, unlike :func:`simplex_lstsq`, which
+    stops on the step norm. The difference matters when ``A`` is rank
+    deficient: the optimum is then a face rather than a point, and the iterate
+    keeps drifting along it long after the loss has settled, so a step-norm
+    rule never fires and the solver runs to ``max_iter`` every time.
+
+    A consequence worth knowing before comparing the two: on such a design this
+    function and a loop over :func:`simplex_lstsq` reach the same objective but
+    generally *different* weights. Neither is wrong -- where on the optimal face
+    a solver lands is not identified by the data. Compare losses, not weights.
+    """
+    A = np.asarray(A, dtype=float)
+    B = np.asarray(B, dtype=float)
+    if B.ndim == 1:
+        B = B[:, None]
+    if B.ndim != 2 or B.shape[0] != A.shape[0]:
+        raise ValueError(
+            f"B must be (m, k) with m={A.shape[0]} to match A; got {B.shape}."
+        )
+    n, k = A.shape[1], B.shape[1]
+    if n == 1:
+        return np.ones((1, k))
+
+    G = A.T @ A
+    if ridge:
+        G = G + float(ridge) * np.eye(n)
+    C = A.T @ B
+    bb = float((B * B).sum())
+    lam = float(np.linalg.eigvalsh(G)[-1])
+    step = 1.0 / (2.0 * lam + _EPS)
+
+    W = np.full((n, k), 1.0 / n)
+    Z = W.copy()
+    t = 1.0
+    prev = None
+    for it in range(max_iter):
+        W_new = project_simplex_cols(Z - step * 2.0 * (G @ Z - C))
+        t_new = 0.5 * (1.0 + np.sqrt(1.0 + 4.0 * t * t))
+        Z = W_new + ((t - 1.0) / t_new) * (W_new - W)
+        W, t = W_new, t_new
+        if (it + 1) % check_every == 0:
+            obj = float(((G @ W) * W).sum() - 2.0 * (C * W).sum() + bb)
+            if prev is not None and prev - obj <= tol * max(1.0, abs(prev)):
+                break
+            prev = obj
+    return W
+
+
 def mspe(y1: np.ndarray, Y0: np.ndarray, w: np.ndarray) -> float:
     """Mean squared prediction error ``mean((y1 - Y0 w)^2)``."""
     resid = y1 - Y0 @ w


### PR DESCRIPTION
## Related Links

- Resolves #337
- Sibling prerequisites: #334 (PR #335, regression `V`) and #336 (PR #338, bias correction). All three are independent and cut from `main`.

## What

Two additions to `mlsynth/utils/bilevel/simplex.py`, exported from `bilevel/__init__.py`:

- `project_simplex_cols(V, z=1.0)` — the column-wise form of `project_simplex`
- `simplex_lstsq_batch(A, B, ridge=0.0, ...)` — FISTA over all right-hand sides at once

18 tests.

## Why

A stacked synthetic-control design fits one weight vector per treated unit, which reads as N independent constrained least-squares problems. It is not. Every treated unit in an adoption cohort solves

```
min_w  || A_g w - b_j ||^2      s.t.  w >= 0,  1'w = 1
```

against the *same* `A_g`, differing only in the right-hand side. That is one multiple-right-hand-side program. Nothing in `simplex.py` could express it, so a stacked design had to loop, re-forming the Gram matrix and the Lipschitz constant per unit when both depend only on `A_g`.

Measured on the Walmart cohort shapes:

```
T0=5  J=39 k=96 : batch 0.02s  loop 1.22s   70.9x
T0=10 J=39 k=114: batch 0.01s  loop 0.09s    6.2x
```

The spread between those two rows is the interesting part, and it is the next section.

## How

`project_simplex_cols` is exact in the same sense as `project_simplex` — the same sort-based algorithm (Held, Wolfe & Crowder 1974; Duchi et al. 2008) applied along `axis=0`, with the per-column threshold located by a single `argmax` over the reversed condition array instead of a Python loop over columns. It agrees with the scalar version to 1e-12 across shapes, scales, and the `n == 1` degenerate branch.

`simplex_lstsq_batch` forms the Gram matrix, the ridge and the step size once, so each iteration is one `(n, n) @ (n, k)` matmul plus a column-wise projection.

## One deliberate difference from the scalar solver

`simplex_lstsq` stops on the step norm (`simplex.py:112`). The batched version stops on the objective.

That is not a style preference. On a rank-deficient design the optimum is a face rather than a point, and the iterate keeps drifting along it long after the loss has settled — so a step-norm rule never fires and the solver runs to `max_iter` every time. That is exactly the `T0=5` row above: the 71x is not vectorisation alone, it is the scalar solver burning all 20,000 iterations on every column.

The consequence is documented on both functions: on such a design the two reach the same objective but generally *different* weights. Neither is wrong — where on the optimal face a solver lands is not identified by the data.

Whether `simplex_lstsq` should switch rules too is deliberately out of scope. It is a shared primitive with many callers and that is a wider change than this branch. Worth noting though that any existing caller hitting a rank-deficient design is exhausting its iteration budget today without knowing.

## Verification

Path: cross-validation against the existing scalar primitives, plus analytic properties.

- batched projection against `project_simplex` column by column, 1e-12, across four shape/scale combinations and the degenerate branch
- batch equals per-column loop on a well-conditioned design, 1e-4
- on a rank-deficient design the objectives agree to 1e-3 while the weights need not
- the solution beats uniform weights (a minimiser cannot do worse than its starting point)
- the ridge shrinks toward uniform
- 771 passed, 2 skipped across `bilevel`, `vanillasc`, `fscm`, `spillsynth`, `scta`, `scmo`

One test needed fixing before it meant anything, and it is worth recording. The first rank-deficient fixture used 5 rows against 39 donors with centred targets — the simplex fit is exact there, both objectives came out at ~1e-31, and asserting they agreed compared numerical noise. The targets are now offset outside the donor hull, and the test asserts `obj.min() > 1.0` before comparing, so it cannot silently regress to vacuity.

## Scope checks

Shared-primitive addition — none of the four blocks fits. Purely additive: two new functions and two new exports, no existing signature or behaviour touched.

## Test Steps

- [x] `pytest mlsynth/tests/test_bilevel_simplex_batch.py -q` — 18 passed
- [x] `pytest mlsynth/tests/ -k "bilevel or vanillasc or fscm or spillsynth or scta or scmo"` — 771 passed, 2 skipped
- [ ] Full `pytest mlsynth/tests/` — deferred to CI

## Other Notes

- Third of three prerequisites for a stacked bias-corrected SCM (Wiltshire 2023).
- No existing caller is migrated to the batched form in this PR; that belongs with whatever needs it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_