### PR TITLE
Add a sum-to-one weight option to DSC, alongside the simplex default

### DIFF
--- a/docs/dsc.rst
+++ b/docs/dsc.rst
@@ -356,6 +356,21 @@ Koksma-Hlawka inequality the QMC approximation error is
 :math:`O(\log M / M)` for Halton / Sobol vs. :math:`O(M^{-1/2})` for i.i.d.
 draws.
 
+Relaxing the simplex. :math:`\Delta^{N_0}` is the set :math:`\mathcal{H}` of
+Zhang, Zhang & Zhang (2026), and it is the default because it keeps the
+synthetic unit a weighted average of observed donors, which is what makes the
+counterfactual interpretable. Setting ``weight_constraint="sum_to_one"`` drops
+non-negativity and keeps :math:`\sum_j w_j = 1` with :math:`w_j \le 1`, the
+feasible set the reference ``DiSCos`` package uses by default. The larger set
+can only lower the fitted loss, and it permits extrapolation beyond the donors'
+convex hull: a treated quantile function lying outside that hull becomes
+reachable, at the cost of a synthetic unit that subtracts one donor's
+distribution from another's. Zhang, Zhang & Zhang (2026) discuss the same
+relaxation as a bounded set :math:`[-C_L, C_U]^{N_0}`, noting that the
+sum-to-unity restriction is what continues to do the work once non-negativity
+goes. Reach for it when the pre-period fit under the simplex is poor and the
+diagnostics above point to the treated unit sitting outside the hull.
+
 Step 3 -- Aggregate over the pre-period. The final weight is a convex
 combination :math:`\widehat{\mathbf{w}} = \sum_{t \in \mathcal{T}_1} \lambda_t
 \mathbf{w}_t`, with :math:`\lambda_t \ge 0` and :math:`\sum_t \lambda_t = 1`.

--- a/mlsynth/estimators/dsc.py
+++ b/mlsynth/estimators/dsc.py
@@ -87,6 +87,7 @@ class DSC:
         self.time: str = config.time
         self.M = config.M
         self.grid_method: str = config.grid_method
+        self.weight_constraint: str = config.weight_constraint
         self.lambda_method: str = config.lambda_method
         self.lambda_decay: float = config.lambda_decay
         self.lambda_weights = config.lambda_weights
@@ -114,6 +115,7 @@ class DSC:
                 inputs=inputs,
                 M=self.M,
                 grid_method=self.grid_method,
+                weight_constraint=self.weight_constraint,
                 lambda_method=self.lambda_method,
                 lambda_decay=self.lambda_decay,
                 lambda_weights=self.lambda_weights,

