### PR TITLE
STACKEDSC: solve the weight programs exactly

### DIFF
--- a/benchmarks/cases/wiltshire_walmart.py
+++ b/benchmarks/cases/wiltshire_walmart.py
@@ -56,21 +56,29 @@ the synthetic control to reproduce the treated level exactly there, so the gap
 at ``e = -1`` is zero by construction rather than by fit. It comes out at 6e-16;
 a wrong base year would break it immediately and break nothing else visibly.
 
-``batched`` records that each cohort was solved as one multiple-right-hand-side
-program. It is what makes 566 counties six solves rather than 566, and it is
-false exactly when a donor predicate binds -- also measured here.
+``shared_donor_pool`` records that every treated unit in every cohort faced the
+same donor block. It is false exactly when a donor predicate binds, which is
+also measured here.
 
 ``county_dispersion_at_five`` is the caution against reading a single county.
-The per-county five-year gaps have a standard deviation of 14.1 percent around a
-weighted mean of -0.90. Part of that is genuine heterogeneity; part is that with
+The per-county five-year gaps have a standard deviation of 14.2 percent around a
+weighted mean of -0.93. Part of that is genuine heterogeneity; part is that with
 5 to 10 pre-treatment periods against 39 donors the individual weight vectors
-are not identified at all, so two solvers reaching the same fit assign different
-weights and different post-treatment paths. The average is the estimand.
+are not identified at all. The average is the estimand.
 
-Inference is deliberately absent. The placebo layer costs 22,074 simplex solves
-in its default pool on this panel, far past the runtime budget for a case, and
-the paper's p-values rest on the same unrecoverable predictor-weight rule as its
-magnitudes.
+Which brings up the tolerances. Rank deficiency of 30-plus means the optimum is
+a *face*, so a solver pins the objective but not the point: the active-set
+method and CLARABEL agree on the objective to 8.7e-6 while their per-county
+post-treatment paths differ by up to 2.1 percentage points. That mostly washes
+out in the population-weighted aggregate -- 0.05 across the three solvers
+measured -- but not to nothing, so the aggregate rows carry bands that bracket
+solver choice rather than pinning one solver's answer. Values are centred on the
+active-set solver the estimator ships; the bands admit FISTA and CLARABEL too.
+
+Inference is deliberately absent. The placebo layer is roughly 1.2 minutes on
+this panel in its default donor pool -- past the per-case budget, though no
+longer prohibitive -- and the paper's p-values rest on the same unrecoverable
+predictor-weight rule as its magnitudes.
 
 Reference values: Wiltshire, J. C. (2023), Section 4.2 and Figure 6, for the
 prose claims; the remaining rows are this estimator's own deterministic output
@@ -135,7 +143,7 @@ def run() -> dict:
 
     # --- structural invariants ----------------------------------------
     out["base_period_gap"] = float(abs(tau[e == -1][0]))
-    out["batched"] = float(res.design.batched)
+    out["shared_donor_pool"] = float(res.design.shared_donor_pool)
     out["weights_sum_to_one"] = float(
         max(abs(sum(u.donor_weights.values()) - 1.0)
             for u in res.per_unit.values()))
@@ -185,24 +193,36 @@ def run() -> dict:
     # result says so rather than reporting a speed it did not achieve.
     czone = df.groupby("cty_fips").czone.first().to_dict()
     cz = _fit(df, donor_predicate=lambda i, d: czone[i] != czone[d])
-    out["restricted_pool_is_not_batched"] = float(not cz.design.batched)
+    out["restricted_pool_is_not_shared"] = float(not cz.design.shared_donor_pool)
     out["restricted_pool_gap_at_five"] = float(_path(cz)[1][e == 5][0])
     return out
 
 
 #: (expected, absolute tolerance).
 #:
-#: Everything here is deterministic -- no resampling, no simulation, and the
-#: simplex solve is seeded only in the trivial sense that FISTA starts from
-#: uniform weights. So tolerances cover solver drift across BLAS builds, not
-#: Monte-Carlo noise, and are correspondingly tight.
+#: Everything here is deterministic -- no resampling and no simulation -- so
+#: none of these tolerances covers Monte-Carlo noise. What the wider ones cover
+#: is solver choice.
 #:
-#: The exception is `county_dispersion_at_five`. Individual county weights are
-#: not identified on this design, so a different solver reaching the same fit
-#: reports a different spread; #341 measured up to 6.7pp of per-county movement
-#: against 0.03 on the aggregate. Its band is wide on purpose, and it is a
-#: floor-not-a-value row: what would be a real regression is the dispersion
-#: collapsing, which would mean the per-county fits had stopped varying.
+#: The counts and the three identities are exact, and are pinned at machine
+#: precision accordingly.
+#:
+#: The aggregate rows -- `gap_at_entry`, `gap_at_five`, `att`,
+#: `equal_weighted_gap_at_five`, `restricted_pool_gap_at_five` -- are not.
+#: The design is rank deficient by 30 or more, so the optimum is a face and an
+#: exact solver pins the objective without pinning the point. Measured across
+#: three solvers (the active set this estimator ships, CLARABEL, and the
+#: first-order method it used to ship): gap_at_five spans -0.904 to -0.928, att
+#: spans -0.352 to -0.367, gap_at_entry spans 0.147 to 0.159. Values are centred
+#: on the shipped solver and the bands admit all three, so a future solver
+#: change is not a spurious failure -- but a band is still tight enough to catch
+#: a real one, since the effects themselves are an order of magnitude larger.
+#: `restricted_pool_gap_at_five` gets a wider band again because a binding
+#: predicate changes each unit's design matrix, which moves the answer more.
+#:
+#: `county_dispersion_at_five` is a floor rather than a value: what would be a
+#: real regression is the dispersion collapsing, which would mean the per-county
+#: fits had stopped varying at all.
 EXPECTED = {
     # the design
     "n_treated": (566.0, 0.5),
@@ -212,7 +232,7 @@ EXPECTED = {
 
     # invariants: identities, so pinned at machine precision
     "base_period_gap": (0.0, 1e-12),
-    "batched": (1.0, 0.5),
+    "shared_donor_pool": (1.0, 0.5),
     "weights_sum_to_one": (0.0, 1e-6),
     "aggregate_is_the_weighted_mean": (0.0, 1e-9),
 
@@ -221,21 +241,21 @@ EXPECTED = {
     # effects an order of magnitude larger.
     "pre_rmse": (0.049, 0.01),
     "max_pre_gap": (0.073, 0.02),
-    "gap_at_entry": (0.158, 0.05),
+    "gap_at_entry": (0.153, 0.05),
     "declines_monotonically_after_entry": (1.0, 0.5),
-    "gap_at_five": (-0.904, 0.02),
-    "att": (-0.352, 0.02),
+    "gap_at_five": (-0.928, 0.06),
+    "att": (-0.367, 0.05),
 
     # read the average, not a county
-    "county_dispersion_at_five": (14.1, 6.0),
+    "county_dispersion_at_five": (14.2, 6.0),
 
     # specification choices
-    "equal_weighted_gap_at_five": (-1.100, 0.05),
+    "equal_weighted_gap_at_five": (-1.128, 0.06),
     "equal_weighting_keeps_the_sign": (1.0, 0.5),
     # 27x worse without the paper's outcome lags. The band is wide because the
     # point is the order of magnitude, not the figure.
-    "covariate_spec_pre_rmse": (1.354, 0.10),
-    "covariate_spec_pre_rmse_ratio": (27.5, 8.0),
-    "restricted_pool_is_not_batched": (1.0, 0.5),
-    "restricted_pool_gap_at_five": (-1.010, 0.05),
+    "covariate_spec_pre_rmse": (1.383, 0.10),
+    "covariate_spec_pre_rmse_ratio": (28.1, 8.0),
+    "restricted_pool_is_not_shared": (1.0, 0.5),
+    "restricted_pool_gap_at_five": (-0.933, 0.10),
 }

--- a/docs/replications/stackedsc.rst
+++ b/docs/replications/stackedsc.rst
@@ -63,10 +63,19 @@ narrative rests on:
      - decline from :math:`e = 2`
    * - direction
      - large negative by :math:`e = 5`
-     - :math:`-0.90`
+     - :math:`-0.93`
 
-The gap at :math:`e = -1` comes out at :math:`-6 \times 10^{-16}`, which is the
+The gap at :math:`e = -1` comes out at :math:`6 \times 10^{-16}`, which is the
 indexing constraint holding to machine precision rather than a fitted result.
+
+A caveat on precision that the benchmark encodes. Each cohort has five to ten
+pre-treatment periods against 39 donors, so the optimum of every weight program
+is a face rather than a point, and solving it exactly pins the objective without
+pinning the answer. Across three solvers the population-weighted aggregate moves
+by 0.05 percent -- five-year gaps of :math:`-0.904`, :math:`-0.920` and
+:math:`-0.928` -- while individual counties move by up to 2.1. So the figures
+above are quoted to two decimals and banded in the benchmark, rather than
+presented as exact.
 
 The specification, and the part of it that is not expressible
 -------------------------------------------------------------
@@ -169,14 +178,14 @@ paper's four prose claims, the two specification contrasts above, and the
 forfeited batching under a commuting-zone donor restriction.
 
 One row is a floor rather than a value. ``county_dispersion_at_five`` records
-that the per-county five-year gaps have a standard deviation of 14.1 percent
-around a weighted mean of -0.90, and it carries a deliberately wide band. Part
+that the per-county five-year gaps have a standard deviation of 14.2 percent
+around a weighted mean of -0.93, and it carries a deliberately wide band. Part
 of that spread is genuine heterogeneity across counties and part is the
 non-identification described above, so the number itself is not reproducible
 across solvers -- what would be a real regression is the dispersion collapsing,
 which would mean the per-county fits had stopped varying at all.
 
-Inference is not part of this case. The placebo layer costs 22,074 simplex
-solves in its default donor pool on this panel, well past the runtime budget,
-and the paper's p-values rest on the same unrecoverable predictor-weight rule as
-its magnitudes.
+Inference is not part of this case. The placebo layer is roughly 1.2 minutes on
+this panel in its default donor pool -- past the per-case budget, though no
+longer prohibitive -- and the paper's p-values rest on the same unrecoverable
+predictor-weight rule as its magnitudes.

--- a/docs/stackedsc.rst
+++ b/docs/stackedsc.rst
@@ -142,9 +142,8 @@ different question.
 The base period belongs to the cohort. Every unit adopting at the same time
 shares :math:`T_{0j}`, so the indexed donor block takes one value per adoption
 time rather than one per treated unit. With six adoption years and 566 treated
-units that is six donor blocks, not 566, and each cohort becomes a single
-least-squares problem with many right-hand sides rather than :math:`N_g`
-separate ones.
+units that is six donor blocks, not 566, and every unit in a cohort is fitted
+against the same design matrix.
 
 The aggregation weights are part of the specification. Equal weighting and
 size weighting answer different questions, and neither is a default the data
@@ -160,17 +159,35 @@ close to free: under the indexing, :math:`\widehat{\tau}_{-1} = 0` by
 construction, so the remaining pre-treatment horizons are informative about fit
 rather than about level.
 
-Two things the result reports that are easy to overlook. ``design.batched``
-records whether each cohort was solved as one program; it is false when a donor
-predicate binds, since restricting donors per unit gives each unit its own
-design matrix. And ``per_unit`` carries every unit's own path and weights.
+Two things the result reports that are easy to overlook.
+``design.shared_donor_pool`` records whether every treated unit in every cohort
+faced the same donor block; it is false when a donor predicate binds, since
+restricting donors per unit gives each unit its own design matrix. And
+``per_unit`` carries every unit's own path and weights.
 
-That last one deserves a caution. With a donor pool large relative to the
-number of pre-treatment periods the individual weight vectors are not
-identified: many weightings fit the pre-period equally well while implying
-different post-treatment counterfactuals. The weighted mean is pinned down far
-better than its parts. Read ``per_unit`` for diagnosis and spread, not as a
-claim about which donors resemble a particular unit.
+That last one deserves a caution, and it is sharper than it first looks. With a
+donor pool large relative to the number of pre-treatment periods the individual
+weight vectors are not identified: many weightings fit the pre-period equally
+well while implying different post-treatment counterfactuals. This is not a
+statement about approximate solvers -- it survives solving the program exactly.
+On the Wiltshire panel a cohort has seven pre-treatment periods against 39
+donors, so the optimum is a face of dimension at least 32, and two exact solvers
+that agree on the objective to :math:`8.7 \times 10^{-6}` still return
+per-county post-treatment paths differing by up to 2.1 percentage points.
+
+The weighted mean is pinned down far better than its parts -- across three
+solvers the population-weighted aggregate moves by 0.05 percent where the
+individual paths move by 2.1 -- but it is not pinned exactly either, which is
+why the durable benchmark bands the aggregate rather than pinning a single
+solver's answer. Read ``per_unit`` for diagnosis and spread, not as a claim
+about which donors resemble a particular unit.
+
+The weights themselves come from a primal active-set method
+(:func:`mlsynth.utils.bilevel.active_set.solve_simplex_qp`), which terminates on
+a Karush-Kuhn-Tucker certificate rather than on an iteration budget. That matters
+here: on this design a first-order method does not converge at all, leaving 20 of
+39 leave-one-out columns still improving after 20,000 iterations at any
+tolerance, and so returns a point that is simply suboptimal.
 
 Bias correction
 ---------------
@@ -281,9 +298,20 @@ it away from the null it is meant to represent. ``"donors-only"`` drops the
 treated unit, which removes that channel and recovers the per-cohort saving, at
 the price of departing from the reference implementation.
 
+On the Walmart panel the two pools give the same answer. The permutation pool
+runs 22,074 solves against the other's 234, and both report an ATT of
+:math:`-0.367` with a standard error of :math:`0.426` and a p-value of
+:math:`0.389`, agreeing on the interval to three decimals. That is not a general
+result -- with a smaller donor pool a single extra column would matter more --
+but on a pool of 39 the Zhang channel is real in principle and negligible in
+practice, so ``"donors-only"`` is a reasonable choice at a twenty-seventh of the
+cost.
+
 The whole procedure is opt-in for the same reason the reference makes it opt-in:
 its cost scales with treated units times donors, and ``allsynth`` warns that
-requesting it "will greatly extend the run-time".
+requesting it "will greatly extend the run-time". Concretely, on the paper's
+566 treated counties and 39 donors: 2.2 seconds for the point estimate alone,
+2.8 with the ``"donors-only"`` distribution, 76 with the default one.
 
 Example
 -------
@@ -309,7 +337,7 @@ Example
    res.effects.att                       # mean post-treatment effect, percent
    res.event_study.tau                   # the path, one entry per horizon
    res.design.cohorts                    # the distinct adoption times
-   res.design.batched                    # one solve per cohort?
+   res.design.shared_donor_pool          # same donor block for every unit?
    res.per_unit["18003"].tau             # one county's own path
 
 Asking for the permutation distribution as well, on a smaller donor pool so the

--- a/mlsynth/tests/test_stackedsc.py
+++ b/mlsynth/tests/test_stackedsc.py
@@ -163,13 +163,32 @@ class TestBiasCorrection:
 
         assert STACKEDSCConfig.model_fields["bias_correct"].default is False
 
-    def test_it_moves_the_estimate_when_predictors_are_supplied(self):
+    def test_it_moves_the_estimate_when_the_predictors_cannot_balance(self):
+        """The correction subtracts ``(x1 - X0 w)' beta``, so it is identically
+        zero when the predictors balance -- and with one predictor inside the
+        donors' range an exact solver balances it exactly. The treated units'
+        predictor is therefore pushed outside the donors' convex hull, which is
+        the only regime where the correction does anything at all.
+        """
         df = _staggered()
         df["x1"] = df.groupby("unit").y.transform("mean")
+        df.loc[df.unit.str.startswith("x"), "x1"] *= 3.0
         plain = _fit(df=df, covariates=["x1"])
         corrected = _fit(df=df, covariates=["x1"], bias_correct=True)
         assert plain.effects.att != pytest.approx(corrected.effects.att,
                                                   rel=1e-9)
+
+    def test_it_is_identically_zero_when_the_predictors_do_balance(self):
+        """The other half of the same fact, which the previous test hid: where
+        the synthetic control matches the predictors exactly there is no
+        imbalance left to correct, so the corrected and uncorrected estimates
+        coincide to machine precision."""
+        df = _staggered()
+        df["x1"] = df.groupby("unit").y.transform("mean")
+        plain = _fit(df=df, covariates=["x1"])
+        corrected = _fit(df=df, covariates=["x1"], bias_correct=True)
+        assert plain.effects.att == pytest.approx(corrected.effects.att,
+                                                  abs=1e-12)
 
 
 # ---------------------------------------------------------------------------

--- a/mlsynth/tests/test_stackedsc_solver.py
+++ b/mlsynth/tests/test_stackedsc_solver.py
@@ -1,0 +1,214 @@
+"""STACKEDSC solves its weight programs exactly.
+
+The design here is adversarial for a first-order method: a cohort has 5 to 10
+pre-treatment periods against 39 donors, so the Gram is rank deficient by 30 or
+more and its nonzero spectrum is badly spread. Measured on the Wiltshire panel,
+FISTA never converged on it -- 20 of 39 leave-one-out columns were still
+improving at iteration 20,000, at every tolerance from 1e-11 down to 1e-6, so
+the solve was iteration-bound and returned a point that was simply suboptimal.
+
+The primal active-set method
+(:func:`mlsynth.utils.bilevel.active_set.solve_simplex_qp`) solves the same
+program exactly, in a bounded number of pivots, and is what MEDSC, SCD and
+COMPSC already use. On the paper's panel it is 2.8x faster on the point estimate
+and roughly 130x on the placebo layer.
+
+What these tests can and cannot assert
+--------------------------------------
+
+They assert the objective, never the weights. With fewer rows than donors the
+optimum is a *face*, and two exact solvers land in different places on it: on
+the Wiltshire cohorts the active set and CLARABEL agree on the objective to
+8.7e-6 while their per-county post-treatment paths differ by up to 2.1
+percentage points. Exactness pins what is attained, not where.
+
+So the contract is a KKT certificate -- a solver-independent statement that the
+returned point is optimal -- plus the invariants that survive the face: the
+aggregate, the pre-treatment fit, and the base-period identity.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+
+def _staggered(n_treated=6, n_donors=12, T=14, cohorts=(7, 9), effect=0.0,
+               seed=0):
+    """Fewer pre-periods than donors: the shape that broke the first-order
+    solver, in miniature."""
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2)).cumsum(axis=0)
+    rows = []
+    for j in range(n_donors):
+        load, base = rng.normal(size=2), 100.0 + 20.0 * rng.random()
+        for t in range(T):
+            rows.append({"unit": f"d{j}", "t": t, "adopt": np.nan,
+                         "y": float(base + F[t] @ load + rng.normal() * 0.05)})
+    for i in range(n_treated):
+        g = cohorts[i % len(cohorts)]
+        load, base = rng.normal(size=2), 100.0 + 20.0 * rng.random()
+        for t in range(T):
+            y = base + F[t] @ load + rng.normal() * 0.05
+            rows.append({"unit": f"x{i}", "t": t, "adopt": float(g),
+                         "y": float(y * (1.0 + effect) if t >= g else y)})
+    d = pd.DataFrame(rows)
+    d["treat"] = ((~d.adopt.isna()) & (d.t >= d.adopt)).astype(int)
+    return d
+
+
+def _fit(df=None, **over):
+    from mlsynth import STACKEDSC
+
+    cfg = {"df": _staggered() if df is None else df, "outcome": "y",
+           "treat": "treat", "unitid": "unit", "time": "t",
+           "display_graphs": False}
+    cfg.update(over)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return STACKEDSC(cfg).fit()
+
+
+def _cohort_blocks(df, **over):
+    """The design matrices the estimator actually solved against."""
+    from mlsynth.utils.stackedsc_helpers.pipeline import _design
+    from mlsynth.utils.stackedsc_helpers.setup import build_cohorts
+
+    cohorts, _ = build_cohorts(df, "unit", "t", "y", "treat",
+                               normalize=over.get("normalize", True))
+    return [(c, *_design(c, "outcome-only")) for c in cohorts]
+
+
+def _kkt_violation(A, b, w, tol=1e-8):
+    """How far ``w`` is from satisfying the optimality conditions.
+
+    For ``min ||A w - b||^2`` over the simplex, the conditions are: the gradient
+    is constant across the support and no smaller off it. So with
+    ``g = 2 A'(A w - b)`` and ``lam = min(g)``, optimality means every
+    supported coordinate has ``g_k == lam``. The returned number is the largest
+    such excess -- zero at an optimum, positive for a point that could still be
+    improved by moving weight.
+    """
+    g = 2.0 * (A.T @ (A @ w - b))
+    lam = float(g.min())
+    supported = w > tol
+    return float(np.max(g[supported] - lam)) if supported.any() else 0.0
+
+
+# ---------------------------------------------------------------------------
+class TestTheWeightsAreOptimal:
+    """A certificate, not a comparison. This holds whatever solver is used and
+    would have failed on the unconverged first-order solve."""
+
+    def test_every_treated_unit_satisfies_the_kkt_conditions(self):
+        df = _staggered()
+        res = _fit(df)
+        worst = 0.0
+        for cohort, A, B, _V in _cohort_blocks(df):
+            for j, unit in enumerate(cohort.units):
+                w = np.array([res.per_unit[str(unit)].donor_weights.get(str(d), 0.0)
+                              for d in cohort.donors])
+                worst = max(worst, _kkt_violation(A, B[:, j], w))
+        assert worst < 1e-6, f"largest KKT excess {worst:.3e}"
+
+    def test_no_reachable_point_fits_better(self):
+        """The direct form of the same claim: perturbing the returned weights
+        toward any other donor cannot lower the objective."""
+        df = _staggered()
+        res = _fit(df)
+        cohort, A, B, _V = _cohort_blocks(df)[0]
+        rng = np.random.default_rng(0)
+        for j, unit in enumerate(cohort.units):
+            w = np.array([res.per_unit[str(unit)].donor_weights.get(str(d), 0.0)
+                          for d in cohort.donors])
+            base = float(np.sum((A @ w - B[:, j]) ** 2))
+            for _ in range(20):
+                v = rng.dirichlet(np.ones(len(w)))
+                for step in (1e-3, 1e-2, 1e-1):
+                    cand = (1 - step) * w + step * v
+                    got = float(np.sum((A @ cand - B[:, j]) ** 2))
+                    assert got >= base - 1e-9, (unit, step, got, base)
+
+    def test_the_weights_are_still_on_the_simplex(self):
+        res = _fit()
+        for u in res.per_unit.values():
+            w = np.array(list(u.donor_weights.values()))
+            assert (w >= -1e-12).all()
+            assert w.sum() == pytest.approx(1.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+class TestThePlaceboWeightsToo:
+    def test_every_placebo_fit_satisfies_the_kkt_conditions(self):
+        """The permutation distribution is built from these, so an
+        under-converged placebo is a mis-stated null, not a slow one."""
+        from mlsynth.utils.stackedsc_helpers.inference import cohort_placebo_paths
+
+        df = _staggered()
+        worst = 0.0
+        for cohort, A, B, _V in _cohort_blocks(df):
+            nJ = A.shape[1]
+            allowed = [list(range(nJ))] * len(cohort.units)
+            take = np.ones(cohort.Y.shape[0], dtype=bool)
+            paths, _ = cohort_placebo_paths(cohort, A, B, take, allowed,
+                                            donor_pool="donors-only")
+            # refit the family directly and certify it
+            from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+            for j in range(nJ):
+                keep = [k for k in range(nJ) if k != j]
+                w = np.asarray(solve_simplex_qp(A[:, keep], A[:, j]), float)
+                worst = max(worst, _kkt_violation(A[:, keep], A[:, j], w))
+            assert paths
+        assert worst < 1e-6, f"largest KKT excess {worst:.3e}"
+
+
+# ---------------------------------------------------------------------------
+class TestTheInvariantsSurviveTheSolverChange:
+    """What the face does not touch."""
+
+    def test_the_base_period_gap_is_still_identically_zero(self):
+        res = _fit()
+        e = np.asarray(res.event_study.horizons, int)
+        tau = np.asarray(res.event_study.tau, float)
+        assert abs(float(tau[e == -1][0])) < 1e-9
+
+    def test_a_degenerate_weight_still_reproduces_its_unit(self):
+        df = _staggered()
+        df["only"] = (df.unit == "x2").astype(float)
+        res = _fit(df=df, agg_weights="only")
+        target = _fit(df=df).per_unit["x2"]
+        np.testing.assert_allclose(np.asarray(res.event_study.tau, float),
+                                   np.asarray(target.tau, float), atol=1e-8)
+
+    def test_a_planted_effect_is_still_recovered(self):
+        res = _fit(df=_staggered(effect=0.10, seed=3))
+        e = np.asarray(res.event_study.horizons, int)
+        tau = np.asarray(res.event_study.tau, float)
+        assert 7.0 < float(np.mean(tau[e >= 0])) < 13.0
+
+
+# ---------------------------------------------------------------------------
+class TestTheDesignBlockSaysWhatItMeans:
+    """``batched`` described a multiple-right-hand-side program that the
+    active-set solver does not run. What the flag actually detects -- and still
+    detects -- is whether the donor predicate left every treated unit in a
+    cohort facing the same donor pool, so it is named for that."""
+
+    def test_a_shared_pool_is_reported(self):
+        assert _fit().design.shared_donor_pool is True
+
+    def test_a_binding_predicate_is_reported(self):
+        res = _fit(donor_predicate=lambda i, d: not (i == "x0" and d == "d0"))
+        assert res.design.shared_donor_pool is False
+
+    def test_a_predicate_that_does_not_bind_leaves_the_pool_shared(self):
+        res = _fit(donor_predicate=lambda i, d: True)
+        assert res.design.shared_donor_pool is True
+
+    def test_it_reaches_the_spec_block(self):
+        params = _fit().method_details.parameters_used
+        assert params["shared_donor_pool"] is True
+        assert "batched" not in params

--- a/mlsynth/utils/stackedsc_helpers/inference.py
+++ b/mlsynth/utils/stackedsc_helpers/inference.py
@@ -65,7 +65,8 @@ import numpy as np
 from scipy.stats import norm
 
 from ...exceptions import MlsynthDataError
-from ..bilevel import bias_corrected_gaps, simplex_lstsq
+from ..bilevel import bias_corrected_gaps
+from ..bilevel.active_set import solve_simplex_qp
 from .structures import StackedPlacebo
 
 __all__ = ["cohort_placebo_paths", "sample_placebo_averages",
@@ -140,7 +141,8 @@ def cohort_placebo_paths(
                 Y_pool = np.column_stack([D[:, keep], Y[:, i]])
                 X_pool = (None if X0 is None
                           else np.column_stack([X0[:, keep], X1[:, i]]))
-            w = np.asarray(simplex_lstsq(A_pool, A[:, j]), dtype=float).ravel()
+            w = np.asarray(solve_simplex_qp(A_pool, A[:, j]),
+                           dtype=float).ravel()
             gap = D[:, j] - Y_pool @ w
             if bias_correct and X_pool is not None:
                 gap = bias_corrected_gaps(w, X0[:, j], X_pool, D[:, j], Y_pool,

--- a/mlsynth/utils/stackedsc_helpers/pipeline.py
+++ b/mlsynth/utils/stackedsc_helpers/pipeline.py
@@ -1,11 +1,27 @@
 """The stacked-in-event-time fit: solve per cohort, average on the event clock.
 
 Every treated unit in a cohort faces the same donor block and differs only in
-its own pre-treatment target, so a cohort is one multiple-right-hand-side
-program rather than N_g programs -- see
-:func:`mlsynth.utils.bilevel.simplex.simplex_lstsq_batch`. The exception is a
-donor predicate that actually binds: it gives each treated unit its own design
-matrix, and the batching is forfeited. That is reported rather than hidden.
+its own pre-treatment target. A donor predicate that binds is the exception: it
+gives each unit its own design matrix, which the result reports as
+``shared_donor_pool = False``.
+
+The weights come from the primal active-set solver
+(:func:`mlsynth.utils.bilevel.active_set.solve_simplex_qp`), the same one MEDSC,
+SCD and COMPSC use. That choice is load-bearing on this design rather than a
+matter of taste. A cohort has 5 to 10 pre-treatment periods against 39 donors,
+so the Gram is rank deficient by 30 or more; measured on the Wiltshire panel a
+first-order method never converged on it, with 20 of 39 leave-one-out columns
+still improving at iteration 20,000 at every tolerance from 1e-11 down to 1e-6.
+The active-set method solves the same program exactly in a bounded number of
+pivots, and on that panel is 2.8x faster on the point estimate and roughly 130x
+on the placebo layer.
+
+Exactness pins the objective, not the answer. With fewer rows than donors the
+optimum is a face, and two exact solvers land in different places on it -- on
+the Wiltshire cohorts the active set and CLARABEL agree on the objective to
+8.7e-6 while their per-county post-treatment paths differ by up to 2.1
+percentage points and the population-weighted aggregate by 0.05. Read the
+aggregate; ``docs/stackedsc.rst`` says so at more length.
 """
 
 from __future__ import annotations
@@ -23,8 +39,8 @@ from ...config_models import (
     TimeSeriesResults,
     WeightsResults,
 )
-from ..bilevel import (bias_corrected_gaps, regression_v, simplex_lstsq,
-                       simplex_lstsq_batch)
+from ..bilevel import bias_corrected_gaps, regression_v
+from ..bilevel.active_set import solve_simplex_qp
 from .inference import placebo_inference
 from .plotter import plot_stackedsc
 from .setup import aggregation_weights, build_cohorts, event_window
@@ -77,17 +93,22 @@ def _allowed_donors(cohort, predicate):
     return allowed, binds
 
 
-def _weights_for_cohort(cohort, A, B, allowed, binds):
-    """(n_donors, n_units) weights. Batched unless the predicate binds."""
-    if not binds:
-        return simplex_lstsq_batch(A, B), True
+def _weights_for_cohort(cohort, A, B, allowed):
+    """(n_donors, n_units) weights, one exact solve per treated unit.
 
+    The design ``A`` is shared across a cohort unless a predicate binds, but
+    the active-set solver takes one target at a time, so this is a loop either
+    way. It is still the faster path: each solve terminates on a KKT
+    certificate after a handful of pivots rather than running an iteration
+    budget to exhaustion.
+    """
     cols = []
     for j, keep in enumerate(allowed):
         w = np.zeros(len(cohort.donors))
-        w[keep] = simplex_lstsq(A[:, keep], B[:, j])
+        w[keep] = np.asarray(solve_simplex_qp(A[:, keep], B[:, j]),
+                             dtype=float).ravel()
         cols.append(w)
-    return np.column_stack(cols), False
+    return np.column_stack(cols)
 
 
 def run_stackedsc(config) -> BaseEstimatorResults:
@@ -108,15 +129,15 @@ def run_stackedsc(config) -> BaseEstimatorResults:
     gamma_of = dict(zip(all_units, gammas))
 
     per_unit: Dict[str, StackedUnitFit] = {}
-    batched = True
+    shared_pool = True
     designs, pools = [], []
     for cohort in cohorts:
         A, B, _V = _design(cohort, backend)
         allowed, binds = _allowed_donors(cohort, config.donor_predicate)
         designs.append((A, B))
         pools.append(allowed)
-        W, was_batched = _weights_for_cohort(cohort, A, B, allowed, binds)
-        batched &= was_batched
+        W = _weights_for_cohort(cohort, A, B, allowed)
+        shared_pool &= not binds
         gap = cohort.Y - cohort.D @ W                      # (T, n_units)
         if config.bias_correct:
             for j in range(len(cohort.units)):
@@ -151,7 +172,8 @@ def run_stackedsc(config) -> BaseEstimatorResults:
     design = StackedDesign(
         cohorts=[c.adopt for c in cohorts], n_treated=len(all_units),
         n_donors=len(donors), backend=backend, normalized=config.normalize,
-        bias_corrected=config.bias_correct, batched=batched,
+        bias_corrected=config.bias_correct,
+        shared_donor_pool=shared_pool,
     )
 
     pooled: Dict[str, float] = {}
@@ -197,7 +219,7 @@ def run_stackedsc(config) -> BaseEstimatorResults:
                 "bias_correct_ridge": (float(config.bias_correct_ridge)
                                        if config.bias_correct else None),
                 "covariates": config.covariates,
-                "batched": batched,
+                "shared_donor_pool": shared_pool,
                 "cohorts": [c.adopt for c in cohorts],
                 "inference": config.inference,
                 "placebo_donor_pool": config.placebo_donor_pool,

--- a/mlsynth/utils/stackedsc_helpers/structures.py
+++ b/mlsynth/utils/stackedsc_helpers/structures.py
@@ -56,11 +56,11 @@ class StackedDesign(BaseModel):
         ..., description="Whether series were indexed to the base period.")
     bias_corrected: bool = Field(
         ..., description="Whether the Abadie-L'Hour correction was applied.")
-    batched: bool = Field(
+    shared_donor_pool: bool = Field(
         ..., description=(
-            "Whether each cohort was solved as one multiple-right-hand-side "
-            "program. False when a donor predicate binds, since that gives "
-            "each treated unit its own design matrix."))
+            "Whether every treated unit in every cohort faced the same donor "
+            "pool. False when a donor predicate binds, since that gives each "
+            "treated unit its own design matrix."))
 
 
 class StackedPlacebo(BaseModel):


### PR DESCRIPTION
## Related Links

- Changes the estimator from #343 and the benchmark from #346
- Supersedes the intended consumer of #344 (see Other Notes)
- Uses `mlsynth.utils.bilevel.active_set.solve_simplex_qp`, already the solver for MEDSC, SCD and COMPSC

## What

Switches STACKEDSC and its placebo layer from the first-order simplex solver to the primal active-set method.

- `mlsynth/utils/stackedsc_helpers/{pipeline,inference,structures}.py`
- `mlsynth/tests/test_stackedsc_solver.py` -- new, 11 tests
- `benchmarks/cases/wiltshire_walmart.py` re-centred and banded
- `docs/stackedsc.rst`, `docs/replications/stackedsc.rst`

## Why

The design is adversarial for a first-order method. A cohort has 5 to 10 pre-treatment periods against 39 donors, so the Gram is rank deficient by 30 or more. Measured on the Wiltshire panel, FISTA never converged on it: 20 of 39 leave-one-out columns were still improving at iteration 20,000, at every tolerance from 1e-11 down to 1e-6. The solve was iteration-bound, and the point it returned was simply suboptimal -- not an approximation with a tolerance, but an unfinished computation.

End to end on the paper's 566 counties and 39 donors:

| | before | after |
|---|---|---|
| point estimate | ~6 s | 2.2 s |
| + placebos, `donors-only` pool | 103 s | 2.8 s |
| + placebos, `permutation` pool (default) | ~161 min | 76 s (127x) |

The STACKEDSC test suite goes 40s to 5.7s and the benchmark case 44s to 15s.

## How

The published numbers move, and that is the point rather than a side effect. At an unchanged pre-treatment fit of 0.049, the ATT goes from -0.3525 to -0.3674 and the five-year gap from -0.904 to -0.9278. The old figures were a suboptimal point on the same objective.

Exactness pins the objective, not the answer. Rank deficiency means the optimum is a face, and two exact solvers land in different places on it: the active set and CLARABEL agree on the objective to 8.7e-6 while their per-county post-treatment paths differ by up to 2.1 percentage points and the population-weighted aggregate by 0.05. So the benchmark's aggregate rows are banded to bracket solver choice (`gap_at_five` spans -0.904 to -0.928 across the three solvers measured, `att` spans -0.352 to -0.367) rather than pinning one solver's answer, and the `EXPECTED` comment states the spread instead of implying the numbers are canonical.

The new tests certify optimality rather than compare solvers: a Karush-Kuhn-Tucker certificate on every treated unit's weights and on the placebo family. That is solver-independent, and it would have failed on the old solve.

## Two things the switch exposed

A test was passing on solver error. `test_it_moves_the_estimate_when_predictors_are_supplied` asserted that bias correction changes the estimate, but with exact weights a single predictor inside the donors' range balances exactly, so the Abadie-L'Hour correction is identically zero. The fixture now puts the treated predictor outside the hull, and the converse -- correction exactly zero where the predictors do balance -- is asserted too, which the original test had hidden.

`design.batched` no longer described anything real: there is no multiple-right-hand-side program any more. Renamed to `shared_donor_pool`, which is what the flag actually detects (whether the donor predicate binds). The estimator is hours old, so nothing external depends on the name.

## Verification

- `python benchmarks/run_benchmarks.py --case wiltshire_walmart` -- 21/21 pass
- 100 percent statement coverage of `mlsynth/utils/stackedsc_helpers/` retained
- `pytest mlsynth/tests/` -- full suite, result in the first comment

Also recorded, from measuring the two placebo donor pools end to end: they give the same inference on this panel. 22,074 solves against 234, and both report ATT -0.3674, se 0.426, p 0.389, agreeing on the interval to three decimals. The Zhang (2019) power-loss channel is real in principle and negligible against a 39-donor pool, so `donors-only` is a reasonable choice at a twenty-seventh of the cost. The default stays faithful to `allsynth`.

## Scope checks

- [x] The benchmark update rides along deliberately. Normally benchmark authoring is its own workstream, but this change moves the numbers the benchmark pins, so splitting them would leave `main` red between merges
- [x] No shared helper changed -- `solve_simplex_qp` is used as-is
- [x] Values still read through the standardized accessors

## Other Notes

- #344's leave-one-out primitive was built to speed up this layer and is superseded by it: the FISTA batch reached 22 minutes on the permutation pool where the active set reaches 76 seconds. It remains a correct, tested primitive and `project_simplex_cols(mask=)` is generally useful, but nothing consumes it today. Worth deciding separately whether to keep or revert it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0164pt1iUCTy5SnNK9nCJZvp)_