### PR TITLE
SDID: solve the placebo draws' weights as one family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,27 @@ now returns and the back-compat guarantee.
   resolves and behaves gracefully for every estimator the package ships.
 
 ### Changed
+- SDID solves its placebo draws' weights as one family. Placebo inference
+  (Arkhangelsky et al. 2021, Algorithm 4) refits both weight programs once per
+  draw and `B` defaults to 500, which is where an SDID fit spends its time: 84
+  percent of `sdid_prop99`'s wall clock was inside the simplex solver. The draws
+  differ only in which donors are in the design, what the target is, and how
+  large the ridge is, and none of that needs its own factorisation -- centring is
+  per column so it survives subsetting, and the ridge augmentation carries no
+  target rows so with the weights summing to one it enters the Gram as
+  `+ ridge I`. `estimate_placebo_variance` now draws every assignment first,
+  solves the family through the new
+  `mlsynth.utils.sdid_helpers.weights.solve_intercept_simplex_many`, then
+  replays; the draws are built in the order the old loop used them, so the RNG
+  stream is untouched and the same controls are cast as pseudo-treated. On
+  Prop 99 at `B = 500` a fit runs in 0.75s against 1.77s, with the ATT unchanged
+  bit for bit and the placebo standard error moving in its eleventh significant
+  figure. `sdid_prop99`, `sdid_ddd_hpv` and `seq_sdid_mc` all pass. Available to
+  SDID because its weight designs are overdetermined, so
+  `gram_reduction_is_safe` passes and the batched and one-at-a-time solvers
+  return the same weights and not merely the same fit; it is checked per problem
+  regardless. Pinned by `tests/test_sdid_weights_batch.py`.
+
 - mlSC scores its penalty grid in one pass under `lambda_est="cross-validation"`.
   Folding a penalty into the design as a `sqrt(lambda sigma_y^2) R` augmentation
   adds rows carrying no target, so with the weights summing to one the augmented

--- a/docs/sdid.rst
+++ b/docs/sdid.rst
@@ -464,6 +464,21 @@ on :py:attr:`SDIDInference.method`.
   placebo iterations whose :math:`|\widehat\tau^{\,*}_{att}|` is at least as
   large as the observed :math:`|\widehat{ATT}|`.
 
+  The :math:`B` draws are solved together. Each draw poses the same two weight
+  programs on a different column subset of the same donor matrix, and nothing in
+  that needs its own factorisation: the intercept is profiled out by centring,
+  which is done column by column and so survives subsetting; the ridge
+  :math:`T_{pre}\zeta^2` is folded in as extra rows carrying no target, so with
+  the weights summing to one it enters as :math:`+\,T_{pre}\zeta^2 \mathbf{I}`
+  even though :math:`\zeta` is recomputed for every draw. Section
+  :ref:`sdid-batched-weights` sets out the reduction the batch rests on. All
+  :math:`B` draws are then one call to an active set that certifies them
+  together, which on Proposition 99 at the default :math:`B = 500` takes the fit
+  from 1.77s to 0.75s. The draws are made in the order the one-at-a-time version
+  made them, so the same controls are cast as pseudo-treated; the ATT is
+  unchanged bit for bit, and the placebo standard error moves in its eleventh
+  significant figure.
+
 ``jackknife`` (Algorithm 3)
   The fitted unit weights :math:`\widehat\omega` and time weights
   :math:`\widehat\lambda` are held fixed and each unit is left out in turn; the
@@ -504,6 +519,49 @@ languages).
    Truncated History diagnostic (:doc:`truncated_history`), which re-estimates
    SDID on truncated pre-treatment windows. It reproduces the California
    Proposition 99 left-TH profile of Spoelstra et al. (2025) to the decimal.
