### PR TITLE
mlSC: score the penalty grid as one batch, where the Gram form is safe to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,32 @@ now returns and the back-compat guarantee.
   resolves and behaves gracefully for every estimator the package ships.
 
 ### Changed
+- mlSC scores its penalty grid in one pass under `lambda_est="cross-validation"`.
+  Folding a penalty into the design as a `sqrt(lambda sigma_y^2) R` augmentation
+  adds rows carrying no target, so with the weights summing to one the augmented
+  Gram is affine in the penalty, `G(p) = (X - Y 1')'(X - Y 1') + p R'R`, verified
+  against the assembled design to 1e-9 across the grid. The two matrices are
+  formed once, each grid point is a broadcast off them, and the batched active
+  set certifies the whole grid together: on the Bottmer et al. panel (108
+  training periods, 90 disaggregate controls, 56 grid points) 0.27s against
+  4.49s, the same penalty selected, and `mlsc_bottmer`'s agreement with the
+  author's `mlSC_estimator` unchanged at `path_a_cv_lambda_rel = 0`.
+
+  The reduction is guarded. Forming the Gram squares the design's condition
+  number, which is free only where the design has full column rank -- and this
+  grid runs the penalty to zero, where the augmentation is a `1e-8` uniqueness
+  ridge. On a rank-deficient training design that ridge is the only thing
+  separating the columns and squaring puts it below what float64 resolves: on a
+  9-period, 12-disaggregate panel the Gram form then finished 225 percent above
+  the optimum at `lambda = 1e-8` and selected a different penalty. The new
+  `mlsynth.utils.bilevel.minnorm.gram_reduction_is_safe` decides this from the
+  design before anything is solved, and a rank-deficient one keeps the
+  one-penalty-at-a-time solve. It states both failure modes the reduction has --
+  the other being a genuinely rank-deficient design, where both solvers are
+  optimal but land on different points of the optimal face, which is why the same
+  batching is not available to STACKEDSC. Pinned by
+  `tests/test_mlsc_crossval_batch.py`.
+
 - VanillaSC's `mscmt` backend (the default when covariates are supplied) solves
   its inner donor-weight program exactly, and for a whole outer-search
   generation at once. Because the weights sum to one the design matrix drops out

--- a/docs/mlsc.rst
+++ b/docs/mlsc.rst
@@ -592,6 +592,62 @@ Three penalty-selection rules are exposed via
   penalty as the reference (e.g. :math:`316.23` on the seed-42 panel),
   and the cross-check is wired into the ``mlsc_bottmer`` benchmark.
 
+  The grid is scored in one pass, not one penalty at a time. Section
+  :ref:`mlsc-batched-grid` gives the identity that allows it; on the
+  Bottmer et al. panel (108 training periods, 90 disaggregate controls,
+  56 grid points) the selection takes 0.27s against 4.49s, choosing the
+  same penalty.
+
+.. _mlsc-batched-grid:
+
+Scoring the Penalty Grid in One Pass
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Cross-validation asks the same question of every candidate penalty, and the
+default grid has fifty-six of them. Solving each separately is avoidable,
+because the penalty enters the problem in a particularly simple way.
+
+The penalized program is folded into an ordinary least-squares one by stacking
+:math:`\sqrt{p}\,\mathbf{R}` beneath the design, where
+:math:`\mathbf{R}^\top\mathbf{R} = \mathbf{Q}` is the block-diagonal penalty
+matrix above and :math:`p = \lambda\widehat\sigma_y^2`. Those extra rows carry no
+target. So, writing :math:`\mathbf{X}` for the training design and
+:math:`\mathbf{y}` for its target, and using
+:math:`\mathbf{1}^\top\boldsymbol{\omega} = 1` to replace
+:math:`\mathbf{X}\boldsymbol{\omega} - \mathbf{y}` with
+:math:`(\mathbf{X} - \mathbf{y}\mathbf{1}^\top)\boldsymbol{\omega}`, the whole
+objective is the quadratic form
+:math:`\boldsymbol{\omega}^\top \mathbf{G}(p)\, \boldsymbol{\omega}` with
+
+.. math::
+
+   \mathbf{G}(p)
+   \;=\;
+   (\mathbf{X} - \mathbf{y}\mathbf{1}^\top)^\top
+   (\mathbf{X} - \mathbf{y}\mathbf{1}^\top)
+   \;+\; p\,\mathbf{Q},
+
+which is affine in the penalty. The two matrices on the right are formed once
+and every grid point is a broadcast off them, after which an active set over the
+disaggregate units certifies the entire grid together. The weights are the point
+of least norm in a convex hull -- Wolfe's (1976) problem [wolfe1976]_ -- which
+that active set solves exactly and in finitely many steps, so this is a change of
+arithmetic and not of estimator.
+
+One condition governs it. Forming :math:`\mathbf{G}` squares the design's
+condition number, which costs nothing where the design has full column rank and a
+great deal where it does not. The grid runs the penalty down to zero, where the
+program is held together only by a :math:`10^{-8}` uniqueness ridge; if the
+training design is itself rank deficient -- more disaggregate controls than
+training periods -- that ridge is the only thing separating the columns, and
+squaring puts it below what double precision resolves. Measured on a nine-period,
+twelve-disaggregate panel the reduction then finished 225 percent above the
+optimum at :math:`\lambda = 10^{-8}` and selected a different penalty, where on
+the 108-period, 90-disaggregate panel the two agree to :math:`4 \times 10^{-16}`.
+:func:`mlsynth.utils.bilevel.minnorm.gram_reduction_is_safe` decides this from
+the design before anything is solved, and a rank-deficient training design keeps
+the one-penalty-at-a-time solve.
+
 Variance Decomposition (Appendix G)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -960,3 +1016,7 @@ Abadie, A., Diamond, A., and Hainmueller, J. (2010). "Synthetic
 Control Methods for Comparative Case Studies: Estimating the Effect
 of California's Tobacco Control Program." *Journal of the American
 Statistical Association* 105(490):493-505.
