### PR TITLE
Guard the PDA prediction intervals against saturated fits

### DIFF
--- a/mlsynth/tests/test_pda.py
+++ b/mlsynth/tests/test_pda.py
@@ -605,8 +605,13 @@ def test_forward_select_degenerate_no_selection(monkeypatch):
     assert np.allclose(cf2, np.mean(y[:20]))
 
 
-def test_forward_select_runs_full_t0_iterations(monkeypatch):
-    """Every step keeps improving the IC -> the range(T0) loop cap is the exit."""
+def test_forward_select_runs_to_the_saturation_cap(monkeypatch):
+    """Every step keeps improving the IC -> the saturation cap is the exit.
+
+    Before the cap this ran to ``T0`` and returned 5 parameters on 4
+    observations. The budget is ``T0 - 1 - intercept``, so the fit keeps a
+    residual degree of freedom however hard the IC pushes.
+    """
     import mlsynth.utils.pda_helpers.fs.estimation as fs_est
     # sigma^2 strictly shrinks as more columns are added, so IC always improves
     monkeypatch.setattr(fs_est, "_ols_sigma2", lambda y, Z: 1.0 / Z.shape[1])
@@ -614,7 +619,8 @@ def test_forward_select_runs_full_t0_iterations(monkeypatch):
     X = rng.normal(0, 1, (4, 6))                       # N=6 > T0=4
     y = rng.normal(0, 1, 4)
     sel, beta, intercept, cf = forward_select(y, X, T0=4, intercept=True)
-    assert len(sel) == 4                                # selected once per iteration
+    assert len(sel) == 2                                # T0 - 1 - intercept
+    assert len(sel) + 1 <= 4 - 1                        # a residual df survives
     assert cf.shape == (4,)
 
 
@@ -677,3 +683,88 @@ def test_plot_pda_failure_warns():
     with pytest.warns(UserWarning, match="PDA plotting failed"):
         plot_pda(_toy_results_for_plot(), outcome="Value", time="Period",
                  counterfactual_color=[], save=False)   # empty list -> modulo-by-zero