+
+.. _sdid-batched-weights:
+
+How the Placebo Draws Are Solved Together
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Both SDID weight programs minimise a squared error over the simplex, and the
+placebo procedure solves them :math:`B` times over. What makes the repetition
+avoidable is that the simplex constraint removes the design matrix from the
+problem. Writing the centred design as :math:`\mathbf{B}` and the centred target
+as :math:`\mathbf{a}`, and using :math:`\mathbf{1}^\top\mathbf{w} = 1`,
+
+.. math::
+
+   \mathbf{B}\mathbf{w} - \mathbf{a}
+   \;=\; \mathbf{B}\mathbf{w} - \mathbf{a}\,(\mathbf{1}^\top\mathbf{w})
+   \;=\; (\mathbf{B} - \mathbf{a}\mathbf{1}^\top)\,\mathbf{w},
+
+so with :math:`\mathbf{R} = \mathbf{B} - \mathbf{a}\mathbf{1}^\top` and
+:math:`\mathbf{G} = \mathbf{R}^\top\mathbf{R}` the objective is the quadratic
+form :math:`\mathbf{w}^\top \mathbf{G}\, \mathbf{w}`. Geometrically the weights
+are the point of least norm in the convex hull of the columns of
+:math:`\mathbf{R}` -- each column being one donor's discrepancy from the target
+-- which is Wolfe's (1976) problem [wolfe1976]_, and an active set over the
+donors solves it exactly and in finitely many steps.
+
+A whole family of these is then carried by its :math:`\mathbf{G}` matrices
+alone, which for the placebo draws are a submatrix of one Gram formed once plus
+terms in the target and the ridge. The active set runs the family in lockstep:
+each iteration is a single batched linear solve over the current supports, so
+:math:`B` draws cost what the hardest single draw costs and not :math:`B` times
+what the average one costs.
+
+The reduction is not always available, and
+:func:`mlsynth.utils.bilevel.minnorm.gram_reduction_is_safe` decides. Forming
+:math:`\mathbf{G}` squares the design's condition number, which is free only
+where the design has full column rank. SDID's designs are overdetermined --
+pre-periods by donors for the unit weights, donors by pre-periods for the time
+weights -- so they qualify, and the batched and one-at-a-time solvers return the
+same weights and not merely the same fit. On a rank-deficient design they would
+not: the optimum is then a face, every point of it is optimal, and the two
+solvers land in different places. Each draw is checked, and one that fails falls
+back to the one-at-a-time solve.
 
 Two-DataFrame and Single-Cohort Convergence
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1157,6 +1215,10 @@ Kranz, S. (2022). "Synthetic Difference-in-Differences with Time-Varying
 Covariates." Working paper; implemented in the `xsynthdid
 <https://github.com/skranz/xsynthdid>`_ R package. The two-step adjustment
 behind SDID's ``covariates`` option.
+
+.. [wolfe1976] Wolfe, P. (1976). "Finding the Nearest Point in a Polytope."
+   *Mathematical Programming* 11:128-149. The minimum-norm-point active set the
+   batched weight solve rests on.
 
 .. [Zhuang2024] Zhuang, C. C. (2024). "A Way to Synthetic Triple
    Difference." `arXiv:2409.12353 <https://arxiv.org/abs/2409.12353>`_.

--- a/mlsynth/tests/test_sdid.py
+++ b/mlsynth/tests/test_sdid.py
@@ -305,13 +305,13 @@ class TestPlaceboVariance:
         real = inference_mod.estimate_cohort_sdid_effects
         seen: list[bool] = []
 
-        def spy(period, cohort_data, accumulator):
+        def spy(period, cohort_data, accumulator, **kwargs):
             y_col = np.asarray(cohort_data["y"])[:, 0]
             donor = np.asarray(cohort_data["donor_matrix"])
             # No donor column may equal the pseudo-treated outcome column.
             clash = any(np.allclose(y_col, donor[:, j]) for j in range(donor.shape[1]))
             seen.append(clash)
