### PR TITLE
Chain the warm start through the batched solver's fallback

### DIFF
--- a/mlsynth/tests/test_sdid_placebo_warmstart.py
+++ b/mlsynth/tests/test_sdid_placebo_warmstart.py
@@ -1,0 +1,240 @@
+"""Warm-start chaining through the batched solver's one-at-a-time fallback.
+
+``solve_intercept_simplex_many`` batches a family of simplex programs, but a
+design that fails ``gram_reduction_is_safe`` is solved one at a time instead.
+SDID's time-weight program is exactly that case -- its design is ``(N0, T0)``
+with ``T0 > N0``, so it is rank deficient and always falls back -- and it is also
+the pivot-heavy half of the placebo loop, since it carries ``T0`` variables
+against the unit program's ``N0``.
+
+Consecutive placebo draws differ by only the treated columns, so the previous
+draw's solution is a near-feasible active set for the next. These tests pin the
+contract that chaining it changes the cost and not the answer.
+"""
+
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthDataError
+from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+from mlsynth.utils.bilevel.minnorm import gram_reduction_is_safe
+from mlsynth.utils.sdid_helpers.weights import (
+    _solve_intercept_simplex,
+    fit_time_weights,
+    solve_intercept_simplex_many,
+)
+
+
+def _objective(design, target, intercept, weights, ridge=0.0):
+    """``||a + design @ w - target||^2 + ridge * ||w||^2``."""
+    resid = intercept + design @ weights - target
+    return float(resid @ resid + ridge * (weights @ weights))
+
+
+def _time_weight_family(n_draws=12, n_donors=14, n_pre=20, seed=0):
+    """A family of SDID time-weight programs, as the placebo loop poses them.
+
+    Design is ``(n_donors, n_pre)`` -- rank deficient whenever
+    ``n_pre > n_donors``, which is the fallback case under test.
+    """
+    rng = np.random.default_rng(seed)
+    base = rng.normal(size=(n_pre + 8, n_donors + 2)).cumsum(axis=0)
+    problems = []
+    for d in range(n_draws):
+        idx = rng.choice(n_donors + 2, size=2, replace=False)
+        mask = np.ones(n_donors + 2, dtype=bool)
+        mask[idx] = False
+        pre = base[:n_pre][:, mask]
+        post_mean = base[n_pre:][:, mask].mean(axis=0)
+        design = pre.T
+        problems.append((design - design.mean(axis=0)[None, :],
+                         post_mean - post_mean.mean(), 0.0))
+    return problems
+
+
+class TestFallbackIsTheCaseUnderTest:
+    """The premise: SDID time-weight designs really do bypass the batch."""
+
+    def test_time_weight_design_is_rank_deficient(self):
+        problems = _time_weight_family()
+        design = problems[0][0]
+        assert design.shape[1] > design.shape[0], (
+            "time-weight design should have more variables than equations")
+        assert not gram_reduction_is_safe(design), (
+            "this family must take the one-at-a-time fallback, or the test "
+            "is not exercising the path it claims to")
+
+    def test_unit_weight_design_is_batched(self):
+        rng = np.random.default_rng(1)
+        pre = rng.normal(size=(30, 8)).cumsum(axis=0)
+        centred = pre - pre.mean(axis=0)[None, :]
+        augmented = np.vstack([centred, np.sqrt(4.0) * np.eye(8)])
+        assert gram_reduction_is_safe(augmented)
+
+
+class TestChainingPreservesTheAnswer:
+    """Chaining must change the cost, not the result."""
+
+    def test_matches_cold_one_at_a_time(self):
+        problems = _time_weight_family()
+        cold = [_solve_intercept_simplex(d, t, r) for d, t, r in problems]
+        got = solve_intercept_simplex_many(problems)
+        assert len(got) == len(cold)
+        for (a_c, w_c), (a_g, w_g) in zip(cold, got):
+            np.testing.assert_allclose(w_g, w_c, atol=1e-8)
+            assert a_g == pytest.approx(a_c, abs=1e-8)
+
+    def test_objective_is_not_worsened(self):
+        problems = _time_weight_family(seed=3)
+        cold = [_solve_intercept_simplex(d, t, r) for d, t, r in problems]
+        got = solve_intercept_simplex_many(problems)
+        for (design, target, ridge), (a_c, w_c), (a_g, w_g) in zip(
+                problems, cold, got):
+            obj_cold = _objective(design, target, a_c, w_c, ridge)
+            obj_warm = _objective(design, target, a_g, w_g, ridge)
+            scale = max(1.0, abs(obj_cold))
+            assert obj_warm <= obj_cold + 1e-8 * scale
+
+    def test_weights_stay_on_the_simplex(self):
+        for _, w in solve_intercept_simplex_many(_time_weight_family(seed=5)):
+            assert w.min() >= -1e-9
+            assert w.sum() == pytest.approx(1.0, abs=1e-9)
+
+    def test_repeated_calls_are_deterministic(self):
+        problems = _time_weight_family(seed=7)
+        first = solve_intercept_simplex_many(problems)
+        second = solve_intercept_simplex_many(problems)
+        for (_, a), (_, b) in zip(first, second):
+            np.testing.assert_array_equal(a, b)
+
+    def test_fit_time_weights_unchanged(self):
+        """The public entry point must be unmoved by the internal change."""
+        rng = np.random.default_rng(11)
+        pre = rng.normal(size=(24, 9)).cumsum(axis=0)
+        post_mean = rng.normal(size=9)
+        intercept, lam = fit_time_weights(pre, post_mean)
+        expect_a, expect_w = _solve_intercept_simplex(pre.T, post_mean, 0.0)
+        np.testing.assert_allclose(lam, expect_w, atol=1e-9)
+        assert intercept == pytest.approx(expect_a, abs=1e-9)
+
+
+class TestEdgeCases:
+    def test_single_problem_has_no_chain_to_build(self):
+        problems = _time_weight_family(n_draws=1)
+        got = solve_intercept_simplex_many(problems)
+        cold = _solve_intercept_simplex(*problems[0])
+        np.testing.assert_allclose(got[0][1], cold[1], atol=1e-9)
+
+    def test_mixed_shapes_do_not_cross_contaminate(self):
+        """A warm start of the wrong length must never be applied."""
+        a = _time_weight_family(n_draws=3, n_donors=14, n_pre=20, seed=2)
+        b = _time_weight_family(n_draws=3, n_donors=10, n_pre=16, seed=4)
+        mixed = [a[0], b[0], a[1], b[1], a[2], b[2]]
+        got = solve_intercept_simplex_many(mixed)
+        for (design, target, ridge), (_, w) in zip(mixed, got):
+            assert w.shape[0] == design.shape[1]
+            cold = _solve_intercept_simplex(design, target, ridge)[1]
+            np.testing.assert_allclose(w, cold, atol=1e-8)
+
+    def test_single_column_problem(self):
+        design = np.array([[2.0], [3.0], [4.0]])
+        target = np.array([1.0, 2.0, 3.0])
+        (_, w), = solve_intercept_simplex_many([(design, target, 0.0)])
+        np.testing.assert_allclose(w, [1.0])
+
+    def test_empty_family(self):
+        assert solve_intercept_simplex_many([]) == []
+
+
+class TestWarmStartRobustness:
+    """A warm start is a hint; a bad one must not corrupt the solve."""
+
+    @pytest.mark.parametrize("bad", ["nan", "negative", "unnormalised",
+                                     "wrong_length"])
+    def test_infeasible_warm_start_is_ignored(self, bad):
+        rng = np.random.default_rng(13)
+        design = rng.normal(size=(12, 20))
+        target = rng.normal(size=12)
+        reference = solve_simplex_qp(design, target)
+        seeds = {
+            "nan": np.full(20, np.nan),
+            "negative": np.full(20, -1.0),
+            "unnormalised": np.full(20, 5.0),
+            "wrong_length": np.full(7, 1.0 / 7),
+        }
+        got = solve_simplex_qp(design, target, warm_start=seeds[bad])
+        np.testing.assert_allclose(got, reference, atol=1e-9)
+
+    def test_degenerate_duplicate_columns_keep_the_same_fit(self):
+        """Duplicated columns make the argmin non-unique.
+
+        The weights may then differ between starting points -- the "same fit,
+        other weights" case -- but the fitted values must not.
+        """
+        rng = np.random.default_rng(17)
+        design = rng.normal(size=(10, 16))
+        design[:, 8:] = design[:, :8]
+        target = rng.normal(size=10)
+        cold = solve_simplex_qp(design, target)
+        neighbour = solve_simplex_qp(
+            design + 1e-3 * rng.normal(size=design.shape), target)
+        warm = solve_simplex_qp(design, target, warm_start=neighbour)
+        np.testing.assert_allclose(design @ warm, design @ cold, atol=1e-8)
+
+    def test_rejects_malformed_design(self):
+        with pytest.raises(MlsynthDataError):
+            fit_time_weights(np.zeros((0, 3)), np.zeros(3))
+
+
+class TestChainingReducesWork:
+    """The point of the change: fewer active-set pivots, same answer.
+
+    Counted through the solver's own ``return_info`` diagnostics, so the
+    assertion is on work done and not on wall-clock.
+    """
+
+    @staticmethod
+    def _pivots(problems):
+        """Total pivots spent solving ``problems`` through the batched entry."""
+        import mlsynth.utils.sdid_helpers.weights as weights_module
+
+        seen = []
+        original = weights_module.solve_simplex_qp
+
+        def counting(B, A, **kwargs):
+            w, info = original(B, A, **{**kwargs, "return_info": True})
+            seen.append(info["pivots"])
+            return w
+
+        weights_module.solve_simplex_qp = counting
+        try:
+            solve_intercept_simplex_many(problems)
+        finally:
+            weights_module.solve_simplex_qp = original
+        return sum(seen), len(seen)
+
+    def test_chain_costs_fewer_pivots_than_cold_starts(self):
+        problems = _time_weight_family(n_draws=16, seed=21)
+        chained, n_solves = self._pivots(problems)
+        assert n_solves == len(problems), (
+            "every problem in this family should hit the fallback solver")
+
+        cold = sum(
+            solve_simplex_qp(
+                design - design.mean(axis=0)[None, :],
+                target - target.mean(),
+                return_info=True,
+            )[1]["pivots"]
+            for design, target, _ in problems
+        )
+        assert chained < cold, (
+            f"chained fallback spent {chained} pivots, cold spent {cold}: "
+            "the warm start is not being threaded through the fallback")
+
+    def test_first_problem_is_unaffected(self):
+        """Nothing to chain from, so the first solve is the cold solve."""
+        problems = _time_weight_family(n_draws=4, seed=23)
+        design, target, ridge = problems[0]
+        got = solve_intercept_simplex_many(problems)[0]
+        cold = _solve_intercept_simplex(design, target, ridge)
+        np.testing.assert_allclose(got[1], cold[1], atol=1e-9)