--- a/mlsynth/tests/test_dsc_weight_constraint.py
+++ b/mlsynth/tests/test_dsc_weight_constraint.py
@@ -1,0 +1,192 @@
+"""Tests for the DSC weight-constraint option (simplex vs sum-to-one).
+
+DiSCo's default feasible set is not the simplex: ``DiSCo_weights_reg`` passes
+``lb = NULL`` unless ``simplex = TRUE``, so weights need only sum to one and be
+at most one, and may be negative. Zhang, Zhang & Zhang (2026) discuss the same
+relaxation as a bounded extrapolation set. This adds it as an option, with the
+simplex kept as the default.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import DSC
+from mlsynth.config_models import DSCConfig
+from mlsynth.exceptions import MlsynthConfigError, MlsynthEstimationError
+from mlsynth.utils.dsc_helpers.weights import (
+    solve_simplex_weights,
+    solve_sum_to_one_weights,
+)
+
+
+def _panel(seed=0, n_units=5, n_periods=6, n_obs=60, t0=4):
+    """Micro-level panel: one row per (unit, period, individual)."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    for u in range(n_units):
+        for t in range(n_periods):
+            y = rng.normal(10.0 + 2.0 * u + 0.3 * t, 1.0 + 0.1 * u, size=n_obs)
+            rows.append(pd.DataFrame({
+                "unit": f"u{u}", "time": t, "y": y,
+                "D": int(u == 0 and t >= t0),
+            }))
+    return pd.concat(rows, ignore_index=True)
+
+
+# --------------------------------------------------------------------------
+# the solver
+# --------------------------------------------------------------------------
+
+def test_sum_to_one_smoke():
+    rng = np.random.default_rng(0)
+    A, b = rng.normal(size=(40, 4)), rng.normal(size=40)
+    w = solve_sum_to_one_weights(A, b)
+    assert w.shape == (4,)
+    assert np.isfinite(w).all()
+    assert w.sum() == pytest.approx(1.0)
+
+
+def test_sum_to_one_respects_the_upper_bound():
+    """DiSCo passes ub = 1 in both modes, so no single weight may exceed one."""
+    rng = np.random.default_rng(1)
+    A, b = rng.normal(size=(30, 3)), rng.normal(size=30) * 50.0
+    assert np.all(solve_sum_to_one_weights(A, b) <= 1.0 + 1e-8)
+
+
+def test_sum_to_one_is_never_worse_than_the_simplex():
+    """The simplex is contained in the sum-to-one set, so the optimum improves."""
+    rng = np.random.default_rng(2)
+    for _ in range(15):
+        A, b = rng.normal(size=(50, 5)), rng.normal(size=50)
+        obj = lambda w: float(np.sum((A @ w - b) ** 2))
+        assert obj(solve_sum_to_one_weights(A, b)) <= obj(solve_simplex_weights(A, b)) + 1e-6
+
+
+def test_sum_to_one_goes_negative_when_extrapolation_helps():
+    """A target outside the donors' convex hull draws a weight below zero.
+
+    Two donors cannot show this: with the weights summing to one, a negative
+    second weight needs a first above one, which the upper bound forbids. Three
+    can, so the target here is built at the feasible point (0.8, 0.8, -0.6).
+    """
+    rng = np.random.default_rng(5)
+    A = rng.normal(size=(60, 3))
+    truth = np.array([0.8, 0.8, -0.6])
+    w = solve_sum_to_one_weights(A, A @ truth)
+    np.testing.assert_allclose(w, truth, atol=1e-6)
+    assert w.min() < 0.0
+    assert w.sum() == pytest.approx(1.0)
+
+
+def test_the_two_solvers_agree_when_the_simplex_does_not_bind():
+    """With an interior simplex optimum, relaxing non-negativity changes nothing."""
+    rng = np.random.default_rng(3)
+    A = rng.normal(size=(200, 3)) + np.array([0.0, 1.0, 2.0])
+    b = A @ np.array([0.3, 0.4, 0.3]) + 0.01 * rng.normal(size=200)
+    w_s = solve_simplex_weights(A, b)
+    assert w_s.min() > 0.02                       # interior, so the bound is slack
+    np.testing.assert_allclose(solve_sum_to_one_weights(A, b), w_s, atol=1e-6)
+
+
+def test_sum_to_one_single_donor():
+    assert solve_sum_to_one_weights(np.ones((10, 1)), np.arange(10.0)) == pytest.approx([1.0])
+
+
+def test_sum_to_one_underdetermined_is_still_feasible():
+    """Fewer rows than donors: the fit interpolates, the constraints still hold."""
+    rng = np.random.default_rng(4)
+    w = solve_sum_to_one_weights(rng.normal(size=(4, 10)), rng.normal(size=4))
+    assert w.sum() == pytest.approx(1.0)
+    assert np.all(w <= 1.0 + 1e-8)
+
+
+@pytest.mark.parametrize("A, b", [
+    (np.ones(10), np.ones(10)),                       # 1-D design
+    (np.ones((10, 2)), np.ones((10, 1))),             # 2-D target
+    (np.ones((10, 2)), np.ones(9)),                   # length mismatch
+])
+def test_sum_to_one_rejects_bad_shapes(A, b):
+    with pytest.raises(MlsynthEstimationError):
+        solve_sum_to_one_weights(A, b)
+
+
+# --------------------------------------------------------------------------
+# the config
+# --------------------------------------------------------------------------
+
+def test_default_is_the_simplex():
+    cfg = DSCConfig(df=_panel(), outcome="y", treat="D", unitid="unit", time="time")
+    assert cfg.weight_constraint == "simplex"
+
+
+def test_pipeline_rejects_an_unknown_constraint():
+    """run_dsc is callable directly, so its own guard has to hold.
+
+    The config Literal stops this at the estimator boundary, which means the
+    pipeline guard is only reachable by a direct helper call -- and that is
+    exactly how the benchmark suite uses these helpers.
+    """
+    from mlsynth.utils.dsc_helpers.pipeline import run_dsc
+    from mlsynth.utils.dsc_helpers.setup import prepare_dsc_inputs
+
+    inputs = prepare_dsc_inputs(df=_panel(), outcome="y", treat="D",
+                                unitid="unit", time="time")
+    with pytest.raises(MlsynthEstimationError, match="weight_constraint"):
+        run_dsc(inputs=inputs, M=100, grid_method="equidistant",
+                weight_constraint="convex-hull")
+
+
+def test_unknown_constraint_is_rejected():
+    with pytest.raises((MlsynthConfigError, ValueError)):
+        DSCConfig(df=_panel(), outcome="y", treat="D", unitid="unit",
+                  time="time", weight_constraint="convex-hull")
+
+
+# --------------------------------------------------------------------------
+# end to end
+# --------------------------------------------------------------------------
+
+def _fit(**kw):
+    return DSC({"df": _panel(), "outcome": "y", "treat": "D", "unitid": "unit",
+                "time": "time", "display_graphs": False, **kw}).fit()
+
+
+def test_the_default_fit_is_unchanged_by_the_new_option():
+    """Passing the default explicitly must reproduce the implicit default exactly."""
+    a = _fit()
+    b = _fit(weight_constraint="simplex")
+    np.testing.assert_allclose(a.weights.weight_vector, b.weights.weight_vector,
+                               rtol=0, atol=0)
+    assert a.att == pytest.approx(b.att, rel=0, abs=0)
+
+
+def test_default_weights_stay_on_the_simplex():
+    w = _fit().weights.weight_vector
+    assert np.all(w >= -1e-9)
+    assert w.sum() == pytest.approx(1.0)
+
+
+def test_sum_to_one_fit_still_sums_to_one():
+    res = _fit(weight_constraint="sum_to_one")
+    w = res.weights.weight_vector
+    assert w.sum() == pytest.approx(1.0)
+    assert np.all(w <= 1.0 + 1e-8)
+    assert np.isfinite(res.att)
+
+
+def test_sum_to_one_fits_the_pre_period_at_least_as_well():
+    """A larger feasible set cannot worsen the pre-period Wasserstein fit."""
+    # pre_period_wasserstein is the per-period loss at that period's own
+    # weights, so the inequality holds period by period, not just on average.
+    tight = np.asarray(_fit().pre_period_wasserstein)
+    loose = np.asarray(_fit(weight_constraint="sum_to_one").pre_period_wasserstein)
+    assert np.all(loose <= tight + 1e-8)
+    assert loose.sum() < tight.sum()
+
+
+def test_inference_uses_the_same_constraint():
+    """Placebo refits must not silently fall back to the simplex."""
+    res = _fit(weight_constraint="sum_to_one", compute_inference=True)
+    assert res.inference is not None

