### PR TITLE
STACKEDSC: stacked-in-event-time bias-corrected SCM (Wiltshire 2023)

### DIFF
--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -95,6 +95,7 @@ At a glance
      + many treated at once, disaggregated/high-dim donors ─► MSQRT
    Staggered (different times)?  ─► SDID · ROLLDID (rolling-transformation DiD)
      + simplex SC per unit, never-treated pool, CFPT intervals ─► VanillaSC (staggered)
+     + unit sizes differ by orders of magnitude, want % effects ─► STACKEDSC
      + want pooling / oracle efficiency  ─► PPSCM · SequentialSDID
      + long pre-period, few never-treated, event study ─► SSC
      + spillovers                        ─► SpSyDiD

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -308,6 +308,7 @@ headline numbers.
    sdid
    seq_sdid
    ppscm
+   stackedsc
    cscm
    ssc
    cast

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -99,6 +99,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    replications/drosc
    replications/rolldid
    replications/ppscm
+   replications/stackedsc
    replications/cscm
    replications/snn
    replications/syndes

--- a/docs/replications/stackedsc.rst
+++ b/docs/replications/stackedsc.rst
@@ -1,0 +1,133 @@
+.. _replication-stackedsc:
+
+STACKEDSC -- Walmart Supercenters and local employment (Wiltshire 2023)
+=======================================================================
+
+:Estimator: :doc:`../stackedsc` -- :class:`mlsynth.STACKEDSC`
+:Source: Wiltshire, J. C. (2023), *"Walmart Supercenters and Monopsony Power:
+   How a Large, Low-Wage Employer Impacts Local Labor Markets,"* Section 4.2.
+:Reference implementation: ``allsynth`` (Stata), Wiltshire (2022)
+:Replication type: Path A -- the paper's empirical result on the author's data.
+:Status: Partial. The event-study shape and the qualitative finding reproduce;
+   the point estimates do not match cell for cell, and the reason is recorded
+   below rather than tuned away.
+
+The question
+------------
+
+Walmart opened Supercenters across the United States over 1990-2005, county by
+county, in different years. Did their arrival raise or lower total local
+employment? A single-treated-unit synthetic control cannot answer that, and a
+regression with two-way fixed effects has the staggered-adoption problems that
+motivated much of the recent difference-in-differences literature.
+
+The paper's answer is to build a separate synthetic control for each treated
+county from a deliberately constructed donor pool -- counties where Walmart
+tried to open a Supercenter and was blocked by local opposition -- and then
+average the county-level effects on a common event clock.
+
+Data
+----
+
+566 treated counties in six adoption cohorts (1995 through 2000) and 39
+never-treated donor counties, over 1990-2005. The donor pool is the paper's
+identifying contribution: places where the firm revealed an intention to enter
+but did not, rather than places selected on observables.
+
+Effects are reported as percent changes, because county employment in the
+sample runs from about 3,900 to 866,000. Aggregation is weighted by 1990
+population, which the paper adopts so that large percentage swings in small
+counties do not drive the average.
+
+What reproduces
+---------------
+
+The event-study shape, which is what the paper's Figure 6 shows and what its
+narrative rests on:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - feature
+     - paper
+     - mlsynth
+   * - pre-treatment fit
+     - "an excellent pre-treatment fit"
+     - within :math:`\pm 0.07` percent
+   * - effect at entry
+     - "no effect in the year of Supercenter entry"
+     - :math:`+0.16`
+   * - onset
+     - "a downward trend begins in the year following"
+     - decline from :math:`e = 2`
+   * - direction
+     - large negative by :math:`e = 5`
+     - :math:`-0.90`
+
+The gap at :math:`e = -1` comes out at :math:`-6 \times 10^{-16}`, which is the
+indexing constraint holding to machine precision rather than a fitted result.
+
+What does not reproduce, and why
+--------------------------------
+
+Table 4 of the paper reports aggregate employment five years after entry at
+:math:`-1.77` percent without bias correction and :math:`-3.14` percent with
+it. The estimator here does not land on either figure, and the reason is a
+component that cannot be recovered from the published materials.
+
+The reference implementation calls Stata's ``synth``, whose default
+predictor-weight rule is a regression on the pre-treatment outcomes rather than
+the nested optimisation of Abadie, Diamond and Hainmueller. That rule ships as
+a compiled Mata library with no source distributed. Its structure is recoverable
+from the library's symbol table -- scale by the pooled standard deviation, pool
+the treated unit into the regression, set the weights proportional to squared
+coefficients -- but two choices are not: whether the regression is run once over
+all unit-period observations or once per pre-treatment period, and whether an
+intercept is fitted.
+
+Those two readings are not a rounding difference. Across eight of the paper's
+reported cells they give total absolute errors of 1.854 and 1.768 -- a tie -- and
+the choice of rule moves the five-year estimate by 1.1 to 1.4 percentage points
+on an effect of about :math:`-1.8`. Larger, that is, than the quantity being
+estimated.
+
+Worse for a clean claim, no single rule reproduces both of the paper's columns.
+The regression rule wins the uncorrected column (:math:`-1.777` against a target
+of :math:`-1.767`); the nested search wins the corrected one. The split is
+systematic rather than noisy, because the bias correction depends on the
+residual predictor imbalance and therefore weights predictor fit differently
+from the uncorrected estimator.
+
+So this replication claims the shape and the sign, and does not claim the
+magnitudes. Closing the gap requires running ``allsynth`` once and capturing the
+per-county weights for a single cohort -- a measurement, not an argument.
+
+One finding worth keeping
+-------------------------
+
+An early version of this port regressed on raw rather than normalised
+predictors, inverting the order in which the reference implementation applies
+its two steps. That single ordering error moved the five-year estimate from
+:math:`-1.43` to :math:`-1.78` on one outcome and flipped the sign on another,
+from :math:`-0.655` to :math:`+0.620` against a target of :math:`+1.112`.
+
+The lesson generalises past this paper: when a predictor-weight rule is
+involved, the order of normalisation and estimation is load-bearing, and
+getting it wrong produces output that looks entirely reasonable.
+
+A second one, about the weights themselves. Each cohort has five to ten
+pre-treatment periods against 39 donors, so the design matrix has a null space
+of at least 29 dimensions. Moving the weights along it changes the
+post-treatment prediction without touching the pre-treatment fit at all: the
+per-county weight vectors are not identified, and two solvers that both reach
+the optimum can differ by several percentage points on an individual county
+while agreeing on the average to within 0.03. Read the aggregate; do not read a
+single county's weights as that county's synthetic control.
+
+Reproducing it
+--------------
+
+.. code-block:: bash
+
+   python benchmarks/run_benchmarks.py --case wiltshire_walmart

--- a/docs/replications/stackedsc.rst
+++ b/docs/replications/stackedsc.rst
@@ -103,8 +103,8 @@ So this replication claims the shape and the sign, and does not claim the
 magnitudes. Closing the gap requires running ``allsynth`` once and capturing the
 per-county weights for a single cohort -- a measurement, not an argument.
 
-One finding worth keeping
--------------------------
+Two findings from the port
+--------------------------
 
 An early version of this port regressed on raw rather than normalised
 predictors, inverting the order in which the reference implementation applies
@@ -124,6 +124,16 @@ per-county weight vectors are not identified, and two solvers that both reach
 the optimum can differ by several percentage points on an individual county
 while agreeing on the average to within 0.03. Read the aggregate; do not read a
 single county's weights as that county's synthetic control.
+
+Inference
+---------
+
+The estimator implements the paper's sampled-placebo-average procedure
+(``inference="placebo"``), described on :doc:`../stackedsc`. It is not part of
+what this page claims: the p-values the paper reports rest on the same
+predictor-weight rule the point estimates do, so a replication of them is
+blocked behind the same missing measurement. Running it on the paper's panel
+costs 566 x 39 simplex solves under the default donor pool.
 
 Reproducing it
 --------------

--- a/docs/stackedsc.rst
+++ b/docs/stackedsc.rst
@@ -120,8 +120,8 @@ and the reported effect is a weighted average over treated units,
    \widehat{\tau}_e \coloneqq \sum_{j \in \mathcal{N}_1} \gamma_j \tau_{je},
    \qquad \gamma_j \ge 0, \quad \sum_{j} \gamma_j = 1 .
 
-Three properties of this construction deserve stating plainly, because each
-looks like an implementation detail and none is.
+Three properties of this construction each look like an implementation detail
+and change the estimand.
 
 The indexing changes the constraint, not just the units. Dividing unit
 :math:`j` and every donor by their own value at :math:`T_{0j}` while requiring
@@ -189,8 +189,101 @@ to that imbalance:
 with :math:`\boldsymbol{\beta}_e` the ridge-regression slope of the donor
 outcome on the donor predictors. The correction is identically zero when the
 predictors balance, and the ridge is what keeps a weakly explanatory predictor
-set from injecting noise in place of removing bias. This is not a refinement
-around the edges: in the motivating application it roughly doubles the estimate.
+set from injecting noise in place of removing bias. In the motivating
+application the correction roughly doubles the estimate.
+
+Inference
+---------
+
+Setting ``inference="placebo"`` runs the procedure Wiltshire uses. With one
+treated unit the in-space placebo test of Abadie, Diamond and Hainmueller (2010)
+has an obvious comparison set: reassign treatment to each donor in turn and see
+how unusual the real gap path looks among the fakes. With many treated units the
+estimate is already an average, so the comparison has to be against other
+averages.
+
+Fix a treated unit :math:`j` and a donor :math:`i \in \mathcal{N}_0`. Refit the
+synthetic control with :math:`i` cast as treated at :math:`j`'s adoption time
+:math:`g_j`, giving a placebo gap path :math:`\tau_e^{(j,i)}`. A placebo average
+draws one donor :math:`i_j` per treated unit and averages under the same weights
+the estimate uses,
+
+.. math::
+
+   \widehat{\tau}^{\,s}_e \coloneqq \sum_{j \in \mathcal{N}_1}
+   \gamma_j \, \tau_e^{(j,\,i_j^s)} .
+
+The number of distinct averages is :math:`\prod_j |\mathcal{N}_0|`, which for
+39 donors and 566 treated units is :math:`39^{566}`, so :math:`S` of them are
+sampled rather than enumerated (``n_placebo_samples``, default 1000).
+
+Two statistics come off that distribution. The first ranks a ratio rather than a
+level, so that an average which already fits badly before treatment is not
+credited for a large gap after it. With :math:`\underline{E}` the earliest
+reported horizon, write
+
+.. math::
+
+   R_s(E) \coloneqq
+   \frac{(E+1)^{-1} \sum_{e=0}^{E} (\widehat{\tau}^{\,s}_e)^2}
+        {|\underline{E}|^{-1} \sum_{e=\underline{E}}^{-1}
+         (\widehat{\tau}^{\,s}_e)^2} ,
+   \qquad
+   p_E \coloneqq \frac{1}{S+1} \sum_{s=1}^{S}
+   \mathbf{1}\bigl\{ R_s(E) \ge R_0(E) \bigr\} ,
+
+where :math:`s = 0` denotes the estimate itself. The second reads the spread of
+the sampled averages as a standard error, following Algorithm 4 of Arkhangelsky
+et al. (2021):
+
+.. math::
+
+   \widehat{V}_e \coloneqq \frac{1}{S} \sum_{s=1}^{S}
+   \bigl(\widehat{\tau}^{\,s}_e - \bar{\tau}_e\bigr)^2 ,
+   \qquad
+   \widehat{\tau}_e \pm z_{\alpha/2} \sqrt{\widehat{V}_e} .
+
+The ranking assumes nothing about the shape of the null distribution; the
+interval assumes homoskedasticity across units and asymptotic normality, which
+with many treated units follows from each average being a sum of independent
+draws. Both are reported because both are informative and they can disagree.
+
+Two mechanical caveats. Under the base-period indexing
+:math:`\widehat{\tau}_{-1} = 0` for every path including the placebos, so a
+reported pre-window of that single period leaves the ratio :math:`0/0`; the
+RMSPE p-values are then NaN and say so. And :math:`p_E` does not count the
+estimate in its own numerator, matching the reference implementation, so a
+p-value of exactly zero is attainable.
+
+One statistical caveat, which is why the two are reported side by side. A donor
+is usually easier to reconstruct from the other donors than a treated unit is
+from any of them, so the placebo averages tend to fit their pre-treatment window
+better than the estimate fits its own. Their denominators are smaller, their
+ratios :math:`R_s(E)` correspondingly larger, and :math:`p_E` is pushed up: the
+ranking can be indecisive on a panel where the interval is not. Hahn and Shi
+(2017) and Ferman and Pinto (2017) discuss size distortion in placebo tests more
+generally. Reading whichever of the two statistics is the more favourable
+defeats the purpose of computing both.
+
+``placebo_donor_pool`` chooses whether the treated unit itself joins each of its
+placebos' donor pools. The default ``"permutation"`` says yes, following the
+reference implementation, on the logic that under the permutation the treated
+unit is a control like any other. It has two consequences. The placebo path
+becomes a property of the pair :math:`(j, i)` rather than of the cohort, so the
+number of solves is the number of treated units times the pool size -- for the
+Walmart panel, :math:`566 \times 39` rather than :math:`6 \times 39`. And under
+the alternative, the treated unit's post-treatment path carries the very effect
+being tested, so any weight the placebo puts on it pulls that placebo's gap away
+from zero and widens the null distribution. This is the stacked-case power loss
+Zhang (2019, section 3.1) describes: as the number of treated units grows,
+genuinely treated units enter the null distribution more and more often, moving
+it away from the null it is meant to represent. ``"donors-only"`` drops the
+treated unit, which removes that channel and recovers the per-cohort saving, at
+the price of departing from the reference implementation.
+
+The whole procedure is opt-in for the same reason the reference makes it opt-in:
+its cost scales with treated units times donors, and ``allsynth`` warns that
+requesting it "will greatly extend the run-time".
 
 Example
 -------
@@ -218,6 +311,50 @@ Example
    res.design.cohorts                    # the distinct adoption times
    res.design.batched                    # one solve per cohort?
    res.per_unit["18003"].tau             # one county's own path
+
+Asking for the permutation distribution as well, on a smaller donor pool so the
+example runs quickly:
+
+.. code-block:: python
+
+   import numpy as np
+   import pandas as pd
+   from mlsynth import STACKEDSC
+
+   rng = np.random.default_rng(0)
+   F = rng.normal(size=(12, 2)).cumsum(axis=0)          # two common factors
+   rows = []
+   for k in range(10):                                  # never-treated donors
+       load, base = rng.normal(size=2), 100 + 20 * rng.random()
+       rows += [{"unit": f"d{k}", "t": t, "adopt": np.nan,
+                 "y": base + F[t] @ load + rng.normal() * 0.05}
+                for t in range(12)]
+   for k in range(5):                                   # treated, two cohorts
+       g = (6, 8)[k % 2]
+       load, base = rng.normal(size=2), 100 + 20 * rng.random()
+       rows += [{"unit": f"x{k}", "t": t, "adopt": float(g),
+                 "y": (base + F[t] @ load + rng.normal() * 0.05)
+                      * (0.9 if t >= g else 1.0)}
+                for t in range(12)]
+   df = pd.DataFrame(rows)
+   df["treat"] = ((~df.adopt.isna()) & (df.t >= df.adopt)).astype(int)
+
+   res = STACKEDSC({
+       "df": df, "outcome": "y", "treat": "treat",
+       "unitid": "unit", "time": "t",
+       "inference": "placebo", "n_placebo_samples": 200, "seed": 0,
+       "display_graphs": False,
+   }).fit()
+
+   print(res.effects.att, res.inference.p_value)     # ATT and its p-value
+   print(res.inference.ci)                           # (lower, upper) for the ATT
+   print(res.placebo.rmspe_p)                        # RMSPE-ranked p by horizon
+   print(res.placebo.se)                             # placebo spread by horizon
+   print(res.placebo.placebo_averages.shape)         # (200, n_horizons)
+
+On this panel the interval is decisive and the ranking is not, for the reason
+given above: the donors reconstruct one another almost exactly, so every placebo
+average has a near-perfect pre-treatment fit and a large :math:`R_s(E)`.
 
 Verification
 ------------
@@ -255,4 +392,7 @@ Core API
    :members:
 
 .. autoclass:: mlsynth.utils.stackedsc_helpers.structures.StackedUnitFit
+   :members:
+
+.. autoclass:: mlsynth.utils.stackedsc_helpers.structures.StackedPlacebo
    :members:

