### PR TITLE
Certify batched simplex solves against the design, and batch STACKEDSC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,17 @@ now returns and the back-compat guarantee.
   donors the outcome-only design goes 396ms -> 43ms, 9.3x. The covariate design
   does not batch (see below) and is unchanged.
 
+- STACKEDSC's placebo layer solves each pool as a leave-one-out family. Casting
+  every donor as treated in turn and refitting against the rest is one matrix's
+  columns fitted against one another, which `solve_simplex_loo_exact` assembles
+  from a single `M' M`. Under `donors-only` that matrix is the cohort's design
+  and the family is shared by the cohort; under `permutation` -- the default,
+  following the reference implementation -- the treated unit's column is
+  appended, a donor to every placebo and a target to none. On the Walmart panel
+  that is 22,074 programs in 21s where the loop takes 101s, 4.8x, with the
+  RMSPE-ranked p-values bit-identical and every other reported statistic
+  unchanged to 1e-11.
+
 - `mlsynth.utils.bilevel.minnorm.simplex_point_is_optimal` certifies a simplex
   weight vector against the design it claims to solve, from the KKT conditions
   on `B'(Bw - A)`. The batched solvers now require it as well as uniqueness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,10 +74,26 @@ now returns and the back-compat guarantee.
   `mlsynth.utils.bilevel.minnorm.gram_reduction_is_safe` decides this from the
   design before anything is solved, and a rank-deficient one keeps the
   one-penalty-at-a-time solve. It states both failure modes the reduction has --
-  the other being a genuinely rank-deficient design, where both solvers are
-  optimal but land on different points of the optimal face, which is why the same
-  batching is not available to STACKEDSC. Pinned by
+  the other being a design whose minimiser is a face and not a point, where
+  both solvers are optimal but land in different places. Pinned by
   `tests/test_mlsc_crossval_batch.py`.
+
+- `mlsynth.utils.bilevel.minnorm.simplex_optimum_is_unique` settles, after
+  solving, whether a simplex least-squares minimiser is the only one -- the
+  question that decides whether the batched and one-at-a-time solvers can stand
+  in for each other. `gram_reduction_is_safe` answers it from the design's shape
+  and is sound but far from tight: rank deficiency is only a precondition for a
+  face, since the objective is flat along a direction only where that direction
+  is also feasible at the solution, which needs a support large relative to the
+  design's rank. Synthetic-control solutions are sparse, so the ordinary
+  geometry -- more donors than pre-treatment periods -- usually has a unique
+  minimiser after all. On the Proposition 99 placebo family all 38 solves do, at
+  37 donors against 19 pre-periods, and the shape test admits none of them; on
+  STACKEDSC's Walmart data 85.5 percent of 2264 real solves do, against the
+  blanket "not available" an earlier synthetic probe suggested. The predicate
+  checks the design restricted to the weakly-active set, costs nothing
+  measurable next to the solve, and is asserted against what the two solvers
+  actually return in `tests/test_simplex_uniqueness.py`.
 
 - VanillaSC's `mscmt` backend (the default when covariates are supplied) solves
   its inner donor-weight program exactly, and for a whole outer-search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,37 @@ now returns and the back-compat guarantee.
   augmentation, the penalized backend), which `tests/test_vanillasc_placebo_batch.py`
   asserts by disabling the family solver and requiring the answer not to move.
 
+- STACKEDSC solves each cohort's weight programs as one shared-design family.
+  Every treated unit in a donor pool faces the same design and differs only in
+  its own pre-treatment target, so with `c_j = A' b_j` and `s_j = b_j' b_j` the
+  `j`-th Gram is `A'A - c_j 1' - 1 c_j' + s_j 1 1'`: one Gram and one cross
+  product carry the group, and
+  `mlsynth.utils.bilevel.minnorm.solve_simplex_shared_design` runs it in
+  lockstep. A donor predicate that binds gives one batch per distinct pool, down
+  to a batch of one per unit. On a Wiltshire cohort of 89 units against 39
+  donors the outcome-only design goes 396ms -> 43ms, 9.3x. The covariate design
+  does not batch (see below) and is unchanged.
+
+- `mlsynth.utils.bilevel.minnorm.simplex_point_is_optimal` certifies a simplex
+  weight vector against the design it claims to solve, from the KKT conditions
+  on `B'(Bw - A)`. The batched solvers now require it as well as uniqueness
+  before standing in for the one-at-a-time solve. Uniqueness alone was not
+  enough, and the gap is not academic: the Gram reduction squares the condition
+  number, so a design merely awkward at `cond(B) ~ 1e7` -- covariates measured
+  in different units -- gives a Gram at the edge of float64, and the batched
+  active set then converges on that Gram to a point that does not solve the
+  program it came from. On the covariate specification of the Wiltshire panel
+  that is 62 of 76 members of a cohort, with a KKT residual of 7e-3 where the
+  design-form solver leaves 6e-10; nothing computed from the Gram reveals it.
+  Those members now fall back and the reported effects are unchanged to 1e-9.
+
+- `solve_simplex_loo_exact` and `solve_simplex_shared_design` take a `fallback`
+  solver, since which one-at-a-time solve a batch stands in for is part of the
+  contract. STACKEDSC calls the primal active set directly; VanillaSC's engine
+  calls it through a wrapper that escalates to CVXPY when the active set reports
+  failure on itself, and on a design pathological enough to trip that hatch the
+  two disagree. Each call site now names its own.
+
 - `mlsynth.utils.bilevel.minnorm.simplex_optimum_is_unique` settles, after
   solving, whether a simplex least-squares minimiser is the only one -- the
   question that decides whether the batched and one-at-a-time solvers can stand

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,28 @@ now returns and the back-compat guarantee.
   both solvers are optimal but land in different places. Pinned by
   `tests/test_mlsc_crossval_batch.py`.
 
+- VanillaSC solves its in-space placebo as one leave-one-out family when there
+  are no covariates. The refits fit each column of the donor matrix from the
+  others, so the family falls out of a single `Y0' Y0` -- deleting a donor
+  deletes a row and a column of it, and each target is itself a column -- and
+  `mlsynth.utils.bilevel.minnorm.solve_simplex_loo_exact` assembles them with no
+  product with the data per refit. The default no-covariate call is where this
+  lands: a Proposition 99 fit is 0.007s with inference off and 0.205s with it on,
+  94 percent of that in the solver.
+
+      38 donors x 19 pre     0.209s -> 0.025s     8.5x
+      48 donors x 89 pre     0.394s -> 0.038s    10.2x
+      119 donors x 30 pre    5.617s -> 0.137s    41.0x
+
+  The p-value is a rank statistic over these fits, so each member is verified
+  with `simplex_optimum_is_unique` and any whose minimiser is a face is
+  re-solved with the single-problem active set the loop used -- a different
+  exact solver has an equal claim there, and the published ranks came from that
+  one. p-value, rank, RMSPE ratio and ATT are identical on every panel tried.
+  Refits that are not a plain simplex fit keep the loop (covariates, ridge
+  augmentation, the penalized backend), which `tests/test_vanillasc_placebo_batch.py`
+  asserts by disabling the family solver and requiring the answer not to move.
+
 - `mlsynth.utils.bilevel.minnorm.simplex_optimum_is_unique` settles, after
   solving, whether a simplex least-squares minimiser is the only one -- the
   question that decides whether the batched and one-at-a-time solvers can stand

--- a/docs/sdid.rst
+++ b/docs/sdid.rst
@@ -558,10 +558,19 @@ The reduction is not always available, and
 where the design has full column rank. SDID's designs are overdetermined --
 pre-periods by donors for the unit weights, donors by pre-periods for the time
 weights -- so they qualify, and the batched and one-at-a-time solvers return the
-same weights and not merely the same fit. On a rank-deficient design they would
-not: the optimum is then a face, every point of it is optimal, and the two
-solvers land in different places. Each draw is checked, and one that fails falls
-back to the one-at-a-time solve.
+same weights and not merely the same fit. Each draw is checked, and one that
+fails falls back to the one-at-a-time solve.
+
+What that test is standing in for is whether the minimiser is a point or a face.
+Where it is a face, every point of it is optimal and two exact solvers may
+return different weights -- the same fit, a different donor table. Full column
+rank rules that out, which is why the test is written on the shape; but it is
+sufficient and not necessary, and the gap matters for panels with more donors
+than pre-treatment periods. There the minimiser is usually still unique, because
+the objective is flat along a direction only where that direction is feasible at
+the solution, and synthetic-control solutions are too sparse for one to be.
+:func:`mlsynth.utils.bilevel.minnorm.simplex_optimum_is_unique` settles it
+exactly, on the support, once a solution is in hand.
 
 Two-DataFrame and Single-Cohort Convergence
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/stackedsc.rst
+++ b/docs/stackedsc.rst
@@ -192,6 +192,18 @@ of 89 counties against 39 donors that is 43ms where the one-at-a-time solve
 takes 396ms. A donor predicate that binds gives each pool its own batch, down to
 a batch of one per unit when no two units share a pool.
 
+The placebo layer poses the same question in a different shape, and it is where
+the estimator's time actually goes: casting each donor in a pool as treated and
+refitting against the rest is 566 x 39 = 22,074 programs on the Wiltshire panel.
+That family is a leave-one-out family over a single matrix -- deleting a column
+deletes a row and a column of :math:`\mathbf{M}^\top\mathbf{M}`, and each
+target is itself a column of :math:`\mathbf{M}` -- so no product with the data
+occurs per refit either. Under ``donors-only`` the matrix is the cohort's design
+and the family is shared by the whole cohort. Under ``permutation``, where the
+treated unit is itself a control, its column is appended: a donor to every
+placebo and a target to none. The layer runs in 21s where solving one at a time
+takes 101s, and the RMSPE-ranked p-values are identical.
+
 Two things have to hold before a batched answer may be reported in place of the
 one-at-a-time answer, and the weights make both strict. STACKEDSC reports
 :math:`\mathbf{w}_j^\ast` per unit and builds each counterfactual from it, so

--- a/docs/stackedsc.rst
+++ b/docs/stackedsc.rst
@@ -151,6 +151,76 @@ chooses for you. Weighting by population avoids letting large percentage
 swings in tiny units drive the average; equal weighting treats each adoption
 as one observation. Say which you mean.
 
+How a Cohort's Weights Are Solved Together
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+That the cohort shares a design is not only a modelling point. It means the
+cohort's weight programs are one family, and solving them together costs a
+fraction of solving them one at a time.
+
+The simplex constraint removes the design matrix from the objective. With
+:math:`\mathbf{1}^\top\mathbf{w} = 1`,
+
+.. math::
+
+   \mathbf{A}\mathbf{w} - \mathbf{b}_j
+   \;=\; \mathbf{A}\mathbf{w} - \mathbf{b}_j\,(\mathbf{1}^\top\mathbf{w})
+   \;=\; (\mathbf{A} - \mathbf{b}_j\mathbf{1}^\top)\,\mathbf{w},
+
+so the program for unit :math:`j` is the quadratic form
+:math:`\mathbf{w}^\top \mathbf{G}_j \mathbf{w}` with :math:`\mathbf{G}_j =
+(\mathbf{A} - \mathbf{b}_j\mathbf{1}^\top)^\top(\mathbf{A} -
+\mathbf{b}_j\mathbf{1}^\top)`. Expanding it, and writing :math:`\mathbf{c}_j
+= \mathbf{A}^\top \mathbf{b}_j` and :math:`s_j = \mathbf{b}_j^\top
+\mathbf{b}_j`,
+
+.. math::
+
+   \mathbf{G}_j
+   \;=\; \mathbf{A}^\top\mathbf{A}
+   \;-\; \mathbf{c}_j \mathbf{1}^\top
+   \;-\; \mathbf{1} \mathbf{c}_j^\top
+   \;+\; s_j \mathbf{1}\mathbf{1}^\top .
+
+Only :math:`\mathbf{c}_j` and :math:`s_j` depend on the unit, and both come from
+:math:`\mathbf{A}^\top\mathbf{B}` and the column norms of :math:`\mathbf{B}`,
+each formed once. So a cohort of any size costs one Gram and one cross product,
+and no product with the data occurs per unit. The active set then runs the
+cohort in lockstep: each iteration is one batched linear solve over the current
+supports, so the cohort costs what its hardest unit costs. On a Wiltshire cohort
+of 89 counties against 39 donors that is 43ms where the one-at-a-time solve
+takes 396ms. A donor predicate that binds gives each pool its own batch, down to
+a batch of one per unit when no two units share a pool.
+
+Two things have to hold before a batched answer may be reported in place of the
+one-at-a-time answer, and the weights make both strict. STACKEDSC reports
+:math:`\mathbf{w}_j^\ast` per unit and builds each counterfactual from it, so
+an equally optimal but different point is a changed answer, not a rounding
+difference.
+
+The first is that the point actually solves the program as posed on
+:math:`\mathbf{A}`. Forming :math:`\mathbf{G}` squares the design's condition
+number, so a design that is merely awkward at :math:`\operatorname{cond}
+(\mathbf{A}) \approx 10^{7}` gives a Gram at the edge of double precision. The
+batched solver then converges on that Gram to a point that does not solve the
+program the Gram came from, and nothing computed from the Gram reveals it. This
+is what covariate matching runs into: predictors measured in different units
+spread the spectrum, and on the covariate specification of the Wiltshire panel
+62 of 76 units in a cohort fail. So each answer is certified against
+:math:`\mathbf{A}` itself, from the first-order conditions
+(:func:`mlsynth.utils.bilevel.minnorm.simplex_point_is_optimal`), and the units
+that fail are re-solved one at a time.
+
+The second is that the program has one solution. Where the minimiser is a face
+-- every point of it optimal -- two exact solvers have equal claim to different
+weights, and with 5 to 10 pre-treatment periods against 39 donors a face is not
+exotic. :func:`mlsynth.utils.bilevel.minnorm.simplex_optimum_is_unique` settles
+it on the solution's own support once a solution is in hand: the objective is
+flat along a direction only where that direction is feasible where the solution
+sits, which needs a support large relative to the design's rank. Synthetic
+control solutions are sparse, so most units qualify -- on the Wiltshire panel
+85.5 percent of 2264 solves do -- and the rest are re-solved.
+
 Diagnostics
 -----------
 

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -477,6 +477,22 @@ distribution -- emits a warning and returns an ``InferenceResults`` whose
     truncated pre-treatment windows to see whether the effect is robust to how
     far back the fit reaches.
 