+
+.. [wolfe1976] Wolfe, P. (1976). "Finding the Nearest Point in a Polytope."
+   *Mathematical Programming* 11:128-149. The minimum-norm-point active set
+   the batched penalty-grid solve rests on.

--- a/mlsynth/tests/test_mlsc_crossval_batch.py
+++ b/mlsynth/tests/test_mlsc_crossval_batch.py
@@ -1,0 +1,213 @@
+"""mlSC's penalty cross-validation, solved as one batch.
+
+Test-first (per ``agents/agents_tests.md``): written before the batched path
+exists, against the sequential one it has to reproduce.
+
+The rolling CV scores every candidate penalty on the same held-out periods, and
+each score needs the disaggregate weights that penalty implies. Those are
+``argmin_w ||[X; sqrt(p) R] w - [Y; 0]||^2`` on the simplex, and because the
+augmentation contributes no target rows the whole family collapses: with the
+weights summing to one,
+
+    G(p) = (X - Y 1')'(X - Y 1') + p R'R
+
+is affine in the penalty. So the grid's Gram matrices are one broadcast off two
+matrices formed once, and a batched active set scores the entire grid at once.
+
+What is asserted here is that this changes only the arithmetic's shape: the same
+penalty is selected, on the same held-out errors, with the same weights.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+from mlsynth.utils.mlsc_helpers.crossval import select_lambda_cv
+from mlsynth.utils.mlsc_helpers.optimization import _augmented_design
+from mlsynth.utils.mlsc_helpers.penalty import build_penalty_matrix
+from mlsynth.utils.mlsc_helpers.structures import MLSCInputs
+
+
+def _inputs(T=14, T0=10, S=3, per=4, seed=0):
+    """A two-level panel: ``S`` aggregates, ``per`` disaggregates in each."""
+    rng = np.random.default_rng(seed)
+    M = S * per
+    disagg_to_agg = np.repeat(np.arange(S), per)
+    X = np.cumsum(rng.normal(size=(T, M)), axis=0) + 10.0
+    v = np.full(M, 1.0 / per)
+    w_true = rng.dirichlet(np.ones(M))
+    y = X @ w_true + 0.05 * rng.normal(size=T)
+    return MLSCInputs(
+        Y_agg_treated=y,
+        X_disagg=X,
+        disagg_to_agg=disagg_to_agg,
+        v_population=v,
+        T0=T0,
+        T=T,
+        agg_labels=[f"s{i}" for i in range(S)],
+        disagg_labels=[f"c{i}" for i in range(M)],
+        Y_disagg_pre_full=X[:T0],
+        disagg_to_agg_full=disagg_to_agg,
+        treated_agg_idx_full=0,
+        treated_unit_name="treated",
+        time_labels=np.arange(T),
+        Ywide_agg=None,
+        outcome="y",
+    )
+
+
+def _sequential_cv_errors(inputs, sigma_y2, grid, cv_holdout_periods=1):
+    """The scores the sequential path produces, computed here independently."""
+    T0 = inputs.T0
+    t_cv = T0 - cv_holdout_periods
+    Y = inputs.Y_agg_treated[:T0]
+    X = inputs.X_disagg[:T0, :]
+    X_train, Y_train = X[:t_cv], Y[:t_cv]
+    X_test, Y_test = X[t_cv:T0], Y[t_cv:T0]
+    out = []
+    for v in grid:
+        B, A = _augmented_design(X_train, Y_train, inputs, float(v) * sigma_y2)
+        omega = solve_simplex_qp(B, A)
+        out.append(float(np.mean((Y_test - X_test @ omega) ** 2)))
+    return np.array(out)
+
+
+def _setup(seed=0, **kw):
+    inputs = _inputs(seed=seed, **kw)
+    Q = build_penalty_matrix(inputs.v_population, inputs.disagg_to_agg)
+    sigma_y2 = float(np.var(inputs.Y_agg_treated[:inputs.T0]))
+    return inputs, Q, sigma_y2
+
+
+# --------------------------------------------------------------------------- #
+# 1. The batched path reproduces the sequential one
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("seed", range(4))
+def test_selects_the_same_penalty_as_the_sequential_path(seed):
+    inputs, Q, sigma_y2 = _setup(seed=seed, T=26, T0=22)
+    grid = np.concatenate(([0.0], np.logspace(-8, np.log10(5), 25),
+                           np.logspace(1, 3, 4)))
+    chosen = select_lambda_cv(inputs, Q, sigma_y2, lambda_grid=grid)
+    errors = _sequential_cv_errors(inputs, sigma_y2, grid)
+    assert np.isclose(chosen, float(grid[int(np.argmin(errors))]))
+
+
+def test_scores_every_grid_point_the_same_way():
+    """Not just the argmin: every held-out score has to match, or the selection
+    agreeing is a coincidence of this grid."""
+    from mlsynth.utils.mlsc_helpers.crossval import _holdout_mse_grid
+
+    inputs, Q, sigma_y2 = _setup(seed=5, T=26, T0=22)
+    grid = np.concatenate(([0.0], np.logspace(-6, np.log10(2), 15)))
+    T0 = inputs.T0
+    t_cv = T0 - 1
+    Y = inputs.Y_agg_treated[:T0]
+    X = inputs.X_disagg[:T0, :]
+    got = _holdout_mse_grid(inputs, X[:t_cv], Y[:t_cv], X[t_cv:T0], Y[t_cv:T0],
+                            grid * sigma_y2)
+    want = _sequential_cv_errors(inputs, sigma_y2, grid)
+    np.testing.assert_allclose(got, want, rtol=1e-7, atol=1e-12)
+
+
+def test_batched_weights_are_on_the_simplex():
+    from mlsynth.utils.mlsc_helpers.crossval import _grid_weights
+
+    inputs, Q, sigma_y2 = _setup(seed=6)
+    grid = np.array([0.0, 1e-6, 0.5, 100.0])
+    T0 = inputs.T0
+    W = _grid_weights(inputs, inputs.X_disagg[:T0 - 1, :],
+                      inputs.Y_agg_treated[:T0 - 1], grid * sigma_y2)
+    assert W.shape == (grid.size, inputs.X_disagg.shape[1])
+    assert W.min() >= -1e-9
+    np.testing.assert_allclose(W.sum(axis=1), 1.0, atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 2. The penalty enters the Gram affinely -- the identity the batch rests on
+# --------------------------------------------------------------------------- #
+def test_gram_is_affine_in_the_penalty():
+    from mlsynth.utils.bilevel.minnorm import simplex_gram
+    from mlsynth.utils.mlsc_helpers.penalty import build_sqrt_factor
+
+    inputs, _, _ = _setup(seed=7)
+    T0 = inputs.T0
+    X, Y = inputs.X_disagg[:T0 - 1, :], inputs.Y_agg_treated[:T0 - 1]
+    R = build_sqrt_factor(inputs.v_population, inputs.disagg_to_agg)
+    G_X, QR = simplex_gram(X, Y), R.T @ R
+    for p in (1e-8, 1e-3, 0.7, 12.0, 900.0):
+        B, A = _augmented_design(X, Y, inputs, p)
+        np.testing.assert_allclose(simplex_gram(B, A), G_X + p * QR,
+                                   rtol=1e-9, atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Edge cases
+# --------------------------------------------------------------------------- #
+def test_single_point_grid():
+    inputs, Q, sigma_y2 = _setup(seed=8)
+    assert select_lambda_cv(inputs, Q, sigma_y2, lambda_grid=[0.25]) == 0.25
+
+
+def test_zero_only_grid_uses_the_uniqueness_ridge():
+    inputs, Q, sigma_y2 = _setup(seed=9)
+    assert select_lambda_cv(inputs, Q, sigma_y2, lambda_grid=[0.0]) == 0.0
+
+
+def test_multi_period_holdout():
+    inputs, Q, sigma_y2 = _setup(seed=10)
+    grid = np.array([0.0, 1e-4, 1.0, 50.0])
+    chosen = select_lambda_cv(inputs, Q, sigma_y2, lambda_grid=grid,
+                              cv_holdout_periods=3)
+    errors = _sequential_cv_errors(inputs, sigma_y2, grid, cv_holdout_periods=3)
+    assert np.isclose(chosen, float(grid[int(np.argmin(errors))]))
+
+
+def test_too_short_a_pre_period_is_rejected():
+    inputs, Q, sigma_y2 = _setup(seed=11)
+    with pytest.raises(ValueError, match="at least one training period"):
+        select_lambda_cv(inputs, Q, sigma_y2, cv_holdout_periods=inputs.T0)
+
+
+# --------------------------------------------------------------------------- #
+# 3b. A rank-deficient training design keeps the one-at-a-time solve
+# --------------------------------------------------------------------------- #
+def test_gram_is_safe_only_when_the_training_design_has_full_column_rank():
+    from mlsynth.utils.mlsc_helpers.crossval import _gram_is_safe
+
+    rng = np.random.default_rng(0)
+    assert _gram_is_safe(rng.normal(size=(40, 12))) is True
+    assert _gram_is_safe(rng.normal(size=(9, 12))) is False      # fewer rows
+    collinear = rng.normal(size=(40, 6))
+    collinear[:, 5] = collinear[:, 0]                            # duplicate column
+    assert _gram_is_safe(collinear) is False
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_rank_deficient_panel_reproduces_the_sequential_selection(seed):
+    """More disaggregates than training periods: the penalty at the small end is
+    the only thing separating the columns, and forming the Gram squares it below
+    what float64 resolves -- measured at 225 percent above the optimum on seed 0.
+    The guard has to send this case down the design-form path, exactly."""
+    from mlsynth.utils.mlsc_helpers.crossval import _gram_is_safe
+
+    inputs, Q, sigma_y2 = _setup(seed=seed)               # 9 training, 12 disagg
+    assert not _gram_is_safe(inputs.X_disagg[:inputs.T0 - 1, :])
+    grid = np.concatenate(([0.0], np.logspace(-8, np.log10(5), 25),
+                           np.logspace(1, 3, 4)))
+    chosen = select_lambda_cv(inputs, Q, sigma_y2, lambda_grid=grid)
+    errors = _sequential_cv_errors(inputs, sigma_y2, grid)
+    assert chosen == float(grid[int(np.argmin(errors))])
+
+
+# --------------------------------------------------------------------------- #
+# 4. The cvxpy escape hatch is untouched
+# --------------------------------------------------------------------------- #
+def test_explicit_solver_still_routes_through_cvxpy():
+    cp = pytest.importorskip("cvxpy")
+    inputs, Q, sigma_y2 = _setup(seed=12)
+    grid = np.array([0.0, 1e-3, 1.0])
+    native = select_lambda_cv(inputs, Q, sigma_y2, lambda_grid=grid)
+    viacvx = select_lambda_cv(inputs, Q, sigma_y2, lambda_grid=grid,
+                              solver=cp.CLARABEL)
+    assert native in set(grid) and viacvx in set(grid)

--- a/mlsynth/tests/test_simplex_minnorm.py
+++ b/mlsynth/tests/test_simplex_minnorm.py
@@ -132,6 +132,56 @@ def test_gram_rejects_a_non_matrix_design():
 
 
 # --------------------------------------------------------------------------- #
+# 1b. When the reduction is safe to use at all
+# --------------------------------------------------------------------------- #
+def test_gram_reduction_is_safe_only_on_a_full_column_rank_design():
+    """Forming ``G`` squares the design's condition number, so the reduction is
+    only faithful where the design has full column rank. The guard says so."""
+    from mlsynth.utils.bilevel.minnorm import gram_reduction_is_safe
+
+    rng = np.random.default_rng(0)
+    assert gram_reduction_is_safe(rng.normal(size=(40, 12))) is True
+    assert gram_reduction_is_safe(rng.normal(size=(8, 39))) is False
+    collinear = rng.normal(size=(40, 6))
+    collinear[:, 5] = collinear[:, 0]
+    assert gram_reduction_is_safe(collinear) is False
+    assert gram_reduction_is_safe(np.zeros((5, 3))) is False
+
+
+def test_full_rank_designs_agree_with_the_design_form_on_the_weights():
+    """Where the guard passes, the two exact solvers return the same weights and
+    not merely the same fit -- which is what makes swapping them safe."""
+    rng = np.random.default_rng(1)
+    from mlsynth.utils.bilevel.minnorm import gram_reduction_is_safe
+
+    for m, J in [(40, 20), (30, 12), (60, 25)]:
+        B, A = _rand(rng, m, J)
+        assert gram_reduction_is_safe(B)
+        w_gram = solve_simplex_minnorm(simplex_gram(B, A))
+        w_design = solve_simplex_qp(B, A)
+        assert np.allclose(w_gram, w_design, atol=1e-6)
+
+
+def test_rank_deficient_designs_agree_on_the_fit_but_not_the_weights():
+    """The other side of the guard, stated as a fact and not an aspiration: on a
+    face the two solvers land in different places, both optimal. The Gram form
+    concentrates the weight; the design form spreads it. Anything reading the
+    weights themselves -- a donor table, a counterfactual built from post-period
+    donor outcomes -- would change if it swapped one for the other."""
+    rng = np.random.default_rng(2)
+    from mlsynth.utils.bilevel.minnorm import gram_reduction_is_safe
+
+    B = np.cumsum(rng.normal(size=(8, 39)), axis=0) + 10.0
+    A = B @ rng.dirichlet(np.ones(39)) + 0.05 * rng.normal(size=8)
+    assert not gram_reduction_is_safe(B)
+    w_gram = solve_simplex_minnorm(simplex_gram(B, A))
+    w_design = solve_simplex_qp(B, A)
+    assert np.allclose(B @ w_gram, B @ w_design, atol=1e-7)     # same fit
+    assert np.abs(w_gram - w_design).max() > 0.05               # different point
+    assert (w_gram > 1e-9).sum() < (w_design > 1e-9).sum()      # and sparser
+
+
+# --------------------------------------------------------------------------- #
 # 2. Smoke
 # --------------------------------------------------------------------------- #
 def test_smoke_single_returns_feasible_weights():

--- a/mlsynth/utils/bilevel/minnorm.py
+++ b/mlsynth/utils/bilevel/minnorm.py
@@ -61,6 +61,51 @@ _KKT_TOL = 1e-10
 _W_TOL = 1e-12
 
 
+def gram_reduction_is_safe(B: np.ndarray, tol: float = 1e-8) -> bool:
+    """Whether ``B`` may be replaced by its Gram without changing the answer.
+
+    Forming ``G`` squares the design's condition number, and that is only free
+    where the design has full column rank. Two things go wrong when it does not,
+    and they are different failures:
+
+    * If the design is rank deficient only because of a small regulariser -- a
+      uniqueness ridge, a near-zero penalty at the end of a grid -- then that
+      regulariser is the only thing separating the columns, and squaring puts it
+      below what float64 resolves. The Gram solve then returns a point that is
+      not optimal at all. Measured on mlSC's penalty grid over a 9-period,
+      12-disaggregate design, it finished 225 percent above the optimum.
+    * If the design is genuinely rank deficient -- more donors than matching
+      rows, the ordinary synthetic-control case -- the optimum is a face and
+      every point of it is optimal. Both solvers are then correct and they land
+      in different places: on an 8-row, 39-donor design they agree on the fitted
+      values to 1e-11 while differing by 0.5 in the weights, the Gram form
+      concentrating on about 9 donors where the design form spreads over 37.
+      Nothing is wrong, but anything reading the weights -- a donor table, a
+      counterfactual built from post-period donor outcomes -- would change.
+
+    So the reduction is for designs this returns ``True`` for. It is a property
+    of the design alone, decidable before any solving.
+
+    Parameters
+    ----------
+    B : np.ndarray, shape (m, J)
+        The design the reduction would be applied to.
+    tol : float
+        Smallest acceptable ratio of the smallest to the largest singular value.
+
+    Returns
+    -------
+    bool
+    """
+    B = np.asarray(B, dtype=float)
+    if B.ndim != 2 or B.shape[0] < B.shape[1]:
+        return False
+    sv = np.linalg.svd(B, compute_uv=False)
+    if sv.size == 0 or sv[0] <= 0.0:
+        return False
+    return bool(sv[-1] / sv[0] > tol)
+
+
 def simplex_gram(B: np.ndarray, A: np.ndarray) -> np.ndarray:
     """Gram matrix ``G`` with ``w' G w == ||B w - A||^2`` on the simplex.
 