--- a/docs/stackedsc.rst
+++ b/docs/stackedsc.rst
@@ -1,0 +1,258 @@
+Stacked-in-Event-Time Synthetic Control (STACKEDSC)
+===================================================
+
+.. currentmodule:: mlsynth
+
+When to Use This Estimator
+--------------------------
+
+Most synthetic control methods answer a question about one treated unit. Many
+policies do not arrive that way. A retail chain opens stores in hundreds of
+counties over a decade; a state law is adopted by different municipalities in
+different years; a firm rolls a change out market by market. Each treated unit
+gets its own intervention date, and the question is what happened on average,
+measured from each unit's own treatment date rather than from the calendar.
+
+STACKEDSC fits a separate synthetic control for every treated unit against a
+common pool of never-treated donors, then lines the resulting effect paths up
+on a shared event clock and averages them. The name comes from that stacking:
+unit 1's third year after treatment sits alongside unit 2's third year, even
+though those are different calendar years.
+
+Reach for it when all of these hold: many treated units adopting at different
+times, a donor pool of units that are never treated, and outcomes whose levels
+differ substantially across units. That last condition is the one people
+overlook, and it is why this estimator rescales before fitting. County
+employment ranges from four thousand to nearly a million in the motivating
+application. Matching such units on raw levels lets the largest ones dominate
+the fit, and an effect of "three thousand jobs" means something entirely
+different in the two places.
+
+Notation
+--------
+
+Let :math:`\mathcal{N} \coloneqq \{1,\dots,N\}` index units. Unlike the
+single-treated-unit case there is no distinguished :math:`j = 1`: write
+:math:`\mathcal{N}_1` for the treated units and
+:math:`\mathcal{N}_0 \coloneqq \mathcal{N}\setminus\mathcal{N}_1` for the
+never-treated donor pool, with :math:`N_0 \coloneqq |\mathcal{N}_0|`.
+
+Time runs over :math:`t \in \mathcal{T} \coloneqq \{1,\dots,T\}`. Each treated
+unit :math:`j \in \mathcal{N}_1` has its own adoption time :math:`g_j`, so its
+last untreated period is :math:`T_{0j} \coloneqq g_j - 1`. Event time is
+
+.. math::
+
+   e \coloneqq t - g_j ,
+
+so :math:`e = -1` is the final pre-treatment period and :math:`e = 0` the first
+treated one. Units sharing an adoption time form a cohort; write
+:math:`\mathcal{G}` for the set of distinct adoption times.
+
+The observed outcome is :math:`y_{jt}`, the donor matrix
+:math:`\mathbf{Y}_0 \in \mathbb{R}^{T \times N_0}`. Because each treated unit is
+rescaled to its own base period, define the indexed series
+
+.. math::
+
+   \widetilde{y}_{jt} \coloneqq 100 \cdot \frac{y_{jt}}{y_{j,T_{0j}}} ,
+
+and likewise :math:`\widetilde{\mathbf{Y}}_0` for the donors, indexed to the
+same period :math:`T_{0j}`.
+
+Assumptions
+-----------
+
+Assumption 1 (Never-treated donors). The units in :math:`\mathcal{N}_0` are
+untreated throughout :math:`\mathcal{T}`.
+
+Remark. This is stronger than the not-yet-treated condition some staggered
+estimators use, and it is deliberate: a not-yet-treated donor contributes
+untreated information early and treated information later, which contaminates
+long-horizon effects precisely where they are largest. The cost is a smaller
+donor pool. In the motivating application the pool is 39 counties for 566
+treated ones, and it is constructed rather than residual -- the donors are
+places where the firm tried to open and was blocked, which is what makes them
+comparable.
+
+Assumption 2 (Pre-treatment fit). For each treated unit there exist weights on
+the simplex reproducing its indexed pre-treatment path.
+
+Remark. The usual convex-hull condition, applied after indexing. Indexing
+makes it easier to satisfy: units of wildly different size can have similar
+growth paths even when their levels are nowhere near each other. It is also
+checkable, which is what the pre-treatment portion of the event study is for.
+A fit that misses before treatment is not evidence about what happened after.
+
+Assumption 3 (Common support in event time). Every treated unit is observed
+over the reported window of event times.
+
+Remark. Reporting a horizon only some units reach makes the average change
+composition along the horizontal axis, so a trend can appear that is really
+units entering and leaving. The default window is the widest one every unit
+supplies; ``n_lags`` and ``n_leads`` narrow it deliberately.
+
+Estimation
+----------
+
+For treated unit :math:`j`, donor weights solve the usual simplex-constrained
+program on the indexed pre-treatment series:
+
+.. math::
+
+   \mathbf{w}_j^\ast \in \operatorname*{argmin}_{\mathbf{w}\in\Delta^{N_0}}
+   \bigl\| \widetilde{\mathbf{y}}_j^{\,\text{pre}}
+   - \widetilde{\mathbf{Y}}_0^{\,\text{pre}} \mathbf{w} \bigr\|_2^2 ,
+
+with :math:`\Delta^{N_0} \coloneqq \{\mathbf{w} \in
+\mathbb{R}_{\ge 0}^{N_0} : \|\mathbf{w}\|_1 = 1\}`. The per-unit effect at
+event time :math:`e` is
+
+.. math::
+
+   \tau_{je} \coloneqq \widetilde{y}_{j,g_j+e}
+   - \bigl(\widetilde{\mathbf{Y}}_0 \mathbf{w}_j^\ast\bigr)_{g_j+e} ,
+
+and the reported effect is a weighted average over treated units,
+
+.. math::
+
+   \widehat{\tau}_e \coloneqq \sum_{j \in \mathcal{N}_1} \gamma_j \tau_{je},
+   \qquad \gamma_j \ge 0, \quad \sum_{j} \gamma_j = 1 .
+
+Three properties of this construction deserve stating plainly, because each
+looks like an implementation detail and none is.
+
+The indexing changes the constraint, not just the units. Dividing unit
+:math:`j` and every donor by their own value at :math:`T_{0j}` while requiring
+:math:`\|\mathbf{w}\|_1 = 1` is algebraically the same as fitting on raw levels
+under the constraint
+
+.. math::
+
+   \sum_{i \in \mathcal{N}_0} v_i \, y_{i,T_{0j}} = y_{j,T_{0j}} ,
+
+where :math:`v_i \coloneqq w_i \, y_{j,T_{0j}} / y_{i,T_{0j}}`. In words: the
+synthetic control must reproduce the treated unit's base-period level exactly.
+That is why :math:`\widehat{\tau}_{-1}` is identically zero rather than merely
+small, and it is a different feasible set from the ordinary simplex on levels.
+Setting ``normalize=False`` gives the level-scale estimator, which answers a
+different question.
+
+The base period belongs to the cohort. Every unit adopting at the same time
+shares :math:`T_{0j}`, so the indexed donor block takes one value per adoption
+time rather than one per treated unit. With six adoption years and 566 treated
+units that is six donor blocks, not 566, and each cohort becomes a single
+least-squares problem with many right-hand sides rather than :math:`N_g`
+separate ones.
+
+The aggregation weights are part of the specification. Equal weighting and
+size weighting answer different questions, and neither is a default the data
+chooses for you. Weighting by population avoids letting large percentage
+swings in tiny units drive the average; equal weighting treats each adoption
+as one observation. Say which you mean.
+
+Diagnostics
+-----------
+
+The pre-treatment portion of the event study is the main diagnostic, and it is
+close to free: under the indexing, :math:`\widehat{\tau}_{-1} = 0` by
+construction, so the remaining pre-treatment horizons are informative about fit
+rather than about level.
+
+Two things the result reports that are easy to overlook. ``design.batched``
+records whether each cohort was solved as one program; it is false when a donor
+predicate binds, since restricting donors per unit gives each unit its own
+design matrix. And ``per_unit`` carries every unit's own path and weights.
+
+That last one deserves a caution. With a donor pool large relative to the
+number of pre-treatment periods the individual weight vectors are not
+identified: many weightings fit the pre-period equally well while implying
+different post-treatment counterfactuals. The weighted mean is pinned down far
+better than its parts. Read ``per_unit`` for diagnosis and spread, not as a
+claim about which donors resemble a particular unit.
+
+Bias correction
+---------------
+
+When the synthetic control does not balance the predictors exactly, the residual
+imbalance can itself move the outcome. Setting ``bias_correct`` applies the
+Abadie and L'Hour (2021) adjustment, subtracting the part of the gap attributable
+to that imbalance:
+
+.. math::
+
+   \tau_{je}^{\text{bc}} \coloneqq \tau_{je}
+   - \bigl(\mathbf{x}_j - \mathbf{X}_0 \mathbf{w}_j^\ast\bigr)^\top
+     \boldsymbol{\beta}_e ,
+
+with :math:`\boldsymbol{\beta}_e` the ridge-regression slope of the donor
+outcome on the donor predictors. The correction is identically zero when the
+predictors balance, and the ridge is what keeps a weakly explanatory predictor
+set from injecting noise in place of removing bias. This is not a refinement
+around the edges: in the motivating application it roughly doubles the estimate.
+
+Example
+-------
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import STACKEDSC
+
+   # long panel: one row per (unit, period), with an adoption year per
+   # treated unit and a size variable to weight the average by
+   df = pd.read_parquet("basedata/allsynth_walmart.parquet")
+   df["treat"] = ((df.supercenter == 1) & (df.year >= df.super_year)).astype(int)
+
+   res = STACKEDSC({
+       "df": df, "outcome": "emps_n10", "treat": "treat",
+       "unitid": "cty_fips", "time": "year",
+       "agg_weights": "pop90",          # gamma_j; None gives equal weights
+       "n_lags": 5, "n_leads": 6,       # the balanced event window
+       "display_graphs": False,
+   }).fit()
+
+   res.effects.att                       # mean post-treatment effect, percent
+   res.event_study.tau                   # the path, one entry per horizon
+   res.design.cohorts                    # the distinct adoption times
+   res.design.batched                    # one solve per cohort?
+   res.per_unit["18003"].tau             # one county's own path
+
+Verification
+------------
+
+Reproduced against Wiltshire (2023) on the author's own panel: the
+pre-treatment path is flat within :math:`\pm 0.07` percent, the effect at
+entry is :math:`+0.16`, and the decline begins at :math:`e = 2` -- the shape the
+paper reports. The point estimates are not claimed, because the reference
+implementation's predictor-weight rule ships compiled and two defensible
+readings of it move the five-year estimate by more than the estimate itself.
+See :doc:`replications/stackedsc` for what that means and what would settle it,
+and `benchmarks/cases/wiltshire_walmart.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/wiltshire_walmart.py>`_
+for the pinned quantities.
+
+Not to be confused with
+-----------------------
+
+:doc:`ppscm` also handles staggered adoption but partially pools across treated
+units, shrinking each unit's fit toward a common one; STACKEDSC fits every unit
+separately and pools only at the averaging step. :doc:`sdid` handles staggered
+adoption through cohort-level time weights rather than per-unit event-time
+stacking.
+
+Core API
+--------
+
+.. autoclass:: STACKEDSC
+   :members: fit
+
+.. autoclass:: mlsynth.utils.stackedsc_helpers.config.STACKEDSCConfig
+   :members:
+
+.. autoclass:: mlsynth.utils.stackedsc_helpers.structures.STACKEDSCResults
+   :members:
+
+.. autoclass:: mlsynth.utils.stackedsc_helpers.structures.StackedUnitFit
+   :members:

--- a/llms.txt
+++ b/llms.txt
@@ -88,6 +88,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **SPOTSYNTH** — Spillover-detecting synthetic control.  (config: SPOTSYNTHConfig)
 - **SRC** — Synthetic Regressing Control estimator.  (config: SRCConfig)
 - **SSC** — Staggered Synthetic Control estimator.  (config: SSCConfig)
+- **STACKEDSC** — Stacked-in-event-time synthetic control for staggered adoption.
 - **SYNDES** — Synthetic Design (Doudchenko et al. 2021) estimator.  (config: SYNDESConfig)
 - **SYNDESPower** — Per-horizon MDE table for a fitted SYNDES design.
 - **SYNDESRecommendation** — Outcome of scoring a SYNDES pool.

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -83,6 +83,7 @@ from .estimators.spsydid import SpSyDiD
 from .estimators.iscm import ISCM
 from .estimators.vanillasc import VanillaSC
 from .estimators.spillsynth import SPILLSYNTH
+from .estimators.stackedsc import STACKEDSC
 from .estimators.ctsc import CTSC
 from .estimators.snn import SNN
 from .estimators.mcnnm import MCNNM