+    Without covariates the :math:`N_0` refits are solved together. Each one fits
+    a column of the donor matrix from the remaining columns, so the family is
+    carried by a single :math:`\mathbf{Y}_0^\top \mathbf{Y}_0`: deleting a donor
+    deletes a row and a column of it, and each target is itself a column, so no
+    product with the data is needed per refit. On a 38-donor, 19-period panel the
+    call runs in 0.025s against 0.205s, and on a 119-donor pool in 0.137s against
+    5.6s.
+
+    The p-value is a rank, so the refits have to come back where they were and
+    not merely optimal. Two exact solvers can differ on a refit whose minimiser
+    is a face -- the same fit, other weights -- so each is checked with
+    :func:`mlsynth.utils.bilevel.minnorm.simplex_optimum_is_unique` and any that
+    is not settled is re-solved with the solver the loop used. Refits that are
+    not a plain simplex fit keep the loop: covariate matching, and the ridge
+    layer of Augmented SCM.
+
 ``"conformal"`` -- prediction intervals (Chernozhukov, Wüthrich & Zhu 2021)
     The ``augsynth`` default for Augmented SCM, and a *distribution-free* test
     by inversion. For a sharp null :math:`H_0:\ \tau_t = \tau_0` the post-period

--- a/mlsynth/tests/test_simplex_loo_exact.py
+++ b/mlsynth/tests/test_simplex_loo_exact.py
@@ -1,0 +1,177 @@
+"""Exact leave-one-out simplex least squares, for the in-space placebo family.
+
+Test-first (per ``agents/agents_tests.md``): written before
+``solve_simplex_loo_exact`` exists.
+
+The in-space placebo casts every donor as treated in turn and refits against the
+others, so it poses ``J`` programs that share one matrix. In Gram form the whole
+family falls out of a single ``M' M``: deleting column ``j`` deletes a row and a
+column of the Gram, and the target is itself a column of ``M``, so the cross term
+is a column of that same Gram. No product with the data appears per problem.
+
+What the family gives up is uniqueness in general -- for some ``j`` the minimiser
+may be a face, and then the batched and one-at-a-time solvers are both right and
+disagree. Since the placebo p-value is a rank statistic over these fits, that has
+to be settled per member rather than assumed, so each is verified and the
+ambiguous ones fall back to the solver that produced the library's existing
+numbers. These tests pin exactly that.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.ridge_augment import simplex_qp
+
+
+def _loop(M, n=None):
+    """The family solved one at a time, which the batch must reproduce."""
+    J = M.shape[1]
+    n = J if n is None else n
+    out = np.zeros((n, J))
+    for j in range(n):
+        others = [k for k in range(J) if k != j]
+        out[j, others] = simplex_qp(M[:, others], M[:, j])
+    return out
+
+
+def _panel(rng, T0, J, kind="sparse"):
+    M = np.cumsum(rng.normal(size=(T0, J)), axis=0) + 50.0
+    if kind == "collinear":
+        M[:, -1] = M[:, 0]
+    return M
+
+
+# --------------------------------------------------------------------------- #
+# 1. The batch reproduces the loop
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("T0,J", [(19, 38), (30, 12), (89, 49), (12, 60), (8, 20)])
+def test_matches_the_one_at_a_time_solve(T0, J):
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    M = _panel(np.random.default_rng(T0 * 100 + J), T0, J)
+    got = solve_simplex_loo_exact(M)
+    want = _loop(M)
+    assert got.shape == (J, J)
+    np.testing.assert_allclose(got, want, atol=1e-7)
+
+
+def test_each_row_is_on_the_simplex_and_excludes_itself():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    M = _panel(np.random.default_rng(1), 20, 15)
+    W = solve_simplex_loo_exact(M)
+    for j, w in enumerate(W):
+        assert w[j] == 0.0                       # a donor never fits itself
+        assert w.min() >= -1e-9
+        assert abs(w.sum() - 1.0) < 1e-9
+
+
+def test_fitted_values_match_the_loop_even_where_weights_need_not():
+    """On a family member whose minimiser is a face the weights may legitimately
+    differ; the fit never may."""
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    rng = np.random.default_rng(2)
+    M = _panel(rng, 6, 25)                        # wide and short: faces likely
+    W = solve_simplex_loo_exact(M)
+    want = _loop(M)
+    for j in range(M.shape[1]):
+        others = [k for k in range(M.shape[1]) if k != j]
+        got_fit = M[:, others] @ W[j, others]
+        want_fit = M[:, others] @ want[j, others]
+        assert np.allclose(got_fit, want_fit, atol=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# 2. Ambiguous members fall back, so existing numbers are preserved
+# --------------------------------------------------------------------------- #
+def test_non_unique_members_reproduce_the_incumbent_solver_exactly():
+    """A panel built so several members have a face for a minimiser. Those must
+    come back bit-comparable to the one-at-a-time solve, not merely optimal."""
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    rng = np.random.default_rng(3)
+    base = np.cumsum(rng.normal(size=(5, 4)), axis=0) + 20.0
+    mix = rng.dirichlet(np.ones(4), size=16).T
+    M = np.hstack([base, base @ mix])             # 20 donors spanning 4 rows
+    W = solve_simplex_loo_exact(M)
+    np.testing.assert_allclose(W, _loop(M), atol=1e-7)
+
+
+def test_collinear_donors_reproduce_the_incumbent_solver():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    M = _panel(np.random.default_rng(4), 15, 10, kind="collinear")
+    np.testing.assert_allclose(solve_simplex_loo_exact(M), _loop(M), atol=1e-7)
+
+
+def test_info_reports_how_many_members_fell_back():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    rng = np.random.default_rng(5)
+    base = np.cumsum(rng.normal(size=(5, 4)), axis=0) + 20.0
+    M = np.hstack([base, base @ rng.dirichlet(np.ones(4), size=16).T])
+    _, info = solve_simplex_loo_exact(M, return_info=True)
+    assert set(info) >= {"n_fallback", "n_problems"}
+    assert info["n_problems"] == M.shape[1]
+    assert 0 <= info["n_fallback"] <= info["n_problems"]
+
+    clean = _panel(np.random.default_rng(6), 40, 12)
+    _, info_clean = solve_simplex_loo_exact(clean, return_info=True)
+    assert info_clean["n_fallback"] == 0
+
+
+# --------------------------------------------------------------------------- #
+# 3. Edges
+# --------------------------------------------------------------------------- #
+def test_two_donors():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    M = _panel(np.random.default_rng(7), 10, 2)
+    W = solve_simplex_loo_exact(M)
+    assert np.allclose(W, np.array([[0.0, 1.0], [1.0, 0.0]]))
+
+
+def test_rejects_a_single_donor():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    with pytest.raises(ValueError, match="at least two"):
+        solve_simplex_loo_exact(np.ones((5, 1)))
+
+
+def test_rejects_a_non_matrix():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    with pytest.raises(ValueError, match="2-D"):
+        solve_simplex_loo_exact(np.ones(5))
+
+
+@pytest.mark.parametrize("bad", [0, -1, 9])
+def test_rejects_an_out_of_range_target_count(bad):
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    M = _panel(np.random.default_rng(8), 10, 6)
+    with pytest.raises(ValueError, match="n_targets"):
+        solve_simplex_loo_exact(M, n_targets=bad)
+
+
+def test_a_target_border_leaves_later_columns_as_donors_only():
+    """A permutation placebo needs the treated unit in every pool without being
+    a placebo itself, which is what ``n_targets`` short of ``J`` gives."""
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    M = _panel(np.random.default_rng(9), 14, 8)
+    W = solve_simplex_loo_exact(M, n_targets=5)
+    assert W.shape == (5, 8)
+    np.testing.assert_allclose(W, _loop(M, n=5), atol=1e-7)
+
+
+def test_identical_donors_still_returns_simplex_rows():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    M = np.tile(np.array([[1.0], [2.0], [3.0]]), (1, 4))
+    W = solve_simplex_loo_exact(M)
+    for j, w in enumerate(W):
+        assert w[j] == 0.0
+        assert abs(w.sum() - 1.0) < 1e-9

--- a/mlsynth/tests/test_simplex_loo_exact.py
+++ b/mlsynth/tests/test_simplex_loo_exact.py
@@ -12,7 +12,7 @@ is a column of that same Gram. No product with the data appears per problem.
 What the family gives up is uniqueness in general -- for some ``j`` the minimiser
 may be a face, and then the batched and one-at-a-time solvers are both right and
 disagree. Since the placebo p-value is a rank statistic over these fits, that has
-to be settled per member rather than assumed, so each is verified and the
+to be settled per member and not assumed, so each is verified and the
 ambiguous ones fall back to the solver that produced the library's existing
 numbers. These tests pin exactly that.
 """
@@ -175,3 +175,24 @@ def test_identical_donors_still_returns_simplex_rows():
     for j, w in enumerate(W):
         assert w[j] == 0.0
         assert abs(w.sum() - 1.0) < 1e-9
+
+
+def test_the_fallback_solver_is_the_callers_own():
+    """VanillaSC's engine reaches the active set through a wrapper that escalates
+    to CVXPY when the active set reports failure on itself. A batch standing in
+    for the engine's placebo loop has to re-solve with that wrapper, not with
+    the bare active set underneath it."""
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_loo_exact
+
+    seen = []
+
+    def spy(B, a):
+        seen.append(B.shape[1])
+        return simplex_qp(B, a)
+
+    rng = np.random.default_rng(11)
+    base = np.cumsum(rng.normal(size=(5, 4)), axis=0) + 20.0
+    M = np.hstack([base, base @ rng.dirichlet(np.ones(4), size=16).T])
+    W, info = solve_simplex_loo_exact(M, fallback=spy, return_info=True)
+    assert len(seen) == info["n_fallback"] > 0
+    np.testing.assert_allclose(W, _loop(M), atol=1e-7)

