### PR TITLE
Add FSC: functional synthetic control for metric space-valued outcomes

### DIFF
--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -657,6 +657,27 @@ for one binary treatment)?
 * Several distinct intervention arms to compare -- :doc:`si`.
 * A vector of shares that sum to a whole (a generation mix, a budget split,
   brand share within a category) -- :doc:`compsc`.
+* A whole object per period rather than a number -- a curve, a distribution, a
+  covariance matrix -- :doc:`fsc`.
+
+*When to reach for Functional Synthetic Controls.* :doc:`fsc` (Okano and Kurisu
+(2026)) is for the case where each unit-period holds an object with internal
+structure worth preserving: an age-specific fertility profile, an age-at-death
+distribution, a covariance matrix across product lines. You can always collapse
+such an object to a scalar and run an ordinary synthetic control, and the
+question is what that costs. East Germany's 1972 abortion law moved fertility
+sharply at ages 20 to 30 and barely at all elsewhere; as a total fertility rate
+that is one negative number, and the shape -- the actual finding -- is gone. The
+obstacle FSC removes is that these objects have no linear structure, so the
+weighted-average counterfactual is not even well defined; it carries them into a
+Hilbert space through a distance-preserving embedding, runs the ordinary simplex
+fit there, and maps back. It also carries the ridge augmentation of :doc:`vanillasc`
+into that space, which is what lets it close a pre-treatment gap the simplex
+cannot. Note the sharp boundary against its neighbours: :doc:`dsc` and
+:doc:`drsc` want individual-level microdata and give you quantile effects from
+it, whereas FSC wants the object already assembled per cell; and :doc:`compsc`
+handles the compositional case, which FSC's framework covers in principle but
+which COMPSC treats with a purpose-built log-ratio model.
 
 *When to reach for Compositional Synthetic Controls.* :doc:`compsc` (Boussim
 (2026)) is for outcomes that live on the simplex, where a gain in one share is