@@ -103,6 +104,7 @@ from .utils.truncated_history import (
 from .spec import save_spec, load_spec
 
 __all__ = [
+    "STACKEDSC",
     "save_spec",
     "load_spec",
     "plot_spcd_design",

--- a/mlsynth/estimators/stackedsc.py
+++ b/mlsynth/estimators/stackedsc.py
@@ -8,8 +8,8 @@ pool, each fitted on series indexed to 100 at that unit's own final
 pre-treatment period, then averaged on a shared event clock under weights the
 caller supplies.
 
-Why the indexing is not cosmetic
---------------------------------
+What the indexing does
+----------------------
 
 Rescaling the treated unit and every donor to their own base-period value and
 requiring the weights to sum to one is algebraically the same as fitting on
@@ -26,6 +26,16 @@ The base period belongs to the adoption time, so units adopting together share
 one normalised donor block. On the paper's panel that is six blocks for 566
 treated counties, which is what makes each cohort a single
 multiple-right-hand-side program instead of hundreds of separate solves.
+
+Inference
+---------
+
+``inference="placebo"`` runs the paper's sampled-placebo-average procedure:
+recast every donor as treated at each treated unit's adoption time, then sample
+averages of the resulting placebo paths to form a permutation distribution.
+Both statistics the reference implementation reports come off it -- an
+RMSPE-ranked p-value at each horizon and a placebo-variance interval. It is
+opt-in because its cost is the number of treated units times the pool size.
 
 When to reach for it
 --------------------
@@ -62,6 +72,9 @@ class STACKEDSC:
     STACKEDSCResults
         Event-time ATT under the supplied aggregation weights, the per-treated
         unit fits it averages, and a design block recording what the fit did.
+        With ``inference="placebo"`` the ``placebo`` field carries the
+        permutation distribution and its statistics, and the standard
+        ``inference`` block carries the headline ones for the ATT.
     """
 
     def __init__(self, config: Union[STACKEDSCConfig, Dict[str, Any]]) -> None:

--- a/mlsynth/estimators/stackedsc.py
+++ b/mlsynth/estimators/stackedsc.py
@@ -1,0 +1,74 @@
+"""STACKEDSC -- stacked-in-event-time bias-corrected synthetic control.
+
+Wiltshire, J. C. (2023). *"Walmart Supercenters and Monopsony Power: How a
+Large, Low-Wage Employer Impacts Local Labor Markets."* Section 4.2.
+
+One synthetic control per treated unit against a common never-treated donor
+pool, each fitted on series indexed to 100 at that unit's own final
+pre-treatment period, then averaged on a shared event clock under weights the
+caller supplies.
+
+Why the indexing is not cosmetic
+--------------------------------
+
+Rescaling the treated unit and every donor to their own base-period value and
+requiring the weights to sum to one is algebraically the same as fitting on
+levels under the constraint that the synthetic control reproduce the treated
+unit's base-period level exactly. So the gap at ``e = -1`` is identically zero,
+and the estimand is a percent change rather than a level difference. Turning
+``normalize`` off gives a level-scale stacked SCM: a different estimator, not a
+different presentation.
+
+Why cohorts rather than units
+-----------------------------
+
+The base period belongs to the adoption time, so units adopting together share
+one normalised donor block. On the paper's panel that is six blocks for 566
+treated counties, which is what makes each cohort a single
+multiple-right-hand-side program instead of hundreds of separate solves.
+
+When to reach for it
+--------------------
+
+Many treated units adopting at different times, a donor pool that is small and
+deliberately constructed, outcomes whose levels differ by orders of magnitude
+across units, and a percent effect as the object of interest. The level
+heterogeneity is the part that matters: matching such units in raw levels lets
+the largest ones dominate the fit.
+
+See :doc:`../stackedsc` for the full treatment.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Union
+
+from ..utils.stackedsc_helpers.config import STACKEDSCConfig
+from ..utils.stackedsc_helpers.pipeline import run_stackedsc
+from ..utils.stackedsc_helpers.structures import STACKEDSCResults
+
+
+class STACKEDSC:
+    """Stacked-in-event-time synthetic control for staggered adoption.
+
+    Parameters
+    ----------
+    config : STACKEDSCConfig or dict
+        Configuration. See
+        :class:`mlsynth.utils.stackedsc_helpers.config.STACKEDSCConfig`.
+
+    Returns
+    -------
+    STACKEDSCResults
+        Event-time ATT under the supplied aggregation weights, the per-treated
+        unit fits it averages, and a design block recording what the fit did.
+    """
+
+    def __init__(self, config: Union[STACKEDSCConfig, Dict[str, Any]]) -> None:
+        if isinstance(config, dict):
+            config = STACKEDSCConfig(**config)
+        self.config = config
+
+    def fit(self) -> STACKEDSCResults:
+        """Fit every treated unit and aggregate on the event clock."""
+        return run_stackedsc(self.config)

--- a/mlsynth/guides/llms.txt
+++ b/mlsynth/guides/llms.txt
@@ -88,6 +88,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **SPOTSYNTH** — Spillover-detecting synthetic control.  (config: SPOTSYNTHConfig)
 - **SRC** — Synthetic Regressing Control estimator.  (config: SRCConfig)
 - **SSC** — Staggered Synthetic Control estimator.  (config: SSCConfig)
+- **STACKEDSC** — Stacked-in-event-time synthetic control for staggered adoption.
 - **SYNDES** — Synthetic Design (Doudchenko et al. 2021) estimator.  (config: SYNDESConfig)
 - **SYNDESPower** — Per-horizon MDE table for a fitted SYNDES design.
 - **SYNDESRecommendation** — Outcome of scoring a SYNDES pool.

--- a/mlsynth/tests/test_stackedsc.py
+++ b/mlsynth/tests/test_stackedsc.py
@@ -6,7 +6,7 @@ period, then averaged on a common event clock under user-supplied weights.
 
 Three things about this estimator drive the tests below.
 
-The normalisation is not cosmetic. Rescaling unit ``j`` and every donor to
+Rescaling unit ``j`` and every donor to
 ``b_j`` and imposing ``sum(w) = 1`` is algebraically the same as fitting on
 levels under the constraint ``sum_j v_j b_j = b_1`` -- the synthetic control
 must reproduce the treated unit's base-period level exactly. That is why the
@@ -22,8 +22,7 @@ path is what detects it.
 Aggregation weights are part of the specification. Wiltshire uses 1990
 population "so each tau_e is not overly-affected by large percentage effects in
 small counties" (fn 28), and reports that equal weighting gives the same pattern
-with different magnitudes. An estimator that silently equal-weights is answering
-a different question.
+with different magnitudes, so the weighting fixes which question is answered.
 """
 from __future__ import annotations
 
@@ -174,6 +173,48 @@ class TestBiasCorrection:
 
 
 # ---------------------------------------------------------------------------
+class TestTheBackend:
+    """``auto`` resolves to the outcome path without predictors and to Stata
+    ``synth``'s regression rule with them; naming one overrides that."""
+
+    def test_auto_resolves_by_whether_predictors_were_given(self):
+        df = _staggered()
+        df["x1"] = df.groupby("unit").y.transform("mean")
+        assert _fit().method_details.parameters_used["backend"] == \
+            "outcome-only"
+        assert _fit(df=df, covariates=["x1"]).method_details.parameters_used[
+            "backend"] == "regression"
+
+    def test_naming_one_overrides_the_resolution(self):
+        df = _staggered()
+        df["x1"] = df.groupby("unit").y.transform("mean")
+        res = _fit(df=df, covariates=["x1"], backend="outcome-only")
+        assert res.method_details.parameters_used["backend"] == "outcome-only"
+
+    def test_the_searching_backends_weight_predictors_uniformly_here(self):
+        """``malo`` and ``mscmt`` search ``V`` at the estimator level; the
+        stacked design solves one program per cohort, so it uses equal
+        predictor weights and reports which rule ran."""
+        df = _staggered()
+        df["x1"] = df.groupby("unit").y.transform("mean")
+        df["x2"] = df.groupby("unit").y.transform("std")
+        res = _fit(df=df, covariates=["x1", "x2"], backend="malo")
+        assert res.method_details.parameters_used["backend"] == "malo"
+        assert np.isfinite(res.effects.att)
+
+
+# ---------------------------------------------------------------------------
+class TestPlotting:
+    def test_the_estimator_renders_when_asked(self, tmp_path):
+        import matplotlib
+        matplotlib.use("Agg")
+
+        out = tmp_path / "es.png"
+        _fit(display_graphs=True, save=str(out))
+        assert out.exists()
+
+
+# ---------------------------------------------------------------------------
 class TestEdgeCases:
     def test_a_single_treated_unit_works(self):
         res = _fit(df=_staggered(n_treated=1, cohorts=(7,)))
@@ -188,6 +229,45 @@ class TestEdgeCases:
     def test_every_cohort_is_represented(self):
         res = _fit(df=_staggered(n_treated=6, cohorts=(5, 7, 9)))
         assert {u.adoption_time for u in res.per_unit.values()} == {5, 7, 9}
+
+
+# ---------------------------------------------------------------------------
+class TestTheEventWindow:
+    """The default window is the one every cohort can supply; ``n_lags`` and
+    ``n_leads`` only tighten it further."""
+
+    def test_the_default_is_the_window_common_to_every_cohort(self):
+        res = _fit(df=_staggered(cohorts=(6, 8)))
+        e = np.asarray(res.event_study.horizons, int)
+        assert e.min() == -6 and e.max() == 3
+
+    def test_leads_and_lags_tighten_it(self):
+        res = _fit(n_lags=2, n_leads=2)
+        e = np.asarray(res.event_study.horizons, int)
+        np.testing.assert_array_equal(e, [-2, -1, 0, 1])
+
+    def test_they_cannot_widen_it(self):
+        res = _fit(n_lags=99, n_leads=99)
+        e = np.asarray(res.event_study.horizons, int)
+        assert e.min() == -6 and e.max() == 3
+
+    def test_normalization_can_be_turned_off_for_a_level_scale_fit(self):
+        """Without the indexing the gap at ``e = -1`` is a fitted residual
+        rather than an identity, so it is generally nonzero."""
+        res = _fit(normalize=False)
+        e = np.asarray(res.event_study.horizons, int)
+        tau = np.asarray(res.event_study.tau, float)
+        assert res.design.normalized is False
+        assert abs(float(tau[e == -1][0])) > 0.0
+
+    def test_a_covariate_window_restricts_the_averaging_period(self):
+        df = _staggered()
+        df["x1"] = df.y.astype(float)
+        early = _fit(df=df, covariates=["x1"],
+                     covariate_windows={"x1": (0, 2)})
+        late = _fit(df=df, covariates=["x1"],
+                    covariate_windows={"x1": (3, 5)})
+        assert early.effects.att != pytest.approx(late.effects.att, rel=1e-12)
 
 
 # ---------------------------------------------------------------------------
@@ -222,3 +302,92 @@ class TestFailuresAreReported:
 
         with pytest.raises((MlsynthConfigError, ValueError), match="covariat"):
             _fit(bias_correct=True)
+
+    def test_a_window_naming_an_unknown_covariate_is_an_error(self):
+        from mlsynth.exceptions import MlsynthConfigError
+
+        df = _staggered()
+        df["x1"] = df.groupby("unit").y.transform("mean")
+        with pytest.raises((MlsynthConfigError, ValueError), match="x9"):
+            _fit(df=df, covariates=["x1"], covariate_windows={"x9": (0, 4)})
+
+    def test_a_panel_with_no_treated_rows_is_an_error(self):
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _staggered()
+        df["treat"] = 0
+        with pytest.raises((MlsynthDataError, ValueError)):
+            _fit(df=df)
+
+    def test_a_missing_aggregation_weight_is_an_error(self):
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _staggered()
+        df.loc[df.unit == "x0", "w"] = np.nan
+        with pytest.raises((MlsynthDataError, ValueError), match="missing"):
+            _fit(df=df, agg_weights="w")
+
+    def test_a_negative_aggregation_weight_is_an_error(self):
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _staggered()
+        df.loc[df.unit == "x0", "w"] = -3.0
+        with pytest.raises((MlsynthDataError, ValueError), match="negative"):
+            _fit(df=df, agg_weights="w")
+
+    def test_aggregation_weights_that_sum_to_zero_are_an_error(self):
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _staggered()
+        df["w"] = 0.0
+        with pytest.raises((MlsynthDataError, ValueError), match="zero"):
+            _fit(df=df, agg_weights="w")
+
+    def test_a_covariate_with_an_empty_window_is_an_error(self):
+        """A predictor averaged over a window containing no observations has no
+        value to match on, so the window is rejected rather than filled in."""
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _staggered()
+        df["x1"] = df.t.astype(float)
+        with pytest.raises((MlsynthDataError, ValueError), match="x1"):
+            _fit(df=df, covariates=["x1"],
+                 covariate_windows={"x1": (900, 999)})
+
+    def test_a_cohort_treated_from_the_first_period_has_no_base_year(self):
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _staggered(n_treated=2, cohorts=(0,))
+        with pytest.raises((MlsynthDataError, ValueError)):
+            _fit(df=df)
+
+    def test_a_zero_outcome_at_the_base_period_cannot_be_indexed(self):
+        """Indexing divides by the base-period level, so a zero there has no
+        percent scale to express the effect on."""
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _staggered()
+        df.loc[(df.unit == "x0") & (df.t == 5), "y"] = 0.0
+        with pytest.raises((MlsynthDataError, ValueError), match="base"):
+            _fit(df=df)
+
+    def test_no_common_post_period_is_an_error(self):
+        """Tested on the window helper directly. A cohort whose base period is
+        the last observed row supplies no post horizon at all, and the balanced
+        window is then empty. A well-formed treatment column cannot produce it
+        -- the adoption period is itself observed, so ``e = 0`` always exists
+        -- but the helper is the guard on that, so it is exercised here."""
+        from mlsynth.exceptions import MlsynthDataError
+        from mlsynth.utils.stackedsc_helpers.setup import Cohort, event_window
+
+        T = 6
+        c = Cohort(adopt=99, base_period=T - 1, units=["x0"], donors=["d0"],
+                   Y=np.zeros((T, 1)), D=np.zeros((T, 1)), t0_index=T - 1)
+        with pytest.raises(MlsynthDataError, match="post"):
+            event_window([c], None, None)
+
+    def test_a_predicate_that_empties_a_pool_is_an_error(self):
+        """A treated unit with no admissible donor has no synthetic control at
+        all, so the predicate names the unit it emptied."""
+        with pytest.raises(ValueError, match="x0"):
+            _fit(donor_predicate=lambda i, d: i != "x0")

--- a/mlsynth/tests/test_stackedsc.py
+++ b/mlsynth/tests/test_stackedsc.py
@@ -1,0 +1,224 @@
+"""STACKEDSC: stacked-in-event-time bias-corrected SCM (Wiltshire 2023).
+
+One synthetic control per treated unit against the never-treated donors, with
+each unit and its donors indexed to 100 at that unit's own final pre-treatment
+period, then averaged on a common event clock under user-supplied weights.
+
+Three things about this estimator drive the tests below.
+
+The normalisation is not cosmetic. Rescaling unit ``j`` and every donor to
+``b_j`` and imposing ``sum(w) = 1`` is algebraically the same as fitting on
+levels under the constraint ``sum_j v_j b_j = b_1`` -- the synthetic control
+must reproduce the treated unit's base-period level exactly. That is why the
+paper's printed gap at ``e = -1`` is exactly zero, and it is the sharpest
+available check that the base year is right.
+
+The base year belongs to the cohort, not the unit. Units adopting in the same
+period share ``T0i``, so the donor block takes as many distinct values as there
+are adoption times -- six on the Walmart panel, not 566. A common base year
+across cohorts would be a different (and wrong) estimator, and the event-time
+path is what detects it.
+
+Aggregation weights are part of the specification. Wiltshire uses 1990
+population "so each tau_e is not overly-affected by large percentage effects in
+small counties" (fn 28), and reports that equal weighting gives the same pattern
+with different magnitudes. An estimator that silently equal-weights is answering
+a different question.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+
+# ---------------------------------------------------------------------------
+# panels
+# ---------------------------------------------------------------------------
+def _staggered(n_treated=6, n_donors=8, T=12, cohorts=(6, 8), effect=0.0,
+               seed=0):
+    """Staggered adoption with a common factor, so donors can span the treated.
+
+    ``effect`` is a proportional post-treatment shift on the treated units, so
+    the true normalised gap is known up to noise.
+    """
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2)).cumsum(axis=0)
+    rows = []
+    for j in range(n_donors):
+        load = rng.normal(size=2)
+        base = 100.0 + 20.0 * rng.random()
+        for t in range(T):
+            rows.append({"unit": f"d{j}", "t": t, "adopt": np.nan,
+                         "y": float(base + F[t] @ load + rng.normal() * 0.05),
+                         "w": 1.0})
+    for i in range(n_treated):
+        g = cohorts[i % len(cohorts)]
+        load = rng.normal(size=2)
+        base = 100.0 + 20.0 * rng.random()
+        for t in range(T):
+            y = base + F[t] @ load + rng.normal() * 0.05
+            if t >= g:
+                y *= (1.0 + effect)
+            rows.append({"unit": f"x{i}", "t": t, "adopt": float(g),
+                         "y": float(y), "w": float(1 + i)})
+    d = pd.DataFrame(rows)
+    d["treat"] = ((~d.adopt.isna()) & (d.t >= d.adopt)).astype(int)
+    return d
+
+
+def _fit(df=None, **over):
+    from mlsynth import STACKEDSC
+
+    cfg = {"df": _staggered() if df is None else df, "outcome": "y",
+           "treat": "treat", "unitid": "unit", "time": "t",
+           "display_graphs": False}
+    cfg.update(over)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return STACKEDSC(cfg).fit()
+
+
+# ---------------------------------------------------------------------------
+class TestSmoke:
+    def test_it_fits_and_returns_the_contract_type(self):
+        from mlsynth.config_models import EffectResult
+
+        assert isinstance(_fit(), EffectResult)
+
+    def test_the_headline_quantities_are_finite(self):
+        res = _fit()
+        assert np.isfinite(res.effects.att)
+        assert np.isfinite(np.asarray(res.event_study.tau, float)).any()
+
+    def test_it_reports_one_fit_per_treated_unit(self):
+        res = _fit()
+        assert len(res.per_unit) == 6
+
+
+# ---------------------------------------------------------------------------
+class TestTheNormalisation:
+    """The constraint the base-year indexing imposes, and its consequences."""
+
+    def test_the_gap_at_the_base_period_is_exactly_zero(self):
+        """Every series is 100 at its own T0i and the weights sum to one, so
+        the synthetic reproduces the treated level there identically. A wrong
+        base year breaks this immediately; nothing else in the output does.
+        """
+        res = _fit()
+        e = np.asarray(res.event_study.horizons, int)
+        tau = np.asarray(res.event_study.tau, float)
+        assert abs(float(tau[e == -1][0])) < 1e-9
+
+    def test_each_cohort_uses_its_own_base_year(self):
+        """Two cohorts adopting at different times must be indexed to different
+        periods. Indexing both to a common year is a different estimator, and
+        it shows up as a nonzero gap at e = -1 for at least one cohort."""
+        res = _fit(df=_staggered(cohorts=(5, 9)))
+        for u in res.per_unit.values():
+            e = np.asarray(u.horizons, int)
+            g = np.asarray(u.tau, float)
+            assert abs(float(g[e == -1][0])) < 1e-9, u.label
+
+    def test_the_effects_are_in_percent_of_the_base_level(self):
+        """A 10 percent post shift on every treated unit should read as about
+        10, not as a level difference in the outcome's own units."""
+        res = _fit(df=_staggered(effect=0.10, seed=3))
+        e = np.asarray(res.event_study.horizons, int)
+        tau = np.asarray(res.event_study.tau, float)
+        post = tau[e >= 0]
+        assert 7.0 < float(np.mean(post)) < 13.0
+
+
+# ---------------------------------------------------------------------------
+class TestAggregationWeights:
+    def test_equal_weighting_is_the_default(self):
+        res = _fit()
+        assert res.method_details.parameters_used["agg_weights"] is None
+
+    def test_a_supplied_weight_column_changes_the_average(self):
+        plain = _fit()
+        weighted = _fit(agg_weights="w")
+        assert plain.effects.att != pytest.approx(weighted.effects.att,
+                                                  rel=1e-9)
+
+    def test_a_degenerate_weight_reproduces_the_unit_it_selects(self):
+        """Putting all the mass on one treated unit must return that unit's own
+        path -- the aggregation is a weighted mean, so this is exact."""
+        df = _staggered()
+        df["only"] = (df.unit == "x2").astype(float)
+        res = _fit(df=df, agg_weights="only")
+        target = _fit(df=df).per_unit["x2"]
+        np.testing.assert_allclose(
+            np.asarray(res.event_study.tau, float),
+            np.asarray(target.tau, float), atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+class TestBiasCorrection:
+    def test_it_is_off_by_default(self):
+        from mlsynth.utils.stackedsc_helpers.config import STACKEDSCConfig
+
+        assert STACKEDSCConfig.model_fields["bias_correct"].default is False
+
+    def test_it_moves_the_estimate_when_predictors_are_supplied(self):
+        df = _staggered()
+        df["x1"] = df.groupby("unit").y.transform("mean")
+        plain = _fit(df=df, covariates=["x1"])
+        corrected = _fit(df=df, covariates=["x1"], bias_correct=True)
+        assert plain.effects.att != pytest.approx(corrected.effects.att,
+                                                  rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+class TestEdgeCases:
+    def test_a_single_treated_unit_works(self):
+        res = _fit(df=_staggered(n_treated=1, cohorts=(7,)))
+        assert len(res.per_unit) == 1
+        assert np.isfinite(res.effects.att)
+
+    def test_a_single_donor_takes_all_the_weight(self):
+        res = _fit(df=_staggered(n_donors=1))
+        for u in res.per_unit.values():
+            assert sum(u.donor_weights.values()) == pytest.approx(1.0, abs=1e-6)
+
+    def test_every_cohort_is_represented(self):
+        res = _fit(df=_staggered(n_treated=6, cohorts=(5, 7, 9)))
+        assert {u.adoption_time for u in res.per_unit.values()} == {5, 7, 9}
+
+
+# ---------------------------------------------------------------------------
+class TestFailuresAreReported:
+    def test_no_never_treated_donors_is_an_error(self):
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _staggered(n_donors=0)
+        with pytest.raises((MlsynthDataError, ValueError)):
+            _fit(df=df)
+
+    def test_a_missing_weight_column_is_an_error(self):
+        from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+
+        with pytest.raises((MlsynthConfigError, MlsynthDataError, ValueError),
+                           match="nope"):
+            _fit(agg_weights="nope")
+
+    def test_a_weight_that_varies_within_a_unit_is_an_error(self):
+        """An aggregation weight is a property of the treated unit. If it moves
+        over time there is no single value to weight by, and silently taking
+        the first would be a guess."""
+        from mlsynth.exceptions import MlsynthDataError
+
+        df = _staggered()
+        df.loc[df.unit == "x0", "w"] = np.arange((df.unit == "x0").sum())
+        with pytest.raises((MlsynthDataError, ValueError)):
+            _fit(df=df, agg_weights="w")
+
+    def test_bias_correction_without_covariates_is_an_error(self):
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises((MlsynthConfigError, ValueError), match="covariat"):
+            _fit(bias_correct=True)

--- a/mlsynth/tests/test_stackedsc_inference.py
+++ b/mlsynth/tests/test_stackedsc_inference.py
@@ -1,0 +1,365 @@
+"""Placebo inference for STACKEDSC: sampled placebo averages.
+
+With more than one treated unit the permutation distribution is not a set of
+placebo *units* but a set of placebo *averages*. Wiltshire's procedure, which
+``allsynth`` automates, reassigns treatment to each donor in each treated unit's
+pool, then builds a sampled average by drawing exactly one placebo path per
+treated unit and averaging under the same ``gamma_i`` used for the estimate. The
+number of such averages is the product of the pool sizes, so it is sampled
+rather than enumerated -- 39 donors and 566 treated counties is 39 ** 566.
+
+Three things drive the tests below.
+
+The placebo paths inherit the estimator's own normalisation. A pseudo-treated
+donor is indexed to 100 at the same cohort base period as everything else, and
+its pool weights sum to one, so its gap at ``e = -1`` is exactly zero just as the
+real one is. A placebo fitted on some other clock fails that check immediately.
+
+The donor pool for a placebo is a choice. ``allsynth`` documents "i and the
+remaining untreated units collectively constituting the donor pool for each j"
+-- under the permutation the treated unit is a control. That reading reproduces
+the published numbers, and it makes the placebo path a property of the pair
+``(i, j)`` rather than of the cohort: 566 x 39 solves instead of 6 x 39.
+
+The two p-values answer different questions. The RMSPE-ranked one is a rank
+within the sampled distribution and needs no distributional assumption; the
+variance one reads the sampled spread as a standard error and assumes normality.
+Both are reported because ``allsynth`` reports both.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+
+# ---------------------------------------------------------------------------
+def _staggered(n_treated=4, n_donors=6, T=12, cohorts=(6, 8), effect=0.0,
+               seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2)).cumsum(axis=0)
+    rows = []
+    for j in range(n_donors):
+        load = rng.normal(size=2)
+        base = 100.0 + 20.0 * rng.random()
+        for t in range(T):
+            rows.append({"unit": f"d{j}", "t": t, "adopt": np.nan,
+                         "y": float(base + F[t] @ load + rng.normal() * 0.05),
+                         "w": 1.0})
+    for i in range(n_treated):
+        g = cohorts[i % len(cohorts)]
+        load = rng.normal(size=2)
+        base = 100.0 + 20.0 * rng.random()
+        for t in range(T):
+            y = base + F[t] @ load + rng.normal() * 0.05
+            if t >= g:
+                y *= (1.0 + effect)
+            rows.append({"unit": f"x{i}", "t": t, "adopt": float(g),
+                         "y": float(y), "w": float(1 + i)})
+    d = pd.DataFrame(rows)
+    d["treat"] = ((~d.adopt.isna()) & (d.t >= d.adopt)).astype(int)
+    return d
+
+
+def _fit(df=None, **over):
+    from mlsynth import STACKEDSC
+
+    cfg = {"df": _staggered() if df is None else df, "outcome": "y",
+           "treat": "treat", "unitid": "unit", "time": "t",
+           "display_graphs": False}
+    cfg.update(over)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return STACKEDSC(cfg).fit()
+
+
+def _infer(df=None, **over):
+    over.setdefault("inference", "placebo")
+    over.setdefault("n_placebo_samples", 60)
+    over.setdefault("seed", 11)
+    return _fit(df=df, **over)
+
+
+# ---------------------------------------------------------------------------
+class TestSmoke:
+    def test_it_populates_the_standard_inference_block(self):
+        res = _infer()
+        inf = res.inference
+        assert inf.method is not None and "placebo" in inf.method
+        assert np.isfinite(inf.standard_error)
+        assert np.isfinite(inf.p_value)
+        assert np.isfinite(inf.ci_lower) and np.isfinite(inf.ci_upper)
+        assert inf.confidence_level == pytest.approx(0.95)
+
+    def test_it_populates_the_typed_placebo_block(self):
+        res = _infer()
+        pb = res.placebo
+        assert pb is not None
+        assert pb.placebo_averages.shape == (60, len(pb.horizons))
+        assert np.isfinite(pb.placebo_averages).all()
+
+    def test_the_detail_field_points_at_the_same_block(self):
+        res = _infer()
+        assert res.inference.details is res.placebo
+
+
+# ---------------------------------------------------------------------------
+class TestItIsOffUnlessAskedFor:
+    """``allsynth`` requires ``pvalues()`` and warns that it "will greatly
+    extend the run-time". The cost is a product of treated units and donors, so
+    it is opt-in here for the same reason."""
+
+    def test_none_is_the_default(self):
+        from mlsynth.utils.stackedsc_helpers.config import STACKEDSCConfig
+
+        assert STACKEDSCConfig.model_fields["inference"].default == "none"
+
+    def test_nothing_is_computed_when_it_is_off(self):
+        res = _fit()
+        assert res.placebo is None
+        assert res.inference.p_value is None
+        assert res.inference.standard_error is None
+
+
+# ---------------------------------------------------------------------------
+class TestThePlacebosShareTheEstimatorsClock:
+    def test_every_placebo_average_is_zero_at_the_base_period(self):
+        """A pseudo-treated donor is indexed to 100 at the same cohort base
+        period, and its pool weights sum to one, so its gap at ``e = -1`` is
+        identically zero -- and therefore so is any weighted average of such
+        paths. A placebo fitted on some other clock breaks this at once."""
+        res = _infer()
+        e = np.asarray(res.placebo.horizons, int)
+        P = np.asarray(res.placebo.placebo_averages, float)
+        assert np.abs(P[:, e == -1]).max() < 1e-8
+
+    def test_the_horizons_match_the_event_study(self):
+        res = _infer()
+        np.testing.assert_array_equal(
+            np.asarray(res.placebo.horizons, int),
+            np.asarray(res.event_study.horizons, int))
+
+
+# ---------------------------------------------------------------------------
+class TestTheSampling:
+    def test_it_returns_the_requested_number_of_averages(self):
+        res = _infer(n_placebo_samples=45)
+        assert res.placebo.n_samples == 45
+        assert res.placebo.placebo_averages.shape[0] == 45
+
+    def test_the_same_seed_gives_the_same_distribution(self):
+        a, b = _infer(seed=7), _infer(seed=7)
+        np.testing.assert_allclose(a.placebo.placebo_averages,
+                                   b.placebo.placebo_averages)
+
+    def test_a_different_seed_gives_a_different_draw(self):
+        a, b = _infer(seed=7), _infer(seed=8)
+        assert not np.allclose(a.placebo.placebo_averages,
+                               b.placebo.placebo_averages)
+
+    def test_the_aggregation_weights_are_the_estimators_own(self):
+        """Putting all the aggregation mass on one treated unit makes each
+        sampled average exactly one of that unit's placebo paths -- the average
+        is a weighted mean, so this is exact rather than approximate."""
+        df = _staggered()
+        df["only"] = (df.unit == "x2").astype(float)
+        res = _infer(df=df, agg_weights="only")
+        paths = np.asarray(res.placebo.paths["x2"], float)
+        for row in np.asarray(res.placebo.placebo_averages, float):
+            assert np.abs(paths - row).max(axis=1).min() < 1e-8
+
+
+# ---------------------------------------------------------------------------
+class TestTheDonorPoolChoice:
+    def test_the_permutation_pool_is_the_default(self):
+        from mlsynth.utils.stackedsc_helpers.config import STACKEDSCConfig
+
+        assert (STACKEDSCConfig.model_fields["placebo_donor_pool"].default
+                == "permutation")
+
+    def test_the_permutation_pool_fits_one_path_per_treated_donor_pair(self):
+        res = _infer()
+        assert res.placebo.n_fits == 4 * 6
+
+    def test_dropping_the_treated_unit_makes_the_path_a_cohort_property(self):
+        """Without the treated unit in the pool, every unit in a cohort faces
+        the same design and the same targets, so one solve per (cohort, donor)
+        serves the whole cohort."""
+        res = _infer(placebo_donor_pool="donors-only")
+        assert res.placebo.n_fits == 2 * 6
+        a = np.asarray(res.placebo.paths["x0"], float)
+        b = np.asarray(res.placebo.paths["x2"], float)   # same cohort
+        np.testing.assert_allclose(a, b, atol=1e-10)
+
+    def test_the_two_pools_do_not_give_the_same_answer(self):
+        """Including the treated unit changes each placebo's design matrix, and
+        under the alternative its post-treatment path carries the very effect
+        being tested."""
+        a = _infer().placebo.se
+        b = _infer(placebo_donor_pool="donors-only").placebo.se
+        assert not np.allclose(a, b, atol=1e-8)
+
+    def test_the_choice_is_recorded(self):
+        for pool in ("permutation", "donors-only"):
+            res = _infer(placebo_donor_pool=pool)
+            assert res.placebo.donor_pool == pool
+            assert res.method_details.parameters_used[
+                "placebo_donor_pool"] == pool
+
+
+# ---------------------------------------------------------------------------
+class TestTheTwoPValues:
+    def test_the_rmspe_p_values_are_reported_for_every_post_horizon(self):
+        res = _infer()
+        e = np.asarray(res.placebo.horizons, int)
+        post = sorted(int(x) for x in e[e >= 0])
+        assert sorted(res.placebo.rmspe_p) == post
+        assert all(0.0 <= p <= 1.0 for p in res.placebo.rmspe_p.values())
+
+    def test_the_rmspe_statistic_is_a_post_over_pre_ratio(self):
+        """``RMSPE_E`` is the mean squared post gap through ``E`` over the mean
+        squared pre gap, so it is recomputable from the reported event path."""
+        res = _infer()
+        e = np.asarray(res.placebo.horizons, int)
+        tau = np.asarray(res.event_study.tau, float)
+        pre = float(np.mean(tau[e < 0] ** 2))
+        E = int(e.max())
+        want = float(np.mean(tau[(e >= 0) & (e <= E)] ** 2)) / pre
+        assert res.placebo.rmspe_actual[E] == pytest.approx(want, rel=1e-9)
+
+    def test_a_placebo_with_a_perfect_pre_fit_counts_rather_than_vanishing(self):
+        """Its ratio has a zero denominator. Taking the limit -- unbounded when
+        it has a post-treatment gap -- keeps it in the numerator; discarding
+        the row would shrink ``p_E``, because the denominator is ``S + 1``
+        either way."""
+        from mlsynth.utils.stackedsc_helpers.inference import _rmspe
+
+        grid = np.array([-2, -1, 0, 1])
+        tau = np.array([1.0, 0.0, 4.0, 4.0])
+        placebo = np.array([
+            [0.0, 0.0, 9.0, 9.0],     # perfect pre-fit, large post gap
+            [3.0, 0.0, 0.1, 0.1],     # poor pre-fit, small post gap
+            [0.0, 0.0, 0.0, 0.0],     # fits everywhere: ratio is 0, not inf
+        ])
+        actual, p = _rmspe(grid, tau, placebo)
+        assert actual[1] == pytest.approx(16.0 / 0.5)
+        assert p[1] == pytest.approx(1.0 / 4.0)
+
+    def test_the_variance_interval_is_symmetric_around_the_estimate(self):
+        res = _infer()
+        e = np.asarray(res.placebo.horizons, int)
+        tau = np.asarray(res.event_study.tau, float)
+        lo = np.asarray(res.placebo.ci_lower, float)
+        hi = np.asarray(res.placebo.ci_upper, float)
+        np.testing.assert_allclose(0.5 * (lo + hi), tau, atol=1e-9)
+        assert (hi >= lo).all()
+
+    def test_the_headline_interval_brackets_the_att(self):
+        res = _infer()
+        assert res.inference.ci_lower <= res.effects.att <= res.inference.ci_upper
+
+    def test_a_narrower_level_gives_a_wider_interval(self):
+        wide = _infer(alpha=0.01).inference
+        narrow = _infer(alpha=0.10).inference
+        assert (wide.ci_upper - wide.ci_lower) > (narrow.ci_upper
+                                                  - narrow.ci_lower)
+
+    def test_a_planted_effect_is_harder_to_call_noise(self):
+        """Not a claim about size or power -- only that the machinery moves in
+        the right direction when a large effect is present."""
+        null = _infer(df=_staggered(effect=0.0, seed=5))
+        real = _infer(df=_staggered(effect=0.50, seed=5))
+        assert real.inference.p_value < null.inference.p_value
+
+
+# ---------------------------------------------------------------------------
+class TestItComposesWithTheEstimatorsOptions:
+    def test_the_estimate_is_untouched_by_asking_for_inference(self):
+        plain, with_p = _fit(), _infer()
+        assert plain.effects.att == pytest.approx(with_p.effects.att, rel=1e-12)
+
+    def test_the_placebos_are_bias_corrected_when_the_estimate_is(self):
+        df = _staggered()
+        df["x1"] = df.groupby("unit").y.transform("mean")
+        plain = _infer(df=df, covariates=["x1"])
+        corrected = _infer(df=df, covariates=["x1"], bias_correct=True)
+        assert not np.allclose(plain.placebo.se, corrected.placebo.se,
+                               atol=1e-10)
+
+    def test_a_donor_predicate_restricts_the_placebo_pool_too(self):
+        """If donor ``d0`` may not serve treated unit ``x0``, it must not appear
+        as a placebo for ``x0`` either -- the permutation is over that unit's
+        own pool."""
+        res = _infer(donor_predicate=lambda i, d: not (i == "x0"
+                                                       and d == "d0"))
+        assert np.asarray(res.placebo.paths["x0"]).shape[0] == 5
+        assert np.asarray(res.placebo.paths["x1"]).shape[0] == 6
+
+
+# ---------------------------------------------------------------------------
+class TestEdgeCases:
+    def test_one_treated_unit_still_gets_a_distribution(self):
+        res = _infer(df=_staggered(n_treated=1, cohorts=(7,)))
+        assert res.placebo.placebo_averages.shape[0] == 60
+        assert np.isfinite(res.inference.standard_error)
+
+    def test_two_donors_is_the_smallest_workable_pool(self):
+        res = _infer(df=_staggered(n_donors=2))
+        assert res.placebo.n_fits == 4 * 2
+
+
+# ---------------------------------------------------------------------------
+class TestThePlot:
+    def test_it_draws_the_interval_when_the_distribution_exists(self, tmp_path):
+        import matplotlib
+        matplotlib.use("Agg")
+        from mlsynth.utils.stackedsc_helpers.plotter import plot_stackedsc
+
+        out = tmp_path / "es.png"
+        plot_stackedsc(_infer(), save=str(out))
+        assert out.exists()
+
+    def test_it_still_draws_without_one(self, tmp_path):
+        import matplotlib
+        matplotlib.use("Agg")
+        from mlsynth.utils.stackedsc_helpers.plotter import plot_stackedsc
+
+        out = tmp_path / "plain.png"
+        plot_stackedsc(_fit(), save=str(out))
+        assert out.exists()
+
+
+# ---------------------------------------------------------------------------
+class TestFailuresAreReported:
+    def test_a_single_donor_cannot_form_a_placebo(self):
+        """Reassigning the only donor leaves nothing to fit it against, so the
+        design admits no placebo distribution at all and says so instead of
+        returning an empty one."""
+        from mlsynth.exceptions import MlsynthDataError
+
+        with pytest.raises((MlsynthDataError, ValueError), match="placebo"):
+            _infer(df=_staggered(n_donors=1))
+
+    def test_too_few_samples_is_a_configuration_error(self):
+        """``allsynth`` requires ``sampleavgs()`` to be at least 30, and the
+        floor is carried over rather than left to the caller."""
+        from mlsynth.exceptions import MlsynthConfigError
+
+        with pytest.raises((MlsynthConfigError, ValueError)):
+            _infer(n_placebo_samples=5)
+
+    def test_an_unknown_inference_mode_is_rejected(self):
+        with pytest.raises(Exception):
+            _fit(inference="bootstrap")
+
+    def test_a_pre_window_of_one_period_cannot_rank_by_rmspe(self):
+        """The RMSPE denominator is the mean squared pre-treatment gap, and at
+        ``e = -1`` that gap is identically zero under the normalisation. With no
+        other pre-period the ratio is 0/0, which is reported as undefined rather
+        than as a p-value."""
+        res = _infer(n_lags=1)
+        assert all(np.isnan(v) for v in res.placebo.rmspe_p.values())
+        assert np.isfinite(res.inference.standard_error)

--- a/mlsynth/utils/stackedsc_helpers/__init__.py
+++ b/mlsynth/utils/stackedsc_helpers/__init__.py
@@ -2,6 +2,7 @@
 
 from .config import STACKEDSCConfig
 from .pipeline import run_stackedsc
+from .plotter import plot_stackedsc
 from .structures import (STACKEDSCResults, StackedDesign, StackedEventStudy,
                          StackedUnitFit)
 
@@ -11,5 +12,6 @@ __all__ = [
     "StackedDesign",
     "StackedEventStudy",
     "StackedUnitFit",
+    "plot_stackedsc",
     "run_stackedsc",
 ]

--- a/mlsynth/utils/stackedsc_helpers/__init__.py
+++ b/mlsynth/utils/stackedsc_helpers/__init__.py
@@ -1,0 +1,15 @@
+"""Helpers for STACKEDSC (Wiltshire 2023)."""
+
+from .config import STACKEDSCConfig
+from .pipeline import run_stackedsc
+from .structures import (STACKEDSCResults, StackedDesign, StackedEventStudy,
+                         StackedUnitFit)
+
+__all__ = [
+    "STACKEDSCConfig",
+    "STACKEDSCResults",
+    "StackedDesign",
+    "StackedEventStudy",
+    "StackedUnitFit",
+    "run_stackedsc",
+]

--- a/mlsynth/utils/stackedsc_helpers/__init__.py
+++ b/mlsynth/utils/stackedsc_helpers/__init__.py
@@ -1,17 +1,20 @@
 """Helpers for STACKEDSC (Wiltshire 2023)."""
 
 from .config import STACKEDSCConfig
+from .inference import placebo_inference
 from .pipeline import run_stackedsc
 from .plotter import plot_stackedsc
 from .structures import (STACKEDSCResults, StackedDesign, StackedEventStudy,
-                         StackedUnitFit)
+                         StackedPlacebo, StackedUnitFit)
 
 __all__ = [
     "STACKEDSCConfig",
     "STACKEDSCResults",
     "StackedDesign",
     "StackedEventStudy",
+    "StackedPlacebo",
     "StackedUnitFit",
+    "placebo_inference",
     "plot_stackedsc",
     "run_stackedsc",
 ]

--- a/mlsynth/utils/stackedsc_helpers/config.py
+++ b/mlsynth/utils/stackedsc_helpers/config.py
@@ -1,0 +1,136 @@
+"""Configuration for STACKEDSC (Wiltshire 2023).
+
+Four inputs beyond the usual columns, and each corresponds to a choice the
+paper makes explicitly rather than a convenience.
+
+``agg_weights`` because the event-time average is over treated units and the
+paper weights it by 1990 population, "so each tau_e is not overly-affected by
+large percentage effects in small counties" (fn 28). Equal weighting is a
+different estimand, not a default worth hiding.
+
+``bias_correct`` because the paper's headline is the corrected figure, and the
+correction roughly doubles it.
+
+``covariates`` and ``backend`` because the synthetic control is fitted on
+predictors, and which predictor-weight rule runs determines the answer by more
+than the estimand itself on this data.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+from pydantic import Field, model_validator
+
+from ...config_models import BaseEstimatorConfig
+
+
+class STACKEDSCConfig(BaseEstimatorConfig):
+    """Typed configuration for :class:`mlsynth.STACKEDSC`."""
+
+    agg_weights: Optional[str] = Field(
+        default=None,
+        description=(
+            "Column holding the per-treated-unit aggregation weight gamma_i, "
+            "constant within a unit. None gives equal weights. Wiltshire uses "
+            "1990 population; the pattern of results holds under equal "
+            "weighting with different magnitudes, so this changes the "
+            "estimand and is worth stating rather than defaulting silently."),
+    )
+    normalize: bool = Field(
+        default=True,
+        description=(
+            "Index the outcome for each treated unit and its donors to 100 at "
+            "that unit's final pre-treatment period, so effects read as "
+            "percent changes and are comparable across units of very "
+            "different size. This is not a display choice: with weights "
+            "summing to one it constrains the synthetic control to reproduce "
+            "the treated unit's base-period level exactly, which is why the "
+            "gap at e = -1 is identically zero. Turning it off gives a "
+            "level-scale stacked SCM, which is a different estimator."),
+    )
+    n_leads: Optional[int] = Field(
+        default=None, gt=0,
+        description=(
+            "Post-treatment horizons to report. None uses the largest window "
+            "every treated unit can supply, which is what `balanced` does in "
+            "the reference implementation."),
+    )
+    n_lags: Optional[int] = Field(
+        default=None, gt=0,
+        description=(
+            "Pre-treatment horizons to report, counting back from e = -1. "
+            "None uses the largest window every treated unit can supply."),
+    )
+    covariates: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Predictor columns matched alongside the pre-treatment outcome "
+            "path. None matches on the outcome alone."),
+    )
+    covariate_windows: Optional[Dict[Any, Tuple[Any, Any]]] = Field(
+        default=None,
+        description=(
+            "Per-covariate inclusive (start, end) averaging window, as "
+            "{column: (start, end)}. The paper averages its ten covariates "
+            "over the five years before any unit is treated."),
+    )
+    backend: Literal["auto", "outcome-only", "regression", "malo", "mscmt"] = (
+        Field(
+            default="auto",
+            description=(
+                "Predictor-weight rule. 'auto' uses 'outcome-only' without "
+                "covariates and 'regression' with them -- the latter because "
+                "Stata's `synth`, which the reference implementation wraps, "
+                "runs its regression rule unless the caller asks for the "
+                "nested search."),
+        )
+    )
+    bias_correct: bool = Field(
+        default=False,
+        description=(
+            "Apply the Abadie-L'Hour correction for residual predictor "
+            "imbalance to each unit's gap before aggregating. Requires "
+            "`covariates`. On the paper's data this roughly doubles the "
+            "estimate, and the corrected figure is the one it reports."),
+    )
+    bias_correct_ridge: float = Field(
+        default=1e-2, ge=0.0,
+        description=(
+            "Ridge penalty on the bias-correction slope; ignored unless "
+            "`bias_correct`. Large values shrink the correction toward zero."),
+    )
+    donor_predicate: Optional[Any] = Field(
+        default=None,
+        description=(
+            "Callable (treated_unit_id, donor_unit_id) -> bool restricting "
+            "each treated unit's donor pool, mirroring the reference "
+            "implementation's `donorif`. None uses every never-treated unit "
+            "for every treated unit. Note that a predicate which actually "
+            "binds forces a per-unit design matrix and forfeits the "
+            "per-cohort batching."),
+    )
+
+    model_config = {"arbitrary_types_allowed": True, "extra": "forbid"}
+
+    @model_validator(mode="after")
+    def _bias_correction_needs_predictors(self):
+        if self.bias_correct and not self.covariates:
+            raise ValueError(
+                "bias_correct=True needs covariates: the correction subtracts "
+                "(X1 - X0 W)' beta from the gap, and with no predictors that "
+                "term does not exist."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _windows_name_real_covariates(self):
+        if self.covariate_windows:
+            named = set(self.covariates or [])
+            unknown = [c for c in self.covariate_windows if c not in named]
+            if unknown:
+                raise ValueError(
+                    f"covariate_windows names {unknown}, which are not in "
+                    f"covariates={sorted(named)}."
+                )
+        return self

--- a/mlsynth/utils/stackedsc_helpers/config.py
+++ b/mlsynth/utils/stackedsc_helpers/config.py
@@ -34,8 +34,8 @@ class STACKEDSCConfig(BaseEstimatorConfig):
             "Column holding the per-treated-unit aggregation weight gamma_i, "
             "constant within a unit. None gives equal weights. Wiltshire uses "
             "1990 population; the pattern of results holds under equal "
-            "weighting with different magnitudes, so this changes the "
-            "estimand and is worth stating rather than defaulting silently."),
+            "weighting with different magnitudes. The choice changes the "
+            "estimand."),
     )
     normalize: bool = Field(
         default=True,
@@ -43,11 +43,11 @@ class STACKEDSCConfig(BaseEstimatorConfig):
             "Index the outcome for each treated unit and its donors to 100 at "
             "that unit's final pre-treatment period, so effects read as "
             "percent changes and are comparable across units of very "
-            "different size. This is not a display choice: with weights "
-            "summing to one it constrains the synthetic control to reproduce "
-            "the treated unit's base-period level exactly, which is why the "
-            "gap at e = -1 is identically zero. Turning it off gives a "
-            "level-scale stacked SCM, which is a different estimator."),
+            "different size. With weights summing to one the indexing "
+            "constrains the synthetic control to reproduce the treated unit's "
+            "base-period level exactly, which is why the gap at e = -1 is "
+            "identically zero. Turning it off gives a level-scale stacked "
+            "SCM, a different estimator."),
     )
     n_leads: Optional[int] = Field(
         default=None, gt=0,
@@ -110,6 +110,51 @@ class STACKEDSCConfig(BaseEstimatorConfig):
             "binds forces a per-unit design matrix and forfeits the "
             "per-cohort batching."),
     )