--- a/mlsynth/utils/dsc_helpers/__init__.py
+++ b/mlsynth/utils/dsc_helpers/__init__.py
@@ -32,7 +32,11 @@ from .quantiles import (
 )
 from .setup import prepare_dsc_inputs
 from .structures import DSCInputs, DSCResults, QTECurve
-from .weights import solve_simplex_weights, wasserstein_loss_at_weights
+from .weights import (
+    solve_simplex_weights,
+    solve_sum_to_one_weights,
+    wasserstein_loss_at_weights,
+)
 
 __all__ = [
     "DSCInference",
@@ -48,5 +52,6 @@ __all__ = [
     "run_dsc",
     "sample_quantile_grid",
     "solve_simplex_weights",
+    "solve_sum_to_one_weights",
     "wasserstein_loss_at_weights",
 ]

--- a/mlsynth/utils/dsc_helpers/config.py
+++ b/mlsynth/utils/dsc_helpers/config.py
@@ -69,6 +69,16 @@ class DSCConfig(BaseEstimatorConfig):
                     "sequences; 'uniform' is the i.i.d. draw the paper writes "
                     "and the R package uses, whose weights vary with the seed.",
     )
+    weight_constraint: Literal["simplex", "sum_to_one"] = Field(
+        default="simplex",
+        description="Feasible set for the donor weights. 'simplex' (default) is "
+                    "the set H of Zhang, Zhang & Zhang (2026): non-negative and "
+                    "summing to one, so the synthetic unit is a weighted average "
+                    "of observed donors. 'sum_to_one' drops non-negativity and "
+                    "keeps the sum and an upper bound of one, which is the "
+                    "reference DiSCos package's default and permits "
+                    "extrapolation beyond the donors' convex hull.",
+    )
     lambda_method: Literal["uniform", "recency"] = Field(
         default="uniform",
         description="Default rule for pre-period aggregation weights lambda_t.",

--- a/mlsynth/utils/dsc_helpers/inference.py
+++ b/mlsynth/utils/dsc_helpers/inference.py
@@ -33,7 +33,7 @@ import numpy as np
 
 from .aggregation import aggregate_period_weights
 from .quantiles import empirical_quantile, sample_quantile_grid
-from .weights import solve_simplex_weights
+from .weights import solve_simplex_weights, solve_sum_to_one_weights
 
 
 @dataclass(frozen=True)
@@ -79,6 +79,7 @@ def _wasserstein_distance_path(
     grid: np.ndarray,
     lam: np.ndarray,
     eval_grid: np.ndarray,
+    weight_constraint: str = "simplex",
 ) -> np.ndarray:
     """Per-period squared 2-Wasserstein distance for one (target, donors) split.
 
@@ -96,7 +97,8 @@ def _wasserstein_distance_path(
         donor_mat = np.column_stack([
             empirical_quantile(inputs.cell_samples[(u, t)], grid) for u in donor_units
         ])
-        period_w[i] = solve_simplex_weights(donor_mat, treated_vec)
+        period_w[i] = (solve_simplex_weights if weight_constraint == "simplex"
+                       else solve_sum_to_one_weights)(donor_mat, treated_vec)
     w_hat = aggregate_period_weights(period_w, lam)
 
     dists = np.empty(inputs.time_labels.size)
@@ -116,6 +118,7 @@ def placebo_permutation_test(
     M: int,
     grid_method: str,
     lam: np.ndarray,
+    weight_constraint: str = "simplex",
     n_eval: int = 200,
     random_state: int = 0,
 ) -> DSCInference:
@@ -145,7 +148,7 @@ def placebo_permutation_test(
     donors = list(inputs.unit_names[1:])
 
     treated_distance = _wasserstein_distance_path(
-        inputs, treated, donors, grid, lam, eval_grid,
+        inputs, treated, donors, grid, lam, eval_grid, weight_constraint,
     )
 
     placebo_rows = []
@@ -154,7 +157,8 @@ def placebo_permutation_test(
         # other donor (DiSCo_per_iter): swap iota into the target slot.
         pool = [treated] + [u for u in donors if u != iota]
         placebo_rows.append(
-            _wasserstein_distance_path(inputs, iota, pool, grid, lam, eval_grid)
+            _wasserstein_distance_path(inputs, iota, pool, grid, lam, eval_grid,
+                                       weight_constraint)
         )
     placebo_distances = np.vstack(placebo_rows) if placebo_rows else np.empty((0, inputs.T))
 

--- a/mlsynth/utils/dsc_helpers/pipeline.py
+++ b/mlsynth/utils/dsc_helpers/pipeline.py
@@ -38,7 +38,11 @@ from .quantiles import (
     sample_quantile_grid,
 )
 from .structures import DSCInputs, DSCResults, QTECurve
-from .weights import solve_simplex_weights, wasserstein_loss_at_weights
+from .weights import (
+    solve_simplex_weights,
+    solve_sum_to_one_weights,
+    wasserstein_loss_at_weights,
+)
 
 
 def run_dsc(
@@ -51,6 +55,7 @@ def run_dsc(
     lambda_weights: Optional[Sequence[float]] = None,
     qte_quantiles: Optional[Sequence[float]] = None,
     n_qte_points: int = 99,
+    weight_constraint: str = "simplex",
     compute_inference: bool = False,
     inference_grid_points: int = 200,
     random_state: int = 0,
@@ -75,6 +80,9 @@ def run_dsc(
     lambda_method : {"uniform", "recency"}
         Default aggregation rule for the pre-period weights. Ignored
         if ``lambda_weights`` is provided explicitly.
+    weight_constraint : {"simplex", "sum_to_one"}
+        Feasible set for the donor weights. See
+        :class:`~mlsynth.config_models.DSCConfig`.
     lambda_decay : float
         Geometric decay for ``lambda_method="recency"``.
     lambda_weights : sequence of float, optional
@@ -111,6 +119,14 @@ def run_dsc(
 
     V = sample_quantile_grid(M=M, method=grid_method, random_state=random_state)
 
+    if weight_constraint not in ("simplex", "sum_to_one"):
+        raise MlsynthEstimationError(
+            f"weight_constraint must be 'simplex' or 'sum_to_one', "
+            f"got {weight_constraint!r}."
+        )
+    solve = (solve_simplex_weights if weight_constraint == "simplex"
+             else solve_sum_to_one_weights)
+
     # ------------------------------------------------------------------
     # Steps 1 & 2: per-pre-period simplex regression on pseudo-samples.
     # ------------------------------------------------------------------
@@ -121,7 +137,7 @@ def run_dsc(
     pre_period_labels = inputs.time_labels[:T0]
     for i, t in enumerate(pre_period_labels):
         donor_mat, treated_vec = build_pseudo_sample_matrix(inputs, t, V)
-        w_t = solve_simplex_weights(donor_mat, treated_vec)
+        w_t = solve(donor_mat, treated_vec)
         period_weight_matrix[i] = w_t
         period_loss[i] = wasserstein_loss_at_weights(donor_mat, treated_vec, w_t)
 
@@ -221,6 +237,7 @@ def run_dsc(
             M=M,
             grid_method=grid_method,
             lam=lam,
+            weight_constraint=weight_constraint,
             n_eval=inference_grid_points,
             random_state=random_state,
         )

--- a/mlsynth/utils/dsc_helpers/weights.py
+++ b/mlsynth/utils/dsc_helpers/weights.py
@@ -171,6 +171,74 @@ def _refine_exact(A: np.ndarray, b: np.ndarray, warm: np.ndarray) -> np.ndarray:
         return warm
 
 
+def solve_sum_to_one_weights(
+    donor_matrix: np.ndarray,
+    treated_vec: np.ndarray,
+) -> np.ndarray:
+    """Least-squares weights that sum to one, without the non-negativity bound.
+
+    Solves
+
+    .. math::
+
+       \\widehat w = \\arg\\min_{w} \\| \\widetilde Y_t\\, w
+                     - \\widehat Y_{1t} \\|_2^2,
+       \\qquad \\mathbf 1^\\top w = 1, \\quad w \\le 1,
+
+    the feasible set the reference ``DiSCos`` package uses by default:
+    ``DiSCo_weights_reg`` passes ``lb = NULL`` unless ``simplex = TRUE`` and
+    ``ub = 1`` in either case, so a weight may go negative but none may exceed
+    one. Zhang, Zhang & Zhang (2026) frame the same relaxation as a bounded
+    extrapolation set :math:`[-C_L, C_U]^J`, which contains the simplex, so the
+    fitted loss here is never above what :func:`solve_simplex_weights` attains.
+
+    Allowing negative weights buys fit when the treated quantile function sits
+    outside the donors' convex hull, and costs the interpretability the simplex
+    provides: the synthetic unit is no longer a weighted average of observed
+    donors. The simplex remains the default.
+
+    Parameters
+    ----------
+    donor_matrix : np.ndarray
+        :math:`(M, J)` design matrix -- donor quantile functions on the grid.
+    treated_vec : np.ndarray
+        Length-``M`` target quantile function.
+
+    Returns
+    -------
+    np.ndarray
+        Length-``J`` weight vector with ``sum(w) == 1`` and ``w <= 1``.
+    """
+    if donor_matrix.ndim != 2 or treated_vec.ndim != 1:
+        raise MlsynthEstimationError(
+            "donor_matrix must be 2-D and treated_vec must be 1-D."
+        )
+    if donor_matrix.shape[0] != treated_vec.shape[0]:
+        raise MlsynthEstimationError(
+            "donor_matrix and treated_vec must have the same number of rows."
+        )
+    A = np.asarray(donor_matrix, dtype=float)
+    b = np.asarray(treated_vec, dtype=float)
+    J = A.shape[1]
+    if J == 1:
+        return np.ones(1)
+    try:
+        import cvxpy as cp
+    except Exception as exc:  # pragma: no cover - cvxpy is a declared dependency
+        raise MlsynthEstimationError(
+            "weight_constraint='sum_to_one' needs cvxpy, which is not importable."
+        ) from exc
+    w = cp.Variable(J)
+    cp.Problem(cp.Minimize(cp.sum_squares(A @ w - b)),
+               [cp.sum(w) == 1, w <= 1]).solve(solver=cp.CLARABEL)
+    if w.value is None:  # pragma: no cover - degenerate
+        raise MlsynthEstimationError("The sum-to-one weight solve did not converge.")
+    out = np.asarray(w.value, dtype=float).ravel()
+    # Renormalise against solver slack on the equality; the residual is ~1e-12
+    # and left uncorrected it would surface as weights that do not sum to one.
+    return out / out.sum()
+
+
 def wasserstein_loss_at_weights(
     donor_matrix: np.ndarray,
     treated_vec: np.ndarray,


### PR DESCRIPTION
## Related Links

- Estimator page: `docs/dsc.rst` (Algorithm, Step 2)
- Reference behaviour: `DiSCo_weights_reg` in [Davidvandijcke/DiSCos](https://github.com/Davidvandijcke/DiSCos) at `ed2b3d94`
- Source: Zhang, L., Zhang, X. & Zhang, X. (2026), [arXiv:2405.00953v3](https://arxiv.org/abs/2405.00953), the discussion of relaxing `H` to a bounded extrapolation set
- Follows from the discussion on #378; a DiSCo cross-validation case is the intended next step and needs this option to reproduce the reference's default configuration

## What

- Added `weight_constraint: Literal["simplex", "sum_to_one"]` to `DSCConfig`, defaulting to `simplex`.
- Added `solve_sum_to_one_weights` to `mlsynth/utils/dsc_helpers/weights.py`, exported from the helper package.
- Threaded the option through `pipeline.run_dsc`, `inference.placebo_permutation_test` and `DSC`.
- Added `mlsynth/tests/test_dsc_weight_constraint.py` (18 tests).
- Documented the relaxation in `docs/dsc.rst` under Step 2.

## Why

DSC has always constrained donor weights to the simplex, which is the set `H` of Zhang, Zhang & Zhang (2026). The reference `DiSCos` package does not. `DiSCo_weights_reg` passes `lb = NULL` unless `simplex = TRUE`, with `ub = 1` in either case, so its default feasible set is sum-to-one with each weight at most one and negatives allowed. mlsynth could not express that set at all, which meant the reference's default configuration was unreachable.

Zhang, Zhang & Zhang frame the same relaxation as a bounded extrapolation set `[-C_L, C_U]^J`, observing that the sum-to-unity restriction is what continues to do the work once non-negativity goes. So the option has a home in the source paper as well as in the reference implementation.

## How

`solve_sum_to_one_weights` solves the same least-squares objective over `sum(w) = 1, w <= 1` with CLARABEL, and renormalises against the solver's equality slack — about 1e-12, but left alone it would surface as weights that do not sum to one.

The option threads all the way into `placebo_permutation_test`. Inference that reverted to the simplex while the point estimate used the relaxation would be measuring a different estimator, and the placebo distribution would not be comparable to the treated distance it is ranked against.

## Verification

- Path: not applicable — no new estimator and no new numerical claim about a paper. The existing DSC benchmarks (`dsc_dube`, `disco_tenure`, `dsc_mc`) all run the default path and are unaffected.

The correctness argument rests on containment: the simplex sits inside the sum-to-one set, so the fitted loss under the relaxation can never be higher. That is asserted two ways — on fifteen random designs at the solver level, and end to end on the per-period Wasserstein fit, which is recorded at each period's own weights and therefore admits the comparison period by period, not merely on average. The converse is pinned too: when the non-negativity bound is slack, the two solvers agree to 1e-6.

The default is pinned as bit-identical. `test_the_default_fit_is_unchanged_by_the_new_option` compares an implicit-default fit against an explicit `weight_constraint="simplex"` fit at `atol=0, rtol=0` on both the weight vector and the ATT.

One thing the tests had to work around: two donors cannot exhibit a negative weight here. With the weights summing to one, a negative second weight requires a first above one, which `ub = 1` forbids. The extrapolation test therefore uses three donors and targets the feasible point `(0.8, 0.8, -0.6)`.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR

- [x] The default preserves existing behaviour exactly, including the units effects are reported in — pinned at zero tolerance.
- [x] Existing pinned benchmark values unchanged; the 62 existing DSC tests pass untouched.
- [x] A test pins that the default is unchanged.
- [x] New config field has a `Field(...)` description saying when to reach for it.

## Designs

No plots. The change is a feasible set, and the behavioural claim is the containment inequality asserted in the tests.

## Test Steps

- [x] `pytest mlsynth/tests/test_dsc_weight_constraint.py -q` — 18 passed
- [x] `pytest` on the four existing DSC test modules — 62 passed, no changes needed
- [x] `coverage run --timid -m pytest` over the DSC modules — `config.py` and `inference.py` at 100 percent; the new solver's branches all covered, including the pipeline-level guard that the config `Literal` hides from the estimator boundary but that direct helper callers can still reach
- [x] Docs build checked with docutils, no new structural errors

## Other Notes

- The intended follow-up is a real DiSCo cross-validation case, which this unblocks: with `sum_to_one` available, mlsynth can be run in the reference's default configuration as well as its `simplex = TRUE` one.
- Two pre-existing lines in `weights.py` trip the repo's banned-word grep ("worth keeping visible", "rather than failing outright"). Left alone, since they are outside this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgS4wcBaq6quoZavEPNsjW)_