### PR TITLE
Re-scope issue #304 in dsc_dube, now that the cross-validation exists

### DIFF
--- a/benchmarks/cases/dsc_dube.py
+++ b/benchmarks/cases/dsc_dube.py
@@ -42,12 +42,25 @@ Provenance / scope
   spurious effect"), which is a single bit -- a materially wrong DSC that still
   failed to reject would satisfy it.
 
-  ``DiSCos`` 0.1.4 *is* now installable here (``benchmarks/R/install_discos.sh``),
-  and running it on this same file shows donor weights disagreeing with mlsynth
-  by up to 0.074, with the two implementations reaching pre-period objective
-  values 4 percent apart. That is tracked in issue #304 and is why these rows are
-  not yet cross-validated: pinning agreement before the disagreement is
-  understood would pin the wrong thing.
+  That is a statement about this case, not about the estimator. DSC is
+  cross-validated twice over: ``disco_tenure`` reproduces the ``disco`` Stata
+  Journal article's published donor weights bit-for-bit at the reference's own
+  settings, and ``dsc_disco_xval`` compares against the ``DiSCos`` R package on
+  this very panel.
+
+  That second case also resolves issue #304, which recorded the R package
+  disagreeing with mlsynth here by up to 0.074 and stood as the reason these
+  rows were left un-cross-validated. The disagreement was a measurement
+  artifact. ``DiSCo_weights_reg`` draws its quadrature points with ``runif``, so
+  a single run's weights are a Monte Carlo estimate; the 0.074 was one seed at
+  the package's default draw count. At ``M = 10,000``, averaged over 40 seeds,
+  the gap is 0.0079 -- half the reference's own across-seed standard deviation
+  of 0.0160.
+
+  The rows here stay as they are. They are pinned at DSC's *default* settings on
+  the vignette's setup, which is what makes them a regression guard on the
+  configuration users actually get; ``dsc_disco_xval`` runs at a draw count
+  chosen to resolve the reference, which is a different question.
 """
 from __future__ import annotations
 

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -57,8 +57,6 @@ Path A — empirical replications
      - CWZ 2025 Table 5 carbon-tax debiased t-test
    * - ``dsc_dube``
      - DSC distributional SC on Dube minimum-wage (Gunsilius/DiSCo vignette)
-   * - ``dsc_disco_xval``
-     - DSC against the authors' ``DiSCos`` R package on the Dube panel, in both feasible sets. The reference draws its quadrature points with ``runif``, so a single run is not a target; this scores mlsynth against the mean of 40 seeds at M = 10,000 and reads the across-seed spread as the yardstick. Max donor-weight gap 0.0079 (simplex) and 0.0103 (sum-to-one) against reference seed standard deviations of 0.0160 and 0.0300 -- closer to the reference's centre than the reference is to itself, which settles issue #304
    * - ``fsc_okano``
      - Okano-Kurisu (2026) functional SC, all three applications from the authors' data: pre-treatment fits for the plain and ridge-augmented estimator in each (fertility curves 0.1259/0.0687, age-at-death distributions 0.2092/0.0634, trade covariance matrices 39.3429/20.0639) plus every weight of Tables 1-3, reproduced exactly by a port of the authors' R code
    * - ``fsc_estimator``
@@ -284,6 +282,8 @@ Cross-validation against reference implementations
      - Validates
    * - ``ascm_kansas``
      - vs augsynth: Kansas ridge-ASCM ladder (SCM/ridge/covariate/residualized)
+   * - ``dsc_disco_xval``
+     - DSC against the authors' ``DiSCos`` R package on the Dube panel, in both feasible sets. The reference draws its quadrature points with ``runif``, so a single run is not a target; this scores mlsynth against the mean of 40 seeds at M = 10,000 and reads the across-seed spread as the yardstick. Max donor-weight gap 0.0079 (simplex) and 0.0103 (sum-to-one) against reference seed standard deviations of 0.0160 and 0.0300 -- closer to the reference's centre than the reference is to itself, which settles issue #304
    * - ``disco_tenure``
      - vs the ``disco`` Stata Journal published results: the tenure example's top-5 donor weights (to 5e-5) and its quantile-effects table (to 5e-4), plus the M-converged readings so the published m(100) values are not mistaken for the estimand
    * - ``ascm_jackknife_plus``

--- a/docs/dsc.rst
+++ b/docs/dsc.rst
@@ -439,12 +439,18 @@ run it with ``python benchmarks/run_benchmarks.py dsc_dube``.
    used a 250-observations-per-cell subsample, which for a *distributional*
    method distorted the very quantity being matched.
 
-   Five of the six pinned rows are regression pins on mlsynth's own output, not
-   external checks. ``DiSCos`` 0.1.4 is installable here
-   (``benchmarks/R/install_discos.sh``), and it disagrees with mlsynth on donor
-   weights by up to 0.074 on identical data -- tracked in issue #304. Until that
-   is resolved, treat the vignette's ``p > 0.05`` as the only externally
-   anchored quantity in this benchmark.
+   Five of the six pinned rows are regression pins on mlsynth's own output, so
+   within this case the vignette's ``p > 0.05`` is the only externally anchored
+   quantity. The external anchors live in the other two cases:
+   :doc:`replications/disco_tenure` reproduces the Stata command's published
+   weights bit-for-bit, and :doc:`replications/dsc_disco_xval` compares against
+   the ``DiSCos`` R package on this same panel.
+
+   Issue #304, which recorded the R package disagreeing with mlsynth here by up
+   to 0.074, is settled by that second case: the package draws its quadrature
+   points with ``runif``, and 0.074 was one seed at its default draw count. At
+   ``M = 10,000`` averaged over 40 seeds the gap is 0.0079, against the
+   reference's own across-seed standard deviation of 0.0160.
 
 A third benchmark (``benchmarks/cases/dsc_mc.py``) runs the Monte Carlo of the
 paper whose Algorithm 1 this estimator implements, Zhang, Zhang & Zhang (2026)


### PR DESCRIPTION
## Related Links

- `benchmarks/cases/dsc_dube.py` docstring, and the matching note on `docs/dsc.rst`
- The case that resolved it: `benchmarks/cases/dsc_disco_xval.py` (#380)
- Issue #304, closed by #380

## What

- Rewrote the `#304` paragraph in `dsc_dube.py`'s docstring and the corresponding `.. note::` on the DSC page.
- Moved the `dsc_disco_xval` row in `docs/benchmarks.rst` out of the Path A table and into the cross-validation table. #380 put it in the wrong one — my error there, caught reading the rendered catalogue.

No pinned value changes; the six `EXPECTED` rows in `dsc_dube` are untouched.

## Why

`dsc_dube` said its rows were "not yet cross-validated: pinning agreement before the disagreement is understood would pin the wrong thing", with the 0.074 gap against the R package as the open question. `docs/dsc.rst` said the same, telling readers to treat the vignette's `p > 0.05` as the only externally anchored quantity until #304 resolved.

Both statements are now false in the same way: they describe an open question that #380 closed. Leaving them would send a reader to an issue that is shut and imply DSC has one bit of external validation when it has two cases' worth.

## How

The rewrite makes three points. The 0.074 was one seed at the package's default draw count, and at `M = 10,000` averaged over 40 seeds the gap is 0.0079. DSC's external anchors live in `disco_tenure` (the Stata command's published weights, bit-for-bit) and `dsc_disco_xval` (the R package, seed-averaged), not in this case. And within this case the `p > 0.05` really is still the only external quantity — that part was accurate and stays.

## Verification

- Path: not applicable — documentation and docstrings only, no numerical code and no pinned value touched.

The judgment call worth surfacing: I did not convert `dsc_dube` into a cross-validation, though the machinery to do so now exists. Its rows are pinned at DSC's *default* settings on the vignette's setup, and that is what makes them a regression guard on the configuration users actually get. `dsc_disco_xval` runs at `M = 10,000` specifically to resolve a stochastic reference, which is a different question with its own case. Retrofitting this one would cost the default-settings guard and duplicate the other case. The docstring now states that reasoning, so the next reader does not re-open the question.

## Scope checks

None of the four blocks fit: documentation and docstrings.

## Designs

None.

## Test Steps

- [x] `docs/dsc.rst` structural error count unchanged from baseline (2, both pre-existing); `docs/benchmarks.rst` at 0
- [x] `dsc_dube` still imports and exposes its 6 `EXPECTED` rows unchanged
- [x] The moved catalogue row verified to sit under the cross-validation heading

## Other Notes

This is the last of the five branches from this thread. The others: #378 (Path B case), #379 (`weight_constraint`), #380 (the DiSCos cross-validation), #381 (the DSC page's validation framing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgS4wcBaq6quoZavEPNsjW)_