+
+    inference: Literal["none", "placebo"] = Field(
+        default="none",
+        description=(
+            "'placebo' runs Wiltshire's sampled-placebo-average procedure: "
+            "recast every donor as treated at each treated unit's adoption "
+            "time, then sample averages of those placebo paths to form a "
+            "permutation distribution. The cost is the number of treated "
+            "units times the pool size, so it is opt-in -- the reference "
+            "implementation likewise requires `pvalues()` and warns that "
+            "specifying it 'will greatly extend the run-time'."),
+    )
+    n_placebo_samples: int = Field(
+        default=1000, ge=30,
+        description=(
+            "Number S of placebo averages sampled from the product of the "
+            "donor pools. The reference implementation requires at least 30 "
+            "and uses 1000 whenever the placebo-variance statistics are "
+            "requested, which is the default here."),
+    )
+    placebo_donor_pool: Literal["permutation", "donors-only"] = Field(
+        default="permutation",
+        description=(
+            "Whether the treated unit joins each of its placebos' donor "
+            "pools. 'permutation' does, following the reference "
+            "implementation ('i and the remaining untreated units "
+            "collectively constituting the donor pool for each j'), and makes "
+            "the placebo path a property of the (treated unit, donor) pair. It "
+            "also lets a placebo put weight on a genuinely treated unit, whose "
+            "post-treatment path carries the effect being tested -- the "
+            "stacked-case power loss of Zhang (2019, section 3.1). "
+            "'donors-only' drops it, which removes that channel, makes the "
+            "path a property of the cohort, and cuts the solve count by the "
+            "number of treated units per cohort, at the price of departing "
+            "from the reference."),
+    )
+    alpha: float = Field(
+        default=0.05, gt=0.0, lt=1.0,
+        description=(
+            "Level of the placebo-variance interval; ignored unless "
+            "`inference='placebo'`. The reference reports 95 percent."),
+    )
+    seed: int = Field(
+        default=0,
+        description="Seed for drawing the placebo averages.")
 
     model_config = {"arbitrary_types_allowed": True, "extra": "forbid"}
 