--- a/mlsynth/tests/test_simplex_optimality_certificate.py
+++ b/mlsynth/tests/test_simplex_optimality_certificate.py
@@ -1,0 +1,150 @@
+"""A solver-independent optimality certificate for a simplex weight vector.
+
+Test-first (per ``agents/agents_tests.md``).
+
+The Gram reduction squares the condition number: ``G = R'R`` has
+``cond(G) = cond(R)^2``, so a design that is merely awkward at 1e7 -- covariates
+in different units, say -- makes the reduced problem singular in float64. The
+batched solver then converges on ``G`` to a point that is not a solution of the
+program ``G`` came from, and no amount of checking ``G`` reveals it: the answer
+has to be checked against the design.
+
+That is what this certificate does. With ``g = B'(Bw - A)`` and ``nu = g'w``, the
+KKT conditions for ``min ||Bw - A||^2`` over the simplex say every donor's
+reduced gradient is at least ``nu``, with equality on the support. It is
+computed from ``B`` and ``A`` directly, so it certifies the point regardless of
+which solver produced it or what form that solver worked in.
+
+Optimality and uniqueness are separate questions and both are asked. A point can
+be optimal on a face (optimal, not unique) or be the unique optimum's neighbour
+that a squared condition number produced (unique optimum, point not optimal).
+Only a point that is both certified optimal and known to be the sole optimum can
+be asserted equal to what another exact solver returns.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+from mlsynth.utils.bilevel.minnorm import simplex_point_is_optimal
+
+
+def _design(rng, m, J):
+    return np.cumsum(rng.normal(size=(m, J)), axis=0) + 50.0
+
+
+# --------------------------------------------------------------------------- #
+# 1. It accepts solutions
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("m,J", [(20, 8), (6, 30), (40, 12), (5, 39), (9, 2)])
+def test_accepts_the_exact_solver(m, J):
+    rng = np.random.default_rng(m * 13 + J)
+    B, A = _design(rng, m, J), _design(rng, m, 1).ravel()
+    assert simplex_point_is_optimal(B, A, solve_simplex_qp(B, A))
+
+
+def test_accepts_a_point_on_a_face():
+    """A target the donors reproduce exactly: many optima, each of them optimal."""
+    rng = np.random.default_rng(1)
+    B = _design(rng, 5, 20)
+    A = B @ rng.dirichlet(np.ones(20))
+    w = solve_simplex_qp(B, A)
+    assert simplex_point_is_optimal(B, A, w)
+
+
+def test_accepts_a_vertex_when_one_donor_is_the_answer():
+    B = np.array([[1.0, 5.0], [2.0, 9.0]])
+    A = np.array([1.0, 2.0])
+    assert simplex_point_is_optimal(B, A, np.array([1.0, 0.0]))
+
+
+def test_accepts_the_only_point_when_there_is_one_donor():
+    B, A = np.array([[1.0], [2.0]]), np.array([3.0, 4.0])
+    assert simplex_point_is_optimal(B, A, np.array([1.0]))
+
+
+# --------------------------------------------------------------------------- #
+# 2. It rejects non-solutions
+# --------------------------------------------------------------------------- #
+def test_rejects_a_feasible_point_that_is_not_optimal():
+    rng = np.random.default_rng(2)
+    B, A = _design(rng, 20, 6), _design(rng, 20, 1).ravel()
+    assert not simplex_point_is_optimal(B, A, np.full(6, 1.0 / 6.0))
+
+
+def test_rejects_a_point_perturbed_off_the_optimum():
+    rng = np.random.default_rng(3)
+    B, A = _design(rng, 25, 5), _design(rng, 25, 1).ravel()
+    w = np.asarray(solve_simplex_qp(B, A), dtype=float)
+    bad = w.copy()
+    bad[0], bad[1] = bad[0] + 0.05, bad[1] - 0.05
+    if bad.min() >= 0:                      # only meaningful while still feasible
+        assert not simplex_point_is_optimal(B, A, bad)
+
+
+def test_rejects_a_point_optimal_for_a_different_target():
+    rng = np.random.default_rng(4)
+    B = _design(rng, 18, 7)
+    A1, A2 = _design(rng, 18, 1).ravel(), _design(rng, 18, 1).ravel()
+    assert not simplex_point_is_optimal(B, A2, solve_simplex_qp(B, A1))
+
+
+def test_rejects_the_squared_condition_number_failure_mode():
+    """The case this exists for: a design whose Gram is singular in float64, where
+    solving in Gram form lands somewhere feasible and wrong."""
+    from mlsynth.utils.bilevel.minnorm import simplex_gram, solve_simplex_minnorm
+
+    rng = np.random.default_rng(5)
+    B = _design(rng, 8, 20)
+    B[:, :4] *= 1e6                          # covariate-scale spread: cond ~ 1e7+
+    A = _design(rng, 8, 1).ravel() * 1e3
+    w_gram = solve_simplex_minnorm(simplex_gram(B, A))
+    w_true = np.asarray(solve_simplex_qp(B, A), dtype=float)
+    obj = lambda w: float(np.sum((B @ w - A) ** 2))
+    if obj(w_gram) > obj(w_true) * (1.0 + 1e-6):
+        assert not simplex_point_is_optimal(B, A, w_gram)
+    assert simplex_point_is_optimal(B, A, w_true)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Scale and tolerance
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("s", [1e-4, 1.0, 1e5])
+def test_the_verdict_does_not_depend_on_the_units(s):
+    rng = np.random.default_rng(6)
+    B, A = _design(rng, 15, 9), _design(rng, 15, 1).ravel()
+    w = solve_simplex_qp(B, A)
+    assert simplex_point_is_optimal(B * s, A * s, w)
+    assert not simplex_point_is_optimal(B * s, A * s, np.full(9, 1.0 / 9.0))
+
+
+def test_a_loose_tolerance_accepts_what_a_tight_one_rejects():
+    rng = np.random.default_rng(7)
+    B, A = _design(rng, 20, 6), _design(rng, 20, 1).ravel()
+    w = np.full(6, 1.0 / 6.0)
+    assert not simplex_point_is_optimal(B, A, w, tol=1e-8)
+    assert simplex_point_is_optimal(B, A, w, tol=1e9)
+
+
+# --------------------------------------------------------------------------- #
+# 4. Failure modes
+# --------------------------------------------------------------------------- #
+def test_rejects_an_infeasible_point():
+    rng = np.random.default_rng(8)
+    B, A = _design(rng, 12, 4), _design(rng, 12, 1).ravel()
+    assert not simplex_point_is_optimal(B, A, np.array([-0.2, 0.4, 0.4, 0.4]))
+    assert not simplex_point_is_optimal(B, A, np.array([0.5, 0.5, 0.5, 0.5]))
+
+
+def test_rejects_a_non_finite_point():
+    rng = np.random.default_rng(9)
+    B, A = _design(rng, 12, 3), _design(rng, 12, 1).ravel()
+    assert not simplex_point_is_optimal(B, A, np.array([np.nan, 0.5, 0.5]))
+
+
+def test_rejects_a_mismatched_length():
+    rng = np.random.default_rng(10)
+    B, A = _design(rng, 12, 4), _design(rng, 12, 1).ravel()
+    with pytest.raises(ValueError, match="len"):
+        simplex_point_is_optimal(B, A, np.array([0.5, 0.5]))

--- a/mlsynth/tests/test_simplex_optimality_certificate.py
+++ b/mlsynth/tests/test_simplex_optimality_certificate.py
@@ -148,3 +148,13 @@ def test_rejects_a_mismatched_length():
     B, A = _design(rng, 12, 4), _design(rng, 12, 1).ravel()
     with pytest.raises(ValueError, match="len"):
         simplex_point_is_optimal(B, A, np.array([0.5, 0.5]))
+
+
+def test_rejects_a_non_matrix_design():
+    with pytest.raises(ValueError, match="2-D"):
+        simplex_point_is_optimal(np.ones(5), np.ones(5), np.ones(5))
+
+
+def test_rejects_a_mismatched_target_length():
+    with pytest.raises(ValueError, match="len"):
+        simplex_point_is_optimal(np.ones((5, 3)), np.ones(4), np.ones(3) / 3.0)

--- a/mlsynth/tests/test_simplex_shared_design.py
+++ b/mlsynth/tests/test_simplex_shared_design.py
@@ -157,3 +157,10 @@ def test_the_fallback_solver_is_the_callers_own():
     W, info = solve_simplex_shared_design(A, B, fallback=spy, return_info=True)
     assert len(seen) == info["n_fallback"] > 0
     np.testing.assert_allclose(W, _loop(A, B), atol=1e-7)
+
+
+def test_rejects_a_higher_dimensional_target_block():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    with pytest.raises(ValueError, match="2-D"):
+        solve_simplex_shared_design(np.ones((5, 3)), np.ones((5, 2, 2)))

--- a/mlsynth/tests/test_simplex_shared_design.py
+++ b/mlsynth/tests/test_simplex_shared_design.py
@@ -1,0 +1,159 @@
+"""Simplex least squares for many targets against one shared design.
+
+Test-first (per ``agents/agents_tests.md``).
+
+A cohort of treated units fitted against a common donor pool poses exactly this:
+one ``A``, one target per unit. The Gram of each problem is
+``A'A - c_j 1' - 1 c_j' + s_j 11'`` with ``c_j = A' b_j`` and ``s_j = b_j' b_j``,
+so ``A'A`` and ``A'B`` computed once carry the whole set.
+
+As everywhere else here, the batch has to reproduce the one-at-a-time solve and
+not merely tie with it -- these weights are reported per treated unit and the
+counterfactuals are built from them -- so ambiguous members are verified and
+re-solved.
+
+Which one-at-a-time solve is part of the contract, not a detail. STACKEDSC calls
+the primal active set directly; VanillaSC's engine calls it through a wrapper
+that escalates to CVXPY when the active set reports failure on itself. The two
+agree everywhere the batch runs and can disagree on a design pathological enough
+to trip that escape hatch, so the caller names the solver it is standing in for.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+
+
+def _loop(A, B, solver=solve_simplex_qp):
+    return np.stack([np.asarray(solver(A, B[:, j]), dtype=float).ravel()
+                     for j in range(B.shape[1])])
+
+
+def _cohort(rng, m, J, k, in_hull=False):
+    A = np.cumsum(rng.normal(size=(m, J)), axis=0) + 40.0
+    if in_hull:
+        B = A @ rng.dirichlet(np.ones(J), size=k).T
+    else:
+        B = np.cumsum(rng.normal(size=(m, k)), axis=0) + 40.0
+    return A, B
+
+
+@pytest.mark.parametrize("m,J,k", [(8, 39, 12), (30, 20, 6), (19, 38, 25), (5, 39, 40)])
+def test_matches_the_one_at_a_time_solve(m, J, k):
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    A, B = _cohort(np.random.default_rng(m * 7 + J), m, J, k)
+    np.testing.assert_allclose(solve_simplex_shared_design(A, B), _loop(A, B),
+                               atol=1e-7)
+
+
+def test_ambiguous_members_reproduce_the_incumbent_solver():
+    """Targets the donors reproduce exactly, so the minimisers are faces."""
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    A, B = _cohort(np.random.default_rng(1), 6, 30, 10, in_hull=True)
+    got, info = solve_simplex_shared_design(A, B, return_info=True)
+    assert info["n_fallback"] > 0
+    np.testing.assert_allclose(got, _loop(A, B), atol=1e-7)
+
+
+def test_rows_are_on_the_simplex():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    A, B = _cohort(np.random.default_rng(2), 12, 25, 8)
+    for w in solve_simplex_shared_design(A, B):
+        assert w.min() >= -1e-9
+        assert abs(w.sum() - 1.0) < 1e-9
+
+
+def test_info_counts_every_problem():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    A, B = _cohort(np.random.default_rng(3), 20, 15, 9)
+    _, info = solve_simplex_shared_design(A, B, return_info=True)
+    assert info["n_problems"] == 9
+    assert info["n_fallback"] == 0
+
+
+def test_single_target():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    A, B = _cohort(np.random.default_rng(4), 10, 7, 1)
+    np.testing.assert_allclose(solve_simplex_shared_design(A, B), _loop(A, B),
+                               atol=1e-7)
+
+
+def test_single_donor():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    A = np.array([[1.0], [2.0], [3.0]])
+    B = np.array([[1.0, 2.0], [2.0, 1.0], [3.0, 0.0]])
+    W = solve_simplex_shared_design(A, B)
+    assert W.shape == (2, 1) and np.allclose(W, 1.0)
+
+
+def test_rejects_mismatched_rows():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    with pytest.raises(ValueError, match="rows"):
+        solve_simplex_shared_design(np.ones((5, 3)), np.ones((4, 2)))
+
+
+def test_rejects_a_non_matrix_design():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    with pytest.raises(ValueError, match="2-D"):
+        solve_simplex_shared_design(np.ones(5), np.ones((5, 2)))
+
+
+def test_a_one_dimensional_target_is_treated_as_one_column():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    A, B = _cohort(np.random.default_rng(5), 14, 9, 1)
+    np.testing.assert_allclose(solve_simplex_shared_design(A, B[:, 0]),
+                               _loop(A, B), atol=1e-7)
+
+
+# --------------------------------------------------------------------------- #
+# Designs whose Gram loses most of float64
+# --------------------------------------------------------------------------- #
+def _ill_conditioned(rng, m=8, J=39, k=20):
+    """Covariate-matching geometry: predictors in different units, so the design
+    is merely awkward at cond ~ 1e7 and its Gram is at the edge of float64."""
+    A = np.cumsum(rng.normal(size=(m, J)), axis=0) + 100.0
+    A[:3, :] *= 1e5
+    A[3:5, :] *= 1e-3
+    B = np.cumsum(rng.normal(size=(m, k)), axis=0) + 100.0
+    B[:3, :] *= 1e5
+    B[3:5, :] *= 1e-3
+    return A, B
+
+
+def test_an_ill_conditioned_design_still_matches_the_loop():
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    A, B = _ill_conditioned(np.random.default_rng(11))
+    sv = np.linalg.svd(A, compute_uv=False)
+    assert sv[-1] / sv[0] < 1e-10                            # precondition
+    np.testing.assert_allclose(solve_simplex_shared_design(A, B), _loop(A, B),
+                               atol=1e-7)
+
+
+def test_the_fallback_solver_is_the_callers_own():
+    """VanillaSC reaches the active set through a wrapper that escalates to
+    CVXPY; STACKEDSC calls it directly. A batch standing in for one must not
+    return the other's answer."""
+    from mlsynth.utils.bilevel.minnorm import solve_simplex_shared_design
+
+    seen = []
+
+    def spy(Bm, a):
+        seen.append(Bm.shape)
+        return solve_simplex_qp(Bm, a)
+
+    A, B = _ill_conditioned(np.random.default_rng(14))
+    W, info = solve_simplex_shared_design(A, B, fallback=spy, return_info=True)
+    assert len(seen) == info["n_fallback"] > 0
+    np.testing.assert_allclose(W, _loop(A, B), atol=1e-7)

