### PR TITLE
Correct how the DSC page describes what the implementation is validated against

### DIFF
--- a/docs/dsc.rst
+++ b/docs/dsc.rst
@@ -16,9 +16,15 @@ treatment effect (QTE) at any quantile :math:`q \in (0, 1)`, and any
 functional of the distribution (Lorenz curves, Gini coefficients,
 interquartile ranges, stochastic-dominance comparisons).
 
-The method is due to Gunsilius (2023); mlsynth's implementation is
-validated against the author's reference ``DiSCo`` R package, and the
-large-sample theory is from Zhang, Zhang & Zhang (2026). The core idea is
+The method is due to Gunsilius (2023), and mlsynth implements the algorithm as
+Zhang, Zhang & Zhang (2026) specify it -- the paper that also supplies the
+large-sample theory. Validation is against the deterministic Stata command of
+Gunsilius & Van Dijcke, whose published weights mlsynth reproduces bit-for-bit
+(:doc:`replications/disco_tenure`), and against the ``DiSCo`` R package averaged
+over seeds (:doc:`replications/dsc_disco_xval`). The averaging is not optional:
+that package draws its quadrature points with ``runif``, so a single run's
+weights are a Monte Carlo estimate that moves with the seed, by up to 0.119 on
+the Dube panel. The core idea is
 the 2-Wasserstein barycenter: the natural
 generalization of a weighted average from points on the real line to
 probability distributions. Averaging quantile functions (not densities)


### PR DESCRIPTION
## Related Links

- `docs/dsc.rst`, the Overview paragraph
- The cases the sentence now names: `benchmarks/cases/disco_tenure.py` and `benchmarks/cases/dsc_disco_xval.py` (#380)
- Follows the discussion on #378 and #380

## What

One paragraph in `docs/dsc.rst`. Docs only, no code.

## Why

The Overview said the implementation "is validated against the author's reference `DiSCo` R package". Two things are off.

It names the wrong reference as the thing mlsynth is checked against. `DiSCo_weights_reg` draws its quadrature points with `runif`, so the package's weights are a Monte Carlo estimate that moves with the seed — by up to 0.119 on the Dube panel, which is exactly why `disco_tenure` says a single R run cannot serve as a target. What mlsynth reproduces bit-for-bit is the deterministic Stata command's published weights. The R package is now also a reference, via #380, but only seed-averaged, and that qualification is the whole reason the comparison works.

It also demoted the algorithm's specification to a subordinate clause about large-sample theory. Zhang, Zhang & Zhang (2026) supply that theory, but they also supply Algorithm 1 — which is what `dsc.py`'s own docstring says the implementation follows — and the mixing condition that licenses the low-discrepancy grids mlsynth defaults to. Gunsilius (2023) is the method; that paper is the specification.

## How

The sentence now names both references it is actually checked against, links their replication pages, and says why the averaging is not optional.

## Verification

- Path: not applicable — no numerical code touched, no pinned value changes.

## Scope checks

None of the four blocks fit: this is a documentation correction.

## Designs

None.

## Test Steps

- [x] Docs checked with docutils — structural error count unchanged from the pre-edit baseline (2, both pre-existing)
- [x] Both `:doc:` targets exist in the tree as of #380

## Other Notes

Nothing outstanding for this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgS4wcBaq6quoZavEPNsjW)_