--- a/mlsynth/utils/stackedsc_helpers/inference.py
+++ b/mlsynth/utils/stackedsc_helpers/inference.py
@@ -1,0 +1,291 @@
+"""Placebo inference for STACKEDSC: sampled placebo averages.
+
+With one treated unit the in-space placebo test of Abadie et al. (2010) has an
+obvious permutation set -- reassign treatment to each donor in turn and compare
+the real gap path to the placebo ones. With many treated units the estimate is
+already an average, so the comparison has to be against other *averages*.
+Wiltshire (2023) builds them as follows, and ``allsynth`` automates it
+(``pvalues(rmspe variance)``, ``stacked(..., sampleavgs(S))``).
+
+For every treated unit ``i`` and every donor ``j`` in that unit's pool, refit
+the synthetic control with ``j`` cast as treated at ``i``'s adoption time. That
+gives a placebo gap path for each pair. A placebo *average* then draws exactly
+one ``j`` per treated unit and averages the drawn paths under the same
+``gamma_i`` the estimate uses. The number of distinct averages is the product of
+the pool sizes -- 39 donors and 566 treated counties is 39 ** 566 -- so ``S`` of
+them are sampled rather than enumerated.
+
+Two statistics come off that distribution:
+
+* RMSPE-ranked p-values. For each post horizon ``E``, the mean squared gap over
+  ``e in [0, E]`` divided by the mean squared gap over the pre-window, then the
+  share of sampled averages whose ratio reaches the estimate's. Ranking a ratio
+  rather than a level discounts averages that fit badly before treatment.
+* Placebo-variance p-values and intervals. The spread of the sampled averages at
+  each horizon is read as a standard error, following Algorithm 4 of
+  Arkhangelsky et al. (2021). This one assumes homoskedasticity across units and
+  asymptotic normality; the RMSPE ranking assumes neither.
+
+The donor pool for a placebo
+----------------------------
+
+``allsynth`` documents "i and the remaining untreated units collectively
+constituting the donor pool for each j", so under the permutation the treated
+unit is itself a control. ``placebo_donor_pool="permutation"`` follows that and
+is the default. It has two consequences. The placebo path becomes a property of
+the pair ``(i, j)`` rather than of the cohort, so the cost is the number of
+treated units times the pool size. And under the alternative, ``i``'s
+post-treatment outcomes carry the effect being tested, so any weight the placebo
+puts on ``i`` pulls the placebo gap away from zero and widens the null
+distribution. That is the stacked-case power loss Zhang (2019, section 3.1)
+describes: as the number of treated units grows, genuinely treated units enter
+the null distribution more and more often, moving it away from the null it is
+meant to represent.
+
+``placebo_donor_pool="donors-only"`` drops the treated unit. Every unit in a
+cohort then faces the same design and the same targets, so one solve per
+``(cohort, donor)`` serves the whole cohort, which on the Walmart panel is 6 x
+39 rather than 566 x 39.
+
+What is reused rather than refitted
+-----------------------------------
+
+The predictor weights ``V`` are taken from the cohort's own fit rather than
+recomputed for each placebo. Recomputing them would mean one regression per
+placebo and would change the design matrix the placebos are compared on; holding
+``V`` fixed keeps every path in the permutation set on the same scale as the
+estimate.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+from scipy.stats import norm
+
+from ...exceptions import MlsynthDataError
+from ..bilevel import bias_corrected_gaps, simplex_lstsq
+from .structures import StackedPlacebo
+
+__all__ = ["cohort_placebo_paths", "sample_placebo_averages",
+           "placebo_inference"]
+
+_EPS = 1e-12
+
+
+def cohort_placebo_paths(
+    cohort,
+    A: np.ndarray,
+    B: np.ndarray,
+    take: np.ndarray,
+    allowed: Sequence[Sequence[int]],
+    *,
+    donor_pool: str = "permutation",
+    bias_correct: bool = False,
+    ridge: float = 1e-2,
+) -> Tuple[Dict[str, np.ndarray], int]:
+    """Placebo gap paths for one cohort, one row per donor in each unit's pool.
+
+    Parameters
+    ----------
+    cohort : Cohort
+        The cohort, supplying the outcome blocks the gaps are formed on.
+    A, B : np.ndarray
+        Donor and treated design blocks from :func:`..pipeline._design` -- the
+        pre-treatment outcome paths without predictors, the ``sqrt(V)``-scaled
+        predictor blocks with them.
+    take : np.ndarray
+        Boolean row mask selecting the reported event-time horizons.
+    allowed : sequence of sequence of int
+        Donor column indices available to each treated unit, in the column
+        order of ``A``. Equal to every donor unless a donor predicate binds.
+    donor_pool : {"permutation", "donors-only"}
+        Whether the treated unit joins each placebo's donor pool.
+    bias_correct, ridge
+        Apply the Abadie-L'Hour correction to the placebo gaps as well, so the
+        permutation distribution matches the estimator it is compared against.
+
+    Returns
+    -------
+    (dict, int)
+        ``{unit id as str: (n_allowed, n_horizons)}`` and the number of simplex
+        programs actually solved.
+    """
+    Y, D, X1, X0 = cohort.Y, cohort.D, cohort.X1, cohort.X0
+    shared: Dict[Any, np.ndarray] = {}
+    paths: Dict[str, np.ndarray] = {}
+    n_fits = 0
+
+    for i, unit in enumerate(cohort.units):
+        idx = list(allowed[i])
+        if len(idx) < 2:
+            raise MlsynthDataError(
+                f"treated unit {unit!r} has {len(idx)} donor(s) available, so "
+                f"no placebo can be formed: casting a donor as treated leaves "
+                f"nothing to fit it against. Placebo inference needs at least "
+                f"two donors per treated unit.")
+        rows: List[np.ndarray] = []
+        for j in idx:
+            keep = [k for k in idx if k != j]
+            key = (tuple(keep), j) if donor_pool == "donors-only" else None
+            if key is not None and key in shared:
+                rows.append(shared[key])
+                continue
+            if donor_pool == "donors-only":
+                A_pool, Y_pool = A[:, keep], D[:, keep]
+                X_pool = None if X0 is None else X0[:, keep]
+            else:
+                A_pool = np.column_stack([A[:, keep], B[:, i]])
+                Y_pool = np.column_stack([D[:, keep], Y[:, i]])
+                X_pool = (None if X0 is None
+                          else np.column_stack([X0[:, keep], X1[:, i]]))
+            w = np.asarray(simplex_lstsq(A_pool, A[:, j]), dtype=float).ravel()
+            gap = D[:, j] - Y_pool @ w
+            if bias_correct and X_pool is not None:
+                gap = bias_corrected_gaps(w, X0[:, j], X_pool, D[:, j], Y_pool,
+                                          ridge=ridge)
+            n_fits += 1
+            g = gap[take]
+            if key is not None:
+                shared[key] = g
+            rows.append(g)
+        paths[str(unit)] = np.vstack(rows)
+    return paths, n_fits
+
+
+def sample_placebo_averages(
+    paths: Dict[str, np.ndarray],
+    units: Sequence[Any],
+    gammas: np.ndarray,
+    n_samples: int,
+    rng: np.random.Generator,
+) -> np.ndarray:
+    """``(n_samples, n_horizons)`` placebo averages.
+
+    Each row draws one placebo path per treated unit, independently and
+    uniformly from that unit's own pool, and averages them under the estimate's
+    aggregation weights.
+    """
+    first = paths[str(units[0])]
+    out = np.zeros((n_samples, first.shape[1]))
+    for unit, gamma in zip(units, gammas):
+        P = paths[str(unit)]
+        out += gamma * P[rng.integers(0, P.shape[0], size=n_samples)]
+    return out
+
+
+def _rmspe(grid: np.ndarray, tau: np.ndarray, placebo: np.ndarray
+           ) -> Tuple[Dict[int, float], Dict[int, float]]:
+    """RMSPE ratios for the estimate and RMSPE-ranked p-values, by horizon.
+
+    The denominator is the mean squared pre-treatment gap. Under the base-period
+    indexing the gap at ``e = -1`` is identically zero, so a pre-window of that
+    single period gives ``0 / 0``; the ratios are then undefined and reported as
+    NaN rather than as a rank.
+    """
+    pre, post = grid < 0, grid >= 0
+    S = placebo.shape[0]
+    actual: Dict[int, float] = {}
+    pvals: Dict[int, float] = {}
+
+    denom0 = float(np.mean(tau[pre] ** 2)) if pre.any() else np.nan
+    denoms = (np.mean(placebo[:, pre] ** 2, axis=1) if pre.any()
+              else np.full(S, np.nan))
+    degenerate = ~np.isfinite(denoms) | (denoms <= _EPS)
+
+    for E in grid[post]:
+        window = post & (grid <= E)
+        num0 = float(np.mean(tau[window] ** 2))
+        if not np.isfinite(denom0) or denom0 <= _EPS:
+            actual[int(E)] = float("nan")
+            pvals[int(E)] = float("nan")
+            continue
+        stat0 = num0 / denom0
+        nums = np.mean(placebo[:, window] ** 2, axis=1)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            stats = nums / denoms
+        # A placebo that reproduces its pre-window exactly has a zero
+        # denominator. Its ratio is the limit rather than a value to discard:
+        # unbounded if it has any post-treatment gap, and zero if it fits
+        # everywhere. Dropping such rows instead would shrink p_E, since the
+        # denominator below stays S + 1 either way.
+        stats = np.where(degenerate,
+                         np.where(nums > _EPS, np.inf, 0.0), stats)
+        actual[int(E)] = stat0
+        # allsynth's two-sided form: the share of the S sampled averages that
+        # reach the estimate's ratio, over S + 1. The estimate itself is not
+        # counted in the numerator, so a p-value of exactly zero is attainable.
+        pvals[int(E)] = float(np.sum(stats >= stat0) / (S + 1))
+    return actual, pvals
+
+
+def _two_sided(estimate: np.ndarray, se: np.ndarray) -> np.ndarray:
+    """Normal two-sided p-value, NaN where the placebo spread is degenerate."""
+    est, s = np.atleast_1d(estimate), np.atleast_1d(se)
+    out = np.full(est.shape, np.nan)
+    ok = np.isfinite(s) & (s > _EPS)
+    out[ok] = 2.0 * norm.sf(np.abs(est[ok]) / s[ok])
+    return out
+
+
+def placebo_inference(
+    cohorts,
+    designs: Sequence[Tuple[np.ndarray, np.ndarray]],
+    allowed: Sequence[Sequence[Sequence[int]]],
+    grid: np.ndarray,
+    tau: np.ndarray,
+    gamma_of: Dict[Any, float],
+    config,
+) -> StackedPlacebo:
+    """Run the whole placebo procedure and package the two sets of statistics.
+
+    ``designs`` and ``allowed`` are the per-cohort design blocks and per-unit
+    donor index lists the point estimate was fitted from, so the permutation is
+    over exactly the pools the estimate used.
+    """
+    paths: Dict[str, np.ndarray] = {}
+    units: List[Any] = []
+    n_fits = 0
+    for cohort, (A, B), allow in zip(cohorts, designs, allowed):
+        e_all = np.arange(cohort.Y.shape[0]) - cohort.t0_index - 1
+        take = np.isin(e_all, grid)
+        block, fits = cohort_placebo_paths(
+            cohort, A, B, take, allow,
+            donor_pool=config.placebo_donor_pool,
+            bias_correct=config.bias_correct,
+            ridge=config.bias_correct_ridge,
+        )
+        paths.update(block)
+        units.extend(cohort.units)
+        n_fits += fits
+
+    rng = np.random.default_rng(config.seed)
+    gammas = np.array([gamma_of[u] for u in units], dtype=float)
+    placebo = sample_placebo_averages(paths, units, gammas,
+                                      int(config.n_placebo_samples), rng)
+
+    # Equation (4): the placebo variance is the population variance of the
+    # sampled averages, so ddof = 0.
+    se = placebo.std(axis=0, ddof=0)
+    z = float(norm.ppf(1.0 - config.alpha / 2.0))
+    rmspe_actual, rmspe_p = _rmspe(grid, tau, placebo)
+
+    post = grid >= 0
+    att = float(np.mean(tau[post])) if post.any() else float("nan")
+    att_draws = (placebo[:, post].mean(axis=1) if post.any()
+                 else np.full(placebo.shape[0], np.nan))
+    att_se = float(np.std(att_draws, ddof=0))
+    att_p = float(_two_sided(np.array([att]), np.array([att_se]))[0])
+
+    return StackedPlacebo(
+        horizons=grid, n_samples=int(config.n_placebo_samples), n_fits=n_fits,
+        donor_pool=config.placebo_donor_pool,
+        placebo_averages=placebo, paths=paths,
+        se=se, ci_lower=tau - z * se, ci_upper=tau + z * se,
+        p_variance=_two_sided(tau, se),
+        rmspe_actual=rmspe_actual, rmspe_p=rmspe_p,
+        att_se=att_se, att_p_value=att_p,
+        att_ci_lower=att - z * att_se, att_ci_upper=att + z * att_se,
+        confidence_level=float(1.0 - config.alpha),
+    )

--- a/mlsynth/utils/stackedsc_helpers/pipeline.py
+++ b/mlsynth/utils/stackedsc_helpers/pipeline.py
@@ -1,0 +1,174 @@
+"""The stacked-in-event-time fit: solve per cohort, average on the event clock.
+
+Every treated unit in a cohort faces the same donor block and differs only in
+its own pre-treatment target, so a cohort is one multiple-right-hand-side
+program rather than N_g programs -- see
+:func:`mlsynth.utils.bilevel.simplex.simplex_lstsq_batch`. The exception is a
+donor predicate that actually binds: it gives each treated unit its own design
+matrix, and the batching is forfeited. That is reported rather than hidden.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from ...config_models import (
+    BaseEstimatorResults,
+    EffectsResults,
+    FitDiagnosticsResults,
+    MethodDetailsResults,
+    TimeSeriesResults,
+    WeightsResults,
+)
+from ..bilevel import (bias_corrected_gaps, regression_v, simplex_lstsq,
+                       simplex_lstsq_batch)
+from .setup import aggregation_weights, build_cohorts, event_window
+from .structures import (STACKEDSCResults, StackedDesign,
+                         StackedEventStudy, StackedUnitFit)
+
+_EPS = 1e-12
+
+
+def _resolve_backend(backend: str, has_cov: bool) -> str:
+    if backend != "auto":
+        return backend
+    return "regression" if has_cov else "outcome-only"
+
+
+def _design(cohort, backend: str):
+    """The matrices the weights are solved against, and the V that scales them.
+
+    Outcome-only matching uses the pre-treatment path. With predictors, the
+    columns are scaled by sqrt(V) so the lower-level problem is the ordinary
+    least-squares one -- the same device the bilevel backends use.
+    """
+    t0 = cohort.t0_index
+    if backend == "outcome-only" or cohort.X0 is None:
+        return cohort.D[:t0 + 1], cohort.Y[:t0 + 1], None
+    if backend == "regression":
+        V = regression_v(cohort.X1[:, 0], cohort.X0,
+                         cohort.Y[:t0 + 1, 0], cohort.D[:t0 + 1])
+    else:
+        V = np.full(cohort.X0.shape[0], 1.0 / cohort.X0.shape[0])
+    root = np.sqrt(V)[:, None]
+    return cohort.X0 * root, cohort.X1 * root, V
+
+
+def _weights_for_cohort(cohort, backend, predicate):
+    """(n_donors, n_units) weights. Batched unless a predicate binds."""
+    A, B, V = _design(cohort, backend)
+    if predicate is None:
+        return simplex_lstsq_batch(A, B), V, True
+
+    cols = []
+    binds = False
+    for j, unit in enumerate(cohort.units):
+        keep = [k for k, d in enumerate(cohort.donors) if predicate(unit, d)]
+        if not keep:
+            raise ValueError(
+                f"donor_predicate excludes every donor for treated unit "
+                f"{unit!r}.")
+        binds |= len(keep) < len(cohort.donors)
+        w = np.zeros(len(cohort.donors))
+        w[keep] = simplex_lstsq(A[:, keep], B[:, j])
+        cols.append(w)
+    return np.column_stack(cols), V, not binds
+
+
+def run_stackedsc(config) -> BaseEstimatorResults:
+    df = config.df
+    unitid, time = config.unitid, config.time
+    outcome, treat = config.outcome, config.treat
+
+    cohorts, donors = build_cohorts(
+        df, unitid, time, outcome, treat,
+        normalize=config.normalize, covariates=config.covariates,
+        covariate_windows=config.covariate_windows,
+    )
+    backend = _resolve_backend(config.backend, bool(config.covariates))
+    grid = event_window(cohorts, config.n_lags, config.n_leads)
+
+    all_units = [u for c in cohorts for u in c.units]
+    gammas = aggregation_weights(df, unitid, config.agg_weights, all_units)
+    gamma_of = dict(zip(all_units, gammas))
+
+    per_unit: Dict[str, StackedUnitFit] = {}
+    batched = True
+    for cohort in cohorts:
+        W, _V, was_batched = _weights_for_cohort(cohort, backend,
+                                                 config.donor_predicate)
+        batched &= was_batched
+        gap = cohort.Y - cohort.D @ W                      # (T, n_units)
+        if config.bias_correct:
+            for j in range(len(cohort.units)):
+                gap[:, j] = bias_corrected_gaps(
+                    W[:, j], cohort.X1[:, j], cohort.X0,
+                    cohort.Y[:, j], cohort.D,
+                    ridge=config.bias_correct_ridge)
+        e_all = np.arange(cohort.Y.shape[0]) - cohort.t0_index - 1
+        take = np.isin(e_all, grid)
+        for j, unit in enumerate(cohort.units):
+            g = gap[take, j]
+            pre = grid < 0
+            per_unit[str(unit)] = StackedUnitFit(
+                label=unit, adoption_time=cohort.adopt,
+                base_period=cohort.base_period, horizons=grid, tau=g,
+                donor_weights={str(d): float(W[k, j])
+                               for k, d in enumerate(cohort.donors)
+                               if abs(W[k, j]) > 1e-10},
+                agg_weight=float(gamma_of[unit]),
+                pre_rmse=float(np.sqrt(np.mean(g[pre] ** 2))) if pre.any()
+                else float("nan"),
+            )
+
+    G = np.column_stack([per_unit[str(u)].tau for u in all_units])
+    w = np.array([gamma_of[u] for u in all_units])
+    tau = G @ w
+    event = StackedEventStudy(horizons=grid, tau=tau,
+                              n_units=np.full(len(grid), len(all_units)))
+
+    post = grid >= 0
+    att = float(np.mean(tau[post])) if post.any() else float("nan")
+    design = StackedDesign(
+        cohorts=[c.adopt for c in cohorts], n_treated=len(all_units),
+        n_donors=len(donors), backend=backend, normalized=config.normalize,
+        bias_corrected=config.bias_correct, batched=batched,
+    )
+
+    pooled: Dict[str, float] = {}
+    for u in all_units:
+        f = per_unit[str(u)]
+        for d, v in f.donor_weights.items():
+            pooled[d] = pooled.get(d, 0.0) + f.agg_weight * v
+
+    return STACKEDSCResults(
+        effects=EffectsResults(att=att, additional_effects={
+            "event_study": {int(e): float(t) for e, t in zip(grid, tau)}}),
+        fit_diagnostics=FitDiagnosticsResults(
+            rmse_pre=float(np.sqrt(np.mean(tau[grid < 0] ** 2)))
+            if (grid < 0).any() else None),
+        time_series=TimeSeriesResults(
+            estimated_gap=tau, time_periods=grid,
+            intervention_time=0),
+        weights=WeightsResults(
+            donor_weights=pooled,
+            summary_stats={"constraint": "simplex (non-negative, sum to 1)",
+                           "aggregation": "gamma-weighted over treated units"}),
+        method_details=MethodDetailsResults(
+            method_name=f"STACKEDSC[{backend}]",
+            parameters_used={
+                "agg_weights": config.agg_weights,
+                "normalize": config.normalize,
+                "backend": backend,
+                "bias_correct": config.bias_correct,
+                "bias_correct_ridge": (float(config.bias_correct_ridge)
+                                       if config.bias_correct else None),
+                "covariates": config.covariates,
+                "batched": batched,
+                "cohorts": [c.adopt for c in cohorts],
+            }),
+        additional_outputs={"donor_names": donors},
+        per_unit=per_unit, event_study=event, design=design,
+    )