--- a/mlsynth/tests/test_simplex_uniqueness.py
+++ b/mlsynth/tests/test_simplex_uniqueness.py
@@ -1,0 +1,185 @@
+"""When a simplex least-squares optimum is unique, and how to know after solving.
+
+Test-first (per ``agents/agents_tests.md``): written before
+``simplex_optimum_is_unique`` exists.
+
+Two exact solvers of the same program return the same weights when the optimum
+is a point and different weights when it is a face. The library needed to know
+which case it was in before batching a family of these, and the condition it
+used -- full column rank of the design -- is sound but far stronger than
+necessary. It rejects the ordinary synthetic-control shape, where donors
+outnumber pre-treatment periods, even though those optima are almost always
+unique.
+
+Rank deficiency is only a precondition. The optimum moves along a direction
+``d`` only if ``B d = 0`` and ``1' d = 0`` *and* ``d`` is feasible where the
+solution sits -- which needs the support to be large relative to the design's
+rank. Synthetic-control solutions are sparse, so it usually is not: on the
+Proposition 99 placebo family every one of the 38 solves has a unique optimum
+despite 37 donors against 19 pre-periods.
+
+So the question is settled after solving, on the support, not before solving,
+on the shape. These tests pin that condition against what the two solvers
+actually do.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.minnorm import (
+    gram_reduction_is_safe,
+    simplex_gram,
+    solve_simplex_minnorm,
+)
+from mlsynth.utils.bilevel.ridge_augment import simplex_qp
+
+
+def _solvers_agree(B, A, atol=1e-6):
+    """Do the design-form and Gram-form active sets return the same weights?"""
+    w_design = simplex_qp(B, A)
+    w_gram = solve_simplex_minnorm(simplex_gram(B, A))
+    return float(np.abs(w_design - w_gram).max()) <= atol, w_design
+
+
+def _in_hull_target(rng, m, J):
+    """A target the donors reproduce exactly, so the optimal set is a face."""
+    B = np.cumsum(rng.normal(size=(m, J)), axis=0) + 10.0
+    return B, B @ rng.dirichlet(np.ones(J))
+
+
+def _outside_hull_target(rng, m, J):
+    """A target no convex combination reaches, so the optimum is a vertex."""
+    B = np.cumsum(rng.normal(size=(m, J)), axis=0) + 10.0
+    return B, B[:, 0] * 3.0 + 50.0
+
+
+def _sparse_fit_target(rng, m, J):
+    """The ordinary case: an imperfect fit off a handful of donors."""
+    B = np.cumsum(rng.normal(size=(m, J)), axis=0) + 50.0
+    return B[:, 1:], B[:, 0]
+
+
+# --------------------------------------------------------------------------- #
+# 1. The predicate agrees with what the solvers do
+# --------------------------------------------------------------------------- #
+def test_unique_when_the_target_is_outside_the_hull():
+    from mlsynth.utils.bilevel.minnorm import simplex_optimum_is_unique
+
+    rng = np.random.default_rng(0)
+    B, A = _outside_hull_target(rng, 8, 39)
+    agree, w = _solvers_agree(B, A)
+    assert simplex_optimum_is_unique(B, A, w) is True
+    assert agree
+
+
+def test_not_unique_when_the_target_is_inside_the_hull():
+    """More donors than rows *and* a reachable target: the optimal set is a face
+    and the two exact solvers land on different points of it."""
+    from mlsynth.utils.bilevel.minnorm import simplex_optimum_is_unique
+
+    rng = np.random.default_rng(0)
+    B, A = _in_hull_target(rng, 8, 39)
+    agree, w = _solvers_agree(B, A)
+    assert simplex_optimum_is_unique(B, A, w) is False
+    assert not agree
+
+
+@pytest.mark.parametrize("m,J", [(19, 37), (30, 119), (8, 60), (89, 48)])
+def test_sparse_fits_are_unique_however_wide_the_donor_pool(m, J):
+    """The shape the old guard rejected. A donor pool far wider than the
+    pre-period still gives a unique optimum when the fit is imperfect, because
+    the solution is sparse and no null direction is feasible at it."""
+    from mlsynth.utils.bilevel.minnorm import simplex_optimum_is_unique
+
+    rng = np.random.default_rng(m * 100 + J)
+    B, A = _sparse_fit_target(rng, m, J)
+    agree, w = _solvers_agree(B, A)
+    assert simplex_optimum_is_unique(B, A, w) is True
+    assert agree
+
+
+@pytest.mark.parametrize("seed", range(12))
+def test_the_predicate_never_disagrees_with_the_solvers(seed):
+    """Fuzz across regimes: whenever the predicate says unique, the two exact
+    solvers must agree. That is the only direction that matters -- a false
+    'unique' would silently change an answer."""
+    from mlsynth.utils.bilevel.minnorm import simplex_optimum_is_unique
+
+    rng = np.random.default_rng(seed)
+    m = int(rng.integers(4, 40))
+    J = int(rng.integers(3, 60))
+    kind = seed % 3
+    if kind == 0:
+        B, A = _in_hull_target(rng, m, J)
+    elif kind == 1:
+        B, A = _outside_hull_target(rng, m, J)
+    else:
+        B, A = _sparse_fit_target(rng, m, J + 1)
+    agree, w = _solvers_agree(B, A)
+    if simplex_optimum_is_unique(B, A, w):
+        assert agree, "predicate said unique but the solvers disagree"
+
+
+# --------------------------------------------------------------------------- #
+# 2. It is strictly more permissive than the shape test, and never less safe
+# --------------------------------------------------------------------------- #
+def test_full_column_rank_designs_are_always_unique():
+    """Anything the old shape guard admits, this admits too."""
+    from mlsynth.utils.bilevel.minnorm import simplex_optimum_is_unique
+
+    rng = np.random.default_rng(3)
+    for m, J in [(40, 20), (30, 12), (60, 25)]:
+        B = rng.normal(size=(m, J))
+        A = rng.normal(size=m)
+        assert gram_reduction_is_safe(B)
+        assert simplex_optimum_is_unique(B, A, simplex_qp(B, A)) is True
+
+
+def test_it_admits_shapes_the_rank_test_rejects():
+    """The point of the change: the ordinary synthetic-control geometry."""
+    from mlsynth.utils.bilevel.minnorm import simplex_optimum_is_unique
+
+    rng = np.random.default_rng(4)
+    B, A = _sparse_fit_target(rng, 19, 38)
+    assert not gram_reduction_is_safe(B)          # the shape test says no
+    assert simplex_optimum_is_unique(B, A, simplex_qp(B, A)) is True
+
+
+# --------------------------------------------------------------------------- #
+# 3. Edges
+# --------------------------------------------------------------------------- #
+def test_single_donor():
+    from mlsynth.utils.bilevel.minnorm import simplex_optimum_is_unique
+
+    B = np.array([[2.0], [3.0]])
+    assert simplex_optimum_is_unique(B, np.array([1.0, 1.0]), np.array([1.0])) is True
+
+
+def test_duplicate_donors_carrying_weight_are_not_unique():
+    """Two identical donors both in the support: weight can slide between them."""
+    from mlsynth.utils.bilevel.minnorm import simplex_optimum_is_unique
+
+    rng = np.random.default_rng(5)
+    B = rng.normal(size=(10, 3))
+    B[:, 2] = B[:, 1]
+    A = B[:, 1:].mean(axis=1)                     # reachable off the duplicates
+    w = simplex_qp(B, A)
+    if (w[1] > 1e-9) and (w[2] > 1e-9):
+        assert simplex_optimum_is_unique(B, A, w) is False
+
+
+def test_all_donors_identical():
+    from mlsynth.utils.bilevel.minnorm import simplex_optimum_is_unique
+
+    B = np.tile(np.array([[1.0], [2.0], [3.0]]), (1, 4))
+    A = B[:, 0].copy()
+    w = simplex_qp(B, A)
+    assert simplex_optimum_is_unique(B, A, w) is False
+
+
+def test_rejects_mismatched_weights():
+    from mlsynth.utils.bilevel.minnorm import simplex_optimum_is_unique
+
+    with pytest.raises(ValueError):
+        simplex_optimum_is_unique(np.ones((4, 3)), np.ones(4), np.ones(2))

--- a/mlsynth/tests/test_stackedsc_cohort_weights.py
+++ b/mlsynth/tests/test_stackedsc_cohort_weights.py
@@ -1,0 +1,138 @@
+"""A cohort's weight programs, solved as one shared-design family.
+
+Test-first (per ``agents/agents_tests.md``).
+
+Every treated unit in a cohort faces the same donor block and differs only in
+its own pre-treatment target, so the cohort is one design against many targets
+and its Grams differ by rank-one pieces of ``A'B``. A donor predicate that binds
+breaks that: each unit then gets its own design. The units sharing a pool are
+still a family, so the loop becomes one batch per distinct pool.
+
+What these tests pin is that the change is invisible in the output. STACKEDSC
+reports per-unit weights and builds per-unit counterfactuals from them, and on
+these designs the optimum is often a face, so an equally optimal but different
+point is a changed answer. The batch has to return what the loop returned.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+from mlsynth.utils.stackedsc_helpers.pipeline import _weights_for_cohort
+
+
+class _Cohort:
+    def __init__(self, n_donors, n_units):
+        self.donors = [f"d{k}" for k in range(n_donors)]
+        self.units = [f"x{i}" for i in range(n_units)]
+
+
+def _loop(cohort, A, B, allowed):
+    """The incumbent one-at-a-time solve, which the batch must reproduce."""
+    cols = []
+    for j, keep in enumerate(allowed):
+        w = np.zeros(len(cohort.donors))
+        w[keep] = np.asarray(solve_simplex_qp(A[:, keep], B[:, j]),
+                             dtype=float).ravel()
+        cols.append(w)
+    return np.column_stack(cols)
+
+
+def _design(rng, m, J, k, in_hull=False):
+    A = np.cumsum(rng.normal(size=(m, J)), axis=0) + 100.0
+    if in_hull:
+        B = A @ rng.dirichlet(np.ones(J), size=k).T
+    else:
+        B = np.cumsum(rng.normal(size=(m, k)), axis=0) + 100.0
+    return A, B
+
+
+# --------------------------------------------------------------------------- #
+# 1. Shared pool: one batch
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("m,J,k", [(5, 39, 12), (10, 39, 4), (8, 20, 25), (7, 12, 1)])
+def test_shared_pool_matches_the_loop(m, J, k):
+    cohort = _Cohort(J, k)
+    A, B = _design(np.random.default_rng(m * 31 + J), m, J, k)
+    allowed = [list(range(J))] * k
+    np.testing.assert_allclose(_weights_for_cohort(cohort, A, B, allowed),
+                               _loop(cohort, A, B, allowed), atol=1e-7)
+
+
+def test_shared_pool_with_a_face_for_an_optimum_matches_the_loop():
+    """Targets the donors reproduce exactly: the minimisers are faces, so an
+    equally optimal but different point is what the batch must not return."""
+    cohort = _Cohort(30, 10)
+    A, B = _design(np.random.default_rng(1), 6, 30, 10, in_hull=True)
+    allowed = [list(range(30))] * 10
+    np.testing.assert_allclose(_weights_for_cohort(cohort, A, B, allowed),
+                               _loop(cohort, A, B, allowed), atol=1e-7)
+
+
+def test_weights_are_on_the_simplex_and_shaped_by_donor_then_unit():
+    cohort = _Cohort(18, 6)
+    A, B = _design(np.random.default_rng(2), 9, 18, 6)
+    W = _weights_for_cohort(cohort, A, B, [list(range(18))] * 6)
+    assert W.shape == (18, 6)
+    assert W.min() >= -1e-9
+    np.testing.assert_allclose(W.sum(axis=0), 1.0, atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 2. A binding predicate: one batch per distinct pool
+# --------------------------------------------------------------------------- #
+def test_a_binding_predicate_matches_the_loop():
+    cohort = _Cohort(20, 8)
+    A, B = _design(np.random.default_rng(3), 9, 20, 8)
+    allowed = [[k for k in range(20) if k % 2 == j % 2] for j in range(8)]
+    np.testing.assert_allclose(_weights_for_cohort(cohort, A, B, allowed),
+                               _loop(cohort, A, B, allowed), atol=1e-7)
+
+
+def test_excluded_donors_get_exactly_zero():
+    cohort = _Cohort(15, 5)
+    A, B = _design(np.random.default_rng(4), 8, 15, 5)
+    allowed = [list(range(j + 2, 15)) for j in range(5)]
+    W = _weights_for_cohort(cohort, A, B, allowed)
+    for j, keep in enumerate(allowed):
+        dropped = [k for k in range(15) if k not in keep]
+        assert np.all(W[dropped, j] == 0.0)
+        assert abs(W[:, j].sum() - 1.0) < 1e-9
+
+
+def test_every_unit_with_its_own_pool_matches_the_loop():
+    """No two units share a pool, so every group is a batch of one."""
+    cohort = _Cohort(12, 6)
+    A, B = _design(np.random.default_rng(5), 7, 12, 6)
+    allowed = [[k for k in range(12) if k != j] for j in range(6)]
+    np.testing.assert_allclose(_weights_for_cohort(cohort, A, B, allowed),
+                               _loop(cohort, A, B, allowed), atol=1e-7)
+
+
+def test_pools_are_grouped_by_content_not_by_position():
+    """Units 0 and 2 share a pool while unit 1 does not; the grouping has to put
+    each unit's weights back in its own column."""
+    cohort = _Cohort(10, 3)
+    A, B = _design(np.random.default_rng(6), 6, 10, 3)
+    allowed = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9], [0, 1, 2, 3, 4]]
+    W = _weights_for_cohort(cohort, A, B, allowed)
+    np.testing.assert_allclose(W, _loop(cohort, A, B, allowed), atol=1e-7)
+    assert np.all(W[5:, 0] == 0.0) and np.all(W[:5, 1] == 0.0)
+
+
+# --------------------------------------------------------------------------- #
+# 3. Edges
+# --------------------------------------------------------------------------- #
+def test_a_single_donor_takes_all_the_weight():
+    cohort = _Cohort(3, 2)
+    A, B = _design(np.random.default_rng(7), 5, 3, 2)
+    W = _weights_for_cohort(cohort, A, B, [[1], [1]])
+    np.testing.assert_allclose(W, np.array([[0.0, 0.0], [1.0, 1.0], [0.0, 0.0]]))
+
+
+def test_one_treated_unit():
+    cohort = _Cohort(9, 1)
+    A, B = _design(np.random.default_rng(8), 6, 9, 1)
+    np.testing.assert_allclose(_weights_for_cohort(cohort, A, B, [list(range(9))]),
+                               _loop(cohort, A, B, [list(range(9))]), atol=1e-7)