+
+
+# ======================================================================
+# fs saturation cap
+# ======================================================================
+class TestForwardSelectionCap:
+    """Forward selection must leave the pre-period fit at least one residual df.
+
+    The IC rule cannot stop a run toward interpolation on its own: the criterion
+    carries ``log(s2)``, which diverges to -inf as the fit approaches an exact
+    one, so every further donor "improves" it. Unchecked, selection reaches
+    ``T0`` donors -- ``T0 + 1`` parameters with an intercept -- and the residual
+    variance collapses to ~1e-31. The Jiang et al. prediction intervals then
+    divide by that scale, so the cap is what keeps them finite.
+    """
+
+    @staticmethod
+    def _noise(T0, N, seed):
+        rng = np.random.default_rng(seed)
+        return (rng.standard_normal(T0 + 5),
+                rng.standard_normal((T0 + 5, N)))
+
+    @pytest.mark.parametrize("T0,N,seed", [(10, 30, 0), (10, 30, 1), (12, 40, 3)])
+    @pytest.mark.parametrize("intercept", [False, True])
+    def test_never_saturates_the_pre_period(self, T0, N, seed, intercept):
+        y, X = self._noise(T0, N, seed)
+        sel, _, _, cf = forward_select(y, X, T0, intercept=intercept)
+        n_params = len(sel) + int(intercept)
+        assert n_params <= T0 - 1, f"{n_params} params on {T0} observations"
+        assert np.mean((y[:T0] - cf[:T0]) ** 2) > 1e-12    # not interpolated
+
+    def test_cap_clears_the_engine_degeneracy_threshold(self):
+        # The contract between the two layers: a capped fit must leave a residual
+        # scale the interval engine accepts, so the point fit never trips the
+        # guard in pda_prediction_intervals. The cap forbids interpolation; it
+        # does not promise a well-conditioned fit, and at T0 - 1 - intercept
+        # donors the residual df is thin -- the margin here is ~3 orders, not
+        # comfortable, which is why the engine guard stays as the backstop.
+        from mlsynth.utils.inferutils import _INTERPOLATION_TOL
+
+        y, X = self._noise(12, 40, 3)
+        _, _, _, cf = forward_select(y, X, 12, intercept=True)
+        s2 = float(np.mean((y[:12] - cf[:12]) ** 2))
+        assert s2 > _INTERPOLATION_TOL * max(float(np.var(y[:12])), 1.0)
+
+    def test_informative_selection_is_unchanged(self):
+        # The cap binds only on runaway fits; a sparse signal is picked as before.
+        rng = np.random.default_rng(11)
+        X = rng.normal(0, 1, (40, 6))
+        y = 2.0 * X[:, 0] - 1.5 * X[:, 3] + rng.normal(0, 0.1, 40)
+        sel, _, _, _ = forward_select(y, X, T0=40)
+        assert 0 in sel and 3 in sel
+        assert len(sel) < 40 - 1
+
+    def test_tiny_pre_period_still_returns(self):
+        # T0 = 3 leaves room for one donor without an intercept; the cap must
+        # not drive the budget to zero or negative.
+        y, X = self._noise(3, 8, 5)
+        sel, beta, _, cf = forward_select(y, X, 3, intercept=False)
+        assert len(sel) <= 2
+        assert cf.shape == (8,) and np.all(np.isfinite(cf))
+
+    def test_prediction_intervals_survive_a_saturating_panel(self):
+        # End to end: the panel that made the engine raise must now produce a
+        # finite interval, because the point fit no longer interpolates.
+        from mlsynth import PDA
+
+        rng = np.random.default_rng(3)
+        T0, T1, N = 12, 4, 40
+        rows = []
+        for t in range(T0 + T1):
+            rows.append({"ID": 1, "Period": t, "Value": float(rng.standard_normal()),
+                         "IsTreated": int(t >= T0)})
+            for j in range(N):
+                rows.append({"ID": j + 2, "Period": t,
+                             "Value": float(rng.standard_normal()), "IsTreated": 0})
+        df = pd.DataFrame(rows)
+        res = PDA({"df": df, "outcome": "Value", "treat": "IsTreated",
+                   "unitid": "ID", "time": "Period", "method": "fs",
+                   "prediction_intervals": True, "pi_n_boot": 99, "pi_seed": 0,
+                   "display_graphs": False}).fit()
+        e = res.fits["fs"].prediction_intervals["effect"]
+        assert np.all(np.isfinite(e["eq_lower"])) and np.all(np.isfinite(e["eq_upper"]))
+        width = float(e["eq_upper"][0] - e["eq_lower"][0])
+        assert 0.0 < width < 1e3, f"width {width:.3g}"

--- a/mlsynth/tests/test_pda_prediction_intervals.py
+++ b/mlsynth/tests/test_pda_prediction_intervals.py
@@ -23,7 +23,11 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.exceptions import (
+    MlsynthConfigError,
+    MlsynthDataError,
+    MlsynthEstimationError,
+)
 from mlsynth.utils.inferutils import pda_prediction_intervals
 
 
@@ -226,6 +230,180 @@ class TestFailures:
         with pytest.raises(MlsynthDataError):
             pda_prediction_intervals(y, X[:, 0], 40, counterfactual=cf, support=[0],
                                      refit=lambda yb: (cf, [0]), n_boot=10)