--- a/mlsynth/utils/stackedsc_helpers/pipeline.py
+++ b/mlsynth/utils/stackedsc_helpers/pipeline.py
@@ -18,12 +18,14 @@ from ...config_models import (
     BaseEstimatorResults,
     EffectsResults,
     FitDiagnosticsResults,
+    InferenceResults,
     MethodDetailsResults,
     TimeSeriesResults,
     WeightsResults,
 )
 from ..bilevel import (bias_corrected_gaps, regression_v, simplex_lstsq,
                        simplex_lstsq_batch)
+from .inference import placebo_inference
 from .plotter import plot_stackedsc
 from .setup import aggregation_weights, build_cohorts, event_window
 from .structures import (STACKEDSCResults, StackedDesign,
@@ -57,25 +59,35 @@ def _design(cohort, backend: str):
     return cohort.X0 * root, cohort.X1 * root, V
 
 
-def _weights_for_cohort(cohort, backend, predicate):
-    """(n_donors, n_units) weights. Batched unless a predicate binds."""
-    A, B, V = _design(cohort, backend)
+def _allowed_donors(cohort, predicate):
+    """Donor column indices available to each treated unit, and whether the
+    predicate actually removes any."""
+    full = list(range(len(cohort.donors)))
     if predicate is None:
-        return simplex_lstsq_batch(A, B), V, True
-
-    cols = []
-    binds = False
-    for j, unit in enumerate(cohort.units):
+        return [full] * len(cohort.units), False
+    allowed, binds = [], False
+    for unit in cohort.units:
         keep = [k for k, d in enumerate(cohort.donors) if predicate(unit, d)]
         if not keep:
             raise ValueError(
                 f"donor_predicate excludes every donor for treated unit "
                 f"{unit!r}.")
-        binds |= len(keep) < len(cohort.donors)
+        binds |= len(keep) < len(full)
+        allowed.append(keep)
+    return allowed, binds
+
+
+def _weights_for_cohort(cohort, A, B, allowed, binds):
+    """(n_donors, n_units) weights. Batched unless the predicate binds."""
+    if not binds:
+        return simplex_lstsq_batch(A, B), True
+
+    cols = []
+    for j, keep in enumerate(allowed):
         w = np.zeros(len(cohort.donors))
         w[keep] = simplex_lstsq(A[:, keep], B[:, j])
         cols.append(w)
-    return np.column_stack(cols), V, not binds
+    return np.column_stack(cols), False
 
 
 def run_stackedsc(config) -> BaseEstimatorResults:
@@ -97,9 +109,13 @@ def run_stackedsc(config) -> BaseEstimatorResults:
 
     per_unit: Dict[str, StackedUnitFit] = {}
     batched = True
+    designs, pools = [], []
     for cohort in cohorts:
-        W, _V, was_batched = _weights_for_cohort(cohort, backend,
-                                                 config.donor_predicate)
+        A, B, _V = _design(cohort, backend)
+        allowed, binds = _allowed_donors(cohort, config.donor_predicate)
+        designs.append((A, B))
+        pools.append(allowed)
+        W, was_batched = _weights_for_cohort(cohort, A, B, allowed, binds)
         batched &= was_batched
         gap = cohort.Y - cohort.D @ W                      # (T, n_units)
         if config.bias_correct:
@@ -144,6 +160,20 @@ def run_stackedsc(config) -> BaseEstimatorResults:
         for d, v in f.donor_weights.items():
             pooled[d] = pooled.get(d, 0.0) + f.agg_weight * v
 
+    placebo = None
+    inference = InferenceResults()
+    if config.inference == "placebo":
+        placebo = placebo_inference(cohorts, designs, pools, grid, tau,
+                                    gamma_of, config)
+        inference = InferenceResults(
+            p_value=placebo.att_p_value,
+            ci_lower=placebo.att_ci_lower, ci_upper=placebo.att_ci_upper,
+            standard_error=placebo.att_se,
+            confidence_level=placebo.confidence_level,
+            method="placebo (sampled placebo averages)",
+            details=placebo,
+        )
+
     results = STACKEDSCResults(
         effects=EffectsResults(att=att, additional_effects={
             "event_study": {int(e): float(t) for e, t in zip(grid, tau)}}),
@@ -169,9 +199,15 @@ def run_stackedsc(config) -> BaseEstimatorResults:
                 "covariates": config.covariates,
                 "batched": batched,
                 "cohorts": [c.adopt for c in cohorts],
+                "inference": config.inference,
+                "placebo_donor_pool": config.placebo_donor_pool,
+                "n_placebo_samples": (int(config.n_placebo_samples)
+                                      if config.inference == "placebo"
+                                      else None),
             }),
