### PR TITLE
Add hypothesis and property-test the mlSC penalty over its domain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
           # exercises the estimators that need it (BFSC, SPOTSYNTH's Bayesian
           # mode). Without it their tests skip and get no CI coverage.
           pip install numpyro
-          pip install pytest pytest-cov pytest-xdist coverage
+          pip install pytest pytest-cov pytest-xdist coverage hypothesis
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
@@ -175,7 +175,7 @@ jobs:
           # The [bayes] extra so BFSC / SPOTSYNTH-Bayesian run on every
           # supported Python version, not just the 3.11 build job.
           pip install numpyro
-          pip install pytest pytest-xdist
+          pip install pytest pytest-xdist hypothesis
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-cov pytest-xdist coverage coverage-badge
+          pip install pytest pytest-cov pytest-xdist coverage coverage-badge hypothesis
 
       - name: Run tests with coverage
         if: steps.guard.outputs.run == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ paper/paper_files/
 # Generated benchmark validation rollups (regenerate with run_benchmarks.py --report)
 benchmarks/REPORT.md
 benchmarks/report.json
+
+# Hypothesis example database (local, machine-specific)
+.hypothesis/

--- a/mlsynth/tests/conftest.py
+++ b/mlsynth/tests/conftest.py
@@ -1,5 +1,21 @@
 """Shared pytest configuration for the mlsynth test suite.
 
+Hypothesis profiles
+-------------------
+Property tests run under one of two profiles, selected by the
+``MLSYNTH_HYPOTHESIS_PROFILE`` environment variable and defaulting to ``ci``
+whenever ``CI`` is set:
+
+* ``ci`` -- ``derandomize=True``, a fixed example count, no deadline. The
+  determinism is not a preference: a flakily-killed mutant corrupts a mutation
+  score, and ``agents/agents_tests.md`` makes derandomization mandatory for any
+  run that feeds one. It also keeps a red CI reproducible from the commit alone.
+* ``dev`` -- more examples and randomized, for finding what ``ci`` will not.
+
+The deadline is disabled in both. Hypothesis times individual examples and
+fails those over 200 ms by default, which numerical code with a cold BLAS or a
+cvxpy solve trips for reasons that have nothing to do with the property.
+
 Optional-solver skip guard
 --------------------------
 Several estimators solve mixed-integer or conic programs through cvxpy and
@@ -27,9 +43,37 @@ skipped tests.
 
 from __future__ import annotations
 
+import os
 import re
 
 import pytest
+
+try:
+    from hypothesis import HealthCheck, Verbosity, settings
+except ImportError:  # pragma: no cover - hypothesis is in the `test` extra
+    settings = None
+
+if settings is not None:
+    settings.register_profile(
+        "ci",
+        max_examples=200,
+        derandomize=True,
+        deadline=None,
+        print_blob=True,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    settings.register_profile(
+        "dev",
+        max_examples=1000,
+        derandomize=False,
+        deadline=None,
+        verbosity=Verbosity.normal,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    settings.load_profile(
+        os.environ.get("MLSYNTH_HYPOTHESIS_PROFILE",
+                       "ci" if os.environ.get("CI") else "dev")
+    )
 
 # Direct "solver not installed" signatures (always safe to skip on).
 _MISSING_SOLVER = re.compile(

--- a/mlsynth/tests/test_mlsc_penalty_properties.py
+++ b/mlsynth/tests/test_mlsc_penalty_properties.py
@@ -49,7 +49,7 @@ _raw_share = st.floats(min_value=0.0, max_value=1e3,
 
 
 @st.composite
-def simplex_vectors(draw, min_size: int = 1, max_size: int = 12) -> np.ndarray:
+def simplex_vectors(draw, min_size: int = 1, max_size: int = 40) -> np.ndarray:
     """A population-share vector: non-negative, summing to one."""
     size = draw(st.integers(min_value=min_size, max_value=max_size))
     raw = np.asarray(draw(st.lists(_raw_share, min_size=size, max_size=size)))
@@ -101,7 +101,7 @@ def test_the_kernel_is_exactly_the_population_ray(v):
 
     The kernel being no larger than the population ray is what makes every
     other weight direction penalised. Written as equality: the weaker ``<=``
-    was the cautious guess, and 3000 draws at block sizes up to 12, including
+    was the cautious guess, and 3000 draws at block sizes up to 40, including
     shares within 1e-16 of a corner, produce no numerical-rank violation.
     """
     assert np.linalg.matrix_rank(build_block(v), tol=1e-9) == v.size - 1