+
+
+# ---------------------------------------------------------------------------
+# Degenerate bootstrap draws (saturated refits)
+# ---------------------------------------------------------------------------
+
+# A short pre-period with a wide donor pool, so a support can saturate it.
+_SAT_T0, _SAT_T1, _SAT_P = 12, 4, 20
+_SAT_SPARSE = [0, 1, 2]
+_SAT_FULL = list(range(_SAT_T0 - 1))     # |support| + intercept == T0
+
+
+def _sat_dgp(seed=11):
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((_SAT_T0 + _SAT_T1, _SAT_P))
+    y = X[:, 0] - 0.5 * X[:, 1] + rng.standard_normal(_SAT_T0 + _SAT_T1) * 0.5
+    return y, X
+
+
+class _SaturatingRefit:
+    """Refit whose support saturates the pre-period on the first ``k`` calls.
+
+    A support of size ``T0 - 1`` plus an intercept interpolates ``T0``
+    observations, leaving a residual variance of order 1e-30 -- tiny but not
+    exactly zero, so the ``se_star > 0`` guard does not catch it. The
+    post-period is a genuine extrapolation and its error stays O(1), so the
+    studentized statistic ``e_star / se_star`` reaches ~1e15. Forward selection
+    does this on about 5% of draws at ``T0 = 30``; here it is deterministic.
+    """
+
+    def __init__(self, X, T0, k):
+        self.X, self.T0, self.k, self.calls = X, T0, k, 0
+
+    def __call__(self, y_boot):
+        self.calls += 1
+        support = _SAT_FULL if self.calls <= self.k else _SAT_SPARSE
+        return (_ols_fit(y_boot, self.X, self.T0, support),
+                np.asarray(support, dtype=int))
+
+
+class TestDegenerateBootstrapDraws:
+    """A saturated refit carries no information about out-of-sample error.
+
+    Jiang et al.'s theory assumes the selected support stays sparse relative to
+    ``T0``; a refit that interpolates violates that, and dividing by its
+    vanishing residual scale produces an interval wide enough to cover
+    unconditionally. Such draws are excluded from the quantiles and counted in
+    the result.
+    """
+
+    def _setup(self, k, n_boot=99):
+        y, X = _sat_dgp()
+        cf = _fit(y, X, _SAT_T0, _SAT_SPARSE)
+        return y, X, cf, _SaturatingRefit(X, _SAT_T0, k), n_boot
+
+    # -- premise: the saturated refit is the pathology ------------------------
+
+    def test_saturated_refit_interpolates_but_extrapolates_badly(self):
+        y, X = _sat_dgp()
+        cf, support = _SaturatingRefit(X, _SAT_T0, k=1)(y)
+        s2 = float(np.mean((y[:_SAT_T0] - cf[:_SAT_T0]) ** 2))
+        assert len(support) + 1 == _SAT_T0        # saturated, intercept included
+        assert 0.0 < s2 < 1e-20                   # tiny, so se_star > 0 passes
+        assert np.abs(y[_SAT_T0:] - cf[_SAT_T0:]).mean() > 1.0   # O(1) numerator
+
+    # -- invariants ----------------------------------------------------------
+
+    def test_degenerate_draws_are_counted(self):
+        y, X, cf, refit, n_boot = self._setup(k=7)
+        out = pda_prediction_intervals(
+            y, X, _SAT_T0, counterfactual=cf, support=_SAT_SPARSE, refit=refit,
+            n_boot=n_boot, seed=1)
+        assert out["n_degenerate"] == 7
+        assert out["n_boot_effective"] == n_boot - 7
+        assert out["n_boot"] == n_boot          # the requested count is unchanged
+
+    def test_interval_stays_finite_despite_degenerate_draws(self):
+        y, X, cf, refit, n_boot = self._setup(k=20)
+        out = pda_prediction_intervals(
+            y, X, _SAT_T0, counterfactual=cf, support=_SAT_SPARSE, refit=refit,
+            n_boot=n_boot, seed=1)
+        e = out["effect"]
+        for key in ("eq_lower", "eq_upper", "sy_lower", "sy_upper"):
+            assert np.all(np.isfinite(e[key])), key
+        assert (e["eq_lower"] <= e["eq_upper"] + 1e-9).all()
+        assert (e["sy_lower"] <= e["sy_upper"] + 1e-9).all()
+
+    def test_width_comparable_to_a_clean_run(self):
+        # Excluding the degenerate draws must leave the interval on the same
+        # scale as one where none occurred -- not orders of magnitude wider.
+        y, X, cf, refit, n_boot = self._setup(k=20)
+        dirty = pda_prediction_intervals(
+            y, X, _SAT_T0, counterfactual=cf, support=_SAT_SPARSE, refit=refit,
+            n_boot=n_boot, seed=1)
+        clean = pda_prediction_intervals(
+            y, X, _SAT_T0, counterfactual=cf, support=_SAT_SPARSE,
+            refit=_make_refit(X, _SAT_T0, _SAT_SPARSE), n_boot=n_boot, seed=1)
+        wd = float(dirty["effect"]["eq_upper"][0] - dirty["effect"]["eq_lower"][0])
+        wc = float(clean["effect"]["eq_upper"][0] - clean["effect"]["eq_lower"][0])
+        assert 0.2 < wd / wc < 5.0, f"width ratio {wd / wc:.3g}"
+
+    # -- the guard is a no-op when nothing degenerates ------------------------
+
+    def test_clean_path_unchanged(self):
+        # Pinned from the implementation before the guard existed: on data where
+        # no draw degenerates the intervals must be identical, to the bit.
+        y, X = _dgp(7)
+        support = [0, 1, 2, 3]
+        cf = _fit(y, X, 40, support)
+        out = pda_prediction_intervals(
+            y, X, 40, counterfactual=cf, support=support,
+            refit=_make_refit(X, 40, support), n_boot=199, seed=42)
+        assert out["n_degenerate"] == 0
+        assert out["n_boot_effective"] == 199
+        np.testing.assert_allclose(
+            out["effect"]["eq_lower"],
+            [-1.148044173333, -0.710756198779, -1.475381568738,
+             -1.379849220776, -1.628921193323, -1.473219215610])
+        np.testing.assert_allclose(
+            out["effect"]["eq_upper"],
+            [1.028535794298, 1.477007898191, 0.923063871361,
+             0.952722049167, 0.749210506010, 0.664584840508])
+        np.testing.assert_allclose(
+            out["effect"]["sy_upper"],
+            [0.872494477313, 1.413704825787, 0.860925699272,
+             0.859676346861, 0.775951061707, 0.548522138988])
+
+    # -- edge cases ----------------------------------------------------------
+
+    def test_all_draws_degenerate_raises(self):
+        y, X, cf, refit, n_boot = self._setup(k=99)
+        with pytest.raises(MlsynthEstimationError, match="degenerate"):
+            pda_prediction_intervals(
+                y, X, _SAT_T0, counterfactual=cf, support=_SAT_SPARSE,
+                refit=refit, n_boot=n_boot, seed=1)
+
+    def test_single_surviving_draw_raises(self):
+        # Two draws are the minimum from which a quantile can be formed.
+        y, X, cf, refit, n_boot = self._setup(k=98)
+        with pytest.raises(MlsynthEstimationError, match="degenerate"):
+            pda_prediction_intervals(
+                y, X, _SAT_T0, counterfactual=cf, support=_SAT_SPARSE,
+                refit=refit, n_boot=n_boot, seed=1)
+
+    def test_two_surviving_draws_succeed(self):
+        y, X, cf, refit, n_boot = self._setup(k=97)
+        out = pda_prediction_intervals(
+            y, X, _SAT_T0, counterfactual=cf, support=_SAT_SPARSE, refit=refit,
+            n_boot=n_boot, seed=1)
+        assert out["n_boot_effective"] == 2
+        assert np.all(np.isfinite(out["effect"]["eq_lower"]))
+
+    def test_interpolating_point_estimator_raises(self):
+        # sigma^2 = 0 leaves no residual scale to studentize against at all.
+        y, X = _dgp(3)
+        with pytest.raises(MlsynthEstimationError, match="pre-period"):
+            pda_prediction_intervals(
+                y, X, 40, counterfactual=y.copy(), support=[0, 1, 2, 3],
+                refit=_make_refit(X, 40, [0, 1, 2, 3]), n_boot=49, seed=1)
+
+    # -- the failure is reported, not swallowed ------------------------------
+
+    def test_degenerate_count_surfaces_through_the_estimator(self):
+        # The engine's count must reach the PDA result, so a user can see that
+        # some draws were dropped without instrumenting the engine.
+        from mlsynth import PDA
+
+        df = _pda_panel(seed=2)
+        res = PDA(_pda_cfg(df, method="fs", prediction_intervals=True,
+                           pi_n_boot=99, pi_seed=0)).fit()
+        pi = res.fits["fs"].prediction_intervals
+        assert "n_degenerate" in pi and "n_boot_effective" in pi
+        assert pi["n_degenerate"] >= 0
+        assert pi["n_boot_effective"] + pi["n_degenerate"] == pi["n_boot"]
 
 
 class TestIndependentBootstrap:

--- a/mlsynth/utils/inferutils.py
+++ b/mlsynth/utils/inferutils.py
@@ -348,6 +348,14 @@ def _hac_matrix(g: np.ndarray, K: int) -> np.ndarray:
     return phi
 
 
+# A fit that leaves this share or less of the reference variance has
+# interpolated its pre-period: there is no residual scale left to studentize
+# against. The separation is stark in practice -- a saturated OLS fit leaves a
+# relative residual variance of order 1e-30, while the sparse fits the method
+# assumes leave order 1e-1 -- so the exact cut-off is not delicate.
+_INTERPOLATION_TOL = 1e-12
+
+
 def _prediction_variance(
     X_pre_Q: np.ndarray, resid_pre: np.ndarray, X_post_Q: np.ndarray, K: int,
 ) -> Optional[np.ndarray]:
@@ -438,12 +446,25 @@ def pda_prediction_intervals(
     Returns
     -------
     dict
-        ``alpha``, ``n_boot``, ``post_periods`` (``T1``), ``studentization``
-        (``"sandwich"`` | ``"sigma2"``), ``se`` ((T1,) :math:`\sqrt{V_t +
-        \sigma^2}`), and two blocks ``effect`` (for :math:`\Delta_t`) and
-        ``counterfactual`` (for :math:`Y_t`), each a dict of ``point``,
-        ``eq_lower``/``eq_upper`` (equal-tailed) and ``sy_lower``/``sy_upper``
-        (symmetric), all ``(T1,)`` arrays.
+        ``alpha``, ``n_boot`` (requested), ``n_degenerate`` and
+        ``n_boot_effective`` (see below), ``post_periods`` (``T1``),
+        ``studentization`` (``"sandwich"`` | ``"sigma2"``), ``se`` ((T1,)
+        :math:`\sqrt{V_t + \sigma^2}`), and two blocks ``effect`` (for
+        :math:`\Delta_t`) and ``counterfactual`` (for :math:`Y_t`), each a dict
+        of ``point``, ``eq_lower``/``eq_upper`` (equal-tailed) and
+        ``sy_lower``/``sy_upper`` (symmetric), all ``(T1,)`` arrays.
+
+    Notes
+    -----
+    A bootstrap draw whose refit saturates the pre-period -- a selected support
+    as large as ``T0``, which forward selection reaches on a few percent of
+    draws -- interpolates it, leaving a residual scale of order 1e-15 against an
+    O(1) post-period extrapolation error. The studentized statistic then reaches
+    ~1e15 and carries the quantiles with it, producing an interval wide enough
+    to cover unconditionally. Theorem 3.1 assumes the selected support stays
+    sparse relative to ``T0``, which such a draw violates, so it takes no part
+    in the quantiles and is counted in ``n_degenerate``; ``n_boot_effective`` is
+    the number that did. Reaching fewer than two usable draws raises.
 
     Raises
     ------
@@ -451,6 +472,10 @@ def pda_prediction_intervals(
         If ``n_boot < 2``, ``alpha`` is out of ``(0, 1)``, or ``T1 = T - T0 < 1``.
     MlsynthDataError
         If array shapes are inconsistent.
+    MlsynthEstimationError
+        If the point estimator interpolates the pre-period (no residual scale to
+        studentize against), or if fewer than two non-degenerate bootstrap draws
+        remain.
     """
     if not isinstance(n_boot, (int, np.integer)) or n_boot < 2:
         raise MlsynthConfigError(f"n_boot must be an integer >= 2; got {n_boot!r}.")
@@ -481,6 +506,14 @@ def pda_prediction_intervals(
 
     resid_pre = y[:T0] - counterfactual[:T0]
     sigma2 = float(np.mean(resid_pre ** 2))
+    y_pre_var = float(np.var(y[:T0]))
+    if sigma2 <= _INTERPOLATION_TOL * max(y_pre_var, 1.0):
+        raise MlsynthEstimationError(
+            "the point estimator interpolates the pre-period (residual variance "
+            f"{sigma2:.3g} against outcome variance {y_pre_var:.3g}), so there "
+            "is no residual scale to studentize the bootstrap against. The "
+            "support is saturated: refit with fewer donors than pre-periods."
+        )
 
     # Original-sample studentization scale.
     s2 = sigma2
@@ -493,6 +526,12 @@ def pda_prediction_intervals(
     # Bootstrap.
     resid_centered = resid_pre - resid_pre.mean()
     S = np.empty((n_boot, T1))
+    # A draw whose refit saturates the bootstrap pre-period leaves a residual
+    # scale of order 1e-15 while its post-period extrapolation error stays O(1),
+    # so the studentized statistic reaches ~1e15 and drags the quantiles with
+    # it. The theory assumes the selected support stays sparse relative to T0,
+    # which such a draw violates, so it is excluded and counted.
+    degenerate = np.zeros(n_boot, dtype=bool)
     for b in range(n_boot):
         if dependent:
             e_pre = (L @ rng.standard_normal(T0)) * resid_pre
@@ -512,9 +551,26 @@ def pda_prediction_intervals(
         ) if supp_star.size else None
         se_star = np.sqrt((Vt_star if Vt_star is not None else 0.0) + s2_star)
         e_star_post = y_star[T0:] - cf_star[T0:]
+        if s2_star <= _INTERPOLATION_TOL * sigma2 or not np.all(
+            np.isfinite(se_star)
+        ):
+            degenerate[b] = True
+            S[b] = 0.0          # excluded below; keeps the array finite
+            continue
         S[b] = e_star_post / np.where(se_star > 0, se_star, np.inf)
 
-    # Quantiles per post-period.
+    n_degenerate = int(degenerate.sum())
+    S = S[~degenerate]
+    if S.shape[0] < 2:
+        raise MlsynthEstimationError(
+            f"{n_degenerate} of {n_boot} bootstrap draws were degenerate "
+            f"(the refit interpolated the bootstrap pre-period), leaving "
+            f"{S.shape[0]} from which no quantile can be formed. The support is "
+            "saturating: refit with fewer donors than pre-periods, or raise "
+            "n_boot."
+        )
+
+    # Quantiles per post-period, over the non-degenerate draws.
     xi_lo = np.quantile(S, alpha / 2.0, axis=0)
     xi_hi = np.quantile(S, 1.0 - alpha / 2.0, axis=0)
     zeta = np.quantile(np.abs(S), 1.0 - alpha, axis=0)
@@ -540,6 +596,8 @@ def pda_prediction_intervals(
     return {
         "alpha": float(alpha),
         "n_boot": int(n_boot),
+        "n_degenerate": n_degenerate,
+        "n_boot_effective": int(n_boot - n_degenerate),
         "post_periods": int(T1),
         "studentization": studentization,
         "se": se if np.ndim(se) else np.full(T1, float(se)),

--- a/mlsynth/utils/pda_helpers/fs/estimation.py
+++ b/mlsynth/utils/pda_helpers/fs/estimation.py
@@ -35,6 +35,9 @@ def forward_select(
     Returns ``(selected_indices, beta_full, intercept, counterfactual)`` where
     ``beta_full`` is an ``N``-vector with zeros off the selected support.
 
+    Selection is capped at ``T0 - 1 - intercept`` donors so the pre-period fit
+    keeps a residual degree of freedom; see the comment on ``max_selected``.
+
     Parameters
     ----------
     intercept : bool, default False
@@ -57,7 +60,14 @@ def forward_select(
 
     selected: List[int] = []
     remaining = list(range(N))
-    for _ in range(T0):
+    # Leave at least one residual degree of freedom. The IC cannot enforce this
+    # itself: it carries log(s2), which diverges to -inf as the fit approaches an
+    # exact one, so every further donor keeps "improving" it and selection runs
+    # to T0 -- T0 + 1 parameters once the intercept is counted. The resulting
+    # residual variance is ~1e-31, which is the scale the Jiang et al. prediction
+    # intervals studentize against.
+    max_selected = max(0, T0 - 1 - int(intercept))
+    for _ in range(max_selected):
         if not remaining:
             break
         best_j, best_s2 = None, np.inf


### PR DESCRIPTION
Recovered from a stale branch during a branch audit; rebased onto current `main` and re-verified.

A PDA fit that saturates its degrees of freedom leaves nothing to estimate the residual scale from, and the prediction interval built on that scale is not a statement about uncertainty. This adds the guard and the tests that pin it.

Touches `mlsynth/utils/inferutils.py` and `mlsynth/utils/pda_helpers/fs/estimation.py`, with the coverage in `test_pda.py` and `test_pda_prediction_intervals.py`.

Local: 101 passed across both test files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N1tjauZqDV6Phs8HLu9Cw9)_