+        inference=inference,
         additional_outputs={"donor_names": donors},
-        per_unit=per_unit, event_study=event, design=design,
+        per_unit=per_unit, event_study=event, design=design, placebo=placebo,
     )
     if config.display_graphs or config.save:
         plot_stackedsc(results, save=config.save)

--- a/mlsynth/utils/stackedsc_helpers/pipeline.py
+++ b/mlsynth/utils/stackedsc_helpers/pipeline.py
@@ -24,6 +24,7 @@ from ...config_models import (
 )
 from ..bilevel import (bias_corrected_gaps, regression_v, simplex_lstsq,
                        simplex_lstsq_batch)
+from .plotter import plot_stackedsc
 from .setup import aggregation_weights, build_cohorts, event_window
 from .structures import (STACKEDSCResults, StackedDesign,
                          StackedEventStudy, StackedUnitFit)
@@ -143,7 +144,7 @@ def run_stackedsc(config) -> BaseEstimatorResults:
         for d, v in f.donor_weights.items():
             pooled[d] = pooled.get(d, 0.0) + f.agg_weight * v
 
-    return STACKEDSCResults(
+    results = STACKEDSCResults(
         effects=EffectsResults(att=att, additional_effects={
             "event_study": {int(e): float(t) for e, t in zip(grid, tau)}}),
         fit_diagnostics=FitDiagnosticsResults(
@@ -172,3 +173,6 @@ def run_stackedsc(config) -> BaseEstimatorResults:
         additional_outputs={"donor_names": donors},
         per_unit=per_unit, event_study=event, design=design,
     )
+    if config.display_graphs or config.save:
+        plot_stackedsc(results, save=config.save)
+    return results

--- a/mlsynth/utils/stackedsc_helpers/plotter.py
+++ b/mlsynth/utils/stackedsc_helpers/plotter.py
@@ -1,0 +1,79 @@
+"""Plotting helper for STACKEDSC: the stacked event study.
+
+The per-unit paths are drawn behind the aggregate rather than omitted. With a
+donor pool small relative to the pre-window the individual weight vectors are
+not identified even where their weighted mean is, so the spread is a property
+of the design worth seeing, not clutter to hide.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+
+from ..plotting import mlsynth_style
+from .structures import STACKEDSCResults
+
+
+def plot_stackedsc(
+    results: STACKEDSCResults,
+    title: str = "Stacked-in-event-time synthetic control",
+    save: Union[bool, str, dict] = False,
+    show_units: bool = True,
+    max_units: int = 200,
+) -> None:
+    """Render the weighted event-time effect path.
+
+    Parameters
+    ----------
+    results : STACKEDSCResults
+        A fitted result.
+    title : str
+        Figure title.
+    save : bool or str or dict
+        Falsy to skip saving; a string is used as the filename.
+    show_units : bool
+        Draw the per-unit paths behind the aggregate.
+    max_units : int
+        Cap on how many per-unit paths are drawn, so a panel with hundreds of
+        treated units stays legible. The cap is stated in the legend rather
+        than applied silently.
+    """
+    import matplotlib.pyplot as plt
+
+    es = results.event_study
+    e = np.asarray(es.horizons, float)
+    tau = np.asarray(es.tau, float)
+    units = list(results.per_unit.values())
+    unit_label = ("percent of base level" if results.design.normalized
+                  else "outcome units")
+
+    with mlsynth_style():
+        fig, ax = plt.subplots(figsize=(7.5, 5))
+        if show_units and units:
+            drawn = units[:max_units]
+            for k, u in enumerate(drawn):
+                ax.plot(np.asarray(u.horizons, float),
+                        np.asarray(u.tau, float),
+                        color="#9aa5b1", linewidth=0.6, alpha=0.35,
+                        zorder=1,
+                        label=(f"per treated unit "
+                               f"({len(drawn)} of {len(units)} shown)"
+                               if k == 0 else None))
+        ax.plot(e, tau, marker="o", color="#1428A0", linewidth=2.0, zorder=3,
+                label=(f"weighted mean (ATT "
+                       f"{results.effects.att:.3f})"))
+        ax.axhline(0.0, color="black", linewidth=0.8, linestyle="--")
+        # The intervention lands between e = -1 and e = 0, so the rule goes
+        # between them rather than on a period that is itself observed.
+        ax.axvline(-0.5, color="grey", linewidth=1.0, linestyle=":")
+        ax.set_xlabel("Event time $e$")
+        ax.set_ylabel(rf"$\widehat{{\tau}}_e$  ({unit_label})")
+        ax.set_title(title)
+        ax.legend(frameon=False)
+        fig.tight_layout()
+        if save:
+            fname = save if isinstance(save, str) else "stackedsc_event_study.png"
+            fig.savefig(fname, dpi=150, bbox_inches="tight")
+    plt.show()

--- a/mlsynth/utils/stackedsc_helpers/plotter.py
+++ b/mlsynth/utils/stackedsc_helpers/plotter.py
@@ -1,9 +1,8 @@
 """Plotting helper for STACKEDSC: the stacked event study.
 
-The per-unit paths are drawn behind the aggregate rather than omitted. With a
-donor pool small relative to the pre-window the individual weight vectors are
-not identified even where their weighted mean is, so the spread is a property
-of the design worth seeing, not clutter to hide.
+With a donor pool small relative to the pre-window the individual weight
+vectors are not identified even where their weighted mean is. The per-unit
+paths are drawn behind the aggregate so that the resulting spread is visible.
 """
 
 from __future__ import annotations
@@ -22,6 +21,7 @@ def plot_stackedsc(
     save: Union[bool, str, dict] = False,
     show_units: bool = True,
     max_units: int = 200,
+    max_placebos: int = 200,
 ) -> None:
     """Render the weighted event-time effect path.
 
@@ -39,6 +39,10 @@ def plot_stackedsc(
         Cap on how many per-unit paths are drawn, so a panel with hundreds of
         treated units stays legible. The cap is stated in the legend rather
         than applied silently.
+    max_placebos : int
+        Cap on how many sampled placebo averages are drawn when
+        ``results.placebo`` is populated. The placebo-variance interval is
+        drawn from all ``S`` of them regardless of this cap.
     """
     import matplotlib.pyplot as plt
 
@@ -46,11 +50,25 @@ def plot_stackedsc(
     e = np.asarray(es.horizons, float)
     tau = np.asarray(es.tau, float)
     units = list(results.per_unit.values())
+    pb = results.placebo
     unit_label = ("percent of base level" if results.design.normalized
                   else "outcome units")
 
     with mlsynth_style():
         fig, ax = plt.subplots(figsize=(7.5, 5))
+        if pb is not None:
+            P = np.asarray(pb.placebo_averages, float)[:max_placebos]
+            for k, row in enumerate(P):
+                ax.plot(e, row, color="#c8b6a6", linewidth=0.5, alpha=0.30,
+                        zorder=0,
+                        label=(f"sampled placebo averages "
+                               f"({len(P)} of {pb.n_samples} shown)"
+                               if k == 0 else None))
+            ax.fill_between(e, np.asarray(pb.ci_lower, float),
+                            np.asarray(pb.ci_upper, float),
+                            color="#1428A0", alpha=0.13, zorder=2,
+                            label=(f"{100 * pb.confidence_level:.0f}% "
+                                   f"placebo-variance interval"))
         if show_units and units:
             drawn = units[:max_units]
             for k, u in enumerate(drawn):
@@ -61,9 +79,10 @@ def plot_stackedsc(
                         label=(f"per treated unit "
                                f"({len(drawn)} of {len(units)} shown)"
                                if k == 0 else None))
+        headline = f"weighted mean (ATT {results.effects.att:.3f}"
+        headline += (f", p = {pb.att_p_value:.3f})" if pb is not None else ")")
         ax.plot(e, tau, marker="o", color="#1428A0", linewidth=2.0, zorder=3,
-                label=(f"weighted mean (ATT "
-                       f"{results.effects.att:.3f})"))
+                label=headline)
         ax.axhline(0.0, color="black", linewidth=0.8, linestyle="--")
         # The intervention lands between e = -1 and e = 0, so the rule goes
         # between them rather than on a period that is itself observed.

--- a/mlsynth/utils/stackedsc_helpers/setup.py
+++ b/mlsynth/utils/stackedsc_helpers/setup.py
@@ -1,0 +1,195 @@
+"""Ingestion for STACKEDSC: cohorts, donors, and the base-period indexing.
+
+Ingestion goes through :func:`mlsynth.utils.datautils.dataprep`, which already
+returns a staggered panel split by adoption time -- exactly the grouping this
+estimator needs, since the base period ``T0i`` is a property of the cohort
+rather than of the unit.
+
+That last point is what makes the design batchable. ``normalize`` indexes the
+treated unit *and every donor* to 100 at ``T0i``, so donors take one normalised
+form per cohort, not one per treated unit. Six cohorts on the Walmart panel
+means six donor blocks for 566 treated units.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from ...exceptions import MlsynthDataError
+
+_EPS = 1e-12
+
+
+class Cohort:
+    """One adoption time: a shared donor block and the units that face it."""
+
+    __slots__ = ("adopt", "base_period", "units", "donors", "Y", "D",
+                 "X1", "X0", "pred_names", "t0_index")
+
+    def __init__(self, adopt, base_period, units, donors, Y, D, t0_index,
+                 X1=None, X0=None, pred_names=None):
+        self.adopt = adopt
+        self.base_period = base_period
+        self.units = units          # treated ids, in column order of Y
+        self.donors = donors        # donor ids, in column order of D
+        self.Y = Y                  # (T, n_units)
+        self.D = D                  # (T, n_donors)
+        self.t0_index = t0_index    # row index of base_period
+        self.X1 = X1                # (K, n_units) or None
+        self.X0 = X0                # (K, n_donors) or None
+        self.pred_names = pred_names or []
+
+
+def adoption_times(df: pd.DataFrame, unitid: str, time: str,
+                   treat: str) -> Dict[Any, Any]:
+    """First treated period per unit; absent for never-treated units."""
+    treated_rows = df[df[treat] == 1]
+    if treated_rows.empty:
+        raise MlsynthDataError(
+            f"no rows have {treat} == 1, so there is nothing to estimate.")
+    return treated_rows.groupby(unitid)[time].min().to_dict()
+
+
+def aggregation_weights(df: pd.DataFrame, unitid: str, column: Optional[str],
+                        units: List[Any]) -> np.ndarray:
+    """Per-unit gamma_i, normalised to sum to one over the treated units.
+
+    The weight is a property of the unit, so a column that varies within one is
+    rejected rather than resolved by taking the first value -- there would be
+    no principled choice among the values it takes.
+    """
+    if column is None:
+        return np.full(len(units), 1.0 / max(len(units), 1))
+    if column not in df.columns:
+        raise MlsynthDataError(
+            f"agg_weights column {column!r} is not in the DataFrame.")
+    sub = df[df[unitid].isin(units)]
+    spread = sub.groupby(unitid)[column].nunique(dropna=False)
+    varying = spread[spread > 1].index.tolist()
+    if varying:
+        raise MlsynthDataError(
+            f"agg_weights column {column!r} varies within unit(s) "
+            f"{varying[:5]}; an aggregation weight must be constant per unit.")
+    w = sub.groupby(unitid)[column].first().reindex(units).to_numpy(float)
+    if not np.isfinite(w).all():
+        raise MlsynthDataError(
+            f"agg_weights column {column!r} has missing values for some "
+            f"treated units.")
+    if (w < 0).any():
+        raise MlsynthDataError(
+            f"agg_weights column {column!r} has negative values.")
+    total = w.sum()
+    if total <= _EPS:
+        raise MlsynthDataError(
+            f"agg_weights column {column!r} sums to zero over treated units.")
+    return w / total
+
+
+def _covariate_block(df, unitid, time, units, covariates, windows,
+                     base_period):
+    """(K, n_units) predictor means, averaged over each covariate's window."""
+    rows = []
+    for c in covariates:
+        lo, hi = (windows or {}).get(c, (None, base_period))
+        sub = df[df[unitid].isin(units)]
+        if lo is not None:
+            sub = sub[sub[time] >= lo]
+        if hi is not None:
+            sub = sub[sub[time] <= hi]
+        m = sub.groupby(unitid)[c].mean().reindex(units)
+        if m.isna().any():
+            missing = m[m.isna()].index.tolist()[:5]
+            raise MlsynthDataError(
+                f"covariate {c!r} has no observations in its window for "
+                f"unit(s) {missing}.")
+        rows.append(m.to_numpy(float))
+    return np.vstack(rows)
+
+
+def build_cohorts(df: pd.DataFrame, unitid: str, time: str, outcome: str,
+                  treat: str, *, normalize: bool = True,
+                  covariates: Optional[List[str]] = None,
+                  covariate_windows=None) -> Tuple[List[Cohort], List[Any]]:
+    """Split the panel into adoption cohorts with their donor blocks.
+
+    Returns the cohorts and the never-treated donor ids.
+    """
+    from ..datautils import dataprep  # local: keeps import cost off the module
+
+    adopt = adoption_times(df, unitid, time, treat)
+    donors = sorted(u for u in df[unitid].unique() if u not in adopt)
+    if not donors:
+        raise MlsynthDataError(
+            "no never-treated units: a stacked synthetic control needs a donor "
+            "pool that is never treated over the sample window.")
+
+    prep = dataprep(df, unitid, time, outcome, treat)
+    periods = np.asarray(prep["time_labels"])
+    wide = df.pivot(index=time, columns=unitid, values=outcome).reindex(
+        periods)
+
+    # dataprep returns a `cohorts` mapping for a staggered panel, but flattens
+    # to top-level keys when there is exactly one treated unit. Normalise the
+    # two shapes here so the rest of the estimator sees one thing.
+    specs = prep.get("cohorts")
+    if specs is None:
+        only = prep["treated_unit_name"]
+        specs = {adopt[only]: {"treated_units": [only],
+                               "pre_periods": prep["pre_periods"]}}
+
+    cohorts: List[Cohort] = []
+    for g, spec in sorted(specs.items()):
+        units = list(spec["treated_units"])
+        t0 = int(spec["pre_periods"]) - 1          # index of T0i
+        if t0 < 0:
+            raise MlsynthDataError(
+                f"cohort adopting at {g} has no pre-treatment period.")
+        base_period = periods[t0]
+        Y = wide[units].to_numpy(float)
+        D = wide[donors].to_numpy(float)
+        if normalize:
+            by, bd = Y[t0].copy(), D[t0].copy()
+            if (np.abs(by) < _EPS).any() or (np.abs(bd) < _EPS).any():
+                raise MlsynthDataError(
+                    f"cohort adopting at {g} has a zero outcome at its base "
+                    f"period {base_period}, so it cannot be indexed to it; "
+                    f"pass normalize=False or shift the outcome.")
+            Y, D = 100.0 * Y / by, 100.0 * D / bd
+        X1 = X0 = None
+        names: List[str] = []
+        if covariates:
+            X1 = _covariate_block(df, unitid, time, units, covariates,
+                                  covariate_windows, base_period)
+            X0 = _covariate_block(df, unitid, time, donors, covariates,
+                                  covariate_windows, base_period)
+            names = list(covariates)
+        cohorts.append(Cohort(g, base_period, units, donors, Y, D, t0,
+                              X1, X0, names))
+    return cohorts, donors
+
+
+def event_window(cohorts: List[Cohort], n_lags: Optional[int],
+                 n_leads: Optional[int]) -> np.ndarray:
+    """The event-time grid every cohort can supply, unless overridden.
+
+    Defaulting to the common window is the reference implementation's
+    ``balanced``: reporting a horizon only some cohorts reach would make the
+    average change composition along the x-axis.
+    """
+    # e = row - t0_index - 1, so the base period sits at e = -1 and the first
+    # treated period at e = 0. Both ends take the *tightest* cohort, since a
+    # horizon only some cohorts reach would change the average's composition
+    # along the x-axis.
+    lo = max(-c.t0_index - 1 for c in cohorts)
+    hi = min(c.Y.shape[0] - c.t0_index - 2 for c in cohorts)
+    if n_lags is not None:
+        lo = max(lo, -int(n_lags))
+    if n_leads is not None:
+        hi = min(hi, int(n_leads) - 1)
+    if hi < 0:
+        raise MlsynthDataError(
+            "no post-treatment period is observed for every cohort.")
+    return np.arange(lo, hi + 1)

--- a/mlsynth/utils/stackedsc_helpers/structures.py
+++ b/mlsynth/utils/stackedsc_helpers/structures.py
@@ -63,6 +63,57 @@ class StackedDesign(BaseModel):
             "each treated unit its own design matrix."))
 
 
+class StackedPlacebo(BaseModel):
+    """The permutation distribution and the two statistics read off it.
+
+    ``paths`` holds every placebo gap path, one block per treated unit with a
+    row per donor in that unit's pool; ``placebo_averages`` holds the ``S``
+    sampled averages built from them. Both are kept because the RMSPE ranking
+    and the variance interval are computed from the averages, while the
+    individual paths are what a reader plots behind the estimate.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    horizons: np.ndarray = Field(
+        ..., description="Event time e, matching the event study.")
+    n_samples: int = Field(..., description="S, placebo averages sampled.")
+    n_fits: int = Field(
+        ..., description="Simplex programs solved to build the placebo paths.")
+    donor_pool: str = Field(
+        ..., description="Whether the treated unit joined each placebo's pool.")
+    placebo_averages: np.ndarray = Field(
+        ..., description="(S, n_horizons) sampled placebo average gaps.")
+    paths: Dict[str, np.ndarray] = Field(
+        ..., description=(
+            "Placebo gap paths per treated unit, (n_donors, n_horizons), "
+            "keyed by treated unit id as a string."))
+    se: np.ndarray = Field(
+        ..., description="Placebo standard deviation at each horizon.")
+    ci_lower: np.ndarray = Field(
+        ..., description="Lower placebo-variance interval by horizon.")
+    ci_upper: np.ndarray = Field(
+        ..., description="Upper placebo-variance interval by horizon.")
+    p_variance: np.ndarray = Field(
+        ..., description=(
+            "Two-sided normal p-value by horizon, NaN where the placebo "
+            "spread is degenerate (as at e = -1, where every gap is zero)."))
+    rmspe_actual: Dict[int, float] = Field(
+        ..., description=(
+            "Post-over-pre mean squared gap ratio for the estimate, keyed by "
+            "the last post horizon E it runs through."))
+    rmspe_p: Dict[int, float] = Field(
+        ..., description="RMSPE-ranked p-value at each E.")
+    att_se: float = Field(
+        ..., description="Placebo standard deviation of the post-period ATT.")
+    att_p_value: float = Field(
+        ..., description="Two-sided placebo-variance p-value for the ATT.")
+    att_ci_lower: float = Field(..., description="Lower interval for the ATT.")
+    att_ci_upper: float = Field(..., description="Upper interval for the ATT.")
+    confidence_level: float = Field(
+        ..., description="1 - alpha, the interval's nominal coverage.")
+
+
 class STACKEDSCResults(BaseEstimatorResults):
     """What :meth:`mlsynth.STACKEDSC.fit` returns.
 
@@ -83,3 +134,8 @@ class STACKEDSCResults(BaseEstimatorResults):
     design: Optional[StackedDesign] = Field(
         default=None, description="What the fit did, as opposed to what was "
                                   "requested.")
+    placebo: Optional[StackedPlacebo] = Field(
+        default=None, description=(
+            "The sampled-placebo-average permutation distribution and its two "
+            "statistics. None unless `inference='placebo'` was requested; the "
+            "same object is also reachable as `inference.details`."))

--- a/mlsynth/utils/stackedsc_helpers/structures.py
+++ b/mlsynth/utils/stackedsc_helpers/structures.py
@@ -1,0 +1,85 @@
+"""Typed containers for STACKEDSC."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field
+
+from ...config_models import BaseEstimatorResults
+
+
+class StackedUnitFit(BaseModel):
+    """One treated unit's synthetic control, on its own event clock."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    label: Any = Field(..., description="Treated unit identifier.")
+    adoption_time: Any = Field(..., description="First treated period.")
+    base_period: Any = Field(
+        ..., description="T0i, the period the series are indexed to.")
+    horizons: np.ndarray = Field(
+        ..., description="Event time e, ascending, including negatives.")
+    tau: np.ndarray = Field(
+        ..., description="Gap at each horizon; percent of the base level when "
+                         "`normalize`, outcome units otherwise.")
+    donor_weights: Dict[str, float] = Field(
+        ..., description="Weight on each donor, summing to one.")
+    agg_weight: float = Field(
+        ..., description="This unit's share in the event-time average.")
+    pre_rmse: float = Field(
+        ..., description="Root mean squared gap over the reported pre-window.")
+
+
+class StackedEventStudy(BaseModel):
+    """The aggregate: a weighted average of the per-unit gaps."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    horizons: np.ndarray = Field(..., description="Event time e, ascending.")
+    tau: np.ndarray = Field(..., description="Weighted mean gap at each e.")
+    n_units: np.ndarray = Field(
+        ..., description="Treated units contributing at each e.")
+
+
+class StackedDesign(BaseModel):
+    """What the fit actually did, as opposed to what was asked for."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    cohorts: List[Any] = Field(..., description="Distinct adoption times.")
+    n_treated: int = Field(..., description="Treated units fitted.")
+    n_donors: int = Field(..., description="Never-treated donors available.")
+    backend: str = Field(..., description="Predictor-weight rule used.")
+    normalized: bool = Field(
+        ..., description="Whether series were indexed to the base period.")
+    bias_corrected: bool = Field(
+        ..., description="Whether the Abadie-L'Hour correction was applied.")
+    batched: bool = Field(
+        ..., description=(
+            "Whether each cohort was solved as one multiple-right-hand-side "
+            "program. False when a donor predicate binds, since that gives "
+            "each treated unit its own design matrix."))
+
+
+class STACKEDSCResults(BaseEstimatorResults):
+    """What :meth:`mlsynth.STACKEDSC.fit` returns.
+
+    The standardized sub-models carry the aggregate; the three fields below are
+    the estimator-specific outputs. ``per_unit`` matters more here than in most
+    estimators: the aggregate is a weighted mean of those paths, and with a
+    donor pool small relative to the pre-window the individual weight vectors
+    are not identified even where the average is.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    per_unit: Dict[str, StackedUnitFit] = Field(
+        default_factory=dict,
+        description="Per-treated-unit fits, keyed by unit id as a string.")
+    event_study: Optional[StackedEventStudy] = Field(
+        default=None, description="Weighted mean gap by event time.")
+    design: Optional[StackedDesign] = Field(
+        default=None, description="What the fit did, as opposed to what was "
+                                  "requested.")


### PR DESCRIPTION
## Related Links

- Closes #340
- Reads the panel added in #341
- Uses the regression-`V` backend (#335) and the batched simplex primitives (#339)
- Source: Wiltshire, J. C. (2023), "Walmart Supercenters and Monopsony Power", Section 4.2
- Reference implementation: `allsynth` (Stata), Wiltshire (2022)

## What

A new estimator, `STACKEDSC`, plus its placebo inference layer.

- `mlsynth/estimators/stackedsc.py`, exported from `mlsynth/__init__.py`
- `mlsynth/utils/stackedsc_helpers/{config,setup,pipeline,structures,plotter,inference}.py`
- `mlsynth/tests/test_stackedsc.py` and `test_stackedsc_inference.py` -- 71 tests
- `docs/stackedsc.rst`, `docs/replications/stackedsc.rst`, `docs/choose.rst` entry, both toctrees

One synthetic control per treated unit against a common never-treated donor pool, each fitted on series indexed to 100 at that unit's own final pre-treatment period, then averaged on a shared event clock under caller-supplied weights.

## Why

The indexing is not presentation. Rescaling unit `j` and every donor to `b_j` while requiring the weights to sum to one is algebraically the same as fitting on levels under the constraint that the synthetic control reproduce the treated unit's base-period level exactly. That is why the gap at `e = -1` is identically zero, and it is the sharpest available check that the base year is right -- `normalize=False` gives a level-scale estimator answering a different question.

The base period belongs to the cohort, not the unit. Units adopting together share `T0i`, so the indexed donor block takes one value per adoption time: six blocks for 566 treated counties, which is what makes each cohort a single multiple-right-hand-side program rather than `N_g` separate solves.

## How

`inference="placebo"` implements the paper's sampled-placebo-average procedure. For each treated unit `i` and donor `j`, refit with `j` cast as treated at `i`'s adoption time; a placebo average then draws one `j` per treated unit and averages under the same `gamma_i` the estimate uses. The number of distinct averages is the product of the pool sizes, so `S` are sampled (`n_placebo_samples`, default 1000, floor 30 as in the reference). Two statistics come off it: RMSPE-ranked p-values per post horizon, and placebo-variance intervals following Algorithm 4 of Arkhangelsky et al. (2021).

`placebo_donor_pool` chooses whether the treated unit joins each of its placebos' pools. The default `"permutation"` does, following the reference ("i and the remaining untreated units collectively constituting the donor pool for each j"). That makes the placebo path a property of the `(i, j)` pair rather than of the cohort, and it lets a placebo weight a genuinely treated unit -- the stacked-case power loss Zhang (2019, section 3.1) describes. `"donors-only"` drops it and recovers the per-cohort batching.

Inference is opt-in for the same reason `allsynth` makes `pvalues()` opt-in: the cost is treated units times pool size.

## Verification

Path A, partial, and the partiality is recorded rather than tuned away. The event-study shape reproduces -- pre-treatment fit within 0.07 percent, `+0.16` at entry, decline from `e = 2`. The point estimates do not, because Stata `synth`'s default predictor-weight rule ships as a compiled Mata library and two defensible readings of it move the five-year estimate by more than the estimate itself. `docs/replications/stackedsc.rst` states what would settle it. The benchmark case is deliberately not in this PR -- benchmark authoring is a separate workstream.

Measured while building the inference layer, and recorded because it bears on how the outputs should be read: individual placebo paths are not identified on this design (5-10 pre-periods against 39 donors), but the sampled averages are. Across two solvers the placebo SEs agree to 0.004pp and the ATT p-value to three significant figures, while individual paths move by up to 1.6pp. Read the distribution, not a path -- the same caution the page already gives for `per_unit`.

## Scope checks

- [x] One estimator, one branch, one scope: config, estimator class, helpers, tests, docs page, export, `choose.rst` entry. Nothing else.
- [x] Rides `dataprep` and the `EffectResult` contract; `test_result_contract.py` passes.
- [x] No shared helper changed. The `bilevel` primitives it uses landed on their own branches first (#335, #339).

## Test Steps

- [x] `pytest mlsynth/tests/` -- 6028 passed, 331 skipped, 0 failed (68 min)
- [x] `pytest mlsynth/tests/test_stackedsc.py mlsynth/tests/test_stackedsc_inference.py` -- 71 passed
- [x] 100 percent statement coverage of `mlsynth/utils/stackedsc_helpers/`
- [x] Both runnable examples on the docs page execute as written
- [x] RST underlines checked; no non-math bold in prose

## Other Notes

- A follow-up branch will cut the placebo layer's cost. Permutation mode is 22,074 simplex solves on the paper's panel, ~161 minutes measured; a leave-one-out batched primitive plus per-cohort Gram reuse brings that down by roughly an order of magnitude without moving the reported distribution.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_