--- a/mlsynth/tests/test_mlsc_penalty_properties.py
+++ b/mlsynth/tests/test_mlsc_penalty_properties.py
@@ -1,0 +1,185 @@
+"""Generative property tests for the mlSC block penalty matrix.
+
+Reference: Bottmer, L., "Synthetic Control with Disaggregated Data" (JMP,
+Stanford), Equation 5.2. The penalty is
+
+    sum_s sum_c (omega_sc - v_sc w_s)^2 = omega' Q omega,
+
+with ``build_block`` returning ``Q = I - v 1' - 1 v' + (v'v) J`` per aggregate
+and ``build_penalty_matrix`` gluing the blocks. The claims below hold for every
+``v`` on the simplex, so they are asserted over the domain instead of at a
+fixture.
+
+Why this layer. Property tests generate inside the specification, which is the
+region a fault of omission lives in -- see the instrument contract in
+``agents/agents_tests.md``. These helpers are the first-choice target for it:
+pure functions, no solver, no DGP, microseconds per call.
+
+The kernel property is the one that carries the estimator's meaning. ``Qv = 0``
+says the penalty vanishes exactly on population-proportional weights, so
+``lambda`` prices departure from the classical aggregation and nothing else.
+Assert it at one ``v`` and you have tested a vector; assert it over the simplex
+and you have tested the claim.
+
+Named corners are kept as ``@example`` instead of left to the generator: a
+block with one disaggregate, a county with no population, and all mass on one
+county are the degenerate shares a real panel produces, and one of them
+(``v = [1, 0]``, where ``Q = diag(0, 2)``) is subtle enough that a probe built
+as a basis vector silently tests the kernel it meant to avoid.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from hypothesis import assume, example, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils.mlsc_helpers.penalty import (
+    build_block,
+    build_penalty_matrix,
+    build_sqrt_factor,
+)
+
+_TOL = 1e-10
+
+# Raw non-negative shares. Normalising these covers the interior of the simplex
+# and its boundary (zeros survive normalisation) without a separate strategy.
+_raw_share = st.floats(min_value=0.0, max_value=1e3,
+                       allow_nan=False, allow_infinity=False)
+
+
+@st.composite
+def simplex_vectors(draw, min_size: int = 1, max_size: int = 12) -> np.ndarray:
+    """A population-share vector: non-negative, summing to one."""
+    size = draw(st.integers(min_value=min_size, max_value=max_size))
+    raw = np.asarray(draw(st.lists(_raw_share, min_size=size, max_size=size)))
+    total = raw.sum()
+    assume(total > 1e-6)                  # all-zero shares are not a panel
+    v = raw / total
+    assume(np.isfinite(v).all())
+    return v
+
+
+@st.composite
+def block_structures(draw, max_blocks: int = 5, max_block_size: int = 6):
+    """``(v, disagg_to_agg)`` for an arbitrary set of aggregates."""
+    n_blocks = draw(st.integers(min_value=1, max_value=max_blocks))
+    blocks = [draw(simplex_vectors(1, max_block_size)) for _ in range(n_blocks)]
+    v = np.concatenate(blocks)
+    idx = np.repeat(np.arange(n_blocks), [b.size for b in blocks])
+    return v, idx
+
+
+# ---------------------------------------------------------------------------
+# One block
+# ---------------------------------------------------------------------------
+
+@given(v=simplex_vectors())
+@example(v=np.array([1.0]))                    # a block with one disaggregate
+@example(v=np.array([1.0, 0.0]))               # a county with no population
+@example(v=np.array([0.0, 0.0, 1.0]))          # all mass on one county
+@example(v=np.array([0.5, 0.5]))
+def test_block_is_symmetric_and_psd(v):
+    Q = build_block(v)
+    assert Q.shape == (v.size, v.size)
+    np.testing.assert_allclose(Q, Q.T, atol=_TOL)
+    assert np.linalg.eigvalsh(Q).min() >= -1e-9
+
+
+@given(v=simplex_vectors())
+@example(v=np.array([1.0, 0.0]))
+@example(v=np.array([0.0, 0.0, 1.0]))
+def test_population_shares_lie_in_the_kernel(v):
+    """The claim that gives ``lambda`` its meaning."""
+    np.testing.assert_allclose(build_block(v) @ v, 0.0, atol=1e-12)
+
+
+@given(v=simplex_vectors(min_size=2))
+@example(v=np.array([1.0, 0.0]))
+def test_the_kernel_is_exactly_the_population_ray(v):
+    """``R = I - v 1'`` drops one dimension, so ``rank(Q) = C - 1`` exactly.
+
+    The kernel being no larger than the population ray is what makes every
+    other weight direction penalised. Written as equality: the weaker ``<=``
+    was the cautious guess, and 3000 draws at block sizes up to 12, including
+    shares within 1e-16 of a corner, produce no numerical-rank violation.
+    """
+    assert np.linalg.matrix_rank(build_block(v), tol=1e-9) == v.size - 1
+
+
+@given(v=simplex_vectors(min_size=2), scale=st.floats(0.1, 50.0))
+@example(v=np.array([1.0, 0.0]), scale=1.0)
+@example(v=np.array([0.2, 0.3, 0.5]), scale=1.0)
+def test_penalty_vanishes_on_proportional_weights_and_not_off_them(v, scale):
+    """The penalty is zero on the population ray and positive off it.
+
+    The off-ray probe is built by projecting ``v`` out. Picking a basis vector
+    instead is wrong at a corner such as ``v = [1, 0]``, where that vector is
+    ``v`` and the assertion would be testing the kernel it meant to avoid.
+    """
+    Q = build_block(v)
+    on_ray = scale * v
+    assert abs(float(on_ray @ Q @ on_ray)) < 1e-10
+
+    probe = np.arange(1.0, v.size + 1.0)
+    probe = probe - (probe @ v / (v @ v)) * v
+    assume(np.linalg.norm(probe) > 1e-6)
+    assert float(probe @ Q @ probe) > 0.0
+
+
+@given(size=st.integers(min_value=1, max_value=30))
+def test_uniform_shares_give_the_centering_matrix(size):
+    """``v = 1/C`` collapses ``Q`` to ``I - J/C``."""
+    Q = build_block(np.full(size, 1.0 / size))
+    np.testing.assert_allclose(
+        Q, np.eye(size) - np.full((size, size), 1.0 / size), atol=_TOL
+    )
+
+
+@given(v=simplex_vectors(), permutation_seed=st.integers(0, 2**32 - 1))
+def test_relabelling_the_disaggregates_permutes_the_penalty(v, permutation_seed):
+    """Column order is a labelling choice, so ``Q`` must permute with it."""
+    order = np.random.default_rng(permutation_seed).permutation(v.size)
+    np.testing.assert_allclose(
+        build_block(v[order]), build_block(v)[np.ix_(order, order)], atol=_TOL
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assembly across blocks
+# ---------------------------------------------------------------------------
+
+@given(structure=block_structures())
+@settings(max_examples=150)
+def test_assembly_is_block_diagonal_and_matches_its_blocks(structure):
+    v, idx = structure
+    Q = build_penalty_matrix(v, idx)
+
+    assert Q.shape == (v.size, v.size)
+    np.testing.assert_allclose(Q[idx[:, None] != idx[None, :]], 0.0, atol=_TOL)
+    for block in np.unique(idx):
+        mask = idx == block
+        np.testing.assert_allclose(
+            Q[np.ix_(mask, mask)], build_block(v[mask]), atol=_TOL
+        )
+
+
+@given(structure=block_structures())
+@settings(max_examples=150)
+def test_assembled_penalty_annihilates_the_population_vector(structure):
+    v, idx = structure
+    np.testing.assert_allclose(build_penalty_matrix(v, idx) @ v, 0.0, atol=1e-12)
+
+
+@given(structure=block_structures())
+@settings(max_examples=150)
+def test_square_root_factor_reproduces_the_penalty(structure):
+    """``R' R == Q``.
+
+    The solver augments the design with ``sqrt(lambda) R`` instead of forming
+    ``Q``, so these two representations agreeing is what makes the augmented
+    least-squares path equal the penalised program.
+    """
+    v, idx = structure
+    R = build_sqrt_factor(v, idx)
+    np.testing.assert_allclose(R.T @ R, build_penalty_matrix(v, idx), atol=1e-10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,20 @@ design = ["pyscipopt>=4.4.0", "highspy>=1.7.0"]
 scip = ["pyscipopt>=4.4.0"]
 # SPOTSYNTH Bayesian synthetic control (NumPyro / JAX).
 bayes = ["numpyro"]
+# The test suite. Not needed to use the library -- the suite is a development
+# artifact and is not shipped in the wheel -- so this exists to make
+# ``pip install -e ".[test]"`` reproduce a working local test environment. The
+# CI workflows install the same set explicitly and must be kept in step.
+# ``hypothesis`` drives the property tests; the profiles that govern them are
+# registered in ``mlsynth/tests/conftest.py`` and the contract for when to
+# reach for it is in ``agents/agents_tests.md``.
+test = [
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+    "coverage",
+    "hypothesis>=6.100",
+]
 # Everything optional, for the full feature set.
 all = ["pyscipopt>=4.4.0", "highspy>=1.7.0", "numpyro"]
 


### PR DESCRIPTION
## Related Links

- Source paper: Bottmer, L., "Synthetic Control with Disaggregated Data" (JMP, Stanford), Equation 5.2 — the specification `MLSC` implements.
- Existing coverage this extends: `mlsynth/tests/test_mlsc.py::TestPenaltyMatrix`.
- Merge order: this is first of three. `claude/mlsc-nesting-tests` trims sweeps that these tests supersede, so it needs this merged to be a net gain in coverage. `claude/synthetic-control-medical-research-go5ril` adds the instrument contract in `agents/agents_tests.md` that this PR's docstrings cite.

## What

- Added `hypothesis` in a new `test` extra in `pyproject.toml`, and to the three CI install steps.
- Registered two Hypothesis profiles in `mlsynth/tests/conftest.py`, selected by `MLSYNTH_HYPOTHESIS_PROFILE` and defaulting to `ci` wherever `CI` is set.
- Added `mlsynth/tests/test_mlsc_penalty_properties.py` — nine generative property tests for the mlSC block penalty matrix.
- Gitignored `.hypothesis/`.

## Why

The mlSC penalty is the object that gives `lambda` its meaning: `build_block` returns `Q = I - v 1' - 1 v' + (v'v) J`, and `Qv = 0` says the penalty vanishes exactly on population-proportional weights, so the penalty prices departure from the classical aggregation and nothing else. `test_mlsc.py` asserts symmetry, PSD-ness and the kernel at a single hand-picked `v = [0.3, 0.2, 0.5]`. Asserting a property at one vector tests that vector; asserting it over the simplex tests the claim.

These helpers are the natural first target for generative testing — pure functions, no solver, no DGP, microseconds per call.

## How

Two strategies: `simplex_vectors` draws non-negative raw shares and normalizes, which covers the interior of the simplex and its boundary (zeros survive normalization) without a second strategy; `block_structures` composes those into an arbitrary set of aggregates.

Properties asserted: symmetric, positive semi-definite, `Qv = 0`, `rank(Q) = C - 1`, permutes with a relabelling of the columns, collapses to the centering matrix at uniform shares; the assembled matrix is block diagonal, annihilates `v` blockwise, and satisfies `R'R == Q`.

Two decisions in the profiles, both deliberate:

- `ci` is derandomized. A flakily-killed mutant corrupts a mutation score, and derandomization also means a red CI reproduces from the commit alone. `dev` is randomized at 1000 examples for finding what `ci` will not.
- Both disable the deadline. Hypothesis fails individual examples over 200 ms by default, which numerical code with a cold BLAS trips for reasons unrelated to the property under test.

The rank claim went in as `<=` on the guess that a numerical rank would break on near-degenerate shares. That guess was wrong: 3000 randomized draws at block sizes up to 40, including shares within 1e-16 of a corner, produce no violation, so the assertion is the equality the algebra actually gives.

## Verification

- Path: not applicable — this adds tests and a test-only dependency, and touches no numerical code. No pinned benchmark value moves.
- The tests were mutation-audited rather than accepted on a green run. Four mutants of `build_block` — `norm_sq` off by 0.1%, a 1e-6 asymmetry in one outer product, the identity term off by 1e-7, and `norm_sq` squared — are each killed by six or seven of the nine tests.
- No regressions: 1805 passed / 105 skipped across the `mlsc`, `pcr`, `scmo` and `si` selection, confirming the `conftest.py` change does not disturb the existing suite.

## Scope checks

None of the four blocks fit — this is test and CI tooling. The library ships unchanged; `hypothesis` is in an optional `test` extra and the suite is not packaged in the wheel.

## Designs

No visual output. The tests are on a matrix constructor.

## Test Steps

- [x] `pip install -e ".[test]"`
- [x] `pytest mlsynth/tests/test_mlsc_penalty_properties.py -q` — 9 passed under both profiles
- [x] `MLSYNTH_HYPOTHESIS_PROFILE=dev pytest mlsynth/tests/test_mlsc_penalty_properties.py -q` — 9 passed at 1000 examples
- [x] `CI=true pytest mlsynth/tests/test_mlsc_penalty_properties.py -q` — 9 passed, as CI will run it
- [x] `pytest mlsynth/tests/ -k "mlsc or pcr or scmo or si"` — 1805 passed, 105 skipped

## Other Notes

- The CI workflows install the test dependencies explicitly rather than via the new extra, so the two lists must be kept in step. Consolidating CI onto `pip install -e ".[test]"` would remove that duplication but changes the install flow, so it is left out of this PR.
- `block_structures` caps block size at 6 while `simplex_vectors` reaches 40; the assembly tests care about the number of blocks rather than their width.
- Natural follow-ups for the same instrument: the `pcr` kernel (which has a matching property gap), and the mlSC solver layer, where a metamorphic scale relation already exists as an example test on `claude/mlsc-nesting-tests`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbWZFe1K2ewxJ4RMgEf5Zb)_