--- a/mlsynth/utils/mlsc_helpers/crossval.py
+++ b/mlsynth/utils/mlsc_helpers/crossval.py
@@ -12,12 +12,23 @@ implementation (``multi_level_sc_estimator.mlSC``): the same train/test split
 the same default grid (with a ``0`` candidate that drops the penalty to recover
 fully-disaggregated SC, regularized by a tiny ridge for a unique solution).
 
-Each grid penalty is solved by the native active-set simplex QP after folding the
-penalty into the design as a ``sqrt(lambda sigma_y^2) R`` augmentation (``R^T R ==
-Q``); since every grid point is strictly convex (the ``lambda = 0`` point via the
-ridge floor), the optimum is unique and matches cvxpy to solver tolerance with no
-canonicalisation overhead in the loop. An explicit ``solver`` routes through
-cvxpy instead.
+The grid is solved as one batch. Folding a penalty into the design as a
+``sqrt(lambda sigma_y^2) R`` augmentation (``R^T R == Q``) adds rows that carry no
+target, so with the weights summing to one the augmented design's Gram is affine
+in the penalty:
+
+    G(p) = (X - Y 1')' (X - Y 1') + p R^T R.
+
+The two matrices on the right are formed once, every grid point's Gram is a
+broadcast off them, and a batched active set
+(:func:`~mlsynth.utils.bilevel.minnorm.solve_simplex_minnorm_batch`) certifies
+the whole grid in a handful of linear solves. On the Bottmer et al. panel (108
+training periods, 90 disaggregate controls, 56 grid points) that is 0.20s against
+4.15s for the same solves one at a time, with the held-out scores agreeing to
+4e-16 and the same penalty selected. Every grid point is strictly convex (the
+``lambda = 0`` point via the ridge floor), so each optimum is unique and the
+batch cannot land anywhere the loop would not have. An explicit ``solver`` routes
+through cvxpy instead.
 """
 from __future__ import annotations
 
@@ -47,6 +58,67 @@ def _holdout_mse_native(
     B, A = _augmented_design(X_train, Y_train, inputs, penalty_scale)
     omega = solve_simplex_qp(B, A)
     return float(np.mean((Y_test - X_test @ omega) ** 2))
+
+
+def _gram_is_safe(X_train: np.ndarray) -> bool:
+    """Whether the grid can be solved through the Gram form without losing the
+    answer at the small-penalty end.
+
+    Forming ``G`` squares the design's condition number, and on this grid the
+    design is ``[X; sqrt(p) R]`` with ``p`` running down to zero, where the
+    augmentation is a ``1e-8`` uniqueness ridge. If ``X_train`` is already of
+    full column rank the ridge is irrelevant -- ``G_X`` is positive definite on
+    its own and well conditioned -- and squaring costs nothing that matters. If
+    it is not, the ridge is the *only* thing separating the columns, and
+    squaring puts it below the precision that separates them: measured on a
+    9-period, 12-disaggregate panel the Gram form then finished 225 percent
+    above the optimum at ``lambda = 1e-8``, where on a full-rank 108-period, 90-
+    disaggregate panel it agrees to 4e-16. So the rank decides, and the
+    rank-deficient case keeps the one-at-a-time design-form solve.
+    """
+    X = np.asarray(X_train, dtype=float)
+    if X.shape[0] < X.shape[1]:
+        return False
+    sv = np.linalg.svd(X, compute_uv=False)
+    if sv.size == 0 or sv[0] <= 0.0:
+        return False
+    return bool(sv[-1] / sv[0] > 1e-8)
+
+
+def _grid_weights(
+    inputs: MLSCInputs, X_train: np.ndarray, Y_train: np.ndarray,
+    penalty_scales: np.ndarray,
+) -> np.ndarray:
+    """Disaggregate weights for every penalty at once, shape ``(n_grid, M)``.
+
+    The augmented design's Gram is ``G(p) = G_X + p R'R``, affine in the penalty
+    because the augmentation rows carry no target and the weights sum to one. So
+    the grid's Grams are a broadcast off two matrices formed once, and the batch
+    is solved in one call. A zero penalty keeps the uniqueness ridge the
+    sequential path gives it (``_augmented_design``'s ``sqrt(_RIDGE_FLOOR) I``),
+    which enters the same way: ``G_X + _RIDGE_FLOOR I``.
+    """
+    from ..bilevel.minnorm import simplex_gram, solve_simplex_minnorm_batch
+
+    p = np.asarray(penalty_scales, dtype=float).ravel()
+    M = X_train.shape[1]
+    G_X = simplex_gram(X_train, Y_train)
+    R = build_sqrt_factor(inputs.v_population, inputs.disagg_to_agg)
+    penalised = p > 0.0
+    G = np.repeat(G_X[None], p.size, axis=0)
+    G += np.where(penalised, p, 0.0)[:, None, None] * (R.T @ R)[None]
+    G += np.where(penalised, 0.0, _RIDGE_FLOOR)[:, None, None] * np.eye(M)[None]
+    return solve_simplex_minnorm_batch(G)
+
+
+def _holdout_mse_grid(
+    inputs: MLSCInputs, X_train: np.ndarray, Y_train: np.ndarray,
+    X_test: np.ndarray, Y_test: np.ndarray, penalty_scales: np.ndarray,
+) -> np.ndarray:
+    """Held-out forecast MSE for every penalty at once, shape ``(n_grid,)``."""
+    W = _grid_weights(inputs, X_train, Y_train, penalty_scales)
+    resid = Y_test[:, None] - X_test @ W.T
+    return (resid * resid).mean(axis=0)
 
 
 def _county_sc_holdout_mse(
@@ -150,6 +222,9 @@ def select_lambda_cv(
         cv_error = _select_lambda_cv_cvxpy(
             inputs, Q, sigma_y2, grid, X_train, Y_train, X_test, Y_test, solver
         )
+    elif _gram_is_safe(X_train):
+        cv_error = _holdout_mse_grid(inputs, X_train, Y_train, X_test, Y_test,
+                                     grid * float(sigma_y2))
     else:
         cv_error = np.array([
             _holdout_mse_native(inputs, X_train, Y_train, X_test, Y_test,

--- a/mlsynth/utils/mlsc_helpers/crossval.py
+++ b/mlsynth/utils/mlsc_helpers/crossval.py
@@ -25,10 +25,17 @@ broadcast off them, and a batched active set
 the whole grid in a handful of linear solves. On the Bottmer et al. panel (108
 training periods, 90 disaggregate controls, 56 grid points) that is 0.20s against
 4.15s for the same solves one at a time, with the held-out scores agreeing to
-4e-16 and the same penalty selected. Every grid point is strictly convex (the
-``lambda = 0`` point via the ridge floor), so each optimum is unique and the
-batch cannot land anywhere the loop would not have. An explicit ``solver`` routes
-through cvxpy instead.
+4e-16 and the same penalty selected.
+
+That holds while ``X_train`` has full column rank, and only while. Forming the
+Gram squares the design's condition number, and at the small-penalty end of the
+grid the augmentation is a ``1e-8`` uniqueness ridge -- so if the columns are not
+already separated, that ridge is what separates them, and squaring puts it below
+what float64 resolves. On a 9-period, 12-disaggregate panel the Gram form then
+finished 225 percent above the optimum at ``lambda = 1e-8`` and selected a
+different penalty. :func:`_gram_is_safe` decides this from the design before any
+solving, and a rank-deficient training design keeps the one-at-a-time
+design-form solve. An explicit ``solver`` routes through cvxpy instead.
 """
 from __future__ import annotations
 
@@ -61,28 +68,19 @@ def _holdout_mse_native(
 
 
 def _gram_is_safe(X_train: np.ndarray) -> bool:
-    """Whether the grid can be solved through the Gram form without losing the
-    answer at the small-penalty end.
+    """Whether this grid can be scored through the Gram form.
 
-    Forming ``G`` squares the design's condition number, and on this grid the
-    design is ``[X; sqrt(p) R]`` with ``p`` running down to zero, where the
-    augmentation is a ``1e-8`` uniqueness ridge. If ``X_train`` is already of
-    full column rank the ridge is irrelevant -- ``G_X`` is positive definite on
-    its own and well conditioned -- and squaring costs nothing that matters. If
-    it is not, the ridge is the *only* thing separating the columns, and
-    squaring puts it below the precision that separates them: measured on a
-    9-period, 12-disaggregate panel the Gram form then finished 225 percent
-    above the optimum at ``lambda = 1e-8``, where on a full-rank 108-period, 90-
-    disaggregate panel it agrees to 4e-16. So the rank decides, and the
-    rank-deficient case keeps the one-at-a-time design-form solve.
+    Defers to :func:`~mlsynth.utils.bilevel.minnorm.gram_reduction_is_safe`,
+    which owns the condition: forming ``G`` squares the design's condition
+    number, and the grid's small-penalty end leaves a ``1e-8`` uniqueness ridge
+    as the only thing separating the columns. Where ``X_train`` already has full
+    column rank that ridge is irrelevant and the two paths agree to 4e-16; where
+    it does not, the Gram form finished 225 percent above the optimum on a
+    9-period, 12-disaggregate panel.
     """
-    X = np.asarray(X_train, dtype=float)
-    if X.shape[0] < X.shape[1]:
-        return False
-    sv = np.linalg.svd(X, compute_uv=False)
-    if sv.size == 0 or sv[0] <= 0.0:
-        return False
-    return bool(sv[-1] / sv[0] > 1e-8)
+    from ..bilevel.minnorm import gram_reduction_is_safe
+
+    return gram_reduction_is_safe(X_train)
 
 
 def _grid_weights(


### PR DESCRIPTION
## Related Links

- Docs: `docs/mlsc.rst` — new "Scoring the Penalty Grid in One Pass" section, cross-linked from the `lambda_est` entry
- Benchmark case: `benchmarks/cases/mlsc_bottmer.py`
- Bottmer, L. (2025). *Synthetic Control with Disaggregated Data*, Section 5.2 (`get_lambda_cv`)
- Wolfe, P. (1976). "Finding the Nearest Point in a Polytope." *Mathematical Programming* 11:128-149
- Follows #357, which added the batched solver this uses

## What

- `select_lambda_cv`'s native path scores the whole penalty grid in one batched solve instead of one solve per grid point
- Added `mlsynth.utils.bilevel.minnorm.gram_reduction_is_safe`: the condition under which the Gram reduction may be used at all, with both of its failure modes stated from measurement
- Guarded the mlSC path on it, so a rank-deficient training design keeps the one-penalty-at-a-time solve

## Why

Cross-validation asks the same question of fifty-six candidate penalties, and on the Bottmer et al. panel that was 4.5s — about half of what an mlSC fit with `lambda_est="cross-validation"` costs.

## How

The penalty is folded into the design as a `sqrt(lambda sigma_y^2) R` augmentation, and those rows carry no target. So with the weights summing to one the augmented design's Gram is affine in the penalty:

```
G(p) = (X - Y 1')' (X - Y 1') + p R'R
```

verified against the assembled design to 1e-9 across the grid (`test_gram_is_affine_in_the_penalty`). The two matrices are formed once, each grid point is a broadcast off them, and the batched active set from #357 certifies the whole grid together — 0.267s against 4.492s, the same penalty selected.

The guard is the part that matters, and it came out of a wrong first implementation that the tests caught. Forming `G` squares the design's condition number, and this grid runs the penalty down to zero where the augmentation is a `1e-8` uniqueness ridge. Where `X_train` already has full column rank that ridge is irrelevant and the two paths agree to 4e-16. Where it does not, the ridge is the only thing separating the columns and squaring puts it under what float64 resolves: on a 9-period, 12-disaggregate panel the Gram form finished **225 percent above the optimum** at `lambda = 1e-8` and selected a different penalty.

That is one of two distinct ways the reduction can fail, and the second was found separately while scoping STACKEDSC: a genuinely rank-deficient design (8 matching rows, 39 donors) makes the optimum a face, where both solvers are correct but land 0.52 apart in the weights — the Gram form concentrating on ~9 donors where the design form spreads over ~37, agreeing on the fitted values to 1e-11. Nothing is wrong there, but a donor table or a counterfactual built from post-period donor outcomes would change, so that batching is not available and STACKEDSC keeps its loop. One rank condition covers both failures, so it now lives in `minnorm` beside the reduction rather than inside mlSC.

`crossval.py`'s module docstring claimed every grid point is strictly convex and so the batch cannot land anywhere the loop would not have. That is false at the small-penalty end of a rank-deficient design, which is why the guard exists; corrected.

## Verification

- Path: cross-validation against the author's reference implementation, unchanged by this PR.
- `mlsc_bottmer` passes with `path_a_cv_lambda_rel = 0` — the CV-selected penalty still matches `mlSC_estimator` exactly.
- `tests/test_mlsc_crossval_batch.py` (new, 15 tests) pins the batch against a locally recomputed sequential path: the same penalty selected across four seeds, every grid point's held-out score to 1e-7, the affine-Gram identity, and the rank-deficient fallback reproducing the sequential selection exactly.
- `tests/test_simplex_minnorm.py` gains the guard's contract, including the rank-deficient case asserted as a fact — same fit, different weights, sparser.
- Full suite green: 6260 passed, 290 skipped.
- `minnorm.py` and `mlsc_helpers/crossval.py` both at 100% coverage.

Nothing failed to match.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR

- [x] The default preserves existing behaviour exactly — the same penalty is selected, and the guard sends anything the reduction cannot handle down the path it already took.
- [x] Existing pinned benchmark values unchanged (`mlsc_bottmer`, all eight metrics).
- [x] Tests pin that the batched and sequential paths agree, on the selection and on every individual grid score.
- [x] No new config field.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1tjauZqDV6Phs8HLu9Cw9)_