--- a/mlsynth/tests/test_stackedsc_placebo_batch.py
+++ b/mlsynth/tests/test_stackedsc_placebo_batch.py
@@ -1,0 +1,212 @@
+"""The placebo layer's refits, solved as leave-one-out families.
+
+Test-first (per ``agents/agents_tests.md``).
+
+Casting each donor in a pool as treated in turn and refitting against the rest
+is a leave-one-out family over one matrix, in both donor pools the estimator
+offers. Under ``donors-only`` that matrix is the cohort's design and the family
+is shared by every unit in the cohort. Under ``permutation`` the treated unit
+joins each pool, so the matrix is the design with that unit's column appended
+and the family is one per treated unit -- its targets are the donors, and the
+appended column is a donor to all of them and a target to none, which is what
+``n_targets`` short of the column count expresses.
+
+This is where STACKEDSC's time is: 566 treated units against 39 donors is 22,074
+programs under the default pool, roughly 1.2 minutes on the Wiltshire panel.
+
+The p-values are rank statistics over these fits, so the batch has to reproduce
+the one-at-a-time solve and not merely tie with it. What these tests pin is that
+nothing observable moves: the same paths, the same fit count, the same p-values.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+
+def _staggered(n_treated=4, n_donors=7, T=12, cohorts=(6, 8), seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(T, 2)).cumsum(axis=0)
+    rows = []
+    for j in range(n_donors):
+        load, base = rng.normal(size=2), 100.0 + 20.0 * rng.random()
+        for t in range(T):
+            rows.append({"unit": f"d{j}", "t": t, "adopt": np.nan,
+                         "y": float(base + F[t] @ load + rng.normal() * 0.05)})
+    for i in range(n_treated):
+        g = cohorts[i % len(cohorts)]
+        load, base = rng.normal(size=2), 100.0 + 20.0 * rng.random()
+        for t in range(T):
+            rows.append({"unit": f"x{i}", "t": t, "adopt": float(g),
+                         "y": float(base + F[t] @ load + rng.normal() * 0.05)})
+    d = pd.DataFrame(rows)
+    d["treat"] = ((~d.adopt.isna()) & (d.t >= d.adopt)).astype(int)
+    return d
+
+
+def _fit(df=None, **kw):
+    from mlsynth import STACKEDSC
+
+    df = _staggered() if df is None else df
+    cfg = dict(df=df, unitid="unit", time="t", outcome="y", treat="treat",
+               inference="placebo", n_placebo_samples=200, seed=0)
+    cfg.update(kw)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return STACKEDSC(cfg).fit()
+
+
+@pytest.fixture
+def unbatched(monkeypatch):
+    """Force the one-at-a-time path, so a run can be compared against it."""
+    import mlsynth.utils.stackedsc_helpers.inference as INF
+
+    monkeypatch.setattr(INF, "_placebo_weights",
+                        lambda *a, **k: None, raising=True)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# 1. Nothing observable moves
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("pool", ["permutation", "donors-only"])
+def test_paths_match_the_one_at_a_time_solve(pool, monkeypatch):
+    import mlsynth.utils.stackedsc_helpers.inference as INF
+
+    batched = _fit(placebo_donor_pool=pool)
+    monkeypatch.setattr(INF, "_placebo_weights", lambda *a, **k: None)
+    looped = _fit(placebo_donor_pool=pool)
+
+    assert set(batched.placebo.paths) == set(looped.placebo.paths)
+    for unit, path in batched.placebo.paths.items():
+        np.testing.assert_allclose(np.asarray(path, float),
+                                   np.asarray(looped.placebo.paths[unit], float),
+                                   atol=1e-9)
+
+
+@pytest.mark.parametrize("pool", ["permutation", "donors-only"])
+def test_the_p_values_are_unchanged(pool, monkeypatch):
+    import mlsynth.utils.stackedsc_helpers.inference as INF
+
+    batched = _fit(placebo_donor_pool=pool)
+    monkeypatch.setattr(INF, "_placebo_weights", lambda *a, **k: None)
+    looped = _fit(placebo_donor_pool=pool)
+
+    # The RMSPE ranking is the statistic the layer exists for, and a rank can
+    # move on an arbitrarily small perturbation, so it is compared exactly.
+    assert batched.placebo.rmspe_p == looped.placebo.rmspe_p
+    assert set(batched.placebo.rmspe_actual) == set(looped.placebo.rmspe_actual)
+    for e, v in batched.placebo.rmspe_actual.items():
+        assert abs(v - looped.placebo.rmspe_actual[e]) < 1e-9
+
+    for attr in ("p_variance", "ci_lower", "ci_upper", "se"):
+        np.testing.assert_allclose(
+            np.asarray(getattr(batched.placebo, attr), float),
+            np.asarray(getattr(looped.placebo, attr), float), atol=1e-9)
+    for attr in ("att_se", "att_p_value", "att_ci_lower", "att_ci_upper"):
+        assert abs(getattr(batched.placebo, attr)
+                   - getattr(looped.placebo, attr)) < 1e-9
+
+
+def test_the_fit_count_still_counts_programs_not_solver_calls():
+    """``n_fits`` reports the programs the placebo layer poses. Solving them
+    together does not change how many there are."""
+    res = _fit()
+    assert res.placebo.n_fits == 4 * 7
+    shared = _fit(placebo_donor_pool="donors-only")
+    assert shared.placebo.n_fits == 2 * 7
+
+
+# --------------------------------------------------------------------------- #
+# 2. The properties the placebo layer is built on survive
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("pool", ["permutation", "donors-only"])
+def test_every_placebo_is_indexed_to_its_own_base_period(pool):
+    """A pseudo-treated donor's gap at e = -1 is zero by construction, the same
+    identity the real treated units satisfy."""
+    res = _fit(placebo_donor_pool=pool)
+    e = np.asarray(res.placebo.horizons)
+    at_base = np.flatnonzero(e == -1)
+    if at_base.size:
+        for path in res.placebo.paths.values():
+            assert np.max(np.abs(np.asarray(path, float)[:, at_base[0]])) < 1e-9
+
+
+def test_dropping_the_treated_unit_makes_the_path_a_cohort_property():
+    """Under ``donors-only`` every unit in a cohort faces the same design and
+    the same targets, so the batch is shared and the paths coincide."""
+    res = _fit(placebo_donor_pool="donors-only")
+    a = np.asarray(res.placebo.paths["x0"], float)
+    b = np.asarray(res.placebo.paths["x2"], float)      # same cohort
+    np.testing.assert_allclose(a, b, atol=1e-10)
+
+
+def test_the_treated_unit_is_a_donor_to_its_placebos_but_never_a_target():
+    """Under ``permutation`` the pool has one more column than there are rows to
+    report, which is what the family's target border expresses."""
+    res = _fit(placebo_donor_pool="permutation")
+    for path in res.placebo.paths.values():
+        assert np.asarray(path, float).shape[0] == 7
+
+
+# --------------------------------------------------------------------------- #
+# 3. A binding predicate and other edges
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("pool", ["permutation", "donors-only"])
+def test_a_binding_predicate_matches_the_one_at_a_time_solve(pool, monkeypatch):
+    import mlsynth.utils.stackedsc_helpers.inference as INF
+
+    pred = lambda unit, donor: donor != "d0"
+    batched = _fit(placebo_donor_pool=pool, donor_predicate=pred)
+    monkeypatch.setattr(INF, "_placebo_weights", lambda *a, **k: None)
+    looped = _fit(placebo_donor_pool=pool, donor_predicate=pred)
+    for unit, path in batched.placebo.paths.items():
+        np.testing.assert_allclose(np.asarray(path, float),
+                                   np.asarray(looped.placebo.paths[unit], float),
+                                   atol=1e-9)
+        assert np.asarray(path, float).shape[0] == 6
+
+
+def test_a_pool_of_two_donors_is_the_smallest_that_admits_a_placebo(monkeypatch):
+    import mlsynth.utils.stackedsc_helpers.inference as INF
+
+    pred = lambda unit, donor: donor in ("d0", "d1")
+    batched = _fit(donor_predicate=pred)
+    monkeypatch.setattr(INF, "_placebo_weights", lambda *a, **k: None)
+    looped = _fit(donor_predicate=pred)
+    for unit, path in batched.placebo.paths.items():
+        np.testing.assert_allclose(np.asarray(path, float),
+                                   np.asarray(looped.placebo.paths[unit], float),
+                                   atol=1e-9)
+
+
+def test_covariate_matching_still_matches_the_one_at_a_time_solve(monkeypatch):
+    """With predictors the design is sqrt(V)-scaled and badly conditioned, so
+    most members fail certification and are re-solved. The answer is the same
+    either way."""
+    import mlsynth.utils.stackedsc_helpers.inference as INF
+
+    df = _staggered()
+    rng = np.random.default_rng(1)
+    df["z"] = rng.normal(size=len(df)) * 1e4
+
+    batched = _fit(df=df, covariates=["z"])
+    monkeypatch.setattr(INF, "_placebo_weights", lambda *a, **k: None)
+    looped = _fit(df=df, covariates=["z"])
+    for unit, path in batched.placebo.paths.items():
+        np.testing.assert_allclose(np.asarray(path, float),
+                                   np.asarray(looped.placebo.paths[unit], float),
+                                   atol=1e-9)
+
+
+def test_a_pool_too_small_for_a_placebo_is_still_reported():
+    """One donor leaves nothing to fit a placebo against, and the batch must not
+    swallow the error the loop raised."""
+    from mlsynth.exceptions import MlsynthDataError
+
+    with pytest.raises(MlsynthDataError, match="donor"):
+        _fit(donor_predicate=lambda unit, donor: donor == "d0")

--- a/mlsynth/tests/test_vanillasc_placebo_batch.py
+++ b/mlsynth/tests/test_vanillasc_placebo_batch.py
@@ -1,0 +1,134 @@
+"""VanillaSC's in-space placebo, solved as one leave-one-out family.
+
+Test-first (per ``agents/agents_tests.md``).
+
+The outcome-only placebo refits every donor against the others, which is one
+family over the donor matrix and not ``J`` unrelated problems. The p-value it
+produces is a *rank* statistic over those fits, so the bar is not that the
+batched path be optimal -- it is that it reproduce the ranks the one-at-a-time
+path produced, exactly. These tests hold it to that, and check that the fast path
+is skipped wherever a refit is not simply that one simplex QP.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import mlsynth.utils.bilevel.minnorm as minnorm
+from mlsynth import VanillaSC
+
+
+def _panel(seed=0, n_units=12, T=20, t0=14, effect=-4.0):
+    rng = np.random.default_rng(seed)
+    rows = []
+    for u in range(n_units):
+        level = 20.0 + 3.0 * u
+        for t in range(T):
+            y = level + 0.8 * t + rng.normal(scale=0.6)
+            treated = int(u == 0 and t >= t0)
+            if treated:
+                y += effect
+            rows.append({"unit": u, "time": t, "y": y, "treat": treated})
+    return pd.DataFrame(rows)
+
+
+def _fit(df, **kw):
+    cfg = dict(df=df, outcome="y", treat="treat", unitid="unit", time="time",
+               display_graphs=False, **kw)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return VanillaSC(cfg).fit()
+
+
+def _without_batching(df, **kw):
+    """The same fit with the family solver disabled, so the loop runs."""
+    real = minnorm.solve_simplex_loo_exact
+
+    def boom(*a, **k):
+        raise RuntimeError("batched path disabled for this test")
+
+    try:
+        minnorm.solve_simplex_loo_exact = boom
+        return _fit(df, **kw)
+    finally:
+        minnorm.solve_simplex_loo_exact = real
+
+
+# --------------------------------------------------------------------------- #
+# 1. The batched family reproduces the loop, on everything the p-value uses
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("seed", range(4))
+def test_placebo_inference_is_identical_to_the_loop(seed):
+    df = _panel(seed=seed)
+    got, want = _fit(df), _without_batching(df)
+    assert got.inference.p_value == want.inference.p_value
+    assert got.inference.details["rank"] == want.inference.details["rank"]
+    assert got.inference.details["n_placebos"] == want.inference.details["n_placebos"]
+    assert np.isclose(got.inference.details["treated_rmspe_ratio"],
+                      want.inference.details["treated_rmspe_ratio"], rtol=0, atol=1e-12)
+    assert np.isclose(got.effects.att, want.effects.att, rtol=0, atol=1e-12)
+
+
+def test_more_donors_than_pre_periods_still_matches():
+    """The geometry a design-shape guard would have refused, and the one the
+    ordinary synthetic control has."""
+    df = _panel(seed=7, n_units=30, T=12, t0=8)
+    got, want = _fit(df), _without_batching(df)
+    assert got.inference.p_value == want.inference.p_value
+    assert got.inference.details["rank"] == want.inference.details["rank"]
+
+
+# --------------------------------------------------------------------------- #
+# 2. The fast path is skipped where a refit is not one plain simplex QP
+# --------------------------------------------------------------------------- #
+def test_ridge_augmented_fits_keep_the_loop():
+    """Augmented SCM puts a ridge layer over the base, so a placebo refit is not
+    the base solve alone. Disabling the family solver must change nothing."""
+    df = _panel(seed=2)
+    got, want = _fit(df, augment="ridge"), _without_batching(df, augment="ridge")
+    assert got.inference.p_value == want.inference.p_value
+    assert np.isclose(got.effects.att, want.effects.att, rtol=0, atol=1e-12)
+
+
+def test_covariate_fits_keep_the_loop():
+    df = _panel(seed=3)
+    df["x"] = df.groupby("unit")["y"].transform("mean") + 0.1
+    got = _fit(df, covariates=["x"], backend="mscmt")
+    want = _without_batching(df, covariates=["x"], backend="mscmt")
+    assert got.inference.p_value == want.inference.p_value
+
+
+def test_penalized_backend_keeps_the_loop():
+    df = _panel(seed=4)
+    got = _fit(df, backend="penalized")
+    want = _without_batching(df, backend="penalized")
+    assert got.inference.p_value == want.inference.p_value
+
+
+# --------------------------------------------------------------------------- #
+# 3. The family solver is actually being used on the default path
+# --------------------------------------------------------------------------- #
+def test_the_default_outcome_only_path_uses_the_family_solver():
+    """A fast path nothing reaches is the failure mode this guards."""
+    calls = []
+    real = minnorm.solve_simplex_loo_exact
+
+    def spy(M, **kw):
+        calls.append(M.shape)
+        return real(M, **kw)
+
+    try:
+        minnorm.solve_simplex_loo_exact = spy
+        _fit(_panel(seed=5))
+    finally:
+        minnorm.solve_simplex_loo_exact = real
+    assert len(calls) == 1, "the placebo family should be solved in one call"
+
+
+def test_a_two_donor_panel_still_works():
+    df = _panel(seed=6, n_units=3, T=16, t0=11)
+    got, want = _fit(df), _without_batching(df)
+    assert got.inference.p_value == want.inference.p_value

--- a/mlsynth/utils/bilevel/minnorm.py
+++ b/mlsynth/utils/bilevel/minnorm.py
@@ -42,7 +42,7 @@ mlsynth.utils.bilevel.active_set.solve_simplex_qp : the single-problem,
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Callable, Optional
 
 import numpy as np
 
@@ -113,6 +113,70 @@ def gram_reduction_is_safe(B: np.ndarray, tol: float = 1e-8) -> bool:
     if sv.size == 0 or sv[0] <= 0.0:
         return False
     return bool(sv[-1] / sv[0] > tol)
+
+
+def simplex_point_is_optimal(
+    B: np.ndarray, A: np.ndarray, w: np.ndarray, tol: float = 1e-7
+) -> bool:
+    """Whether ``w`` solves ``min ||B w - A||^2`` on the simplex, checked on ``B``.
+
+    With ``g = B'(B w - A)`` and ``nu = g' w``, the KKT conditions for this
+    program are ``g_j >= nu`` for every donor, with equality wherever ``w_j > 0``.
+    Feasibility plus that inequality is a certificate: it is computed from the
+    design and the target, so it holds whatever solver produced ``w`` and
+    whatever form that solver worked in.
+
+    Which is the point of it here. The Gram reduction squares the condition
+    number -- ``G = R'R`` for ``R = B - A 1'`` -- so a design that is merely
+    awkward at ``cond(B) ~ 1e7``, as covariates measured in different units are,
+    gives a ``G`` that is singular in float64. The batched solver then converges
+    on that ``G``, correctly, to a point that does not solve the program ``G``
+    came from, and nothing computed from ``G`` can tell. On the covariate
+    specification of the Wiltshire panel that is 62 of 76 members of a cohort,
+    with a KKT residual of 7e-3 where the design-form solver leaves 6e-10.
+
+    Optimality and uniqueness are separate questions, and standing one solver in
+    for another needs both: see :func:`simplex_optimum_is_unique`. A point may be
+    optimal on a face, or be a near-miss for a unique optimum.
+
+    Parameters
+    ----------
+    B : np.ndarray, shape (m, J)
+        The design the weights are claimed to solve.
+    A : np.ndarray, shape (m,)
+        The target.
+    w : np.ndarray, shape (J,)
+        The candidate weights.
+    tol : float
+        Relative tolerance, applied to the reduced gradient's own magnitude, and
+        absolutely to simplex feasibility.
+
+    Returns
+    -------
+    bool
+        ``True`` only when ``w`` is feasible and satisfies the KKT conditions.
+    """
+    B = np.asarray(B, dtype=float)
+    A = np.asarray(A, dtype=float).ravel()
+    w = np.asarray(w, dtype=float).ravel()
+    if B.ndim != 2:
+        raise ValueError(f"B must be a 2-D (m, J) matrix; got shape {B.shape}.")
+    if w.shape[0] != B.shape[1]:
+        raise ValueError(
+            f"len(w)={w.shape[0]} must equal B's column count {B.shape[1]}.")
+    if A.shape[0] != B.shape[0]:
+        raise ValueError(
+            f"len(A)={A.shape[0]} must equal B's row count {B.shape[0]}.")
+    if not np.all(np.isfinite(w)):
+        return False
+    if w.min() < -_W_TOL or abs(w.sum() - 1.0) > 1e-9:
+        return False
+    g = B.T @ (B @ w - A)
+    if not np.all(np.isfinite(g)):  # pragma: no cover - overflow on absurd input
+        return False
+    nu = float(g @ w)
+    scale = 1.0 + float(np.max(np.abs(g)))
+    return bool(float(g.min()) >= nu - tol * scale)
 
 
 def simplex_optimum_is_unique(
@@ -436,10 +500,23 @@ def solve_simplex_minnorm_batch(
     return W
 
 
+def _reproduces_the_loop(B: np.ndarray, A: np.ndarray, w: np.ndarray) -> bool:
+    """Whether a batched answer may stand in for the one-at-a-time solve.
+
+    Both halves are needed and neither implies the other. ``w`` has to solve the
+    program as posed on the design, which the Gram form can fail to do when
+    ``cond(B)^2`` exceeds float64; and the program has to have one solution, or
+    two exact solvers land in different places on a face.
+    """
+    return (simplex_point_is_optimal(B, A, w)
+            and simplex_optimum_is_unique(B, A, w))
+
+
 def solve_simplex_loo_exact(
     M: np.ndarray,
     *,
     n_targets: Optional[int] = None,
+    fallback: Optional[Callable] = None,
     return_info: bool = False,
 ):
     """Leave-one-out simplex least squares over the columns of ``M``, exactly.
