### PR TITLE
Add SDIDGEO: synthetic DiD geo experiment design

### DIFF
--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -947,6 +947,14 @@ left over -- as in a geo roll-out?
   matches on the full pre-period *trajectory* for a downstream
   difference-in-differences read.
 
+* Scoring by simulated power on your own history -- :doc:`sdidgeo` slides a
+  pretend treatment window backwards through the panel, injects a lift of known
+  size, and ranks candidate test regions by the smallest lift it reliably
+  detects. It scores with synthetic difference-in-differences, so the design is
+  chosen by the estimator that will analyse the result, and a level gap between
+  the test region and its donors is differenced out instead of having to be
+  matched.
+
 Q3.4 · Are you planning a marketing geo-lift test -- pick which markets to treat
 so the untreated markets form a clean control, often under a budget?
 
@@ -1057,7 +1065,7 @@ A reverse lookup: the symptom, and the method named for it.
    * - Designing a geo roll-out (no pure donors)
      - :doc:`pangeo`
    * - Designing a geo-lift test (pick markets, one or many cells)
-     - :doc:`syndes`, :doc:`lexscm`, :doc:`marex`
+     - :doc:`sdidgeo`, :doc:`syndes`, :doc:`lexscm`, :doc:`marex`
 
 When in doubt, fit two or three of the candidate methods and compare the
 counterfactuals and ATTs. Disagreement is itself diagnostic: it usually means

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -349,6 +349,7 @@ headline numbers.
    marex
    syndes
    pangeo
+   sdidgeo
    spcd
    musc
    rolldid

