### PR TITLE
GSYNTH: support all four `force` settings

### DIFF
--- a/docs/gsynth.rst
+++ b/docs/gsynth.rst
@@ -134,12 +134,60 @@ Step 3 imputes and differences:
 :math:`\widehat{Y}_{it}(0) = \mathbf{x}_{it}^\top \widehat{\boldsymbol{\beta}}
 + \widehat{\boldsymbol{\lambda}}_i^\top \widehat{\mathbf{f}}_t`.
 
-Under two-way effects a column of ones is appended to
+When unit effects are in the specification a column of ones is appended to
 :math:`\widehat{\mathbf{F}}` before Step 2, so a treated unit's own level is
 estimated jointly with its loadings off its pre-periods. The control units'
 unit effects say nothing about the level of a unit outside that group, so
 this is the only place :math:`\alpha_i` for :math:`i \in \mathcal{T}` can
 come from.
+
+Which additive effects
+----------------------
+
+The ``force`` option chooses which of :math:`\alpha_i` and :math:`\xi_t`
+accompany the factors, named and coded as in gsynth and fect:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 16 20 20 44
+
+   * - ``force``
+     - unit effects
+     - period effects
+     - what it means
+   * - ``"none"``
+     - no
+     - no
+     - the grand mean and the factors carry everything
+   * - ``"unit"``
+     - yes
+     - no
+     - levels differ across units, common shocks left to the factors
+   * - ``"time"``
+     - no
+     - yes
+     - a common time path, with unit levels left to the factors
+   * - ``"two-way"``
+     - yes
+     - yes
+     - the default, and the specification Xu (2017) Table 2 reports
+
+An effect that is switched off is not estimated and not removed, so it stays
+in the residual and the factors absorb what they can of it. The choice
+therefore moves the estimate instead of merely relabelling it, and it moves
+the estimate most where the pre-treatment fit is worst. Applied work varies
+it deliberately: Lang et al. (2026) run their preregistered specification at
+``force="none"`` and sweep all four in a multiverse.
+
+Two settings differ in what they can identify, not only in what they fit. A
+treated unit with :math:`T_0` pre-periods supports :math:`T_0` regressors in
+Step 2, and under ``"unit"`` or ``"two-way"`` one of those is the intercept.
+So the largest rank the cross-validation will consider is one lower for those
+two than for ``"none"`` and ``"time"``.
+
+``two_way`` was the first release's spelling of this option. It still
+resolves — ``True`` to ``"two-way"`` and ``False`` to ``"time"`` — with a
+``DeprecationWarning``. Passing both is an error.
 
 Assumptions
 -----------
@@ -282,7 +330,9 @@ Example
    res.per_unit["MN"].prefit_rmse   # how well one state's pre-period is tracked
 
 Passing ``r`` fixes the count instead, and ``design.cv`` is then ``None``
-because no selection was run.
+because no selection was run. Adding ``"force": "none"`` drops the additive
+effects and leaves the factors to carry them, which is how a good deal of
+applied work runs this estimator; ``design.force`` records the setting used.
 
 ``time_series`` carries the treated-average observed and imputed paths in
 calendar time, with the gap between them; ``event_study`` carries the same
@@ -299,7 +349,9 @@ Verification
 
 GSYNTH reproduces Xu (2017) Table 2 columns (3) and (4) on the author's own
 data, and matches a live ``fect`` 2.4.5 reference across every rank from