--- a/mlsynth/utils/sdid_helpers/weights.py
+++ b/mlsynth/utils/sdid_helpers/weights.py
@@ -58,7 +58,8 @@ from mlsynth.utils.bilevel.minnorm import gram_reduction_is_safe
 
 
 def _solve_intercept_simplex(
-    design: np.ndarray, target: np.ndarray, ridge: float = 0.0
+    design: np.ndarray, target: np.ndarray, ridge: float = 0.0,
+    warm_start: Optional[np.ndarray] = None,
 ) -> Tuple[float, np.ndarray]:
     """Simplex least squares with a free intercept and optional L2 ridge.
 
@@ -75,6 +76,10 @@ def _solve_intercept_simplex(
         Target vector.
     ridge : float, optional
         Non-negative L2 penalty coefficient on ``w`` (default ``0``).
+    warm_start : np.ndarray, shape (J,), optional
+        Feasible weights to seed the active set with, e.g. the solution of a
+        neighbouring problem. A hint only: ``solve_simplex_qp`` ignores one that
+        is infeasible or the wrong length, so it cannot change the optimum.
 
     Returns
     -------
@@ -91,7 +96,7 @@ def _solve_intercept_simplex(
         design_c = np.vstack([design_c, np.sqrt(ridge) * np.eye(J)])
         target_c = np.concatenate([target_c, np.zeros(J)])
 
-    weights = solve_simplex_qp(design_c, target_c)
+    weights = solve_simplex_qp(design_c, target_c, warm_start=warm_start)
     intercept = target_mean - float(col_mean @ weights)
     return intercept, weights
 
@@ -128,15 +133,34 @@ def solve_intercept_simplex_many(
     centred design, and solved one at a time otherwise. Forming the Gram squares
     the design's condition number, and on a rank-deficient design the optimum is
     a face whose points the two solvers pick differently -- the same fit, other
-    weights. SDID's own designs are overdetermined (pre-periods by donors for the
-    unit weights, donors by pre-periods for the time weights) and so land on the
-    safe side; the guard is on the design, not on the caller.
+    weights. The guard is on the design, not on the caller.
+
+    Which of SDID's two programs clears that guard depends on the panel's shape.
+    The unit-weight design is ``T0`` by ``N0`` and carries the ridge, so it
+    batches. The time-weight design is ``N0`` by ``T0``, so it batches only when
+    ``N0 > T0``: Prop 99 (38 donors, 19 pre-years) does, and a daily geo panel
+    (40 markets, 75 pre-days) does not. Where it does not, every draw takes the
+    fallback -- and that is also the pivot-heavy program, carrying ``T0``
+    variables against the unit program's ``N0``.
+
+    The fallback therefore chains its warm start: consecutive placebo draws
+    differ only in which columns were reassigned to treatment, so the previous
+    draw's solution seeds the next one's active set. The chain is keyed by
+    centred-design shape, and ``solve_simplex_qp`` ignores an infeasible or
+    wrongly sized seed, so it can only change how many pivots the solve takes.
+    On a 40-market daily panel this cuts ``vce="placebo"`` at ``B=500`` by about
+    6x with the ATT and its standard error unchanged to full precision.
     """
     from ..bilevel.minnorm import simplex_gram, solve_simplex_minnorm_batch
 
     out: List[Optional[Tuple[float, np.ndarray]]] = [None] * len(problems)
     groups: Dict[Tuple[int, int], List[int]] = {}
     prepared: List[Optional[Tuple[np.ndarray, np.ndarray, float, np.ndarray, float]]] = []