--- a/docs/sdidgeo.rst
+++ b/docs/sdidgeo.rst
@@ -1,0 +1,328 @@
+Synthetic DiD Geo Experiment Design (SDIDGEO)
+=============================================
+
+.. currentmodule:: mlsynth
+
+When to Use This Estimator
+--------------------------
+
+SDIDGEO decides which geographic markets to treat in a marketing geo
+experiment, before the experiment runs. You have daily or weekly sales
+for a few dozen cities, you can turn a campaign on in some of them, and
+you must pick which ones. SDIDGEO answers that by rehearsing the
+experiment on history you already have: it slides a pretend treatment
+window backwards through the past, injects a lift of known size, and
+counts how often the estimator would have caught it. The region with the
+smallest lift it can reliably detect is the one to test in.
+
+Use it when:
+
+- you can assign treatment at the geo level, and geos are the unit of
+  analysis;
+- you have pre-period history for every candidate market, with no gaps;
+- the number of markets is in the tens, as with DMAs or metros;
+- you want the design chosen by the same estimator that will analyse the
+  result, so the power calculation is not about a different model than
+  the one you will report.
+
+Use something else when the design question is different in kind.
+:doc:`pangeo` pairs geos into balanced supergeos and randomises within
+pairs, which suits a rollout where every market must be used. SDIDGEO
+picks a small test region and leaves the rest as donors. :doc:`spcd`
+scores a design from holdout residuals when the estimator is a fixed
+linear contrast.
+
+What Distinguishes It
+---------------------
+
+The market-selection loop follows GeoLift, Meta's geo-experiment
+package: anchor a candidate region at each market, add that market's
+most correlated neighbours, sweep effect sizes over several backward
+placements, and rank by a composite score. What changes is the estimator
+doing the scoring.
+
+GeoLift scores with augmented synthetic control, which matches the
+treated market's path period by period. SDIDGEO scores with synthetic
+difference-in-differences (Arkhangelsky, Athey, Hirshberg, Imbens and
+Wager, 2021), which weights donor markets and pre-periods at the same
+time. Two consequences follow.
+
+The first is that no single pre-period has to be matched. Synthetic
+control asks the donors to reproduce the treated path everywhere before
+treatment; synthetic DiD asks only that a weighted average of
+pre-periods line up, and lets the weights decide which periods carry the
+comparison. On a 105-day panel of 40 US metros, the fitted design puts
+weight on 7 of 91 pre-days and none on the rest. Days that resemble the
+post-period window count; days that do not are set aside.
+
+The second is that a level difference between the treated region and its
+donors is absorbed. Synthetic DiD differences it out, so the donor pool
+does not have to contain the treated region's scale, only its shape.
+A two-city test region in a pool of small markets remains estimable.
+
+Notation
+--------
+
+Let :math:`i = 1, \dots, N` index markets and :math:`t = 1, \dots, T`
+index periods, with outcome :math:`Y_{it}`. A candidate test region
+:math:`\mathcal{T}` is a set of :math:`N_{\mathrm{tr}}` markets; the
+donors are the rest, :math:`\mathcal{C}`. Write
+:math:`y_t = N_{\mathrm{tr}}^{-1}\sum_{i \in \mathcal{T}} Y_{it}` for the
+treated average and :math:`\mathbf{Y}_{0}` for the
+:math:`T \times |\mathcal{C}|` donor matrix.
+
+A pseudo-experiment is a pre/post split of the observed history. For a
+duration :math:`D` and a placement :math:`s = 1, \dots, S`, the pretend
+treatment runs over periods
+
+.. math::
+
+   [\,T_0,\; T_0 + D - 1\,], \qquad T_0 = T - D - s + 1 ,
+
+so :math:`s = 1` ends flush with the last observed period and each
+increment slides the window one period earlier. Everything before
+:math:`T_0` is the pre-period.
+
+Synthetic DiD chooses unit weights :math:`\omega` over donors and time
+weights :math:`\lambda` over pre-periods, and estimates
+
+.. math::
+
+   \hat\tau \;=\;
+   \Big( \bar y_{\mathrm{post}} - \lambda' y_{\mathrm{pre}} \Big)
+   \;-\;
+   \Big( \omega' \bar{\mathbf{Y}}_{0,\mathrm{post}}
+         - \lambda' \mathbf{Y}_{0,\mathrm{pre}}\, \omega \Big).
+
+Both weight vectors are non-negative and sum to one. Rearranged, the
+counterfactual path is
+:math:`\mathbf{Y}_{0}\omega + \big(\lambda' y_{\mathrm{pre}} - \lambda'
+\mathbf{Y}_{0,\mathrm{pre}}\omega\big)`, and :math:`\hat\tau` is the
+average gap against it over the window.
+
+An effect of size :math:`e` is injected multiplicatively,
+:math:`y_t \mapsto (1 + e)\, y_t` on the window, matching GeoLift's
+convention that an effect size reads as a percentage lift on the treated
+markets' own volume.
+
+Assumptions
+-----------
+
+1. Balanced panel, no gaps.
+
+   Every market is observed in every period. Ingestion goes through
+   ``geoex_dataprep``, which raises when the panel is ragged.
+
+   *Remark.* A market that starts reporting halfway through cannot serve
+   as a donor for a placement that begins before it exists, and silently
+   dropping it would change the donor pool between placements.
+
+2. The history is untreated.
+
+   The simulation reuses observed periods as pretend post-periods, so
+   those periods must carry no real treatment effect. If a campaign ran
+   in month three, placements overlapping it inherit its effect and
+   report power that the design will not reproduce.
+
+   *Remark.* Where a genuine post-period exists, name it with
+   ``post_col`` and it is held out of the simulation.
+
+3. No interference between markets.
+
+   Treating one market does not move another's outcome. Neighbouring
+   metros that share media markets or commuters violate this, and the
+   donor pool then contains partially treated units.
+
+   *Remark.* SDIDGEO does not model spillover. Exclude the markets you
+   suspect with ``not_to_be_treated``, which keeps them out of candidate
+   regions while leaving them as donors.
+
+4. The pre-period relationship persists into the test.
+
+   Weights fit on history are used for the future. A market that
+   tracked the test region for a year and then diverges breaks the
+   design regardless of how the design was chosen.
+
+   *Remark.* ``scaled_l2`` and ``pre_rmspe`` in the shortlist report how
+   well the fit held historically, which is the available evidence for
+   this assumption and not proof of it.
+
+5. The placebo distribution represents the null.
+
+   Detection compares the estimate to a standard error built by
+   reassigning donor markets as pretend-treated. This presumes the donors
+   are exchangeable enough that a donor-based null describes what a
+   no-effect test region would look like.
+
+   *Remark.* With few donors the placebo draws overlap heavily and the
+   standard error is optimistic. The design needs a donor pool comfortably
+   larger than the test region.
+
+Inference and Diagnostics
+-------------------------
+
+Arkhangelsky et al. give three variance procedures. Jackknife and
+bootstrap are undefined for a single treated series, which is what a
+candidate region collapses to, so SDIDGEO uses the placebo procedure
+(their Algorithm 4): reassign :math:`N_{\mathrm{tr}}` donors as
+pretend-treated, drop them from the pool, refit, and take the standard
+deviation of the resulting estimates. Detection is the two-sided normal
+test :math:`2\big(1 - \Phi(|\hat\tau| / \hat\sigma)\big)` against
+``alpha``.
+
+This is where SDIDGEO parts company with GeoLift, which uses a conformal
+permutation test. The conformal argument needs the residuals to be
+exchangeable across the matching window, and synthetic DiD's time
+weights exist because pre-periods are not interchangeable.
+
+Power at an effect size is the detection rate across placements. The
+minimum detectable effect is the smallest magnitude whose power exceeds
+``power_threshold``, taking the smaller of the detectable positive and
+negative effects. Candidates are then ranked on a composite of three
+dense ranks: :math:`|\mathrm{MDE}|`, the power at the MDE, and how far
+the recovered lift sits from the injected one.
+
+Two properties keep the sweep cheap, and both are consequences of where
+the weights get their information. The unit-weight program reads the
+treated pre-period, the time-weight program reads only donors, and the
+ridge reads only donors and counts, so no program sees the treated post
+block. Injecting an effect there cannot move :math:`\omega` or
+:math:`\lambda`, which makes
+
+.. math:: \hat\tau(e) = \hat\tau(0) + e \cdot \bar y_{\mathrm{post}}
+
+exact. The placebo draws reassign control markets, so
+:math:`\hat\sigma` does not depend on :math:`e` either. One fit and one
+placebo run therefore cover the whole grid of effect sizes.
+
+Example
+-------
+
+.. code-block:: python
+
+   import numpy as np
+   import pandas as pd
+   from mlsynth import SDIDGEO
+   from mlsynth.config_models import SDIDGEOConfig
+
+   df = pd.read_csv("basedata/geolift_test_data.csv")
+   df["date"] = pd.to_datetime(df["date"])
+
+   design = SDIDGEO(SDIDGEOConfig(
+       df=df, unitid="location", time="date", outcome="Y",
+       treatment_size=2,
+       durations=[14],
+       effect_sizes=[round(x, 2) for x in np.arange(-0.30, 0.35, 0.05)],
+       lookback_window=5,
+       n_draws=100,
+       seed=0,
+       n_jobs=-1,
+   )).fit()
+
+   print(design.selected_units)
+   print(design.metadata["winner_mde"])
+   print(design.power.head())
+
+On the 40-market, 105-day panel this selects ``atlanta`` and
+``nashville`` with a minimum detectable effect of 0.15, out of 31
+candidate regions:
+
+.. code-block:: text
+
+                    candidate  duration   mde  power  scaled_l2  rank
+          atlanta + nashville        14  0.15    1.0      0.324   1.0
+   jacksonville + minneapolis        14  0.20    1.0      0.529   2.0
+          milwaukee + orlando        14  0.15    1.0      0.263   2.0
+           cleveland + denver        14 -0.15    1.0      0.223   4.0
+       detroit + new orleans        14 -0.15    1.0      0.530   5.0
+
+Read that as: a 15% lift in Atlanta and Nashville together would be
+detected at the 10% level in essentially every placement tried.
+Anything smaller would not be, so an experiment expecting a 5% lift needs
+a longer test, a bigger region, or a different metric.
+
+``design.design_weights`` carries both weight vectors, ``donor_weights``
+over markets and ``time_weights`` over pre-period dates. The time weights
+are sparse: on this panel 7 of 91 pre-days carry any weight.
+
+``design.report`` is ``None``. It is the slot for the realized effect and
+stays empty until the experiment has run and post-treatment outcomes
+exist.
+
+Plots
+-----
+
+``plot_sdidgeo_design`` draws the two views GeoLift shows for a market
+selection: the power curve, with the detection threshold and the minimum
+detectable effect marked and the other candidates drawn faintly behind, and
+the fit the design rests on.
+
+.. code-block:: python
+
+   from mlsynth import plot_mde_ranking, plot_sdidgeo_design
+
+   plot_sdidgeo_design(design, power_threshold=0.8)
+   plot_mde_ranking(design, top=12)
+
+The power curve is U-shaped by construction: power falls to zero at no
+injected effect and rises to one as the lift grows in either direction. Where
+it crosses the threshold is the minimum detectable effect.
+``plot_mde_ranking`` gives the market-selection view instead, ranking the
+shortlisted regions by the smallest lift each can detect.
+
+Verification
+------------
+
+The engine is cross-validated against mlsynth's own :doc:`sdid`
+implementation: ``tests/test_sdidgeo.py`` asserts that the ATT SDIDGEO
+scores a placement with matches ``SDID(...).fit()`` on the same panel and
+window. The two structural properties the effect sweep relies on are
+checked against brute-force recomputation in the same file, so the
+shortcut is proved and not assumed.
+
+A durable benchmark case is not yet attached. Ranking a design against an
+external reference needs known ground truth, since no published
+implementation pairs synthetic DiD with GeoLift's market-selection loop;
+the natural route is a Path B simulation that injects a known lift and
+scores recovery.
+
+Core API
+--------
+
+.. automodule:: mlsynth.estimators.sdidgeo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: mlsynth.config_models.SDIDGEOConfig
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: mlsynth.utils.sdidgeo_helpers.engine
+   :members:
+   :undoc-members:
+
+.. automodule:: mlsynth.utils.sdidgeo_helpers.simulate
+   :members:
+   :undoc-members:
+
+.. automodule:: mlsynth.utils.sdidgeo_helpers.batch
+   :members:
+   :undoc-members:
+
+.. automodule:: mlsynth.utils.sdidgeo_helpers.aggregate
+   :members:
+   :undoc-members:
+
+.. automodule:: mlsynth.utils.sdidgeo_helpers.orchestration
+   :members:
+   :undoc-members:
+
+.. automodule:: mlsynth.utils.sdidgeo_helpers.structures
+   :members:
+   :undoc-members:
+
+.. automodule:: mlsynth.utils.sdidgeo_helpers.plotter
+   :members:
+   :undoc-members:

--- a/docs/sdidgeo.rst
+++ b/docs/sdidgeo.rst
@@ -210,7 +210,7 @@ Example
 
    design = SDIDGEO(SDIDGEOConfig(
        df=df, unitid="location", time="date", outcome="Y",
-       treatment_size=2,
+       treatment_size=[2, 3, 4, 5],
        durations=[14],
        effect_sizes=[round(x, 2) for x in np.arange(-0.30, 0.35, 0.05)],
        lookback_window=5,
@@ -248,6 +248,38 @@ are sparse: on this panel 7 of 91 pre-days carry any weight.
 ``design.report`` is ``None``. It is the slot for the realized effect and
 stays empty until the experiment has run and post-treatment outcomes
 exist.
+
+Scanning several region sizes
+-----------------------------
+
+``treatment_size`` takes a list, so one run can score two-market regions
+against five-market ones (GeoLift's ``N = c(2, 3, 4, 5)``). Candidates are
+nominated once per size, pooled, and ranked together, so the shortlist
+answers how large a test region has to be and which markets it should
+contain at the same time. A ``treatment_size`` column carries each
+candidate's size, and ``metadata["treatment_sizes"]`` the sizes scanned.
+
+Each candidate is fit with its own treated count, which enters the SDID
+ridge as :math:`(N_{\mathrm{tr}} T_{\mathrm{post}})^{1/4}`, so a
+five-market region is regularised more strongly than a two-market one on
+the same panel.
+
+Scanning sizes 2 through 5 on the test panel gives 123 candidates, and
+the best of each size:
+
+.. code-block:: text
+
+    size  candidate                                                          mde  scaled_l2
+       5  columbus + jacksonville + milwaukee + minneapolis + new orleans   0.10      0.370
+       4  columbus + jacksonville + milwaukee + minneapolis                 0.15      0.290
+       2  atlanta + nashville                                               0.15      0.324
+       3  atlanta + chicago + nashville                                     0.15      0.325
+
+Bigger regions detect smaller lifts, which is the usual trade: five
+markets carry more volume than two, so the same proportional effect is
+easier to see. Set against that, a larger test region costs more to run
+and holds out more of the country from the control pool. The scan prices
+that choice instead of assuming it.
 
 Plots
 -----

--- a/docs/sdidgeo.rst
+++ b/docs/sdidgeo.rst
@@ -38,7 +38,7 @@ What Distinguishes It
 The market-selection loop follows GeoLift, Meta's geo-experiment
 package: anchor a candidate region at each market, add that market's
 most correlated neighbours, sweep effect sizes over several backward
-placements, and rank by a composite score. What changes is the estimator
+backtests, and rank by a composite score. What changes is the estimator
 doing the scoring.
 
 GeoLift scores with augmented synthetic control, which matches the
@@ -72,7 +72,7 @@ treated average and :math:`\mathbf{Y}_{0}` for the
 :math:`T \times |\mathcal{C}|` donor matrix.
 
 A pseudo-experiment is a pre/post split of the observed history. For a
-duration :math:`D` and a placement :math:`s = 1, \dots, S`, the pretend
+duration :math:`D` and a backtest :math:`s = 1, \dots, S`, the pretend
 treatment runs over periods
 
 .. math::
@@ -114,14 +114,14 @@ Assumptions
    ``geoex_dataprep``, which raises when the panel is ragged.
 
    *Remark.* A market that starts reporting halfway through cannot serve
-   as a donor for a placement that begins before it exists, and silently
-   dropping it would change the donor pool between placements.
+   as a donor for a backtest that begins before it exists, and silently
+   dropping it would change the donor pool between backtests.
 
 2. The history is untreated.
 
    The simulation reuses observed periods as pretend post-periods, so
    those periods must carry no real treatment effect. If a campaign ran
-   in month three, placements overlapping it inherit its effect and
+   in month three, backtests overlapping it inherit its effect and
    report power that the design will not reproduce.
 
    *Remark.* Where a genuine post-period exists, name it with
@@ -175,7 +175,7 @@ permutation test. The conformal argument needs the residuals to be
 exchangeable across the matching window, and synthetic DiD's time
 weights exist because pre-periods are not interchangeable.
 
-Power at an effect size is the detection rate across placements. The
+Power at an effect size is the detection rate across backtests. The
 minimum detectable effect is the smallest magnitude whose power exceeds
 ``power_threshold``, taking the smaller of the detectable positive and
 negative effects. Candidates are then ranked on a composite of three
@@ -213,7 +213,7 @@ Example
        treatment_size=[2, 3, 4, 5],
        durations=[14],
        effect_sizes=[round(x, 2) for x in np.arange(-0.30, 0.35, 0.05)],
-       lookback_window=5,
+       n_backtests=5,
        n_draws=100,
        seed=0,
        n_jobs=-1,
@@ -237,7 +237,7 @@ candidate regions:
        detroit + new orleans        14 -0.15    1.0      0.530   5.0
 
 Read that as: a 15% lift in Atlanta and Nashville together would be
-detected at the 10% level in essentially every placement tried.
+detected at the 10% level in essentially every backtest tried.
 Anything smaller would not be, so an experiment expecting a 5% lift needs
 a longer test, a bigger region, or a different metric.
 
@@ -307,7 +307,7 @@ Verification
 
 The engine is cross-validated against mlsynth's own :doc:`sdid`
 implementation: ``tests/test_sdidgeo.py`` asserts that the ATT SDIDGEO
-scores a placement with matches ``SDID(...).fit()`` on the same panel and
+scores a backtest with matches ``SDID(...).fit()`` on the same panel and
 window. The two structural properties the effect sweep relies on are
 checked against brute-force recomputation in the same file, so the
 shortcut is proved and not assumed.

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -56,6 +56,11 @@ from .utils.counterfactual_compare import (
     plot_counterfactual_comparison,
 )
 from .estimators.spcd import SPCD
+from .estimators.sdidgeo import SDIDGEO
+from .utils.sdidgeo_helpers.plotter import (
+    plot_mde_ranking,
+    plot_sdidgeo_design,
+)
 from .estimators.tasc import TASC
 from .estimators.cmbsts import CMBSTS
 from .estimators.sbc import SBC
@@ -146,6 +151,9 @@ __all__ = [
     "MAREX",
     "LEXSCM",
     "SPCD",
+    "SDIDGEO",
+    "plot_sdidgeo_design",
+    "plot_mde_ranking",
     "TASC",
     "CMBSTS",
     "SBC", "BVSS", "BSCM", "BFSC", "MVBBSC", "MTGP", "BPSCS",

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -595,6 +595,7 @@ _RELOCATED_CONFIGS = {
     "SPCDConfig": "mlsynth.utils.spcd_helpers.config",
     "NSCConfig": "mlsynth.utils.nsc_helpers.config",
     "SDIDConfig": "mlsynth.utils.sdid_helpers.config",
+    "SDIDGEOConfig": "mlsynth.utils.sdidgeo_helpers.config",
     "SparseSCConfig": "mlsynth.utils.sparse_sc_helpers.config",
     "MicroSynthConfig": "mlsynth.utils.microsynth_helpers.config",
     "PPSCMConfig": "mlsynth.utils.ppscm_helpers.config",

--- a/mlsynth/estimators/sdidgeo.py
+++ b/mlsynth/estimators/sdidgeo.py
@@ -8,7 +8,7 @@ detected it. The region with the smallest reliably detectable effect wins.
 
 The market-selection loop follows GeoLift (Meta's geo-experiment package):
 anchor a candidate at each market and take its most correlated neighbours,
-sweep effect sizes over backward placements, then rank by a composite of the
+sweep effect sizes over backward backtests, then rank by a composite of the
 minimum detectable effect, the power at that effect, and how faithfully the
 estimator recovers the injected lift.
 
@@ -48,7 +48,7 @@ class SDIDGEO:
     >>> design = SDIDGEO(SDIDGEOConfig(          # doctest: +SKIP
     ...     df=df, unitid="location", time="date", outcome="Y",
     ...     treatment_size=2, durations=[14],
-    ...     effect_sizes=[-0.1, 0.0, 0.1, 0.2], lookback_window=5,
+    ...     effect_sizes=[-0.1, 0.0, 0.1, 0.2], n_backtests=5,
     ... )).fit()
     >>> design.selected_units                     # doctest: +SKIP
     ['chicago', 'portland']

--- a/mlsynth/estimators/sdidgeo.py
+++ b/mlsynth/estimators/sdidgeo.py
@@ -1,0 +1,70 @@
+"""SDIDGEO: synthetic difference-in-differences geo experiment design.
+
+SDIDGEO chooses which geographic markets to treat in a marketing geo experiment,
+before the experiment runs. It scores every candidate test region by simulated
+power: slide a pseudo-treatment window back through the observed history, inject
+a known lift, and ask how often synthetic difference-in-differences would have
+detected it. The region with the smallest reliably detectable effect wins.
+
+The market-selection loop follows GeoLift (Meta's geo-experiment package):
+anchor a candidate at each market and take its most correlated neighbours,
+sweep effect sizes over backward placements, then rank by a composite of the
+minimum detectable effect, the power at that effect, and how faithfully the
+estimator recovers the injected lift.
+
+The estimator underneath is synthetic difference-in-differences (Arkhangelsky,
+Athey, Hirshberg, Imbens & Wager 2021), not the augmented synthetic control
+GeoLift uses. SDID reweights donor markets *and* pre-periods, so it does not
+demand that any single pre-period be matched exactly, and its unit weights carry
+a closed-form ridge instead of a cross-validated one. Detection is a
+normal-approximation test against the placebo standard error (the paper's
+Algorithm 4, the only one of its three variance procedures defined for a single
+treated series).
+
+The output is a *design* -- which markets to treat, the donor weights the
+analysis will use, and the power table behind the choice -- not a treatment
+effect. The ``report`` slot stays ``None`` until the experiment has run.
+"""
+
+from ..utils.sdidgeo_helpers.config import SDIDGEOConfig
+from ..utils.sdidgeo_helpers.orchestration import run_design
+from ..utils.sdidgeo_helpers.structures import SDIDGEOResults
+
+
+class SDIDGEO:
+    """Synthetic difference-in-differences geo experiment design.
+
+    Parameters
+    ----------
+    config : SDIDGEOConfig
+        Panel, candidate-region constraints, simulation grid, and decision rule.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from mlsynth import SDIDGEO
+    >>> from mlsynth.config_models import SDIDGEOConfig
+    >>> df = pd.read_csv("basedata/geolift_test_data.csv")  # doctest: +SKIP
+    >>> design = SDIDGEO(SDIDGEOConfig(          # doctest: +SKIP
+    ...     df=df, unitid="location", time="date", outcome="Y",
+    ...     treatment_size=2, durations=[14],
+    ...     effect_sizes=[-0.1, 0.0, 0.1, 0.2], lookback_window=5,
+    ... )).fit()
+    >>> design.selected_units                     # doctest: +SKIP
+    ['chicago', 'portland']
+    """
+
+    def __init__(self, config: SDIDGEOConfig) -> None:
+        self.config = config
+
+    def fit(self) -> SDIDGEOResults:
+        """Run the design search and return the chosen test region.
+
+        Returns
+        -------
+        SDIDGEOResults
+            A :class:`~mlsynth.config_models.DesignResult` carrying
+            ``selected_units``, ``assignment``, ``design_weights``, the ranked
+            ``power`` table, and the full ``search`` detail.
+        """
+        return run_design(self.config)

--- a/mlsynth/tests/test_sdidgeo.py
+++ b/mlsynth/tests/test_sdidgeo.py
@@ -74,7 +74,7 @@ class TestWindows:
             start, end = backtest_treatment_window(105, 14, sim)
             assert end - start + 1 == 14
 
-    def test_placement_off_the_panel_raises(self):
+    def test_backtest_off_the_panel_raises(self):
         with pytest.raises(MlsynthConfigError, match="runs off the start"):
             backtest_pre_periods(20, 15, 10)
 
@@ -187,7 +187,7 @@ class TestInjectEffect:
             inject_effect(np.arange(10.0), window[0], window[1], 0.1)
 
 
-class TestSimulateLookback:
+class TestSimulateBacktest:
     def test_row_schema_and_one_row_per_effect_size(self, arrays):
         treated, donors, n_periods, duration, sim, *_ = arrays
         rows = simulate_backtest(treated, donors, n_periods, duration, sim,
@@ -586,12 +586,12 @@ class TestPlaceboWarmStart:
         assert first == second
 
 
-class TestHoldoutMDE:
-    """The winner's MDE is a selected minimum; the holdout one is not.
+class TestPlanningMDE:
+    """The winner's MDE is a selected minimum; the validation one is not.
 
     ``compute_rank`` returns the smallest MDE in the field, so the region most
     likely to be picked is the one whose estimate came out low by luck. The
-    holdout placements sit deeper in history and take no part in the search, so
+    validation backtests sit deeper in history and take no part in the search, so
     re-scoring the winner on them gives a figure that was not selected on.
     """
 
@@ -600,59 +600,59 @@ class TestHoldoutMDE:
             df=panel, unitid="location", time="date", outcome="Y",
             treatment_size=2, durations=[14],
             effect_sizes=[-0.2, -0.1, 0.0, 0.1, 0.2],
-            lookback_window=4, holdout_placements=4, n_draws=20, seed=0,
+            n_backtests=4, n_validation_backtests=4, n_draws=20, seed=0,
         )
         args.update(kw)
         return SDIDGEO(SDIDGEOConfig(**args)).fit()
 
     def test_both_numbers_are_reported(self, panel):
         result = self._design(panel)
-        assert result.metadata["winner_mde"] is not None
-        assert result.metadata["winner_mde_holdout"] is not None
-        assert result.metadata["holdout_placements"] == 4
-        assert result.search.winner.mde_holdout == pytest.approx(
-            result.metadata["winner_mde_holdout"])
+        assert result.metadata["winner_mde_optimistic"] is not None
+        assert result.metadata["winner_mde_planning"] is not None
+        assert result.metadata["n_validation_backtests"] == 4
+        assert result.search.winner.mde_planning == pytest.approx(
+            result.metadata["winner_mde_planning"])
 
-    def test_holdout_is_an_effect_size_from_the_grid(self, panel):
+    def test_planning_mde_is_an_effect_size_from_the_grid(self, panel):
         result = self._design(panel)
         grid = [-0.2, -0.1, 0.0, 0.1, 0.2]
-        assert float(result.metadata["winner_mde_holdout"]) in grid
+        assert float(result.metadata["winner_mde_planning"]) in grid
 
     def test_disabled_by_zero(self, panel):
-        result = self._design(panel, holdout_placements=0)
-        assert result.metadata["winner_mde_holdout"] is None
-        assert result.search.winner.mde_holdout is None
-        assert result.metadata["winner_mde"] is not None
+        result = self._design(panel, n_validation_backtests=0)
+        assert result.metadata["winner_mde_planning"] is None
+        assert result.search.winner.mde_planning is None
+        assert result.metadata["winner_mde_optimistic"] is not None
 
     def test_only_the_winner_is_rescored(self, panel):
-        """Scoring every candidate on the holdout would reintroduce selection."""
+        """Scoring every candidate on the validation would reintroduce selection."""
         result = self._design(panel)
         rescored = [c for c in result.search.candidates
-                    if c.mde_holdout is not None]
+                    if c.mde_planning is not None]
         assert len(rescored) == 1
         assert rescored[0].units == result.selected_units
 
-    def test_none_when_the_panel_cannot_carry_the_placements(self, panel):
-        # 105 periods; duration 14 with lookback 8 needs 8 more placements to
+    def test_none_when_the_panel_cannot_carry_the_backtests(self, panel):
+        # 105 periods; duration 14 with 8 backtests needs 8 more backtests to
         # reach depth 16, which fits -- so ask for a depth the panel cannot hold.
-        result = self._design(panel, lookback_window=4, holdout_placements=200)
-        assert result.metadata["winner_mde_holdout"] is None
-        assert result.metadata["winner_mde"] is not None
+        result = self._design(panel, n_backtests=4, n_validation_backtests=200)
+        assert result.metadata["winner_mde_planning"] is None
+        assert result.metadata["winner_mde_optimistic"] is not None
 
-    def test_holdout_uses_placements_the_search_did_not(self, panel):
-        """Changing only the holdout depth must not move the selection."""
-        a = self._design(panel, holdout_placements=4)
-        b = self._design(panel, holdout_placements=6)
+    def test_validation_uses_backtests_the_search_did_not(self, panel):
+        """Changing only the validation depth must not move the selection."""
+        a = self._design(panel, n_validation_backtests=4)
+        b = self._design(panel, n_validation_backtests=6)
         assert a.selected_units == b.selected_units
-        assert a.metadata["winner_mde"] == b.metadata["winner_mde"]
+        assert a.metadata["winner_mde_optimistic"] == b.metadata["winner_mde_optimistic"]
 
     @pytest.mark.parametrize("bad", [-1, -10])
-    def test_negative_holdout_raises(self, panel, bad):
-        with pytest.raises(MlsynthConfigError, match="holdout_placements"):
-            self._design(panel, holdout_placements=bad)
+    def test_negative_validation_backtests_raises(self, panel, bad):
+        with pytest.raises(MlsynthConfigError, match="n_validation_backtests"):
+            self._design(panel, n_validation_backtests=bad)
 
     def test_reproducible(self, panel):
         a = self._design(panel)
         b = self._design(panel)
-        assert (a.metadata["winner_mde_holdout"]
-                == b.metadata["winner_mde_holdout"])
+        assert (a.metadata["winner_mde_planning"]
+                == b.metadata["winner_mde_planning"])

--- a/mlsynth/tests/test_sdidgeo.py
+++ b/mlsynth/tests/test_sdidgeo.py
@@ -1,0 +1,457 @@
+"""Tests for SDIDGEO: synthetic difference-in-differences geo experiment design.
+
+The estimator scores candidate test regions by simulated power, so the tests are
+layered: the SDID engine's invariants first, then one pseudo-experiment, then the
+grid, then the end-to-end design on GeoLift's published test panel
+(``basedata/geolift_test_data.csv``, 40 markets x 105 days).
+
+Two engine properties carry the whole design and are checked against brute-force
+alternatives, not asserted:
+
+* neither SDID weight program reads the treated post block, so injecting an
+  effect cannot move omega or lambda, and the effect-size sweep is exact
+  arithmetic on the ATT;
+* the placebo draws reassign control units, so the placebo sigma does not depend
+  on the injected effect either.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SDIDGEO
+from mlsynth.config_models import DesignResult, SDIDGEOConfig
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.sdidgeo_helpers.engine import (
+    placebo_sigma, sdid_att, sdid_fit_once)
+from mlsynth.utils.sdidgeo_helpers.simulate import inject_effect, simulate_lookback
+from mlsynth.utils.sdidgeo_helpers.batch import run_simulations
+from mlsynth.utils.sdidgeo_helpers.shaping import aggregate_treated, donor_matrix
+from mlsynth.utils.sdidgeo_helpers.windows import (
+    lookback_pre_periods, lookback_treatment_window)
+
+DATA = Path(__file__).resolve().parents[2] / "basedata" / "geolift_test_data.csv"
+EFFECT_SIZES = [-0.20, -0.10, 0.0, 0.10, 0.20]
+
+
+@pytest.fixture(scope="module")
+def panel():
+    df = pd.read_csv(DATA)
+    df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+@pytest.fixture(scope="module")
+def wide(panel):
+    from mlsynth.utils.datautils import geoex_dataprep
+    return geoex_dataprep(panel, "location", "date", "Y")["Ywide"]
+
+
+@pytest.fixture(scope="module")
+def arrays(wide):
+    """One candidate's treated series, donor pool, and placement."""
+    units = list(wide.columns)
+    candidate = frozenset(units[:2])
+    treated = aggregate_treated(wide, candidate, how="mean").to_numpy()
+    donors = donor_matrix(wide, candidate).to_numpy()
+    n_periods = wide.shape[0]
+    duration, sim = 14, 3
+    n_pre = lookback_pre_periods(n_periods, duration, sim)
+    start, end = lookback_treatment_window(n_periods, duration, sim)
+    return treated, donors, n_periods, duration, sim, n_pre, start, end
+
+
+class TestWindows:
+    def test_lookback_matches_geolift_arithmetic(self):
+        assert lookback_pre_periods(100, 15, 1) == 85
+        assert lookback_treatment_window(100, 15, 1) == (85, 99)
+        assert lookback_treatment_window(100, 15, 5) == (81, 95)
+
+    def test_post_block_length_is_always_the_duration(self):
+        for sim in range(1, 6):
+            start, end = lookback_treatment_window(105, 14, sim)
+            assert end - start + 1 == 14
+
+    def test_placement_off_the_panel_raises(self):
+        with pytest.raises(MlsynthConfigError, match="runs off the start"):
+            lookback_pre_periods(20, 15, 10)
+
+    @pytest.mark.parametrize("bad", [0, -1, 2.5, True])
+    def test_non_positive_integers_raise(self, bad):
+        with pytest.raises(MlsynthConfigError):
+            lookback_pre_periods(100, 15, bad)
+
+
+class TestEngineInvariants:
+    def test_fit_returns_finite_weights_on_the_simplex(self, arrays):
+        treated, donors, _, _, _, n_pre, start, end = arrays
+        fit = sdid_fit_once(treated, donors, n_pre, start, end, n_tr=2)
+        assert fit.omega.shape[0] == donors.shape[1]
+        assert fit.lam.shape[0] == n_pre
+        for w in (fit.omega, fit.lam):
+            assert np.all(np.isfinite(w))
+            assert w.min() >= -1e-9
+            assert w.sum() == pytest.approx(1.0, abs=1e-8)
+        assert np.isfinite(fit.pre_rmspe) and fit.pre_rmspe >= 0.0
+        assert np.isfinite(fit.zeta) and fit.zeta > 0.0
+
+    def test_counterfactual_spans_the_panel(self, arrays):
+        treated, donors, n_periods, _, _, n_pre, start, end = arrays
+        fit = sdid_fit_once(treated, donors, n_pre, start, end, n_tr=2)
+        assert fit.counterfactual.shape == (n_periods,)
+        assert np.all(np.isfinite(fit.counterfactual))
+
+    def test_weights_are_blind_to_the_treated_post_block(self, arrays):
+        """The property the analytic sweep rests on."""
+        treated, donors, _, _, _, n_pre, start, end = arrays
+        base = sdid_fit_once(treated, donors, n_pre, start, end, n_tr=2)
+        for es in (-0.5, 0.25, 3.0):
+            moved = inject_effect(treated, start, end, es)
+            other = sdid_fit_once(moved, donors, n_pre, start, end, n_tr=2)
+            np.testing.assert_array_equal(other.omega, base.omega)
+            np.testing.assert_array_equal(other.lam, base.lam)
+
+    def test_att_shifts_analytically_with_the_injected_effect(self, arrays):
+        treated, donors, _, _, _, n_pre, start, end = arrays
+        fit = sdid_fit_once(treated, donors, n_pre, start, end, n_tr=2)
+        tau0 = sdid_att(fit, treated, start, end)
+        baseline = float(np.mean(treated[start:end + 1]))
+        for es in (-0.3, 0.15, 0.75):
+            moved = inject_effect(treated, start, end, es)
+            assert sdid_att(fit, moved, start, end) == pytest.approx(
+                tau0 + es * baseline, rel=1e-10, abs=1e-9)
+
+    def test_placebo_sigma_is_positive_and_effect_invariant(self, arrays):
+        treated, donors, _, _, _, n_pre, start, end = arrays
+        base = placebo_sigma(treated, donors, n_pre, start, end,
+                             n_draws=25, n_tr=2, seed=0)
+        assert np.isfinite(base) and base > 0.0
+        for es in (-0.4, 0.6):
+            moved = inject_effect(treated, start, end, es)
+            assert placebo_sigma(moved, donors, n_pre, start, end,
+                                 n_draws=25, n_tr=2, seed=0) == base
+
+    def test_matches_the_shipped_sdid_estimator(self, wide):
+        """SDIDGEO's engine must be SDID, not a lookalike."""
+        from mlsynth import SDID
+        from mlsynth.config_models import SDIDConfig
+
+        units = list(wide.columns)
+        candidate = frozenset(units[:2])
+        n_pre, duration = 80, 14
+        start, end = n_pre, n_pre + duration - 1
+        sub = wide.iloc[:end + 1]
+        idx_name = sub.index.name or "index"
+        long = (sub.reset_index()
+                .melt(id_vars=idx_name, var_name="location", value_name="Y")
+                .rename(columns={idx_name: "date"}))
+        long["treated"] = ((long["location"].isin(candidate))
+                           & (long["date"] >= sub.index[start])).astype(int)
+        shipped = SDID(SDIDConfig(
+            df=long, outcome="Y", treat="treated", unitid="location",
+            time="date", display_graphs=False, vce="placebo", B=25, seed=0
+        )).fit()
+
+        treated = aggregate_treated(wide, candidate, how="mean").to_numpy()
+        donors = donor_matrix(wide, candidate).to_numpy()
+        fit = sdid_fit_once(treated[:end + 1], donors[:end + 1], n_pre,
+                            start, end, n_tr=2)
+        assert sdid_att(fit, treated[:end + 1], start, end) == pytest.approx(
+            float(shipped.effects.att), rel=1e-6)
+
+    def test_too_few_donors_gives_nan_sigma(self, arrays):
+        treated, donors, _, _, _, n_pre, start, end = arrays
+        assert np.isnan(placebo_sigma(treated, donors[:, :2], n_pre, start,
+                                      end, n_draws=10, n_tr=2, seed=0))
+
+
+class TestInjectEffect:
+    def test_scales_only_the_post_block(self):
+        y = np.arange(10.0)
+        out = inject_effect(y, 4, 6, 0.5)
+        np.testing.assert_array_equal(out[:4], y[:4])
+        np.testing.assert_array_equal(out[7:], y[7:])
+        np.testing.assert_allclose(out[4:7], y[4:7] * 1.5)
+
+    def test_does_not_mutate_the_input(self):
+        y = np.arange(10.0)
+        before = y.copy()
+        inject_effect(y, 2, 5, 0.3)
+        np.testing.assert_array_equal(y, before)
+
+    @pytest.mark.parametrize("window", [(-1, 3), (5, 4), (8, 12)])
+    def test_invalid_window_raises(self, window):
+        with pytest.raises(MlsynthConfigError):
+            inject_effect(np.arange(10.0), window[0], window[1], 0.1)
+
+
+class TestSimulateLookback:
+    def test_row_schema_and_one_row_per_effect_size(self, arrays):
+        treated, donors, n_periods, duration, sim, *_ = arrays
+        rows = simulate_lookback(treated, donors, n_periods, duration, sim,
+                                 EFFECT_SIZES, n_draws=20, n_tr=2, seed=0)
+        assert len(rows) == len(EFFECT_SIZES)
+        expected = {"sim", "duration", "effect_size", "p_value",
+                    "placebo_mean_effect", "detected_lift", "scaled_l2",
+                    "pre_rmspe", "investment"}
+        for row in rows:
+            assert expected <= set(row)
+            assert 0.0 <= row["p_value"] <= 1.0
+
+    def test_p_value_peaks_at_no_effect(self, arrays):
+        treated, donors, n_periods, duration, sim, *_ = arrays
+        rows = simulate_lookback(treated, donors, n_periods, duration, sim,
+                                 EFFECT_SIZES, n_draws=40, n_tr=2, seed=0)
+        p = {r["effect_size"]: r["p_value"] for r in rows}
+        assert p[0.0] == max(p.values())
+        assert p[0.20] < p[0.10] and p[-0.20] < p[-0.10]
+
+    def test_deterministic_under_a_fixed_seed(self, arrays):
+        treated, donors, n_periods, duration, sim, *_ = arrays
+        kw = dict(n_draws=20, n_tr=2, seed=7)
+        a = simulate_lookback(treated, donors, n_periods, duration, sim,
+                              EFFECT_SIZES, **kw)
+        b = simulate_lookback(treated, donors, n_periods, duration, sim,
+                              EFFECT_SIZES, **kw)
+        assert [r["p_value"] for r in a] == [r["p_value"] for r in b]
+
+    def test_investment_is_nan_without_cpic(self, arrays):
+        treated, donors, n_periods, duration, sim, *_ = arrays
+        rows = simulate_lookback(treated, donors, n_periods, duration, sim,
+                                 [0.1], n_draws=10, n_tr=2, seed=0)
+        assert np.isnan(rows[0]["investment"])
+
+    def test_investment_scales_with_cpic_and_effect(self, arrays):
+        treated, donors, n_periods, duration, sim, *_ = arrays
+        total = treated * 2.0
+        rows = simulate_lookback(treated, donors, n_periods, duration, sim,
+                                 [0.1, 0.2], n_draws=10, n_tr=2, seed=0,
+                                 cpic=3.0, treated_total=total)
+        assert rows[1]["investment"] == pytest.approx(
+            2.0 * rows[0]["investment"])
+
+    def test_mismatched_panel_length_raises(self, arrays):
+        treated, donors, n_periods, duration, sim, *_ = arrays
+        with pytest.raises(MlsynthConfigError, match="n_periods"):
+            simulate_lookback(treated[:-1], donors, n_periods, duration, sim,
+                              EFFECT_SIZES, n_draws=10, n_tr=2, seed=0)
+
+
+class TestRunSimulations:
+    def test_cube_shape_and_columns(self, wide):
+        units = list(wide.columns)
+        cands = [frozenset(units[:2]), frozenset(units[2:4])]
+        cube = run_simulations(wide, cands, [14], 2, EFFECT_SIZES,
+                               n_draws=15, seed=0)
+        assert len(cube) == len(cands) * 1 * 2 * len(EFFECT_SIZES)
+        assert list(cube.columns)[:4] == ["candidate", "duration", "sim",
+                                          "effect_size"]
+
+    def test_empty_candidate_list_gives_an_empty_cube(self, wide):
+        cube = run_simulations(wide, [], [14], 2, EFFECT_SIZES, n_draws=10)
+        assert cube.empty and "p_value" in cube.columns
+
+    @pytest.mark.parametrize("bad", [0, -3, 2.5, True])
+    def test_bad_lookback_window_raises(self, wide, bad):
+        units = list(wide.columns)
+        with pytest.raises(MlsynthConfigError, match="lookback_window"):
+            run_simulations(wide, [frozenset(units[:2])], [14], bad,
+                            EFFECT_SIZES, n_draws=10)
+
+
+class TestConfigValidation:
+    def _base(self, panel, **kw):
+        args = dict(df=panel, unitid="location", time="date", outcome="Y",
+                    treatment_size=2, durations=[14], effect_sizes=[0.1],
+                    lookback_window=2)
+        args.update(kw)
+        return SDIDGEOConfig(**args)
+
+    def test_minimal_config_builds(self, panel):
+        assert self._base(panel).treatment_size == 2
+
+    def test_forbids_unknown_fields(self, panel):
+        with pytest.raises(Exception):
+            self._base(panel, not_a_real_option=1)
+
+    @pytest.mark.parametrize("kw", [
+        {"durations": []}, {"durations": [0]}, {"effect_sizes": []},
+        {"lookback_window": 0}, {"alpha": 0.0}, {"alpha": 1.0},
+        {"power_threshold": 1.5}, {"treatment_size": 0}, {"n_draws": 2},
+    ])
+    def test_invalid_values_raise(self, panel, kw):
+        with pytest.raises(MlsynthConfigError):
+            self._base(panel, **kw)
+
+    def test_budget_without_cpic_raises(self, panel):
+        with pytest.raises(MlsynthConfigError, match="cpic"):
+            self._base(panel, budget=1000.0)
+
+
+class TestEndToEnd:
+    @pytest.fixture(scope="class")
+    def result(self, panel):
+        return SDIDGEO(SDIDGEOConfig(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14], effect_sizes=[-0.15, -0.10, 0.0,
+                                                            0.10, 0.15, 0.20],
+            lookback_window=3, n_draws=25, seed=0,
+        )).fit()
+
+    def test_returns_a_design_result(self, result):
+        assert isinstance(result, DesignResult)
+
+    def test_selects_a_test_region_of_the_requested_size(self, result):
+        assert result.selected_units is not None
+        assert len(result.selected_units) == 2
+        assert result.assignment["treated"] == result.selected_units
+
+    def test_shortlist_is_ranked_and_finite(self, result):
+        shortlist = result.power
+        assert not shortlist.empty
+        assert shortlist["rank"].is_monotonic_increasing
+        assert shortlist["mde"].notna().all()
+
+    def test_design_weights_carry_both_sdid_vectors(self, result):
+        weights = result.design_weights
+        for vector in (weights.donor_weights, weights.time_weights):
+            assert vector, "SDID reports donor and time weights alike"
+            w = np.asarray(list(vector.values()), dtype=float)
+            assert w.min() >= -1e-9
+            assert w.sum() == pytest.approx(1.0, abs=1e-8)
+
+    def test_donor_weights_exclude_the_treated_markets(self, result):
+        assert not (set(result.design_weights.donor_weights)
+                    & set(result.selected_units))
+
+    def test_metadata_reports_the_search(self, result):
+        meta = result.metadata
+        assert meta["treatment_size"] == 2
+        assert meta["n_candidates"] > 0
+        assert meta["pre_periods"] > 0
+
+    def test_report_is_absent_before_the_experiment_runs(self, result):
+        assert result.report is None
+
+    def test_reproducible(self, panel):
+        kw = dict(df=panel, unitid="location", time="date", outcome="Y",
+                  treatment_size=2, durations=[14], effect_sizes=[0.0, 0.15],
+                  lookback_window=2, n_draws=15, seed=3)
+        a = SDIDGEO(SDIDGEOConfig(**kw)).fit()
+        b = SDIDGEO(SDIDGEOConfig(**kw)).fit()
+        assert a.selected_units == b.selected_units
+
+    def test_forced_and_forbidden_markets_are_respected(self, panel):
+        units = sorted(panel["location"].unique())
+        forced, banned = units[0], units[1]
+        res = SDIDGEO(SDIDGEOConfig(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14], effect_sizes=[0.0, 0.15],
+            lookback_window=2, n_draws=15, seed=0,
+            to_be_treated=[forced], not_to_be_treated=[banned],
+        )).fit()
+        assert forced in res.selected_units
+        assert banned not in res.selected_units
+
+
+class TestDegenerateInputs:
+    def test_treatment_size_exceeding_the_panel_raises(self, panel):
+        with pytest.raises(MlsynthConfigError):
+            SDIDGEO(SDIDGEOConfig(
+                df=panel, unitid="location", time="date", outcome="Y",
+                treatment_size=500, durations=[14], effect_sizes=[0.1],
+                lookback_window=2, n_draws=15,
+            )).fit()
+
+    def test_duration_longer_than_the_panel_raises(self, panel):
+        with pytest.raises(MlsynthConfigError):
+            SDIDGEO(SDIDGEOConfig(
+                df=panel, unitid="location", time="date", outcome="Y",
+                treatment_size=2, durations=[500], effect_sizes=[0.1],
+                lookback_window=2, n_draws=15,
+            )).fit()
+
+    def test_unknown_forced_market_raises(self, panel):
+        with pytest.raises((MlsynthConfigError, MlsynthDataError)):
+            SDIDGEO(SDIDGEOConfig(
+                df=panel, unitid="location", time="date", outcome="Y",
+                treatment_size=2, durations=[14], effect_sizes=[0.1],
+                lookback_window=2, n_draws=15, to_be_treated=["atlantis"],
+            )).fit()
+
+    def test_candidate_with_no_donors_left_raises(self, wide):
+        with pytest.raises(MlsynthDataError, match="No donor"):
+            donor_matrix(wide, frozenset(wide.columns))
+
+    def test_unknown_candidate_unit_raises(self, wide):
+        with pytest.raises(MlsynthDataError):
+            aggregate_treated(wide, frozenset(["nowhere"]))
+
+
+class TestPlots:
+    """The design plots: a power curve and the fit behind it."""
+
+    @staticmethod
+    def _agg():
+        import matplotlib
+        matplotlib.use("Agg")
+
+    def test_design_plot_has_both_panels(self, panel):
+        self._agg()
+        from mlsynth import plot_sdidgeo_design
+
+        result = SDIDGEO(SDIDGEOConfig(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14],
+            effect_sizes=[-0.2, -0.1, 0.0, 0.1, 0.2],
+            lookback_window=3, n_draws=20, seed=0,
+        )).fit()
+        fig = plot_sdidgeo_design(result, power_threshold=0.8)
+        assert len(fig.axes) == 2
+        assert "power" in fig.axes[0].get_ylabel().lower()
+        assert fig.axes[1].get_lines(), "the fit panel should draw the series"
+
+    def test_mde_ranking_plot_marks_the_winner(self, panel):
+        self._agg()
+        from mlsynth import plot_mde_ranking
+
+        result = SDIDGEO(SDIDGEOConfig(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14],
+            effect_sizes=[-0.2, -0.1, 0.0, 0.1, 0.2],
+            lookback_window=3, n_draws=20, seed=0,
+        )).fit()
+        fig = plot_mde_ranking(result, top=5)
+        bars = fig.axes[0].patches
+        assert 0 < len(bars) <= 5
+        reds = [b for b in bars if b.get_facecolor()[:3] == (1.0, 0.0, 0.0)]
+        assert len(reds) == 1, "exactly the winning region is highlighted"
+
+    def test_power_table_is_retained_for_the_curve(self, panel):
+        result = SDIDGEO(SDIDGEOConfig(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14], effect_sizes=[0.0, 0.15],
+            lookback_window=2, n_draws=15, seed=0,
+        )).fit()
+        table = result.search.power_table
+        assert not table.empty
+        assert set(table["effect_size"]) == {0.0, 0.15}
+        assert table["power"].between(0.0, 1.0).all()
+
+    def test_plot_without_a_winner_raises(self, panel):
+        self._agg()
+        from mlsynth import plot_mde_ranking, plot_sdidgeo_design
+
+        # An effect grid of only zero detects nothing, so nothing is ranked.
+        result = SDIDGEO(SDIDGEOConfig(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14], effect_sizes=[0.0],
+            lookback_window=2, n_draws=15, seed=0,
+        )).fit()
+        assert result.selected_units is None
+        with pytest.raises(ValueError, match="no winning design"):
+            plot_sdidgeo_design(result)
+        with pytest.raises(ValueError, match="shortlist is empty"):
+            plot_mde_ranking(result)

--- a/mlsynth/tests/test_sdidgeo.py
+++ b/mlsynth/tests/test_sdidgeo.py
@@ -584,3 +584,75 @@ class TestPlaceboWarmStart:
         first = placebo_sigma(treated, donors, n_pre, start, end, **kw)
         second = placebo_sigma(treated, donors, n_pre, start, end, **kw)
         assert first == second
+
+
+class TestHoldoutMDE:
+    """The winner's MDE is a selected minimum; the holdout one is not.
+
+    ``compute_rank`` returns the smallest MDE in the field, so the region most
+    likely to be picked is the one whose estimate came out low by luck. The
+    holdout placements sit deeper in history and take no part in the search, so
+    re-scoring the winner on them gives a figure that was not selected on.
+    """
+
+    def _design(self, panel, **kw):
+        args = dict(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14],
+            effect_sizes=[-0.2, -0.1, 0.0, 0.1, 0.2],
+            lookback_window=4, holdout_placements=4, n_draws=20, seed=0,
+        )
+        args.update(kw)
+        return SDIDGEO(SDIDGEOConfig(**args)).fit()
+
+    def test_both_numbers_are_reported(self, panel):
+        result = self._design(panel)
+        assert result.metadata["winner_mde"] is not None
+        assert result.metadata["winner_mde_holdout"] is not None
+        assert result.metadata["holdout_placements"] == 4
+        assert result.search.winner.mde_holdout == pytest.approx(
+            result.metadata["winner_mde_holdout"])
+
+    def test_holdout_is_an_effect_size_from_the_grid(self, panel):
+        result = self._design(panel)
+        grid = [-0.2, -0.1, 0.0, 0.1, 0.2]
+        assert float(result.metadata["winner_mde_holdout"]) in grid
+
+    def test_disabled_by_zero(self, panel):
+        result = self._design(panel, holdout_placements=0)
+        assert result.metadata["winner_mde_holdout"] is None
+        assert result.search.winner.mde_holdout is None
+        assert result.metadata["winner_mde"] is not None
+
+    def test_only_the_winner_is_rescored(self, panel):
+        """Scoring every candidate on the holdout would reintroduce selection."""
+        result = self._design(panel)
+        rescored = [c for c in result.search.candidates
+                    if c.mde_holdout is not None]
+        assert len(rescored) == 1
+        assert rescored[0].units == result.selected_units
+
+    def test_none_when_the_panel_cannot_carry_the_placements(self, panel):
+        # 105 periods; duration 14 with lookback 8 needs 8 more placements to
+        # reach depth 16, which fits -- so ask for a depth the panel cannot hold.
+        result = self._design(panel, lookback_window=4, holdout_placements=200)
+        assert result.metadata["winner_mde_holdout"] is None
+        assert result.metadata["winner_mde"] is not None
+
+    def test_holdout_uses_placements_the_search_did_not(self, panel):
+        """Changing only the holdout depth must not move the selection."""
+        a = self._design(panel, holdout_placements=4)
+        b = self._design(panel, holdout_placements=6)
+        assert a.selected_units == b.selected_units
+        assert a.metadata["winner_mde"] == b.metadata["winner_mde"]
+
+    @pytest.mark.parametrize("bad", [-1, -10])
+    def test_negative_holdout_raises(self, panel, bad):
+        with pytest.raises(MlsynthConfigError, match="holdout_placements"):
+            self._design(panel, holdout_placements=bad)
+
+    def test_reproducible(self, panel):
+        a = self._design(panel)
+        b = self._design(panel)
+        assert (a.metadata["winner_mde_holdout"]
+                == b.metadata["winner_mde_holdout"])

--- a/mlsynth/tests/test_sdidgeo.py
+++ b/mlsynth/tests/test_sdidgeo.py
@@ -455,3 +455,84 @@ class TestPlots:
             plot_sdidgeo_design(result)
         with pytest.raises(ValueError, match="shortlist is empty"):
             plot_mde_ranking(result)
+
+
+class TestMultipleTreatmentSizes:
+    """``treatment_size`` accepts a list, scanning several region sizes at once.
+
+    GeoLift's ``N = c(2, 3, 4)``: candidates of every requested size are
+    generated, scored on the same grid, and ranked against each other, so a
+    three-market region competes with a two-market one on its MDE.
+    """
+
+    def _design(self, panel, size, **kw):
+        args = dict(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=size, durations=[14],
+            effect_sizes=[-0.2, -0.1, 0.0, 0.1, 0.2],
+            lookback_window=2, n_draws=15, seed=0,
+        )
+        args.update(kw)
+        return SDIDGEO(SDIDGEOConfig(**args)).fit()
+
+    def test_scalar_still_works(self, panel):
+        result = self._design(panel, 2)
+        assert len(result.selected_units) == 2
+        assert {len(c.units) for c in result.search.candidates} == {2}
+
+    def test_list_generates_every_requested_size(self, panel):
+        result = self._design(panel, [2, 3, 4])
+        assert {len(c.units) for c in result.search.candidates} == {2, 3, 4}
+
+    def test_shortlist_reports_the_size_of_each_candidate(self, panel):
+        result = self._design(panel, [2, 3])
+        shortlist = result.power
+        assert "treatment_size" in shortlist.columns
+        for _, row in shortlist.iterrows():
+            assert row["treatment_size"] == len(row["candidate"])
+        assert set(shortlist["treatment_size"]) <= {2, 3}
+
+    def test_sizes_are_ranked_against_each_other(self, panel):
+        """One ranking over the pooled field, not one ranking per size."""
+        result = self._design(panel, [2, 3, 4])
+        shortlist = result.power
+        assert shortlist["rank"].is_monotonic_increasing
+        assert len(shortlist) == shortlist["rank"].count()
+        # The winner is whichever size scored best, so its size must be one of
+        # the requested ones and need not be the smallest.
+        assert len(result.selected_units) in {2, 3, 4}
+
+    def test_metadata_records_the_scanned_sizes(self, panel):
+        result = self._design(panel, [2, 4])
+        assert result.metadata["treatment_sizes"] == [2, 4]
+
+    def test_duplicates_and_order_are_normalised(self, panel):
+        result = self._design(panel, [3, 2, 3])
+        assert result.metadata["treatment_sizes"] == [2, 3]
+
+    def test_each_size_uses_its_own_treated_count(self, panel):
+        """A three-market region must be fit as three treated units.
+
+        ``n_tr`` feeds the SDID ridge as ``(n_tr * T_post)^(1/4)``, so a size
+        mix that ignored it would regularise every candidate identically.
+        """
+        result = self._design(panel, [2, 4])
+        by_size = {len(c.units): c for c in result.search.candidates}
+        assert set(by_size) == {2, 4}
+        for size, design in by_size.items():
+            assert len(design.units) == size
+            assert not set(design.units) & set(design.weights.donor_weights)
+
+    def test_forced_markets_larger_than_a_size_raise(self, panel):
+        units = sorted(panel["location"].unique())
+        with pytest.raises(MlsynthConfigError, match="to_be_treated"):
+            self._design(panel, [2, 3], to_be_treated=units[:3])
+
+    @pytest.mark.parametrize("bad", [[], [0], [2, -1], [2, 0]])
+    def test_invalid_sizes_raise(self, panel, bad):
+        with pytest.raises(MlsynthConfigError):
+            self._design(panel, bad)
+
+    def test_size_exceeding_the_panel_raises(self, panel):
+        with pytest.raises(MlsynthConfigError):
+            self._design(panel, [2, 500])

--- a/mlsynth/tests/test_sdidgeo.py
+++ b/mlsynth/tests/test_sdidgeo.py
@@ -536,3 +536,51 @@ class TestMultipleTreatmentSizes:
     def test_size_exceeding_the_panel_raises(self, panel):
         with pytest.raises(MlsynthConfigError):
             self._design(panel, [2, 500])
+
+
+class TestPlaceboWarmStart:
+    """The placebo loop chains its warm start; the sigma must not move.
+
+    Consecutive draws differ only in which donors were reassigned, so each
+    draw's weights seed the next. ``solve_simplex_qp`` discards an infeasible
+    or wrongly sized seed, so the chain can only change pivot count -- and
+    ``sdid_fit_once`` still solves each placement cold, which gives an
+    independent path to the same number.
+    """
+
+    @staticmethod
+    def _cold_sigma(y, Y0, n_pre, start, end, *, n_draws, n_tr, seed):
+        """The same draws, each refit from scratch through ``sdid_fit_once``."""
+        Y0 = np.asarray(Y0, dtype=float)
+        rng = np.random.default_rng(seed)
+        taus = []
+        for _ in range(n_draws):
+            idx = rng.choice(Y0.shape[1], size=n_tr, replace=False)
+            mask = np.ones(Y0.shape[1], dtype=bool)
+            mask[idx] = False
+            pseudo_y = Y0[:, idx].mean(axis=1)
+            fit = sdid_fit_once(pseudo_y, Y0[:, mask], n_pre, start, end,
+                                n_tr=n_tr)
+            taus.append(sdid_att(fit, pseudo_y, start, end))
+        return float(np.std(np.asarray(taus), ddof=1))
+
+    @pytest.mark.parametrize("sim", [1, 3, 5])
+    def test_chained_sigma_matches_cold_refitting(self, wide, sim):
+        units = list(wide.columns)
+        candidate = frozenset(units[:2])
+        treated = aggregate_treated(wide, candidate, how="mean").to_numpy()
+        donors = donor_matrix(wide, candidate).to_numpy()
+        n_pre = wide.shape[0] - 14 - sim + 1
+        start, end = n_pre, n_pre + 13
+        kw = dict(n_draws=40, n_tr=2, seed=0)
+        assert placebo_sigma(treated, donors, n_pre, start, end,
+                             **kw) == pytest.approx(
+            self._cold_sigma(treated, donors, n_pre, start, end, **kw),
+            rel=1e-9)
+
+    def test_still_deterministic_across_calls(self, arrays):
+        treated, donors, _, _, _, n_pre, start, end = arrays
+        kw = dict(n_draws=30, n_tr=2, seed=4)
+        first = placebo_sigma(treated, donors, n_pre, start, end, **kw)
+        second = placebo_sigma(treated, donors, n_pre, start, end, **kw)
+        assert first == second

--- a/mlsynth/tests/test_sdidgeo.py
+++ b/mlsynth/tests/test_sdidgeo.py
@@ -26,11 +26,11 @@ from mlsynth.config_models import DesignResult, SDIDGEOConfig
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 from mlsynth.utils.sdidgeo_helpers.engine import (
     placebo_sigma, sdid_att, sdid_fit_once)
-from mlsynth.utils.sdidgeo_helpers.simulate import inject_effect, simulate_lookback
+from mlsynth.utils.sdidgeo_helpers.simulate import inject_effect, simulate_backtest
 from mlsynth.utils.sdidgeo_helpers.batch import run_simulations
 from mlsynth.utils.sdidgeo_helpers.shaping import aggregate_treated, donor_matrix
 from mlsynth.utils.sdidgeo_helpers.windows import (
-    lookback_pre_periods, lookback_treatment_window)
+    backtest_pre_periods, backtest_treatment_window)
 
 DATA = Path(__file__).resolve().parents[2] / "basedata" / "geolift_test_data.csv"
 EFFECT_SIZES = [-0.20, -0.10, 0.0, 0.10, 0.20]
@@ -51,37 +51,37 @@ def wide(panel):
 
 @pytest.fixture(scope="module")
 def arrays(wide):
-    """One candidate's treated series, donor pool, and placement."""
+    """One candidate's treated series, donor pool, and backtest."""
     units = list(wide.columns)
     candidate = frozenset(units[:2])
     treated = aggregate_treated(wide, candidate, how="mean").to_numpy()
     donors = donor_matrix(wide, candidate).to_numpy()
     n_periods = wide.shape[0]
     duration, sim = 14, 3
-    n_pre = lookback_pre_periods(n_periods, duration, sim)
-    start, end = lookback_treatment_window(n_periods, duration, sim)
+    n_pre = backtest_pre_periods(n_periods, duration, sim)
+    start, end = backtest_treatment_window(n_periods, duration, sim)
     return treated, donors, n_periods, duration, sim, n_pre, start, end
 
 
 class TestWindows:
-    def test_lookback_matches_geolift_arithmetic(self):
-        assert lookback_pre_periods(100, 15, 1) == 85
-        assert lookback_treatment_window(100, 15, 1) == (85, 99)
-        assert lookback_treatment_window(100, 15, 5) == (81, 95)
+    def test_backtest_window_matches_geolift_arithmetic(self):
+        assert backtest_pre_periods(100, 15, 1) == 85
+        assert backtest_treatment_window(100, 15, 1) == (85, 99)
+        assert backtest_treatment_window(100, 15, 5) == (81, 95)
 
     def test_post_block_length_is_always_the_duration(self):
         for sim in range(1, 6):
-            start, end = lookback_treatment_window(105, 14, sim)
+            start, end = backtest_treatment_window(105, 14, sim)
             assert end - start + 1 == 14
 
     def test_placement_off_the_panel_raises(self):
         with pytest.raises(MlsynthConfigError, match="runs off the start"):
-            lookback_pre_periods(20, 15, 10)
+            backtest_pre_periods(20, 15, 10)
 
     @pytest.mark.parametrize("bad", [0, -1, 2.5, True])
     def test_non_positive_integers_raise(self, bad):
         with pytest.raises(MlsynthConfigError):
-            lookback_pre_periods(100, 15, bad)
+            backtest_pre_periods(100, 15, bad)
 
 
 class TestEngineInvariants:
@@ -190,7 +190,7 @@ class TestInjectEffect:
 class TestSimulateLookback:
     def test_row_schema_and_one_row_per_effect_size(self, arrays):
         treated, donors, n_periods, duration, sim, *_ = arrays
-        rows = simulate_lookback(treated, donors, n_periods, duration, sim,
+        rows = simulate_backtest(treated, donors, n_periods, duration, sim,
                                  EFFECT_SIZES, n_draws=20, n_tr=2, seed=0)
         assert len(rows) == len(EFFECT_SIZES)
         expected = {"sim", "duration", "effect_size", "p_value",
@@ -202,7 +202,7 @@ class TestSimulateLookback:
 
     def test_p_value_peaks_at_no_effect(self, arrays):
         treated, donors, n_periods, duration, sim, *_ = arrays
-        rows = simulate_lookback(treated, donors, n_periods, duration, sim,
+        rows = simulate_backtest(treated, donors, n_periods, duration, sim,
                                  EFFECT_SIZES, n_draws=40, n_tr=2, seed=0)
         p = {r["effect_size"]: r["p_value"] for r in rows}
         assert p[0.0] == max(p.values())
@@ -211,22 +211,22 @@ class TestSimulateLookback:
     def test_deterministic_under_a_fixed_seed(self, arrays):
         treated, donors, n_periods, duration, sim, *_ = arrays
         kw = dict(n_draws=20, n_tr=2, seed=7)
-        a = simulate_lookback(treated, donors, n_periods, duration, sim,
+        a = simulate_backtest(treated, donors, n_periods, duration, sim,
                               EFFECT_SIZES, **kw)
-        b = simulate_lookback(treated, donors, n_periods, duration, sim,
+        b = simulate_backtest(treated, donors, n_periods, duration, sim,
                               EFFECT_SIZES, **kw)
         assert [r["p_value"] for r in a] == [r["p_value"] for r in b]
 
     def test_investment_is_nan_without_cpic(self, arrays):
         treated, donors, n_periods, duration, sim, *_ = arrays
-        rows = simulate_lookback(treated, donors, n_periods, duration, sim,
+        rows = simulate_backtest(treated, donors, n_periods, duration, sim,
                                  [0.1], n_draws=10, n_tr=2, seed=0)
         assert np.isnan(rows[0]["investment"])
 
     def test_investment_scales_with_cpic_and_effect(self, arrays):
         treated, donors, n_periods, duration, sim, *_ = arrays
         total = treated * 2.0
-        rows = simulate_lookback(treated, donors, n_periods, duration, sim,
+        rows = simulate_backtest(treated, donors, n_periods, duration, sim,
                                  [0.1, 0.2], n_draws=10, n_tr=2, seed=0,
                                  cpic=3.0, treated_total=total)
         assert rows[1]["investment"] == pytest.approx(
@@ -235,7 +235,7 @@ class TestSimulateLookback:
     def test_mismatched_panel_length_raises(self, arrays):
         treated, donors, n_periods, duration, sim, *_ = arrays
         with pytest.raises(MlsynthConfigError, match="n_periods"):
-            simulate_lookback(treated[:-1], donors, n_periods, duration, sim,
+            simulate_backtest(treated[:-1], donors, n_periods, duration, sim,
                               EFFECT_SIZES, n_draws=10, n_tr=2, seed=0)
 
 
@@ -254,9 +254,9 @@ class TestRunSimulations:
         assert cube.empty and "p_value" in cube.columns
 
     @pytest.mark.parametrize("bad", [0, -3, 2.5, True])
-    def test_bad_lookback_window_raises(self, wide, bad):
+    def test_bad_n_backtests_raises(self, wide, bad):
         units = list(wide.columns)
-        with pytest.raises(MlsynthConfigError, match="lookback_window"):
+        with pytest.raises(MlsynthConfigError, match="n_backtests"):
             run_simulations(wide, [frozenset(units[:2])], [14], bad,
                             EFFECT_SIZES, n_draws=10)
 
@@ -265,7 +265,7 @@ class TestConfigValidation:
     def _base(self, panel, **kw):
         args = dict(df=panel, unitid="location", time="date", outcome="Y",
                     treatment_size=2, durations=[14], effect_sizes=[0.1],
-                    lookback_window=2)
+                    n_backtests=2)
         args.update(kw)
         return SDIDGEOConfig(**args)
 
@@ -278,7 +278,7 @@ class TestConfigValidation:
 
     @pytest.mark.parametrize("kw", [
         {"durations": []}, {"durations": [0]}, {"effect_sizes": []},
-        {"lookback_window": 0}, {"alpha": 0.0}, {"alpha": 1.0},
+        {"n_backtests": 0}, {"alpha": 0.0}, {"alpha": 1.0},
         {"power_threshold": 1.5}, {"treatment_size": 0}, {"n_draws": 2},
     ])
     def test_invalid_values_raise(self, panel, kw):
@@ -297,7 +297,7 @@ class TestEndToEnd:
             df=panel, unitid="location", time="date", outcome="Y",
             treatment_size=2, durations=[14], effect_sizes=[-0.15, -0.10, 0.0,
                                                             0.10, 0.15, 0.20],
-            lookback_window=3, n_draws=25, seed=0,
+            n_backtests=3, n_draws=25, seed=0,
         )).fit()
 
     def test_returns_a_design_result(self, result):
@@ -338,7 +338,7 @@ class TestEndToEnd:
     def test_reproducible(self, panel):
         kw = dict(df=panel, unitid="location", time="date", outcome="Y",
                   treatment_size=2, durations=[14], effect_sizes=[0.0, 0.15],
-                  lookback_window=2, n_draws=15, seed=3)
+                  n_backtests=2, n_draws=15, seed=3)
         a = SDIDGEO(SDIDGEOConfig(**kw)).fit()
         b = SDIDGEO(SDIDGEOConfig(**kw)).fit()
         assert a.selected_units == b.selected_units
@@ -349,7 +349,7 @@ class TestEndToEnd:
         res = SDIDGEO(SDIDGEOConfig(
             df=panel, unitid="location", time="date", outcome="Y",
             treatment_size=2, durations=[14], effect_sizes=[0.0, 0.15],
-            lookback_window=2, n_draws=15, seed=0,
+            n_backtests=2, n_draws=15, seed=0,
             to_be_treated=[forced], not_to_be_treated=[banned],
         )).fit()
         assert forced in res.selected_units
@@ -362,7 +362,7 @@ class TestDegenerateInputs:
             SDIDGEO(SDIDGEOConfig(
                 df=panel, unitid="location", time="date", outcome="Y",
                 treatment_size=500, durations=[14], effect_sizes=[0.1],
-                lookback_window=2, n_draws=15,
+                n_backtests=2, n_draws=15,
             )).fit()
 
     def test_duration_longer_than_the_panel_raises(self, panel):
@@ -370,7 +370,7 @@ class TestDegenerateInputs:
             SDIDGEO(SDIDGEOConfig(
                 df=panel, unitid="location", time="date", outcome="Y",
                 treatment_size=2, durations=[500], effect_sizes=[0.1],
-                lookback_window=2, n_draws=15,
+                n_backtests=2, n_draws=15,
             )).fit()
 
     def test_unknown_forced_market_raises(self, panel):
@@ -378,7 +378,7 @@ class TestDegenerateInputs:
             SDIDGEO(SDIDGEOConfig(
                 df=panel, unitid="location", time="date", outcome="Y",
                 treatment_size=2, durations=[14], effect_sizes=[0.1],
-                lookback_window=2, n_draws=15, to_be_treated=["atlantis"],
+                n_backtests=2, n_draws=15, to_be_treated=["atlantis"],
             )).fit()
 
     def test_candidate_with_no_donors_left_raises(self, wide):
@@ -406,7 +406,7 @@ class TestPlots:
             df=panel, unitid="location", time="date", outcome="Y",
             treatment_size=2, durations=[14],
             effect_sizes=[-0.2, -0.1, 0.0, 0.1, 0.2],
-            lookback_window=3, n_draws=20, seed=0,
+            n_backtests=3, n_draws=20, seed=0,
         )).fit()
         fig = plot_sdidgeo_design(result, power_threshold=0.8)
         assert len(fig.axes) == 2
@@ -421,7 +421,7 @@ class TestPlots:
             df=panel, unitid="location", time="date", outcome="Y",
             treatment_size=2, durations=[14],
             effect_sizes=[-0.2, -0.1, 0.0, 0.1, 0.2],
-            lookback_window=3, n_draws=20, seed=0,
+            n_backtests=3, n_draws=20, seed=0,
         )).fit()
         fig = plot_mde_ranking(result, top=5)
         bars = fig.axes[0].patches
@@ -433,7 +433,7 @@ class TestPlots:
         result = SDIDGEO(SDIDGEOConfig(
             df=panel, unitid="location", time="date", outcome="Y",
             treatment_size=2, durations=[14], effect_sizes=[0.0, 0.15],
-            lookback_window=2, n_draws=15, seed=0,
+            n_backtests=2, n_draws=15, seed=0,
         )).fit()
         table = result.search.power_table
         assert not table.empty
@@ -448,7 +448,7 @@ class TestPlots:
         result = SDIDGEO(SDIDGEOConfig(
             df=panel, unitid="location", time="date", outcome="Y",
             treatment_size=2, durations=[14], effect_sizes=[0.0],
-            lookback_window=2, n_draws=15, seed=0,
+            n_backtests=2, n_draws=15, seed=0,
         )).fit()
         assert result.selected_units is None
         with pytest.raises(ValueError, match="no winning design"):
@@ -470,7 +470,7 @@ class TestMultipleTreatmentSizes:
             df=panel, unitid="location", time="date", outcome="Y",
             treatment_size=size, durations=[14],
             effect_sizes=[-0.2, -0.1, 0.0, 0.1, 0.2],
-            lookback_window=2, n_draws=15, seed=0,
+            n_backtests=2, n_draws=15, seed=0,
         )
         args.update(kw)
         return SDIDGEO(SDIDGEOConfig(**args)).fit()
@@ -544,7 +544,7 @@ class TestPlaceboWarmStart:
     Consecutive draws differ only in which donors were reassigned, so each
     draw's weights seed the next. ``solve_simplex_qp`` discards an infeasible
     or wrongly sized seed, so the chain can only change pivot count -- and
-    ``sdid_fit_once`` still solves each placement cold, which gives an
+    ``sdid_fit_once`` still solves each backtest cold, which gives an
     independent path to the same number.
     """
 

--- a/mlsynth/utils/sdidgeo_helpers/__init__.py
+++ b/mlsynth/utils/sdidgeo_helpers/__init__.py
@@ -1,0 +1,13 @@
+"""Helpers for SDIDGEO: synthetic difference-in-differences geo experiment design."""
+
+from .config import SDIDGEOConfig
+from .orchestration import run_design
+from .structures import CandidateDesign, MarketSearch, SDIDGEOResults
+
+__all__ = [
+    "SDIDGEOConfig",
+    "run_design",
+    "CandidateDesign",
+    "MarketSearch",
+    "SDIDGEOResults",
+]

--- a/mlsynth/utils/sdidgeo_helpers/aggregate.py
+++ b/mlsynth/utils/sdidgeo_helpers/aggregate.py
@@ -3,8 +3,8 @@
 Pure array/groupby reductions on the long p-value cube from
 :func:`run_simulations`, faithful to ``GeoLiftMarketSelection``:
 
-1. :func:`compute_power` -- collapse the lookback dimension: power = detection
-   rate, plus the lookback-averaged metrics.
+1. :func:`compute_power` -- collapse the backtest dimension: power = detection
+   rate, plus the backtest-averaged metrics.
 2. :func:`compute_mde` -- the minimum detectable effect per (candidate,
    duration), with GeoLift's signed positive/negative selection.
 
@@ -24,10 +24,10 @@ _POWER_COLUMNS = [
 
 
 def compute_power(cube: pd.DataFrame, *, alpha: float = 0.1) -> pd.DataFrame:
-    """Collapse the lookback (``sim``) dimension into power + averaged metrics.
+    """Collapse the backtest (``sim``) dimension into power + averaged metrics.
 
-    Power is the detection rate ``mean(p_value < alpha)`` over the lookback
-    placements; the other quantities are averaged over the same placements
+    Power is the detection rate ``mean(p_value < alpha)`` over the backtest
+    backtests; the other quantities are averaged over the same backtests
     (``scaled_l2`` / ``pre_rmspe`` are constant across ``sim`` only if the panel
     is, so they are averaged for generality).
 
@@ -56,7 +56,7 @@ def compute_power(cube: pd.DataFrame, *, alpha: float = 0.1) -> pd.DataFrame:
         pre_rmspe=("pre_rmspe", "mean"),
     )
     if has_investment:
-        # investment = cpic * es * volume is constant across lookback placements.
+        # investment = cpic * es * volume is constant across backtests.
         aggs["investment"] = ("investment", "mean")
     # sort=False: candidate keys are frozensets (unorderable).
     return tmp.groupby(

--- a/mlsynth/utils/sdidgeo_helpers/aggregate.py
+++ b/mlsynth/utils/sdidgeo_helpers/aggregate.py
@@ -1,0 +1,176 @@
+"""Aggregation of the simulation cube for SDIDGEO market selection.
+
+Pure array/groupby reductions on the long p-value cube from
+:func:`run_simulations`, faithful to ``GeoLiftMarketSelection``:
+
+1. :func:`compute_power` -- collapse the lookback dimension: power = detection
+   rate, plus the lookback-averaged metrics.
+2. :func:`compute_mde` -- the minimum detectable effect per (candidate,
+   duration), with GeoLift's signed positive/negative selection.
+
+(The composite rank is built on top of these.)
+"""
+
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+_POWER_COLUMNS = [
+    "candidate", "duration", "effect_size",
+    "power", "placebo_mean_effect", "detected_lift", "scaled_l2", "pre_rmspe",
+    "investment",
+]
+
+
+def compute_power(cube: pd.DataFrame, *, alpha: float = 0.1) -> pd.DataFrame:
+    """Collapse the lookback (``sim``) dimension into power + averaged metrics.
+
+    Power is the detection rate ``mean(p_value < alpha)`` over the lookback
+    placements; the other quantities are averaged over the same placements
+    (``scaled_l2`` / ``pre_rmspe`` are constant across ``sim`` only if the panel
+    is, so they are averaged for generality).
+
+    Parameters
+    ----------
+    cube : pd.DataFrame
+        Long simulation table from :func:`run_simulations`.
+    alpha : float, default 0.1
+        Significance level for the detection test.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per (candidate, duration, effect_size) with ``power``,
+        ``placebo_mean_effect``, ``scaled_l2``, ``pre_rmspe``.
+    """
+    if cube.empty:
+        return pd.DataFrame(columns=_POWER_COLUMNS)
+    tmp = cube.assign(_detected=(cube["p_value"] < alpha).astype(float))
+    has_investment = "investment" in cube.columns
+    aggs = dict(
+        power=("_detected", "mean"),
+        placebo_mean_effect=("placebo_mean_effect", "mean"),
+        detected_lift=("detected_lift", "mean"),
+        scaled_l2=("scaled_l2", "mean"),
+        pre_rmspe=("pre_rmspe", "mean"),
+    )
+    if has_investment:
+        # investment = cpic * es * volume is constant across lookback placements.
+        aggs["investment"] = ("investment", "mean")
+    # sort=False: candidate keys are frozensets (unorderable).
+    return tmp.groupby(
+        ["candidate", "duration", "effect_size"], as_index=False, sort=False
+    ).agg(**aggs)
+
+
+def compute_mde(power_table: pd.DataFrame, *, power_threshold: float = 0.8) -> pd.DataFrame:
+    """Minimum detectable effect per (candidate, duration).
+
+    Faithful to GeoLift: among effect sizes whose power exceeds
+    ``power_threshold``, take the smallest-magnitude detectable positive and
+    negative effects and keep the smaller magnitude (ties -> positive). If
+    nothing is detectable, the MDE is ``nan``.
+
+    Parameters
+    ----------
+    power_table : pd.DataFrame
+        Output of :func:`compute_power` (needs ``effect_size`` and ``power``).
+    power_threshold : float, default 0.8
+        Power a candidate must exceed to "detect" an effect.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per (candidate, duration) with the signed ``mde``.
+    """
+    if power_table.empty:
+        return pd.DataFrame(columns=["candidate", "duration", "mde"])
+
+    es_min = float(power_table["effect_size"].min())
+    es_max = float(power_table["effect_size"].max())
+
+    rows: List[dict] = []
+    for (candidate, duration), group in power_table.groupby(
+        ["candidate", "duration"], sort=False
+    ):
+        detectable = group.loc[group["power"] > power_threshold, "effect_size"].to_numpy()
+        if detectable.size == 0:
+            mde = float("nan")
+        else:
+            negatives = detectable[detectable < 0]
+            positives = detectable[detectable > 0]
+            # Sentinels mirror GeoLift's min(effect_size)-1 / max(effect_size)+1.
+            negative_mde = float(negatives.max()) if negatives.size else (es_min - 1.0)
+            positive_mde = float(positives.min()) if positives.size else (es_max + 1.0)
+            if positive_mde > abs(negative_mde) and negative_mde != 0:
+                mde = negative_mde
+            else:
+                mde = positive_mde
+        rows.append({"candidate": candidate, "duration": duration, "mde": mde})
+    return pd.DataFrame(rows)
+
+
+_RANK_COLUMNS = [
+    "candidate", "duration", "mde", "power", "detected_lift", "abs_lift_in_zero",
+    "scaled_l2", "pre_rmspe", "investment",
+    "rank_mde", "rank_pvalue", "rank_abszero", "rank",
+]
+
+
+def compute_rank(power_table: pd.DataFrame, *, power_threshold: float = 0.8,
+                 budget: Optional[float] = None) -> pd.DataFrame:
+    """Rank candidate designs, haircut-faithful to ``GeoLiftMarketSelection``.
+
+    Builds the per-(candidate, duration) MDE row, then the GeoLift composite
+    rank: the mean of three ``dense_rank`` components -- ``|mde|``, ``power`` (at
+    the MDE; ascending, as in GeoLift), and ``abs_lift_in_zero`` (the recovery
+    error ``|AvgDetectedLift - mde|`` at the MDE). ``scaled_l2`` / ``pre_rmspe``
+    are carried for reporting but are **not** ranked. Candidates with no
+    detectable effect (``mde`` NaN) are dropped. Lower ``rank`` = better.
+
+    Parameters
+    ----------
+    power_table : pd.DataFrame
+        Output of :func:`compute_power`.
+    power_threshold : float, default 0.8
+        Forwarded to :func:`compute_mde`.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per ranked (candidate, duration), sorted by ``rank``.
+    """
+    if power_table.empty:
+        return pd.DataFrame(columns=_RANK_COLUMNS)
+
+    # CPIC budget gate (GeoLift: filter abs(budget) > abs(Investment)). Drop the
+    # over-budget effect-size rows *before* the MDE, so a candidate whose
+    # cheapest detectable effect still busts the budget falls out entirely.
+    if budget is not None and "investment" in power_table.columns:
+        power_table = power_table[
+            power_table["investment"].abs() < abs(budget)
+        ].copy()
+        if power_table.empty:
+            return pd.DataFrame(columns=_RANK_COLUMNS)
+
+    mde_table = compute_mde(power_table, power_threshold=power_threshold)
+    merged = mde_table.merge(power_table, on=["candidate", "duration"])
+    # Keep only each group's MDE row (drops NaN-MDE groups: NaN != any effect).
+    at_mde = merged[merged["effect_size"] == merged["mde"]].copy()
+    if at_mde.empty:
+        return pd.DataFrame(columns=_RANK_COLUMNS)
+    if "investment" not in at_mde.columns:          # cpic not supplied
+        at_mde["investment"] = float("nan")
+
+    at_mde["abs_lift_in_zero"] = (at_mde["detected_lift"] - at_mde["mde"]).abs().round(3)
+
+    # GeoLift dense ranks (ascending; lower value -> rank 1). Note rank_pvalue
+    # ranks power ascending, i.e. lower power-at-MDE ranks better.
+    at_mde["rank_mde"] = at_mde["mde"].abs().rank(method="dense")
+    at_mde["rank_pvalue"] = at_mde["power"].rank(method="dense")
+    at_mde["rank_abszero"] = at_mde["abs_lift_in_zero"].rank(method="dense")
+    mean_rank = at_mde[["rank_mde", "rank_pvalue", "rank_abszero"]].mean(axis=1)
+    at_mde["rank"] = mean_rank.rank(method="min")
+
+    return at_mde[_RANK_COLUMNS].sort_values("rank").reset_index(drop=True)

--- a/mlsynth/utils/sdidgeo_helpers/batch.py
+++ b/mlsynth/utils/sdidgeo_helpers/batch.py
@@ -1,7 +1,7 @@
 """Batch driver for SDIDGEO market-selection scoring.
 
-Loops the single-placement :func:`~mlsynth.utils.sdidgeo_helpers.simulate.simulate_lookback`
-over the full ``candidates x durations x lookback-windows`` grid and stacks the
+Loops the single-backtest :func:`~mlsynth.utils.sdidgeo_helpers.simulate.simulate_backtest`
+over the full ``candidates x durations x backtests`` grid and stacks the
 rows into one long table, ready for the power -> MDE -> rank aggregation.
 """
 
@@ -12,7 +12,7 @@ import pandas as pd
 
 from ...exceptions import MlsynthConfigError
 from .shaping import aggregate_treated, donor_matrix
-from .simulate import simulate_lookback
+from .simulate import simulate_backtest
 
 _COLUMNS = [
     "candidate", "duration", "sim", "effect_size",
@@ -21,7 +21,7 @@ _COLUMNS = [
 ]
 
 
-def _simulate_candidate(candidate, Ywide, durations, lookback_window,
+def _simulate_candidate(candidate, Ywide, durations, n_backtests,
                         effect_sizes, *, n_periods, n_draws, seed, cpic):
     """Every row for one candidate.
 
@@ -38,8 +38,8 @@ def _simulate_candidate(candidate, Ywide, durations, lookback_window,
     n_tr = len(candidate)
     rows: List[dict] = []
     for duration in durations:
-        for sim in range(1, int(lookback_window) + 1):
-            for row in simulate_lookback(
+        for sim in range(1, int(n_backtests) + 1):
+            for row in simulate_backtest(
                 treated, donors, n_periods, duration, sim, effect_sizes,
                 n_draws=n_draws, n_tr=n_tr, seed=seed, cpic=cpic,
                 treated_total=treated_total,
@@ -53,7 +53,7 @@ def run_simulations(
     Ywide: pd.DataFrame,
     candidates: Iterable[frozenset],
     durations: Iterable[int],
-    lookback_window: int,
+    n_backtests: int,
     effect_sizes: Iterable[float],
     *,
     n_draws: int = 200,
@@ -63,8 +63,8 @@ def run_simulations(
 ) -> pd.DataFrame:
     """Run the simulation grid and stack the results into one long table.
 
-    For each candidate test region, each treatment duration, and each lookback
-    placement ``sim = 1 .. lookback_window``, fit SDID once and sweep the effect
+    For each candidate test region, each treatment duration, and each backtest
+    backtest ``sim = 1 .. n_backtests``, fit SDID once and sweep the effect
     sizes, tagging every row with its candidate.
 
     Returns
@@ -76,15 +76,15 @@ def run_simulations(
     Raises
     ------
     MlsynthConfigError
-        If ``lookback_window`` is not a positive integer, or a placement runs
+        If ``n_backtests`` is not a positive integer, or a backtest runs
         off the start of the panel.
     """
-    if (isinstance(lookback_window, bool)
-            or not isinstance(lookback_window, (int, np.integer))
-            or lookback_window < 1):
+    if (isinstance(n_backtests, bool)
+            or not isinstance(n_backtests, (int, np.integer))
+            or n_backtests < 1):
         raise MlsynthConfigError(
-            f"lookback_window must be a positive integer; got "
-            f"{lookback_window!r}.")
+            f"n_backtests must be a positive integer; got "
+            f"{n_backtests!r}.")
 
     n_periods = Ywide.shape[0]
     candidates = list(candidates)
@@ -92,7 +92,7 @@ def run_simulations(
 
     if n_jobs == 1 or len(candidates) <= 1:
         per_candidate = [
-            _simulate_candidate(c, Ywide, durations, lookback_window,
+            _simulate_candidate(c, Ywide, durations, n_backtests,
                                 effect_sizes, **work)
             for c in candidates
         ]
@@ -103,7 +103,7 @@ def run_simulations(
         from joblib import Parallel, delayed
 
         per_candidate = Parallel(n_jobs=n_jobs)(
-            delayed(_simulate_candidate)(c, Ywide, durations, lookback_window,
+            delayed(_simulate_candidate)(c, Ywide, durations, n_backtests,
                                          effect_sizes, **work)
             for c in candidates
         )

--- a/mlsynth/utils/sdidgeo_helpers/batch.py
+++ b/mlsynth/utils/sdidgeo_helpers/batch.py
@@ -1,0 +1,114 @@
+"""Batch driver for SDIDGEO market-selection scoring.
+
+Loops the single-placement :func:`~mlsynth.utils.sdidgeo_helpers.simulate.simulate_lookback`
+over the full ``candidates x durations x lookback-windows`` grid and stacks the
+rows into one long table, ready for the power -> MDE -> rank aggregation.
+"""
+
+from typing import Iterable, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from ...exceptions import MlsynthConfigError
+from .shaping import aggregate_treated, donor_matrix
+from .simulate import simulate_lookback
+
+_COLUMNS = [
+    "candidate", "duration", "sim", "effect_size",
+    "p_value", "placebo_mean_effect", "detected_lift", "scaled_l2", "pre_rmspe",
+    "investment",
+]
+
+
+def _simulate_candidate(candidate, Ywide, durations, lookback_window,
+                        effect_sizes, *, n_periods, n_draws, seed, cpic):
+    """Every row for one candidate.
+
+    Pure and deterministic given a fixed ``seed``, and defined at module level so
+    it pickles for the joblib backend; the serial path calls it directly.
+
+    SDID fits the *mean* of the treated units, so the candidate is aggregated
+    that way for the fit. The investment volume stays a sum, since cost scales
+    with total treated conversions and not with the per-market average.
+    """
+    treated = aggregate_treated(Ywide, candidate, how="mean").to_numpy()
+    treated_total = aggregate_treated(Ywide, candidate, how="sum").to_numpy()
+    donors = donor_matrix(Ywide, candidate).to_numpy()
+    n_tr = len(candidate)
+    rows: List[dict] = []
+    for duration in durations:
+        for sim in range(1, int(lookback_window) + 1):
+            for row in simulate_lookback(
+                treated, donors, n_periods, duration, sim, effect_sizes,
+                n_draws=n_draws, n_tr=n_tr, seed=seed, cpic=cpic,
+                treated_total=treated_total,
+            ):
+                row["candidate"] = candidate
+                rows.append(row)
+    return rows
+
+
+def run_simulations(
+    Ywide: pd.DataFrame,
+    candidates: Iterable[frozenset],
+    durations: Iterable[int],
+    lookback_window: int,
+    effect_sizes: Iterable[float],
+    *,
+    n_draws: int = 200,
+    seed: int = 0,
+    cpic: Optional[float] = None,
+    n_jobs: int = 1,
+) -> pd.DataFrame:
+    """Run the simulation grid and stack the results into one long table.
+
+    For each candidate test region, each treatment duration, and each lookback
+    placement ``sim = 1 .. lookback_window``, fit SDID once and sweep the effect
+    sizes, tagging every row with its candidate.
+
+    Returns
+    -------
+    pd.DataFrame
+        Long-form table with one row per (candidate, duration, sim, effect
+        size). Empty (with the right columns) when there are no candidates.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``lookback_window`` is not a positive integer, or a placement runs
+        off the start of the panel.
+    """
+    if (isinstance(lookback_window, bool)
+            or not isinstance(lookback_window, (int, np.integer))
+            or lookback_window < 1):
+        raise MlsynthConfigError(
+            f"lookback_window must be a positive integer; got "
+            f"{lookback_window!r}.")
+
+    n_periods = Ywide.shape[0]
+    candidates = list(candidates)
+    work = dict(n_periods=n_periods, n_draws=n_draws, seed=seed, cpic=cpic)
+
+    if n_jobs == 1 or len(candidates) <= 1:
+        per_candidate = [
+            _simulate_candidate(c, Ywide, durations, lookback_window,
+                                effect_sizes, **work)
+            for c in candidates
+        ]
+    else:
+        # Embarrassingly parallel over candidates. joblib preserves input order
+        # and each candidate is pure at the fixed seed, so any worker count
+        # returns the identical table.
+        from joblib import Parallel, delayed
+
+        per_candidate = Parallel(n_jobs=n_jobs)(
+            delayed(_simulate_candidate)(c, Ywide, durations, lookback_window,
+                                         effect_sizes, **work)
+            for c in candidates
+        )
+
+    records = [row for rows in per_candidate for row in rows]
+    if not records:
+        return pd.DataFrame(columns=_COLUMNS)
+    return pd.DataFrame(records)[_COLUMNS]

--- a/mlsynth/utils/sdidgeo_helpers/candidates.py
+++ b/mlsynth/utils/sdidgeo_helpers/candidates.py
@@ -1,0 +1,228 @@
+"""Candidate test-market generation for SDIDGEO market selection.
+
+Port of GeoLift's ``stochastic_market_selector``: turn the ranked-neighbor
+table (Function 1, :func:`rank_markets_by_correlation`) into candidate
+test-market *sets* of a chosen size, ready for the power-analysis scoring
+stage.
+
+The trick that keeps this tractable is GeoLift's: instead of enumerating the
+astronomically many ``choose(N, k)`` subsets, anchor a candidate at each unit
+and take that unit plus its nearest correlated neighbors. With ``L`` units that
+yields ``L`` candidate sets instead of ``choose(L, N)``.
+
+Each candidate set is returned as a :class:`frozenset` of unit labels — order
+is irrelevant for a test region, and immutability makes whole-batch
+de-duplication a one-liner.
+"""
+
+from typing import Iterable, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from mlsynth.exceptions import MlsynthConfigError
+
+
+def _as_generator(
+    rng: Optional[Union[int, np.random.Generator]]
+) -> np.random.Generator:
+    """Coerce ``None`` / an int seed / a Generator into a Generator."""
+    if isinstance(rng, np.random.Generator):
+        return rng
+    return np.random.default_rng(rng)
+
+
+def _generate_from_ranked(
+    ranked: pd.DataFrame,
+    n: int,
+    *,
+    run_stochastic: bool,
+    stochastic_mode: str,
+    rng: Optional[Union[int, np.random.Generator]],
+) -> List[frozenset]:
+    """Core generator: anchor + neighbours from a ranked table, no constraints.
+
+    Assumes ``n >= 1``. Used directly when there are no forced units, and on the
+    free-pool ranked table when there are.
+    """
+    anchors = ranked.index
+    num_units = len(anchors)
+
+    augmented = np.column_stack([anchors.to_numpy(), ranked.to_numpy()])
+
+    if not run_stochastic:
+        if n > num_units:
+            raise MlsynthConfigError(
+                f"treatment_size ({n}) cannot exceed the number of units "
+                f"({num_units}) in deterministic mode."
+            )
+        selected = augmented[:, :n]
+    else:
+        if stochastic_mode not in ("global", "per_anchor"):
+            raise MlsynthConfigError(
+                "stochastic_mode must be 'global' or 'per_anchor'; "
+                f"got {stochastic_mode!r}."
+            )
+        if 2 * n > num_units:
+            raise MlsynthConfigError(
+                f"treatment_size ({n}) must be <= half the number of units "
+                f"({num_units}) in stochastic mode."
+            )
+        generator = _as_generator(rng)
+        tier_base = 2 * np.arange(n)
+        if stochastic_mode == "global":
+            columns = tier_base + generator.integers(0, 2, size=n)
+            selected = augmented[:, columns]
+        else:  # per_anchor
+            coins = generator.integers(0, 2, size=(num_units, n))
+            columns = tier_base[None, :] + coins
+            selected = np.take_along_axis(augmented, columns, axis=1)
+
+    seen: set = set()
+    candidates: List[frozenset] = []
+    for row in selected:
+        candidate = frozenset(row.tolist())
+        if candidate not in seen:
+            seen.add(candidate)
+            candidates.append(candidate)
+    return candidates
+
+
+def generate_candidate_markets(
+    ranked: pd.DataFrame,
+    treatment_size: int,
+    *,
+    to_be_treated: Optional[Iterable] = None,
+    not_to_be_treated: Optional[Iterable] = None,
+    run_stochastic: bool = False,
+    stochastic_mode: str = "global",
+    rng: Optional[Union[int, np.random.Generator]] = None,
+) -> List[frozenset]:
+    """Generate candidate test-market sets from a ranked-neighbor table.
+
+    Parameters
+    ----------
+    ranked : pd.DataFrame
+        Output of :func:`rank_markets_by_correlation`: index is the anchor unit
+        :class:`~pandas.Index`, columns are integer similarity ranks, and each
+        cell holds a neighbor unit id (self excluded, descending correlation).
+    treatment_size : int
+        Number of markets ``N`` in each candidate test set (anchor included).
+    to_be_treated : iterable, optional
+        Units forced into **every** candidate test set (GeoLift's "include"
+        markets). The remaining ``N - len(to_be_treated)`` slots are filled from
+        the free pool. Must not exceed ``treatment_size``.
+    not_to_be_treated : iterable, optional
+        Units forbidden from **any** candidate (GeoLift's "exclude" markets);
+        they remain available as donors. Must be disjoint from ``to_be_treated``.
+    run_stochastic : bool, default False
+        If ``False`` (deterministic), each anchor's set is the anchor plus its
+        top ``N - 1`` neighbors. If ``True``, the set is built by GeoLift's
+        paired-jitter walk over the ranked positions ``{0,1}, {2,3}, ...``,
+        picking one position per pair.
+    stochastic_mode : {"global", "per_anchor"}, default "global"
+        Only used when ``run_stochastic`` is ``True``.
+
+        - ``"global"`` (faithful to GeoLift): one coin per rank-tier, applied to
+          every anchor at once.
+        - ``"per_anchor"`` (corrected): an independent coin per (anchor, tier),
+          so anchors jitter independently. GeoLift's global coin is effectively
+          a bug; this is the intended behavior, kept opt-in for now.
+    rng : int, numpy.random.Generator, or None, optional
+        Seed or generator for the stochastic draws (reproducibility).
+
+    Returns
+    -------
+    list of frozenset
+        De-duplicated candidate test-market sets, each a ``frozenset`` of
+        ``treatment_size`` unit labels.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``treatment_size < 1``; if it exceeds the number of units
+        (deterministic) or half the number of units (stochastic, whose paired
+        walk indexes up to position ``2N - 1``); or if ``stochastic_mode`` is
+        not recognized.
+    """
+    n = treatment_size
+    if n < 1:
+        raise MlsynthConfigError(f"treatment_size must be >= 1; got {n}.")
+
+    units = set(ranked.index)
+    forced_in = frozenset(to_be_treated or ())
+    forced_out = frozenset(not_to_be_treated or ())
+
+    unknown = (forced_in | forced_out) - units
+    if unknown:
+        raise MlsynthConfigError(
+            "to_be_treated/not_to_be_treated contain units not in the panel: "
+            f"{sorted(map(str, unknown))}."
+        )
+    overlap = forced_in & forced_out
+    if overlap:
+        raise MlsynthConfigError(
+            "units cannot be both to_be_treated and not_to_be_treated: "
+            f"{sorted(map(str, overlap))}."
+        )
+    if len(forced_in) > n:
+        raise MlsynthConfigError(
+            f"to_be_treated ({len(forced_in)}) cannot exceed treatment_size ({n})."
+        )
+
+    # No constraints: the plain anchor + neighbours generator.
+    if not (forced_in or forced_out):
+        return _generate_from_ranked(
+            ranked, n, run_stochastic=run_stochastic,
+            stochastic_mode=stochastic_mode, rng=rng,
+        )
+
+    # Forced-in units fully specify the test set: use it directly.
+    if forced_in and len(forced_in) == n:
+        return [frozenset(forced_in)]
+
+    # GeoLift's generate-then-filter (``pre_test_power.R``): generate candidates
+    # from the full ranked table with only the *forbidden* (``not_to_be_treated``)
+    # units removed -- those stay donors -- then keep the candidates that already
+    # contain every forced-in (``include``) unit. GeoLift runs
+    # ``stochastic_market_selector`` ignoring ``include_markets`` and filters the
+    # result afterwards, so a forced unit is never welded onto an anchor it is
+    # uncorrelated with: only correlation-natural sets survive. (Re-attaching the
+    # forced unit to every anchor's neighbourhood -- the previous approach --
+    # manufactured low-correlation candidates GeoLift never forms.)
+    pool = [u for u in ranked.index if u not in forced_out]
+    if n > len(pool):
+        raise MlsynthConfigError(
+            f"free pool ({len(pool)}) too small for {n} market(s) "
+            f"(treatment_size {n} after removing "
+            f"{len(forced_out)} not_to_be_treated)."
+        )
+
+    # Restrict each anchor's neighbour list to the pool (uniform length, since
+    # every unit appears in every original row).
+    pool_set = set(pool)
+    rows = [
+        [neighbor for neighbor in ranked.loc[anchor].tolist()
+         if neighbor in pool_set]
+        for anchor in pool
+    ]
+    filtered_ranked = pd.DataFrame(
+        rows, index=pd.Index(pool, name=ranked.index.name)
+    )
+    filtered_ranked.columns = range(1, filtered_ranked.shape[1] + 1)
+
+    generated = _generate_from_ranked(
+        filtered_ranked, n, run_stochastic=run_stochastic,
+        stochastic_mode=stochastic_mode, rng=rng,
+    )
+    if not forced_in:                       # only not_to_be_treated given
+        return generated
+
+    kept = [c for c in generated if forced_in <= c]
+    if not kept:
+        raise MlsynthConfigError(
+            "no correlation-natural candidate contains all to_be_treated units "
+            f"{sorted(map(str, forced_in))} at treatment_size {n}; increase "
+            "treatment_size or reduce to_be_treated."
+        )
+    return kept

--- a/mlsynth/utils/sdidgeo_helpers/config.py
+++ b/mlsynth/utils/sdidgeo_helpers/config.py
@@ -7,7 +7,7 @@ plus panel validation) and adds the market-selection knobs.
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from pydantic import Field, model_validator
 
@@ -19,8 +19,11 @@ class SDIDGEOConfig(BaseMAREXConfig):
     """Configuration for the SDIDGEO market-selection design."""
 
     # --- candidate test region ---
-    treatment_size: int = Field(
-        ..., description="Number of markets to treat (test-region size)."
+    treatment_size: Union[int, List[int]] = Field(
+        ...,
+        description="Number of markets to treat. A list scans several region "
+        "sizes in one run (e.g. [2, 3, 4]) and ranks them against each other, "
+        "as GeoLift's N = c(2, 3, 4) does.",
     )
     to_be_treated: Optional[List] = Field(
         default=None, description="Markets forced into every candidate region."
@@ -94,11 +97,33 @@ class SDIDGEOConfig(BaseMAREXConfig):
         "at the fixed seed, so any worker count returns the same shortlist.",
     )
 
+    @property
+    def treatment_sizes(self) -> List[int]:
+        """The requested region sizes, sorted and de-duplicated.
+
+        A scalar ``treatment_size`` reads as a one-element scan, so the rest of
+        the pipeline never has to branch on which form was given.
+        """
+        raw = (self.treatment_size if isinstance(self.treatment_size, list)
+               else [self.treatment_size])
+        return sorted({int(n) for n in raw})
+
     @model_validator(mode="after")
     def _validate_grid(self) -> "SDIDGEOConfig":
-        if self.treatment_size < 1:
+        sizes = (self.treatment_size if isinstance(self.treatment_size, list)
+                 else [self.treatment_size])
+        if not sizes:
+            raise MlsynthConfigError("treatment_size must not be empty.")
+        if any(int(n) < 1 for n in sizes):
             raise MlsynthConfigError(
-                f"treatment_size must be >= 1; got {self.treatment_size}.")
+                f"every treatment_size must be >= 1; got {self.treatment_size}.")
+        forced = len(self.to_be_treated or ())
+        too_small = [int(n) for n in sizes if int(n) < forced]
+        if too_small:
+            raise MlsynthConfigError(
+                f"to_be_treated names {forced} market(s), which does not fit a "
+                f"region of size {too_small}. Drop those sizes or shorten "
+                "to_be_treated.")
         if not self.durations or any(d < 1 for d in self.durations):
             raise MlsynthConfigError(
                 "durations must be a non-empty list of positive integers.")

--- a/mlsynth/utils/sdidgeo_helpers/config.py
+++ b/mlsynth/utils/sdidgeo_helpers/config.py
@@ -68,13 +68,13 @@ class SDIDGEOConfig(BaseMAREXConfig):
     power_threshold: float = Field(
         default=0.8, description="Power an effect must exceed to count as detected."
     )
-    holdout_placements: int = Field(
+    n_validation_backtests: int = Field(
         default=8,
-        description="Extra lookback placements, deeper in history, used only to "
+        description="Extra backtests, deeper in history, used only to "
         "re-score the winning region after it has been chosen. The reported "
         "MDE is the smallest in a field of candidates, so it is optimistic for "
         "the same reason the best of many noisy estimates is: the region most "
-        "likely to be picked is the one that got lucky. These placements take "
+        "likely to be picked is the one that got lucky. These backtests take "
         "no part in the selection, so the MDE they give for the winner is not "
         "selected on and is the number to plan against. Set to 0 to skip, at "
         "the cost of having only the optimistic figure.",
@@ -149,10 +149,10 @@ class SDIDGEOConfig(BaseMAREXConfig):
         if not 0.0 < self.power_threshold < 1.0:
             raise MlsynthConfigError(
                 f"power_threshold must be in (0, 1); got {self.power_threshold}.")
-        if self.holdout_placements < 0:
+        if self.n_validation_backtests < 0:
             raise MlsynthConfigError(
-                "holdout_placements must be >= 0; got "
-                f"{self.holdout_placements}.")
+                "n_validation_backtests must be >= 0; got "
+                f"{self.n_validation_backtests}.")
         if self.n_draws < 3:
             raise MlsynthConfigError(
                 "n_draws must be at least 3 for a placebo standard error; got "

--- a/mlsynth/utils/sdidgeo_helpers/config.py
+++ b/mlsynth/utils/sdidgeo_helpers/config.py
@@ -68,6 +68,17 @@ class SDIDGEOConfig(BaseMAREXConfig):
     power_threshold: float = Field(
         default=0.8, description="Power an effect must exceed to count as detected."
     )
+    holdout_placements: int = Field(
+        default=8,
+        description="Extra lookback placements, deeper in history, used only to "
+        "re-score the winning region after it has been chosen. The reported "
+        "MDE is the smallest in a field of candidates, so it is optimistic for "
+        "the same reason the best of many noisy estimates is: the region most "
+        "likely to be picked is the one that got lucky. These placements take "
+        "no part in the selection, so the MDE they give for the winner is not "
+        "selected on and is the number to plan against. Set to 0 to skip, at "
+        "the cost of having only the optimistic figure.",
+    )
     n_draws: int = Field(
         default=200,
         description="Placebo draws behind each standard error (Arkhangelsky "
@@ -138,6 +149,10 @@ class SDIDGEOConfig(BaseMAREXConfig):
         if not 0.0 < self.power_threshold < 1.0:
             raise MlsynthConfigError(
                 f"power_threshold must be in (0, 1); got {self.power_threshold}.")
+        if self.holdout_placements < 0:
+            raise MlsynthConfigError(
+                "holdout_placements must be >= 0; got "
+                f"{self.holdout_placements}.")
         if self.n_draws < 3:
             raise MlsynthConfigError(
                 "n_draws must be at least 3 for a placebo standard error; got "

--- a/mlsynth/utils/sdidgeo_helpers/config.py
+++ b/mlsynth/utils/sdidgeo_helpers/config.py
@@ -55,9 +55,9 @@ class SDIDGEOConfig(BaseMAREXConfig):
     effect_sizes: List[float] = Field(
         ..., description="Effect sizes to inject, as proportional lifts."
     )
-    lookback_window: int = Field(
+    n_backtests: int = Field(
         default=5,
-        description="Backward pseudo-treatment placements per (candidate, "
+        description="backtests per (candidate, "
         "duration).",
     )
 
@@ -129,9 +129,9 @@ class SDIDGEOConfig(BaseMAREXConfig):
                 "durations must be a non-empty list of positive integers.")
         if not self.effect_sizes:
             raise MlsynthConfigError("effect_sizes must be non-empty.")
-        if self.lookback_window < 1:
+        if self.n_backtests < 1:
             raise MlsynthConfigError(
-                f"lookback_window must be >= 1; got {self.lookback_window}.")
+                f"n_backtests must be >= 1; got {self.n_backtests}.")
         if not 0.0 < self.alpha < 1.0:
             raise MlsynthConfigError(
                 f"alpha must be in (0, 1); got {self.alpha}.")

--- a/mlsynth/utils/sdidgeo_helpers/config.py
+++ b/mlsynth/utils/sdidgeo_helpers/config.py
@@ -1,0 +1,128 @@
+"""Configuration for the SDIDGEO geo-experiment design.
+
+Co-located with the helper package (mirrors MAREX / lexscm). Inherits the
+experimental-design base :class:`BaseMAREXConfig` (df / outcome / unitid / time
+plus panel validation) and adds the market-selection knobs.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import Field, model_validator
+
+from ...config_models import BaseMAREXConfig
+from ...exceptions import MlsynthConfigError
+
+
+class SDIDGEOConfig(BaseMAREXConfig):
+    """Configuration for the SDIDGEO market-selection design."""
+
+    # --- candidate test region ---
+    treatment_size: int = Field(
+        ..., description="Number of markets to treat (test-region size)."
+    )
+    to_be_treated: Optional[List] = Field(
+        default=None, description="Markets forced into every candidate region."
+    )
+    not_to_be_treated: Optional[List] = Field(
+        default=None,
+        description="Markets barred from any candidate; they remain donors.",
+    )
+    run_stochastic: bool = Field(
+        default=False,
+        description="Sample each candidate's neighbours from adjacent "
+        "correlation tiers instead of taking the top ones deterministically.",
+    )
+    stochastic_mode: str = Field(
+        default="global",
+        description="'global' draws one tier pattern for every anchor; "
+        "'per_anchor' draws a fresh one per anchor.",
+    )
+    post_col: Optional[str] = Field(
+        default=None,
+        description="Column flagging post-treatment periods. Absent, the whole "
+        "panel is treated as pre-period history to simulate over.",
+    )
+
+    # --- simulation grid ---
+    durations: List[int] = Field(
+        ..., description="Treatment durations (periods) to scan."
+    )
+    effect_sizes: List[float] = Field(
+        ..., description="Effect sizes to inject, as proportional lifts."
+    )
+    lookback_window: int = Field(
+        default=5,
+        description="Backward pseudo-treatment placements per (candidate, "
+        "duration).",
+    )
+
+    # --- inference and decision rule ---
+    alpha: float = Field(
+        default=0.1, description="Significance level for detection."
+    )
+    power_threshold: float = Field(
+        default=0.8, description="Power an effect must exceed to count as detected."
+    )
+    n_draws: int = Field(
+        default=200,
+        description="Placebo draws behind each standard error (Arkhangelsky "
+        "et al. Algorithm 4).",
+    )
+
+    # --- budgeting ---
+    cpic: Optional[float] = Field(
+        default=None,
+        description="Cost per incremental conversion. When set, the required "
+        "investment = cpic x effect_size x summed-treated-volume is reported.",
+    )
+    budget: Optional[float] = Field(
+        default=None,
+        description="Spend cap. When set (with cpic), candidates whose "
+        "detectable investment exceeds it are dropped from the design.",
+    )
+
+    # --- execution ---
+    seed: int = Field(
+        default=0,
+        description="RNG seed for candidate sampling and placebo draws.",
+    )
+    n_jobs: int = Field(
+        default=1,
+        description="Worker processes over candidates. Each candidate is pure "
+        "at the fixed seed, so any worker count returns the same shortlist.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_grid(self) -> "SDIDGEOConfig":
+        if self.treatment_size < 1:
+            raise MlsynthConfigError(
+                f"treatment_size must be >= 1; got {self.treatment_size}.")
+        if not self.durations or any(d < 1 for d in self.durations):
+            raise MlsynthConfigError(
+                "durations must be a non-empty list of positive integers.")
+        if not self.effect_sizes:
+            raise MlsynthConfigError("effect_sizes must be non-empty.")
+        if self.lookback_window < 1:
+            raise MlsynthConfigError(
+                f"lookback_window must be >= 1; got {self.lookback_window}.")
+        if not 0.0 < self.alpha < 1.0:
+            raise MlsynthConfigError(
+                f"alpha must be in (0, 1); got {self.alpha}.")
+        if not 0.0 < self.power_threshold < 1.0:
+            raise MlsynthConfigError(
+                f"power_threshold must be in (0, 1); got {self.power_threshold}.")
+        if self.n_draws < 3:
+            raise MlsynthConfigError(
+                "n_draws must be at least 3 for a placebo standard error; got "
+                f"{self.n_draws}.")
+        if self.stochastic_mode not in ("global", "per_anchor"):
+            raise MlsynthConfigError(
+                "stochastic_mode must be 'global' or 'per_anchor'; got "
+                f"{self.stochastic_mode!r}.")
+        if self.budget is not None and self.cpic is None:
+            raise MlsynthConfigError(
+                "budget needs cpic: without a cost per incremental conversion "
+                "there is no investment to compare the budget against.")
+        return self

--- a/mlsynth/utils/sdidgeo_helpers/engine.py
+++ b/mlsynth/utils/sdidgeo_helpers/engine.py
@@ -1,0 +1,213 @@
+"""The SDID scoring engine for SDIDGEO.
+
+One synthetic difference-in-differences fit on a pseudo-experiment, plus the
+placebo standard error its p-value is read against.
+
+SDID (Arkhangelsky, Athey, Hirshberg, Imbens & Wager 2021) estimates the ATT as
+a doubly weighted difference in differences: unit weights ``omega`` match the
+donors to the treated pre-period trajectory, and time weights ``lambda`` match
+the pre-periods to the post-period donor average. The estimate is
+
+.. math::
+
+   \\hat\\tau = \\big(\\bar y_{post} - \\lambda' y_{pre}\\big)
+              - \\big(\\omega' \\bar Y_{0,post} - \\lambda' Y_{0,pre}\\omega\\big),
+
+which rearranges to a per-period path: the counterfactual is
+``Y0 @ omega + bias_correction`` with ``bias_correction = lambda' y_pre -
+lambda' Y0_pre omega``, and the effect at ``t`` is the gap against it. That is
+the same decomposition
+:func:`mlsynth.utils.sdid_helpers.cohort.estimate_cohort_sdid_effects` uses, so
+the design is scored by the estimator that will analyse the experiment.
+
+Two structural properties make the power sweep cheap, and both are consequences
+of where the weights get their information:
+
+* :func:`~mlsynth.utils.sdid_helpers.weights.unit_weights` reads the treated
+  *pre*-period trajectory, :func:`~mlsynth.utils.sdid_helpers.weights.fit_time_weights`
+  reads only donors, and
+  :func:`~mlsynth.utils.sdid_helpers.weights.compute_regularization` reads only
+  donors and counts. No program sees the treated post block, so injecting an
+  effect there cannot move ``omega`` or ``lambda`` and
+
+  .. math:: \\hat\\tau(e) = \\hat\\tau(0) + e \\cdot \\bar y_{post}
+
+  holds exactly. The effect-size sweep is arithmetic, not refitting.
+* The placebo draws reassign *control* units as pseudo-treated, so the injected
+  effect never enters them. One placebo run covers the whole sweep.
+
+Both are pinned in ``tests/test_sdidgeo.py`` against brute-force recomputation.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+from ..sdid_helpers.weights import (
+    compute_regularization, fit_time_weights, unit_weights)
+
+
+@dataclass
+class SDIDFit:
+    """One SDID fit on a pseudo-experiment's pre-period.
+
+    Attributes
+    ----------
+    omega : np.ndarray, shape (J,)
+        Unit (donor) weights; non-negative and summing to one.
+    lam : np.ndarray, shape (T0,)
+        Time weights over the placement's pre-period.
+    bias_correction : float
+        ``lambda' y_pre - lambda' Y0_pre omega``, the difference-in-differences
+        level term that turns ``Y0 @ omega`` into a counterfactual path.
+    counterfactual : np.ndarray, shape (T,)
+        ``Y0 @ omega + bias_correction`` over every period of the panel.
+    pre_rmspe : float
+        Root mean squared pre-period gap against the counterfactual.
+    scaled_l2 : float
+        ``pre_rmspe`` as a fraction of the treated series' own pre-period
+        standard deviation, so it compares across candidates of different size.
+    zeta : float
+        The unit-weight ridge (:func:`compute_regularization`). SDID's analogue
+        of augmented SCM's penalty, but closed form instead of cross-validated.
+    """
+
+    omega: np.ndarray
+    lam: np.ndarray
+    bias_correction: float
+    counterfactual: np.ndarray
+    pre_rmspe: float
+    scaled_l2: float
+    zeta: float
+
+    def tau_path(self, y) -> np.ndarray:
+        """Per-period effect ``y - counterfactual`` over every period."""
+        return np.asarray(y, dtype=float).ravel() - self.counterfactual
+
+
+def sdid_fit_once(y, Y0, n_pre: int, start: int, end: int,
+                  n_tr: int = 1) -> SDIDFit:
+    """Fit SDID once on the placement ``[:n_pre]`` / ``[start:end+1]``.
+
+    Parameters
+    ----------
+    y : array-like, shape (T,)
+        Treated (aggregated candidate) outcomes over the full panel.
+    Y0 : array-like, shape (T, J)
+        Donor outcomes over the full panel.
+    n_pre : int
+        Number of pre-treatment periods.
+    start, end : int
+        Inclusive 0-indexed bounds of the pseudo-treatment block.
+    n_tr : int
+        Number of treated units, which enters the ridge as
+        ``(n_tr * T_post)^(1/4)`` (``synthdid``'s ``eta.omega``).
+
+    Returns
+    -------
+    SDIDFit
+
+    Raises
+    ------
+    MlsynthConfigError
+        If the window is malformed or a weight program fails to converge.
+    MlsynthDataError
+        If the donor pool is empty.
+    """
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    if Y0.ndim != 2 or Y0.shape[0] != y.shape[0]:
+        raise MlsynthConfigError(
+            f"Y0 must be (T, J) with T={y.shape[0]}; got shape {Y0.shape}.")
+    if Y0.shape[1] == 0:
+        raise MlsynthDataError("SDID needs at least one donor unit.")
+    if not (0 < n_pre <= start <= end < y.shape[0]):
+        raise MlsynthConfigError(
+            f"invalid placement: n_pre={n_pre}, window=[{start}, {end}] for a "
+            f"panel of length {y.shape[0]}.")
+
+    y_pre, Y0_pre = y[:n_pre], Y0[:n_pre]
+    zeta = compute_regularization(Y0_pre, int(end - start + 1), int(n_tr))
+    _, omega = unit_weights(Y0_pre, y_pre, zeta)
+    _, lam = fit_time_weights(Y0_pre, Y0[start:end + 1].mean(axis=0))
+    if omega is None or lam is None:  # pragma: no cover - solver failure
+        raise MlsynthConfigError(
+            "an SDID weight program failed to converge on this placement.")
+    omega = np.asarray(omega, dtype=float).ravel()
+    lam = np.asarray(lam, dtype=float).ravel()
+
+    bias_correction = float(lam @ y_pre - lam @ (Y0_pre @ omega))
+    counterfactual = Y0 @ omega + bias_correction
+
+    pre_gap = y_pre - counterfactual[:n_pre]
+    pre_rmspe = float(np.sqrt(np.mean(pre_gap ** 2)))
+    spread = float(np.std(y_pre))
+    scaled_l2 = pre_rmspe / spread if spread > 0 else float("nan")
+
+    return SDIDFit(omega=omega, lam=lam, bias_correction=bias_correction,
+                   counterfactual=counterfactual, pre_rmspe=pre_rmspe,
+                   scaled_l2=scaled_l2, zeta=float(zeta))
+
+
+def sdid_att(fit: SDIDFit, y, start: int, end: int) -> float:
+    """The SDID ATT over ``[start, end]``: the mean per-period effect."""
+    return float(np.mean(fit.tau_path(y)[start:end + 1]))
+
+
+def placebo_sigma(y, Y0, n_pre: int, start: int, end: int, *,
+                  n_draws: int = 200, n_tr: int = 1, seed: int = 0) -> float:
+    """Placebo standard error of the ATT (Arkhangelsky et al., Algorithm 4).
+
+    Reassigns ``n_tr`` donors as pseudo-treated, drops them from the donor pool,
+    reruns the full SDID fit, and takes the standard deviation of the resulting
+    ATTs. This is the only one of the paper's three variance procedures defined
+    for a single treated series, which is what a candidate test region collapses
+    to, and it is what ``synthdid`` defaults to for that case.
+
+    The treated series is never read, so the returned sigma is the null
+    distribution's scale and does not depend on any injected effect.
+
+    Returns
+    -------
+    float
+        The placebo standard error, or ``nan`` when the donor pool is too small
+        to draw from or too few draws converge.
+    """
+    Y0 = np.asarray(Y0, dtype=float)
+    n_donors = Y0.shape[1]
+    if n_donors <= n_tr + 1:
+        return float("nan")
+
+    rng = np.random.default_rng(seed)
+    taus: List[float] = []
+    for _ in range(int(n_draws)):
+        idx = rng.choice(n_donors, size=int(n_tr), replace=False)
+        mask = np.ones(n_donors, dtype=bool)
+        mask[idx] = False
+        pseudo_y = Y0[:, idx].mean(axis=1)
+        try:
+            fit = sdid_fit_once(pseudo_y, Y0[:, mask], n_pre, start, end,
+                                n_tr=n_tr)
+        except (MlsynthConfigError, MlsynthDataError, ValueError):
+            continue  # a degenerate draw contributes nothing
+        taus.append(sdid_att(fit, pseudo_y, start, end))
+
+    if len(taus) < 3:
+        return float("nan")
+    return float(np.std(np.asarray(taus), ddof=1))
+
+
+def normal_p_value(tau: float, sigma: Optional[float]) -> float:
+    """Two-sided p-value ``2 (1 - Phi(|tau| / sigma))`` for the null of no effect.
+
+    SDID's variance procedures deliver a standard error, so detection is a
+    normal-approximation test, not the conformal permutation test an augmented
+    SCM design would use.
+    """
+    from math import erfc, sqrt
+
+    if sigma is None or not np.isfinite(sigma) or sigma <= 0:
+        return float("nan")
+    return float(erfc(abs(float(tau)) / (float(sigma) * sqrt(2.0))))

--- a/mlsynth/utils/sdidgeo_helpers/engine.py
+++ b/mlsynth/utils/sdidgeo_helpers/engine.py
@@ -46,7 +46,8 @@ import numpy as np
 
 from ...exceptions import MlsynthConfigError, MlsynthDataError
 from ..sdid_helpers.weights import (
-    compute_regularization, fit_time_weights, unit_weights)
+    _solve_intercept_simplex, compute_regularization, fit_time_weights,
+    unit_weights)
 
 
 @dataclass
@@ -182,17 +183,35 @@ def placebo_sigma(y, Y0, n_pre: int, start: int, end: int, *,
 
     rng = np.random.default_rng(seed)
     taus: List[float] = []
+    # Consecutive draws differ only in which donors were reassigned, so the
+    # previous draw's weights seed the next one's active set. Shapes are
+    # constant within a placement, so the chain never breaks. The seed only
+    # changes how many pivots a solve takes: solve_simplex_qp discards one that
+    # is infeasible or the wrong length, so the optimum is untouched.
+    prev_omega = prev_lam = None
     for _ in range(int(n_draws)):
         idx = rng.choice(n_donors, size=int(n_tr), replace=False)
         mask = np.ones(n_donors, dtype=bool)
         mask[idx] = False
         pseudo_y = Y0[:, idx].mean(axis=1)
+        pY0 = Y0[:, mask]
+        pre = pY0[:n_pre]
         try:
-            fit = sdid_fit_once(pseudo_y, Y0[:, mask], n_pre, start, end,
-                                n_tr=n_tr)
+            zeta = compute_regularization(pre, int(end - start + 1), int(n_tr))
+            # Posed exactly as unit_weights / fit_time_weights pose them, so a
+            # chained draw solves the same programs the unchained one did.
+            _, omega = _solve_intercept_simplex(
+                pre, pseudo_y[:n_pre], n_pre * float(zeta) ** 2,
+                warm_start=prev_omega)
+            _, lam = _solve_intercept_simplex(
+                pre.T, pY0[start:end + 1].mean(axis=0), 0.0,
+                warm_start=prev_lam)
         except (MlsynthConfigError, MlsynthDataError, ValueError):
             continue  # a degenerate draw contributes nothing
-        taus.append(sdid_att(fit, pseudo_y, start, end))
+        prev_omega, prev_lam = omega, lam
+        bias = float(lam @ pseudo_y[:n_pre] - lam @ (pre @ omega))
+        gap = pseudo_y - (pY0 @ omega + bias)
+        taus.append(float(np.mean(gap[start:end + 1])))
 
     if len(taus) < 3:
         return float("nan")

--- a/mlsynth/utils/sdidgeo_helpers/engine.py
+++ b/mlsynth/utils/sdidgeo_helpers/engine.py
@@ -59,7 +59,7 @@ class SDIDFit:
     omega : np.ndarray, shape (J,)
         Unit (donor) weights; non-negative and summing to one.
     lam : np.ndarray, shape (T0,)
-        Time weights over the placement's pre-period.
+        Time weights over the backtest's pre-period.
     bias_correction : float
         ``lambda' y_pre - lambda' Y0_pre omega``, the difference-in-differences
         level term that turns ``Y0 @ omega`` into a counterfactual path.
@@ -90,7 +90,7 @@ class SDIDFit:
 
 def sdid_fit_once(y, Y0, n_pre: int, start: int, end: int,
                   n_tr: int = 1) -> SDIDFit:
-    """Fit SDID once on the placement ``[:n_pre]`` / ``[start:end+1]``.
+    """Fit SDID once on the backtest ``[:n_pre]`` / ``[start:end+1]``.
 
     Parameters
     ----------
@@ -126,7 +126,7 @@ def sdid_fit_once(y, Y0, n_pre: int, start: int, end: int,
         raise MlsynthDataError("SDID needs at least one donor unit.")
     if not (0 < n_pre <= start <= end < y.shape[0]):
         raise MlsynthConfigError(
-            f"invalid placement: n_pre={n_pre}, window=[{start}, {end}] for a "
+            f"invalid backtest window: n_pre={n_pre}, window=[{start}, {end}] for a "
             f"panel of length {y.shape[0]}.")
 
     y_pre, Y0_pre = y[:n_pre], Y0[:n_pre]
@@ -135,7 +135,7 @@ def sdid_fit_once(y, Y0, n_pre: int, start: int, end: int,
     _, lam = fit_time_weights(Y0_pre, Y0[start:end + 1].mean(axis=0))
     if omega is None or lam is None:  # pragma: no cover - solver failure
         raise MlsynthConfigError(
-            "an SDID weight program failed to converge on this placement.")
+            "an SDID weight program failed to converge on this backtest.")
     omega = np.asarray(omega, dtype=float).ravel()
     lam = np.asarray(lam, dtype=float).ravel()
 
@@ -185,7 +185,7 @@ def placebo_sigma(y, Y0, n_pre: int, start: int, end: int, *,
     taus: List[float] = []
     # Consecutive draws differ only in which donors were reassigned, so the
     # previous draw's weights seed the next one's active set. Shapes are
-    # constant within a placement, so the chain never breaks. The seed only
+    # constant within a backtest, so the chain never breaks. The seed only
     # changes how many pivots a solve takes: solve_simplex_qp discards one that
     # is infeasible or the wrong length, so the optimum is untouched.
     prev_omega = prev_lam = None

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -67,10 +67,11 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
     n_periods = Ywide.shape[0]
     units = list(Ywide.columns)
 
-    if config.treatment_size >= len(units):
+    sizes = config.treatment_sizes
+    if max(sizes) >= len(units):
         raise MlsynthConfigError(
-            f"treatment_size ({config.treatment_size}) must leave at least one "
-            f"donor market; the panel has {len(units)}.")
+            f"every treatment_size must leave at least one donor market; the "
+            f"panel has {len(units)} and the largest requested is {max(sizes)}.")
 
     longest = max(config.durations)
     if longest + config.lookback_window - 1 >= n_periods:
@@ -86,14 +87,23 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
         raise MlsynthDataError(f"markets not found in the panel: {unknown}.")
 
     ranked = rank_markets_by_correlation(Ywide)
-    candidates = generate_candidate_markets(
-        ranked, config.treatment_size,
-        to_be_treated=config.to_be_treated,
-        not_to_be_treated=config.not_to_be_treated,
-        run_stochastic=config.run_stochastic,
-        stochastic_mode=config.stochastic_mode,
-        rng=config.seed,
-    )
+    # One nomination pass per requested size, pooled into a single field. A
+    # size-3 region competes with a size-2 one on the same ranking, which is
+    # the point of scanning sizes together.
+    candidates: List[frozenset] = []
+    seen = set()
+    for size in sizes:
+        for candidate in generate_candidate_markets(
+            ranked, size,
+            to_be_treated=config.to_be_treated,
+            not_to_be_treated=config.not_to_be_treated,
+            run_stochastic=config.run_stochastic,
+            stochastic_mode=config.stochastic_mode,
+            rng=config.seed,
+        ):
+            if candidate not in seen:
+                seen.add(candidate)
+                candidates.append(candidate)
     if not candidates:
         raise MlsynthConfigError(
             "no candidate test region satisfies the constraints; relax "
@@ -108,6 +118,11 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
     shortlist = compute_rank(power_table,
                              power_threshold=config.power_threshold,
                              budget=config.budget)
+    if not shortlist.empty:
+        # Surface the region size next to its MDE, so a size scan is readable
+        # without unpacking the candidate frozensets.
+        shortlist.insert(1, "treatment_size",
+                         shortlist["candidate"].map(len).astype(int))
 
     # Deployable fit per candidate, with the design window at the end of history.
     deploy_duration = max(config.durations)
@@ -151,6 +166,7 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
         metadata={
             "n_candidates": len(designs),
             "treatment_size": config.treatment_size,
+            "treatment_sizes": sizes,
             "pre_periods": prep["pre_periods"],
             "post_col": prep["post_col"],
             "n_draws": config.n_draws,

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -1,0 +1,161 @@
+"""End-to-end assembly for the SDIDGEO design.
+
+``run_design`` wires the pipeline together:
+
+    geoex_dataprep -> rank_markets_by_correlation -> generate_candidate_markets
+    -> run_simulations -> compute_power -> compute_rank -> design_fit
+    -> SDIDGEOResults
+"""
+
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from ...config_models import WeightsResults
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+from ..datautils import geoex_dataprep
+from .aggregate import compute_power, compute_rank
+from .batch import run_simulations
+from .candidates import generate_candidate_markets
+from .config import SDIDGEOConfig
+from .engine import sdid_fit_once
+from .shaping import aggregate_treated, donor_matrix
+from .similarity import rank_markets_by_correlation
+from .structures import CandidateDesign, MarketSearch, SDIDGEOResults
+
+
+def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
+               duration: int) -> CandidateDesign:
+    """Deployable SDID design for one candidate, fit on the full pre-period.
+
+    The scoring stage fits each lookback placement; this fits the design the
+    experiment will actually deploy, with the pseudo-treatment window sitting at
+    the end of the observed history.
+    """
+    treated = aggregate_treated(Ywide, candidate, how="mean").to_numpy()
+    donors_df = donor_matrix(Ywide, candidate)
+    donors = donors_df.to_numpy()
+    start = n_pre
+    end = min(n_pre + duration - 1, Ywide.shape[0] - 1)
+    fit = sdid_fit_once(treated, donors, n_pre, start, end,
+                        n_tr=len(candidate))
+    # SDID carries two weight vectors, so both go into the standard container:
+    # donors over markets, and lambda over the pre-period dates.
+    weights = WeightsResults(
+        donor_weights={str(name): float(w)
+                       for name, w in zip(donors_df.columns, fit.omega)},
+        time_weights={period: float(w)
+                      for period, w in zip(Ywide.index[:n_pre], fit.lam)},
+    )
+    return CandidateDesign(
+        units=sorted(map(str, candidate)),
+        weights=weights,
+        observed=treated,
+        counterfactual=fit.counterfactual,
+        n_pre=int(n_pre),
+        pre_rmspe=fit.pre_rmspe,
+        scaled_l2=fit.scaled_l2,
+    )
+
+
+def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
+    """Run the full SDIDGEO market-selection design from a config."""
+    prep = geoex_dataprep(config.df, config.unitid, config.time,
+                          config.outcome, post_col=config.post_col)
+    Ywide = prep["Ywide"]
+    n_periods = Ywide.shape[0]
+    units = list(Ywide.columns)
+
+    if config.treatment_size >= len(units):
+        raise MlsynthConfigError(
+            f"treatment_size ({config.treatment_size}) must leave at least one "
+            f"donor market; the panel has {len(units)}.")
+
+    longest = max(config.durations)
+    if longest + config.lookback_window - 1 >= n_periods:
+        raise MlsynthConfigError(
+            f"the deepest lookback placement (duration {longest}, sim "
+            f"{config.lookback_window}) leaves no pre-period in a panel of "
+            f"{n_periods} periods. Shorten durations or lookback_window.")
+
+    forced = list(config.to_be_treated or ())
+    unknown = [u for u in forced + list(config.not_to_be_treated or ())
+               if u not in units]
+    if unknown:
+        raise MlsynthDataError(f"markets not found in the panel: {unknown}.")
+
+    ranked = rank_markets_by_correlation(Ywide)
+    candidates = generate_candidate_markets(
+        ranked, config.treatment_size,
+        to_be_treated=config.to_be_treated,
+        not_to_be_treated=config.not_to_be_treated,
+        run_stochastic=config.run_stochastic,
+        stochastic_mode=config.stochastic_mode,
+        rng=config.seed,
+    )
+    if not candidates:
+        raise MlsynthConfigError(
+            "no candidate test region satisfies the constraints; relax "
+            "to_be_treated / not_to_be_treated or the treatment_size.")
+
+    cube = run_simulations(
+        Ywide, candidates, config.durations, config.lookback_window,
+        config.effect_sizes, n_draws=config.n_draws, seed=config.seed,
+        cpic=config.cpic, n_jobs=config.n_jobs,
+    )
+    power_table = compute_power(cube, alpha=config.alpha)
+    shortlist = compute_rank(power_table,
+                             power_threshold=config.power_threshold,
+                             budget=config.budget)
+
+    # Deployable fit per candidate, with the design window at the end of history.
+    deploy_duration = max(config.durations)
+    n_pre_deploy = n_periods - deploy_duration
+    designs: Dict[frozenset, CandidateDesign] = {
+        c: design_fit(Ywide, c, n_pre_deploy, deploy_duration)
+        for c in candidates
+    }
+
+    # Stitch each candidate's best (lowest-rank) shortlist row into its design.
+    best: Dict[frozenset, dict] = {}
+    for _, row in shortlist.iterrows():
+        cand = row["candidate"]
+        if cand not in best or row["rank"] < best[cand]["rank"]:
+            best[cand] = {"rank": row["rank"], "mde": row["mde"],
+                          "power": row["power"]}
+    for cand, design in designs.items():
+        match = best.get(cand)
+        if match is not None:
+            design.rank = float(match["rank"])
+            design.mde = float(match["mde"])
+            design.power = float(match["power"])
+
+    winner = None
+    winner_units = None
+    if not shortlist.empty:
+        winning = shortlist.sort_values("rank").iloc[0]["candidate"]
+        winner = designs[winning]
+        winner_units = sorted(map(str, winning))
+
+    search = MarketSearch(shortlist=shortlist, power_table=power_table,
+                          candidates=list(designs.values()), winner=winner)
+
+    return SDIDGEOResults(
+        report=None,  # realized once post-treatment outcomes are observed
+        power=shortlist,
+        selected_units=winner_units,
+        assignment=({"treated": winner_units}
+                    if winner_units is not None else None),
+        design_weights=(winner.weights if winner is not None else None),
+        metadata={
+            "n_candidates": len(designs),
+            "treatment_size": config.treatment_size,
+            "pre_periods": prep["pre_periods"],
+            "post_col": prep["post_col"],
+            "n_draws": config.n_draws,
+            "winner_mde": (float(winner.mde) if winner is not None
+                           and winner.mde is not None else None),
+        },
+        search=search,
+    )

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -29,7 +29,7 @@ def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
                duration: int) -> CandidateDesign:
     """Deployable SDID design for one candidate, fit on the full pre-period.
 
-    The scoring stage fits each lookback placement; this fits the design the
+    The scoring stage fits each backtest; this fits the design the
     experiment will actually deploy, with the pseudo-treatment window sitting at
     the end of the observed history.
     """
@@ -74,11 +74,11 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
             f"panel has {len(units)} and the largest requested is {max(sizes)}.")
 
     longest = max(config.durations)
-    if longest + config.lookback_window - 1 >= n_periods:
+    if longest + config.n_backtests - 1 >= n_periods:
         raise MlsynthConfigError(
-            f"the deepest lookback placement (duration {longest}, sim "
-            f"{config.lookback_window}) leaves no pre-period in a panel of "
-            f"{n_periods} periods. Shorten durations or lookback_window.")
+            f"the deepest backtest (duration {longest}, sim "
+            f"{config.n_backtests}) leaves no pre-period in a panel of "
+            f"{n_periods} periods. Shorten durations or n_backtests.")
 
     forced = list(config.to_be_treated or ())
     unknown = [u for u in forced + list(config.not_to_be_treated or ())
@@ -110,7 +110,7 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
             "to_be_treated / not_to_be_treated or the treatment_size.")
 
     cube = run_simulations(
-        Ywide, candidates, config.durations, config.lookback_window,
+        Ywide, candidates, config.durations, config.n_backtests,
         config.effect_sizes, n_draws=config.n_draws, seed=config.seed,
         cpic=config.cpic, n_jobs=config.n_jobs,
     )

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -15,12 +15,13 @@ import pandas as pd
 from ...config_models import WeightsResults
 from ...exceptions import MlsynthConfigError, MlsynthDataError
 from ..datautils import geoex_dataprep
-from .aggregate import compute_power, compute_rank
+from .aggregate import compute_mde, compute_power, compute_rank
 from .batch import run_simulations
 from .candidates import generate_candidate_markets
 from .config import SDIDGEOConfig
 from .engine import sdid_fit_once
 from .shaping import aggregate_treated, donor_matrix
+from .simulate import simulate_lookback
 from .similarity import rank_markets_by_correlation
 from .structures import CandidateDesign, MarketSearch, SDIDGEOResults
 
@@ -57,6 +58,54 @@ def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
         pre_rmspe=fit.pre_rmspe,
         scaled_l2=fit.scaled_l2,
     )
+
+
+
+def holdout_mde(Ywide: pd.DataFrame, candidate, config: SDIDGEOConfig,
+                power_table: pd.DataFrame) -> Optional[float]:
+    """The winner's MDE re-scored on placements that did not choose it.
+
+    ``compute_rank`` hands back the smallest MDE in the field, and the smallest
+    of many noisy estimates is optimistic: the region most likely to be picked
+    is the one whose estimate happened to come out low. Re-scoring the winner on
+    placements held back from the search removes that, because those placements
+    played no part in selecting it -- the same reason a region fixed in advance
+    is calibrated at any lookback depth.
+
+    Placements ``lookback_window + 1 .. lookback_window + holdout_placements``
+    sit deeper in history, so their pseudo-treatment windows differ from every
+    window the search used. Returns ``None`` when the panel cannot carry them.
+    """
+    if config.holdout_placements < 1:
+        return None
+    n_periods = Ywide.shape[0]
+    longest = max(config.durations)
+    deepest = config.lookback_window + config.holdout_placements
+    if longest + deepest - 1 >= n_periods:
+        return None  # the panel cannot carry the extra placements
+
+    treated = aggregate_treated(Ywide, candidate, how="mean").to_numpy()
+    donors = donor_matrix(Ywide, candidate).to_numpy()
+    rows: List[dict] = []
+    for duration in config.durations:
+        for sim in range(config.lookback_window + 1, deepest + 1):
+            for row in simulate_lookback(
+                treated, donors, n_periods, duration, sim, config.effect_sizes,
+                n_draws=config.n_draws, n_tr=len(candidate), seed=config.seed,
+            ):
+                row["candidate"] = candidate
+                rows.append(row)
+    if not rows:  # pragma: no cover - guarded by the depth check above
+        return None
+
+    held = compute_power(pd.DataFrame(rows), alpha=config.alpha)
+    mde_table = compute_mde(held, power_threshold=config.power_threshold)
+    values = mde_table["mde"].dropna()
+    if values.empty:
+        return None  # nothing detectable on the held-back placements
+    # Across durations, the design deploys the one it ranked best; take the
+    # smallest magnitude, matching how compute_rank reads a candidate's row.
+    return float(values.loc[values.abs().idxmin()])
 
 
 def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
@@ -152,6 +201,9 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
         winning = shortlist.sort_values("rank").iloc[0]["candidate"]
         winner = designs[winning]
         winner_units = sorted(map(str, winning))
+        # Scored only now, and only for the winner, so the placements behind it
+        # cannot have influenced which region was picked.
+        winner.mde_holdout = holdout_mde(Ywide, winning, config, power_table)
 
     search = MarketSearch(shortlist=shortlist, power_table=power_table,
                           candidates=list(designs.values()), winner=winner)
@@ -172,6 +224,12 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
             "n_draws": config.n_draws,
             "winner_mde": (float(winner.mde) if winner is not None
                            and winner.mde is not None else None),
+            # The same region scored on placements that did not select it. Plan
+            # against this one; winner_mde is the optimistic end.
+            "winner_mde_holdout": (
+                float(winner.mde_holdout) if winner is not None
+                and winner.mde_holdout is not None else None),
+            "holdout_placements": config.holdout_placements,
         },
         search=search,
     )

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -21,7 +21,7 @@ from .candidates import generate_candidate_markets
 from .config import SDIDGEOConfig
 from .engine import sdid_fit_once
 from .shaping import aggregate_treated, donor_matrix
-from .simulate import simulate_lookback
+from .simulate import simulate_backtest
 from .similarity import rank_markets_by_correlation
 from .structures import CandidateDesign, MarketSearch, SDIDGEOResults
 
@@ -61,35 +61,35 @@ def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
 
 
 
-def holdout_mde(Ywide: pd.DataFrame, candidate, config: SDIDGEOConfig,
+def planning_mde(Ywide: pd.DataFrame, candidate, config: SDIDGEOConfig,
                 power_table: pd.DataFrame) -> Optional[float]:
-    """The winner's MDE re-scored on placements that did not choose it.
+    """The winner's MDE re-scored on backtests that did not choose it.
 
     ``compute_rank`` hands back the smallest MDE in the field, and the smallest
     of many noisy estimates is optimistic: the region most likely to be picked
     is the one whose estimate happened to come out low. Re-scoring the winner on
-    placements held back from the search removes that, because those placements
+    backtests held back from the search removes that, because those backtests
     played no part in selecting it -- the same reason a region fixed in advance
-    is calibrated at any lookback depth.
+    is calibrated at any backtest count.
 
-    Placements ``lookback_window + 1 .. lookback_window + holdout_placements``
+    Backtests ``n_backtests + 1 .. n_backtests + n_validation_backtests``
     sit deeper in history, so their pseudo-treatment windows differ from every
     window the search used. Returns ``None`` when the panel cannot carry them.
     """
-    if config.holdout_placements < 1:
+    if config.n_validation_backtests < 1:
         return None
     n_periods = Ywide.shape[0]
     longest = max(config.durations)
-    deepest = config.lookback_window + config.holdout_placements
+    deepest = config.n_backtests + config.n_validation_backtests
     if longest + deepest - 1 >= n_periods:
-        return None  # the panel cannot carry the extra placements
+        return None  # the panel cannot carry the extra backtests
 
     treated = aggregate_treated(Ywide, candidate, how="mean").to_numpy()
     donors = donor_matrix(Ywide, candidate).to_numpy()
     rows: List[dict] = []
     for duration in config.durations:
-        for sim in range(config.lookback_window + 1, deepest + 1):
-            for row in simulate_lookback(
+        for sim in range(config.n_backtests + 1, deepest + 1):
+            for row in simulate_backtest(
                 treated, donors, n_periods, duration, sim, config.effect_sizes,
                 n_draws=config.n_draws, n_tr=len(candidate), seed=config.seed,
             ):
@@ -102,7 +102,7 @@ def holdout_mde(Ywide: pd.DataFrame, candidate, config: SDIDGEOConfig,
     mde_table = compute_mde(held, power_threshold=config.power_threshold)
     values = mde_table["mde"].dropna()
     if values.empty:
-        return None  # nothing detectable on the held-back placements
+        return None  # nothing detectable on the held-back backtests
     # Across durations, the design deploys the one it ranked best; take the
     # smallest magnitude, matching how compute_rank reads a candidate's row.
     return float(values.loc[values.abs().idxmin()])
@@ -201,9 +201,9 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
         winning = shortlist.sort_values("rank").iloc[0]["candidate"]
         winner = designs[winning]
         winner_units = sorted(map(str, winning))
-        # Scored only now, and only for the winner, so the placements behind it
+        # Scored only now, and only for the winner, so the backtests behind it
         # cannot have influenced which region was picked.
-        winner.mde_holdout = holdout_mde(Ywide, winning, config, power_table)
+        winner.mde_planning = planning_mde(Ywide, winning, config, power_table)
 
     search = MarketSearch(shortlist=shortlist, power_table=power_table,
                           candidates=list(designs.values()), winner=winner)
@@ -222,14 +222,17 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
             "pre_periods": prep["pre_periods"],
             "post_col": prep["post_col"],
             "n_draws": config.n_draws,
-            "winner_mde": (float(winner.mde) if winner is not None
-                           and winner.mde is not None else None),
-            # The same region scored on placements that did not select it. Plan
+            # The smallest MDE in the field, so the region most likely to be
+            # picked is the one whose estimate came out low by luck.
+            "winner_mde_optimistic": (
+                float(winner.mde) if winner is not None
+                and winner.mde is not None else None),
+            # The same region scored on backtests that did not select it. Plan
             # against this one; winner_mde is the optimistic end.
-            "winner_mde_holdout": (
-                float(winner.mde_holdout) if winner is not None
-                and winner.mde_holdout is not None else None),
-            "holdout_placements": config.holdout_placements,
+            "winner_mde_planning": (
+                float(winner.mde_planning) if winner is not None
+                and winner.mde_planning is not None else None),
+            "n_validation_backtests": config.n_validation_backtests,
         },
         search=search,
     )

--- a/mlsynth/utils/sdidgeo_helpers/plotter.py
+++ b/mlsynth/utils/sdidgeo_helpers/plotter.py
@@ -64,10 +64,18 @@ def _power_panel(ax, result, power_threshold):
     if winner_design is not None and winner_design.mde is not None:
         mde = float(winner_design.mde)
         ax.axvline(mde, color="red", ls=":", lw=1.4, zorder=2)
-        # Anchored above the curve so it clears the legend in the lower right.
+        # Anchored above the curve so it clears the legend below.
         ax.annotate(f"MDE {mde:+.2f}", xy=(mde, 1.0),
                     xytext=(5, -12), textcoords="offset points",
                     color="red", fontsize=9, va="top", ha="left")
+        # The planning figure sits beside it, so the gap between what the
+        # search selected and what it can be held to is visible.
+        if winner_design.mde_planning is not None:
+            plan = float(winner_design.mde_planning)
+            ax.axvline(plan, color="darkorange", ls="-.", lw=1.4, zorder=2)
+            ax.annotate(f"planning {plan:+.2f}", xy=(plan, 1.0),
+                        xytext=(5, -26), textcoords="offset points",
+                        color="darkorange", fontsize=9, va="top", ha="left")
 
     ax.set_xlabel("Injected effect size (proportional lift)")
     ax.set_ylabel("Power (detection rate across backtests)")
@@ -139,10 +147,15 @@ def plot_sdidgeo_design(
         _power_panel(axes[0], result, power_threshold)
         _fit_panel(axes[1], result)
         units = " + ".join(result.selected_units or ())
-        mde = result.metadata.get("winner_mde")
         title = f"SDIDGEO design — {units}"
-        if mde is not None:
-            title += f"   (MDE {mde:+.2f})"
+        # Both figures, since the optimistic one is what the search selected on
+        # and the planning one is what to budget against.
+        optimistic = result.metadata.get("winner_mde_optimistic")
+        planning = result.metadata.get("winner_mde_planning")
+        if optimistic is not None:
+            title += f"   MDE {optimistic:+.2f} selected"
+            if planning is not None:
+                title += f", {planning:+.2f} planning"
         fig.suptitle(title, fontsize=12)
         return _finish(fig, save_path, show)
 

--- a/mlsynth/utils/sdidgeo_helpers/plotter.py
+++ b/mlsynth/utils/sdidgeo_helpers/plotter.py
@@ -70,9 +70,9 @@ def _power_panel(ax, result, power_threshold):
                     color="red", fontsize=9, va="top", ha="left")
 
     ax.set_xlabel("Injected effect size (proportional lift)")
-    ax.set_ylabel("Power (detection rate across placements)")
+    ax.set_ylabel("Power (detection rate across backtests)")
     ax.set_ylim(-0.03, 1.03)
-    ax.set_title("Simulated power across lookback placements")
+    ax.set_title("Simulated power across backtests")
     ax.legend(frameon=False, loc="lower center", fontsize=8)
 
 

--- a/mlsynth/utils/sdidgeo_helpers/plotter.py
+++ b/mlsynth/utils/sdidgeo_helpers/plotter.py
@@ -1,0 +1,179 @@
+"""Plots for an SDIDGEO design.
+
+Two views, matching what GeoLift shows for a market selection:
+
+- the power curve, power against injected effect size, with the detection
+  threshold and the minimum detectable effect marked, and every other candidate
+  drawn faintly behind so the winner is placed among the alternatives;
+- the fit being bought, the test region's aggregate against its synthetic
+  counterfactual over the pre-period.
+
+Both render in the mlsynth house style (:func:`mlsynth_style`); pass ``theme``
+to override.
+"""
+
+from typing import Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from ..plotting import mlsynth_style
+
+
+def _finish(fig, save_path, show):
+    fig.tight_layout()
+    if save_path:
+        fig.savefig(save_path, dpi=140, bbox_inches="tight")
+    if show:  # pragma: no cover - interactive
+        plt.show()
+    return fig
+
+
+def _label(candidate) -> str:
+    return " + ".join(sorted(map(str, candidate)))
+
+
+def _power_panel(ax, result, power_threshold):
+    """Power against effect size: the winner in front, the field behind."""
+    table = result.search.power_table
+    winner_units = result.selected_units
+    winner_key = None
+    for candidate in table["candidate"].unique():
+        if sorted(map(str, candidate)) == list(winner_units or ()):
+            winner_key = candidate
+            break
+
+    for candidate, group in table.groupby("candidate", sort=False):
+        if candidate is winner_key:
+            continue
+        curve = group.groupby("effect_size")["power"].mean().sort_index()
+        ax.plot(curve.index, curve.values, color="0.8", lw=0.7, alpha=0.45,
+                zorder=1)
+
+    if winner_key is not None:
+        best = table[table["candidate"] == winner_key]
+        curve = best.groupby("effect_size")["power"].mean().sort_index()
+        ax.plot(curve.index, curve.values, color="black", lw=2.0, zorder=3,
+                marker="o", ms=3.5, label=_label(winner_key))
+
+    ax.axhline(power_threshold, color="red", ls="--", lw=1.2, zorder=2,
+               label=f"power threshold ({power_threshold:g})")
+    ax.axvline(0.0, color="0.5", lw=0.8, zorder=0)
+
+    winner_design = result.search.winner
+    if winner_design is not None and winner_design.mde is not None:
+        mde = float(winner_design.mde)
+        ax.axvline(mde, color="red", ls=":", lw=1.4, zorder=2)
+        # Anchored above the curve so it clears the legend in the lower right.
+        ax.annotate(f"MDE {mde:+.2f}", xy=(mde, 1.0),
+                    xytext=(5, -12), textcoords="offset points",
+                    color="red", fontsize=9, va="top", ha="left")
+
+    ax.set_xlabel("Injected effect size (proportional lift)")
+    ax.set_ylabel("Power (detection rate across placements)")
+    ax.set_ylim(-0.03, 1.03)
+    ax.set_title("Simulated power across lookback placements")
+    ax.legend(frameon=False, loc="lower center", fontsize=8)
+
+
+def _fit_panel(ax, result, index=None):
+    """The test region's aggregate against its synthetic counterfactual."""
+    winner = result.search.winner
+    if winner is None:  # pragma: no cover - guarded by the caller
+        return
+    cf = np.asarray(winner.counterfactual, dtype=float)
+    observed = getattr(winner, "observed", None)
+    x = index if index is not None else np.arange(cf.shape[0])
+
+    if observed is not None:
+        ax.plot(x, np.asarray(observed, dtype=float), color="black", lw=1.5,
+                label="Test markets (observed)")
+    ax.plot(x, cf, color="red", ls="--", lw=1.5, label="Synthetic control")
+
+    n_pre = getattr(winner, "n_pre", None)
+    if n_pre is not None and 0 < n_pre < cf.shape[0]:
+        ax.axvline(x[n_pre], color="0.4", lw=1.0, ls=":")
+
+    ax.set_xlabel("Time")
+    ax.set_ylabel("Outcome")
+    ax.set_title(f"Design fit (pre-period scaled L2 {winner.scaled_l2:.3f})")
+    ax.legend(frameon=False, fontsize=8)
+
+
+def plot_sdidgeo_design(
+    result, *, power_threshold: float = 0.8, theme=None,
+    figsize=(12, 4.8), save_path: Optional[str] = None, show: bool = False,
+):
+    """Plot an SDIDGEO design: the power curve and the fit it rests on.
+
+    Parameters
+    ----------
+    result : SDIDGEOResults
+        The design returned by ``SDIDGEO(...).fit()``.
+    power_threshold : float, default 0.8
+        Threshold line to draw; match the config used for the design.
+    theme : dict or str, optional
+        rcParams dict or named Matplotlib style overriding the house style.
+    figsize : tuple, default (12, 4.8)
+    save_path : str, optional
+        Write the figure here.
+    show : bool, default False
+        Call ``plt.show()`` before returning.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+
+    Raises
+    ------
+    ValueError
+        If no candidate cleared the power threshold, so there is no design.
+    """
+    if result.search is None or result.search.winner is None:
+        raise ValueError(
+            "no winning design to plot: no candidate cleared the power "
+            "threshold. Widen effect_sizes or lower power_threshold.")
+
+    with mlsynth_style(theme):
+        fig, axes = plt.subplots(1, 2, figsize=figsize)
+        _power_panel(axes[0], result, power_threshold)
+        _fit_panel(axes[1], result)
+        units = " + ".join(result.selected_units or ())
+        mde = result.metadata.get("winner_mde")
+        title = f"SDIDGEO design — {units}"
+        if mde is not None:
+            title += f"   (MDE {mde:+.2f})"
+        fig.suptitle(title, fontsize=12)
+        return _finish(fig, save_path, show)
+
+
+def plot_mde_ranking(
+    result, *, top: int = 12, theme=None, figsize=(8, 5),
+    save_path: Optional[str] = None, show: bool = False,
+):
+    """Rank the shortlisted test regions by minimum detectable effect.
+
+    The market-selection view: which regions can detect the smallest lift, with
+    the chosen one highlighted.
+    """
+    shortlist = result.power
+    if shortlist is None or shortlist.empty:
+        raise ValueError("the shortlist is empty: no candidate cleared the "
+                         "power threshold.")
+
+    best = (shortlist.sort_values("rank")
+            .drop_duplicates(subset="candidate")
+            .head(int(top))[::-1])
+    labels = [_label(c) for c in best["candidate"]]
+    values = best["mde"].abs().to_numpy()
+    winner_units = list(result.selected_units or ())
+    colours = ["red" if sorted(map(str, c)) == winner_units else "0.65"
+               for c in best["candidate"]]
+
+    with mlsynth_style(theme):
+        fig, ax = plt.subplots(figsize=figsize)
+        ax.barh(labels, values, color=colours)
+        ax.set_xlabel("Minimum detectable effect (absolute)")
+        ax.set_title("Candidate test regions, best first")
+        ax.tick_params(axis="y", labelsize=8)
+        return _finish(fig, save_path, show)

--- a/mlsynth/utils/sdidgeo_helpers/shaping.py
+++ b/mlsynth/utils/sdidgeo_helpers/shaping.py
@@ -1,0 +1,83 @@
+"""Data-shaping helpers for SDIDGEO market-selection scoring.
+
+Given the canonical wide panel (``geoex_dataprep(...)["Ywide"]``) and a candidate
+test-market set, produce the two arrays one SCM fit needs: the aggregated
+treated series and the donor pool. Each helper does a single trivial reshaping
+step — and nothing else — so they stay easy to reason about, debug, and test.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+import pandas as pd
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+
+
+def _validate_candidate(Ywide: pd.DataFrame, candidate: Iterable) -> List:
+    """Return the candidate's members; reject empty or unknown-unit candidates."""
+    members = list(candidate)
+    if len(members) == 0:
+        raise MlsynthConfigError("candidate must contain at least one unit.")
+    missing = [unit for unit in members if unit not in Ywide.columns]
+    if missing:
+        raise MlsynthDataError(f"Candidate units not found in the panel: {missing}.")
+    return members
+
+
+def aggregate_treated(
+    Ywide: pd.DataFrame, candidate: Iterable, how: str = "sum"
+) -> pd.Series:
+    """Collapse the candidate's units into a single treated series.
+
+    ``how="sum"`` (faithful to GeoLift) totals the units — the right aggregation
+    for cost/total-lift reporting. ``how="mean"`` averages them, keeping the
+    target at donor scale (in the donor convex hull) for the SCM fit. Returns a
+    time-indexed Series named ``"treated"``.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If the candidate is empty, or ``how`` is not ``"sum"``/``"mean"``.
+    MlsynthDataError
+        If any candidate unit is absent from ``Ywide``.
+    """
+    members = _validate_candidate(Ywide, candidate)
+    if how == "sum":
+        treated = Ywide[members].sum(axis=1)
+    elif how == "mean":
+        treated = Ywide[members].mean(axis=1)
+    else:
+        raise MlsynthConfigError(f"how must be 'sum' or 'mean'; got {how!r}.")
+    treated.name = "treated"
+    return treated
+
+
+def donor_matrix(
+    Ywide: pd.DataFrame, candidate: Iterable, exclude: Optional[Iterable] = None
+) -> pd.DataFrame:
+    """The donor pool: every unit NOT in the candidate, in panel-column order.
+
+    ``exclude`` drops additional units beyond the candidate — the spillover
+    "exclusion restriction": a treated geo's conflict-neighbours
+    (:func:`~mlsynth.utils.geolift_helpers.marketselect.helpers.constraints.conflict_neighbors`)
+    must not enter its synthetic control. ``None`` (the default) leaves the donor
+    pool exactly as the candidate complement.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If the candidate is empty.
+    MlsynthDataError
+        If any candidate unit is absent from ``Ywide``, or if removing the
+        candidate (and any excluded units) leaves no donors.
+    """
+    _validate_candidate(Ywide, candidate)
+    removed = set(candidate) | set(exclude or ())
+    donors = [unit for unit in Ywide.columns if unit not in removed]
+    if len(donors) == 0:
+        raise MlsynthDataError(
+            "No donor units remain after removing the candidate from the panel."
+        )
+    return Ywide[donors]

--- a/mlsynth/utils/sdidgeo_helpers/similarity.py
+++ b/mlsynth/utils/sdidgeo_helpers/similarity.py
@@ -1,0 +1,102 @@
+"""Correlation-based market similarity for geo-experiment market selection.
+
+These are the first, purely treatment-agnostic leaves of the market-selection
+port: they take the wide ``time x unit`` outcome matrix (as produced by
+:func:`mlsynth.utils.datautils.geoex_dataprep`) and answer "which units look
+like which". Everything stays label-carrying — units flow through as the
+``Ywide`` column :class:`pandas.Index`, not positional bookkeeping.
+
+``correlation_matrix`` is the single seam for the similarity metric; swapping
+in a residualized / mean-based metric later leaves :func:`rank_markets_by_correlation`
+and every downstream consumer untouched.
+"""
+
+import numpy as np
+import pandas as pd
+
+from mlsynth.exceptions import MlsynthDataError
+
+
+def correlation_matrix(Ywide: pd.DataFrame) -> pd.DataFrame:
+    """Pairwise Pearson correlation between units (the columns of ``Ywide``).
+
+    Faithful to GeoLift's ``MarketCorrelations``: raw Pearson on the level
+    series, no detrending or scaling. This is deliberately the GeoLift baseline
+    so the port has a direct validation target; it is also the one place to
+    substitute a better-behaved similarity metric.
+
+    Parameters
+    ----------
+    Ywide : pd.DataFrame
+        Wide outcome matrix, shape ``(n_periods, n_units)`` — rows are time,
+        columns are units.
+
+    Returns
+    -------
+    pd.DataFrame
+        An ``(n_units, n_units)`` correlation matrix indexed by the unit
+        :class:`~pandas.Index` on both axes. Constant (zero-variance) units
+        yield ``NaN`` correlations.
+    """
+    return Ywide.corr()
+
+
+def rank_markets_by_correlation(Ywide: pd.DataFrame) -> pd.DataFrame:
+    """Rank, for each unit, the other units from most to least correlated.
+
+    The label-carrying analogue of GeoLift's ranked-neighbor matrix. Each
+    anchor unit (a row) gets the *other* units ordered by descending Pearson
+    correlation; the anchor itself is excluded (its self-correlation is a
+    trivial ``1``). Units whose correlation is undefined — a constant series
+    gives ``NaN`` — sort to the bottom instead of raising.
+
+    Parameters
+    ----------
+    Ywide : pd.DataFrame
+        Wide outcome matrix, shape ``(n_periods, n_units)``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Shape ``(n_units, n_units - 1)``. The index is the anchor unit
+        :class:`~pandas.Index`; columns are integer ranks ``1 .. n_units - 1``
+        (``rank``); each cell holds the unit id at that similarity rank for the
+        anchor.
+
+    Raises
+    ------
+    MlsynthDataError
+        If fewer than two units are present (nothing to rank against).
+    """
+    units = Ywide.columns
+    if len(units) < 2:
+        raise MlsynthDataError(
+            "Need at least 2 units to rank markets by correlation; "
+            f"got {len(units)}."
+        )
+
+    correlations = correlation_matrix(Ywide)
+
+    # Vectorized ranking: a single argsort over the whole correlation matrix
+    # instead of one pandas sort per anchor. Set the diagonal to +inf so each
+    # anchor's self-correlation sorts to the front (then dropped by index, which
+    # is robust even when a constant anchor's self-correlation is NaN); map any
+    # remaining NaN (constant series) to -inf so it sorts last. ``argsort(-C,
+    # kind="stable")`` gives descending order with ties keeping the original
+    # column order -- identical to the per-anchor ``sort_values(ascending=False,
+    # kind="stable")`` it replaces.
+    C = correlations.to_numpy().astype(float, copy=True)
+    np.fill_diagonal(C, np.inf)
+    C = np.where(np.isnan(C), -np.inf, C)
+    order = np.argsort(-C, kind="stable")                  # (n_units, n_units)
+
+    n = C.shape[0]
+    keep = order != np.arange(n)[:, None]                  # drop each row's own anchor
+    neighbours = order[keep].reshape(n, n - 1)
+    ranked = units.to_numpy()[neighbours]                  # indices -> unit labels
+
+    return pd.DataFrame(
+        ranked,
+        index=pd.Index(units, name=units.name),
+        columns=pd.Index(range(1, len(units)), name="rank"),
+    )

--- a/mlsynth/utils/sdidgeo_helpers/simulate.py
+++ b/mlsynth/utils/sdidgeo_helpers/simulate.py
@@ -1,0 +1,136 @@
+"""One pseudo-experiment for SDIDGEO market-selection scoring.
+
+A single lookback placement: fit SDID on the placement's pre-period, take the
+placebo standard error once, then sweep the effect sizes. Because neither SDID
+weight program reads the treated post block (see
+:mod:`~mlsynth.utils.sdidgeo_helpers.engine`), the sweep is exact arithmetic on
+the ATT and the placebo sigma is shared across it -- so the whole grid of effect
+sizes costs one fit and one placebo run.
+
+The row schema matches what
+:func:`~mlsynth.utils.sdidgeo_helpers.aggregate.compute_power` consumes, one row
+per effect size.
+"""
+
+from typing import List, Optional
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError
+from .engine import normal_p_value, placebo_sigma, sdid_att, sdid_fit_once
+from .windows import lookback_pre_periods, lookback_treatment_window
+
+
+def inject_effect(treated, start: int, end: int, es: float) -> np.ndarray:
+    """Scale the block ``[start, end]`` of ``treated`` by ``(1 + es)``.
+
+    The multiplicative injection GeoLift uses (``Y[D == 1] *= 1 + es``), so an
+    effect size reads as a percentage lift on the treated markets' own volume.
+    Returns a new array; the input is never mutated.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``[start, end]`` is not a valid in-bounds, non-empty window.
+    """
+    t = np.asarray(treated, dtype=float).ravel()
+    n = t.shape[0]
+    if not (0 <= start <= end < n):
+        raise MlsynthConfigError(
+            f"invalid post window [{start}, {end}] for a series of length {n}.")
+    out = t.copy()
+    out[start:end + 1] = out[start:end + 1] * (1.0 + float(es))
+    return out
+
+
+def simulate_lookback(
+    treated, donors, n_periods: int, duration: int, sim: int, effect_sizes,
+    *, n_draws: int = 200, n_tr: int = 1, seed: int = 0,
+    cpic: Optional[float] = None, treated_total: Optional[np.ndarray] = None,
+    analytic: bool = True,
+) -> List[dict]:
+    """Simulate one lookback placement across a grid of effect sizes.
+
+    Parameters
+    ----------
+    treated : array-like, shape (n_periods,)
+        Aggregated treated series over the full panel.
+    donors : array-like, shape (n_periods, J)
+        Donor pool over the full panel.
+    n_periods, duration, sim : int
+        Panel length, pseudo-treatment duration, and lookback placement index.
+    effect_sizes : iterable of float
+        Effect sizes to sweep.
+    n_draws : int
+        Placebo draws behind the standard error.
+    n_tr : int
+        Number of treated markets in the candidate.
+    cpic : float, optional
+        Cost per incremental conversion. When given, each row reports the
+        required ``cpic * effect_size * summed-treated-volume`` investment.
+    treated_total : np.ndarray, optional
+        Summed treated series for the investment volume, which stays a total
+        even when the fit runs on the per-market mean.
+    analytic : bool, default True
+        Use the closed-form ``tau(es) = tau(0) + es * mean(y_post)``. Setting
+        this to ``False`` re-injects and recomputes for each effect size, which
+        gives the same answer and exists so the tests can prove the shortcut.
+
+    Returns
+    -------
+    list of dict
+        One row per effect size, carrying ``sim``, ``duration``,
+        ``effect_size``, ``p_value``, ``placebo_mean_effect`` (the SDID ATT),
+        ``detected_lift`` (ATT over the counterfactual post mean),
+        ``scaled_l2``, ``pre_rmspe`` and ``investment``.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If the placement runs off the start of the panel, or ``treated`` /
+        ``donors`` do not have ``n_periods`` rows.
+    """
+    n_pre = lookback_pre_periods(n_periods, duration, sim)
+    start, end = lookback_treatment_window(n_periods, duration, sim)
+
+    treated_arr = np.asarray(treated, dtype=float).ravel()
+    donors_arr = np.asarray(donors, dtype=float)
+    if treated_arr.shape[0] != n_periods or donors_arr.shape[0] != n_periods:
+        raise MlsynthConfigError(
+            f"treated and donors must both have n_periods={n_periods} rows; got "
+            f"{treated_arr.shape[0]} and {donors_arr.shape[0]}.")
+
+    fit = sdid_fit_once(treated_arr, donors_arr, n_pre, start, end, n_tr=n_tr)
+    tau0 = sdid_att(fit, treated_arr, start, end)
+    post_baseline = float(np.mean(treated_arr[start:end + 1]))
+    cf_post_mean = float(np.mean(fit.counterfactual[start:end + 1]))
+
+    # Invariant to the injected effect, so one run serves the whole sweep.
+    sigma = placebo_sigma(treated_arr, donors_arr, n_pre, start, end,
+                          n_draws=n_draws, n_tr=n_tr, seed=seed)
+
+    total_arr = (np.asarray(treated_total, dtype=float).ravel()
+                 if treated_total is not None else treated_arr)
+    window_volume = float(np.sum(total_arr[start:end + 1]))
+
+    rows: List[dict] = []
+    for es in effect_sizes:
+        if analytic:
+            tau = tau0 + float(es) * post_baseline
+        else:
+            tau = sdid_att(fit, inject_effect(treated_arr, start, end, es),
+                           start, end)
+        rows.append({
+            "sim": sim,
+            "duration": duration,
+            "effect_size": float(es),
+            "p_value": normal_p_value(tau, sigma),
+            "placebo_mean_effect": tau,
+            "detected_lift": (tau / cf_post_mean if cf_post_mean != 0.0
+                              else float("nan")),
+            "scaled_l2": fit.scaled_l2,
+            "pre_rmspe": fit.pre_rmspe,
+            "investment": (cpic * float(es) * window_volume
+                           if cpic is not None else float("nan")),
+        })
+    return rows

--- a/mlsynth/utils/sdidgeo_helpers/simulate.py
+++ b/mlsynth/utils/sdidgeo_helpers/simulate.py
@@ -1,6 +1,6 @@
 """One pseudo-experiment for SDIDGEO market-selection scoring.
 
-A single lookback placement: fit SDID on the placement's pre-period, take the
+A single backtest: fit SDID on the backtest's pre-period, take the
 placebo standard error once, then sweep the effect sizes. Because neither SDID
 weight program reads the treated post block (see
 :mod:`~mlsynth.utils.sdidgeo_helpers.engine`), the sweep is exact arithmetic on
@@ -18,7 +18,7 @@ import numpy as np
 
 from ...exceptions import MlsynthConfigError
 from .engine import normal_p_value, placebo_sigma, sdid_att, sdid_fit_once
-from .windows import lookback_pre_periods, lookback_treatment_window
+from .windows import backtest_pre_periods, backtest_treatment_window
 
 
 def inject_effect(treated, start: int, end: int, es: float) -> np.ndarray:
@@ -43,13 +43,13 @@ def inject_effect(treated, start: int, end: int, es: float) -> np.ndarray:
     return out
 
 
-def simulate_lookback(
+def simulate_backtest(
     treated, donors, n_periods: int, duration: int, sim: int, effect_sizes,
     *, n_draws: int = 200, n_tr: int = 1, seed: int = 0,
     cpic: Optional[float] = None, treated_total: Optional[np.ndarray] = None,
     analytic: bool = True,
 ) -> List[dict]:
-    """Simulate one lookback placement across a grid of effect sizes.
+    """Simulate one backtest across a grid of effect sizes.
 
     Parameters
     ----------
@@ -58,7 +58,7 @@ def simulate_lookback(
     donors : array-like, shape (n_periods, J)
         Donor pool over the full panel.
     n_periods, duration, sim : int
-        Panel length, pseudo-treatment duration, and lookback placement index.
+        Panel length, pseudo-treatment duration, and backtest index.
     effect_sizes : iterable of float
         Effect sizes to sweep.
     n_draws : int
@@ -87,11 +87,11 @@ def simulate_lookback(
     Raises
     ------
     MlsynthConfigError
-        If the placement runs off the start of the panel, or ``treated`` /
+        If the backtest runs off the start of the panel, or ``treated`` /
         ``donors`` do not have ``n_periods`` rows.
     """
-    n_pre = lookback_pre_periods(n_periods, duration, sim)
-    start, end = lookback_treatment_window(n_periods, duration, sim)
+    n_pre = backtest_pre_periods(n_periods, duration, sim)
+    start, end = backtest_treatment_window(n_periods, duration, sim)
 
     treated_arr = np.asarray(treated, dtype=float).ravel()
     donors_arr = np.asarray(donors, dtype=float)

--- a/mlsynth/utils/sdidgeo_helpers/structures.py
+++ b/mlsynth/utils/sdidgeo_helpers/structures.py
@@ -38,6 +38,11 @@ class CandidateDesign:
         Stitched in from the shortlist: the minimum detectable effect, the power
         at that effect, and the composite rank. ``None`` when the candidate
         cleared no effect size.
+    mde_holdout : float or None
+        The winner's MDE re-scored on placements that took no part in choosing
+        it. ``mde`` is the smallest in a field of candidates and so is
+        optimistic; this one is not selected on. Set only on the winner, and
+        ``None`` when ``holdout_placements`` is 0 or the panel is too short.
     """
 
     units: List
@@ -50,6 +55,7 @@ class CandidateDesign:
     mde: Optional[float] = None
     power: Optional[float] = None
     rank: Optional[float] = None
+    mde_holdout: Optional[float] = None
 
 
 @dataclass

--- a/mlsynth/utils/sdidgeo_helpers/structures.py
+++ b/mlsynth/utils/sdidgeo_helpers/structures.py
@@ -38,11 +38,11 @@ class CandidateDesign:
         Stitched in from the shortlist: the minimum detectable effect, the power
         at that effect, and the composite rank. ``None`` when the candidate
         cleared no effect size.
-    mde_holdout : float or None
-        The winner's MDE re-scored on placements that took no part in choosing
+    mde_planning : float or None
+        The winner's MDE re-scored on backtests that took no part in choosing
         it. ``mde`` is the smallest in a field of candidates and so is
         optimistic; this one is not selected on. Set only on the winner, and
-        ``None`` when ``holdout_placements`` is 0 or the panel is too short.
+        ``None`` when ``n_validation_backtests`` is 0 or the panel is too short.
     """
 
     units: List
@@ -55,7 +55,7 @@ class CandidateDesign:
     mde: Optional[float] = None
     power: Optional[float] = None
     rank: Optional[float] = None
-    mde_holdout: Optional[float] = None
+    mde_planning: Optional[float] = None
 
 
 @dataclass

--- a/mlsynth/utils/sdidgeo_helpers/structures.py
+++ b/mlsynth/utils/sdidgeo_helpers/structures.py
@@ -1,0 +1,91 @@
+"""Result containers for SDIDGEO.
+
+SDIDGEO produces a *design*, not a treatment effect, so its result is a
+:class:`~mlsynth.config_models.DesignResult`: which markets to treat, the donor
+weights the analysis will use, the power table behind the choice, and a
+``report`` slot that stays ``None`` until the experiment has actually run.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from ...config_models import DesignResult, WeightsResults
+
+
+@dataclass
+class CandidateDesign:
+    """One candidate test region's deployable design.
+
+    Attributes
+    ----------
+    units : list
+        The markets in the candidate region.
+    weights : WeightsResults
+        Both SDID weight vectors: ``donor_weights`` over markets and
+        ``time_weights`` over the pre-period dates.
+    observed : np.ndarray
+        The test region's aggregated outcome over the panel.
+    counterfactual : np.ndarray
+        Synthetic path over the panel.
+    n_pre : int
+        Pre-period length the design was fit on.
+    pre_rmspe, scaled_l2 : float
+        Pre-period fit quality.
+    mde, power, rank : float or None
+        Stitched in from the shortlist: the minimum detectable effect, the power
+        at that effect, and the composite rank. ``None`` when the candidate
+        cleared no effect size.
+    """
+
+    units: List
+    weights: WeightsResults
+    observed: np.ndarray
+    counterfactual: np.ndarray
+    n_pre: int
+    pre_rmspe: float
+    scaled_l2: float
+    mde: Optional[float] = None
+    power: Optional[float] = None
+    rank: Optional[float] = None
+
+
+@dataclass
+class MarketSearch:
+    """The design search: every candidate region and the winner.
+
+    Attributes
+    ----------
+    shortlist : pd.DataFrame
+        Ranked table, one row per (candidate, duration) that cleared the power
+        threshold.
+    power_table : pd.DataFrame
+        Power at every (candidate, duration, effect size), before the MDE
+        collapses it. This is what the power curves are drawn from.
+    candidates : list of CandidateDesign
+        Every candidate's deployable design.
+    winner : CandidateDesign or None
+        The top-ranked design, or ``None`` when nothing cleared the threshold.
+    """
+
+    shortlist: pd.DataFrame
+    power_table: pd.DataFrame = field(default_factory=pd.DataFrame)
+    candidates: List[CandidateDesign] = field(default_factory=list)
+    winner: Optional[CandidateDesign] = None
+
+
+class SDIDGEOResults(DesignResult):
+    """Top-level result of the SDIDGEO design.
+
+    A :class:`~mlsynth.config_models.DesignResult` front door
+    (``selected_units`` / ``assignment`` / ``design_weights`` / ``power`` /
+    ``metadata`` / ``report``) plus the grouped :class:`MarketSearch` detail.
+    """
+
+    search: Optional[MarketSearch] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+        extra = "allow"

--- a/mlsynth/utils/sdidgeo_helpers/windows.py
+++ b/mlsynth/utils/sdidgeo_helpers/windows.py
@@ -1,0 +1,72 @@
+"""Lookback-window arithmetic for GeoLift market-selection power simulation.
+
+The power analysis slides a fixed-length pseudo-treatment window back from the
+end of the historical panel, one period at a time, and fits the SCM once per
+placement. These dumb helpers translate a ``(n_periods, duration, sim)`` triple
+into the pre/post split for a *single* such placement — nothing more, so they
+stay trivial to reason about, debug, and test.
+
+Faithful to GeoLift's ``treatment_start_time = max_time - tp - sim + 2``,
+expressed here in 0-indexed positions over the time axis:
+
+- ``sim`` is the 1-indexed lookback placement (``sim = 1`` is flush with the
+  end of the panel; higher ``sim`` slides the window back one period each).
+- ``duration`` is the length of the pseudo-treatment (effect) block.
+"""
+
+from typing import Tuple
+
+import numpy as np
+
+from mlsynth.exceptions import MlsynthConfigError
+
+
+def _check_positive_int(name: str, value: object) -> None:
+    """Reject anything that is not an integer >= 1 (booleans included)."""
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)) or value < 1:
+        raise MlsynthConfigError(
+            f"{name} must be a positive integer; got {value!r}."
+        )
+
+
+def lookback_pre_periods(n_periods: int, duration: int, sim: int) -> int:
+    """Number of pre-treatment periods for lookback placement ``sim``.
+
+    Equivalently, the 0-indexed position of the *first* pseudo-treatment period
+    (everything before it is pre-period). Faithful to GeoLift's
+    ``max_time - tp - sim + 2``, in 0-indexed counts:
+
+        n_pre = n_periods - duration - sim + 1
+
+    Raises
+    ------
+    MlsynthConfigError
+        If any argument is not a positive integer, or if the placement runs off
+        the start of the panel (fewer than one pre-period remains).
+    """
+    _check_positive_int("n_periods", n_periods)
+    _check_positive_int("duration", duration)
+    _check_positive_int("sim", sim)
+
+    n_pre = int(n_periods) - int(duration) - int(sim) + 1
+    if n_pre < 1:
+        raise MlsynthConfigError(
+            "Lookback placement runs off the start of the panel: "
+            f"n_periods={n_periods}, duration={duration}, sim={sim} leaves "
+            f"{n_pre} pre-period(s); need >= 1."
+        )
+    return n_pre
+
+
+def lookback_treatment_window(
+    n_periods: int, duration: int, sim: int
+) -> Tuple[int, int]:
+    """0-indexed ``(start, end)`` inclusive positions of the pseudo-treatment block.
+
+    The block has length ``duration`` and ends ``sim - 1`` periods before the
+    final period (``sim = 1`` ends exactly at the last period, ``n_periods - 1``).
+    Shares the same validation/guards as :func:`lookback_pre_periods`.
+    """
+    start = lookback_pre_periods(n_periods, duration, sim)
+    end = start + int(duration) - 1
+    return start, end

--- a/mlsynth/utils/sdidgeo_helpers/windows.py
+++ b/mlsynth/utils/sdidgeo_helpers/windows.py
@@ -2,14 +2,14 @@
 
 The power analysis slides a fixed-length pseudo-treatment window back from the
 end of the historical panel, one period at a time, and fits the SCM once per
-placement. These dumb helpers translate a ``(n_periods, duration, sim)`` triple
-into the pre/post split for a *single* such placement — nothing more, so they
+backtest. These dumb helpers translate a ``(n_periods, duration, sim)`` triple
+into the pre/post split for a *single* such backtest — nothing more, so they
 stay trivial to reason about, debug, and test.
 
 Faithful to GeoLift's ``treatment_start_time = max_time - tp - sim + 2``,
 expressed here in 0-indexed positions over the time axis:
 
-- ``sim`` is the 1-indexed lookback placement (``sim = 1`` is flush with the
+- ``sim`` is the 1-indexed backtest (``sim = 1`` is flush with the
   end of the panel; higher ``sim`` slides the window back one period each).
 - ``duration`` is the length of the pseudo-treatment (effect) block.
 """
@@ -29,8 +29,8 @@ def _check_positive_int(name: str, value: object) -> None:
         )
 
 
-def lookback_pre_periods(n_periods: int, duration: int, sim: int) -> int:
-    """Number of pre-treatment periods for lookback placement ``sim``.
+def backtest_pre_periods(n_periods: int, duration: int, sim: int) -> int:
+    """Number of pre-treatment periods for backtest ``sim``.
 
     Equivalently, the 0-indexed position of the *first* pseudo-treatment period
     (everything before it is pre-period). Faithful to GeoLift's
@@ -41,7 +41,7 @@ def lookback_pre_periods(n_periods: int, duration: int, sim: int) -> int:
     Raises
     ------
     MlsynthConfigError
-        If any argument is not a positive integer, or if the placement runs off
+        If any argument is not a positive integer, or if the backtest runs off
         the start of the panel (fewer than one pre-period remains).
     """
     _check_positive_int("n_periods", n_periods)
@@ -51,22 +51,22 @@ def lookback_pre_periods(n_periods: int, duration: int, sim: int) -> int:
     n_pre = int(n_periods) - int(duration) - int(sim) + 1
     if n_pre < 1:
         raise MlsynthConfigError(
-            "Lookback placement runs off the start of the panel: "
+            "Backtest runs off the start of the panel: "
             f"n_periods={n_periods}, duration={duration}, sim={sim} leaves "
             f"{n_pre} pre-period(s); need >= 1."
         )
     return n_pre
 
 
-def lookback_treatment_window(
+def backtest_treatment_window(
     n_periods: int, duration: int, sim: int
 ) -> Tuple[int, int]:
     """0-indexed ``(start, end)`` inclusive positions of the pseudo-treatment block.
 
     The block has length ``duration`` and ends ``sim - 1`` periods before the
     final period (``sim = 1`` ends exactly at the last period, ``n_periods - 1``).
-    Shares the same validation/guards as :func:`lookback_pre_periods`.
+    Shares the same validation/guards as :func:`backtest_pre_periods`.
     """
-    start = lookback_pre_periods(n_periods, duration, sim)
+    start = backtest_pre_periods(n_periods, duration, sim)
     end = start + int(duration) - 1
     return start, end

--- a/mlsynth/utils/sdidgeo_helpers/windows.py
+++ b/mlsynth/utils/sdidgeo_helpers/windows.py
@@ -1,4 +1,4 @@
-"""Lookback-window arithmetic for GeoLift market-selection power simulation.
+"""Backtest-window arithmetic for SDIDGEO market-selection power simulation.
 
 The power analysis slides a fixed-length pseudo-treatment window back from the
 end of the historical panel, one period at a time, and fits the SCM once per


### PR DESCRIPTION
## Related Links

- Docs page: `docs/sdidgeo.rst`; decision-tree entry in `docs/choose.rst`
- Source papers: Arkhangelsky, Athey, Hirshberg, Imbens & Wager (2021), [10.1257/aer.20190159](https://doi.org/10.1257/aer.20190159); market-selection loop after Meta's GeoLift; Clarke, Pailañir, Athey & Imbens (2023) for the Stata implementation notes
- Cross-validated against: mlsynth's own `SDID` (`docs/sdid.rst`)
- Follows: #371
- Followed by: `claude/sdidgeo-benchmark`, the Path B case that validates the numbers this PR reports

## What

- Added `SDIDGEO` (`mlsynth/estimators/sdidgeo.py`) plus `mlsynth/utils/sdidgeo_helpers/`: config, engine, simulate, batch, aggregate, candidates, similarity, shaping, windows, structures, orchestration, plotter.
- `treatment_size` takes a scalar or a list, so one run scores two-market regions against five-market ones and ranks them together.
- Reports two MDE figures, `winner_mde_optimistic` and `winner_mde_planning`, the second re-scored on backtests that took no part in choosing the region.
- `plot_sdidgeo_design` and `plot_mde_ranking`, exported from `mlsynth`.
- Docs page, `docs/index.rst` toctree entry, `docs/choose.rst` entry, `__init__.py` export, `config_models.py` re-export.

## Why

Picking which geos to treat is a design decision made before the experiment runs, and the usual tool is GeoLift, which scores candidate regions with augmented synthetic control. Scoring with synthetic difference-in-differences instead changes two things that matter for geo panels.

No single pre-period has to be matched. Synthetic control asks donors to reproduce the treated path everywhere before treatment; SDID's time weights choose which pre-periods carry the comparison. On the 105-day panel the fitted design puts weight on 7 of 91 pre-days.

A level gap between the test region and its donors is differenced out instead of having to be spanned, so a small test region in a pool of larger markets stays estimable.

## How

Two structural properties of SDID make the effect sweep cheap, and both follow from where the weights get their information. `unit_weights` reads the treated pre-period, `fit_time_weights` reads only donors, `compute_regularization` reads only donors and counts — no program reads the treated post block. So injecting an effect there cannot move omega or lambda, `tau(e) = tau(0) + e * mean(y_post)` holds exactly, and the placebo sigma is invariant to `e` as well. One fit and one placebo run cover the whole effect grid.

Detection is a normal test against the placebo standard error (Algorithm 4). Jackknife and bootstrap are undefined for a single treated series, which is what a candidate region collapses to. GeoLift's conformal permutation test does not carry over: that argument needs residuals exchangeable across the matching window, and SDID's time weights exist because pre-periods are not interchangeable.

The market-selection scaffolding — backtest arithmetic, candidate nomination, power/MDE/rank aggregation — is the GeoLift-faithful logic; only the scoring engine is new.

Two things were measured and then fixed rather than assumed:

The placebo loop chains its warm start across draws. The chaining merged in #371 lives in `solve_intercept_simplex_many`, which this path never calls, so rebasing onto #371 alone left the estimator unchanged (85s to 69s, noise). Chaining inside `placebo_sigma` gives 8.9x with the sigma unmoved, and the design run drops from 243s to 28s on a size 2-5 scan.

The reported MDE is the smallest in a field of candidates, so the region most likely to be picked is the one whose estimate came out low by luck. A control isolates this: at four backtests the *selected* region's MDE delivers 0.45 out-of-sample power against a claimed 0.80, while a region fixed before any MDE was computed delivers 0.775 at the same depth. So `run_design` re-scores the winner on validation backtests that took no part in choosing it, and reports both figures.

## Verification

- Path: cross-validation against mlsynth's own `SDID`.
- `test_matches_the_shipped_sdid_estimator` builds the same panel and window as a long frame, runs `SDID(...).fit()` with `vce="placebo"`, and asserts SDIDGEO's scored ATT matches to `rel=1e-6`. This is what establishes the engine is SDID and not a lookalike.
- The two properties the effect sweep rests on are checked against brute force, not asserted: weights are bit-identical under injection (`assert_array_equal`), the analytic ATT sweep matches re-injecting and recomputing to `rel=1e-10`, and the placebo sigma is exactly equal across injected effect sizes.
- The warm-start chain is pinned against a cold path rather than a recorded constant: `sdid_fit_once` still refits each draw from scratch, so the test rebuilds the same draws through it and asserts the chained sigma matches at three backtests. Measured separately over 18 backtests at `B=100`: 25.77s to 2.91s with all 18 sigmas identical to full float repr.
- The planning MDE is validated out of sample on a known-truth DGP in `claude/sdidgeo-benchmark`: at four backtests it delivers 0.787 power against a claimed 0.80, where the selected figure delivers 0.420.
- 87 tests in `mlsynth/tests/test_sdidgeo.py`. `test_result_contract.py` and `test_config_models.py` pass.

## Scope checks

<!-- NEW ESTIMATOR -->
- [x] Dedicated Pydantic config (`SDIDGEOConfig`) inheriting `BaseMAREXConfig`, `extra="forbid"`, every field with a `Field(...)` description, validators raising `MlsynthConfigError` / `MlsynthDataError`
- [x] Ingestion through `geoex_dataprep` — no hand-pivoted pandas in the estimator
- [x] `fit()` returns a `DesignResult` populating `selected_units` / `assignment` / `design_weights` / `power` / `metadata`, with `report` left `None` until the experiment runs; `test_result_contract.py` passes
- [x] One estimator, one package; exported in `mlsynth/__init__.py`; entry in `docs/choose.rst`
- [x] Tests at all four levels: smoke, unit invariants, edge cases (no donors left, unknown market, duration longer than the panel, treatment size exceeding the panel, too few donors for a placebo draw), and failure tests asserting the correct translated error
- [x] Branch carries only this estimator

## Designs

`plot_sdidgeo_design` gives the two views GeoLift shows for a market selection: the power curve, with the detection threshold and both MDE figures marked and the other candidates drawn faintly behind, and the fit the design rests on. `plot_mde_ranking` ranks the shortlisted regions.

On `basedata/geolift_test_data.csv`, scanning sizes 2 through 5 over 123 candidates:

```
size  candidate                                                          mde  scaled_l2
   5  columbus + jacksonville + milwaukee + minneapolis + new orleans   0.10      0.370
   4  columbus + jacksonville + milwaukee + minneapolis                 0.15      0.290
   2  atlanta + nashville                                               0.15      0.324
   3  atlanta + chicago + nashville                                     0.15      0.325
```

Bigger regions detect smaller lifts, which is the expected direction. The size-4 winner has the better pre-period fit at a worse MDE, so the ranking is not simply tracking size.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_sdidgeo.py -q` — 87 passed
- [x] `pytest mlsynth/tests/test_result_contract.py mlsynth/tests/test_config_models.py -q` — 199 passed, 4 skipped
- [ ] `pytest mlsynth/tests/` — full suite not run locally; CI covers it
- [ ] `coverage run --timid -m pytest mlsynth/tests/test_sdidgeo.py && coverage report` — not run locally
- [ ] `python benchmarks/run_benchmarks.py --all` — the case for this estimator is on the follow-up branch
- [x] Docs build; section underlines checked programmatically

## Other Notes

- Vocabulary: what GeoLift calls a `lookback_window` is `n_backtests` here, and a backtest is one full rehearsal — a pretend treatment window in the past plus the history before it. GeoLift's name is not kept as an alias. SDIDGEO is not GeoLift — different engine, different inference, different p-value — and matching parameter names invites the assumption that the numbers are comparable.
- The two engines disagree. Scoring the same panel with the augmented-SCM engine and with SDID gives Spearman 0.52 on the candidate ranking and different winners, with SDID the more conservative. Nothing here adjudicates which is right, and the p-value construction differs on top of the estimator, so the two differences are confounded.
- Size sits above nominal on the benchmark DGP, 0.135 against 0.10, because the placebo draws overlap heavily when the donor pool is thin. Recorded in the follow-up branch and in assumption 5 on the docs page.
- Separately, in the unmerged GeoLift branch at `e0fd6ec` the augmented-SCM engine passes the full panel to `conformal_pvalue` with `pre=n_pre`, so its conformal post block is `[n_pre, T-1]` while the injected block is only `duration` long. Isolating it by truncation, p-values come out 0.011 lower at the third backtest and 0.019 at the fifth. SDIDGEO uses `[start, end]` throughout and is unaffected, but that branch would want a look.