-zero to five on both specifications. See :doc:`replications/gsynth` for the
+zero to five on both specifications. All four ``force`` settings match that
+reference to 6.4e-14 over 48 fits, on the turnout panel and on a weekly
+46-state panel with staggered adoption. See :doc:`replications/gsynth` for the
 cell-by-cell comparison and for what the replication turned up about rank
 selection, and the durable case
 `benchmarks/cases/gsynth_xu_turnout.py

--- a/mlsynth/estimators/gsynth.py
+++ b/mlsynth/estimators/gsynth.py
@@ -91,7 +91,7 @@ class GSYNTH:
         self.covariates = config.covariates
         self.r = config.r
         self.r_max: int = config.r_max
-        self.two_way: bool = config.two_way
+        self.force: str = config.force
         self.run_inference: bool = config.inference
         self.n_bootstrap: int = config.n_bootstrap
         self.alpha: float = config.alpha
@@ -111,14 +111,14 @@ class GSYNTH:
             # ----- Rank -----
             if self.r is None:
                 cv = cross_validate_rank(
-                    inputs, r_max=self.r_max, two_way=self.two_way,
+                    inputs, r_max=self.r_max, force=self.force,
                     tol=self.tol, max_iter=self.max_iter)
                 r, source = cv.r_selected, "cv"
             else:
                 cv, r, source = None, int(self.r), "user"
 
             # ----- Steps 1-3 -----
-            fit = gsc_fit(inputs, r, two_way=self.two_way, tol=self.tol,
+            fit = gsc_fit(inputs, r, force=self.force, tol=self.tol,
                           max_iter=self.max_iter)
             control = fit.control_fit
             es = event_study_from_effect(fit.effect, inputs.adoption_index)
@@ -127,7 +127,7 @@ class GSYNTH:
             if self.run_inference:
                 inference = parametric_bootstrap(
                     inputs, fit, r, n_bootstrap=self.n_bootstrap,
-                    alpha=self.alpha, seed=self.seed, two_way=self.two_way,
+                    alpha=self.alpha, seed=self.seed, force=self.force,
                     tol=self.tol, max_iter=self.max_iter)
             else:
                 inference = GSYNTHInference(
@@ -139,7 +139,7 @@ class GSYNTH:
             design = GSYNTHDesign(
                 r_selected=int(r),
                 r_source=source,
-                two_way=bool(self.two_way),
+                force=self.force,
                 beta=np.asarray(control.beta, dtype=float),
                 covariate_names=names,
                 dropped_covariates=tuple(names[k] for k in control.dropped),

--- a/mlsynth/tests/test_gsynth.py
+++ b/mlsynth/tests/test_gsynth.py
@@ -302,6 +302,47 @@ class TestForce:
                 for f in ("none", "unit", "time", "two-way")}
         assert len({round(v, 9) for v in atts.values()}) == 4
 
+    # fect 2.4.5, method="gsynth", r=2, on the vendored Xu turnout panel. These
+    # are reference values, not values this implementation produced: a change
+    # that alters what any setting sweeps out moves one of them.
+    _FECT_R2 = {"none": 8.7337025497, "unit": 5.4947978847,
+                "time": 5.4455352964, "two-way": 5.1304931630}
+
+    @pytest.mark.skipif(not TURNOUT.exists(), reason="turnout panel not vendored")
+    @pytest.mark.parametrize("force", ["none", "unit", "time", "two-way"])
+    def test_matches_the_reference_at_each_setting(self, turnout, force):
+        res = GSYNTH(dict(df=turnout, unitid="abb", time="year",
+                          outcome="turnout", treat="policy_edr", r=2,
+                          force=force, inference=False,
+                          display_graphs=False)).fit()
+        assert abs(res.att - self._FECT_R2[force]) < 1e-6
+
+    @pytest.mark.skipif(not TURNOUT.exists(), reason="turnout panel not vendored")
+    def test_the_settings_are_far_apart_on_real_data(self, turnout):
+        """The four span 3.6 percentage points here, so a setting that swept
+        out the wrong thing could not hide inside solver noise."""
+        got = [GSYNTH(dict(df=turnout, unitid="abb", time="year",
+                           outcome="turnout", treat="policy_edr", r=2,
+                           force=f, inference=False, display_graphs=False)).fit().att
+               for f in ("none", "unit", "time", "two-way")]
+        assert max(got) - min(got) > 3.0
+
+    def test_the_intercept_is_counted_against_the_pre_period(self, staggered):
+        """At the boundary, a setting carrying an intercept needs one more
+        pre-period than one without, and says so instead of solving something
+        singular."""
+        df, _ = staggered
+        inputs = prepare_gsynth_inputs(df, "y", "d", "unit", "time")
+        r = inputs.min_pre_periods
+        with pytest.raises(MlsynthEstimationError, match="regressors"):
+            gsc_fit(inputs, r=r, force="two-way")
+        with pytest.raises(MlsynthEstimationError, match="regressors"):
+            gsc_fit(inputs, r=r, force="unit")
+        # Without one, exactly r regressors fit in r pre-periods.
+        for f in ("none", "time"):
+            with pytest.raises(MlsynthEstimationError, match="regressors"):
+                gsc_fit(inputs, r=r + 1, force=f)
+
     def test_rank_ceiling_follows_the_intercept(self, staggered):
         """A setting with an intercept column spends one more regressor, so it
         can identify one fewer factor."""

--- a/mlsynth/tests/test_gsynth.py
+++ b/mlsynth/tests/test_gsynth.py
@@ -174,16 +174,24 @@ class TestInteractiveFixedEffects:
         np.testing.assert_allclose(fit.beta, beta_true, atol=1e-6)
 
     def test_factor_space_is_recovered(self):
-        """The estimated factors span the true factor space."""
+        """The estimated factors span the true factor space.
+
+        The factors are centered so the panel's grand mean is zero. Under
+        ``force="none"`` the grand mean is the one thing still swept out, and
+        removing a nonzero one from a rank-2 matrix would raise its rank and
+        tilt the estimated space away from the truth.
+        """
         rng = np.random.default_rng(6)
         T, N = 30, 40
-        F, lam = rng.standard_normal((T, 2)), rng.standard_normal((N, 2))
+        F = rng.standard_normal((T, 2))
+        F -= F.mean(axis=0)
+        lam = rng.standard_normal((N, 2))
         Y = F @ lam.T
-        fit = interactive_fixed_effects(Y, np.empty((T, N, 0)), 2, two_way=False)
+        assert abs(Y.mean()) < 1e-12
+        fit = interactive_fixed_effects(Y, np.empty((T, N, 0)), 2, force="none")
         # Projection onto the estimated space leaves the true factors alone.
         P = fit.factor @ np.linalg.pinv(fit.factor)
-        Fc = F - F.mean(axis=1, keepdims=True) * 0  # F itself, kept explicit
-        np.testing.assert_allclose(P @ Fc, Fc, atol=1e-7)
+        np.testing.assert_allclose(P @ F, F, atol=1e-7)
 
     def test_time_invariant_covariate_is_dropped(self):
         """A covariate with no within variation cannot be identified and is
@@ -206,6 +214,143 @@ class TestInteractiveFixedEffects:
             rng.standard_normal((T, N)), rng.standard_normal((T, N, 1)), 1,
             max_iter=3)
         assert fit.niter <= 3
+
+
+class TestForce:
+    """The four additive-effect specifications, following gsynth's ``force``.
+
+    ``"none"`` removes the grand mean only, ``"unit"`` adds unit effects,
+    ``"time"`` adds period effects, ``"two-way"`` adds both. The intercept
+    column that Step 2 uses to identify a treated unit's own level belongs to
+    the settings that carry unit effects.
+    """
+
+    @staticmethod
+    def _additive(seed=11, T=14, N=11):
+        rng = np.random.default_rng(seed)
+        alpha, xi = rng.standard_normal(N), rng.standard_normal(T)
+        return 4.0, alpha, xi, 4.0 + alpha[None, :] + xi[:, None]
+
+    def test_none_removes_only_the_grand_mean(self):
+        mu, alpha, xi, Y = self._additive()
+        T, N = Y.shape
+        fit = interactive_fixed_effects(Y, np.empty((T, N, 0)), 0, force="none")
+        assert abs(fit.mu - Y.mean()) < 1e-12
+        np.testing.assert_allclose(fit.alpha, 0.0, atol=1e-12)
+        np.testing.assert_allclose(fit.xi, 0.0, atol=1e-12)
+
+    def test_unit_recovers_unit_effects_only(self):
+        mu, alpha, xi, Y = self._additive()
+        T, N = Y.shape
+        fit = interactive_fixed_effects(Y, np.empty((T, N, 0)), 0, force="unit")
+        np.testing.assert_allclose(fit.alpha, alpha - alpha.mean(), atol=1e-9)
+        np.testing.assert_allclose(fit.xi, 0.0, atol=1e-12)
+
+    def test_time_recovers_period_effects_only(self):
+        mu, alpha, xi, Y = self._additive()
+        T, N = Y.shape
+        fit = interactive_fixed_effects(Y, np.empty((T, N, 0)), 0, force="time")
+        np.testing.assert_allclose(fit.xi, xi - xi.mean(), atol=1e-9)
+        np.testing.assert_allclose(fit.alpha, 0.0, atol=1e-12)
+
+    def test_two_way_recovers_both(self):
+        mu, alpha, xi, Y = self._additive()
+        T, N = Y.shape
+        fit = interactive_fixed_effects(Y, np.empty((T, N, 0)), 0, force="two-way")
+        recon = fit.mu + fit.alpha[None, :] + fit.xi[:, None]
+        np.testing.assert_allclose(recon, Y, atol=1e-9)
+
+    def test_a_pure_unit_panel_is_exact_under_unit(self):
+        """With no period variation, ``unit`` fits the panel and ``time``
+        cannot."""
+        rng = np.random.default_rng(12)
+        T, N = 10, 9
+        alpha = rng.standard_normal(N)
+        Y = 2.0 + alpha[None, :] + np.zeros((T, 1))
+        X = np.empty((T, N, 0))
+        exact = interactive_fixed_effects(Y, X, 0, force="unit")
+        recon = np.broadcast_to(exact.mu + exact.alpha[None, :], Y.shape)
+        np.testing.assert_allclose(recon, Y, atol=1e-9)
+        loose = interactive_fixed_effects(Y, X, 0, force="time")
+        assert np.abs(Y - loose.mu - loose.xi[:, None]).max() > 1e-3
+
+    @pytest.mark.parametrize("force,cols", [("none", 0), ("time", 0),
+                                            ("unit", 1), ("two-way", 1)])
+    def test_intercept_column_iff_unit_effects(self, staggered, force, cols):
+        df, _ = staggered
+        inputs = prepare_gsynth_inputs(df, "y", "d", "unit", "time")
+        out = gsc_fit(inputs, r=2, force=force)
+        assert out.factors_used.shape[1] == 2 + cols
+        if cols:
+            np.testing.assert_allclose(out.factors_used[:, -1], 1.0)
+        else:
+            np.testing.assert_allclose(out.unit_effects, 0.0)
+
+    @pytest.mark.parametrize("force", ["none", "unit", "time", "two-way"])
+    def test_every_setting_runs_end_to_end(self, staggered, force):
+        df, effect = staggered
+        res = GSYNTH(_cfg(df, r=2, force=force)).fit()
+        assert res.design.force == force
+        assert np.isfinite(res.att)
+        assert abs(res.att - effect) < 0.5
+
+    def test_the_settings_disagree(self, staggered):
+        """A DGP with both additive effects separates the four; a setting that
+        omits one leaves it in the residual."""
+        df, _ = staggered
+        atts = {f: GSYNTH(_cfg(df, r=2, force=f)).fit().att
+                for f in ("none", "unit", "time", "two-way")}
+        assert len({round(v, 9) for v in atts.values()}) == 4
+
+    def test_rank_ceiling_follows_the_intercept(self, staggered):
+        """A setting with an intercept column spends one more regressor, so it
+        can identify one fewer factor."""
+        df, _ = staggered
+        inputs = prepare_gsynth_inputs(df, "y", "d", "unit", "time")
+        without = max(cross_validate_rank(inputs, r_max=99, force="time").mspe)
+        with_ = max(cross_validate_rank(inputs, r_max=99, force="two-way").mspe)
+        assert without == with_ + 1 == inputs.min_pre_periods - 1
+
+
+class TestForceConfig:
+    def test_default_is_two_way(self, staggered):
+        df, _ = staggered
+        assert GSYNTHConfig(**_cfg(df)).force == "two-way"
+
+    def test_invalid_force_rejected(self, staggered):
+        df, _ = staggered
+        with pytest.raises(MlsynthConfigError):
+            GSYNTH(_cfg(df, force="both"))
+
+    @pytest.mark.parametrize("flag,expected", [(True, "two-way"), (False, "time")])
+    def test_two_way_alias_maps_and_warns(self, staggered, flag, expected):
+        """``two_way`` is the superseded spelling; it still resolves, so code
+        written against the first release keeps working."""
+        df, _ = staggered
+        with pytest.warns(DeprecationWarning, match="two_way"):
+            cfg = GSYNTHConfig(**_cfg(df, two_way=flag))
+        assert cfg.force == expected
+
+    def test_helper_guards_a_bad_force(self):
+        """The config rejects it first, so this guards a direct caller of the
+        numerical layer."""
+        rng = np.random.default_rng(13)
+        with pytest.raises(ValueError, match="force must be one of"):
+            interactive_fixed_effects(rng.standard_normal((8, 6)),
+                                      np.empty((8, 6, 0)), 1, force="twoway")
+
+    def test_supplying_both_is_rejected(self, staggered):
+        df, _ = staggered
+        with pytest.raises(MlsynthConfigError, match="both"):
+            GSYNTH(_cfg(df, force="none", two_way=True))
+
+    def test_alias_reproduces_the_old_default(self, staggered):
+        """The superseded ``two_way=True`` path and the new default agree, so
+        the change moves no existing result."""
+        df, _ = staggered
+        with pytest.warns(DeprecationWarning):
+            old = GSYNTH(_cfg(df, r=2, two_way=True)).fit().att
+        assert old == GSYNTH(_cfg(df, r=2)).fit().att
 
 
 class TestGscFit:
@@ -272,7 +417,7 @@ class TestGscFit:
         alone, and the treated units carry no separate level."""
         df, _ = staggered
         inputs = prepare_gsynth_inputs(df, "y", "d", "unit", "time")
-        out = gsc_fit(inputs, r=2, two_way=False)
+        out = gsc_fit(inputs, r=2, force="time")
         assert out.factors_used.shape[1] == 2
         np.testing.assert_allclose(out.unit_effects, 0.0)
 
@@ -325,7 +470,7 @@ class TestCrossValidateRank:
         """Without an intercept there is one fewer regressor to identify."""
         df, _ = staggered
         inputs = prepare_gsynth_inputs(df, "y", "d", "unit", "time")
-        cv = cross_validate_rank(inputs, r_max=99, two_way=False)
+        cv = cross_validate_rank(inputs, r_max=99, force="time")
         assert max(cv.mspe) == inputs.min_pre_periods - 1
 
     def test_no_scorable_rank_raises(self, staggered):

--- a/mlsynth/utils/gsynth_helpers/config.py
+++ b/mlsynth/utils/gsynth_helpers/config.py
@@ -6,7 +6,8 @@ Co-located with the helper package; re-exported from
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+import warnings
+from typing import Any, List, Literal, Optional
 
 from pydantic import Field, model_validator
 
@@ -38,10 +39,19 @@ class GSYNTHConfig(BaseEstimatorConfig):
         Largest rank the cross-validation considers. The estimator lowers this
         further when the shortest treated pre-period history cannot identify
         that many loadings.
-    two_way : bool
-        Include additive unit and period effects alongside the factors. This is
-        the specification Table 2 reports and the default everywhere in the
-        paper.
+    force : {"none", "unit", "time", "two-way"}
+        Which additive effects accompany the factors, named and coded as in
+        gsynth and fect: ``"none"`` keeps the grand mean alone, ``"unit"`` adds
+        unit effects, ``"time"`` adds period effects, ``"two-way"`` adds both.
+        Two-way is the specification Xu (2017) Table 2 reports and the default
+        here. An effect that is switched off is not removed from the panel, so
+        the factors absorb it; the choice moves the estimate, and applied work
+        varies it deliberately.
+    two_way : bool or None
+        Superseded by ``force``, and kept so code written against the first
+        release keeps running: ``True`` resolves to ``"two-way"`` and ``False``
+        to ``"time"``, with a :class:`DeprecationWarning`. Supplying both is an
+        error.
     inference : bool
         Run Algorithm 2, the parametric bootstrap.
     n_bootstrap : int
@@ -70,9 +80,20 @@ class GSYNTHConfig(BaseEstimatorConfig):
         default=5, ge=0,
         description="Largest rank the cross-validation considers.",
     )
-    two_way: bool = Field(
-        default=True,
-        description="Include additive unit and period effects.",
+    force: Literal["none", "unit", "time", "two-way"] = Field(
+        default="two-way",
+        description=(
+            "Which additive effects accompany the factors, as in gsynth: none, "
+            "unit, time, or two-way. Reach for a setting other than two-way "
+            "when the specification you are matching used one."
+        ),
+    )
+    two_way: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Superseded by force; True maps to two-way and False to time, with "
+            "a DeprecationWarning."
+        ),
     )
     inference: bool = Field(
         default=True,
@@ -97,6 +118,24 @@ class GSYNTHConfig(BaseEstimatorConfig):
         default=500, ge=1,
         description="Iteration cap for the alternating least squares.",
     )
+
+    @model_validator(mode="after")
+    def resolve_force_alias(cls, values: Any) -> Any:
+        if values.two_way is not None:
+            if "force" in values.model_fields_set:
+                raise MlsynthConfigError(
+                    "force and two_way both given; two_way is the superseded "
+                    "spelling, so pass force alone."
+                )
+            resolved = "two-way" if values.two_way else "time"
+            warnings.warn(
+                f"two_way is superseded by force; two_way={values.two_way} "
+                f"means force={resolved!r}.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            object.__setattr__(values, "force", resolved)
+        return values
 
     @model_validator(mode="after")
     def check_gsynth_params(cls, values: Any) -> Any:

--- a/mlsynth/utils/gsynth_helpers/ife.py
+++ b/mlsynth/utils/gsynth_helpers/ife.py
@@ -14,9 +14,16 @@ swept out by demeaning first, so the factor step sees only the interactive part;
 what remains alternates between a pooled regression for ``\\beta`` and principal
 components for ``(F, \\Lambda)`` until the coefficient vector stops moving.
 
+Which additive effects are present is the ``force`` setting, named and coded as
+in gsynth and fect: ``"none"`` keeps the grand mean alone, ``"unit"`` adds
+:math:`\\alpha_i`, ``"time"`` adds :math:`\\xi_t`, and ``"two-way"`` adds both.
+An effect that is switched off is not estimated and not removed, so it stays in
+the residual for the factors to absorb -- which is why the choice moves the
+answer instead of merely relabelling it.
+
 The two coefficient-free cases are closed form: with no covariates the factors
 are the principal components of the demeaned panel, and with ``r = 0`` the fit
-is the two-way within estimator.
+is the corresponding within estimator.
 """
 
 from __future__ import annotations
@@ -25,6 +32,19 @@ from dataclasses import dataclass, field
 from typing import Tuple
 
 import numpy as np
+
+#: The additive-effect specifications, as gsynth and fect name them.
+FORCE_OPTIONS = ("none", "unit", "time", "two-way")
+
+
+def has_unit_effects(force: str) -> bool:
+    """Whether ``force`` carries unit effects (gsynth's codes 1 and 3)."""
+    return force in ("unit", "two-way")
+
+
+def has_time_effects(force: str) -> bool:
+    """Whether ``force`` carries period effects (gsynth's codes 2 and 3)."""
+    return force in ("time", "two-way")
 
 
 @dataclass(frozen=True)
@@ -36,9 +56,11 @@ class ControlFit:
     mu : float
         Grand mean.
     alpha : np.ndarray
-        Control-unit effects, shape ``(N_co,)``. Zero when ``two_way`` is off.
+        Control-unit effects, shape ``(N_co,)``. Zero unless ``force`` carries
+        unit effects.
     xi : np.ndarray
-        Period effects, shape ``(T,)``.
+        Period effects, shape ``(T,)``. Zero unless ``force`` carries period
+        effects.
     beta : np.ndarray
         Covariate coefficients, shape ``(p,)``, with zeros in the positions of
         any covariate dropped for want of within variation.
@@ -113,7 +135,7 @@ def interactive_fixed_effects(
     X: np.ndarray,
     r: int,
     *,
-    two_way: bool = True,
+    force: str = "two-way",
     tol: float = 1e-5,
     max_iter: int = 500,
 ) -> ControlFit:
@@ -127,8 +149,8 @@ def interactive_fixed_effects(
         Covariates, shape ``(T, N_co, p)``; ``p = 0`` is allowed.
     r : int
         Number of factors.
-    two_way : bool
-        Include additive unit effects alongside the period effects.
+    force : {"none", "unit", "time", "two-way"}
+        Which additive effects to include.
     tol : float
         Convergence tolerance on the coefficient vector.
     max_iter : int
@@ -137,7 +159,16 @@ def interactive_fixed_effects(
     Returns
     -------
     ControlFit
+
+    Raises
+    ------
+    ValueError
+        If ``force`` is not one of the four settings. The configuration layer
+        rejects a bad value first; this guards direct callers.
     """
+    if force not in FORCE_OPTIONS:
+        raise ValueError(
+            f"force must be one of {list(FORCE_OPTIONS)}; got {force!r}.")
     T, N = Y.shape
     p = int(X.shape[2]) if X.size or X.ndim == 3 else 0
 
@@ -151,19 +182,20 @@ def interactive_fixed_effects(
         XX -= mu_X
 
     alpha_Y, alpha_X = np.zeros(N), np.zeros((N, p))
-    if two_way:
+    if has_unit_effects(force):
         alpha_Y = YY.mean(axis=0)
         YY -= alpha_Y[None, :]
         if p:
             alpha_X = XX.mean(axis=0)
             XX -= alpha_X[None, :, :]
 
-    xi_Y = YY.mean(axis=1)
-    YY -= xi_Y[:, None]
-    xi_X = np.zeros((T, p))
-    if p:
-        xi_X = XX.mean(axis=1)
-        XX -= xi_X[:, None, :]
+    xi_Y, xi_X = np.zeros(T), np.zeros((T, p))
+    if has_time_effects(force):
+        xi_Y = YY.mean(axis=1)
+        YY -= xi_Y[:, None]
+        if p:
+            xi_X = XX.mean(axis=1)
+            XX -= xi_X[:, None, :]
 
     # A covariate with no within variation left is collinear with the fixed
     # effects. It contributes nothing and would make X'X singular, so it is
@@ -200,8 +232,9 @@ def interactive_fixed_effects(
 
     return ControlFit(
         mu=float(mu_Y - mu_X @ beta),
-        alpha=(alpha_Y - alpha_X @ beta) if two_way else np.zeros(N),
-        xi=xi_Y - xi_X @ beta,
+        alpha=(alpha_Y - alpha_X @ beta) if has_unit_effects(force)
+        else np.zeros(N),
+        xi=(xi_Y - xi_X @ beta) if has_time_effects(force) else np.zeros(T),
         beta=beta,
         factor=factor,
         lam=lam,

--- a/mlsynth/utils/gsynth_helpers/ife.py
+++ b/mlsynth/utils/gsynth_helpers/ife.py
@@ -230,11 +230,12 @@ def interactive_fixed_effects(
     for slot, k in enumerate(keep):
         beta[k] = beta_k[slot]
 
+    # An effect the setting excludes was never accumulated, so both terms are
+    # still the zeros they were initialized to and no guard is needed here.
     return ControlFit(
         mu=float(mu_Y - mu_X @ beta),
-        alpha=(alpha_Y - alpha_X @ beta) if has_unit_effects(force)
-        else np.zeros(N),
-        xi=(xi_Y - xi_X @ beta) if has_time_effects(force) else np.zeros(T),
+        alpha=alpha_Y - alpha_X @ beta,
+        xi=xi_Y - xi_X @ beta,
         beta=beta,
         factor=factor,
         lam=lam,

--- a/mlsynth/utils/gsynth_helpers/inference.py
+++ b/mlsynth/utils/gsynth_helpers/inference.py
@@ -68,7 +68,7 @@ def _control_fitted_and_residuals(inputs: GSYNTHInputs, fit) -> tuple:
 
 def _prediction_error_pool(
     inputs: GSYNTHInputs, r: int, n_draws: int, rng: np.random.Generator,
-    *, two_way: bool, tol: float, max_iter: int,
+    *, force: str, tol: float, max_iter: int,
 ) -> np.ndarray:
     """Loop 1: prediction errors for a unit the control model did not fit.
 
@@ -108,7 +108,7 @@ def _prediction_error_pool(
             covariate_names=inputs.covariate_names,
         )
         try:
-            out = gsc_fit(pseudo, r, two_way=two_way, tol=tol, max_iter=max_iter)
+            out = gsc_fit(pseudo, r, force=force, tol=tol, max_iter=max_iter)
         except (MlsynthEstimationError, np.linalg.LinAlgError):
             continue
         pool.append(out.effect)
@@ -128,7 +128,7 @@ def parametric_bootstrap(
     n_bootstrap: int = 200,
     alpha: float = 0.05,
     seed: int = 0,
-    two_way: bool = True,
+    force: str = "two-way",
     tol: float = 1e-5,
     max_iter: int = 500,
 ) -> GSYNTHInference:
@@ -149,7 +149,7 @@ def parametric_bootstrap(
         Two-sided significance level.
     seed : int
         Seed for the resampling.
-    two_way, tol, max_iter
+    force, tol, max_iter
         Passed through to the refits.
 
     Returns
@@ -168,7 +168,7 @@ def parametric_bootstrap(
 
     pool = _prediction_error_pool(
         inputs, r, n_bootstrap, rng,
-        two_way=two_way, tol=tol, max_iter=max_iter)
+        force=force, tol=tol, max_iter=max_iter)
     n_pool = pool.shape[2]
 
     es = event_study_from_effect(fit.effect, inputs.adoption_index)
@@ -189,8 +189,8 @@ def parametric_bootstrap(
         boot = _rebuild(inputs, Y)
         try:
             control_boot = fit_control_model(
-                boot, r, two_way=two_way, tol=tol, max_iter=max_iter)
-            out = gsc_fit(boot, r, two_way=two_way, tol=tol, max_iter=max_iter,
+                boot, r, force=force, tol=tol, max_iter=max_iter)
+            out = gsc_fit(boot, r, force=force, tol=tol, max_iter=max_iter,
                           control_fit=control_boot)
         except (MlsynthEstimationError, np.linalg.LinAlgError):
             continue

--- a/mlsynth/utils/gsynth_helpers/pipeline.py
+++ b/mlsynth/utils/gsynth_helpers/pipeline.py
@@ -41,13 +41,23 @@ from typing import Dict, Optional
 import numpy as np
 
 from ...exceptions import MlsynthEstimationError
-from .ife import ControlFit, interactive_fixed_effects
+from .ife import (
+    ControlFit,
+    has_unit_effects,
+    interactive_fixed_effects,
+)
 from .structures import GSYNTHCrossValidation, GSYNTHFit, GSYNTHInputs
 
 
-def _regressors(fit: ControlFit, T: int, two_way: bool) -> np.ndarray:
-    """The matrix Step 2 projects the treated pre-periods onto."""
-    if two_way:
+def _regressors(fit: ControlFit, T: int, force: str) -> np.ndarray:
+    """The matrix Step 2 projects the treated pre-periods onto.
+
+    A column of ones joins the factors exactly when ``force`` carries unit
+    effects. The control units' unit effects say nothing about the level of a
+    unit outside that group, so a treated unit's own level has to be estimated
+    alongside its loadings, off its own pre-periods.
+    """
+    if has_unit_effects(force):
         return np.hstack([fit.factor, np.ones((T, 1))])
     return fit.factor
 
@@ -65,31 +75,32 @@ def _treated_residual(inputs: GSYNTHInputs, fit: ControlFit) -> np.ndarray:
     return U - fit.mu - fit.xi[:, None]
 
 
-def _rank_ceiling(inputs: GSYNTHInputs, two_way: bool) -> int:
+def _rank_ceiling(inputs: GSYNTHInputs, force: str) -> int:
     """Largest rank the shortest treated pre-period history can identify.
 
     A unit with ``T0`` pre-periods supports ``T0`` regressors, one of which is
-    the intercept under two-way effects. One fewer than that keeps the loading
+    the intercept when unit effects are on. One fewer than that keeps the loading
     regression overdetermined, which is what the cross-validation needs so a
     period can be held back.
     """
-    return max(int(inputs.min_pre_periods) - (2 if two_way else 1), 0)
+    return max(int(inputs.min_pre_periods)
+               - (2 if has_unit_effects(force) else 1), 0)
 
 
 def fit_control_model(
-    inputs: GSYNTHInputs, r: int, *, two_way: bool = True,
+    inputs: GSYNTHInputs, r: int, *, force: str = "two-way",
     tol: float = 1e-5, max_iter: int = 500,
 ) -> ControlFit:
     """Run Step 1 on the never-treated units."""
     co = inputs.control_index
     return interactive_fixed_effects(
         inputs.Y[:, co], inputs.X[:, co, :], r,
-        two_way=two_way, tol=tol, max_iter=max_iter,
+        force=force, tol=tol, max_iter=max_iter,
     )
 
 
 def gsc_fit(
-    inputs: GSYNTHInputs, r: int, *, two_way: bool = True,
+    inputs: GSYNTHInputs, r: int, *, force: str = "two-way",
     tol: float = 1e-5, max_iter: int = 500,
     control_fit: Optional[ControlFit] = None,
 ) -> GSYNTHFit:
@@ -101,8 +112,8 @@ def gsc_fit(
         Preprocessed panel.
     r : int
         Number of factors.
-    two_way : bool
-        Include additive unit and period effects.
+    force : {"none", "unit", "time", "two-way"}
+        Which additive effects to include.
     tol, max_iter : float, int
         Passed to the Step 1 alternating least squares.
     control_fit : ControlFit, optional
@@ -120,19 +131,19 @@ def gsc_fit(
         regression has regressors, or if that regression is singular.
     """
     T = inputs.T
-    k = int(r) + (1 if two_way else 0)
+    k = int(r) + (1 if has_unit_effects(force) else 0)
     shortest = int(inputs.min_pre_periods)
     if k > shortest:
         raise MlsynthEstimationError(
             f"r = {r} needs {k} regressors per treated unit but the shortest "
             f"pre-treatment history is {shortest} period(s); lower r to at most "
-            f"{max(shortest - (1 if two_way else 0), 0)}."
+            f"{max(shortest - (1 if has_unit_effects(force) else 0), 0)}."
         )
 
     fit = control_fit if control_fit is not None else fit_control_model(
-        inputs, r, two_way=two_way, tol=tol, max_iter=max_iter)
+        inputs, r, force=force, tol=tol, max_iter=max_iter)
     U = _treated_residual(inputs, fit)
-    F = _regressors(fit, T, two_way)
+    F = _regressors(fit, T, force)
 
     loadings = np.zeros((inputs.n_treated, F.shape[1]))
     for j, t0 in enumerate(inputs.adoption_index):
@@ -150,7 +161,8 @@ def gsc_fit(
     effect = U - F @ loadings.T
     counterfactual = inputs.Y[:, inputs.treated_index] - effect
     post = inputs.D[:, inputs.treated_index] > 0
-    unit_effects = loadings[:, -1] if two_way else np.zeros(inputs.n_treated)
+    unit_effects = (loadings[:, -1] if has_unit_effects(force)
+                    else np.zeros(inputs.n_treated))
 
     return GSYNTHFit(
         effect=effect,
@@ -165,7 +177,7 @@ def gsc_fit(
 
 
 def cross_validate_rank(
-    inputs: GSYNTHInputs, *, r_max: int = 5, two_way: bool = True,
+    inputs: GSYNTHInputs, *, r_max: int = 5, force: str = "two-way",
     tol: float = 1e-5, max_iter: int = 500,
 ) -> GSYNTHCrossValidation:
     """Algorithm 1: leave-one-period-out selection of the factor count.
@@ -177,8 +189,8 @@ def cross_validate_rank(
     r_max : int
         Largest rank considered. Lowered to what the shortest treated
         pre-period history can identify.
-    two_way : bool
-        Include additive unit and period effects.
+    force : {"none", "unit", "time", "two-way"}
+        Which additive effects to include.
     tol, max_iter : float, int
         Passed to the Step 1 alternating least squares.
 
@@ -192,16 +204,16 @@ def cross_validate_rank(
         If no rank could be scored, which happens when no treated unit has a
         pre-period history long enough to hold a period back from.
     """
-    ceiling = min(int(r_max), _rank_ceiling(inputs, two_way))
+    ceiling = min(int(r_max), _rank_ceiling(inputs, force))
     T = inputs.T
 
     mspe: Dict[int, float] = {}
     scored: Dict[int, int] = {}
     for r in range(0, ceiling + 1):
-        fit = fit_control_model(inputs, r, two_way=two_way, tol=tol,
+        fit = fit_control_model(inputs, r, force=force, tol=tol,
                                 max_iter=max_iter)
         U = _treated_residual(inputs, fit)
-        F = _regressors(fit, T, two_way)
+        F = _regressors(fit, T, force)
         k = F.shape[1]
 
         sse, n = 0.0, 0

--- a/mlsynth/utils/gsynth_helpers/structures.py
+++ b/mlsynth/utils/gsynth_helpers/structures.py
@@ -131,15 +131,16 @@ class GSYNTHFit:
     n_post_cells : int
         How many cells that mean is taken over.
     loadings : np.ndarray
-        Treated-unit loadings, shape ``(N_tr, r + 1)`` under two-way effects --
-        the trailing column is the unit effect, estimated jointly with the
-        loadings off the pre-periods.
+        Treated-unit loadings, shape ``(N_tr, r + 1)`` when ``force`` carries
+        unit effects -- the trailing column is the unit effect, estimated
+        jointly with the loadings off the pre-periods -- and ``(N_tr, r)``
+        otherwise.
     unit_effects : np.ndarray
         That trailing column on its own, shape ``(N_tr,)``; zeros when additive
         unit effects are off.
     factors_used : np.ndarray
-        The regressor matrix Step 2 projects onto, shape ``(T, r + 1)`` under
-        two-way effects: the estimated factors with a column of ones appended.
+        The regressor matrix Step 2 projects onto: the estimated factors, with
+        a column of ones appended when ``force`` carries unit effects.
     control_fit : ControlFit
         The Step 1 fit these were built from.
     """
@@ -164,8 +165,8 @@ class GSYNTHDesign:
         Factor count used.
     r_source : {"cv", "user"}
         Whether Algorithm 1 chose it or the caller fixed it.
-    two_way : bool
-        Whether additive unit and period effects were included.
+    force : {"none", "unit", "time", "two-way"}
+        Which additive effects were included.
     beta : np.ndarray
         Covariate coefficients, shape ``(p,)``.
     covariate_names : tuple of str
@@ -193,7 +194,7 @@ class GSYNTHDesign:
 
     r_selected: int
     r_source: str
-    two_way: bool
+    force: str
     beta: np.ndarray
     covariate_names: Tuple[str, ...]
     dropped_covariates: Tuple[str, ...]
@@ -443,7 +444,7 @@ class GSYNTHResults(BaseEstimatorResults):
             parameters_used={
                 "r": int(self.design.r_selected),
                 "r_source": self.design.r_source,
-                "two_way": bool(self.design.two_way),
+                "force": self.design.force,
                 "covariates": list(self.design.covariate_names),
             }))
         return self

--- a/tools/mutate_gsynth_force.py
+++ b/tools/mutate_gsynth_force.py
@@ -1,0 +1,164 @@
+"""Targeted mutation test of the `force` decision points.
+
+Coverage says a line ran. This asks the sharper question: if the line were
+wrong, would a test fail? Each mutant is a single textual edit to one of the
+places `force` decides something -- the two predicates, the demeaning branches
+in Step 1, the intercept column in Step 2, the rank ceiling, and the config
+alias. A mutant that SURVIVES is a hole in the suite.
+
+Blind mutation over the whole package would mostly mutate arithmetic the
+reference comparison already pins. These are the branches `force` introduced,
+which nothing outside the unit tests guards.
+
+Run it from the repo root::
+
+    python tools/mutate_gsynth_force.py
+
+It edits source files in place and restores them in a ``finally``, so do not
+run it against a dirty tree. Exit status is 0 when every mutant is killed.
+
+Two mutants were surviving when this was written, and both were real. Making
+Step 1 sweep out period effects unconditionally moved ``force="none"`` from
+4.1105 to 3.9784 with the suite still green, because nothing pinned that
+setting against a reference. And dropping the intercept from the regressor
+count relaxed the guard that refuses a rank the pre-period cannot identify,
+which only bit exactly at the boundary. Two tests were added for those, not a
+tolerance loosened.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+IFE = REPO / "mlsynth/utils/gsynth_helpers/ife.py"
+PIPE = REPO / "mlsynth/utils/gsynth_helpers/pipeline.py"
+CFG = REPO / "mlsynth/utils/gsynth_helpers/config.py"
+
+# (label, file, old, new)
+MUTANTS = [
+    # --- the two predicates ---
+    ("has_unit_effects drops 'unit'", IFE,
+     'return force in ("unit", "two-way")', 'return force in ("two-way",)'),
+    ("has_unit_effects drops 'two-way'", IFE,
+     'return force in ("unit", "two-way")', 'return force in ("unit",)'),
+    ("has_unit_effects always True", IFE,
+     'return force in ("unit", "two-way")', 'return True'),
+    ("has_unit_effects always False", IFE,
+     'return force in ("unit", "two-way")', 'return False'),
+    ("has_time_effects drops 'time'", IFE,
+     'return force in ("time", "two-way")', 'return force in ("two-way",)'),
+    ("has_time_effects drops 'two-way'", IFE,
+     'return force in ("time", "two-way")', 'return force in ("time",)'),
+    ("has_time_effects always True", IFE,
+     'return force in ("time", "two-way")', 'return True'),
+    ("has_time_effects always False", IFE,
+     'return force in ("time", "two-way")', 'return False'),
+    ("predicates swapped", IFE,
+     'return force in ("unit", "two-way")', 'return force in ("time", "two-way")'),
+
+    # --- Step 1 demeaning branches ---
+    ("Step 1 sweeps unit effects always", IFE,
+     "    if has_unit_effects(force):\n        alpha_Y = YY.mean(axis=0)",
+     "    if True:\n        alpha_Y = YY.mean(axis=0)"),
+    ("Step 1 never sweeps unit effects", IFE,
+     "    if has_unit_effects(force):\n        alpha_Y = YY.mean(axis=0)",
+     "    if False:\n        alpha_Y = YY.mean(axis=0)"),
+    ("Step 1 sweeps period effects always", IFE,
+     "    if has_time_effects(force):\n        xi_Y = YY.mean(axis=1)",
+     "    if True:\n        xi_Y = YY.mean(axis=1)"),
+    ("Step 1 never sweeps period effects", IFE,
+     "    if has_time_effects(force):\n        xi_Y = YY.mean(axis=1)",
+     "    if False:\n        xi_Y = YY.mean(axis=1)"),
+    ("returned alpha zeroed", IFE,
+     "alpha=alpha_Y - alpha_X @ beta,", "alpha=np.zeros(N),"),
+    ("returned xi zeroed", IFE,
+     "xi=xi_Y - xi_X @ beta,", "xi=np.zeros(T),"),
+    ("force validation removed", IFE,
+     "    if force not in FORCE_OPTIONS:", "    if False:"),
+
+    # --- Step 2 intercept column ---
+    ("intercept column always appended", PIPE,
+     "    if has_unit_effects(force):\n        return np.hstack",
+     "    if True:\n        return np.hstack"),
+    ("intercept column never appended", PIPE,
+     "    if has_unit_effects(force):\n        return np.hstack",
+     "    if False:\n        return np.hstack"),
+    ("intercept keyed off time effects", PIPE,
+     "    if has_unit_effects(force):\n        return np.hstack",
+     "    if has_time_effects(force):\n        return np.hstack"),
+
+    # --- rank ceiling and regressor count ---
+    ("rank ceiling ignores the intercept", PIPE,
+     "- (2 if has_unit_effects(force) else 1), 0)", "- 1, 0)"),
+    ("rank ceiling always reserves one", PIPE,
+     "- (2 if has_unit_effects(force) else 1), 0)", "- 2, 0)"),
+    ("regressor count ignores the intercept", PIPE,
+     "k = int(r) + (1 if has_unit_effects(force) else 0)", "k = int(r)"),
+    ("unit_effects reported regardless", PIPE,
+     "unit_effects = (loadings[:, -1] if has_unit_effects(force)\n                    else np.zeros(inputs.n_treated))",
+     "unit_effects = loadings[:, -1]"),
+
+    # --- config alias ---
+    ("two_way alias inverted", CFG,
+     'resolved = "two-way" if values.two_way else "time"',
+     'resolved = "time" if values.two_way else "two-way"'),
+    ("two_way alias always two-way", CFG,
+     'resolved = "two-way" if values.two_way else "time"',
+     'resolved = "two-way"'),
+    ("both-given check removed", CFG,
+     '            if "force" in values.model_fields_set:', "            if False:"),
+]
+
+TESTS = ["mlsynth/tests/test_gsynth.py", "-q", "-x", "-p", "no:cacheprovider",
+         "--no-header", "-W", "ignore"]
+
+
+def run_tests() -> bool:
+    """True when the suite passes."""
+    p = subprocess.run([sys.executable, "-m", "pytest", *TESTS],
+                       cwd=REPO, capture_output=True, text=True, timeout=1800)
+    return p.returncode == 0
+
+
+def main() -> int:
+    originals = {f: f.read_text() for f in (IFE, PIPE, CFG)}
+
+    if not run_tests():
+        print("baseline suite is RED; fix that before mutating")
+        return 2
+    print(f"baseline green; {len(MUTANTS)} mutants\n")
+
+    survived = []
+    try:
+        for i, (label, path, old, new) in enumerate(MUTANTS, 1):
+            src = originals[path]
+            if old not in src:
+                print(f"[{i:2d}/{len(MUTANTS)}] SKIP  {label} (pattern absent)")
+                survived.append((label, "pattern absent"))
+                continue
+            path.write_text(src.replace(old, new, 1))
+            try:
+                passed = run_tests()
+            finally:
+                path.write_text(src)
+            mark = "SURVIVED" if passed else "killed"
+            if passed:
+                survived.append((label, "tests still pass"))
+            print(f"[{i:2d}/{len(MUTANTS)}] {mark:8s} {label}")
+    finally:
+        for f, src in originals.items():
+            f.write_text(src)
+
+    print(f"\n==== {len(MUTANTS) - len(survived)}/{len(MUTANTS)} killed ====")
+    if survived:
+        print("SURVIVING MUTANTS (holes in the suite):")
+        for label, why in survived:
+            print(f"  - {label}  [{why}]")
+    return 1 if survived else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Related Links

- Closes #364.
- Unblocks #365 (the Lang et al. age-verification cross-validation case), which cannot be written until `force="none"` is runnable.
- Docs page: `docs/gsynth.rst`, new "Which additive effects" section.
- Reference: [`xuyiqing/fect`](https://github.com/xuyiqing/fect) 2.4.5 and [`xuyiqing/gsynth`](https://github.com/xuyiqing/gsynth) 1.2.1, whose `force` argument this follows in name and coding.
- Follows #362, which added the estimator.

## What

- `GSYNTHConfig.force` takes `"none"`, `"unit"`, `"time"` or `"two-way"`, defaulting to `"two-way"`.
- `two_way` kept as a superseded spelling: `True` resolves to `"two-way"`, `False` to `"time"`, with a `DeprecationWarning`. Supplying both raises `MlsynthConfigError`.
- `GSYNTHDesign.force` replaces `GSYNTHDesign.two_way`; `method_details.parameters_used` reports it.
- `tools/mutate_gsynth_force.py` — a 26-mutant harness over the branches this adds.
- `docs/gsynth.rst` gains a section on the four settings and what switching one off does.

## Why

The estimator covered two of the reference implementation's four specifications, and `interactive_fixed_effects` swept out period effects unconditionally, so the two without them were unreachable.

The gap is not cosmetic. Lang et al. (2026), *Age Verification and Public Adaptation: A Pre-Registered Synthetic Control Multiverse*, Journal of Law and Empirical Analysis 3(1):23-50, runs its preregistered specification at `force='none'` and sweeps all four in a multiverse. On that panel the VPN outcome moves from 11.42 at `"none"` to 9.70 at `"time"` — 1.7 points on an estimate of 10 — and it is the outcome with the worst pre-treatment fit, so the least well-identified and the most exposed to the choice. Reproducing that paper's own specification was impossible.

More generally, any comparison against a `gsynth`/`fect` run at those two settings was out of reach, and that is a large share of the applied literature using this estimator.

## How

Following gsynth's own coding (`force` 0/1/2/3):

- unit effects enter for `"unit"` and `"two-way"`;
- period effects enter for `"time"` and `"two-way"`;
- the column of ones appended to the factor matrix before Step 2 — the one that identifies a treated unit's own level off its pre-periods — appears exactly when unit effects are on.

An effect that is switched off is neither estimated nor removed, so it stays in the residual and the factors absorb what they can of it. That is why the choice moves the estimate instead of relabelling it.

One consequence is not just about fit. The rank ceiling follows the intercept: a treated unit with `T0` pre-periods supports `T0` regressors in Step 2, so a setting that spends one on the intercept can identify one fewer factor from the same history. `_rank_ceiling` now keys off that, and a test pins the two ceilings differing by exactly one.

The predicates are named (`has_unit_effects`, `has_time_effects`) instead of open-coded, so the two places that ask the question — the demeaning in Step 1 and the intercept column in Step 2 — cannot drift apart.

## Verification

- Path: cross-validation against a live `fect` 2.4.5 run.

All four settings, ranks 0–5, on two panels — 48 fits:

| panel | force | max \|mlsynth − fect\| |
|---|---|---|
| turnout | none | 1.9e-14 |
| turnout | unit | 2.6e-14 |
| turnout | time | 2.5e-14 |
| turnout | two-way | 1.5e-14 |
| age-verification | none | 4.3e-14 |
| age-verification | unit | 6.4e-14 |
| age-verification | time | 4.3e-14 |
| age-verification | two-way | 4.3e-14 |

The second panel is 46 states × 149 weekly periods with 14 treated across staggered dates — 6× the periods and 3× the adoption dates of the turnout panel this estimator was originally validated on.

The default is unchanged, and this is checked rather than asserted: every one of the 18 pinned rows in `benchmarks/cases/gsynth_xu_turnout.py` is bit-identical, and a test fits the superseded `two_way=True` path against the new default and requires exact equality.

### Mutation testing

Coverage reached 100% on the new branches, which says every line ran, not that a test would fail if one were wrong. `tools/mutate_gsynth_force.py` asks the second question: 26 single-edit mutants across the two predicates, the Step 1 demeaning branches, the Step 2 intercept column, the rank ceiling, the regressor count and the config alias.

The first run left four survivors. Two were real:

- Making Step 1 sweep out period effects unconditionally left the suite green while moving `force="none"` from 4.1105 to 3.9784 on the fixture. Nothing pinned the settings without period effects against a reference — the fect comparison that would have caught it lived in a scratch script, not in the suite. Four reference values from fect 2.4.5 on the vendored turnout panel now pin all four settings, and a second test asserts they span more than three points there, so a setting that swept out the wrong thing cannot hide in solver noise.
- Dropping the intercept from the regressor count relaxed the guard that refuses a rank the shortest pre-period history cannot identify. It bites only exactly at the boundary, which the existing test overshot by using `r = T`. A boundary test now pins that a setting carrying an intercept needs one more pre-period than one without.

The other two were equivalent mutants, not holes: an effect the setting excludes is never accumulated, so the guards on the returned `alpha` and `xi` were zeroing values already exactly zero. Removed, with a comment saying why.

All 26 are now killed. Two tests were added; no tolerance was loosened.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR

- [x] The default preserves existing behaviour exactly, including the units effects are reported in
- [x] Existing pinned benchmark values unchanged — `gsynth_xu_turnout` passes 18/18 with identical values
- [x] A test pins that the default is unchanged (`test_alias_reproduces_the_old_default`)
- [x] New config field has a `Field(...)` description saying when to reach for it

## Designs

No visual change. `design.force` now records the setting, and the plotter's title already reports the rank and its source.

## Test Steps

- [x] `pytest mlsynth/tests/test_gsynth.py -q` — 109 passed (28 new)
- [x] `pytest mlsynth/tests/test_result_contract.py -k GSYNTH` — 4 passed
- [x] `coverage run --timid -m pytest mlsynth/tests/test_gsynth.py && coverage report` — 100% on the estimator (72 statements) and all seven helper modules (526 statements), no `# pragma: no cover`
- [x] `python tools/mutate_gsynth_force.py` — 26/26 mutants killed
- [x] `python benchmarks/run_benchmarks.py --case gsynth_xu_turnout` — 18/18, values bit-identical to `main`
- [x] `python tools/gen_llms_txt.py` — regenerated (no delta; the summary line is unchanged)
- [x] Prose swept for the banned constructions; RST underlines checked
- [ ] `pytest mlsynth/tests/` — full suite; this PR's gate runs it
- [ ] Docs build — Sphinx is not installed in this environment and the PR gate does not build docs, so Read the Docs builds it on merge

## Other Notes

Two test bugs surfaced while porting the existing tests to `force`, both fixed here and both worth naming because they were passing for the wrong reason. `test_factor_space_is_recovered` used a DGP whose grand mean was nonzero; under `force="none"` the grand mean is the one thing still swept out, and removing it from a rank-2 matrix raises its rank, so the factors no longer span the truth. The DGP now centers the factors and asserts the grand mean is zero. `test_a_pure_unit_panel_is_exact_under_unit` compared a `(1, N)` reconstruction against a `(T, N)` panel, which `assert_allclose` rejects on shape rather than value; it now broadcasts explicitly.

`two_way` is retained rather than removed outright even though it is one commit old and unreleased, since `main` has carried it since #362 and a silent rename is worse than a mapped alias. It can be dropped at the next release that breaks compatibility.

`tools/mutate_gsynth_force.py` edits source files in place and restores them in a `finally`, so it should not be run against a dirty tree. It is not wired into CI — each mutant is a full suite run, so the 26 take a few minutes.