@@ -455,13 +532,16 @@ def solve_simplex_loo_exact(
     remaining indices. No product with the data occurs per problem, and the
     batched active set then certifies the whole family together.
 
-    Every member is checked with :func:`simplex_optimum_is_unique` and the ones
-    whose minimiser is a face -- where two exact solvers may return different
-    weights for the same fit -- are re-solved with the single-problem active set
-    of :mod:`~mlsynth.utils.bilevel.active_set`. So the result is not merely
-    optimal but identical to solving the family one at a time, which matters
-    here: the placebo p-value is a rank statistic over these fits, and the
-    library's published ranks came from that solver.
+    Every member is then certified against its own design: the returned point
+    has to satisfy the KKT conditions there (:func:`simplex_point_is_optimal`,
+    which the Gram form can fail when ``cond(M)^2`` exceeds float64) and its
+    optimum has to be a point and not a face
+    (:func:`simplex_optimum_is_unique`, since on a face two exact solvers land
+    in different places). Members failing either are re-solved with the
+    single-problem active set of :mod:`~mlsynth.utils.bilevel.active_set`. So
+    the result is not merely optimal but identical to solving the family one at
+    a time, which matters here: the placebo p-value is a rank statistic over
+    these fits, and the library's published ranks came from that solver.
 
     Parameters
     ----------
@@ -470,6 +550,13 @@ def solve_simplex_loo_exact(
     n_targets : int, optional
         How many leading columns are cast as treated. Columns beyond it stay in
         every donor pool without being a target themselves. Defaults to ``J``.
+    fallback : callable, optional
+        ``(B, A) -> w``, the one-at-a-time solver this batch is standing in for,
+        used on members that fail certification. Defaults to
+        :func:`~mlsynth.utils.bilevel.active_set.solve_simplex_qp`. Pass the
+        caller's own: VanillaSC's engine reaches that solver through a wrapper
+        that escalates to CVXPY when it reports failure on itself, and the two
+        can disagree exactly where the certification fails.
     return_info : bool
         If ``True`` also return ``{"n_problems", "n_fallback"}``.
 
@@ -478,7 +565,8 @@ def solve_simplex_loo_exact(
     np.ndarray, shape (n_targets, J)
         Row ``j`` holds the weights fitting ``M[:, j]``, with ``W[j, j]`` zero.
     """
-    from .active_set import solve_simplex_qp
+    if fallback is None:
+        from .active_set import solve_simplex_qp as fallback
 
     M = np.asarray(M, dtype=float)
     if M.ndim != 2:
@@ -492,10 +580,9 @@ def solve_simplex_loo_exact(
     if not 1 <= n <= J:
         raise ValueError(f"n_targets must be between 1 and {J}; got {n}.")
 
-    Mg = M.T @ M
     keep = ~np.eye(J, dtype=bool)[:n]                      # (n, J)
     idx = np.argsort(~keep, axis=1, kind="stable")[:, :J - 1]   # donors per target
-    rows = np.arange(n)[:, None]
+    Mg = M.T @ M
     # G_j from the Gram alone: the deleted column enters only through its own
     # row, column and diagonal entry.
     G = (Mg[idx[:, :, None], idx[:, None, :]]
@@ -509,9 +596,95 @@ def solve_simplex_loo_exact(
     n_fallback = 0
     for j in range(n):
         cols = idx[j]
-        if not simplex_optimum_is_unique(M[:, cols], M[:, j], W[j, cols]):
-            W[j, cols] = solve_simplex_qp(M[:, cols], M[:, j])
+        if not _reproduces_the_loop(M[:, cols], M[:, j], W[j, cols]):
+            W[j, cols] = np.asarray(fallback(M[:, cols], M[:, j]),
+                                    dtype=float).ravel()
             n_fallback += 1
     if return_info:
         return W, {"n_problems": n, "n_fallback": n_fallback}
+    return W
+
+
+def solve_simplex_shared_design(
+    A: np.ndarray,
+    B: np.ndarray,
+    *,
+    fallback: Optional[Callable] = None,
+    return_info: bool = False,
+):
+    """Simplex least squares for many targets against one shared design.
+
+    Solves ``min ||A w - b_j||^2`` on the simplex for every column ``b_j`` of
+    ``B``. This is the shape a cohort of treated units poses when they are
+    fitted against a common donor pool.
+
+    One design means the family costs one Gram plus one cross product. With
+    ``c_j = A' b_j`` and ``s_j = b_j' b_j``, the ``j``-th problem's Gram is
+
+        ``G_j = A'A - c_j 1' - 1 c_j' + s_j 1 1'``,
+
+    so ``A'A`` and ``A'B`` formed once carry the whole set, and the batched
+    active set then runs the cohort in lockstep.
+
+    Every member is then certified against the design: the returned point has to
+    satisfy the KKT conditions there (:func:`simplex_point_is_optimal`) and its
+    optimum has to be a point and not a face (:func:`simplex_optimum_is_unique`).
+    Members failing either are re-solved one at a time. The weights are reported
+    per treated unit and the counterfactuals are built from them, so the batch
+    has to reproduce the one-at-a-time solve and not merely tie with it. The
+    optimality test is what covariate matching needs: predictors in different
+    units push ``cond(A)`` to 1e7 and the Gram past what float64 keeps, and
+    there most of the group falls back and the batch buys nothing. On the
+    outcome-only design it is 89 members with 6 falling back, at 43ms against
+    the loop's 396ms.
+
+    Parameters
+    ----------
+    A : np.ndarray, shape (m, J)
+        Design shared by every target.
+    B : np.ndarray, shape (m, k) or (m,)
+        Targets, one per column. A 1-D array is one target.
+    fallback : callable, optional
+        ``(B, A) -> w``, the one-at-a-time solver this batch is standing in for,
+        used on members that fail certification. Defaults to
+        :func:`~mlsynth.utils.bilevel.active_set.solve_simplex_qp`, which is
+        what STACKEDSC calls.
+    return_info : bool
+        If ``True`` also return ``{"n_problems", "n_fallback"}``.
+
+    Returns
+    -------
+    np.ndarray, shape (k, J)
+        Row ``j`` holds the weights fitting ``B[:, j]``.
+    """
+    if fallback is None:
+        from .active_set import solve_simplex_qp as fallback
+
+    A = np.asarray(A, dtype=float)
+    B = np.asarray(B, dtype=float)
+    if A.ndim != 2:
+        raise ValueError(f"A must be 2-D (m, J); got shape {A.shape}.")
+    if B.ndim == 1:
+        B = B[:, None]
+    if B.ndim != 2:
+        raise ValueError(f"B must be 2-D (m, k) or 1-D (m,); got shape {B.shape}.")
+    if B.shape[0] != A.shape[0]:
+        raise ValueError(
+            f"B has {B.shape[0]} rows but A has {A.shape[0]}; the targets and "
+            f"the design must be measured over the same rows.")
+
+    k = B.shape[1]
+    AtA = A.T @ A
+    C = (A.T @ B).T                                        # (k, J), row j is c_j
+    s = np.einsum("ij,ij->j", B, B)                        # (k,)
+    G = AtA[None] - C[:, :, None] - C[:, None, :] + s[:, None, None]
+    W = solve_simplex_minnorm_batch(0.5 * (G + np.swapaxes(G, 1, 2)))
+
+    n_fallback = 0
+    for j in range(k):
+        if not _reproduces_the_loop(A, B[:, j], W[j]):
+            W[j] = np.asarray(fallback(A, B[:, j]), dtype=float).ravel()
+            n_fallback += 1
+    if return_info:
+        return W, {"n_problems": int(B.shape[1]), "n_fallback": n_fallback}
     return W

--- a/mlsynth/utils/bilevel/minnorm.py
+++ b/mlsynth/utils/bilevel/minnorm.py
@@ -434,3 +434,84 @@ def solve_simplex_minnorm_batch(
     if return_info:
         return W, {"iterations": iterations, "converged": converged}
     return W
+
+
+def solve_simplex_loo_exact(
+    M: np.ndarray,
+    *,
+    n_targets: Optional[int] = None,
+    return_info: bool = False,
+):
+    """Leave-one-out simplex least squares over the columns of ``M``, exactly.
+
+    For each ``j`` solves ``min ||M[:, k != j] w - M[:, j]||^2`` on the simplex.
+    This is the shape of an in-space placebo test, where every donor is cast as
+    treated in turn against the others.
+
+    The family is carried by one Gram. Deleting a column deletes a row and a
+    column of ``M' M``, and each target is itself a column of ``M``, so the cross
+    term is a column of that same Gram: with ``Mg = M' M``, the ``j``-th
+    problem's Gram is ``Mg[a,b] - Mg[a,j] - Mg[j,b] + Mg[j,j]`` over the
+    remaining indices. No product with the data occurs per problem, and the
+    batched active set then certifies the whole family together.
+
+    Every member is checked with :func:`simplex_optimum_is_unique` and the ones
+    whose minimiser is a face -- where two exact solvers may return different
+    weights for the same fit -- are re-solved with the single-problem active set
+    of :mod:`~mlsynth.utils.bilevel.active_set`. So the result is not merely
+    optimal but identical to solving the family one at a time, which matters
+    here: the placebo p-value is a rank statistic over these fits, and the
+    library's published ranks came from that solver.
+
+    Parameters
+    ----------
+    M : np.ndarray, shape (m, J)
+        Columns to fit against one another; ``J >= 2``.
+    n_targets : int, optional
+        How many leading columns are cast as treated. Columns beyond it stay in
+        every donor pool without being a target themselves. Defaults to ``J``.
+    return_info : bool
+        If ``True`` also return ``{"n_problems", "n_fallback"}``.
+
+    Returns
+    -------
+    np.ndarray, shape (n_targets, J)
+        Row ``j`` holds the weights fitting ``M[:, j]``, with ``W[j, j]`` zero.
+    """
+    from .active_set import solve_simplex_qp
+
+    M = np.asarray(M, dtype=float)
+    if M.ndim != 2:
+        raise ValueError(f"M must be 2-D (m, J); got shape {M.shape}.")
+    J = M.shape[1]
+    if J < 2:
+        raise ValueError(
+            f"M has {J} column(s); leaving one out needs at least two, since the "
+            f"remaining columns are what the left-out one is fitted against.")
+    n = J if n_targets is None else int(n_targets)
+    if not 1 <= n <= J:
+        raise ValueError(f"n_targets must be between 1 and {J}; got {n}.")
+
+    Mg = M.T @ M
+    keep = ~np.eye(J, dtype=bool)[:n]                      # (n, J)
+    idx = np.argsort(~keep, axis=1, kind="stable")[:, :J - 1]   # donors per target
+    rows = np.arange(n)[:, None]
+    # G_j from the Gram alone: the deleted column enters only through its own
+    # row, column and diagonal entry.
+    G = (Mg[idx[:, :, None], idx[:, None, :]]
+         - Mg[idx, np.arange(n)[:, None]][:, :, None]
+         - Mg[np.arange(n)[:, None], idx][:, None, :]
+         + Mg[np.arange(n), np.arange(n)][:, None, None])
+    Wc = solve_simplex_minnorm_batch(0.5 * (G + np.swapaxes(G, 1, 2)))
+
+    W = np.zeros((n, J))
+    np.put_along_axis(W, idx, Wc, axis=1)
+    n_fallback = 0
+    for j in range(n):
+        cols = idx[j]
+        if not simplex_optimum_is_unique(M[:, cols], M[:, j], W[j, cols]):
+            W[j, cols] = solve_simplex_qp(M[:, cols], M[:, j])
+            n_fallback += 1
+    if return_info:
+        return W, {"n_problems": n, "n_fallback": n_fallback}
+    return W

--- a/mlsynth/utils/bilevel/minnorm.py
+++ b/mlsynth/utils/bilevel/minnorm.py
@@ -74,17 +74,26 @@ def gram_reduction_is_safe(B: np.ndarray, tol: float = 1e-8) -> bool:
       below what float64 resolves. The Gram solve then returns a point that is
       not optimal at all. Measured on mlSC's penalty grid over a 9-period,
       12-disaggregate design, it finished 225 percent above the optimum.
-    * If the design is genuinely rank deficient -- more donors than matching
-      rows, the ordinary synthetic-control case -- the optimum is a face and
-      every point of it is optimal. Both solvers are then correct and they land
-      in different places: on an 8-row, 39-donor design they agree on the fitted
-      values to 1e-11 while differing by 0.5 in the weights, the Gram form
-      concentrating on about 9 donors where the design form spreads over 37.
+    * If the design is rank deficient and the minimiser is a face and not a
+      point, both solvers are correct and they land in different places: on an
+      8-row, 39-donor design whose target the donors reproduce exactly, they
+      agree on the fitted values to 1e-11 while differing by 0.19 in the weights.
       Nothing is wrong, but anything reading the weights -- a donor table, a
       counterfactual built from post-period donor outcomes -- would change.
 
-    So the reduction is for designs this returns ``True`` for. It is a property
-    of the design alone, decidable before any solving.
+    So the reduction is for designs this returns ``True`` for, and it is a
+    property of the design alone, decidable before any solving.
+
+    For the second failure it is sound but far from tight, and the slack is not
+    small. Rank deficiency is only a precondition for a non-unique minimiser:
+    the objective is flat along a direction only if that direction is also
+    *feasible* where the solution sits, which needs a support large relative to
+    the design's rank. Synthetic-control solutions are sparse, so a donor pool
+    wider than the pre-period usually still has a unique minimiser -- on the
+    Proposition 99 placebo family all 38 solves do, at 37 donors against 19
+    pre-periods, and this test admits none of them. A caller that can afford to
+    solve first should ask :func:`simplex_optimum_is_unique` instead, which
+    settles the same question exactly, on the support.
 
     Parameters
     ----------
@@ -104,6 +113,71 @@ def gram_reduction_is_safe(B: np.ndarray, tol: float = 1e-8) -> bool:
     if sv.size == 0 or sv[0] <= 0.0:
         return False
     return bool(sv[-1] / sv[0] > tol)
+
+
+def simplex_optimum_is_unique(
+    B: np.ndarray, A: np.ndarray, w: np.ndarray, tol: float = 1e-7
+) -> bool:
+    """Whether ``min ||B w - A||^2`` on the simplex has one minimiser, given one.
+
+    Two exact solvers of this program return the same weights when the minimiser
+    is a point and different weights when it is a face, so this is the question
+    that decides whether one may stand in for the other -- and it is answerable
+    after solving, cheaply, on the solution's own support.
+
+    The objective is flat along a direction ``d`` only if ``B d = 0``, and ``d``
+    stays feasible only if ``1' d = 0`` and ``d`` does not push a coordinate
+    below zero. A donor outside the support with a strictly positive reduced
+    gradient cannot be entered at all, so only the weakly-active set can move.
+    The minimiser is therefore unique exactly when no such ``d`` exists, i.e.
+    when ``B`` restricted to that set, with the sum-to-one row appended, has full
+    column rank.
+
+    This is what :func:`gram_reduction_is_safe` approximates from the design
+    alone, and it approximates it conservatively: full column rank of the whole
+    design implies this, but not the reverse. The gap is the ordinary
+    synthetic-control geometry -- more donors than pre-treatment periods -- where
+    the fit is imperfect and the solution sparse, so no null direction is
+    feasible and the minimiser is unique after all. On the Proposition 99 placebo
+    family all 38 solves are unique, at 37 donors against 19 pre-periods, and the
+    shape test admits none of them.
+
+    Parameters
+    ----------
+    B : np.ndarray, shape (m, J)
+        The design the weights were solved against.
+    A : np.ndarray, shape (m,)
+        The target.
+    w : np.ndarray, shape (J,)
+        A minimiser, from any exact solver.
+    tol : float
+        Relative tolerance for the weakly-active set and the rank test.
+
+    Returns
+    -------
+    bool
+        ``True`` only when the minimiser is provably the only one. Use it that
+        way round: a ``False`` costs a second solve, a wrong ``True`` would
+        change an answer.
+    """
+    B = np.asarray(B, dtype=float)
+    A = np.asarray(A, dtype=float).ravel()
+    w = np.asarray(w, dtype=float).ravel()
+    if B.ndim != 2 or w.shape[0] != B.shape[1] or A.shape[0] != B.shape[0]:
+        raise ValueError(
+            f"shapes do not line up: B {B.shape}, A {A.shape}, w {w.shape}.")
+    if B.shape[1] == 1:
+        return True
+    g = B.T @ (B @ w - A)
+    nu = float(g @ w)
+    scale = 1.0 + float(np.max(np.abs(g)))
+    # Weakly active: carrying weight, or able to enter without raising the loss.
+    active = (w > tol * 1e-2) | (np.abs(g - nu) <= tol * scale)
+    n_active = int(active.sum())
+    if n_active == 0:  # pragma: no cover - a simplex point always has support
+        return True
+    M = np.vstack([B[:, active], np.ones((1, n_active))])
+    return bool(np.linalg.matrix_rank(M, tol=tol * 1e-2) == n_active)
 
 
 def simplex_gram(B: np.ndarray, A: np.ndarray) -> np.ndarray:

--- a/mlsynth/utils/stackedsc_helpers/inference.py
+++ b/mlsynth/utils/stackedsc_helpers/inference.py
@@ -33,8 +33,8 @@ The donor pool for a placebo
 constituting the donor pool for each j", so under the permutation the treated
 unit is itself a control. ``placebo_donor_pool="permutation"`` follows that and
 is the default. It has two consequences. The placebo path becomes a property of
-the pair ``(i, j)`` rather than of the cohort, so the cost is the number of
-treated units times the pool size. And under the alternative, ``i``'s
+the pair ``(i, j)`` and not of the cohort, so the cost is the number of treated
+units times the pool size. And under the alternative, ``i``'s
 post-treatment outcomes carry the effect being tested, so any weight the placebo
 puts on ``i`` pulls the placebo gap away from zero and widens the null
 distribution. That is the stacked-case power loss Zhang (2019, section 3.1)
@@ -45,12 +45,31 @@ meant to represent.
 ``placebo_donor_pool="donors-only"`` drops the treated unit. Every unit in a
 cohort then faces the same design and the same targets, so one solve per
 ``(cohort, donor)`` serves the whole cohort, which on the Walmart panel is 6 x
-39 rather than 566 x 39.
+39 instead of 566 x 39.
 
-What is reused rather than refitted
------------------------------------
+How the refits are solved
+-------------------------
 
-The predictor weights ``V`` are taken from the cohort's own fit rather than
+Either pool poses a leave-one-out family: each donor in a pool is cast as
+treated and fitted against the rest, which is one matrix's columns fitted
+against one another. In Gram form the whole family falls out of a single
+``M' M`` -- deleting a column deletes a row and a column of it, and each target
+is itself a column -- so
+:func:`mlsynth.utils.bilevel.minnorm.solve_simplex_loo_exact` assembles it with
+no product with the data per refit. Under ``donors-only`` the matrix is the
+cohort's design restricted to the pool and the family is shared by the cohort;
+under ``permutation`` the treated unit's column is appended, a donor to every
+placebo and a target to none. On the Walmart panel's 22,074 programs that is
+101s down to 21s, with every reported statistic unchanged to 1e-11.
+
+The p-values are rank statistics over these fits, so each member is certified
+against its own design and the ones that fail are re-solved with the same active
+set the loop used.
+
+What is reused instead of refitted
+----------------------------------
+
+The predictor weights ``V`` are taken from the cohort's own fit and not
 recomputed for each placebo. Recomputing them would mean one regression per
 placebo and would change the design matrix the placebos are compared on; holding
 ``V`` fixed keeps every path in the permutation set on the same scale as the
@@ -73,6 +92,36 @@ __all__ = ["cohort_placebo_paths", "sample_placebo_averages",
            "placebo_inference"]
 
 _EPS = 1e-12
+
+
+def _placebo_weights(A, B, idx, i, donor_pool):
+    """Weights for one treated unit's whole placebo pool, in one solve.
+
+    Casting each donor in ``idx`` as treated and refitting against the rest is a
+    leave-one-out family over a single matrix, so
+    :func:`~mlsynth.utils.bilevel.minnorm.solve_simplex_loo_exact` assembles all
+    of it from one Gram. Under ``donors-only`` that matrix is the cohort's design
+    restricted to the pool. Under ``permutation`` the treated unit is a control,
+    so its column is appended: it is a donor to every placebo and a target to
+    none, which is the family's target border.
+
+    Returns ``(len(idx), n_pool)`` with row ``r`` in the column order the caller
+    builds its pool in -- ``idx`` minus the pseudo-treated donor, then the
+    treated unit under ``permutation`` -- or ``None`` if the family cannot be
+    formed, in which case the caller solves one at a time.
+    """
+    from ..bilevel.minnorm import solve_simplex_loo_exact
+
+    n = len(idx)
+    M = (A[:, idx] if donor_pool == "donors-only"
+         else np.column_stack([A[:, idx], B[:, i]]))
+    try:
+        W = solve_simplex_loo_exact(M, n_targets=n)
+    except Exception:  # pragma: no cover - fall back to the loop
+        return None
+    # Row r fits column r, which carries zero weight; drop it so the row lines
+    # up with the pool the caller assembles.
+    return W[~np.eye(n, W.shape[1], dtype=bool)].reshape(n, W.shape[1] - 1)
 
 
 def cohort_placebo_paths(
@@ -115,6 +164,7 @@ def cohort_placebo_paths(
     """
     Y, D, X1, X0 = cohort.Y, cohort.D, cohort.X1, cohort.X0
     shared: Dict[Any, np.ndarray] = {}
+    batches: Dict[Any, Optional[np.ndarray]] = {}
     paths: Dict[str, np.ndarray] = {}
     n_fits = 0
 
@@ -126,8 +176,15 @@ def cohort_placebo_paths(
                 f"no placebo can be formed: casting a donor as treated leaves "
                 f"nothing to fit it against. Placebo inference needs at least "
                 f"two donors per treated unit.")
+        # Under ``donors-only`` the family is a property of the pool, so units
+        # sharing one share the solve; under ``permutation`` each unit's own
+        # column is in it and no two units share.
+        wkey = tuple(idx) if donor_pool == "donors-only" else (tuple(idx), i)
+        if wkey not in batches:
+            batches[wkey] = _placebo_weights(A, B, idx, i, donor_pool)
+        batch = batches[wkey]
         rows: List[np.ndarray] = []
-        for j in idx:
+        for r, j in enumerate(idx):
             keep = [k for k in idx if k != j]
             key = (tuple(keep), j) if donor_pool == "donors-only" else None
             if key is not None and key in shared:
@@ -141,8 +198,11 @@ def cohort_placebo_paths(
                 Y_pool = np.column_stack([D[:, keep], Y[:, i]])
                 X_pool = (None if X0 is None
                           else np.column_stack([X0[:, keep], X1[:, i]]))
-            w = np.asarray(solve_simplex_qp(A_pool, A[:, j]),
-                           dtype=float).ravel()
+            if batch is not None:
+                w = batch[r]
+            else:
+                w = np.asarray(solve_simplex_qp(A_pool, A[:, j]),
+                               dtype=float).ravel()
             gap = D[:, j] - Y_pool @ w
             if bias_correct and X_pool is not None:
                 gap = bias_corrected_gaps(w, X0[:, j], X_pool, D[:, j], Y_pool,

--- a/mlsynth/utils/stackedsc_helpers/pipeline.py
+++ b/mlsynth/utils/stackedsc_helpers/pipeline.py
@@ -5,16 +5,24 @@ its own pre-treatment target. A donor predicate that binds is the exception: it
 gives each unit its own design matrix, which the result reports as
 ``shared_donor_pool = False``.
 
-The weights come from the primal active-set solver
-(:func:`mlsynth.utils.bilevel.active_set.solve_simplex_qp`), the same one MEDSC,
-SCD and COMPSC use. That choice is load-bearing on this design rather than a
-matter of taste. A cohort has 5 to 10 pre-treatment periods against 39 donors,
-so the Gram is rank deficient by 30 or more; measured on the Wiltshire panel a
-first-order method never converged on it, with 20 of 39 leave-one-out columns
-still improving at iteration 20,000 at every tolerance from 1e-11 down to 1e-6.
-The active-set method solves the same program exactly in a bounded number of
-pivots, and on that panel is 2.8x faster on the point estimate and roughly 130x
-on the placebo layer.
+The weights come from an active-set solver, the same family MEDSC, SCD and
+COMPSC use. That choice decides whether this estimator works at all. A cohort
+has 5 to 10 pre-treatment periods against 39 donors, so the Gram is rank
+deficient by 30 or more; measured on the Wiltshire panel a first-order method
+never converged on it, with 20 of 39 leave-one-out columns still improving at
+iteration 20,000 at every tolerance from 1e-11 down to 1e-6. The active-set
+method solves the same program exactly in a bounded number of pivots, and on
+that panel is 2.8x faster on the point estimate and roughly 130x on the placebo
+layer.
+
+Because the units in a pool share their design, the cohort's programs are one
+family: they differ only in the target, so their Gram matrices differ by
+rank-one pieces of a single cross product. The batched active set
+(:func:`mlsynth.utils.bilevel.minnorm.solve_simplex_shared_design`) solves them
+together, verifies each, and re-solves the ambiguous ones with the
+single-problem active set
+(:func:`mlsynth.utils.bilevel.active_set.solve_simplex_qp`) so the weights are
+the same points the loop returned.
 
 Exactness pins the objective, not the answer. With fewer rows than donors the
 optimum is a face, and two exact solvers land in different places on it -- on
@@ -40,7 +48,7 @@ from ...config_models import (
     WeightsResults,
 )
 from ..bilevel import bias_corrected_gaps, regression_v
-from ..bilevel.active_set import solve_simplex_qp
+from ..bilevel.minnorm import solve_simplex_shared_design
 from .inference import placebo_inference
 from .plotter import plot_stackedsc
 from .setup import aggregation_weights, build_cohorts, event_window
@@ -94,21 +102,33 @@ def _allowed_donors(cohort, predicate):
 
 
 def _weights_for_cohort(cohort, A, B, allowed):
-    """(n_donors, n_units) weights, one exact solve per treated unit.
+    """(n_donors, n_units) weights for a cohort's treated units.
 
-    The design ``A`` is shared across a cohort unless a predicate binds, but
-    the active-set solver takes one target at a time, so this is a loop either
-    way. It is still the faster path: each solve terminates on a KKT
-    certificate after a handful of pivots rather than running an iteration
-    budget to exhaustion.
+    The units sharing a donor pool share a design and differ only in their own
+    target, which is one batch: their Grams are ``A'A`` shifted by rank-one
+    pieces of ``A'B``, so the whole group costs one Gram and one cross product
+    and the active set runs it in lockstep
+    (:func:`~mlsynth.utils.bilevel.minnorm.solve_simplex_shared_design`). With no
+    predicate that is the entire cohort in one solve; with one that binds it is
+    one solve per distinct pool, down to a batch of one per unit in the worst
+    case.
+
+    The batch verifies each member and re-solves the ambiguous ones with the
+    one-at-a-time active set, so the weights are the same points the loop
+    returned. That is the operative constraint here: with fewer pre-periods than
+    donors the optimum is usually a face, and STACKEDSC reports these weights
+    per unit and builds each counterfactual from them.
     """
-    cols = []
+    groups: Dict[tuple, List[int]] = {}
     for j, keep in enumerate(allowed):
-        w = np.zeros(len(cohort.donors))
-        w[keep] = np.asarray(solve_simplex_qp(A[:, keep], B[:, j]),
-                             dtype=float).ravel()
-        cols.append(w)
-    return np.column_stack(cols)
+        groups.setdefault(tuple(keep), []).append(j)
+
+    W = np.zeros((len(cohort.donors), len(allowed)))
+    for keep, units in groups.items():
+        cols = list(keep)
+        W[np.ix_(cols, units)] = solve_simplex_shared_design(
+            A[:, cols], B[:, units]).T
+    return W
 
 
 def run_stackedsc(config) -> BaseEstimatorResults:

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -674,15 +674,16 @@ def run_vanillasc(config) -> BaseEstimatorResults:
         # matrix, so they are solved together. Restricted to the case where a
         # refit is exactly that one simplex QP: no covariates to weight, no
         # augmentation layer over the base, and a backend that reduces to it.
-        # ``solve_simplex_loo_exact`` verifies each member and re-solves the
-        # ambiguous ones with the same active set the loop below would have
-        # used, so the ranks this p-value is built from are unchanged.
+        # ``solve_simplex_loo_exact`` certifies each member and re-solves the
+        # rest with ``simplex_qp``, the same solver the engine calls below, so
+        # the ranks this p-value is built from are unchanged.
         loo_W = None
         if (engine is not None and not covariates and engine.augment != "ridge"
                 and str(config.backend) in ("auto", "outcome-only")):
             from ..bilevel.minnorm import solve_simplex_loo_exact
+            from ..bilevel.ridge_augment import simplex_qp
             try:
-                loo_W = solve_simplex_loo_exact(Y0[:pre])
+                loo_W = solve_simplex_loo_exact(Y0[:pre], fallback=simplex_qp)
             except Exception:  # pragma: no cover - fall back to the loop
                 loo_W = None
         if loo_W is not None:

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -670,7 +670,29 @@ def run_vanillasc(config) -> BaseEstimatorResults:
     # In-space placebo inference (Abadie): reassign treatment to each donor.
     if mode == "placebo" and J >= 2 and gap[pre:].size:
         ratios = []
-        for j in range(J):
+        # The outcome-only refits are one leave-one-out family over the donor
+        # matrix, so they are solved together. Restricted to the case where a
+        # refit is exactly that one simplex QP: no covariates to weight, no
+        # augmentation layer over the base, and a backend that reduces to it.
+        # ``solve_simplex_loo_exact`` verifies each member and re-solves the
+        # ambiguous ones with the same active set the loop below would have
+        # used, so the ranks this p-value is built from are unchanged.
+        loo_W = None
+        if (engine is not None and not covariates and engine.augment != "ridge"
+                and str(config.backend) in ("auto", "outcome-only")):
+            from ..bilevel.minnorm import solve_simplex_loo_exact
+            try:
+                loo_W = solve_simplex_loo_exact(Y0[:pre])
+            except Exception:  # pragma: no cover - fall back to the loop
+                loo_W = None
+        if loo_W is not None:
+            for j in range(J):
+                others = [k for k in range(J) if k != j]
+                cfj = Y0[:, others] @ loo_W[j, others]
+                _, _, ratio_j = _rmspe_ratio(Y0[:, j], cfj, pre)
+                if np.isfinite(ratio_j):
+                    ratios.append(ratio_j)
+        for j in ([] if loo_W is not None else range(J)):
             others = [k for k in range(J) if k != j]
             yj = Y0[:, j]
             Y0j = Y0[:, others]


### PR DESCRIPTION
## Related Links

- Follows PRs #357, #358, #359 (the mscmt / mlSC / SDID batching work). This one corrects a guard those introduced and applies the reduction to the two remaining families.
- Docs: `docs/stackedsc.rst` (new "How a Cohort's Weights Are Solved Together"), `docs/vanillasc.rst`, `docs/sdid.rst`
- Benchmark case for the estimator most changed: `benchmarks/cases/wiltshire_walmart.py`
- Wolfe, P. (1976). Finding the nearest point in a polytope. Mathematical Programming 11, 128-149. https://doi.org/10.1007/BF01580381

## What

- Added `mlsynth.utils.bilevel.minnorm.simplex_point_is_optimal`, a solver-independent KKT certificate checked against the design.
- Added `solve_simplex_shared_design`: many targets, one shared design, solved as one family.
- Both batch helpers (`solve_simplex_loo_exact`, `solve_simplex_shared_design`) now require optimality as well as uniqueness before standing in for the one-at-a-time solve, and both take a `fallback` solver.
- STACKEDSC solves each cohort's weight programs as one shared-design family (`_weights_for_cohort`).
- STACKEDSC solves each placebo pool as one leave-one-out family (`_placebo_weights`), in both donor pools.
- VanillaSC's placebo family now names its own fallback solver.

## Why

The uniqueness check introduced in the earlier PRs was not sufficient, and the gap is reachable from ordinary use. Forming the Gram squares the design's condition number, so a design merely awkward at `cond(A) ~ 1e7` -- covariates measured in different units -- gives a Gram at the edge of float64. The batched active set then converges on that Gram, correctly, to a point that does not solve the program the Gram came from. Nothing computed from the Gram reveals it. On the covariate specification of the Wiltshire panel that is 62 of 76 members of a cohort, with a KKT residual of 7e-3 where the design-form solver leaves 6e-10.

Uniqueness and optimality are separate questions. A point can be optimal on a face, or be a near miss for a unique optimum; standing one solver in for another needs both.

With the certificate in place, the reduction is safe to apply to STACKEDSC, where the cohort geometry makes it natural: a cohort shares its design and its units differ only in their own target, and a placebo pool is one matrix's columns fitted against one another.

## How

For a shared design, `G_j = A'A - c_j 1' - 1 c_j' + s_j 11'` with `c_j = A'b_j` and `s_j = b_j'b_j`, so `A'A` and `A'B` formed once carry the group and no product with the data occurs per unit. A binding donor predicate gives one batch per distinct pool, down to a batch of one per unit.

For a placebo pool the family is leave-one-out over a single matrix. Under `donors-only` that matrix is the cohort's design restricted to the pool, and the family is a property of the pool, so units sharing one share the solve. Under `permutation` -- the default, following the reference implementation -- the treated unit is itself a control, so its column is appended: a donor to every placebo and a target to none, which is what `n_targets` short of the column count expresses.

Two things were measured and then not shipped:

- A conditioning pre-gate that skipped the batch on designs whose Gram loses most of float64. Measured in isolation it saves 7.6ms against a 2.1s loop, and the certificate already makes those members correct, so it was removed instead of kept as a magic constant.
- The initial fallback used the bare active set everywhere. That is right for STACKEDSC but wrong for VanillaSC, whose engine reaches the active set through a wrapper that escalates to CVXPY when the active set reports failure on itself. On a design pathological enough to trip that hatch the two disagree, and the active set attains the lower objective. Hence the `fallback` parameter and each call site naming its own.

## Verification

- Path: cross-validation against the incumbent one-at-a-time solver, plus the full benchmark registry.

Directly compared, before against after:

| Case | Before | After | Agreement |
|---|---|---|---|
| `wiltshire_walmart` (point estimates, end to end) | 20.3s | 12.5s | every reported quantity to 1.2e-9 |
| Wiltshire cohort, 89 units x 39 donors, outcome-only | 396ms | 43ms | exact |
| STACKEDSC placebo layer, 22,074 programs | 101.3s | 21.0s | `rmspe_p` bit-identical, `rmspe_actual` 0.0, `p_variance` / intervals / SEs / `att_p_value` to 1e-11, NaN pattern at `e = -1` preserved |

The affected set was measured, not assumed. Every function this branch changed was instrumented and all 161 pure-Python registry cases were run, recording which ones execute them:

```
cases run       : 161
affected        : 21
affected pass   : 21
affected fail   : 0
all fail        : 0
all error       : 3     (missing optional deps; none entered a changed function)
all skip        : 21    (reference cases needing R packages / external repos)
```

The 21 affected cases, with the changed functions they reach:

| Case | Reached |
|---|---|
| `wiltshire_walmart` | `simplex_point_is_optimal` x2264, `simplex_optimum_is_unique` x1835, `_weights_for_cohort`, `_placebo_weights` |
| `vanillasc_prop99`, `vanillasc_xval_references` | `solve_simplex_minnorm_batch` x4861 |
| `masc_basque` | x2715 |
| `lamba_tigers` | x2675 |
| `mscmt_basque` | x2017 |
| `wine_tennessee` | x1502 |
| `vanillasc_carbontax` | x1091 |
| `mscmt_solver` | x363 |
| `spillsynth_iterative_germany` | x183 |
| `dtwsc_basque` | x195 |
| `synth_jhai_prop99` | x86 |
| `malo_prop99`, `malo_basque` | x22 / x33 |
| `tasc_mc` | `solve_simplex_loo_exact` x60, certificate x2220 |
| `secession_scm`, `brazil_vaccine_scm_vs_proximal` | `solve_simplex_loo_exact` |
| `th_prop99` | `gram_reduction_is_safe` x18000, `simplex_gram` x18000 |
| `sdid_prop99`, `sdid_ddd_hpv` | `gram_reduction_is_safe` x1000 / x2000 |
| `mlsc_bottmer` | `gram_reduction_is_safe` x1 |

The `wiltshire_walmart` gap between 2264 optimality checks and 1835 uniqueness checks is the covariate specification's members short-circuiting on optimality before uniqueness is asked -- the mechanism this PR adds, visible in the call counts.

The three errors (`syndes_bls`, `marex_walmart` -- `pyscipopt` absent; `spotsynth_real_data` -- NumPyro absent) each recorded zero calls into any changed function, so they are container dependency gaps and not regressions.

Pinned durably by `test_stackedsc_cohort_weights.py`, `test_stackedsc_placebo_batch.py`, `test_simplex_shared_design.py` and `test_simplex_optimality_certificate.py`, each comparing against the one-at-a-time solve directly.

## Scope checks

None of the four blocks fits: this is a solver change behind two existing estimators plus a shared helper, with no new estimator, config field, or benchmark case. The behavioural contract is that no reported number moves, which the tables above and the tests cover.

## Designs

No visual output changed. The placebo band and event-study figures are built from the same paths, which agree to 1e-9.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/` — 6393 passed, 290 skipped, no regressions
- [x] `coverage run --timid -m pytest ...` — `minnorm.py` and `stackedsc_helpers/inference.py` both at 100% statement coverage; the `# pragma: no cover` marks are the fall-back-to-the-loop paths, each with a stated reason
- [x] All 161 pure-Python benchmark cases run, with the changed functions instrumented — 0 failures, 21 affected and all passing
- [x] Docs build clean; section underlines checked

## Other Notes

- The covariate specification cannot use the reduction, because the conditioning is intrinsic to a design whose predictors are measured in different units. Rescaling would change the estimand, so it is left alone; the certificate makes it correct and it pays for one wasted batch per group (7.6ms against a 2.1s loop).
- `mlsynth/utils/stackedsc_helpers/inference.py` still has four pre-existing uses of the banned word "rather" in prose this branch did not touch (lines 16, 23, 247, 271). Left for a repo-wide sweep, to keep this diff to the solver change.