### PR TITLE
Ban self-referential framing in docs and docstrings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,17 @@ migration or refactor PR.
   (`\mathbf{}` in math). For emphasis use wording, not weight; for terms-of-art
   use ``literal`` or *italic* sparingly. (Table content and section headings are
   fine; the rule is about emphasis in prose.)
+- No self-referential framing. Never tell the reader that something is worth
+  stating, worth knowing, worth noting, deserves mention, needs to be precise
+  about, or is being recorded/flagged/emphasized. If it did not merit inclusion
+  it would not be on the page, so the announcement is pure filler and reads as
+  padding. Delete the frame and assert the thing: "The other two diverge, and by
+  amounts worth stating." becomes "The other two diverge."; "One detail is worth
+  recording: X." becomes "X."; "It is worth being precise about the norm here."
+  becomes the precise statement of the norm. The same goes for "importantly",
+  "note that", "crucially", and "interestingly" — cut them. This applies to docs
+  pages, module and function docstrings, benchmark-case prose, and commit
+  messages alike.
 - Write for a non-expert reader: assume the reader wants to learn what the
   method is and does, not that they already know synthetic control. Define
   jargon on first use.


### PR DESCRIPTION
## Related Links

- `CLAUDE.md`, under Docs conventions, alongside the existing no-bold-in-prose rule
- Requested during the FSC work (#348, #349, #350), where the pattern kept showing up in drafts

## What

- Added one rule to the Docs conventions section of `CLAUDE.md`

## Why

Phrases that announce the value of what follows — "worth stating", "worth noting", "deserves mention", "needs to be precise about", "is being recorded/flagged/emphasized", along with "importantly", "note that", "crucially", "interestingly" — are padding. If a thing did not merit inclusion it would not be on the page, so the announcement adds nothing and reads as filler. It also tends to bloat: the frame costs a clause every time and displaces the actual claim.

It sits next to the existing rule against bold in prose because both are about the same thing — the author's voice asserts rather than gestures.

## How

Written to the same shape as the neighbouring conventions: the rule, then before/after examples so the fix is unambiguous, then the scope. Concretely:

- "The other two diverge, and by amounts worth stating." becomes "The other two diverge."
- "One detail is worth recording: X." becomes "X."
- "It is worth being precise about the norm here." becomes the precise statement of the norm.

Scoped to docs pages, module and function docstrings, benchmark-case prose, and commit messages — the four places this kind of text actually gets written.

## Verification

- Path: not applicable. No numerical code is touched; this is a one-file convention change.

## Scope checks

None of the four blocks fits — this is a conventions/docs change to `CLAUDE.md` only, which the repo's own branch rules say belongs on its own branch.

## Test Steps

- [x] No code changed; nothing to run

## Other Notes

The FSC PRs already follow this rule, so it does not create a backlog of its own. Applying it to existing pages across the docs would be a separate, larger sweep and is not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018pCxVmiL5CoLeUfjU8tgKu

---
_Generated by [Claude Code](https://claude.ai/code/session_018pCxVmiL5CoLeUfjU8tgKu)_