-            return real(period, cohort_data, accumulator)
+            return real(period, cohort_data, accumulator, **kwargs)
 
         monkeypatch.setattr(inference_mod, "estimate_cohort_sdid_effects", spy)
         estimate_placebo_variance(

--- a/mlsynth/tests/test_sdid_weights_batch.py
+++ b/mlsynth/tests/test_sdid_weights_batch.py
@@ -1,0 +1,238 @@
+"""SDID's intercept-plus-simplex solve, run for a family of problems at once.
+
+Test-first (per ``agents/agents_tests.md``): written before the batched helper
+exists, against the one-at-a-time solve it has to reproduce exactly.
+
+Placebo inference (Arkhangelsky et al. 2021, Algorithm 4) reassigns controls as
+pseudo-treated ``B`` times -- 500 by default -- and refits the unit and time
+weights for every draw. Each refit is the same program on a different column
+subset of the same donor matrix, with a ridge that varies by draw, so the family
+has a closed form: centring is per column and so survives subsetting, and the
+ridge enters the Gram affinely. What makes the batch usable here rather than in
+STACKEDSC is the shape: SDID's designs have more rows than columns, so the
+optimum is a point and not a face, and the batched and sequential solvers return
+the same weights and not merely the same fit.
+
+That equality is what these tests pin. Anything looser would not be enough --
+the weights are what the placebo counterfactuals are built from.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.minnorm import gram_reduction_is_safe
+from mlsynth.utils.sdid_helpers.weights import _solve_intercept_simplex
+
+
+def _family(rng, m=30, J=20, n_drop=1, n=25, ridge=0.4, vary_ridge=False):
+    """A donor matrix plus ``n`` leave-some-out placebo draws off it."""
+    D = np.cumsum(rng.normal(size=(m, J)), axis=0) + 10.0
+    problems = []
+    for i in range(n):
+        perm = rng.permutation(J)
+        drop, keep = perm[:n_drop], perm[n_drop:]
+        design = D[:, keep]
+        target = D[:, drop].mean(axis=1)
+        r = ridge * (1.0 + 0.5 * (i % 4)) if vary_ridge else ridge
+        problems.append((design, target, r))
+    return problems
+
+
+def _loop(problems):
+    return [_solve_intercept_simplex(d, t, r) for d, t, r in problems]
+
+
+# --------------------------------------------------------------------------- #
+# 1. The batch equals the loop, on the weights and the intercept
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("seed", range(4))
+def test_batch_matches_the_loop(seed):
+    from mlsynth.utils.sdid_helpers.weights import solve_intercept_simplex_many
+
+    problems = _family(np.random.default_rng(seed))
+    got = solve_intercept_simplex_many(problems)
+    want = _loop(problems)
+    assert len(got) == len(want)
+    for (a_g, w_g), (a_w, w_w) in zip(got, want):
+        np.testing.assert_allclose(w_g, w_w, atol=1e-8)
+        assert np.isclose(a_g, a_w, atol=1e-8)
+
+
+def test_batch_matches_the_loop_with_a_ridge_that_varies_by_draw():
+    """The placebo ridge is recomputed from each draw's donors, so the family
+    does not share one. It enters the Gram affinely, which is what allows it."""
+    from mlsynth.utils.sdid_helpers.weights import solve_intercept_simplex_many
+
+    problems = _family(np.random.default_rng(9), vary_ridge=True)
+    for (a_g, w_g), (a_w, w_w) in zip(solve_intercept_simplex_many(problems),
+                                      _loop(problems)):
+        np.testing.assert_allclose(w_g, w_w, atol=1e-8)
+        assert np.isclose(a_g, a_w, atol=1e-8)
+
+
+def test_mixed_shapes_are_handled():
+    """Unit and time weights have different shapes, and cohorts differ from one
+    another; a caller may hand over the lot."""
+    from mlsynth.utils.sdid_helpers.weights import solve_intercept_simplex_many
+
+    rng = np.random.default_rng(3)
+    problems = (_family(rng, m=30, J=20, n=6)
+                + _family(rng, m=25, J=12, n=5)
+                + _family(rng, m=40, J=20, n=4, ridge=0.0))
+    for (a_g, w_g), (a_w, w_w) in zip(solve_intercept_simplex_many(problems),
+                                      _loop(problems)):
+        np.testing.assert_allclose(w_g, w_w, atol=1e-8)
+        assert np.isclose(a_g, a_w, atol=1e-8)
+
+
+def test_zero_ridge_is_handled():
+    from mlsynth.utils.sdid_helpers.weights import solve_intercept_simplex_many
+
+    problems = _family(np.random.default_rng(4), ridge=0.0)
+    for (a_g, w_g), (a_w, w_w) in zip(solve_intercept_simplex_many(problems),
+                                      _loop(problems)):
+        np.testing.assert_allclose(w_g, w_w, atol=1e-8)
+        assert np.isclose(a_g, a_w, atol=1e-8)
+
+
+# --------------------------------------------------------------------------- #
+# 2. Feasibility and edges
+# --------------------------------------------------------------------------- #
+def test_weights_are_on_the_simplex():
+    from mlsynth.utils.sdid_helpers.weights import solve_intercept_simplex_many
+
+    for _, w in solve_intercept_simplex_many(_family(np.random.default_rng(5))):
+        assert w.min() >= -1e-9
+        assert abs(w.sum() - 1.0) < 1e-9
+
+
+def test_empty_family():
+    from mlsynth.utils.sdid_helpers.weights import solve_intercept_simplex_many
+
+    assert solve_intercept_simplex_many([]) == []
+
+
+def test_single_problem_family():
+    from mlsynth.utils.sdid_helpers.weights import solve_intercept_simplex_many
+
+    problems = _family(np.random.default_rng(6), n=1)
+    (a_g, w_g), = solve_intercept_simplex_many(problems)
+    a_w, w_w = _loop(problems)[0]
+    np.testing.assert_allclose(w_g, w_w, atol=1e-8)
+    assert np.isclose(a_g, a_w, atol=1e-8)
+
+
+def test_single_donor_family():
+    from mlsynth.utils.sdid_helpers.weights import solve_intercept_simplex_many
+
+    rng = np.random.default_rng(7)
+    problems = [(rng.normal(size=(8, 1)), rng.normal(size=8), 0.0)]
+    (_, w), = solve_intercept_simplex_many(problems)
+    assert w.shape == (1,) and np.isclose(w[0], 1.0)
+
+
+# --------------------------------------------------------------------------- #
+# 3. A rank-deficient design keeps the one-at-a-time solve
+# --------------------------------------------------------------------------- #
+def test_rank_deficient_designs_fall_back_and_still_match_the_loop():
+    """More donors than periods: the optimum is a face and the two solvers pick
+    different points of it, so the guard has to send these down the sequential
+    path. SDID's own shapes are the other way round, but a caller's need not be."""
+    from mlsynth.utils.sdid_helpers.weights import solve_intercept_simplex_many
+
+    rng = np.random.default_rng(8)
+    problems = _family(rng, m=8, J=30, n=5, ridge=0.0)
+    assert not gram_reduction_is_safe(problems[0][0] - problems[0][0].mean(axis=0))
+    for (a_g, w_g), (a_w, w_w) in zip(solve_intercept_simplex_many(problems),
+                                      _loop(problems)):
+        np.testing.assert_allclose(w_g, w_w, atol=1e-8)
+        assert np.isclose(a_g, a_w, atol=1e-8)
+
+
+# --------------------------------------------------------------------------- #
+# 4. Through the estimator: batching the placebo draws changes nothing
+# --------------------------------------------------------------------------- #
+def _placebo_panel(seed=0, n_units=14, T=16, t0=10):
+    import pandas as pd
+
+    rng = np.random.default_rng(seed)
+    rows = []
+    for u in range(n_units):
+        level = 10.0 + 2.0 * u
+        for t in range(T):
+            y = level + 0.5 * t + rng.normal(scale=0.4)
+            treated = int(u == 0 and t >= t0)
+            if treated:
+                y -= 5.0
+            rows.append({"unit": u, "time": t, "y": y, "treat": treated})
+    return pd.DataFrame(rows)
+
+
+def test_placebo_inference_is_unchanged_by_batching():
+    """The estimand this touches is the placebo variance, so it is the thing to
+    compare. Solving the draws as a family moves the standard error in the
+    eleventh significant figure, which is the batched and sequential solvers'
+    agreement on the weights (~1e-11) carried through."""
+    import mlsynth.utils.sdid_helpers.inference as INF
+    from mlsynth import SDID
+
+    real = INF._solve_placebo_weights
+
+    def sequential(payloads):
+        return {(i, p): (None, None) for i, c in enumerate(payloads) for p in c}
+
+    cfg = dict(df=_placebo_panel(), outcome="y", treat="treat", unitid="unit",
+               time="time", display_graphs=False, B=60, seed=7)
+    try:
+        INF._solve_placebo_weights = sequential
+        want = SDID(dict(cfg)).fit()
+        INF._solve_placebo_weights = real
+        got = SDID(dict(cfg)).fit()
+    finally:
+        INF._solve_placebo_weights = real
+
+    assert np.isclose(got.effects.att, want.effects.att, rtol=0, atol=1e-12)
+    for a, b in ((got.inference.ci_lower, want.inference.ci_lower),
+                 (got.inference.ci_upper, want.inference.ci_upper)):
+        assert np.isclose(a, b, rtol=1e-9, atol=1e-9)
+
+
+def test_every_placebo_draw_gets_its_weights():
+    """A draw whose key is missing would silently fall back to a fresh solve and
+    look correct while undoing the batch, so the mapping is checked directly."""
+    import mlsynth.utils.sdid_helpers.inference as INF
+
+    seen = {}
+    real = INF._solve_placebo_weights
+
+    def spy(payloads):
+        out = real(payloads)
+        seen["payloads"] = sum(len(c) for c in payloads)
+        seen["solved"] = sum(1 for v in out.values() if v[0] is not None)
+        return out
+
+    from mlsynth import SDID
+    try:
+        INF._solve_placebo_weights = spy
+        SDID(dict(df=_placebo_panel(), outcome="y", treat="treat", unitid="unit",
+                  time="time", display_graphs=False, B=25, seed=3)).fit()
+    finally:
+        INF._solve_placebo_weights = real
+    assert seen["payloads"] == 25
+    assert seen["solved"] == 25
+
+
+def test_sdid_shapes_are_in_the_safe_regime():
+    """The premise of batching SDID at all, asserted rather than assumed: its
+    unit-weight design (pre-periods plus the ridge block, by donors) and its
+    time-weight design (donors by pre-periods) both have full column rank on the
+    Prop 99 geometry."""
+    rng = np.random.default_rng(10)
+    T0, J = 19, 37
+    donor_pre = np.cumsum(rng.normal(size=(T0, J)), axis=0) + 10.0
+    unit_design = np.vstack([donor_pre - donor_pre.mean(axis=0),
+                             np.sqrt(0.4) * np.eye(J)])
+    time_design = donor_pre.T - donor_pre.T.mean(axis=0)
+    assert gram_reduction_is_safe(unit_design)
+    assert gram_reduction_is_safe(time_design)

--- a/mlsynth/utils/sdid_helpers/cohort.py
+++ b/mlsynth/utils/sdid_helpers/cohort.py
@@ -33,10 +33,64 @@ from mlsynth.exceptions import (
 
 from .weights import (
     compute_regularization, fit_time_weights, match_unit_weights, unit_weights)
+
+
+def cohort_weight_problems(cohort_data_dict: Dict[str, Any]):
+    """The two weight programs a cohort implies, as ``(design, target, ridge)``.
+
+    Both are the same object :func:`estimate_cohort_sdid_effects` solves, and it
+    reads them from here, so a caller that wants to solve a family of them ahead
+    of time -- placebo inference refits them once per draw -- cannot drift from
+    what the estimator would have done.
+
+    Returns ``(zeta, unit_problem, time_problem)``. Either problem is ``None``
+    where the estimator would not have solved it: no pre-periods, no
+    post-periods, all-NaN post-period donor means, or (for the unit problem) a
+    cohort carrying covariates, whose weights come from the stacked
+    de Brabander et al. (2025) program instead.
+    """
+    donor = cohort_data_dict["donor_matrix"]
+    treated = cohort_data_dict["y"]
+    n_pre = cohort_data_dict["pre_periods"]
+    n_post = cohort_data_dict["post_periods"]
+
+    if n_pre == 0:
+        return np.nan, None, None
+
+    donor_pre = donor[:n_pre, :]
+    zeta_override = cohort_data_dict.get("zeta_override")
+    if zeta_override is not None:
+        zeta = float(zeta_override)
+    else:
+        zeta = compute_regularization(donor_pre, n_post,
+                                      num_treated_units=treated.shape[1])
+
+    unit_problem = None
+    has_covariates = (cohort_data_dict.get("donor_covariates") is not None
+                      and cohort_data_dict.get("treated_covariates") is not None)
+    if not has_covariates:
+        mean_treated_pre = treated.mean(axis=1)[:n_pre]
+        # unit_weights folds the ridge as T0 * zeta^2 (eq. 4); mirror it here.
+        unit_problem = (donor_pre, mean_treated_pre, n_pre * zeta ** 2)
+
+    time_problem = None
+    if n_post > 0:
+        post_block = donor[n_pre:, :]
+        if post_block.size == 0:
+            mean_post = np.full(donor.shape[1], np.nan)
+        else:
+            mean_post = post_block.mean(axis=0)
+        if not np.all(np.isnan(mean_post)):
+            time_problem = (donor_pre.T, mean_post, 0.0)
+
+    return zeta, unit_problem, time_problem
+
+
 def estimate_cohort_sdid_effects(
     cohort_adoption_period: int,
     cohort_data_dict: Dict[str, Any],
-    pooled_event_time_effects_accumulator: DefaultDict[float, List[Tuple[int, float]]]
+    pooled_event_time_effects_accumulator: DefaultDict[float, List[Tuple[int, float]]],
+    precomputed_weights: Optional[Tuple[Any, Any]] = None,
 ) -> Dict[str, Any]:
     """Estimate Synthetic Difference-in-Differences (SDID) effects for a specific cohort.
 
@@ -246,15 +300,8 @@ def estimate_cohort_sdid_effects(
         # A caller-supplied zeta replaces that quantity outright rather than
         # scaling it, so reproducing a published specification means passing the
         # number that paper used (commonly 0, which switches the ridge off).
-        zeta_override = cohort_data_dict.get("zeta_override")
-        if zeta_override is not None:
-            regularization_parameter_zeta = float(zeta_override)
-        else:
-            regularization_parameter_zeta = compute_regularization(
-                donor_outcomes_pre_treatment_cohort,
-                num_post_treatment_periods_cohort,
-                num_treated_units=cohort_treated_outcomes_matrix.shape[1],
-            )
+        regularization_parameter_zeta, _unit_problem, _time_problem = (
+            cohort_weight_problems(cohort_data_dict))
         # Estimate unit weights (omega) and intercept. When the caller asked for
         # covariates={"match": ...} the cohort payload carries per-unit
         # covariate summaries, and the weights come from the stacked program of
@@ -271,6 +318,9 @@ def estimate_cohort_sdid_effects(
                     pre_periods=cohort_data_dict.get("match_pre_periods"),
                 )
             )
+        elif precomputed_weights is not None and precomputed_weights[0] is not None:
+            optimal_unit_weight_intercept, optimal_unit_weights_vector = (
+                precomputed_weights[0])
         else:
             optimal_unit_weight_intercept, optimal_unit_weights_vector = unit_weights(
                 donor_outcomes_pre_treatment_cohort, mean_treated_outcome_pre_treatment_cohort, regularization_parameter_zeta
@@ -289,6 +339,9 @@ def estimate_cohort_sdid_effects(
             # Proceed with time weight estimation if mean post-treatment donor outcomes are not all NaN.
             if np.all(np.isnan(mean_donor_outcomes_post_treatment_cohort)):
                 pass # optimal_time_weights_vector remains None if all post-period donor means are NaN.
+            elif precomputed_weights is not None and precomputed_weights[1] is not None:
+                optimal_time_weight_intercept, optimal_time_weights_vector = (
+                    precomputed_weights[1])
             else:
                 optimal_time_weight_intercept, optimal_time_weights_vector = fit_time_weights(
                     donor_outcomes_pre_treatment_cohort, mean_donor_outcomes_post_treatment_cohort

--- a/mlsynth/utils/sdid_helpers/inference.py
+++ b/mlsynth/utils/sdid_helpers/inference.py
@@ -37,6 +37,52 @@ from mlsynth.exceptions import (
 )
 
 from .cohort import estimate_cohort_sdid_effects
+def _solve_placebo_weights(
+    payloads: List[Dict[int, Dict[str, Any]]]
+) -> Dict[Tuple[int, int], Tuple[Any, Any]]:
+    """Unit and time weights for every placebo draw, solved family by family.
+
+    Each draw poses the same two programs on a different column subset of the
+    same donor matrix, and the whole set is the shape the batched active set
+    wants: ``(design, target, ridge)`` triples, grouped by shape, with the ridge
+    varying by draw and entering the Gram affinely.
+
+    The programs are read from
+    :func:`~mlsynth.utils.sdid_helpers.cohort.cohort_weight_problems`, the same
+    function :func:`~mlsynth.utils.sdid_helpers.cohort.estimate_cohort_sdid_effects`
+    reads them from, so what is solved here cannot drift from what the estimator
+    would have solved. A draw whose design fails
+    :func:`~mlsynth.utils.bilevel.minnorm.gram_reduction_is_safe` falls back to
+    the one-at-a-time solve inside
+    :func:`~mlsynth.utils.sdid_helpers.weights.solve_intercept_simplex_many`, and
+    a cohort carrying covariates yields no unit problem at all and is left to the
+    estimator's own stacked solve.
+
+    Returns ``{(iteration, cohort_period): (unit_weights, time_weights)}`` with
+    either entry ``None`` where there was no program to solve.
+    """
+    from .cohort import cohort_weight_problems
+    from .weights import solve_intercept_simplex_many
+
+    problems: List[Tuple[np.ndarray, np.ndarray, float]] = []
+    slots: List[Tuple[Tuple[int, int], int]] = []
+    out: Dict[Tuple[int, int], List[Any]] = {}
+
+    for iteration_idx, cohorts in enumerate(payloads):
+        for cohort_period, cohort_data in cohorts.items():
+            key = (iteration_idx, cohort_period)
+            out[key] = [None, None]
+            _, unit_problem, time_problem = cohort_weight_problems(cohort_data)
+            for which, problem in enumerate((unit_problem, time_problem)):
+                if problem is not None:
+                    problems.append(problem)
+                    slots.append((key, which))
+
+    for (key, which), solved in zip(slots, solve_intercept_simplex_many(problems)):
+        out[key][which] = solved
+    return {key: (value[0], value[1]) for key, value in out.items()}
+
+
 def estimate_placebo_variance(
     prepped_event_study_data: Dict[str, Any], num_placebo_iterations: int, seed: int
 ) -> Dict[str, Any]:
@@ -174,7 +220,12 @@ def estimate_placebo_variance(
             "Consider if units can be controls for multiple cohorts or if data is limited."
             )
 
-    # Perform placebo iterations.
+    # Draw every placebo assignment first, then solve every draw's weights as one
+    # family, then replay. The draws are built in exactly the order the
+    # one-iteration-at-a-time version used them, so the RNG stream -- and
+    # therefore which controls are cast as pseudo-treated -- is unchanged; only
+    # when the weights are computed moves. See ``_solve_placebo_weights``.
+    placebo_iteration_payloads: List[Dict[int, Dict[str, Any]]] = []
     for iteration_idx in range(num_placebo_iterations):
         # Create a deep copy of the original cohort data for this placebo iteration to avoid modifying original data.
         current_placebo_iteration_cohorts_data: Dict[int, Dict[str, Any]] = deepcopy(original_cohorts_data_dict)
@@ -220,6 +271,13 @@ def estimate_placebo_variance(
                 axis=1,
             )
 
+        placebo_iteration_payloads.append(current_placebo_iteration_cohorts_data)
+
+    # Every draw's unit and time weights, solved as one family per shape.
+    placebo_weights = _solve_placebo_weights(placebo_iteration_payloads)
+
+    for iteration_idx, current_placebo_iteration_cohorts_data in enumerate(
+            placebo_iteration_payloads):
         # Estimate effects for this placebo iteration.
         current_placebo_iteration_pooled_effects_accumulator: DefaultDict[float, List[Tuple[int, float]]] = defaultdict(list)
         current_placebo_iteration_cohort_atts: Dict[int, float] = {} # Stores ATTs for each cohort in this placebo iteration.
@@ -227,7 +285,8 @@ def estimate_placebo_variance(
         # Estimate SDID effects for each placebo cohort.
         for current_placebo_cohort_period, current_placebo_cohort_data in current_placebo_iteration_cohorts_data.items():
             current_placebo_cohort_result = estimate_cohort_sdid_effects(
-                current_placebo_cohort_period, current_placebo_cohort_data, current_placebo_iteration_pooled_effects_accumulator
+                current_placebo_cohort_period, current_placebo_cohort_data, current_placebo_iteration_pooled_effects_accumulator,
+                precomputed_weights=placebo_weights[(iteration_idx, current_placebo_cohort_period)],
             )
             current_placebo_iteration_cohort_atts[current_placebo_cohort_period] = current_placebo_cohort_result["att"]
 

--- a/mlsynth/utils/sdid_helpers/weights.py
+++ b/mlsynth/utils/sdid_helpers/weights.py
@@ -50,10 +50,11 @@ the objective near the optimum is nearly flat. See ``TestSynthdidsEarlyStop`` in
 
 import numbers
 import numpy as np
-from typing import Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from mlsynth.exceptions import MlsynthDataError, MlsynthConfigError
 from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+from mlsynth.utils.bilevel.minnorm import gram_reduction_is_safe
 
 
 def _solve_intercept_simplex(
@@ -93,6 +94,81 @@ def _solve_intercept_simplex(
     weights = solve_simplex_qp(design_c, target_c)
     intercept = target_mean - float(col_mean @ weights)
     return intercept, weights
+
+
+def solve_intercept_simplex_many(
+    problems: Sequence[Tuple[np.ndarray, np.ndarray, float]]
+) -> List[Tuple[float, np.ndarray]]:
+    """:func:`_solve_intercept_simplex` for a family of problems at once.
+
+    Placebo inference refits the same program once per draw -- 500 times by
+    default -- and the draws differ only in which donors are in the design, what
+    the target is, and how large the ridge is. None of that needs a fresh
+    factorisation. Centring is per column, so it survives subsetting; the ridge
+    augmentation carries no target rows, so with the weights summing to one it
+    enters the Gram as ``+ ridge I``; and the whole family's Grams are therefore
+    a broadcast off quantities formed once. The batched active set then
+    certifies a shape-group in a handful of linear solves.
+
+    Parameters
+    ----------
+    problems : sequence of (design, target, ridge)
+        One entry per solve, as :func:`_solve_intercept_simplex` takes them.
+        Entries may differ in shape; they are grouped before solving.
+
+    Returns
+    -------
+    list of (intercept, weights)
+        In the order given, identical to solving them one at a time.
+
+    Notes
+    -----
+    A group is batched only where
+    :func:`~mlsynth.utils.bilevel.minnorm.gram_reduction_is_safe` passes on its
+    centred design, and solved one at a time otherwise. Forming the Gram squares
+    the design's condition number, and on a rank-deficient design the optimum is
+    a face whose points the two solvers pick differently -- the same fit, other
+    weights. SDID's own designs are overdetermined (pre-periods by donors for the
+    unit weights, donors by pre-periods for the time weights) and so land on the
+    safe side; the guard is on the design, not on the caller.
+    """
+    from ..bilevel.minnorm import simplex_gram, solve_simplex_minnorm_batch
+
+    out: List[Optional[Tuple[float, np.ndarray]]] = [None] * len(problems)
+    groups: Dict[Tuple[int, int], List[int]] = {}
+    prepared: List[Optional[Tuple[np.ndarray, np.ndarray, float, np.ndarray, float]]] = []
+
+    for i, (design, target, ridge) in enumerate(problems):
+        design = np.asarray(design, dtype=float)
+        target = np.asarray(target, dtype=float).ravel()
+        ridge = float(ridge)
+        col_mean = design.mean(axis=0)
+        design_c = design - col_mean[None, :]
+        J = design_c.shape[1]
+        # The safety test is on the design the solve actually sees, ridge block
+        # included: a ridge large enough to condition the problem is what makes
+        # an otherwise rank-deficient design safe, and one too small to do that
+        # is precisely the case the guard exists to catch.
+        augmented = (np.vstack([design_c, np.sqrt(ridge) * np.eye(J)])
+                     if ridge > 0.0 else design_c)
+        if J == 1 or not gram_reduction_is_safe(augmented):
+            out[i] = _solve_intercept_simplex(design, target, ridge)
+            prepared.append(None)
+            continue
+        prepared.append((design_c, target - float(target.mean()), ridge,
+                         col_mean, float(target.mean())))
+        groups.setdefault(design_c.shape, []).append(i)
+
+    for shape, idx in groups.items():
+        J = shape[1]
+        G = np.stack([simplex_gram(prepared[i][0], prepared[i][1]) for i in idx])
+        G += np.array([prepared[i][2] for i in idx])[:, None, None] * np.eye(J)[None]
+        W = solve_simplex_minnorm_batch(G)
+        for slot, i in enumerate(idx):
+            w = W[slot]
+            out[i] = (prepared[i][4] - float(prepared[i][3] @ w), w)
+
+    return [o for o in out]  # type: ignore[misc]
 
 
 def fit_time_weights(


### PR DESCRIPTION
## Related Links

- Docs: `docs/sdid.rst` — new "How the Placebo Draws Are Solved Together" section, plus a paragraph in the `placebo` entry of the Inference section
- Benchmark cases: `benchmarks/cases/sdid_prop99.py`, `sdid_ddd_hpv.py`, `seq_sdid_mc.py`
- Arkhangelsky, Athey, Hirshberg, Imbens & Wager (2021), *AER* — Algorithm 4
- Wolfe, P. (1976). "Finding the Nearest Point in a Polytope." *Mathematical Programming* 11:128-149
- Follows #357 (the batched solver) and #358 (the guard on when it may be used)

## What

- Added `mlsynth.utils.sdid_helpers.weights.solve_intercept_simplex_many`: the intercept-plus-simplex solve for a family of problems at once, grouped by shape
- Added `mlsynth.utils.sdid_helpers.cohort.cohort_weight_problems`: the single definition of the two weight programs a cohort implies
- `estimate_placebo_variance` draws every placebo assignment first, solves the family, then replays
- `estimate_cohort_sdid_effects` gains an optional `precomputed_weights`

## Why

Placebo inference is the default `vce` and `B` defaults to 500, so it is where an SDID fit spends its time — 84 percent of `sdid_prop99`'s wall clock was inside the simplex solver, across 1000 calls of two shapes.

## How

The draws are one family. They differ only in which donors are in the design, what the target is, and how large the ridge is, and none of that needs its own factorisation: the intercept is profiled out by centring, which is per column and so survives subsetting, and the ridge `T_pre * zeta^2` is folded in as rows carrying no target, so with the weights summing to one it enters the Gram as `+ ridge I` even though `zeta` is recomputed for every draw. `solve_intercept_simplex_many` takes the `(design, target, ridge)` triples, groups them by shape, and hands each group to the batched active set from #357.

Two things keep this honest. The draws are built in the order the one-at-a-time version used them, so the RNG stream is untouched and the same controls are cast as pseudo-treated. And `cohort_weight_problems` is read both by the pre-pass and by `estimate_cohort_sdid_effects`, so what the batch solves cannot drift from what the estimator would have solved on its own.

Prop 99 at `B = 500`: **1.77s against 0.75s**. The ATT is unchanged bit for bit — the point estimate never went through this path — and the placebo standard error moves in its eleventh significant figure (9.697380435243 against 9.697380435231), which is the two solvers' agreement on the weights carried through.

This is available to SDID because its weight designs are overdetermined — pre-periods by donors for the unit weights, donors by pre-periods for the time weights — so the optimum is a point, `gram_reduction_is_safe` passes, and the batched and one-at-a-time solvers return the same weights and not merely the same fit (2.65e-11 apart). That is the distinction #358 drew: on a rank-deficient design the optimum is a face and the two land 0.52 apart, which is why STACKEDSC keeps its loop. The guard is checked per problem here regardless of SDID's own shapes.

## Verification

- Path: cross-validation against the `synthdid` R package, unchanged by this PR.
- `sdid_prop99`, `sdid_ddd_hpv`, `seq_sdid_mc` all pass.
- `tests/test_sdid_weights_batch.py` (new, 15 tests) pins the batch against a loop over the one-at-a-time solve — weights *and* intercepts — across seeds, mixed shapes, a ridge that varies by draw, a zero ridge, and the rank-deficient fallback. Two integration tests go through the estimator: the placebo CI is unchanged, and every draw is checked to have received its weights, since a missing key would silently fall back to a fresh solve and look correct while undoing the batch.
- A precondition test asserts SDID's own shapes are in the safe regime, so the premise of batching it is checked rather than assumed.
- Full suite green: 6278 passed, 290 skipped.

Nothing failed to match. One existing test changed: `test_pseudo_treated_unit_is_dropped_from_its_own_donor_pool` substitutes a spy for the per-cohort estimator, and its positional signature did not admit the new keyword. The invariant it asserts is untouched — the sampling and column deletion are the same code — and the spy now forwards what it is handed.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR

- [x] The default preserves existing behaviour exactly: same draws, ATT bit for bit, standard error to eleven significant figures.
- [x] Existing pinned benchmark values unchanged across all three SDID cases.
- [x] `test_placebo_inference_is_unchanged_by_batching` pins the estimator-level equivalence against the sequential path.
- [x] No new config field.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1tjauZqDV6Phs8HLu9Cw9)_