+    # Last fallback solution per centred-design shape, to seed the next one.
+    # Keyed by shape so a warm start is never offered to a differently sized
+    # program; consecutive placebo draws share a shape, which is what the chain
+    # exploits.
+    last_fallback: Dict[Tuple[int, int], np.ndarray] = {}
 
     for i, (design, target, ridge) in enumerate(problems):
         design = np.asarray(design, dtype=float)
@@ -152,7 +176,12 @@ def solve_intercept_simplex_many(
         augmented = (np.vstack([design_c, np.sqrt(ridge) * np.eye(J)])
                      if ridge > 0.0 else design_c)
         if J == 1 or not gram_reduction_is_safe(augmented):
-            out[i] = _solve_intercept_simplex(design, target, ridge)
+            shape = design_c.shape
+            solved = _solve_intercept_simplex(
+                design, target, ridge, warm_start=last_fallback.get(shape)
+            )
+            last_fallback[shape] = solved[1]
+            out[i] = solved
             prepared.append(None)
             continue
         prepared.append((design_c, target - float(target.mean()), ridge,


### PR DESCRIPTION
## Related Links

- Solver: `mlsynth/utils/bilevel/active_set.py` (`solve_simplex_qp`, already accepts `warm_start`)
- Batched entry point changed: `mlsynth/utils/sdid_helpers/weights.py` (`solve_intercept_simplex_many`)
- Consumer that benefits: `mlsynth/utils/sdid_helpers/inference.py` (`_solve_placebo_weights`, `estimate_placebo_variance`)
- Follow-on PR that depends on this for speed, but not for correctness: SDIDGEO (`claude/sdidgeo`)

## What

- Added an optional `warm_start` argument to `_solve_intercept_simplex`, passed straight through to `solve_simplex_qp`.
- `solve_intercept_simplex_many` now chains the previous fallback solution into the next one, keyed by centred-design shape.
- Corrected a claim in the `solve_intercept_simplex_many` docstring about which SDID programs clear the batching guard.

## Why

`solve_intercept_simplex_many` batches a family of simplex programs, but a design that fails `gram_reduction_is_safe` is solved one at a time instead. The docstring said both SDID programs land on the safe side. That holds only when `N0 > T0`:

- the unit-weight design is `T0 x N0` and carries the ridge, so it batches;
- the time-weight design is `N0 x T0`, so it batches only when `N0 > T0`.

Prop 99 (38 donors, 19 pre-years) clears it. A daily geo panel (40 markets, 75 pre-days) does not, so every placebo draw takes the fallback. That is also the pivot-heavy program, carrying `T0` variables against the unit program's `N0`. Profiling a `B=500` placebo run put 6.5s of its 7.0s in that fallback, so on such panels the batching was skipping the expensive half of the loop.

Consecutive placebo draws differ only in which columns were reassigned to treatment, so the previous draw's solution is a near-feasible active set for the next.

## How

The chain is keyed by centred-design shape, so a warm start is never offered to a differently sized program. `solve_simplex_qp` already ignores a seed that is infeasible or the wrong length, so the seed can only change how many pivots a solve takes, never which optimum it reaches.

Batching and chaining were measured against each other before choosing. On 2500 real SDID programs, batching alone gave 1.2x, `check_finite=False` gave 1.04x, and warm-start chaining gave 5.5x — the cost is pivot count, not per-call setup, so chaining is the lever and it composes with the existing batch instead of replacing it.

## Verification

- Path: cross-validation against the pre-change output of the same code.
- ATT and standard error compared across 3 seeds x 2 treated sets at `B=500` on `basedata/geolift_market_data.csv`: identical to full float repr in all 6 runs (e.g. `46.43641988206952` / `245.59424529951494` before and after). Total time 44.58s to 7.10s, 6.3x.
- Regression suite over the SDID, solver, benchmark-parity and result-contract tests: 1015 passed, 6 skipped.
- Pinned durably in `mlsynth/tests/test_sdid_placebo_warmstart.py` (19 tests): the premise (the time-weight design does take the fallback), the invariant (chained output matches cold one-at-a-time solving, the objective is never worsened, weights stay on the simplex, repeated calls agree), the edge cases (single problem, interleaved shapes, single column, empty family), and a pivot-count test that fails without the change (293 vs 293 pivots before, strictly fewer after).
- Does not match, and recorded: exactly duplicated columns make the argmin non-unique, so weights may differ between starting points. Fuzzing six design families x 200 draws, rank-deficient / collinear / square / tall designs are bit-identical; only duplicated and tied columns diverge, with fitted values agreeing to 1.3e-15 and the objective to 2.1e-14. This is the "same fit, other weights" case the docstring already names, and the warm start does not create the ambiguity — it picks a different arbitrary point on a face the solver was already choosing arbitrarily. `test_degenerate_duplicate_columns_keep_the_same_fit` pins that the fit cannot move. Worth noting for a future change: `synthdid`'s `zeta.lambda = 1e-6 * noise.level` tie-breaker closes the tied case exactly and shrinks the duplicated-column gap from 4.6e-1 to 2.9e-3; mlsynth deliberately omits it, and this PR does not change that.

## Scope checks

<!-- FEATURE ON AN EXISTING ESTIMATOR -->
This is a performance change to a shared solver helper, so none of the four blocks fits exactly. The nearest guarantees hold and are tested: the default preserves existing behaviour exactly, existing pinned benchmark values are unchanged, and the invariant tests pin that chained output matches cold solving.

## Designs

No visual output. The change is internal to the solver and produces byte-identical estimates; the evidence is the A/B table above rather than a figure.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_sdid_placebo_warmstart.py -q` — 19 passed
- [x] `pytest mlsynth/tests/ -k "sdid or simplex or minnorm or active_set or benchmark_reference or result_contract"` — 1015 passed, 6 skipped
- [x] A/B of ATT and standard error before vs after, 6 runs, identical to full precision
- [ ] `python benchmarks/run_benchmarks.py --all` — not run locally; the benchmark parity tests in the suite above cover the pinned SDID values

## Other Notes

- The speedup only shows on panels where `T0 >= N0`, which is the common shape for daily geo panels and the uncommon one for the annual policy panels most benchmarks use. Prop 99 batches as before and is unaffected either way.
- `vce="bootstrap"` goes through the same batched entry point and should benefit identically; I measured `vce="placebo"` only.
- The infinitesimal tie-breaker discussed under Verification is a separate decision and would want its own branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_