--- a/docs/fsc.rst
+++ b/docs/fsc.rst
@@ -1,0 +1,298 @@
+Functional Synthetic Control (FSC)
+==================================
+
+.. currentmodule:: mlsynth
+
+When to Use This Estimator
+--------------------------
+
+Almost every synthetic control method assumes that what you observe each period
+is a number. FSC is for the case where it is a whole object: a fertility rate
+recorded separately for every age, a distribution of ages at death, a covariance
+matrix across a country's export categories.
+
+You can always turn such an object into a number and run an ordinary synthetic
+control on that. The question is what you lose. East Germany legalised abortion
+in 1972, and the effect on fertility was concentrated among women aged roughly
+20 to 30 and close to nil at either end of the childbearing range. Collapse the
+age profile to a total fertility rate and that result becomes a single negative
+number; the shape of the response, which is the part a demographer would want,
+is gone. The same argument applies whenever the interesting variation is
+*within* the object rather than in its total: a policy that compresses a wage
+distribution without moving its mean, a shock that reallocates trade between
+categories without changing the total.
+
+Reach for FSC when the object per unit-period is a curve, a distribution, or a
+matrix, and when you already have it in that form. If your rows are individual
+people rather than points on a grid, :doc:`dsc` is the right tool for
+unconditional quantile effects and :doc:`drsc` for conditional ones. If your
+object is a vector of shares summing to one, use :doc:`compsc`.
+
+Notation
+--------
+
+There are :math:`N` units observed over :math:`T` periods. Unit :math:`i = 1` is
+treated from period :math:`T_0 + 1` onward; the rest are the donor pool. The
+outcome :math:`\nu_{it}` is not a number but a point in a metric space
+:math:`(\mathcal M, d)` -- the set of curves, of distributions, of positive
+semidefinite matrices.
+
+The difficulty is that :math:`\mathcal M` has no linear structure. Averaging two
+probability distributions by averaging their density values does not generally
+give a sensible "average distribution", so the weighted-average counterfactual
+that defines synthetic control is not even well posed.
+
+FSC removes the difficulty with an isometric embedding: a map
+:math:`\Psi : \mathcal M \to \mathcal H` into a Hilbert space that preserves
+distances exactly,
+
+.. math::
+
+   d(x, y) \;=\; \lVert \Psi(x) - \Psi(y) \rVert_{\mathcal H}
+   \qquad \text{for all } x, y \in \mathcal M .
+
+An isometry is a relabelling that gets the geometry right: distances measured
+after the embedding are the same distances as before, so nothing about the
+problem is distorted by moving into :math:`\mathcal H`. Inside :math:`\mathcal H`
+addition and scalar multiplication are available again, and the ordinary
+synthetic control construction goes through. Write
+:math:`Y_{it} = \Psi(\nu_{it})` for the embedded outcomes and
+:math:`\mathcal Y = \Psi(\mathcal M)` for their image.
+
+Which map :math:`\Psi` to use depends on the space, and the ``space`` option
+picks it:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 32 26 26
+
+   * - ``space``
+     - Objects
+     - :math:`\Psi`
+     - :math:`\mathcal Y`
+   * - ``"function"``
+     - curves in :math:`L^2`
+     - the identity
+     - all of :math:`\mathcal H`
+   * - ``"distribution"``
+     - distributions under the 2-Wasserstein metric
+     - the quantile function
+     - increasing functions
+   * - ``"matrix"``
+     - symmetric positive semidefinite matrices, Frobenius metric
+     - the half-vectorisation
+     - the PSD cone
+
+The estimand is the counterfactual object :math:`\nu^N_{1t}` for the treated
+unit after treatment. What you do with it is up to you: the difference of
+embedded objects :math:`Y_{1t} - Y^N_{1t}` is a curve, reported here as
+``curve.effect``, and its length
+
+.. math::
+
+   d_t \;=\; d(\nu^I_{1t}, \nu^N_{1t})
+        \;=\; \lVert Y_{1t} - Y^N_{1t} \rVert_{\mathcal H}
+
+is the scalar magnitude of the effect, reported as ``curve.magnitude``.
+
+Assumptions
+-----------
+
+Assumption 1 (Embeddability). :math:`(\mathcal M, d)` admits an isometric
+embedding into a Hilbert space, and the image :math:`\Psi(\mathcal M)` is closed
+and convex.
+
+Remark. This is a real restriction, not a formality. A metric space embeds
+isometrically into a Hilbert space exactly when it has 2-negative type
+(Schoenberg), and many do not -- notably the space of probability measures on
+:math:`\mathbb{R}^k` under the 2-Wasserstein metric for :math:`k \ge 2`. So
+"metric space-valued" here does not mean any metric space. The three spaces
+this estimator supports all satisfy it. Convexity of the image is what makes the
+plain estimator work at all: a convex combination of donor objects then lands
+back in :math:`\mathcal Y` automatically, so it corresponds to a real object.
+
+Assumption 2 (Common grid). Every unit-period cell is observed at the same
+argument values.
+
+Remark. Enforced at ingestion rather than assumed. Objects observed on different
+grids are not comparable coordinate by coordinate, and interpolating them onto a
+common grid is a modelling choice the estimator should not make silently on your
+behalf. Do it yourself first if you need to.
+
+Assumption 3 (Data-generating process). The embedded control outcomes follow
+either a functional autoregression or a latent factor model, with independent
+mean-zero errors bounded in :math:`\mathcal H`.
+
+Remark. These are the same two processes the scalar synthetic control literature
+assumes, lifted to :math:`\mathcal H`. They are what deliver the error bounds
+below; the estimator itself does not need them, but the guarantee does.
+
+Assumption 4 (Pre-treatment fit). The treated unit's pre-treatment objects are
+approximately matched by the weighted donors.
+
+Remark. This is the assumption that does the work, and it is checkable. The
+finite-sample bound says the estimation error is controlled by the pre-treatment
+fit and the norm of the weights and by nothing else, so a poor pre-fit is a
+direct warning about the estimate. ``pre_treatment_fit`` on the result is that
+quantity.
+
+Estimation
+----------
+
+The donor weights match the pre-treatment objects in :math:`\mathcal H`:
+
+.. math::
+
+   \widehat\gamma^{\mathrm{scm}} \in
+   \operatorname*{arg\,min}_{\gamma \in \Delta^{N-1}}
+   \sum_{t=1}^{T_0} \Bigl\lVert Y_{1t} - \sum_{i=2}^{N} \gamma_i Y_{it}
+   \Bigr\rVert_{\mathcal H}^{2} ,
+
+over the simplex, and the counterfactual is
+:math:`\widehat\nu^{N}_{1t} = \Psi^{-1}\bigl(\sum_i \widehat\gamma_i Y_{it}\bigr)`.
+
+Once each object is sampled on a common grid this is the ordinary simplex
+least-squares problem, with the :math:`(\text{period}, \text{grid point})` pairs
+stacked into one long vector. So the base solve here is mlsynth's own exact
+quadratic program, the same one :doc:`vanillasc` uses. Nothing about the
+optimisation is special; the embedding is what makes it applicable.
+
+When the pre-treatment fit is imperfect the estimator is biased, and section 3.2
+of the paper corrects it the way augmented synthetic control corrects the scalar
+case: fit a ridge regression of the post-period object on the pre-period ones,
+and add the imbalance it predicts. Expanding each centered object in a cubic
+B-spline basis :math:`\{\varphi_k\}_{k=1}^{K}` and writing
+:math:`r_{i\cdot}` for the stacked coefficients gives a closed form,
+
+.. math::
+
+   \widehat\gamma^{\mathrm{aug}}_i = \widehat\gamma^{\mathrm{scm}}_i
+     + \bigl(r_{1\cdot} - r_{0\cdot}' \widehat\gamma^{\mathrm{scm}}\bigr)'
+       \bigl(r_{0\cdot}' r_{0\cdot} + \lambda I\bigr)^{-1} r_{i\cdot} ,
+
+which is exactly the ridge-augmented synthetic control formula with the
+pre-period axis replaced by the (period, basis coefficient) axis. Two properties
+follow directly. The correction vanishes when the
+simplex fit is already perfect, so augmentation never disturbs a good fit. And
+the augmented weights still sum to one but may go negative, which means the
+synthetic unit is allowed outside the donor hull -- extrapolation, bought
+deliberately in exchange for balance.
+
+Because negative weights can push the result out of :math:`\mathcal Y`, the
+augmented estimate is projected back:
+
+.. math::
+
+   \widetilde Y^{N,\mathrm{aug}}_{1t}
+     = \operatorname*{arg\,min}_{y \in \mathcal Y}
+       \lVert y - \widehat Y^{N,\mathrm{aug}}_{1t} \rVert_{\mathcal H} .
+
+Both projections have closed forms. For quantile functions it is the increasing
+rearrangement -- sort the values -- and for matrices it is the eigenvalue clip:
+symmetrise, set negative eigenvalues to zero, reassemble. For plain curves
+:math:`\mathcal Y` is everything and there is nothing to do.
+
+The penalty :math:`\lambda` is chosen by leave-one-pre-period-out
+cross-validation unless you pass ``ridge_lambda``. One caution about reading it:
+the cross-validation objective is typically very flat near its minimum. On the
+paper's fertility data it varies by 0.03 percent across :math:`\lambda \in [5,7]`
+while the pre-treatment fit moves in its fourth decimal. The penalty is weakly
+identified and the estimate is insensitive to it, so do not read the selected
+value as an estimated quantity.
+
+Inference and diagnostics
+-------------------------
+
+Two procedures, selected by ``inference``.
+
+The conformal band inverts the sharp null :math:`Y^N_{1t}(x) = y_0` pointwise in
+the argument, comparing the post-treatment residual against the :math:`T_0`
+pre-treatment ones. The inversion is closed-form: the accepted set is an
+interval centred on the estimate whose half-width is a quantile of the absolute
+pre-treatment residuals. It requires :math:`\alpha > 1/(T_0 + 1)`; below that
+threshold nothing is ever excluded and the band is unbounded, which the
+estimator reports rather than returning an infinite interval.
+
+Two caveats belong with any band you report from this. The weights are held
+fixed across candidate nulls rather than refit, unlike Chernozhukov, Wüthrich and
+Zhu (2021); that is a deliberate choice which guarantees the band contains the
+point estimate, at the cost of the exchangeability argument that would justify
+it. And the paper conjectures asymptotic validity rather than proving it. Treat
+the band as a descriptive uncertainty measure, not a calibrated confidence set.
+
+The placebo test recomputes everything with each donor cast as the treated unit
+and ranks the real treated unit's effect magnitude among them. It is honest and
+assumption-light, and it costs :math:`N` times a full fit. Its resolution is set
+by the donor pool: with :math:`N` units the smallest attainable p-value is
+:math:`1/N`, so 21 units can never produce a p-value below 0.048.
+
+Example
+-------
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import FSC
+
+   # one row per (country, year, age): the fertility rate at that age
+   df = pd.read_csv("basedata/okano_fsc_fertility.csv")
+
+   res = FSC({
+       "df": df,
+       "outcome": "asfr",       # the value
+       "argument": "age",       # where along the object it sits
+       "treat": "treat",
+       "unitid": "unit",
+       "time": "time",
+       "space": "function",
+       "display_graphs": False,
+   }).fit()
+
+   res.pre_treatment_fit_fsc     # fit before augmentation
+   res.pre_treatment_fit         # fit after
+   res.effects.att               # grid-averaged post-treatment effect
+
+   last = res.curves[-1]
+   last.effect                   # the effect as a curve over age
+   last.magnitude                # its length, the paper's d_t
+
+For a distribution, pass the quantile function and set
+``space="distribution"``; ``value_bounds`` truncates to the support before the
+rearrangement. For a covariance matrix, pass the row-major lower triangle with
+``space="matrix"`` -- the off-diagonal coordinates are rescaled internally so
+that the half-vectorisation really is a Frobenius isometry.
+
+Verification
+------------
+
+Reproduced against Okano and Kurisu (2026) on the authors' own data. The
+fertility application matches the published pre-treatment fits and every donor
+weight of Table 1; the divergences on the other two applications are measured
+and explained on the replication page rather than smoothed over. See
+:doc:`replications/fsc`, `benchmarks/cases/fsc_okano.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/fsc_okano.py>`_
+and `benchmarks/cases/fsc_estimator.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/fsc_estimator.py>`_.
+
+Not to be confused with
+-----------------------
+
+:doc:`fscm` is Forward-Selected synthetic control (Cerulli), an entirely
+different method that happens to share three letters. :doc:`dsc` and :doc:`drsc`
+work on individual-level microdata rather than on objects supplied per cell.
+:doc:`compsc` covers compositions, which are the paper's Example 5.
+
+Core API
+--------
+
+.. autoclass:: FSC
+   :members: fit
+
+.. autoclass:: mlsynth.utils.fsc_helpers.config.FSCConfig
+   :members:
+
+.. autoclass:: mlsynth.utils.fsc_helpers.structures.FSCResults
+   :members:
+
+.. autoclass:: mlsynth.utils.fsc_helpers.structures.FSCCurve
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -246,6 +246,7 @@ headline numbers.
    scta
    ctsc
    drsc
+   fsc
    dsc
    scd
    drosc

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -51,6 +51,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    :caption: Dedicated replication pages
 
    replications/drsc
+   replications/fsc
    replications/fdid
    replications/wine_tennessee
    replications/cast

--- a/docs/replications/fsc.rst
+++ b/docs/replications/fsc.rst
@@ -1,0 +1,151 @@
+FSC — Okano and Kurisu (2026)
+=============================
+
+Okano, R. and Kurisu, D. (2026). *Functional Synthetic Control Methods for
+Metric Space-Valued Outcomes.* arXiv:2601.07539. Replication package:
+`RyoOkano21/FSC <https://github.com/RyoOkano21/FSC>`_.
+
+Path A, on the authors' own data, for all three of the paper's empirical
+applications. Two artefacts back it, and they answer different questions.
+
+`benchmarks/cases/fsc_okano.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/fsc_okano.py>`_
+pins a faithful port of the authors' R code and reproduces every number they
+publish, exactly. It answers: is the method as implemented by its authors
+correctly understood here?
+
+`benchmarks/cases/fsc_estimator.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/fsc_estimator.py>`_
+runs :class:`mlsynth.FSC` itself. It answers a different question: does the
+estimator mlsynth ships land on the paper's results? It does on one application
+exactly, and diverges on the other two for reasons that are measured and stated
+below rather than tuned away.
+
+What the reference port reproduces
+----------------------------------
+
+Every published figure, at the four decimals the paper prints.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 14 14 14 14
+
+   * - Application
+     - FSC
+     - paper
+     - augmented
+     - paper
+   * - 6.1 fertility, ASFR curves in :math:`L^2`
+     - 0.1259
+     - 0.1259
+     - 0.0687
+     - 0.0687
+   * - 6.2 mortality, age-at-death distributions
+     - 0.2092
+     - 0.2092
+     - 0.0634
+     - 0.0634
+   * - 6.3 service trade, covariance matrices
+     - 39.3429
+     - 39.3429
+     - 20.0639
+     - 20.0639
+
+All twenty augmented donor weights of Table 1, all seventeen of Table 2, and the
+three nonzero FSC weights of Table 3 match to their printed three decimals, with
+a maximum deviation of 0.000. The cross-validated penalties of Remark 5
+reproduce too: mortality lands on 5.889182 to eight digits and service on
+0.001864 against a printed 0.00186.
+
+Four details of the reference code are load-bearing, and none is visible from
+the paper alone.
+
+The rounding. ``FSCM`` returns ``round(weight_scm, 4)``, and the rounding is
+carried into every downstream number. On the service application it is the
+difference between the published 39.3429 and the exact quadratic program's
+39.3423.
+
+The norm is not consistent across the reported figures. The pre-treatment fit is
+computed as ``sum(diffs[-1])`` — dropping the first grid point — for the plain
+estimator in all three applications, but the augmented leg is coded
+``sum(diffs)``. The published augmented figures come out under drop-first for
+fertility and mortality and under all-points for service, so the three reported
+pairs are not on one common norm.
+
+The rearrangement is not a sort. ``Rearrangement::rearrangement`` rescales the
+grid to the unit interval, interpolates onto 1001 equispaced points, and returns
+their type-7 empirical quantiles at the rescaled grid. Substituting a plain sort
+lands the mortality figure at 0.0640 where the published value is 0.0634.
+
+The covariance outcome is a plain half-vectorisation, with no :math:`\sqrt 2` on
+the off-diagonals. The Frobenius metric of the paper's Example 3 counts each
+off-diagonal entry twice, so that map is not an isometry and 39.3429 is a vech
+norm rather than a Frobenius one. The same weights scored under Example 3's own
+metric give 51.9613.
+
+Table 1 also contains an arithmetic slip: the Switzerland entry of 0.089 makes the FSC column sum to 1.089, which the simplex
+constraint forbids. Evaluating the objective settles it — the reported fit of
+0.1259 is attained at Austria 0.396, Bulgaria 0.416, Czechia 0.188 and nothing
+else, while the Table 1 vector gives 0.2324 and its renormalisation 0.1482.
+
+What the shipped estimator reproduces
+-------------------------------------
+
+:class:`mlsynth.FSC` matches the fertility application exactly — 0.1259 before
+augmentation and 0.0687 after, from the standard configuration with the penalty
+cross-validated rather than supplied. That is the paper's flagship application
+and the one its Example 1 is built around.
+
+The other two diverge.
+
+Mortality reproduces on the plain estimator, 0.2092, which does not involve the
+basis. The augmented figure comes out at 0.0630 against a published 0.0634, a gap
+of 0.6 percent. The cause is the basis inner product: mlsynth integrates over the
+whole argument grid, the reference code drops the first point. For fertility that
+choice is invisible — the fertility rate at age 12 is essentially zero for every
+country, so the dropped coordinate carries no information and the weights agree
+to 7e-7. For mortality it is not, because the quantile function at
+:math:`p = 0.01` is a real number and dropping it discards real information;
+holding everything else fixed, the augmented weights move by up to 0.109. Using
+every point the data provides is the defensible reading of an :math:`L^2` inner
+product, so that is what mlsynth does.
+
+Service trade is not a divergence in the estimate so much as in the yardstick.
+The estimator applies the :math:`\sqrt 2` off-diagonal scaling that makes the
+half-vectorisation a genuine Frobenius isometry, which the reference code does
+not, so its fit is a Frobenius norm and the published 39.3429 is a vech norm.
+The two are not comparable and should not be compared. The like-for-like
+comparator is 51.9613 — the authors' own weights scored under Frobenius — and
+mlsynth attains 51.7665, which is what re-optimising under the correct metric
+should do.
+
+Both are corrections rather than discrepancies, and both are pinned in the
+estimator benchmark so a future change to either surfaces as a failure rather
+than drifting quietly.
+
+The penalty needs one more note, because getting it wrong caused a real bug
+here. The cross-validation objective of Remark 5 is nearly flat near its
+minimum: on the fertility data it varies by 0.03 percent across
+:math:`\lambda \in [5, 7]` while the pre-treatment fit moves in its fourth
+decimal. The penalty is weakly identified, so its selected value is not a
+quantity to interpret. Worse, its natural *scale* is set by the Gram matrix of
+the basis coefficients, which moves with the square of the outcome — so a fixed
+absolute search interval means something different on every dataset. The
+authors' scripts search :math:`(0, 10)`, which suits their fertility panel and
+is four orders of magnitude too coarse for their mortality panel once the
+coefficients are a genuine :math:`L^2` inner product; searching it there puts
+the optimum outside the interval and lands the augmented fit at 0.1688 instead
+of 0.0630. mlsynth therefore searches the penalty as a multiple of the design's
+own Gram scale and reports both the relative and the absolute value.
+
+Data
+----
+
+``basedata/okano_fsc_fertility.csv``, ``basedata/okano_fsc_mortality.csv`` and
+``basedata/okano_fsc_service.csv``, converted from the authors' ``asfr.RData``,
+``aad.RData`` and ``service.RData`` with the ``rdata`` package — nested R lists,
+which ``pyreadr`` cannot read, so no R installation is needed to rebuild them.
+`benchmarks/reference/fsc_okano_data.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/reference/fsc_okano_data.py>`_
+regenerates them. Underlying sources are the Human Fertility Database, the Human
+Mortality Database, and UN Trade and Development.

--- a/llms.txt
+++ b/llms.txt
@@ -48,6 +48,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **ESC** — Ensemble Synthetic Control estimator.  (config: ESCConfig)
 - **FDID** — Forward Difference-in-Differences (FDID) estimator.  (config: FDIDConfig)
 - **FMA** — Factor Model Approach (Li & Sonnier 2023) estimator.  (config: FMAConfig)
+- **FSC** — Functional synthetic control estimator.
 - **FSCM** — Forward-Selected Synthetic Control estimator.  (config: FSCMConfig)
 - **HSC** — Harmonic Synthetic Control (HSC) estimator.  (config: HSCConfig)
 - **ISCM** — Imperfect Synthetic Controls estimator.  (config: ISCMConfig)

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -75,6 +75,7 @@ from .estimators.orthsc import ORTHSC
 from .estimators.beast import BEAST
 from .estimators.dpsc import DPSC
 from .estimators.drsc import DRSC
+from .estimators.fsc import FSC
 from .estimators.dsc import DSC
 from .estimators.drosc import DROSC
 from .estimators.dscar import DSCAR
@@ -176,6 +177,7 @@ __all__ = [
     "from_syndes",
     "plot_compare_pareto",
     "DRSC",
+    "FSC",
     "DSC",
     "DROSC",
     "SpSyDiD",

--- a/mlsynth/estimators/fsc.py
+++ b/mlsynth/estimators/fsc.py
@@ -1,0 +1,141 @@
+"""FSC -- functional synthetic control for metric space-valued outcomes.
+
+Okano, R. & Kurisu, D. (2026). *"Functional Synthetic Control Methods for Metric
+Space-Valued Outcomes."* arXiv:2601.07539.
+
+Ordinary synthetic control wants a number per unit per period. FSC is for the
+case where what you observe is a whole object instead: an age-specific fertility
+curve, an age-at-death distribution, a covariance matrix across product lines.
+Collapsing such an object to a scalar -- a total, a mean, a Gini -- often
+throws away the shape of the effect. The East German abortion
+law in the paper's first application moves fertility down sharply at ages 20-30
+and barely at all elsewhere; a total-fertility-rate synthetic control returns
+that as one number.
+
+How it works
+------------
+
+The obstacle is that these objects have no linear structure -- you cannot
+average two networks by averaging their entries and expect a network -- so the
+usual weighted-average counterfactual is not defined. FSC removes the obstacle
+by carrying the objects into a Hilbert space through an isometry
+:math:`\\Psi`, a map that preserves distances exactly. Inside that space
+everything is linear again: the counterfactual is the weighted average of the
+donor images, the donor weights solve the ordinary simplex problem on the
+stacked pre-treatment objects, and the answer is carried back by
+:math:`\\Psi^{-1}`.
+
+Two consequences follow, and both are handled here. Because the image of
+:math:`\\Psi` is convex, a convex combination of donors is always a valid object,
+so the plain estimator needs no repair. The ridge augmentation of section 3.2 --
+which corrects residual pre-treatment imbalance the simplex cannot, at the cost
+of allowing negative weights -- can leave that image, so its output is projected
+back onto it.
+
+Spaces
+------
+
+``space`` selects the isometry and the projection, following the paper's
+examples:
+
+* ``"function"`` -- curves in :math:`L^2`. :math:`\\Psi` is the identity and the
+  image is the whole space, so nothing is projected.
+* ``"distribution"`` -- probability distributions under the 2-Wasserstein
+  metric, supplied as quantile functions. The image is the set of increasing
+  functions, so the projection is the increasing rearrangement.
+* ``"matrix"`` -- symmetric positive semidefinite matrices under the Frobenius
+  metric, supplied as the row-major lower triangle. The projection clips
+  negative eigenvalues. Since :math:`\\mathcal H` is Euclidean here the spline
+  expansion is skipped, and the off-diagonal coordinates are scaled by
+  :math:`\\sqrt 2` so that the half-vectorisation really is an isometry.
+
+Data
+----
+
+A long panel with one row per ``(unit, time, argument)``, where ``argument``
+names the point at which each value is observed -- the age, the quantile level,
+the matrix cell. Every cell must be observed on the same grid. Ingestion pivots
+each argument slice through
+:func:`mlsynth.utils.datautils.dataprep` and stacks them.
+
+Related estimators
+------------------
+
+:class:`mlsynth.DSC` targets unconditional quantile effects from individual-level
+microdata; reach for it when your rows are people rather than grid points.
+:class:`mlsynth.COMPSC` handles compositions, which are the paper's Example 5.
+The scalar special case of FSC is :class:`mlsynth.VanillaSC` with
+``augment="ridge"`` -- the same ridge correction, one grid point wide.
+
+Note the unrelated :class:`mlsynth.FSCM`, which is Cerulli's forward-selected
+synthetic control.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from ..exceptions import (MlsynthConfigError, MlsynthDataError,
+                          MlsynthEstimationError)
+from ..utils.fsc_helpers.config import FSCConfig
+from ..utils.fsc_helpers.pipeline import run_fsc
+from ..utils.fsc_helpers.plotter import plot_fsc
+from ..utils.fsc_helpers.setup import prepare_fsc_inputs
+from ..utils.fsc_helpers.structures import FSCResults
+
+try:  # pydantic v2 / v1 compatibility for the error type
+    from pydantic import ValidationError
+except Exception:  # pragma: no cover
+    ValidationError = Exception  # type: ignore
+
+
+class FSC:
+    """Functional synthetic control estimator.
+
+    Parameters
+    ----------
+    config : FSCConfig or dict
+        Configuration. See
+        :class:`mlsynth.utils.fsc_helpers.config.FSCConfig`.
+
+    Examples
+    --------
+    >>> from mlsynth import FSC                                # doctest: +SKIP
+    >>> res = FSC({                                            # doctest: +SKIP
+    ...     "df": fertility, "outcome": "asfr", "treat": "treat",
+    ...     "unitid": "unit", "time": "time", "argument": "age",
+    ...     "space": "function",
+    ... }).fit()
+    >>> res.pre_treatment_fit                                  # doctest: +SKIP
+    >>> res.curves[-1].effect                                  # doctest: +SKIP
+    """
+
+    def __init__(self, config: Union[FSCConfig, dict]) -> None:
+        if isinstance(config, dict):
+            try:
+                config = FSCConfig(**config)
+            except MlsynthConfigError:
+                raise
+            except (ValidationError, MlsynthDataError) as exc:
+                raise MlsynthConfigError(
+                    f"Invalid FSC configuration: {exc}") from exc
+        if not isinstance(config, FSCConfig):
+            raise MlsynthConfigError(
+                "config must be an FSCConfig or a dict of its fields.")
+        self.config: FSCConfig = config
+
+    def fit(self) -> FSCResults:
+        """Estimate the counterfactual objects and return standardized results."""
+        inputs = prepare_fsc_inputs(
+            df=self.config.df, outcome=self.config.outcome,
+            treat=self.config.treat, unitid=self.config.unitid,
+            time=self.config.time, argument=self.config.argument,
+            numeric_grid=self.config.space != "matrix")
+        results = run_fsc(inputs, self.config)
+
+        plot = self.config.resolved_plot()
+        if plot.display or plot.save:
+            plot_fsc(results, argument_label=self.config.argument,
+                     outcome_label=self.config.outcome, save=plot.save,
+                     display=bool(plot.display))
+        return results

--- a/mlsynth/guides/llms.txt
+++ b/mlsynth/guides/llms.txt
@@ -48,6 +48,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **ESC** — Ensemble Synthetic Control estimator.  (config: ESCConfig)
 - **FDID** — Forward Difference-in-Differences (FDID) estimator.  (config: FDIDConfig)
 - **FMA** — Factor Model Approach (Li & Sonnier 2023) estimator.  (config: FMAConfig)
+- **FSC** — Functional synthetic control estimator.
 - **FSCM** — Forward-Selected Synthetic Control estimator.  (config: FSCMConfig)
 - **HSC** — Harmonic Synthetic Control (HSC) estimator.  (config: HSCConfig)
 - **ISCM** — Imperfect Synthetic Controls estimator.  (config: ISCMConfig)

--- a/mlsynth/tests/test_fsc.py
+++ b/mlsynth/tests/test_fsc.py
@@ -1,0 +1,614 @@
+"""Tests for FSC -- functional synthetic control (Okano & Kurisu 2026).
+
+Layered as the contract asks: a smoke test that the thing runs end to end on
+minimal input, invariant tests that pin the properties the paper proves rather
+than the floats a solver happens to produce, edge cases on degenerate panels,
+and failure tests asserting every bad input is *reported* through the right
+translated exception rather than swallowed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import FSC
+from mlsynth.exceptions import (MlsynthConfigError, MlsynthDataError,
+                                MlsynthEstimationError)
+from mlsynth.utils.fsc_helpers.basis import cubic_bspline_basis
+from mlsynth.utils.fsc_helpers.config import FSCConfig
+from mlsynth.utils.fsc_helpers.project import (project_increasing,
+                                               project_psd, vech_to_matrix)
+from mlsynth.utils.fsc_helpers.structures import FSCResults
+
+
+# ---------------------------------------------------------------------------
+# panel builders
+# ---------------------------------------------------------------------------
+def curve_panel(n_units=6, n_times=16, n_grid=15, n_pre=12, seed=0,
+                effect=0.0, weights=None):
+    """Factor-model panel of curves; unit 0 is treated from ``n_pre`` on.
+
+    Each unit's curve is a loading-weighted combination of smooth factors, so
+    the treated unit lies near the donor hull and the pre-fit is informative.
+    """
+    rng = np.random.default_rng(seed)
+    x = np.linspace(0.0, 1.0, n_grid)
+    factors = np.stack([np.ones_like(x), np.sin(np.pi * x), np.cos(2 * np.pi * x)])
+    loads = rng.uniform(0.2, 1.0, size=(n_units, factors.shape[0]))
+    drift = rng.uniform(0.9, 1.1, size=(n_times, factors.shape[0]))
+    cube = np.einsum("if,tf,fm->itm", loads, drift, factors)
+    cube += rng.normal(scale=0.01, size=cube.shape)
+    if weights is not None:                       # treated = exact donor mix
+        cube[0] = np.einsum("j,jtm->tm", np.asarray(weights), cube[1:])
+    cube[0, n_pre:] += effect
+    return _to_long(cube, n_pre), cube
+
+
+def _to_long(cube, n_pre, argument="x", value="y"):
+    n_units, n_times, n_grid = cube.shape
+    ui, ti, ai = np.meshgrid(np.arange(n_units), np.arange(n_times),
+                             np.arange(n_grid), indexing="ij")
+    return pd.DataFrame({
+        "unit": [f"u{i}" for i in ui.ravel()],
+        "time": ti.ravel(),
+        argument: ai.ravel().astype(float) / (n_grid - 1),
+        value: cube.ravel(),
+        "treat": ((ui.ravel() == 0) & (ti.ravel() >= n_pre)).astype(int),
+    })
+
+
+def quantile_panel(n_units=5, n_times=16, n_grid=20, n_pre=12, seed=1):
+    """Panel of quantile functions -- increasing in the argument by construction."""
+    rng = np.random.default_rng(seed)
+    p = np.linspace(0.02, 0.98, n_grid)
+    base = np.sqrt(2.0) * np.vectorize(lambda q: float(np.sqrt(2) * q))(p)
+    cube = np.empty((n_units, n_times, n_grid))
+    for i in range(n_units):
+        loc, scale = rng.uniform(0, 1), rng.uniform(0.8, 1.4)
+        for t in range(n_times):
+            cube[i, t] = loc + scale * (base + 0.05 * t * p)
+    return _to_long(cube, n_pre, argument="p", value="q"), cube
+
+
+def matrix_panel(n_units=5, n_times=16, dim=3, n_pre=12, seed=2):
+    """Panel of symmetric PSD matrices stored as row-major lower triangles."""
+    rng = np.random.default_rng(seed)
+    rows, cols = np.tril_indices(dim)
+    cube = np.empty((n_units, n_times, rows.size))
+    for i in range(n_units):
+        A = rng.normal(size=(dim, dim))
+        for t in range(n_times):
+            M = A @ A.T + (0.1 * t + 0.5) * np.eye(dim)
+            cube[i, t] = M[rows, cols]
+    return _to_long(cube, n_pre, argument="cell", value="cov"), cube
+
+
+def base_config(df, **kw):
+    # n_basis defaults to 50 in the config, which makes every cross-validation
+    # solve a (50 * T0) square system. These tests check invariants, not the
+    # paper's K, so a small basis keeps the suite quick; the applications in
+    # benchmarks/cases/fsc_estimator.py run at the paper's K = 50.
+    cfg = dict(df=df, outcome="y", treat="treat", unitid="unit", time="time",
+               argument="x", n_basis=10, display_graphs=False)
+    cfg.update(kw)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# smoke
+# ---------------------------------------------------------------------------
+def test_fit_returns_populated_results():
+    df, _ = curve_panel()
+    res = FSC(base_config(df)).fit()
+
+    assert isinstance(res, FSCResults)
+    assert len(res.curves) == 16
+    assert np.isfinite(res.effects.att)
+    assert np.isfinite(res.pre_treatment_fit)
+    assert res.method_details.method_name == "FSC"
+    for curve in res.curves:
+        assert curve.counterfactual.shape == curve.observed.shape
+        assert np.all(np.isfinite(curve.counterfactual))
+        assert np.allclose(curve.effect, curve.observed - curve.counterfactual)
+
+
+def test_time_series_gap_is_the_difference_of_the_reported_series():
+    """The scalar series is a linear functional, so the identity must hold."""
+    df, _ = curve_panel()
+    ts = FSC(base_config(df)).fit().time_series
+    assert np.allclose(ts.estimated_gap,
+                       ts.observed_outcome - ts.counterfactual_outcome)
+    assert ts.time_periods.size == ts.observed_outcome.size
+
+
+# ---------------------------------------------------------------------------
+# invariants
+# ---------------------------------------------------------------------------
+def test_plain_fsc_weights_lie_on_the_simplex():
+    df, _ = curve_panel()
+    res = FSC(base_config(df, augment=False)).fit()
+    w = res.fsc_weights
+    assert w.min() >= -1e-9
+    assert res.augmented_weights is None
+    assert np.isclose(w.sum(), 1.0)
+
+
+def test_augmented_weights_sum_to_one_and_may_leave_the_simplex():
+    """Eq. (10) constrains the sum, not the sign."""
+    df, _ = curve_panel()
+    res = FSC(base_config(df)).fit()
+    assert np.isclose(res.augmented_weights.sum(), 1.0)
+    assert np.isclose(res.fsc_weights.sum(), 1.0)
+
+
+def test_augmentation_weakly_improves_the_pre_treatment_fit():
+    df, _ = curve_panel()
+    res = FSC(base_config(df)).fit()
+    assert res.pre_treatment_fit <= res.pre_treatment_fit_fsc + 1e-9
+
+
+def test_perfect_pre_fit_leaves_the_weights_unaugmented():
+    """r_1 = r_0' gamma makes the correction in eq. (9) vanish identically."""
+    w = np.array([0.5, 0.3, 0.2, 0.0, 0.0])
+    df, _ = curve_panel(weights=w)
+    res = FSC(base_config(df)).fit()
+    assert res.pre_treatment_fit_fsc < 1e-6
+    assert np.allclose(res.fsc_weights, res.augmented_weights, atol=1e-6)
+
+
+def test_recovers_a_known_donor_mix():
+    w = np.array([0.5, 0.3, 0.2, 0.0, 0.0])
+    df, _ = curve_panel(weights=w)
+    res = FSC(base_config(df)).fit()
+    assert np.allclose(res.fsc_weights, w, atol=1e-3)
+    assert max(np.abs(c.effect).max() for c in res.curves) < 1e-4
+
+
+def test_constant_shift_is_recovered_as_the_effect():
+    w = np.array([0.5, 0.3, 0.2, 0.0, 0.0])
+    df, _ = curve_panel(weights=w, effect=0.75)
+    res = FSC(base_config(df)).fit()
+    post = [c for c in res.curves if c.is_post]
+    assert len(post) == 4
+    for curve in post:
+        assert np.allclose(curve.effect, 0.75, atol=1e-3)
+    assert np.isclose(res.effects.att, 0.75, atol=1e-3)
+
+
+def test_weights_are_invariant_to_relabelling_the_grid():
+    """The stacked design only sees the values, so a monotone relabel is inert."""
+    df, _ = curve_panel()
+    shifted = df.copy()
+    shifted["x"] = shifted["x"] * 7.0 + 3.0
+    a = FSC(base_config(df)).fit()
+    b = FSC(base_config(shifted)).fit()
+    assert np.allclose(a.fsc_weights, b.fsc_weights, atol=1e-8)
+
+
+def test_distribution_space_returns_an_increasing_counterfactual():
+    df, _ = quantile_panel()
+    res = FSC(base_config(df, outcome="q", argument="p",
+                          space="distribution")).fit()
+    for curve in res.curves:
+        assert np.all(np.diff(curve.counterfactual) >= -1e-9)
+
+
+def test_matrix_space_returns_a_psd_counterfactual():
+    df, _ = matrix_panel()
+    res = FSC(base_config(df, outcome="cov", argument="cell",
+                          space="matrix")).fit()
+    for curve in res.curves:
+        M = vech_to_matrix(curve.counterfactual, 3)
+        assert np.linalg.eigvalsh(M).min() >= -1e-8
+
+
+def test_matrix_space_skips_the_basis_expansion():
+    """H is Euclidean there, so the standard basis is already orthonormal."""
+    df, _ = matrix_panel()
+    res = FSC(base_config(df, outcome="cov", argument="cell",
+                          space="matrix")).fit()
+    assert res.method_details.parameters_used["n_basis"] is None
+
+
+# ---------------------------------------------------------------------------
+# penalty selection
+# ---------------------------------------------------------------------------
+def test_explicit_lambda_is_used_verbatim():
+    df, _ = curve_panel()
+    res = FSC(base_config(df, ridge_lambda=2.5)).fit()
+    assert res.ridge_lambda == pytest.approx(2.5)
+    assert res.lambda_selected_by_cv is False
+
+
+def test_cross_validated_lambda_lies_inside_the_bounds():
+    df, _ = curve_panel()
+    res = FSC(base_config(df, lambda_bounds=(0.0, 4.0))).fit()
+    assert 0.0 <= res.ridge_lambda <= 4.0
+    assert res.lambda_selected_by_cv is True
+
+
+def test_cross_validated_penalty_is_scale_free():
+    """Rescaling the outcome must not change what the penalty search can reach.
+
+    The natural size of the ridge penalty is set by the Gram matrix of the basis
+    coefficients, which scales with the square of the outcome. A fixed absolute
+    search interval therefore means something different on every dataset, and on
+    a badly scaled one the optimum falls outside it entirely -- which is exactly
+    what happens on the paper's mortality panel, where the units are years.
+    """
+    df, _ = curve_panel()
+    scaled = df.copy()
+    scaled["y"] = scaled["y"] * 1000.0
+
+    plain = FSC(base_config(df, inference="none")).fit()
+    big = FSC(base_config(scaled, inference="none")).fit()
+
+    assert np.allclose(plain.augmented_weights, big.augmented_weights,
+                       atol=1e-6)
+    assert np.isclose(plain.ridge_lambda_relative, big.ridge_lambda_relative,
+                      rtol=1e-6)
+    # the absolute penalty does move, by the square of the rescaling
+    assert big.ridge_lambda > plain.ridge_lambda * 1e5
+
+
+def test_relative_penalty_is_reported_alongside_the_absolute_one():
+    df, _ = curve_panel()
+    res = FSC(base_config(df, inference="none")).fit()
+    assert res.ridge_lambda_relative is not None
+    assert 0.0 <= res.ridge_lambda_relative <= 10.0
+    assert res.ridge_lambda > 0.0
+
+
+def test_explicit_lambda_is_absolute_not_relative():
+    """An explicit penalty is taken at face value, as the paper's scripts use it."""
+    df, _ = curve_panel()
+    res = FSC(base_config(df, ridge_lambda=2.5, inference="none")).fit()
+    assert res.ridge_lambda == pytest.approx(2.5)
+    assert res.ridge_lambda_relative is None
+
+
+def test_large_lambda_collapses_augmentation_onto_the_simplex_fit():
+    """As lambda grows the correction in eq. (9) vanishes."""
+    df, _ = curve_panel()
+    res = FSC(base_config(df, ridge_lambda=1e12)).fit()
+    assert np.allclose(res.fsc_weights, res.augmented_weights, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# inference
+# ---------------------------------------------------------------------------
+def test_conformal_band_brackets_the_counterfactual():
+    df, _ = curve_panel()
+    res = FSC(base_config(df, inference="conformal")).fit()
+    for curve in res.curves:
+        if curve.is_post:
+            assert np.all(curve.lower <= curve.counterfactual + 1e-12)
+            assert np.all(curve.upper >= curve.counterfactual - 1e-12)
+            assert np.all(curve.upper - curve.lower > 0)
+
+
+def test_conformal_band_widens_with_a_smaller_alpha():
+    df, _ = curve_panel()
+    wide = FSC(base_config(df, conformal_alpha=0.10)).fit()
+    narrow = FSC(base_config(df, conformal_alpha=0.40)).fit()
+    w = [c for c in wide.curves if c.is_post][0]
+    n = [c for c in narrow.curves if c.is_post][0]
+    assert np.mean(w.upper - w.lower) >= np.mean(n.upper - n.lower)
+
+
+def test_placebo_p_values_are_ranks_over_the_units():
+    df, _ = curve_panel()
+    res = FSC(base_config(df, inference="placebo", ridge_lambda=1.0)).fit()
+    n_units = 6
+    for p in res.placebo_p_values:
+        assert 1 / n_units - 1e-12 <= p <= 1.0
+        assert np.isclose(p * n_units, round(p * n_units))
+
+
+def test_inference_none_leaves_the_band_and_p_values_absent():
+    df, _ = curve_panel()
+    res = FSC(base_config(df, inference="none")).fit()
+    assert res.placebo_p_values is None
+    assert all(c.lower is None for c in res.curves)
+    assert res.time_series.has_prediction_interval is False
+
+
+def test_inference_both_populates_band_and_p_values():
+    df, _ = curve_panel()
+    res = FSC(base_config(df, inference="both", ridge_lambda=1.0)).fit()
+    assert res.placebo_p_values is not None
+    assert res.time_series.has_prediction_interval is True
+
+
+# ---------------------------------------------------------------------------
+# basis and projection units
+# ---------------------------------------------------------------------------
+def test_bspline_basis_is_a_partition_of_unity():
+    B = cubic_bspline_basis(np.linspace(0, 1, 30), 12)
+    assert B.shape == (30, 12)
+    assert np.allclose(B.sum(axis=1), 1.0)
+    assert B.min() >= 0.0
+
+
+def test_bspline_basis_spans_the_grid_span():
+    """A basis that vanishes on part of the grid would drop information."""
+    B = cubic_bspline_basis(np.linspace(-2.0, 5.0, 40), 9)
+    assert np.all(B.sum(axis=1) > 0)
+
+
+def test_project_increasing_is_idempotent_on_increasing_input():
+    x = np.linspace(0, 1, 25)
+    v = np.sqrt(x)
+    assert np.allclose(project_increasing(x, v), v, atol=1e-8)
+
+
+def test_project_increasing_sorts_and_respects_bounds():
+    x = np.linspace(0, 1, 25)
+    v = np.linspace(1.0, 0.0, 25)                     # decreasing
+    out = project_increasing(x, v, bounds=(0.25, 0.75))
+    assert np.all(np.diff(out) >= -1e-12)
+    assert out.min() >= 0.25 - 1e-12 and out.max() <= 0.75 + 1e-12
+
+
+def test_project_psd_clips_negative_eigenvalues_only():
+    rng = np.random.default_rng(0)
+    A = rng.normal(size=(4, 4))
+    M = A + A.T                                        # symmetric, indefinite
+    rows, cols = np.tril_indices(4)
+    out = vech_to_matrix(project_psd(M[rows, cols], 4), 4)
+    assert np.linalg.eigvalsh(out).min() >= -1e-10
+    good = vech_to_matrix(project_psd((M @ M.T)[rows, cols], 4), 4)
+    assert np.allclose(good, M @ M.T, atol=1e-8)
+
+
+def test_vech_roundtrip():
+    rng = np.random.default_rng(3)
+    A = rng.normal(size=(5, 5)); M = A + A.T
+    rows, cols = np.tril_indices(5)
+    assert np.allclose(vech_to_matrix(M[rows, cols], 5), M)
+
+
+# ---------------------------------------------------------------------------
+# edge cases
+# ---------------------------------------------------------------------------
+def test_single_donor_is_forced_to_weight_one():
+    """With one donor the simplex has one point, and centering kills the design.
+
+    Subtracting the donor mean leaves a single donor identically zero, so the
+    ridge correction is zero whatever the penalty. Augmentation has to degrade
+    to a no-op rather than divide by the design's (zero) scale.
+    """
+    df, _ = curve_panel(n_units=2)
+    res = FSC(base_config(df)).fit()
+    assert res.fsc_weights.shape == (1,)
+    assert np.isclose(res.fsc_weights[0], 1.0)
+    assert np.isclose(res.augmented_weights[0], 1.0)
+    assert res.pre_treatment_fit == pytest.approx(res.pre_treatment_fit_fsc)
+
+
+def test_single_pre_period_runs():
+    df, _ = curve_panel(n_times=6, n_pre=1)
+    res = FSC(base_config(df, ridge_lambda=1.0, inference="none")).fit()
+    assert np.isfinite(res.effects.att)
+
+
+def test_single_post_period_runs():
+    df, _ = curve_panel(n_times=14, n_pre=13)
+    res = FSC(base_config(df)).fit()
+    assert sum(c.is_post for c in res.curves) == 1
+
+
+def test_collinear_donors_do_not_blow_up():
+    df, cube = curve_panel(n_units=5)
+    dup = cube.copy()
+    dup[2] = dup[1]                                    # exact duplicate donor
+    res = FSC(base_config(_to_long(dup, 12))).fit()
+    assert np.all(np.isfinite(res.augmented_weights))
+    assert np.isclose(res.augmented_weights.sum(), 1.0)
+
+
+def test_two_grid_points_runs_with_a_small_basis():
+    df, _ = curve_panel(n_grid=2)
+    res = FSC(base_config(df, n_basis=4)).fit()
+    assert np.isfinite(res.pre_treatment_fit)
+
+
+def test_unsorted_input_rows_do_not_change_the_answer():
+    df, _ = curve_panel()
+    shuffled = df.sample(frac=1.0, random_state=7).reset_index(drop=True)
+    a = FSC(base_config(df)).fit()
+    b = FSC(base_config(shuffled)).fit()
+    assert np.allclose(a.augmented_weights, b.augmented_weights, atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# failures -- every one must be reported, not swallowed
+# ---------------------------------------------------------------------------
+def test_missing_argument_column_is_reported():
+    df, _ = curve_panel()
+    with pytest.raises(MlsynthDataError, match="argument"):
+        FSC(base_config(df, argument="not_a_column")).fit()
+
+
+def test_argument_column_colliding_with_a_reserved_column_is_reported():
+    df, _ = curve_panel()
+    with pytest.raises(MlsynthConfigError, match="distinct"):
+        FSC(base_config(df, argument="time"))
+
+
+def test_ragged_grid_is_reported():
+    df, _ = curve_panel()
+    ragged = df.drop(df.index[[3]])
+    with pytest.raises(MlsynthDataError, match="grid"):
+        FSC(base_config(ragged)).fit()
+
+
+def test_matrix_space_accepts_labelled_cells():
+    """A matrix cell is an index, not a point -- 'SC:SD' is a legitimate label.
+
+    No basis is built in the Euclidean case, so nothing needs a numeric grid.
+    """
+    df, cube = matrix_panel(dim=3)
+    rows, cols = np.tril_indices(3)
+    labels = [f"c{r}:c{c}" for r, c in zip(rows, cols)]
+    df = df.copy()
+    df["cell"] = [labels[int(round(v * (len(labels) - 1)))] for v in df["cell"]]
+    res = FSC(base_config(df, outcome="cov", argument="cell",
+                          space="matrix")).fit()
+    assert list(res.grid) == labels
+    for curve in res.curves:
+        M = vech_to_matrix(curve.counterfactual, 3)
+        assert np.linalg.eigvalsh(M).min() >= -1e-8
+
+
+def test_labelled_cells_in_an_inconsistent_order_are_reported():
+    """Order carries the coordinate identity, so a permuted cell is an error."""
+    df, _ = matrix_panel(dim=3)
+    rows, cols = np.tril_indices(3)
+    labels = [f"c{r}:c{c}" for r, c in zip(rows, cols)]
+    df = df.copy()
+    df["cell"] = [labels[int(round(v * (len(labels) - 1)))] for v in df["cell"]]
+    idx = df.index[(df["unit"] == "u1") & (df["time"] == 0)].tolist()
+    df.loc[idx[0], "cell"], df.loc[idx[1], "cell"] = (
+        df.loc[idx[1], "cell"], df.loc[idx[0], "cell"])
+    with pytest.raises(MlsynthDataError, match="order"):
+        FSC(base_config(df, outcome="cov", argument="cell",
+                        space="matrix")).fit()
+
+
+def test_non_numeric_argument_is_reported_for_the_spline_spaces():
+    """A spline basis needs somewhere to put its knots."""
+    df, _ = curve_panel()
+    df = df.copy()
+    df["x"] = df["x"].astype(str)
+    with pytest.raises(MlsynthDataError, match="numeric"):
+        FSC(base_config(df)).fit()
+
+
+def test_non_numeric_outcome_is_reported():
+    df, _ = curve_panel()
+    df["y"] = df["y"].astype(str)
+    with pytest.raises(MlsynthDataError, match="numeric"):
+        FSC(base_config(df)).fit()
+
+
+def test_non_finite_values_are_reported():
+    df, _ = curve_panel()
+    df.loc[0, "y"] = np.nan
+    with pytest.raises(MlsynthDataError, match="finite|NaN"):
+        FSC(base_config(df)).fit()
+
+
+def test_no_treated_unit_is_reported():
+    df, _ = curve_panel()
+    df["treat"] = 0
+    with pytest.raises(MlsynthDataError, match="treated"):
+        FSC(base_config(df)).fit()
+
+
+def test_two_treated_units_are_reported():
+    df, _ = curve_panel()
+    df.loc[(df["unit"] == "u1") & (df["time"] >= 8), "treat"] = 1
+    with pytest.raises(MlsynthDataError, match="single treated"):
+        FSC(base_config(df)).fit()
+
+
+def test_no_donors_is_reported():
+    df, _ = curve_panel(n_units=1)
+    with pytest.raises(MlsynthDataError, match="donor"):
+        FSC(base_config(df)).fit()
+
+
+def test_treatment_from_the_first_period_is_reported():
+    df, _ = curve_panel(n_pre=0)
+    with pytest.raises(MlsynthDataError, match="pre-treatment"):
+        FSC(base_config(df)).fit()
+
+
+def test_matrix_space_with_a_non_triangular_grid_is_reported():
+    df, _ = curve_panel(n_grid=15)                    # 15 = vech of 5x5, fine
+    bad, _ = curve_panel(n_grid=8)                    # 8 is not m(m+1)/2
+    with pytest.raises(MlsynthDataError, match="triangle"):
+        FSC(base_config(bad, space="matrix")).fit()
+    FSC(base_config(df, space="matrix")).fit()        # 15 is a valid vech
+
+
+def test_unknown_space_is_reported():
+    df, _ = curve_panel()
+    with pytest.raises(MlsynthConfigError):
+        FSCConfig(**base_config(df, space="hyperbolic"))
+
+
+def test_bad_alpha_is_reported():
+    df, _ = curve_panel()
+    with pytest.raises(MlsynthConfigError):
+        FSCConfig(**base_config(df, conformal_alpha=1.5))
+
+
+def test_alpha_below_the_conformal_resolution_is_reported():
+    """The band needs alpha > 1 / (T0 + 1); below that the test never rejects."""
+    df, _ = curve_panel(n_times=6, n_pre=3)
+    with pytest.raises(MlsynthEstimationError, match="alpha"):
+        FSC(base_config(df, conformal_alpha=0.01)).fit()
+
+
+def test_too_few_basis_functions_is_reported():
+    df, _ = curve_panel()
+    with pytest.raises(MlsynthConfigError):
+        FSCConfig(**base_config(df, n_basis=3))
+
+
+def test_inverted_lambda_bounds_are_reported():
+    df, _ = curve_panel()
+    with pytest.raises(MlsynthConfigError, match="lambda_bounds"):
+        FSCConfig(**base_config(df, lambda_bounds=(5.0, 1.0)))
+
+
+def test_negative_lambda_is_reported():
+    df, _ = curve_panel()
+    with pytest.raises(MlsynthConfigError):
+        FSCConfig(**base_config(df, ridge_lambda=-1.0))
+
+
+def test_extra_config_field_is_forbidden():
+    df, _ = curve_panel()
+    with pytest.raises(MlsynthConfigError):
+        FSC(base_config(df, not_a_field=1))
+
+
+def test_config_must_be_a_config_or_dict():
+    with pytest.raises(MlsynthConfigError, match="FSCConfig"):
+        FSC("not a config")
+
+
+def test_value_bounds_only_apply_to_the_distribution_space():
+    df, _ = curve_panel()
+    with pytest.raises(MlsynthConfigError, match="value_bounds"):
+        FSCConfig(**base_config(df, space="function", value_bounds=(0.0, 1.0)))
+
+
+# ---------------------------------------------------------------------------
+# plotting
+# ---------------------------------------------------------------------------
+def test_plot_smoke(monkeypatch):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    monkeypatch.setattr(plt, "show", lambda *a, **k: None)
+
+    df, _ = curve_panel()
+    FSC(base_config(df, display_graphs=True)).fit()
+
+
+def test_plot_save_to_file(tmp_path, monkeypatch):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    monkeypatch.setattr(plt, "show", lambda *a, **k: None)
+
+    df, _ = curve_panel()
+    target = tmp_path / "fsc"
+    FSC(base_config(df, display_graphs=True, save=str(target))).fit()
+    assert target.with_suffix(".png").exists()

--- a/mlsynth/utils/fsc_helpers/__init__.py
+++ b/mlsynth/utils/fsc_helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers for FSC (Okano & Kurisu 2026)."""

--- a/mlsynth/utils/fsc_helpers/basis.py
+++ b/mlsynth/utils/fsc_helpers/basis.py
@@ -1,0 +1,57 @@
+"""Cubic B-spline basis for the FSC ridge augmentation.
+
+Section 3.2 expands each curve in an orthonormal basis of :math:`\\mathcal H`
+and truncates at :math:`K` terms; the authors' code uses cubic B-splines with
+:math:`K - 2` equispaced knots spanning the grid. B-splines are not orthonormal,
+so this is a departure from the theory that the implementation makes and the
+paper's numbers depend on -- the ridge quadratic form in eq. (9) is invariant
+only under an orthogonal change of basis.
+
+The knot construction follows ``cubicBsplines::Bsplines``: the interior knots
+are extended by three equispaced knots on each side, which makes the resulting
+basis the ordinary partition-of-unity cubic B-spline design matrix on that
+extended sequence. Verified against the authors' Fortran to 3e-15 over the grids
+of all three applications.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.interpolate import BSpline
+
+from ...exceptions import MlsynthEstimationError
+
+
+def cubic_bspline_basis(grid: np.ndarray, n_basis: int) -> np.ndarray:
+    """Return the ``(len(grid), n_basis)`` cubic B-spline design matrix.
+
+    Parameters
+    ----------
+    grid : numpy.ndarray
+        Argument values, ascending. Only its span matters for the knots.
+    n_basis : int
+        Number of basis functions ``K``; the interior knot sequence has
+        ``K - 2`` points, so ``K >= 4``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Non-negative, rows summing to one across the grid's span.
+
+    Raises
+    ------
+    MlsynthEstimationError
+        The grid is degenerate (all points equal), so no knot spacing exists.
+    """
+    grid = np.asarray(grid, dtype=float)
+    lo, hi = float(grid.min()), float(grid.max())
+    if not hi > lo:
+        raise MlsynthEstimationError(
+            "the argument grid is a single point, so no B-spline basis can be "
+            "built. FSC needs at least two distinct argument values.")
+    knots = np.linspace(lo, hi, int(n_basis) - 2)
+    step = knots[1] - knots[0]
+    full = np.concatenate([knots[0] - step * np.arange(3, 0, -1),
+                           knots,
+                           knots[-1] + step * np.arange(1, 4)])
+    return BSpline.design_matrix(grid, full, 3, extrapolate=True).toarray()

--- a/mlsynth/utils/fsc_helpers/config.py
+++ b/mlsynth/utils/fsc_helpers/config.py
@@ -1,0 +1,173 @@
+"""Configuration for FSC (Okano & Kurisu 2026).
+
+One input beyond the usual four columns, and it is what makes the estimator
+possible rather than a convenience. ``argument`` names the column holding the
+point at which each outcome is observed -- the age, the quantile level, the
+matrix cell -- because an FSC outcome is a whole object per ``(unit, time)``
+cell rather than a number, and the panel has to say where along that object
+each row sits.
+
+``space`` then says which metric space the objects live in, which fixes two
+things the method needs and nothing else: whether a basis expansion is used in
+the augmentation, and how the augmented estimate is projected back into the
+image of the isometry. The three values correspond to Examples 1, 2 and 3 of the
+paper, which are also its three empirical applications.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional, Tuple
+
+from pydantic import Field, field_validator, model_validator
+
+from ...config_models import BaseEstimatorConfig
+from ...exceptions import MlsynthConfigError
+
+
+class FSCConfig(BaseEstimatorConfig):
+    """Typed configuration for :class:`mlsynth.FSC`."""
+
+    argument: str = Field(
+        ...,
+        description=(
+            "Column giving the point at which each outcome value is observed: "
+            "age for a fertility curve, quantile level for a distribution, "
+            "cell index for a matrix. Every (unit, time) cell must be observed "
+            "on the same grid."),
+    )
+    space: Literal["function", "distribution", "matrix"] = Field(
+        default="function",
+        description=(
+            "Metric space the outcomes live in, following the paper's "
+            "examples. 'function' -- curves in L2, the identity isometry and "
+            "no projection (Example 1). 'distribution' -- quantile functions "
+            "in the 2-Wasserstein space, projected back by increasing "
+            "rearrangement (Example 2). 'matrix' -- symmetric positive "
+            "semidefinite matrices under the Frobenius metric, supplied as the "
+            "row-major lower triangle and projected back by clipping negative "
+            "eigenvalues (Example 3). The matrix case is Euclidean, so it uses "
+            "the standard basis and skips the spline expansion."),
+    )
+    augment: bool = Field(
+        default=True,
+        description=(
+            "Apply the ridge augmentation of section 3.2. The plain FSC "
+            "weights are always reported; augmentation adds the bias "
+            "correction on top, which closes pre-treatment imbalance the "
+            "simplex cannot at the cost of allowing negative weights."),
+    )
+    n_basis: int = Field(
+        default=50,
+        description=(
+            "Number of cubic B-spline basis functions K used to expand the "
+            "curves before the ridge correction. The paper uses 50. Ignored "
+            "when space='matrix', where the standard basis is already "
+            "orthonormal. The floor of 4 is structural: a cubic basis needs at "
+            "least two knots."),
+    )
+    ridge_lambda: Optional[float] = Field(
+        default=None,
+        description=(
+            "Ridge penalty in eq. (9). None (the default) selects it by "
+            "leave-one-pre-period-out cross-validation over `lambda_bounds` "
+            "(Remark 5). Note the objective is typically flat near its "
+            "minimum, so the penalty is weakly identified and the estimate is "
+            "insensitive to it over a wide range."),
+    )
+    lambda_bounds: Tuple[float, float] = Field(
+        default=(0.0, 10.0),
+        description=(
+            "Search interval for the cross-validated penalty. The paper's "
+            "scripts use (0, 10) for the two functional applications and "
+            "(0, 1) for the covariance one."),
+    )
+    value_bounds: Optional[Tuple[float, float]] = Field(
+        default=None,
+        description=(
+            "Optional (low, high) truncation applied before the increasing "
+            "rearrangement, for space='distribution' only -- the support of "
+            "the distribution, e.g. (0, 110) for an age-at-death quantile "
+            "function. Left open when None."),
+    )
+    inference: Literal["conformal", "placebo", "both", "none"] = Field(
+        default="conformal",
+        description=(
+            "'conformal' returns a pointwise prediction band for the "
+            "counterfactual curve by inverting the sharp null against the "
+            "pre-treatment residuals (section 4.3). 'placebo' returns a "
+            "per-period p-value by re-running the estimator with each donor "
+            "cast as treated -- accurate but N times the work. 'both' does "
+            "both; 'none' skips inference."),
+    )
+    conformal_alpha: float = Field(
+        default=0.10,
+        description=(
+            "Nominal level of the prediction band. Must exceed 1 / (T0 + 1): "
+            "below that the inverted test never excludes anything and the "
+            "band is unbounded."),
+    )
+
+    @field_validator("space", "inference", mode="before")
+    @classmethod
+    def _check_choice(cls, value, info):
+        """Reject an unknown choice before pydantic's Literal check fires.
+
+        Without this the caller sees pydantic's ValidationError; the library
+        contract is that a bad config raises MlsynthConfigError.
+        """
+        allowed = {"space": ("function", "distribution", "matrix"),
+                   "inference": ("conformal", "placebo", "both", "none")}
+        options = allowed[info.field_name]
+        if value not in options:
+            raise MlsynthConfigError(
+                f"{info.field_name}={value!r} is not one of "
+                f"{', '.join(map(repr, options))}.")
+        return value
+
+    @model_validator(mode="after")
+    def _check(self) -> "FSCConfig":
+        # Bounds live here rather than on the Field so a bad value surfaces as
+        # MlsynthConfigError. Field constraints raise pydantic's own
+        # ValidationError, which would leak the wrong exception type to callers
+        # constructing the config directly.
+        if self.n_basis < 4:
+            raise MlsynthConfigError(
+                f"n_basis={self.n_basis} is below 4; a cubic B-spline basis "
+                "needs at least two knots, so K = 4 is the smallest usable "
+                "value.")
+        if self.ridge_lambda is not None and self.ridge_lambda < 0.0:
+            raise MlsynthConfigError(
+                f"ridge_lambda={self.ridge_lambda} is negative; the penalty in "
+                "eq. (9) must be non-negative. Pass None to select it by "
+                "cross-validation.")
+        if not 0.0 < self.conformal_alpha < 1.0:
+            raise MlsynthConfigError(
+                f"conformal_alpha={self.conformal_alpha} is not in (0, 1); it "
+                "is a nominal coverage level.")
+        reserved = {"outcome": self.outcome, "treat": self.treat,
+                    "unitid": self.unitid, "time": self.time}
+        clash = [k for k, v in reserved.items() if v == self.argument]
+        if clash:
+            raise MlsynthConfigError(
+                f"argument={self.argument!r} also names the {clash[0]} column; "
+                "the five column roles must be distinct.")
+        lo, hi = self.lambda_bounds
+        if not lo < hi:
+            raise MlsynthConfigError(
+                f"lambda_bounds must be (low, high) with low < high; got "
+                f"({lo}, {hi}).")
+        if lo < 0.0:
+            raise MlsynthConfigError(
+                f"lambda_bounds must be non-negative; got ({lo}, {hi}).")
+        if self.value_bounds is not None:
+            if self.space != "distribution":
+                raise MlsynthConfigError(
+                    "value_bounds truncates the support of a quantile function "
+                    f"and only applies to space='distribution'; got "
+                    f"space={self.space!r}.")
+            blo, bhi = self.value_bounds
+            if not blo < bhi:
+                raise MlsynthConfigError(
+                    f"value_bounds must be (low, high) with low < high; got "
+                    f"({blo}, {bhi}).")
+        return self

--- a/mlsynth/utils/fsc_helpers/inference.py
+++ b/mlsynth/utils/fsc_helpers/inference.py
@@ -1,0 +1,91 @@
+"""Inference for FSC: conformal prediction bands and the placebo test.
+
+Both are section 4.3, and both are cheap because the weights are held fixed.
+
+The band inverts the sharp null :math:`Y^N_{1t}(x) = y_0` pointwise in
+:math:`x`, comparing the post-treatment residual with the :math:`T_0`
+pre-treatment ones. The inversion has a closed form: the accepted set is the
+interval centred on the estimate with half-width the appropriate quantile of the
+absolute pre-treatment residuals. Note the departure from Chernozhukov, Wüthrich
+& Zhu (2021) that the paper makes deliberately -- the weights are *not* refit
+under each candidate null, which is what guarantees the band contains the point
+estimate but costs the exchangeability argument. The paper conjectures
+asymptotic validity rather than proving it.
+
+The placebo test re-runs the whole estimator with each donor cast as the treated
+unit and ranks the treated unit's effect magnitude among them. With :math:`N`
+units the smallest attainable p-value is :math:`1/N`, so the test's resolution
+is set by the donor pool, not the data.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Tuple
+
+import numpy as np
+
+from ...exceptions import MlsynthEstimationError
+
+
+def conformal_halfwidth(values: np.ndarray, n_pre: int, synthetic: np.ndarray,
+                        alpha: float) -> np.ndarray:
+    """Pointwise half-width ``q_alpha(x)`` of the prediction band.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        The ``(N, T, M)`` cube of embedded objects.
+    n_pre : int
+        Number of pre-treatment periods.
+    synthetic : numpy.ndarray
+        The ``(T, M)`` counterfactual objects.
+    alpha : float
+        Nominal level.
+
+    Returns
+    -------
+    numpy.ndarray
+        Half-width at each grid point, shape ``(M,)``.
+
+    Raises
+    ------
+    MlsynthEstimationError
+        ``alpha <= 1 / (n_pre + 1)``, where the inverted test excludes nothing
+        and the band is unbounded.
+    """
+    if alpha <= 1.0 / (n_pre + 1.0):
+        raise MlsynthEstimationError(
+            f"conformal_alpha={alpha} is not above 1 / (T0 + 1) = "
+            f"{1.0 / (n_pre + 1.0):.4f} with {n_pre} pre-treatment period(s). "
+            "Below that threshold the inverted test never excludes a value and "
+            "the band is unbounded. Raise conformal_alpha, lengthen the "
+            "pre-period, or use inference='placebo'.")
+    residuals = np.abs(values[0, :n_pre] - synthetic[:n_pre])   # (T0, M)
+    level = 1.0 - ((n_pre + 1.0) * alpha - 1.0) / n_pre
+    return np.quantile(residuals, level, axis=0, method="linear")
+
+
+def placebo_p_values(values: np.ndarray, n_pre: int,
+                     estimate: Callable[[np.ndarray], np.ndarray]
+                     ) -> np.ndarray:
+    """Per-post-period p-values by casting each donor as treated.
+
+    ``estimate`` maps a cube whose unit 0 is the candidate treated unit to that
+    unit's ``(T, M)`` counterfactual, so the placebo runs are the same
+    computation as the real one -- including the penalty selection.
+    """
+    n_units, n_times, _ = values.shape
+    n_post = n_times - n_pre
+    magnitudes = np.empty((n_units, n_post))
+    for i in range(n_units):
+        order = [i] + [j for j in range(n_units) if j != i]
+        rotated = values[order]
+        gap = rotated[0, n_pre:] - estimate(rotated)[n_pre:]
+        magnitudes[i] = np.sqrt(np.sum(gap ** 2, axis=1))
+    return (magnitudes[0] <= magnitudes).mean(axis=0)
+
+
+def band_from_halfwidth(synthetic: np.ndarray, halfwidth: np.ndarray
+                        ) -> Tuple[np.ndarray, np.ndarray]:
+    """``(lower, upper)`` band on the counterfactual objects."""
+    return synthetic - halfwidth, synthetic + halfwidth

--- a/mlsynth/utils/fsc_helpers/pipeline.py
+++ b/mlsynth/utils/fsc_helpers/pipeline.py
@@ -1,0 +1,211 @@
+"""End-to-end FSC: embed, weight, augment, project, infer, assemble."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from ...config_models import (EffectsResults, FitDiagnosticsResults,
+                              MethodDetailsResults, TimeSeriesResults,
+                              WeightsResults)
+from .basis import cubic_bspline_basis
+from .config import FSCConfig
+from .project import (frobenius_weights, project_increasing, project_psd,
+                      triangular_dimension)
+from .structures import FSCCurve, FSCInputs, FSCResults
+from .weights import (augmented_weights, fsc_weights, pre_treatment_fit,
+                      select_lambda, synthetic_objects)
+from .inference import (band_from_halfwidth, conformal_halfwidth,
+                        placebo_p_values)
+
+
+def _embedding(inputs: FSCInputs, space: str) -> np.ndarray:
+    """Coordinate weights realising the isometry ``Psi`` on the argument axis.
+
+    For curves and quantile functions the sampled values already are the
+    coordinates. For matrices they are not: the Frobenius metric counts each
+    off-diagonal entry twice, so the half-vectorisation becomes an isometry only
+    once the off-diagonal coordinates are scaled by ``sqrt(2)``.
+    """
+    if space != "matrix":
+        return np.ones(inputs.grid.size)
+    return frobenius_weights(triangular_dimension(inputs.grid.size))
+
+
+def _project(objects: np.ndarray, inputs: FSCInputs, config: FSCConfig,
+             scale: np.ndarray) -> np.ndarray:
+    """Project each object back onto ``Psi(M)``, in embedded coordinates."""
+    if config.space == "function":
+        return objects
+    if config.space == "distribution":
+        return np.array([project_increasing(inputs.grid, o,
+                                            bounds=config.value_bounds)
+                         for o in objects])
+    dim = triangular_dimension(inputs.grid.size)
+    return np.array([project_psd(o / scale, dim) * scale for o in objects])
+
+
+def run_fsc(inputs: FSCInputs, config: FSCConfig) -> FSCResults:
+    """Fit FSC and return the typed results."""
+    scale = _embedding(inputs, config.space)
+    values = inputs.values * scale                 # embedded coordinates
+    n_pre = inputs.pre_periods
+
+    basis: Optional[np.ndarray] = None
+    if config.space != "matrix":
+        basis = cubic_bspline_basis(inputs.grid, config.n_basis)
+
+    gamma = fsc_weights(values, n_pre)
+    synthetic_fsc = synthetic_objects(values, gamma)
+    fit_fsc = pre_treatment_fit(values, n_pre, synthetic_fsc)
+
+    lam: Optional[float] = None
+    lam_relative: Optional[float] = None
+    by_cv: Optional[bool] = None
+    weights = gamma
+    augmented: Optional[np.ndarray] = None
+    if config.augment:
+        by_cv = config.ridge_lambda is None
+        if by_cv:
+            lam, lam_relative = select_lambda(
+                values, n_pre, config.lambda_bounds, basis=basis,
+                grid=inputs.grid)
+        else:
+            lam = float(config.ridge_lambda)
+        augmented = augmented_weights(values, n_pre, lam, basis=basis,
+                                      grid=inputs.grid)
+        weights = augmented
+
+    synthetic = _project(synthetic_objects(values, weights), inputs, config,
+                         scale)
+    fit = pre_treatment_fit(values, n_pre, synthetic)
+
+    lower = upper = None
+    if config.inference in ("conformal", "both"):
+        halfwidth = conformal_halfwidth(values, n_pre, synthetic,
+                                        config.conformal_alpha)
+        lower, upper = band_from_halfwidth(synthetic, halfwidth)
+
+    p_values = None
+    if config.inference in ("placebo", "both"):
+        p_values = placebo_p_values(
+            values, n_pre,
+            lambda cube: _project(
+                synthetic_objects(
+                    cube,
+                    augmented_weights(cube, n_pre, lam, basis=basis,
+                                      grid=inputs.grid)
+                    if config.augment else fsc_weights(cube, n_pre)),
+                inputs, config, scale))
+
+    curves = _build_curves(inputs, values, synthetic, scale, lower, upper)
+    return _assemble(inputs, config, curves, gamma, augmented, fit, fit_fsc,
+                     lam, lam_relative, by_cv, p_values, basis)
+
+
+def _build_curves(inputs: FSCInputs, values: np.ndarray, synthetic: np.ndarray,
+                  scale: np.ndarray, lower, upper) -> List[FSCCurve]:
+    """Un-embed and package one :class:`FSCCurve` per period."""
+    curves: List[FSCCurve] = []
+    for t, label in enumerate(inputs.time_labels):
+        gap = values[0, t] - synthetic[t]
+        curves.append(FSCCurve(
+            time=label,
+            is_post=t >= inputs.pre_periods,
+            observed=values[0, t] / scale,
+            counterfactual=synthetic[t] / scale,
+            effect=gap / scale,
+            magnitude=float(np.sqrt(np.sum(gap ** 2))),
+            lower=None if lower is None else lower[t] / scale,
+            upper=None if upper is None else upper[t] / scale,
+        ))
+    return curves
+
+
+def _assemble(inputs: FSCInputs, config: FSCConfig, curves: List[FSCCurve],
+              gamma: np.ndarray, augmented: Optional[np.ndarray], fit: float,
+              fit_fsc: float, lam: Optional[float],
+              lam_relative: Optional[float], by_cv: Optional[bool],
+              p_values, basis: Optional[np.ndarray]) -> FSCResults:
+    """Lift the curve-valued output into the standardized sub-models."""
+    observed = np.array([c.observed.mean() for c in curves])
+    counterfactual = np.array([c.counterfactual.mean() for c in curves])
+    gap = observed - counterfactual
+    post = np.array([c.is_post for c in curves])
+    weights = gamma if augmented is None else augmented
+
+    band: Dict[str, Any] = {}
+    if curves and curves[0].lower is not None:
+        band = {
+            "counterfactual_lower": np.array([c.lower.mean() for c in curves]),
+            "counterfactual_upper": np.array([c.upper.mean() for c in curves]),
+            "prediction_interval_level": 1.0 - config.conformal_alpha,
+            "prediction_interval_kind": "conformal",
+        }
+
+    return FSCResults(
+        curves=curves,
+        grid=inputs.grid,
+        fsc_weights=gamma,
+        augmented_weights=augmented,
+        pre_treatment_fit=fit,
+        pre_treatment_fit_fsc=fit_fsc,
+        ridge_lambda=lam,
+        ridge_lambda_relative=lam_relative,
+        lambda_selected_by_cv=by_cv,
+        placebo_p_values=p_values,
+        n_negative_weights=None if augmented is None
+        else int((augmented < 0).sum()),
+        effects=EffectsResults(
+            att=float(gap[post].mean()),
+            additional_effects={
+                "mean_effect_magnitude": float(
+                    np.mean([c.magnitude for c in curves if c.is_post])),
+                "effect_magnitude_by_period": {
+                    str(c.time): c.magnitude for c in curves if c.is_post},
+            }),
+        fit_diagnostics=FitDiagnosticsResults(
+            rmse_pre=float(np.sqrt(np.mean(gap[~post] ** 2))),
+            rmse_post=float(np.sqrt(np.mean(gap[post] ** 2))),
+            additional_metrics={
+                "pre_treatment_fit": fit,
+                "pre_treatment_fit_fsc": fit_fsc,
+                "fit_improvement": (float("nan") if fit_fsc == 0.0
+                                    else 1.0 - fit / fit_fsc),
+            }),
+        time_series=TimeSeriesResults(
+            observed_outcome=observed,
+            counterfactual_outcome=counterfactual,
+            estimated_gap=gap,
+            time_periods=np.asarray(inputs.time_labels, dtype=object),
+            intervention_time=inputs.time_labels[inputs.pre_periods]
+            if inputs.post_periods else None,
+            **band),
+        weights=WeightsResults(
+            donor_weights={str(u): float(v)
+                           for u, v in zip(inputs.donor_names, weights)},
+            summary_stats={
+                "constraint": ("simplex" if augmented is None
+                               else "sum to one (negative weights allowed)"),
+                "sum": float(weights.sum())}),
+        method_details=MethodDetailsResults(
+            method_name="FSC",
+            parameters_used={
+                "space": config.space,
+                "augment": config.augment,
+                "n_basis": None if basis is None else int(config.n_basis),
+                "ridge_lambda": lam,
+                "ridge_lambda_relative": lam_relative,
+                "inference": config.inference,
+                "n_donors": inputs.n_donors,
+                "n_pre": inputs.pre_periods,
+                "n_grid": int(inputs.grid.size),
+            }),
+        metadata={
+            "treated_unit": inputs.treated_unit_name,
+            "donor_names": list(inputs.donor_names),
+            "argument": inputs.argument,
+            "outcome": inputs.outcome,
+        },
+    )

--- a/mlsynth/utils/fsc_helpers/plotter.py
+++ b/mlsynth/utils/fsc_helpers/plotter.py
@@ -1,0 +1,58 @@
+"""Plot FSC output: the observed and counterfactual objects, and the effect.
+
+A scalar synthetic control plots one line against time. Here every period holds
+a whole object, so the natural display is a small multiple: one panel per
+period, the argument on the horizontal axis, the observed and counterfactual
+objects overlaid, and the conformal band shaded on the post-treatment panels.
+That is the layout the paper's own figures use.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+
+
+def plot_fsc(results, argument_label: str = "argument",
+             outcome_label: str = "outcome", max_panels: int = 12,
+             save: Union[bool, str] = False, display: bool = True) -> None:
+    """Small multiple of observed vs counterfactual objects, one panel a period.
+
+    Shows the last ``max_panels`` periods so the post-treatment ones are always
+    visible; a long pre-period is summarised by the fit statistics rather than
+    by dozens of near-identical panels.
+    """
+    import matplotlib.pyplot as plt
+
+    curves = list(results.curves)[-int(max_panels):]
+    grid = np.asarray(results.grid, dtype=float)
+    n = len(curves)
+    ncol = min(4, n)
+    nrow = int(np.ceil(n / ncol))
+    fig, axes = plt.subplots(nrow, ncol, figsize=(3.4 * ncol, 2.8 * nrow),
+                             squeeze=False, sharex=True)
+
+    for ax, curve in zip(axes.ravel(), curves):
+        if curve.lower is not None and curve.is_post:
+            ax.fill_between(grid, curve.lower, curve.upper, color="#c8d8e8",
+                            alpha=0.7, lw=0)
+        ax.plot(grid, curve.observed, color="black", lw=1.6, label="observed")
+        ax.plot(grid, curve.counterfactual, color="#c0392b", lw=1.5, ls="--",
+                label="synthetic")
+        ax.set_title(f"{curve.time}{'' if curve.is_post else ' (pre)'}",
+                     fontsize=9)
+        ax.grid(alpha=0.22)
+        ax.set_xlabel(argument_label)
+        ax.set_ylabel(outcome_label)
+    for ax in axes.ravel()[n:]:
+        ax.axis("off")
+    axes.ravel()[0].legend(fontsize=8, frameon=False)
+    fig.tight_layout()
+
+    if save:
+        fig.savefig(f"{save}.png" if isinstance(save, str) else "fsc.png",
+                    dpi=150, bbox_inches="tight")
+    if display:
+        plt.show()
+    plt.close(fig)

--- a/mlsynth/utils/fsc_helpers/project.py
+++ b/mlsynth/utils/fsc_helpers/project.py
@@ -1,0 +1,100 @@
+"""Projection of the augmented estimate back onto the image of the isometry.
+
+The plain FSC estimate is a convex combination of donor objects, so it lands in
+:math:`\\Psi(\\mathcal M)` automatically -- that set is convex. The augmented
+estimate need not, because eq. (9) allows negative weights, so section 3.2
+projects it back:
+
+.. math::
+
+   \\tilde Y^{N,\\mathrm{aug}}_{1t}
+     = \\arg\\min_{y \\in \\mathcal Y} \\lVert y - \\hat Y^{N,\\mathrm{aug}}_{1t}
+       \\rVert_{\\mathcal H}.
+
+Two spaces admit a closed form and are implemented here. For quantile functions
+:math:`\\mathcal Y` is the set of increasing functions and the projection is the
+increasing rearrangement (Remark 4). For symmetric positive semidefinite
+matrices under the Frobenius metric it is the eigenvalue clip: symmetrize, set
+negative eigenvalues to zero, reassemble. For the plain functional case
+:math:`\\mathcal Y = \\mathcal H` and there is nothing to do.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import numpy as np
+
+from ...exceptions import MlsynthDataError
+
+
+def project_increasing(grid: np.ndarray, values: np.ndarray,
+                       bounds: Optional[Tuple[float, float]] = None
+                       ) -> np.ndarray:
+    """Increasing rearrangement of ``values``, optionally truncated first.
+
+    On an ascending grid the L2 projection onto the cone of non-decreasing
+    functions sampled at those points is the sorted vector, which is what this
+    returns. Truncation to ``bounds`` is applied first and is itself a
+    projection onto a convex set, so the composition stays inside
+    :math:`\\mathcal Y`.
+    """
+    values = np.asarray(values, dtype=float)
+    if bounds is not None:
+        values = np.clip(values, bounds[0], bounds[1])
+    order = np.argsort(np.asarray(grid, dtype=float), kind="stable")
+    out = np.empty_like(values)
+    out[order] = np.sort(values[order])
+    return out
+
+
+def triangular_dimension(n_cells: int) -> int:
+    """Recover ``m`` from ``m (m + 1) / 2`` cells, or report the mismatch."""
+    m = int(round((np.sqrt(8.0 * n_cells + 1.0) - 1.0) / 2.0))
+    if m * (m + 1) // 2 != n_cells:
+        raise MlsynthDataError(
+            f"space='matrix' expects the row-major lower triangle of a "
+            f"symmetric matrix, so the grid must have m(m+1)/2 points; got "
+            f"{n_cells}, which is not a triangle number. The nearest valid "
+            f"sizes are {m * (m + 1) // 2} and {(m + 1) * (m + 2) // 2}.")
+    return m
+
+
+def vech_to_matrix(vech: np.ndarray, dim: int) -> np.ndarray:
+    """Rebuild the symmetric ``(dim, dim)`` matrix from its lower triangle."""
+    rows, cols = np.tril_indices(dim)
+    M = np.zeros((dim, dim), dtype=float)
+    M[rows, cols] = np.asarray(vech, dtype=float)
+    return M + M.T - np.diag(np.diag(M))
+
+
+def matrix_to_vech(matrix: np.ndarray) -> np.ndarray:
+    """Row-major lower triangle of a square matrix."""
+    rows, cols = np.tril_indices(matrix.shape[0])
+    return np.asarray(matrix, dtype=float)[rows, cols]
+
+
+def project_psd(vech: np.ndarray, dim: int) -> np.ndarray:
+    """Frobenius projection onto the positive semidefinite cone.
+
+    Exact rather than iterative: for a symmetric matrix the nearest PSD matrix
+    in Frobenius norm is obtained by clipping the eigenvalues at zero.
+    """
+    M = vech_to_matrix(vech, dim)
+    eigenvalues, eigenvectors = np.linalg.eigh(M)
+    if eigenvalues.min() >= 0.0:
+        return np.asarray(vech, dtype=float)
+    clipped = eigenvectors @ np.diag(np.maximum(eigenvalues, 0.0)) @ eigenvectors.T
+    return matrix_to_vech(clipped)
+
+
+def frobenius_weights(dim: int) -> np.ndarray:
+    """Coordinate weights making the half-vectorisation an isometry.
+
+    The Frobenius metric counts each off-diagonal entry twice, so the map
+    ``A -> vech(A)`` is an isometry only once the off-diagonal coordinates are
+    scaled by ``sqrt(2)``. Applying these weights is what makes ``space='matrix'``
+    fit in the metric Example 3 specifies rather than in the plain vech norm.
+    """
+    rows, cols = np.tril_indices(dim)
+    return np.where(rows == cols, 1.0, np.sqrt(2.0))

--- a/mlsynth/utils/fsc_helpers/setup.py
+++ b/mlsynth/utils/fsc_helpers/setup.py
@@ -1,0 +1,164 @@
+"""Ingestion for FSC: a long panel of (unit, time, argument, value) rows.
+
+Each argument slice is a perfectly ordinary scalar panel, so each goes through
+:func:`mlsynth.utils.datautils.dataprep` and the slices are stacked along the
+argument axis. That is the same construction :mod:`mlsynth.utils.compsc_helpers`
+uses for its share columns, and it means the treated/donor split, the period
+ordering and the pre-period count are the library's rather than this module's.
+
+What this module adds on top is the grid contract: every ``(unit, time)`` cell
+must be observed at the same argument values, in the same order. A panel that
+fails that is not a panel of objects and there is nothing sensible to embed.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+import pandas as pd
+
+from ...exceptions import MlsynthDataError
+from ..datautils import dataprep
+from .structures import FSCInputs
+
+
+def _resolve_grid(df: pd.DataFrame, unitid: str, time: str, argument: str,
+                  numeric_grid: bool) -> np.ndarray:
+    """The common argument grid, in the order the coordinates are indexed by.
+
+    A numeric grid is sorted ascending -- it is a set of points on a line, and
+    the spline basis needs it that way. A labelled grid has no natural order, so
+    the order of the first ``(unit, time)`` cell defines the coordinate
+    identity and every other cell must repeat it.
+    """
+    if numeric_grid:
+        return np.sort(pd.unique(df[argument].to_numpy()))
+
+    first = df.groupby([unitid, time], sort=False).ngroup() == 0
+    grid = pd.unique(df.loc[first, argument].to_numpy())
+    for (unit, period), cell in df.groupby([unitid, time], sort=False):
+        labels = cell[argument].to_numpy()
+        if labels.shape != grid.shape or not np.array_equal(labels, grid):
+            raise MlsynthDataError(
+                f"cell ({unit!r}, {period!r}) lists the argument values in a "
+                f"different order from the first cell. With a non-numeric "
+                "argument the row order carries the coordinate identity, so "
+                "every cell must repeat the same sequence. Expected "
+                f"{list(grid[:4])}..., got {list(labels[:4])}...")
+    return grid
+
+
+def prepare_fsc_inputs(df: pd.DataFrame, outcome: str, treat: str, unitid: str,
+                       time: str, argument: str,
+                       numeric_grid: bool = True) -> FSCInputs:
+    """Pivot a long panel of objects into an ``(N, T, M)`` cube.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        One row per (unit, time, argument).
+    outcome, treat, unitid, time, argument : str
+        Column names. ``treat`` is constant within a ``(unit, time)`` cell.
+    numeric_grid : bool
+        Whether the argument must be numeric. True for the spaces that build a
+        spline basis, which needs somewhere to put its knots. False for the
+        Euclidean case, where the argument is a coordinate label -- a matrix
+        cell -- and only its position matters.
+
+    Returns
+    -------
+    FSCInputs
+
+    Raises
+    ------
+    MlsynthDataError
+        A column is missing or non-numeric, the grid is ragged, values are not
+        finite, or the panel has no treated unit, no donors, or no pre-periods.
+    """
+    missing = [c for c in (outcome, treat, unitid, time, argument)
+               if c not in df.columns]
+    if missing:
+        raise MlsynthDataError(
+            f"column(s) {missing} not in the panel; available: "
+            f"{list(df.columns)}. Note FSC needs an argument column naming "
+            "the point at which each outcome value is observed.")
+
+    if not pd.api.types.is_numeric_dtype(df[outcome]):
+        raise MlsynthDataError(
+            f"column {outcome!r} is not numeric; FSC needs a numeric outcome.")
+    if numeric_grid and not pd.api.types.is_numeric_dtype(df[argument]):
+        raise MlsynthDataError(
+            f"column {argument!r} is not numeric. FSC expands the objects in a "
+            "spline basis for this space, which needs a numeric grid to place "
+            "its knots. Only space='matrix' -- where the argument is a "
+            "coordinate label rather than a point -- accepts labels.")
+
+    treated_units = list(pd.unique(df.loc[df[treat] == 1, unitid]))
+    if not treated_units:
+        raise MlsynthDataError(
+            "no treated rows found; FSC needs exactly one treated unit with at "
+            f"least one post-treatment period (column {treat!r} == 1).")
+    if len(treated_units) > 1:
+        # dataprep would cohort these and return a different payload shape;
+        # FSC targets one treated object per period, so say so here instead.
+        raise MlsynthDataError(
+            f"FSC supports a single treated unit; found {len(treated_units)}: "
+            f"{treated_units[:5]}. Fit them separately, or aggregate them into "
+            "one unit first.")
+
+    grid = _resolve_grid(df, unitid, time, argument, numeric_grid)
+    if grid.size < 2:
+        raise MlsynthDataError(
+            f"the argument column {argument!r} takes {grid.size} distinct "
+            "value(s); an FSC outcome is an object sampled at several points, "
+            "so at least two are needed. With a single value per cell the "
+            "outcome is a scalar -- use VanillaSC.")
+
+    counts = df.groupby([unitid, time], sort=False)[argument].agg(
+        ["count", "nunique"])
+    bad = counts[(counts["count"] != grid.size)
+                 | (counts["nunique"] != grid.size)]
+    if not bad.empty:
+        cell = bad.index[0]
+        raise MlsynthDataError(
+            f"the argument grid is ragged: {len(bad)} (unit, time) cell(s) are "
+            f"not observed at all {grid.size} argument values, e.g. {cell} "
+            f"with {int(bad.iloc[0]['nunique'])} distinct value(s). FSC needs "
+            "every cell on a common grid.")
+
+    slices: List[np.ndarray] = []
+    pre_periods = 0
+    unit_names: List = []
+    time_labels: List = []
+    for value in grid:
+        prepped = dataprep(
+            df[df[argument] == value].drop(columns=[argument]),
+            unit_id_column_name=unitid, time_period_column_name=time,
+            outcome_column_name=outcome, treatment_indicator_column_name=treat,
+        )
+        treated = np.asarray(prepped["y"], dtype=float).ravel()
+        donors = np.asarray(prepped["donor_matrix"], dtype=float)
+        slices.append(np.vstack([treated, donors.T]))
+        pre_periods = int(prepped["pre_periods"])
+        unit_names = [prepped["treated_unit_name"], *prepped["donor_names"]]
+        time_labels = list(prepped.get("time_labels", range(treated.size)))
+
+    values = np.stack(slices, axis=-1)                       # (N, T, M)
+    if not np.all(np.isfinite(values)):
+        raise MlsynthDataError(
+            "the panel carries NaN or inf in the outcome; FSC needs complete "
+            "objects -- every cell observed at every argument value.")
+    if values.shape[0] < 2:
+        raise MlsynthDataError(
+            "no donor units: FSC needs at least one untreated unit to form "
+            "the counterfactual object.")
+    if pre_periods < 1:
+        raise MlsynthDataError(
+            "no pre-treatment periods: treatment is in force from the first "
+            "period. FSC matches on the pre-treatment objects, so at least "
+            "one pre-period is required.")
+
+    return FSCInputs(values=values, grid=grid, unit_names=unit_names,
+                     time_labels=time_labels, pre_periods=pre_periods,
+                     outcome=outcome, argument=argument)

--- a/mlsynth/utils/fsc_helpers/structures.py
+++ b/mlsynth/utils/fsc_helpers/structures.py
@@ -1,0 +1,139 @@
+"""Typed containers for FSC."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from pydantic import ConfigDict, Field
+
+from ...config_models import BaseEstimatorResults
+
+
+@dataclass(frozen=True)
+class FSCInputs:
+    """The ``(N, T, M)`` cube of embedded outcomes, treated unit first."""
+
+    values: np.ndarray                 # (N, T, M)
+    grid: np.ndarray                   # (M,) argument values, ascending
+    unit_names: List[Any]              # index 0 is the treated unit
+    time_labels: List[Any]
+    pre_periods: int
+    outcome: str
+    argument: str
+
+    @property
+    def n_donors(self) -> int:
+        return int(self.values.shape[0]) - 1
+
+    @property
+    def donor_names(self) -> List[Any]:
+        return list(self.unit_names[1:])
+
+    @property
+    def post_periods(self) -> int:
+        return int(self.values.shape[1]) - self.pre_periods
+
+    @property
+    def treated_unit_name(self) -> Any:
+        return self.unit_names[0]
+
+
+@dataclass(frozen=True)
+class FSCCurve:
+    """One period's observed object, its counterfactual, and their difference.
+
+    Attributes
+    ----------
+    time : Any
+        The period label.
+    is_post : bool
+        Whether the period is post-treatment.
+    observed, counterfactual, effect : numpy.ndarray
+        Values on the argument grid. ``effect`` is ``observed - counterfactual``,
+        the causal effect of section 2.1 read in the Hilbert space.
+    magnitude : float
+        ``||effect||_H``, the paper's ``d_t`` -- the length of the geodesic
+        between the treated and counterfactual objects.
+    lower, upper : numpy.ndarray or None
+        Pointwise conformal band on the counterfactual, absent unless a band
+        was requested.
+    """
+
+    time: Any
+    is_post: bool
+    observed: np.ndarray
+    counterfactual: np.ndarray
+    effect: np.ndarray
+    magnitude: float
+    lower: Optional[np.ndarray] = None
+    upper: Optional[np.ndarray] = None
+
+
+class FSCResults(BaseEstimatorResults):
+    """Container returned by :meth:`mlsynth.FSC.fit`.
+
+    An :class:`~mlsynth.config_models.EffectResult`. The estimand here is a
+    curve per period, so the standardized sub-models carry a scalar summary and
+    the objects themselves live on :attr:`curves`.
+
+    The summary is the grid average of each object. That choice is deliberate:
+    averaging is linear, so ``estimated_gap`` on :attr:`time_series` really is
+    ``observed_outcome - counterfactual_outcome`` and the usual accessors mean
+    what they say. It is also interpretable in the applications -- the grid
+    average of an age-specific fertility curve is proportional to the total
+    fertility rate, and of a quantile function is the distribution's mean.
+    ``effects.att`` is that summary averaged over the post-treatment periods.
+
+    The magnitude ``d_t = ||Y_1t - Y^N_1t||_H`` is reported alongside on each
+    curve and, averaged over post-periods, as
+    ``effects.additional_effects['mean_effect_magnitude']``. It is non-negative
+    by construction, which is why it is not the headline number.
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    curves: List[FSCCurve] = Field(
+        default_factory=list,
+        description="Per-period observed / counterfactual / effect objects.")
+    grid: Optional[np.ndarray] = Field(
+        default=None, description="Argument grid the objects are sampled on.")
+    fsc_weights: Optional[np.ndarray] = Field(
+        default=None,
+        description="Simplex weights from eq. (1), in donor order.")
+    augmented_weights: Optional[np.ndarray] = Field(
+        default=None,
+        description=("Ridge augmented weights from eq. (9); None when "
+                     "augment=False. They sum to one but may be negative."))
+    pre_treatment_fit: Optional[float] = Field(
+        default=None,
+        description=("Pre-treatment fit of the reported estimator, "
+                     "sqrt(sum_t ||Y_1t - sum_i w_i Y_it||^2)."))
+    pre_treatment_fit_fsc: Optional[float] = Field(
+        default=None,
+        description="The same quantity for the unaugmented FSC weights.")
+    ridge_lambda: Optional[float] = Field(
+        default=None, description="Penalty used in eq. (9).")
+    ridge_lambda_relative: Optional[float] = Field(
+        default=None,
+        description=("The cross-validated penalty as a multiple of the "
+                     "design's own scale (the mean eigenvalue of the Gram "
+                     "matrix). This is the quantity `lambda_bounds` searches "
+                     "over, and it is comparable across datasets in a way the "
+                     "absolute penalty is not. None when the penalty was "
+                     "supplied rather than selected."))
+    lambda_selected_by_cv: Optional[bool] = Field(
+        default=None,
+        description="Whether `ridge_lambda` came from cross-validation.")
+    placebo_p_values: Optional[np.ndarray] = Field(
+        default=None,
+        description=("Per-post-period placebo p-values, aligned to the "
+                     "post-treatment periods. Rank-limited: with N units the "
+                     "smallest attainable value is 1/N."))
+    n_negative_weights: Optional[int] = Field(
+        default=None,
+        description=("Donors given negative weight by the augmentation -- "
+                     "extrapolation outside the donor hull, expected when the "
+                     "simplex fit is imperfect, not a fault."))
+    metadata: Dict[str, Any] = Field(default_factory=dict)

--- a/mlsynth/utils/fsc_helpers/weights.py
+++ b/mlsynth/utils/fsc_helpers/weights.py
@@ -1,0 +1,211 @@
+"""FSC and ridge augmented FSC weights.
+
+Both are the scalar synthetic control applied to a *stacked* design. Section 3.1
+matches on the pre-treatment objects in :math:`\\mathcal H`,
+
+.. math::
+
+   \\hat\\gamma^{\\mathrm{scm}} \\in \\arg\\min_{\\gamma \\in \\Delta^{N-1}}
+     \\sum_{t \\le T_0} \\Bigl\\lVert Y_{1t} - \\sum_i \\gamma_i Y_{it}
+     \\Bigr\\rVert_{\\mathcal H}^2 ,
+
+which, once each object is carried into :math:`\\mathcal H` by the isometry and
+evaluated on a common grid, is the ordinary simplex least-squares problem on the
+``(period, grid point)`` pairs stacked into one long vector. So the base solve is
+mlsynth's own exact QP, :func:`mlsynth.utils.bilevel.ridge_augment.simplex_qp`,
+unchanged.
+
+Everything in this module therefore works on *embedded* coordinates: the caller
+has already applied :math:`\\Psi` (see
+:func:`mlsynth.utils.fsc_helpers.project.frobenius_weights` for the one space
+where that is not the identity), so the norm here is the plain Euclidean norm on
+the sampled coordinates.
+
+Section 3.2's augmentation is likewise the ridge-augmented SCM of Ben-Michael,
+Feller & Rothstein (2021) with the pre-period axis replaced by the
+``(period, basis coefficient)`` axis:
+
+.. math::
+
+   \\hat\\gamma^{\\mathrm{aug}}_i = \\hat\\gamma^{\\mathrm{scm}}_i
+     + (r_{1\\cdot} - r_{0\\cdot}' \\hat\\gamma^{\\mathrm{scm}})'
+       (r_{0\\cdot}' r_{0\\cdot} + \\lambda I)^{-1} r_{i\\cdot} .
+
+The correction vanishes when the simplex fit is perfect and as
+:math:`\\lambda \\to \\infty`, and it is what allows negative weights.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import numpy as np
+from scipy.optimize import minimize_scalar
+
+from ...exceptions import MlsynthEstimationError
+from ..bilevel.ridge_augment import simplex_qp
+
+# R's optimise() default tolerance, .Machine$double.eps^0.25. Used here for the
+# same reason the authors' scripts do: the cross-validation objective is flat
+# near its minimum, so a tighter tolerance buys precision on a quantity that
+# does not need it.
+_BRENT_TOL = float(np.finfo(float).eps ** 0.25)
+
+
+def stacked_design(values: np.ndarray, n_pre: int
+                   ) -> Tuple[np.ndarray, np.ndarray]:
+    """``(treated, donors)`` with the pre-periods and grid stacked into rows."""
+    treated = values[0, :n_pre].ravel()
+    donors = values[1:, :n_pre].reshape(values.shape[0] - 1, -1).T
+    return treated, donors
+
+
+def fsc_weights(values: np.ndarray, n_pre: int) -> np.ndarray:
+    """Simplex weights of eq. (1)."""
+    treated, donors = stacked_design(values, n_pre)
+    return np.asarray(simplex_qp(donors, treated), dtype=float).ravel()
+
+
+def center_pre_periods(values: np.ndarray, n_pre: int) -> np.ndarray:
+    """Subtract the donor mean object at each pre-period (section 3.2).
+
+    The simplex fit is invariant to this -- the shift cancels because the
+    weights sum to one -- but the ridge correction is not.
+    """
+    centered = values.copy()
+    centered[:, :n_pre] -= centered[1:, :n_pre].mean(axis=0, keepdims=True)
+    return centered
+
+
+def trapezoid_weights(grid: np.ndarray) -> np.ndarray:
+    """Quadrature weights approximating ``int f`` from samples on ``grid``."""
+    grid = np.asarray(grid, dtype=float)
+    weights = np.zeros_like(grid)
+    step = np.diff(grid)
+    weights[:-1] += step / 2.0
+    weights[1:] += step / 2.0
+    return weights
+
+
+def basis_coefficients(values: np.ndarray, basis: Optional[np.ndarray],
+                       grid: Optional[np.ndarray]) -> np.ndarray:
+    """Inner products ``r_{i,t,k} = <phi_k, X_it>`` over the argument grid.
+
+    The integral is approximated by the trapezoid rule, so the coefficients are
+    a genuine :math:`L^2` inner product whatever the grid spacing.
+    ``basis=None`` is the Euclidean case, where the coordinates already are the
+    coefficients in the standard basis and no expansion is needed.
+
+    A uniform rescaling of the basis only reparameterises the penalty -- scaling
+    ``r`` by ``c`` and ``lambda`` by ``c^2`` leaves eq. (9) unchanged -- so the
+    normalisation convention here is immaterial to a cross-validated fit.
+    """
+    if basis is None:
+        return values
+    return values @ (basis * trapezoid_weights(grid)[:, None])
+
+
+def augmented_weights(values: np.ndarray, n_pre: int, lam: float, *,
+                      basis: Optional[np.ndarray] = None,
+                      grid: Optional[np.ndarray] = None) -> np.ndarray:
+    """Ridge augmented weights of eq. (9)."""
+    centered = center_pre_periods(values, n_pre)
+    gamma = fsc_weights(centered, n_pre)
+    R = basis_coefficients(centered, basis, grid)
+    r0 = R[1:, :n_pre].reshape(R.shape[0] - 1, -1)
+    r1 = R[0, :n_pre].ravel()
+    gram = r0.T @ r0 + lam * np.eye(r0.shape[1])
+    residual = r1 - r0.T @ gamma
+    try:
+        correction = np.linalg.solve(gram, residual)
+    except np.linalg.LinAlgError:  # pragma: no cover - lambda >= 0 keeps it PSD
+        correction = np.linalg.lstsq(gram, residual, rcond=None)[0]
+    return gamma + r0 @ correction
+
+
+def cross_validation_error(lam: float, values: np.ndarray, n_pre: int, *,
+                           basis: Optional[np.ndarray] = None,
+                           grid: Optional[np.ndarray] = None) -> float:
+    """Leave-one-pre-period-out cross-validation error of Remark 5."""
+    total = 0.0
+    for k in range(n_pre):
+        keep = [t for t in range(values.shape[1]) if t != k]
+        w = augmented_weights(values[:, keep], n_pre - 1, lam,
+                              basis=basis, grid=grid)
+        total += float(np.sum((values[0, k] - w @ values[1:, k]) ** 2))
+    return total
+
+
+def penalty_scale(values: np.ndarray, n_pre: int, *,
+                  basis: Optional[np.ndarray] = None,
+                  grid: Optional[np.ndarray] = None) -> float:
+    """Natural size of the ridge penalty for this design.
+
+    The penalty in eq. (9) is added to ``r_0' r_0``, so what counts as "small"
+    is set by that matrix, which scales with the square of the outcome and with
+    whatever normalisation the basis carries. An absolute search interval
+    therefore means something different on every dataset: the authors' scripts
+    search (0, 10), which suits their fertility panel and is four orders of
+    magnitude too coarse for their mortality panel once the coefficients are a
+    genuine L2 inner product.
+
+    Reported as the mean eigenvalue of the Gram matrix, so a relative penalty of
+    1 shrinks about as hard as the design's own average curvature. This is the
+    same idea as ``augsynth``'s data-driven lambda grid, reduced to one number
+    because the search here is a scalar minimisation rather than a grid.
+    """
+    centered = center_pre_periods(values, n_pre)
+    R = basis_coefficients(centered, basis, grid)
+    r0 = R[1:, :n_pre].reshape(R.shape[0] - 1, -1)
+    return float(np.sum(r0 * r0) / r0.shape[1])
+
+
+def select_lambda(values: np.ndarray, n_pre: int, bounds, *,
+                  basis: Optional[np.ndarray] = None,
+                  grid: Optional[np.ndarray] = None) -> Tuple[float, float]:
+    """Cross-validate the penalty, searching on the design's own scale.
+
+    ``bounds`` are read as multiples of :func:`penalty_scale`, which makes the
+    default interval mean the same thing whatever the units of the outcome.
+
+    Returns
+    -------
+    (absolute, relative) : tuple of float
+        The penalty to use in eq. (9), and the multiple of the design scale it
+        corresponds to.
+
+    Raises
+    ------
+    MlsynthEstimationError
+        Fewer than two pre-treatment periods, where leaving one out leaves
+        nothing to fit the weights on.
+    """
+    if n_pre < 2:
+        raise MlsynthEstimationError(
+            f"cross-validating the ridge penalty needs at least two "
+            f"pre-treatment periods (it is leave-one-out); the panel has "
+            f"{n_pre}. Pass ridge_lambda explicitly, or set augment=False.")
+    scale = penalty_scale(values, n_pre, basis=basis, grid=grid)
+    if not scale > 0.0:
+        # The centered design is identically zero, which happens whenever there
+        # is a single donor: subtracting the donor mean leaves nothing. The
+        # ridge correction is then zero for every penalty, so there is nothing
+        # to cross-validate and augmentation degrades to a no-op.
+        return 0.0, 0.0
+    result = minimize_scalar(
+        lambda ratio: cross_validation_error(ratio * scale, values, n_pre,
+                                             basis=basis, grid=grid),
+        bounds=tuple(bounds), method="bounded", options={"xatol": _BRENT_TOL})
+    return float(result.x) * scale, float(result.x)
+
+
+def synthetic_objects(values: np.ndarray, weights: np.ndarray) -> np.ndarray:
+    """Weighted average of the donor objects, ``(T, M)``."""
+    return np.einsum("j,jtm->tm", np.asarray(weights, dtype=float), values[1:])
+
+
+def pre_treatment_fit(values: np.ndarray, n_pre: int,
+                      synthetic: np.ndarray) -> float:
+    """``sqrt(sum_{t <= T0} ||Y_1t - synthetic_t||^2)`` on embedded coordinates."""
+    gap = values[0, :n_pre] - synthetic[:n_pre]
+    return float(np.sqrt(np.sum(gap ** 2)))


### PR DESCRIPTION
## Related Links

- Source paper: Okano, R. & Kurisu, D. (2026), "Functional Synthetic Control Methods for Metric Space-Valued Outcomes", [arXiv:2601.07539](https://arxiv.org/abs/2601.07539)
- Reference implementation: [github.com/RyoOkano21/FSC](https://github.com/RyoOkano21/FSC) (R)
- Docs: `docs/fsc.rst`, `docs/replications/fsc.rst`
- Follows #348, which lands the replication evidence this is measured against
- Followed by the `fsc_estimator` benchmark case, per the one-estimator-one-scope convention

## What

- Added `mlsynth.FSC` — estimator class, `FSCConfig`, and a nine-module `utils/fsc_helpers/` package (setup, basis, project, weights, inference, pipeline, structures, plotter)
- Added `docs/fsc.rst` and `docs/replications/fsc.rst`, both toctrees, and a `docs/choose.rst` entry under the non-standard-estimand branch
- Exported in `mlsynth/__init__.py`; `llms.txt` regenerated

## Why

Ordinary synthetic control wants a number per unit per period. FSC is for the case where what you observe is a whole object instead — an age-specific fertility curve, an age-at-death distribution, a covariance matrix across product lines. Collapsing such an object to a scalar often discards the shape of the effect: the East German abortion law in the paper's first application moves fertility down sharply at ages 20-30 and barely elsewhere, which a total-fertility-rate synthetic control returns as one number.

Nothing in mlsynth covered this. `DSC` targets unconditional quantile effects from individual-level microdata, `COMPSC` covers compositions, and `VanillaSC(augment="ridge")` is the scalar special case — but curves, distributions supplied per cell, and matrix-valued outcomes had no home.

## How

The method carries the objects into a Hilbert space through an isometry, where the ordinary simplex fit applies, and maps back. `space` selects the isometry and the projection, following the paper's Examples 1-3: curves in L2 (identity, nothing projected); distributions under the 2-Wasserstein metric, supplied as quantile functions and projected back by increasing rearrangement; and PSD matrices under the Frobenius metric, supplied as the row-major lower triangle and projected back by clipping negative eigenvalues.

Ingestion pivots each argument slice through `dataprep` and stacks them, following the pattern `COMPSC` uses for its share columns. The base simplex solve reuses `utils/bilevel/ridge_augment.simplex_qp` unchanged, and eq. (9) is that module's ridge formula with the pre-period axis replaced by the (period, basis coefficient) axis.

Two deliberate departures from the authors' implementation:

- The half-vectorisation is not a Frobenius isometry without a sqrt(2) on the off-diagonals, which the reference code omits — it understates off-diagonal discrepancies by a factor of two. FSC applies it, so the trade application is fit in the metric Example 3 specifies.
- The basis inner product integrates over the whole argument grid where the reference drops the first point. Invisible on fertility, where the weights agree to 7e-7; material on mortality, where the quantile function at p = 0.01 carries real information.

One thing found by verification rather than by reading. The ridge penalty is now searched as a multiple of the design's Gram scale rather than on a fixed absolute interval. The Gram scales with the square of the outcome, so a fixed interval means something different on every dataset: the paper's (0, 10) puts the optimum outside the interval on the authors' own mortality panel and lands the augmented fit at 0.1688 instead of 0.0630. Pinned by `test_cross_validated_penalty_is_scale_free`.

## Verification

- Path: A (the paper's empirical result on the authors' own data), landing as its own case in the follow-up PR
- Fertility reproduces exactly from the ordinary configuration: 0.1259 before augmentation, 0.0687 after, with the penalty cross-validated rather than supplied
- Mortality reproduces on the plain leg (0.2092) and gives 0.0630 against a published 0.0634 on the augmented one — the grid-integration difference above
- Service trade is fit under Frobenius, so the published 39.3429 is not the comparator; against the authors' own weights scored under the same metric, 51.9613, this attains 51.7665
- Both divergences are pinned with their measured size, so a change to either surfaces as a failure rather than drifting

## Scope checks

NEW ESTIMATOR

- [x] Dedicated Pydantic config inheriting `BaseEstimatorConfig`, `extra="forbid"`, every field with a `Field(...)` description, validators raising `MlsynthConfigError` / `MlsynthDataError`
- [x] Ingestion through `datautils.dataprep` — each argument slice pivoted and stacked, no hand-pivoted pandas in the estimator
- [x] `fit()` returns an `EffectResult` populating the standardized sub-models; the curve-valued output lifts to a grid-average scalar so `estimated_gap == observed - counterfactual` holds exactly
- [x] One estimator, one package; exported in `mlsynth/__init__.py`; entry in `docs/choose.rst`
- [x] Tests at all four levels: smoke, unit invariants, edge cases (single donor, single pre-period, single post-period, collinear donors, two grid points, treatment at t=0), and failure tests asserting the correct translated error
- [x] Branch carries only this estimator

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_fsc.py -q` — 59 passed, re-run against the current `main` after rebase
- [ ] `pytest mlsynth/tests/` — full suite. Ran to 31% locally with zero failures before I stopped it for CPU contention; leaving the complete run to CI, which gates the full suite on this PR
- [x] `coverage run --timid -m pytest mlsynth/tests/test_fsc.py && coverage report` — 98% on the new package (417 statements, 10 missed)
- [x] Section underlines checked against their titles

## Other Notes

Tests were written first and confirmed red on the missing export before any implementation existed.

The name sits next to the unrelated `FSCM` (Cerulli's forward-selected synthetic control); both docstrings say so, and `docs/fsc.rst` carries a "Not to be confused with" section.

The conformal band's validity is conjectured rather than proved in the paper, and the weights are held fixed across candidate nulls rather than refit — a departure from Chernozhukov, Wüthrich & Zhu (2021) that buys the band containing the point estimate at the cost of the exchangeability argument. Both are stated on the docs page rather than left for a reader to discover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pCxVmiL5CoLeUfjU8tgKu

---
_Generated by [Claude Code](https://claude.ai/code/session_018pCxVmiL5CoLeUfjU8tgKu)_