### PR TITLE
Ground the testing philosophy in standard vocabulary, guard the PCR pseudo-inverse, and stage the SSC replication spike

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,10 @@ donor, no pre-periods, near-singular / collinear, treatment at `t=0`), and
 and a test asserts the failure is *reported*, not swallowed). A change is not
 done until it is red→green across these levels and the new code is fully
 covered — defensive / unreachable branches get `# pragma: no cover` with a
-stated reason, never an untested gap. The layered architecture, patterns, and
-exception contract live in `agents/agents_tests.md`.
+stated reason, never an untested gap. The layered architecture, patterns,
+exception contract, and the instrument-selection contract — which of
+`coverage` / `pytest` / `hypothesis` / `cosmic-ray` answers which question, and
+why two of them are complements — live in `agents/agents_tests.md`.
 
 ## The replication contract
 

--- a/agents/agents_tests.md
+++ b/agents/agents_tests.md
@@ -535,6 +535,100 @@ with no setter, so assigning to them raises `AttributeError`, *not*
 
 ---
 
+# Four Instruments, Four Questions
+
+Testing `mlsynth` uses four instruments, and they are not interchangeable. Each
+answers a different question, and whether one can catch a given defect follows
+from which question it asks.
+
+| Instrument | Question it answers | Varies | Holds fixed |
+| --- | --- | --- | --- |
+| `coverage` | Did the suite execute this line? | — | — |
+| `pytest` example tests | Does *this* input give the expected output? | — | inputs and code |
+| `hypothesis` property tests | Does the invariant hold across the *input domain*? | inputs | code |
+| `cosmic-ray` mutation runs | Are the *assertions* strong enough to notice? | code | inputs |
+
+Status: `pytest`, `pytest-cov`, `pytest-xdist` and `coverage` are wired up and
+run in CI. `hypothesis` and `cosmic-ray` are not yet dependencies. This section
+fixes the contract before they land, so the styles do not blur once they do.
+
+## Two of them are complements, not substitutes
+
+Hypothesis varies the inputs and holds the code fixed, so it finds inputs the
+code mishandles. Mutation runs vary the code and reuse your inputs, so they find
+assertions too weak to separate right from wrong. Neither subsumes the other,
+and the library has a case on each side.
+
+Mutation alone is not enough. `pcr_weights` divided by a singular value with no
+cutoff, so a design whose numerical rank fell below the requested rank returned
+NaN or weights of order `1e14`. Three mutants on that line — `/` to `*`, a
+perturbed denominator, the division deleted — were all killed by the suite that
+existed at the time. The line scored 100 percent while carrying the defect,
+because the fault was an omission and there is no line to mutate into a missing
+guard. The defect lived in the input domain, which mutation runs do not explore.
+
+Property tests alone are not enough. `assert w is not None` holds for every
+generated input forever. Only a mutant demonstrates that such an assertion
+separates nothing.
+
+The composition rule follows:
+
+> Hypothesis supplies the inputs; mutation runs audit whether the properties you
+> asserted are strong enough to notice the code being wrong.
+
+A mutant surviving a property-backed suite says something specific: no property
+separates correct behaviour from this corruption. That is a specification gap,
+not a missing fixture.
+
+## Which instrument for which test
+
+Choose by what the test claims.
+
+* A **number** — a paper's reported value, a reference implementation's cell, a
+  pinned regression — is a `pytest` example. Generated inputs carry no known
+  truth, so the replication contract stays example-based.
+* A **property** — symmetry, positive semi-definiteness, feasibility,
+  normalization, monotonicity, equivariance, or a differential equality between
+  two implementations — is a `hypothesis` test. Asserting it at one fixture
+  tests an example; asserting it over the domain tests the claim.
+* A **named edge case** stays a `pytest` example even when a property test
+  covers the same ground. Named edges are documentation, and `@example` pins
+  one inside a property test when both are wanted.
+
+Layer 1 helpers are the first target for property tests: pure functions, no
+solver, no DGP, microseconds per call. Layer 4 `fit()` contracts are the last —
+there is no known truth to assert a generated panel against.
+
+## Metamorphic properties, for statistical code
+
+Exact properties are scarce in econometric kernels. Metamorphic relations — how
+an output must respond to a transformation of the input — are abundant, and are
+where property testing earns its keep here:
+
+* scale: `Y -> cY` scales the ATT by `c` and leaves the weights unchanged
+* location: adding a constant to every outcome leaves the weights unchanged
+* permutation: relabelling donors permutes the weight vector identically
+* duplication: duplicating a donor leaves the fitted counterfactual unchanged
+* monotonicity: pre-period fit is non-decreasing in a regularisation penalty
+* differential: two implementations of one program agree to solver tolerance
+
+## Standing constraints (decide once, not per test)
+
+* **Determinism.** Fixed seeds are already required above; property tests
+  inherit it. Any run feeding a mutation score must set `derandomize=True`,
+  because a flakily-killed mutant corrupts the score.
+* **Runtime multiplies.** A mutation run executes the suite once per mutant and
+  a property test runs many examples per call, so composing them naively costs
+  a multiple of the suite per mutant. Mutation targets the fast deterministic
+  layers only, never `fit()`.
+* **Solver noise.** `cvxpy` / SCS results move at tolerance. Property tolerances
+  come from measured solver spread, not a guessed constant.
+* **Equivalent mutants are real.** A surviving mutant is a question, not a
+  defect. Do not chase a perfect score. Record accepted survivors and the reason
+  they are accepted, the way `# pragma: no cover` records unreachable branches.
+
+---
+
 # Preferred Testing Patterns
 
 ## Prefer Parametrization

--- a/agents/agents_tests.md
+++ b/agents/agents_tests.md
@@ -19,6 +19,131 @@ The guiding principle is:
 
 ---
 
+# Vocabulary and Framework
+
+The terminology below follows Jorgensen, *Software Testing: A Craftsman's
+Approach*, 4th ed. (CRC Press, 2013), which is compatible with the ISTQB
+glossary. Using it precisely is what lets the rest of this document make claims
+that can be checked instead of asserted.
+
+## Error, fault, failure, incident (§1.1)
+
+* **Error** — a mistake a person makes. Errors propagate: a specification error
+  is amplified in design and again in code.
+* **Fault** — the representation of an error in some artifact. Source code,
+  a docstring, and a config validator can each carry one. `defect` and `bug`
+  are synonyms.
+* **Failure** — what happens when the code corresponding to a fault executes.
+* **Incident** — the symptom that alerts someone to a failure.
+
+A fault of **commission** puts something incorrect into the artifact. A fault of
+**omission** leaves out something that should be there. Omission is the harder
+of the two, and the reason is definitional: a failure requires code to execute,
+so the failure concept attaches to faults of commission. Absent code cannot
+execute, so no amount of running the program reveals it.
+
+## Specified, programmed, tested (§1.3)
+
+Three sets of behaviors, and every testing claim in this repo is a claim about
+their overlap:
+
+| Set | In `mlsynth` |
+| --- | --- |
+| `S` — specified | the estimator as defined by its source paper, plus this repo's own contracts (result families, exception translation, config validation) |
+| `P` — programmed | what `mlsynth` actually computes |
+| `T` — tested | what the suite exercises |
+
+The regions name the problems. `S \ P` is a fault of omission: the paper
+specifies behavior the library does not implement. `P \ S` is a fault of
+commission: the library does something the paper never asked for. `S ∩ P \ T`
+is untested correct behavior. Testing is the determination of how much of
+`S ∩ P` is in `T`, and correctness is meaningful only relative to a chosen `S`
+— which for this library means relative to a named paper or reference
+implementation, never in the abstract.
+
+## Specification-based and code-based (§1.4, Figure 1.7)
+
+Two ways to identify test cases, with different reach:
+
+* **Specification-based** (black box) derives cases from `S` alone. It
+  establishes confidence. It cannot find behavior in `P \ S`, because nothing
+  in the specification points at it.
+* **Code-based** (white box) derives cases from `P`. It seeks faults and
+  supports coverage measurement. It cannot find behavior in `S \ P`, because
+  there is no code to look at.
+
+Neither is sufficient alone, and the deficiency of each is exactly the other's
+territory. Specification-based methods additionally suffer gaps and
+redundancies, both of which become visible once their cases are run under a
+code-based coverage metric. That pairing — generate from the specification,
+measure against the code — is the whole argument for using more than one
+instrument, and the section on instruments below is an application of it.
+
+## Consequence: what each instrument can and cannot reach
+
+This frame settles by definition what was earlier observed by accident.
+
+Mutation runs derive from `P` and produce mutants of `P`, so every mutant they
+construct is a fault of commission. A fault of omission has no code to mutate.
+The `pcr_weights` guard is the worked case: three mutants on the offending line
+were all killed, giving that line a perfect mutation score while the defect
+stood, because the missing cutoff was in `S \ P` and mutation never leaves `P`.
+
+Property tests derive from `S` — an invariant is a statement of specified
+behavior — and generate inputs, so they expand `T` inside `S`. That is the
+region a fault of omission lives in, which is why they reach what mutation
+cannot. They in turn cannot judge whether an assertion is strong enough, since
+that is a question about sensitivity within `P`.
+
+---
+
+# The Oracle Problem
+
+Jorgensen puts the hard part of a test case in its expected output (§1.2): for
+software computing something nobody knows the answer to, the academic response
+is to postulate an **oracle** that knows all answers, and the industrial
+response is **reference testing**, running the system in the presence of expert
+users who judge whether the outputs are acceptable.
+
+This is the central problem of testing `mlsynth`, and naming it explains the
+shape of the whole repository. For most estimators there is no oracle. Given a
+panel, nobody knows the true counterfactual — that is the entire reason the
+estimator exists. So a Layer 4 test on real data has no expected output to
+assert, and no amount of test-design technique manufactures one.
+
+`mlsynth` answers this the industrial way, and `benchmarks/` is that answer.
+The replication contract is reference testing with the source paper and the
+authors' implementation as the expert:
+
+* **Path A** — the paper's empirical result on the authors' data. The expert is
+  the published number.
+* **Path B** — the paper's Monte Carlo. The DGP supplies a known truth, so this
+  is the one route where a real oracle exists, and the estimand is computable in
+  closed form.
+* **Cross-validation** — an authoritative reference implementation, run live and
+  compared cell by cell. The expert is the other program.
+
+Three consequences follow, and they are binding.
+
+1. A benchmark case is not documentation or a nice-to-have. It is the source of
+   expected outputs for an entire estimator, so an estimator without one has a
+   testable `S` only for its invariants, never for its values.
+2. Where a real oracle exists, prefer it. Path B and constructed fixtures with
+   analytic answers (a factor model with known loadings, a survival design whose
+   estimand is `exp(-rate * t)`) admit exact assertions that reference testing
+   cannot.
+3. Where no oracle exists at any price, say so and stop. A design whose
+   behaviour depends on a quantity the paper never reports is not reproducible
+   in principle, and the honest output is a recorded finding, not a widened
+   tolerance.
+
+Metamorphic relations are the third way out, and they need no oracle at all:
+they assert how an output must *respond* to a transformation of the input,
+which is checkable without knowing any correct answer. See the instrument
+section below.
+
+---
+
 # Test-Driven Development (test-first is the default)
 
 **Write the tests before the code.** Whenever you add a new feature, helper,
@@ -52,6 +177,45 @@ Measure with the per-estimator coverage command in `CLAUDE.md`.
 
 The layered architecture below says *where* each level lives; this section says
 the levels are *non-optional* and come *first*.
+
+## What the four levels are, in the classical vocabulary
+
+The levels are not an invention; each is a named specification-based method
+(Jorgensen §§5–6), and naming them shows what the set does and does not cover.
+
+| Level | Classical method | Assumption |
+| --- | --- | --- |
+| Smoke | weak normal equivalence class testing — one representative valid input | single fault |
+| Unit | invariant and special-value testing over the valid domain | single fault |
+| Edge | boundary value analysis — `min`, `min+`, `nom`, `max-`, `max` on each input | single fault |
+| Failure | robustness testing — inputs outside the valid domain, plus exception handling | single fault |
+
+Every one of them varies one thing at a time. That is the **single-fault
+assumption**: failures arise from one variable being extreme, so holding the
+others nominal is enough. It is what makes the levels affordable — `4n + 1`
+cases for `n` inputs instead of `5^n`.
+
+The assumption is not always warranted here, and where it fails the levels have
+a blind spot the coverage number will not show. `mlsynth`'s inputs are
+**physical** quantities (donor count, pre-period length, panel dimensions) and
+they are **dependent** — `N` versus `T0` governs overfitting, `J > T0` changes
+which solver branch is feasible, a short pre-period interacts with a
+rank-deficient donor matrix. Under the classical selection guidance (§10.5,
+Table 10.13) dependent variables indicate decision-table testing, and a
+warranted multiple-fault assumption indicates worst-case testing — the cross
+product of boundaries, not one boundary at a time.
+
+Two standing gaps follow, and both are open:
+
+* **No worst-case testing anywhere.** Combinations such as "single donor *and*
+  no pre-periods *and* collinear" are untested at every estimator. Where an
+  estimator's failure modes interact, add the cross product deliberately for the
+  two or three inputs that interact, not for all of them.
+* **Config validators are a decision table nobody has written down.** Each
+  `*Config` enforces a set of conditions with dependencies between them, which
+  is exactly the shape a decision table represents. Writing the table first
+  makes the impossible rules explicit and shows which rule combinations no test
+  reaches.
 
 ---
 
@@ -554,22 +718,10 @@ fixes the contract before they land, so the styles do not blur once they do.
 
 ## Two of them are complements, not substitutes
 
-Hypothesis varies the inputs and holds the code fixed, so it finds inputs the
-code mishandles. Mutation runs vary the code and reuse your inputs, so they find
-assertions too weak to separate right from wrong. Neither subsumes the other,
-and the library has a case on each side.
-
-Mutation alone is not enough. `pcr_weights` divided by a singular value with no
-cutoff, so a design whose numerical rank fell below the requested rank returned
-NaN or weights of order `1e14`. Three mutants on that line — `/` to `*`, a
-perturbed denominator, the division deleted — were all killed by the suite that
-existed at the time. The line scored 100 percent while carrying the defect,
-because the fault was an omission and there is no line to mutate into a missing
-guard. The defect lived in the input domain, which mutation runs do not explore.
-
-Property tests alone are not enough. `assert w is not None` holds for every
-generated input forever. Only a mutant demonstrates that such an assertion
-separates nothing.
+This is the Figure 1.7 argument applied, and it is settled above by definition,
+not by anecdote: property tests generate inside `S`, mutation runs operate inside
+`P`, and each is blind exactly where the other looks. `pcr_weights` is the
+worked case in that section.
 
 The composition rule follows:
 
@@ -579,6 +731,40 @@ The composition rule follows:
 A mutant surviving a property-backed suite says something specific: no property
 separates correct behaviour from this corruption. That is a specification gap,
 not a missing fixture.
+
+## Reading a mutation score (§21.1)
+
+The definitions are precise, and the third one is why the score is a diagnostic
+and not a target:
+
+* A **mutant** `P'` is `P` with one small source change.
+* Given a suite `T` where every test passes on `P`, `P'` is **killed** if at
+  least one test fails on `P'`, and is a **live mutant** otherwise.
+* A live mutant means one of two things: `P'` is logically equivalent to `P`, or
+  `T` is too weak to separate them. Deciding which is **formally undecidable**.
+* The **mutation score** is `x / y`, killed over total, and its denominator
+  therefore contains an unknown number of equivalent mutants.
+
+So a score below 1 is not a defect count and 1 is not a goal — an equivalent
+mutant can never be killed by any suite. Read survivors individually and record
+the accepted ones with a reason, the way `# pragma: no cover` records
+unreachable branches.
+
+## Reading a coverage number (§10.3)
+
+Coverage is a ratio of a specification-based method against a code-based metric,
+and it comes with two companions the badge does not show. For a method `M`
+generating `m` cases, a code-based metric `S` identifying `s` elements, of which
+the cases traverse `n`:
+
+* **coverage** `C(M, S) = n / s` — below 1 means gaps
+* **redundancy** `R(M, S) = m / s`
+* **net redundancy** `NR(M, S) = m / n` — the useful one: cases per element
+  actually reached
+
+A high line-coverage number with high net redundancy is a suite testing the same
+few paths repeatedly. `pcr_weights` sat at full line coverage the whole time it
+carried the defect, because coverage counts execution, not input variety.
 
 ## Which instrument for which test
 
@@ -822,3 +1008,23 @@ This is a core design principle of the library.
 The central testing philosophy of `mlsynth` is:
 
 > Validate econometric behavior, optimization feasibility, numerical stability, and public API contracts — not implementation details.
+
+Stated in the vocabulary of the framework section: determine how much of
+`S ∩ P` lies in `T`, using specification-based methods to generate cases and
+code-based metrics to measure the gaps and redundancies they leave — and, for
+the estimators, remember that `S` is a named paper and the expected outputs come
+from reference testing against it, since no oracle exists.
+
+---
+
+# Reference
+
+Jorgensen, P. C. (2013). *Software Testing: A Craftsman's Approach*, 4th ed.
+CRC Press. Section numbers cited above refer to this edition: §1.1 the
+error/fault/failure progression and the omission–commission distinction, §1.2
+the oracle problem and reference testing, §1.3 the specified/programmed/tested
+sets, §1.4 and Figure 1.7 specification-based versus code-based reach, §§5–6
+boundary value and equivalence class methods with the single- and multiple-fault
+assumptions, §10.3 the coverage and redundancy metrics, §10.5 and Table 10.13
+method selection from variable attributes, §21.1 the formalization of program
+mutation.

--- a/agents/future_integrations.md
+++ b/agents/future_integrations.md
@@ -1759,6 +1759,154 @@ uses the recursive one.
 
 ---
 
+## 18. SURVSC -- Synthetic Survival Control (censored time-to-event outcomes)
+
+**Status: Parked, build-ready. Paper reviewed in full; Path B replication DONE
+and reproduces (`benchmarks/reference/survsc_mc/`). No estimator code. Nothing
+blocks a build -- this is parked on sequencing, not on doubt.**
+
+### Source
+
+> Han, J. X., & Shah, D. (2025). "Synthetic Survival Control: Extending
+> Synthetic Controls for 'When-If' Decision." arXiv:2511.14133v1 (MIT).
+
+No code release, no data release. The clinical application uses proprietary
+retrospective T-cell-lymphoma records from 13 institutions across 10 countries,
+so the paper's Section 4 Monte Carlo is the only external check that exists.
+
+### The idea in one line
+
+Synthetic control where each unit-period outcome is an entire survival curve:
+Kaplan-Meier per unit-period absorbs the censoring, the curves are subsampled
+onto a shared grid, PCR learns donor weights from the pre-period curves, and
+those weights are applied to the donors' post-period curves.
+
+### Why it fills a real gap
+
+`grep -rilE "survival|hazard|kaplan|meier|time-to-event|censoring" mlsynth
+--include=*.py` returns zero files across all 99 exports. Nothing in the
+library touches censored time-to-event data.
+
+Closest existing estimators, by two different measures. By estimand shape,
+`DSC` -- distributional SC also has a functional outcome built from grouped
+microdata, and a survival function is `1 - F`, so absent censoring the target
+is the object DSC already models. They differ in aggregation geometry: DSC
+averages quantile functions (2-Wasserstein barycenter), SURVSC averages
+survival functions pointwise in probability space. By machinery, `SI` -- same
+author lineage, same latent-factor plus PCR construction.
+
+### Naming (do not collide)
+
+`SSC` is taken: `mlsynth.SSC` is Staggered Synthetic Control (Cao, Lu & Wu).
+Use `SURVSC`.
+
+### What the Path B spike established (KEEP THESE)
+
+All six Table 1 cells land within 1.5x of the published sup-norm error, two of
+them on top of it, and the Figure 4 claim that error falls in `K` holds in both
+the Cox and Aalen designs. Step 3 needs no new code: the paper's closed form is
+`mlsynth.utils.pcr.pcr_weights` to 8e-17.
+
+Three design details the paper leaves unstated, two of them decisive:
+
+* The rank `r0`. Section 3.4.2 says "a gap rule, elbow, or cross-validation"
+  and picks none. Of the rules mlsynth ships, only USVT reproduces the paper;
+  `cumvar` and `spectral` report error that *grows* as data is added.
+* Whether the latent design is redrawn per replication. Independent draws per
+  `K` break the monotone decrease, because the latent draw moves the evaluation
+  horizon over two orders of magnitude (pooled 90th percentile: median 93,
+  range [20, 5743] on Cox) and swamps the effect of `K`. Common random numbers
+  restore it.
+* Whether `tau_tilde` pools every cell or uses the treated unit. Not decisive;
+  both readings give the same picture.
+
+### Two build decisions, already settled by the spike
+
+The paper's PCR weights are unconstrained, so the counterfactual
+`sum_m w_m S_m(t)` need not be monotone or stay inside [0, 1] -- it is a valid
+survival function in a minority of replications (monotone in 0-55 percent,
+inside [0, 1] in 15-45 percent; at Aalen `K = 100`, zero of twenty). Abadie's
+convex-hull condition fixes it for free, since a convex combination of monotone
+[0, 1] curves is monotone in [0, 1]. The simplex fit already in
+`mlsynth.utils.inferutils._outcome_only_simplex` gives 100 percent valid output
+at every cell and costs nothing on average. Ship both weight schemes; simplex
+is the defensible default, PCR reproduces the paper.
+
+The estimand is a curve, not a scalar, so `EffectsResults` needs an RMST
+difference over `[0, tau_tilde]` as the scalar ATT, with the gap curve in
+`TimeSeriesResults`.
+
+### Build path
+
+`estimators/survsc.py` (thin) plus `utils/survsc_helpers/{config, setup, km,
+pipeline, inference, plotter, structures}.py`. Ingestion is patient-level
+`(unit, period, T, Delta)`, which `dataprep` cannot take -- but Kaplan-Meier
+collapses each cohort to a curve on a shared grid, and at that point the data
+is a standard panel of units x `2 * T0` points with `pre_periods = T0`, so the
+contract reappears after step 1. `MicroSynth` is the precedent for
+estimator-owned patient-level ingestion. Inference is the paper's donor-pool
+bootstrap (Section 5.2, 500 resamples). Pure NumPy/SciPy; no new dependency.
+
+### Caveats to carry into the build
+
+Theorem 2's rate contains no `K` at all -- `K` enters only as a threshold for
+the PCR stability argument -- while the simulation's entire finding is error
+falling in `K`. The spike explains the discrepancy: the reported error is the
+same order as a single Kaplan-Meier curve's error (Cox 0.0658 / 0.0376 / 0.0235
+against Table 1's 0.1177 / 0.0652 / 0.0542), and the KM error falls at
+`1/sqrt(K)`. The convergence Figure 4 displays lives in step 1, which the
+theorem treats as a precondition. The docs page should say this instead of
+restating the theorem as if it covered the regime.
+
+The threshold itself is unmet by the paper's own experiments: at `T0 = 100`,
+`N0 = 19` it is about `755c`, so `K = 100` fails it. In the application
+`N0 = 9` makes the `N0^{-1/2}` term 0.33, a vacuous bound on a quantity in
+[0, 1].
+
+Scope the authors concede: `P = 2` periods only, non-informative censoring
+assumed (IPCW left to future work), observed covariates unused in the
+latent-confounding case.
+
+### Verdict
+
+Build when the queue allows. New method, real gap, most of the machinery
+already exists, and the validation target is reproduced and staged.
+
+### Learnings
+
+* **A replication can fail on seeding, not on the port.** The first grid showed
+  no monotone decrease in `K` and looked like a failed reproduction. The port
+  was correct; the seeds were not. Where a DGP's nuisance draw has orders of
+  magnitude more spread than the parameter being varied, common random numbers
+  are not a variance-reduction nicety -- they decide whether the paper's claim
+  is visible at all.
+* **Check what the error metric is actually measuring.** Comparing the reported
+  sup-norm error against the error of one Kaplan-Meier curve showed the headline
+  convergence belongs to step 1, not to the synthetic-control step. That
+  reconciled the simulation with a theorem whose rate has no `K` in it. Measure
+  the floor before crediting an estimator with the decline above it.
+* **Unconstrained SC weights do not preserve the object's shape.** Whenever the
+  unit-level outcome is a function with structure -- a survival curve, a CDF, a
+  density -- a linear-span condition lets the estimate leave the space the
+  object lives in. The convex-hull constraint is what buys closure, and here it
+  cost nothing.
+* **An unguarded pseudo-inverse hides two failure modes, and the quiet one is
+  worse.** `pcr_weights` divided by `s_r` with no cutoff: an exactly-zero
+  singular value gives 0/0 and NaN with a `RuntimeWarning`, while a near-zero
+  one gives weights of order 1e14 and no warning at all. Only the first is
+  caught by an `isfinite` assertion. Fixed in `mlsynth/utils/pcr/core.py` with
+  `mlsynth/tests/test_pcr.py`.
+* **Mutation testing would not have found that bug, and would have said the
+  line was fine.** Three mutants on the offending line (`/` to `*`, perturbed
+  denominator, division deleted) were all killed by the existing suite, so it
+  scored 100 percent while carrying the defect. The fault was an omission -- a
+  missing guard -- and there is no line to mutate into one. Mutation testing
+  perturbs code and reuses the test inputs; the defect lived in the input
+  domain. Property-based testing is the technique matched to that fault, and
+  `agents_tests.md` already required the edge cases that would have exposed it.
+
+---
+
 ## Done
 
 *(empty -- move completed items here, preserving their Learnings subsection.)*

--- a/benchmarks/reference/survsc_mc/README.md
+++ b/benchmarks/reference/survsc_mc/README.md
@@ -1,0 +1,159 @@
+# SSC Path-B targets — Han & Shah (2025), Section 4
+
+A pre-build replication spike for Synthetic Survival Control
+([arXiv:2511.14133v1](https://arxiv.org/abs/2511.14133)), the synthetic-control
+estimator for censored time-to-event outcomes. No estimator has been added to
+`mlsynth` yet; this bundle establishes that the paper's Monte Carlo reproduces
+before one is built, and records the design details the paper leaves unstated.
+
+The paper ships no code and no data. Its clinical application uses proprietary
+multi-country T-cell-lymphoma records, so Table 1 is the only external check
+that exists.
+
+## What is here
+
+```
+survsc_oracle.py   readable port of the estimator + the Section 4 DGPs
+run_grid.py        driver: the grid against Table 1
+dump_results.py    regenerates results.json (every number below)
+km_floor.py        how much of the Table 1 error is the Kaplan-Meier step
+results.json       generated
+```
+
+```bash
+python benchmarks/reference/survsc_mc/dump_results.py
+python benchmarks/reference/survsc_mc/km_floor.py
+```
+
+## The estimator
+
+Four steps (paper Section 3.4.2). Kaplan-Meier per unit-period; subsample the
+curves onto a shared grid of `T0` points; principal-component regression of the
+treated unit's pre-period curve on the donors' pre-period curves; apply those
+weights to the donors' post-period curves.
+
+Step 3 needs nothing new. The paper's closed form,
+`w = sum_{i<=r0} (1/s_i) v_i u_i' S_0n`, is `mlsynth.utils.pcr.pcr_weights`
+verbatim — they agree to 8e-17 across ranks 1, 3, 6 and 10.
+
+## What reproduced
+
+Table 1 is the sup-norm error against the true post-period control survival
+trajectory. Both Section 4 DGPs fix the baseline hazard, so event times are
+exponential and the estimand has the closed form `exp(-rate * t)`; the error is
+measured against that, not against a simulated approximation.
+
+Twenty replications, `r0` by USVT, horizon pooled, weights as the paper
+specifies them:
+
+| DGP | K | this port | Table 1 | ratio |
+|---|---|---|---|---|
+| Cox | 100 | 0.1061 +/- 0.1318 | 0.1177 +/- 0.0835 | 0.90 |
+| Cox | 300 | 0.0949 +/- 0.1298 | 0.0652 +/- 0.0497 | 1.46 |
+| Cox | 700 | 0.0724 +/- 0.1251 | 0.0542 +/- 0.0413 | 1.34 |
+| Aalen | 100 | 0.0796 +/- 0.0394 | 0.0621 +/- 0.0307 | 1.28 |
+| Aalen | 300 | 0.0436 +/- 0.0158 | 0.0507 +/- 0.0388 | 0.86 |
+| Aalen | 700 | 0.0337 +/- 0.0177 | 0.0245 +/- 0.0102 | 1.38 |
+
+Every cell lands within 1.5x, two of them on top of the published value, and the
+Figure 4 claim — error falling in `K` — holds in both DGPs.
+
+## What did not
+
+The confounder-aware parametric comparator. This port fits the correctly
+specified exponential model on the true latent factors and gets 0.0120 / 0.0068
+/ 0.0033 on Cox against the paper's 0.0247 / 0.0204 / 0.0194. Two to six times
+more accurate, and falling much faster in `K`. The likely cause is the baseline:
+Section 3.3.2 fits a Cox model with a Breslow cumulative-hazard estimator, whose
+nonparametric baseline converges more slowly than the parametric fit here. The
+gap between SSC and the comparator is therefore wider in this port than in the
+paper, which flatters neither method — it makes SSC look worse.
+
+The Cox standard deviations are also wider here (0.1318 against 0.0835 at
+K = 100), driven by the design draw, not the patient draw; see below.
+
+## Three details the paper does not state
+
+The rank `r0`. Decisive. Section 3.4.2 says "a gap rule, elbow, or
+cross-validation as explained in Agarwal et al." and picks none of them. Of the
+rules `mlsynth` ships, only USVT reproduces the paper; the other two get the
+sign of the K-effect wrong, reporting error that grows as data is added:
+
+| rule | mean r0 | Cox K=100 / 300 / 700 | Aalen K=100 / 300 / 700 |
+|---|---|---|---|
+| cumvar (0.95) | 1.0-2.5 | 0.158 / 0.205 / 0.223 | 0.247 / 0.255 / 0.259 |
+| spectral | 1.6-2.1 | 0.274 / 0.281 / 0.286 | 0.132 / 0.129 / 0.125 |
+| usvt | 5.5-6.9 | 0.106 / 0.095 / 0.072 | 0.080 / 0.044 / 0.034 |
+| Table 1 | — | 0.118 / 0.065 / 0.054 | 0.062 / 0.051 / 0.025 |
+
+Whether the latent design is redrawn per replication. Also decisive, for the
+Figure 4 claim specifically. Under this DGP the latent draw moves the evaluation
+horizon over two orders of magnitude — the pooled 90th percentile of observed
+times has median 93 and range [20, 5743] across Cox draws — which swamps the
+effect of `K`. Drawing an independent design at each `K` breaks the monotone
+decrease (Cox runs 0.143 / 0.051 / 0.085); holding the design fixed across `K`,
+as common random numbers, restores it. The grid above uses common random
+numbers. The paper says the factors are "fixed throughout the simulation", which
+is consistent with this but does not settle it.
+
+Whether `tau_tilde` pools every cell or uses the treated unit. Not decisive.
+Reading `quantile_0.90({T_{p,n,i}})` as the pooled sample gives the table above;
+reading it as the treated unit's own times gives 0.1182 / 0.0999 / 0.0766 on Cox
+and 0.0827 / 0.0573 / 0.0429 on Aalen, the same picture. Carried in
+`results.json` as `grid_pcr_treated`.
+
+## Two findings that bear on a build
+
+The estimator's output is usually not a survival function. The PCR weights are
+unconstrained — Assumption 6 asks only that the treated unit lie in the linear
+span of the donors — so the counterfactual `sum_m w_m S_m(t)` need not be
+monotone or stay inside [0, 1]. Across the grid it is monotone in 0-55 percent
+of replications and inside [0, 1] in 15-45 percent. The paper does not raise
+this; with nine donors its own figures happen to come out clean. The worst cell
+is Aalen at K = 100, where no replication out of twenty returns a monotone
+curve.
+
+Abadie's convex-hull condition fixes it for free, because a convex combination
+of monotone [0, 1] curves is monotone in [0, 1]. Replacing step 3 with the
+simplex fit already in `mlsynth.utils.inferutils._outcome_only_simplex` gives
+monotone, in-range output in 100 percent of replications at every cell, and
+costs nothing on average — better than PCR on Cox at all three sample sizes
+(0.0909 / 0.0786 / 0.0675), slightly worse on Aalen (0.0864 / 0.0560 / 0.0450),
+with the K-monotonicity intact in both.
+
+Table 1 is mostly measuring Kaplan-Meier. `km_floor.py` measures the sup-norm
+distance between one unit-period Kaplan-Meier curve and its own truth, on the
+estimator's grid:
+
+| DGP | K | one KM curve | Table 1 SSC | ratio |
+|---|---|---|---|---|
+| Cox | 100 | 0.0658 | 0.1177 | 1.79 |
+| Cox | 300 | 0.0376 | 0.0652 | 1.73 |
+| Cox | 700 | 0.0235 | 0.0542 | 2.30 |
+| Aalen | 100 | 0.0812 | 0.0621 | 0.76 |
+| Aalen | 300 | 0.0457 | 0.0507 | 1.11 |
+| Aalen | 700 | 0.0293 | 0.0245 | 0.84 |
+
+The reported error is the same order as a single Kaplan-Meier curve's error, and
+on Aalen it sits below one — the weighted average over nineteen donors averages
+part of that noise away. The Kaplan-Meier error falls at 1/sqrt(K) (0.0658 ->
+0.0376 -> 0.0235 tracks sqrt(1/3) and sqrt(3/7) to two digits), which is where
+the K-dependence in Figure 4 comes from. This squares with Theorem 2, whose rate
+contains no `K` at all: `K` enters the theorem only as a threshold for the PCR
+stability argument, and the convergence the simulation displays lives in step 1,
+which the theorem treats as a precondition.
+
+## A robustness gap in mlsynth, found here
+
+`mlsynth/utils/pcr/core.py:78` divides by `s_r` with no guard:
+
+```python
+return Vt_r.T @ ((U_r.T @ target) / s_r)
+```
+
+When the requested rank exceeds the design matrix's numerical rank this returns
+NaN silently. It is reachable on this design: the Cox rates span `exp(+/-4)`, so
+draws with a long horizon leave most donor curves flat at zero and the donor
+matrix near rank one. `survsc_oracle.py` caps the rank at the numerical rank
+before calling `pcr_weights`. The guard belongs upstream, on its own branch —
+every PCR caller (`SI`, `CLUSTERSC`, `RSC`) shares the exposure.

--- a/benchmarks/reference/survsc_mc/dump_results.py
+++ b/benchmarks/reference/survsc_mc/dump_results.py
@@ -1,0 +1,76 @@
+"""Regenerate ``results.json`` — every number the README reports.
+
+    python benchmarks/reference/survsc_mc/dump_results.py
+
+Runs the Section 4 grid under both weight modes and both readings of the
+evaluation horizon, plus the rank-rule sweep that shows how much the
+unstated ``r0`` rule decides. Deterministic: seeds are fixed in
+``run_grid.py``.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
+from run_grid import DGPS, KS, PAPER, cell  # noqa: E402
+
+OUT = pathlib.Path(__file__).parent / "results.json"
+
+
+def grid(weight_mode: str, horizon: str) -> dict:
+    out = {}
+    for dgp in DGPS:
+        for K in KS:
+            c = cell(dgp, K, rank_rule="usvt", horizon_mode=horizon,
+                     weight_mode=weight_mode)
+            out[f"{dgp}_K{K}"] = {
+                "ssc_mean": round(c["ssc"][0], 4),
+                "ssc_sd": round(c["ssc"][1], 4),
+                "oracle_mean": round(c["oracle"][0], 4),
+                "oracle_sd": round(c["oracle"][1], 4),
+                "share_monotone": round(c["monotone"][0], 2),
+                "share_in_unit_range": round(c["in_unit_range"][0], 2),
+                "median_horizon": round(c["horizon"][2], 3),
+                "paper_ssc": list(PAPER[(dgp, K)]["ssc"]),
+                "paper_oracle": list(PAPER[(dgp, K)]["oracle"]),
+            }
+    return out
+
+
+def rank_sweep() -> dict:
+    out = {}
+    for rule in ("cumvar", "spectral", "usvt"):
+        for dgp in DGPS:
+            for K in KS:
+                c = cell(dgp, K, rank_rule=rule, oracle=False)
+                out[f"{rule}_{dgp}_K{K}"] = {
+                    "ssc_mean": round(c["ssc"][0], 4),
+                    "mean_rank": round(c["rank"][0], 1),
+                    "paper_ssc_mean": PAPER[(dgp, K)]["ssc"][0],
+                }
+    return out
+
+
+def main() -> None:
+    payload = {
+        "provenance": {
+            "paper": "arXiv:2511.14133v1, Han & Shah, Synthetic Survival Control",
+            "target": "Table 1 (sup-norm error, mean +/- sd over 20 replications)",
+            "design": "Section 4",
+            "replications": 20,
+            "common_random_numbers_across_K": True,
+        },
+        "grid_pcr_pooled": grid("pcr", "pooled"),
+        "grid_pcr_treated": grid("pcr", "treated"),
+        "grid_simplex_pooled": grid("simplex", "pooled"),
+        "rank_sweep": rank_sweep(),
+    }
+    OUT.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"wrote {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/reference/survsc_mc/km_floor.py
+++ b/benchmarks/reference/survsc_mc/km_floor.py
@@ -1,0 +1,66 @@
+"""How much of the Table 1 error is the Kaplan-Meier step?
+
+    python benchmarks/reference/survsc_mc/km_floor.py
+
+Measures the sup-norm distance between a single unit-period Kaplan-Meier curve
+and its own analytic truth, on the same grid the estimator uses and at the same
+rates and censoring the Section 4 design produces. Compare the result against
+Table 1: it sets the floor the SSC error is measured on top of.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from survsc_oracle import (
+    N_PERIODS,
+    N_UNITS,
+    TREATED,
+    draw_design,
+    kaplan_meier,
+    sample_cell,
+    solve_censoring_rate,
+)
+
+KS = (100, 300, 700)
+REPS = 20
+SEED0 = 777
+
+PAPER_SSC = {
+    ("cox", 100): 0.1177, ("cox", 300): 0.0652, ("cox", 700): 0.0542,
+    ("aalen", 100): 0.0621, ("aalen", 300): 0.0507, ("aalen", 700): 0.0245,
+}
+
+
+def per_curve_error(dgp: str, K: int) -> float:
+    out = []
+    for s in range(REPS):
+        rng = np.random.default_rng(SEED0 + s)
+        design = draw_design(rng, dgp)
+        nu = solve_censoring_rate(design.rate)
+        cells = {}
+        for p in range(N_PERIODS):
+            for n in range(N_UNITS):
+                if p == 1 and n == TREATED:
+                    continue
+                cells[(p, n)] = sample_cell(design.rate[p, n], nu, K, rng)
+        pooled = np.concatenate([t for t, _ in cells.values()])
+        grid = np.linspace(0.0, float(np.quantile(pooled, 0.90)), 100)
+        out.append(np.mean([
+            np.max(np.abs(kaplan_meier(t, e, grid)
+                          - np.exp(-design.rate[p, n] * grid)))
+            for (p, n), (t, e) in cells.items()
+        ]))
+    return float(np.mean(out))
+
+
+def main() -> None:
+    print(f"{'DGP':6} {'K':>4} {'KM sup-error':>13} {'Table 1 SSC':>12} {'ratio':>7}")
+    for dgp in ("cox", "aalen"):
+        for K in KS:
+            km = per_curve_error(dgp, K)
+            ssc = PAPER_SSC[(dgp, K)]
+            print(f"{dgp:6} {K:>4} {km:>13.4f} {ssc:>12.4f} {ssc / km:>7.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/reference/survsc_mc/results.json
+++ b/benchmarks/reference/survsc_mc/results.json
@@ -1,0 +1,413 @@
+{
+  "provenance": {
+    "paper": "arXiv:2511.14133v1, Han & Shah, Synthetic Survival Control",
+    "target": "Table 1 (sup-norm error, mean +/- sd over 20 replications)",
+    "design": "Section 4",
+    "replications": 20,
+    "common_random_numbers_across_K": true
+  },
+  "grid_pcr_pooled": {
+    "cox_K100": {
+      "ssc_mean": 0.1061,
+      "ssc_sd": 0.1318,
+      "oracle_mean": 0.012,
+      "oracle_sd": 0.0128,
+      "share_monotone": 0.15,
+      "share_in_unit_range": 0.15,
+      "median_horizon": 218.579,
+      "paper_ssc": [
+        0.1177,
+        0.0835
+      ],
+      "paper_oracle": [
+        0.0247,
+        0.0121
+      ]
+    },
+    "cox_K300": {
+      "ssc_mean": 0.0949,
+      "ssc_sd": 0.1298,
+      "oracle_mean": 0.0068,
+      "oracle_sd": 0.0061,
+      "share_monotone": 0.3,
+      "share_in_unit_range": 0.25,
+      "median_horizon": 223.407,
+      "paper_ssc": [
+        0.0652,
+        0.0497
+      ],
+      "paper_oracle": [
+        0.0204,
+        0.0096
+      ]
+    },
+    "cox_K700": {
+      "ssc_mean": 0.0724,
+      "ssc_sd": 0.1251,
+      "oracle_mean": 0.0033,
+      "oracle_sd": 0.0031,
+      "share_monotone": 0.25,
+      "share_in_unit_range": 0.4,
+      "median_horizon": 223.102,
+      "paper_ssc": [
+        0.0542,
+        0.0413
+      ],
+      "paper_oracle": [
+        0.0194,
+        0.0104
+      ]
+    },
+    "aalen_K100": {
+      "ssc_mean": 0.0796,
+      "ssc_sd": 0.0394,
+      "oracle_mean": 0.0119,
+      "oracle_sd": 0.0141,
+      "share_monotone": 0.0,
+      "share_in_unit_range": 0.25,
+      "median_horizon": 0.704,
+      "paper_ssc": [
+        0.0621,
+        0.0307
+      ],
+      "paper_oracle": [
+        0.0185,
+        0.0052
+      ]
+    },
+    "aalen_K300": {
+      "ssc_mean": 0.0436,
+      "ssc_sd": 0.0158,
+      "oracle_mean": 0.0057,
+      "oracle_sd": 0.0036,
+      "share_monotone": 0.3,
+      "share_in_unit_range": 0.45,
+      "median_horizon": 0.691,
+      "paper_ssc": [
+        0.0507,
+        0.0388
+      ],
+      "paper_oracle": [
+        0.0136,
+        0.0067
+      ]
+    },
+    "aalen_K700": {
+      "ssc_mean": 0.0337,
+      "ssc_sd": 0.0177,
+      "oracle_mean": 0.0058,
+      "oracle_sd": 0.0061,
+      "share_monotone": 0.55,
+      "share_in_unit_range": 0.45,
+      "median_horizon": 0.697,
+      "paper_ssc": [
+        0.0245,
+        0.0102
+      ],
+      "paper_oracle": [
+        0.0099,
+        0.0044
+      ]
+    }
+  },
+  "grid_pcr_treated": {
+    "cox_K100": {
+      "ssc_mean": 0.1182,
+      "ssc_sd": 0.1711,
+      "oracle_mean": 0.0119,
+      "oracle_sd": 0.0114,
+      "share_monotone": 0.15,
+      "share_in_unit_range": 0.3,
+      "median_horizon": 47.21,
+      "paper_ssc": [
+        0.1177,
+        0.0835
+      ],
+      "paper_oracle": [
+        0.0247,
+        0.0121
+      ]
+    },
+    "cox_K300": {
+      "ssc_mean": 0.0999,
+      "ssc_sd": 0.1601,
+      "oracle_mean": 0.0064,
+      "oracle_sd": 0.006,
+      "share_monotone": 0.45,
+      "share_in_unit_range": 0.5,
+      "median_horizon": 49.092,
+      "paper_ssc": [
+        0.0652,
+        0.0497
+      ],
+      "paper_oracle": [
+        0.0204,
+        0.0096
+      ]
+    },
+    "cox_K700": {
+      "ssc_mean": 0.0766,
+      "ssc_sd": 0.128,
+      "oracle_mean": 0.003,
+      "oracle_sd": 0.0027,
+      "share_monotone": 0.55,
+      "share_in_unit_range": 0.45,
+      "median_horizon": 50.637,
+      "paper_ssc": [
+        0.0542,
+        0.0413
+      ],
+      "paper_oracle": [
+        0.0194,
+        0.0104
+      ]
+    },
+    "aalen_K100": {
+      "ssc_mean": 0.0827,
+      "ssc_sd": 0.0571,
+      "oracle_mean": 0.0164,
+      "oracle_sd": 0.0268,
+      "share_monotone": 0.2,
+      "share_in_unit_range": 0.35,
+      "median_horizon": 0.539,
+      "paper_ssc": [
+        0.0621,
+        0.0307
+      ],
+      "paper_oracle": [
+        0.0185,
+        0.0052
+      ]
+    },
+    "aalen_K300": {
+      "ssc_mean": 0.0573,
+      "ssc_sd": 0.0432,
+      "oracle_mean": 0.0081,
+      "oracle_sd": 0.0101,
+      "share_monotone": 0.35,
+      "share_in_unit_range": 0.4,
+      "median_horizon": 0.584,
+      "paper_ssc": [
+        0.0507,
+        0.0388
+      ],
+      "paper_oracle": [
+        0.0136,
+        0.0067
+      ]
+    },
+    "aalen_K700": {
+      "ssc_mean": 0.0429,
+      "ssc_sd": 0.0482,
+      "oracle_mean": 0.009,
+      "oracle_sd": 0.0196,
+      "share_monotone": 0.7,
+      "share_in_unit_range": 0.5,
+      "median_horizon": 0.528,
+      "paper_ssc": [
+        0.0245,
+        0.0102
+      ],
+      "paper_oracle": [
+        0.0099,
+        0.0044
+      ]
+    }
+  },
+  "grid_simplex_pooled": {
+    "cox_K100": {
+      "ssc_mean": 0.0909,
+      "ssc_sd": 0.1123,
+      "oracle_mean": 0.012,
+      "oracle_sd": 0.0128,
+      "share_monotone": 1.0,
+      "share_in_unit_range": 1.0,
+      "median_horizon": 218.579,
+      "paper_ssc": [
+        0.1177,
+        0.0835
+      ],
+      "paper_oracle": [
+        0.0247,
+        0.0121
+      ]
+    },
+    "cox_K300": {
+      "ssc_mean": 0.0786,
+      "ssc_sd": 0.1231,
+      "oracle_mean": 0.0068,
+      "oracle_sd": 0.0061,
+      "share_monotone": 1.0,
+      "share_in_unit_range": 1.0,
+      "median_horizon": 223.407,
+      "paper_ssc": [
+        0.0652,
+        0.0497
+      ],
+      "paper_oracle": [
+        0.0204,
+        0.0096
+      ]
+    },
+    "cox_K700": {
+      "ssc_mean": 0.0675,
+      "ssc_sd": 0.1209,
+      "oracle_mean": 0.0033,
+      "oracle_sd": 0.0031,
+      "share_monotone": 1.0,
+      "share_in_unit_range": 1.0,
+      "median_horizon": 223.102,
+      "paper_ssc": [
+        0.0542,
+        0.0413
+      ],
+      "paper_oracle": [
+        0.0194,
+        0.0104
+      ]
+    },
+    "aalen_K100": {
+      "ssc_mean": 0.0864,
+      "ssc_sd": 0.0375,
+      "oracle_mean": 0.0119,
+      "oracle_sd": 0.0141,
+      "share_monotone": 1.0,
+      "share_in_unit_range": 1.0,
+      "median_horizon": 0.704,
+      "paper_ssc": [
+        0.0621,
+        0.0307
+      ],
+      "paper_oracle": [
+        0.0185,
+        0.0052
+      ]
+    },
+    "aalen_K300": {
+      "ssc_mean": 0.056,
+      "ssc_sd": 0.0335,
+      "oracle_mean": 0.0057,
+      "oracle_sd": 0.0036,
+      "share_monotone": 1.0,
+      "share_in_unit_range": 1.0,
+      "median_horizon": 0.691,
+      "paper_ssc": [
+        0.0507,
+        0.0388
+      ],
+      "paper_oracle": [
+        0.0136,
+        0.0067
+      ]
+    },
+    "aalen_K700": {
+      "ssc_mean": 0.045,
+      "ssc_sd": 0.0345,
+      "oracle_mean": 0.0058,
+      "oracle_sd": 0.0061,
+      "share_monotone": 1.0,
+      "share_in_unit_range": 1.0,
+      "median_horizon": 0.697,
+      "paper_ssc": [
+        0.0245,
+        0.0102
+      ],
+      "paper_oracle": [
+        0.0099,
+        0.0044
+      ]
+    }
+  },
+  "rank_sweep": {
+    "cumvar_cox_K100": {
+      "ssc_mean": 0.158,
+      "mean_rank": 2.5,
+      "paper_ssc_mean": 0.1177
+    },
+    "cumvar_cox_K300": {
+      "ssc_mean": 0.2053,
+      "mean_rank": 2.3,
+      "paper_ssc_mean": 0.0652
+    },
+    "cumvar_cox_K700": {
+      "ssc_mean": 0.2229,
+      "mean_rank": 2.2,
+      "paper_ssc_mean": 0.0542
+    },
+    "cumvar_aalen_K100": {
+      "ssc_mean": 0.2468,
+      "mean_rank": 1.1,
+      "paper_ssc_mean": 0.0621
+    },
+    "cumvar_aalen_K300": {
+      "ssc_mean": 0.2547,
+      "mean_rank": 1.1,
+      "paper_ssc_mean": 0.0507
+    },
+    "cumvar_aalen_K700": {
+      "ssc_mean": 0.2586,
+      "mean_rank": 1.0,
+      "paper_ssc_mean": 0.0245
+    },
+    "spectral_cox_K100": {
+      "ssc_mean": 0.2741,
+      "mean_rank": 2.1,
+      "paper_ssc_mean": 0.1177
+    },
+    "spectral_cox_K300": {
+      "ssc_mean": 0.2812,
+      "mean_rank": 2.0,
+      "paper_ssc_mean": 0.0652
+    },
+    "spectral_cox_K700": {
+      "ssc_mean": 0.2858,
+      "mean_rank": 2.0,
+      "paper_ssc_mean": 0.0542
+    },
+    "spectral_aalen_K100": {
+      "ssc_mean": 0.1317,
+      "mean_rank": 1.6,
+      "paper_ssc_mean": 0.0621
+    },
+    "spectral_aalen_K300": {
+      "ssc_mean": 0.1293,
+      "mean_rank": 1.6,
+      "paper_ssc_mean": 0.0507
+    },
+    "spectral_aalen_K700": {
+      "ssc_mean": 0.1247,
+      "mean_rank": 1.6,
+      "paper_ssc_mean": 0.0245
+    },
+    "usvt_cox_K100": {
+      "ssc_mean": 0.1061,
+      "mean_rank": 6.8,
+      "paper_ssc_mean": 0.1177
+    },
+    "usvt_cox_K300": {
+      "ssc_mean": 0.0949,
+      "mean_rank": 6.9,
+      "paper_ssc_mean": 0.0652
+    },
+    "usvt_cox_K700": {
+      "ssc_mean": 0.0724,
+      "mean_rank": 6.9,
+      "paper_ssc_mean": 0.0542
+    },
+    "usvt_aalen_K100": {
+      "ssc_mean": 0.0796,
+      "mean_rank": 5.5,
+      "paper_ssc_mean": 0.0621
+    },
+    "usvt_aalen_K300": {
+      "ssc_mean": 0.0436,
+      "mean_rank": 5.5,
+      "paper_ssc_mean": 0.0507
+    },
+    "usvt_aalen_K700": {
+      "ssc_mean": 0.0337,
+      "mean_rank": 5.8,
+      "paper_ssc_mean": 0.0245
+    }
+  }
+}

--- a/benchmarks/reference/survsc_mc/run_grid.py
+++ b/benchmarks/reference/survsc_mc/run_grid.py
@@ -1,0 +1,86 @@
+"""Run the Section 4 grid and compare against the paper's Table 1.
+
+Common random numbers: the latent design for replication ``r`` is seeded by
+``r`` alone, so the same 20 designs are reused at every ``K`` and the
+K-comparison isolates the patient-sampling effect Figure 4 is about.
+"""
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+
+from survsc_oracle import replication
+
+KS = (100, 300, 700)
+DGPS = ("cox", "aalen")
+N_REPS = 20
+SEED0 = 20_251_114
+
+# Table 1 of arXiv:2511.14133v1: (mean, sd) of the sup-norm error.
+PAPER = {
+    ("cox", 100): {"ssc": (0.1177, 0.0835), "oracle": (0.0247, 0.0121)},
+    ("cox", 300): {"ssc": (0.0652, 0.0497), "oracle": (0.0204, 0.0096)},
+    ("cox", 700): {"ssc": (0.0542, 0.0413), "oracle": (0.0194, 0.0104)},
+    ("aalen", 100): {"ssc": (0.0621, 0.0307), "oracle": (0.0185, 0.0052)},
+    ("aalen", 300): {"ssc": (0.0507, 0.0388), "oracle": (0.0136, 0.0067)},
+    ("aalen", 700): {"ssc": (0.0245, 0.0102), "oracle": (0.0099, 0.0044)},
+}
+DGP_OFFSET = {"cox": 0, "aalen": 500_000}
+
+
+def cell(dgp, K, reps=N_REPS, oracle=True, **kw):
+    rows = [
+        replication(
+            dgp, K,
+            seed=SEED0 + DGP_OFFSET[dgp] + 1000 * K + r,
+            design_seed=SEED0 + DGP_OFFSET[dgp] + r,     # common across K
+            run_oracle=oracle, **kw
+        )
+        for r in range(reps)
+    ]
+    out = {}
+    for key in ("ssc", "oracle", "rank", "monotone", "in_unit_range", "horizon"):
+        if key in rows[0]:
+            vals = np.array([r[key] for r in rows], dtype=float)
+            out[key] = (float(vals.mean()), float(vals.std(ddof=1)),
+                        float(np.median(vals)))
+    return out
+
+
+def main(argv: list[str]) -> None:
+    rule = argv[0] if argv else "usvt"
+    horizon = argv[1] if len(argv) > 1 else "pooled"
+    kw = {"rank_rule": rule} if not rule.isdigit() else {"fixed_rank": int(rule)}
+    kw["horizon_mode"] = horizon
+    if len(argv) > 2:
+        kw["weight_mode"] = argv[2]
+
+    print(f"rank rule: {rule}   horizon: {horizon}   "
+          f"weights: {kw.get('weight_mode', 'pcr')}   reps: {N_REPS}   "
+          f"common random numbers across K\n")
+    print(f"{'DGP':6} {'K':>4} | {'SSC (mine)':>19} {'SSC (paper)':>19} | "
+          f"{'oracle (mine)':>19} {'oracle (paper)':>19} | {'mono':>5} {'in01':>5}")
+    summary = {}
+    for dgp in DGPS:
+        col = []
+        for K in KS:
+            c = cell(dgp, K, **kw)
+            p = PAPER[(dgp, K)]
+            col.append(c["ssc"][0])
+            print(f"{dgp:6} {K:>4} | {c['ssc'][0]:>8.4f} +/- {c['ssc'][1]:<8.4f} "
+                  f"{p['ssc'][0]:>8.4f} +/- {p['ssc'][1]:<8.4f} | "
+                  f"{c['oracle'][0]:>8.4f} +/- {c['oracle'][1]:<8.4f} "
+                  f"{p['oracle'][0]:>8.4f} +/- {p['oracle'][1]:<8.4f} | "
+                  f"{c['monotone'][0]:>5.2f} {c['in_unit_range'][0]:>5.2f}")
+        summary[dgp] = col
+    print()
+    for dgp in DGPS:
+        col = summary[dgp]
+        falls = all(b < a for a, b in zip(col, col[1:]))
+        print(f"{dgp:6} error falls monotonically in K: {falls}   "
+              f"({' -> '.join(f'{v:.4f}' for v in col)})")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/benchmarks/reference/survsc_mc/survsc_oracle.py
+++ b/benchmarks/reference/survsc_mc/survsc_oracle.py
@@ -1,0 +1,294 @@
+"""Readable oracle port of Synthetic Survival Control (Han & Shah 2025).
+
+Provenance: arXiv:2511.14133v1, Section 3.4.2 (estimator) and Section 4
+(simulation design). Every step below cites the paper.
+
+The design in Section 4 makes both DGPs exponential: the Cox specification
+fixes the baseline hazard at ``h(t) = lambda`` and the Aalen specification
+fixes ``h'(t) = lambda_0``, so in each case the hazard is constant in ``t``
+and the potential event time under control is ``Exp(rate[p, n])``. That
+gives a closed form for the estimand,
+
+    S^(0)_{p,n}(t) = exp(-rate[p, n] * t),
+
+which is what the sup-norm error in Table 1 is measured against.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.optimize import brentq, minimize
+
+from mlsynth.utils.pcr import pcr_weights, select_rank, spectral_rank
+
+# --- Section 4 design constants -------------------------------------------
+
+R_LATENT = 4            # r = 4 latent factors
+N_UNITS = 20            # N = 20 units, one of them treated
+N_PERIODS = 2           # p in {0, 1}
+TREATED = 0             # "one unit designated as the treated unit"
+LAMBDA_COX = 0.05       # Cox baseline hazard, h(t) = lambda
+AALEN_FLOOR = 0.05      # lambda_0 chosen so the minimum hazard is 0.05
+GRID_POINTS = 100       # T0 = 100 equally spaced timestamps
+HORIZON_Q = 0.90        # tau_tilde = quantile_0.90 of observed times
+CENSOR_TARGET = 0.10    # "empirical censoring proportion ~ 10%"
+
+
+@dataclass(frozen=True)
+class Design:
+    """One draw of the latent structure, shared by both periods."""
+
+    rate: np.ndarray        # (N_PERIODS, N_UNITS) exponential rates under control
+    covariates: np.ndarray  # (N_PERIODS, N_UNITS, 2 * R_LATENT) true [V_n, U_p]
+
+
+def draw_design(rng: np.random.Generator, dgp: str) -> Design:
+    """Draw latent factors and coefficients, then form the control hazards.
+
+    Cox (Section 4, model 1):  h^(0)_{p,n}(t) = lambda * exp(b1'V_n + b2'U_p).
+    Aalen (Section 4, model 2): h^(0)_{p,n}(t) = lambda_0 + b1'V_n + b2'U_p,
+    with lambda_0 = 0.05 - min_{p,n}(b1'V_n + b2'U_p) so hazards stay positive.
+    """
+    V = rng.standard_normal((N_UNITS, R_LATENT))
+    U = rng.standard_normal((N_PERIODS, R_LATENT))
+    b1 = rng.standard_normal(R_LATENT)
+    b2 = rng.standard_normal(R_LATENT)
+
+    linear = (V @ b1)[None, :] + (U @ b2)[:, None]      # (P, N)
+    if dgp == "cox":
+        rate = LAMBDA_COX * np.exp(linear)
+    elif dgp == "aalen":
+        rate = (AALEN_FLOOR - linear.min()) + linear
+    else:  # pragma: no cover - guarded by the caller
+        raise ValueError(f"unknown dgp {dgp!r}")
+
+    covariates = np.empty((N_PERIODS, N_UNITS, 2 * R_LATENT))
+    for p in range(N_PERIODS):
+        for n in range(N_UNITS):
+            covariates[p, n] = np.concatenate([V[n], U[p]])
+    return Design(rate=rate, covariates=covariates)
+
+
+def solve_censoring_rate(rate: np.ndarray, target: float = CENSOR_TARGET) -> float:
+    """Find nu with C ~ Exp(nu) giving the target pooled censoring share.
+
+    For a cell with event rate ``r``, P(C < tau) = nu / (nu + r); the paper
+    calibrates nu so the pooled share is about 10 percent.
+    """
+    def share(nu: float) -> float:
+        return float(np.mean(nu / (nu + rate)) - target)
+
+    lo, hi = 1e-12, 1.0
+    while share(hi) < 0.0:
+        hi *= 2.0
+        if hi > 1e12:  # pragma: no cover - unreachable for positive rates
+            raise RuntimeError("censoring calibration failed to bracket")
+    return float(brentq(share, lo, hi, xtol=1e-14, rtol=1e-12))
+
+
+def sample_cell(rate: float, nu: float, size: int, rng: np.random.Generator):
+    """Right-censored draws for one unit-period cohort.
+
+    Inverse transform exactly as in Section 4: tau = -log(W) / rate.
+    """
+    W = rng.uniform(size=size)
+    tau = -np.log(W) / rate
+    censor = rng.exponential(scale=1.0 / nu, size=size)
+    observed = np.minimum(tau, censor)
+    event = (tau <= censor).astype(float)
+    return observed, event
+
+
+def kaplan_meier(times: np.ndarray, events: np.ndarray, grid: np.ndarray) -> np.ndarray:
+    """Kaplan-Meier survival curve evaluated on ``grid`` (Appendix D).
+
+    S(t) = prod_{t_(j) <= t} (1 - d(t_(j)) / n(t_(j))), with S(0) = 1.
+    """
+    event_times = np.unique(times[events > 0])
+    if event_times.size == 0:
+        return np.ones_like(grid)
+    deaths = np.array([(times[events > 0] == e).sum() for e in event_times], dtype=float)
+    at_risk = np.array([(times >= e).sum() for e in event_times], dtype=float)
+    factors = np.cumprod(1.0 - deaths / at_risk)
+    steps = np.concatenate([[1.0], factors])
+    # number of distinct event times at or before each grid point
+    return steps[np.searchsorted(event_times, grid, side="right")]
+
+
+def ssc_counterfactual(
+    donors_pre: np.ndarray,
+    treated_pre: np.ndarray,
+    donors_post: np.ndarray,
+    rank: int,
+) -> np.ndarray:
+    """Steps 3-4 of Section 3.4.2.
+
+    ``pcr_weights`` computes w = V_r diag(1/s_r) U_r' y, which is the paper's
+    closed form  w-hat = sum_{i<=r0} (1/s_i) v_i u_i' S-hat_{0,n}  verbatim.
+    """
+    weights = pcr_weights(donors_pre, treated_pre, rank)
+    return donors_post @ weights
+
+
+def _exponential_loglik(rate: np.ndarray, times: np.ndarray, events: np.ndarray) -> float:
+    """Observed-data log-likelihood for exponential event times under censoring."""
+    return float(np.sum(events * np.log(rate) - rate * times))
+
+
+def confounder_aware_parametric(
+    dgp: str,
+    covariates: np.ndarray,
+    times: list[np.ndarray],
+    events: list[np.ndarray],
+    target_covariate: np.ndarray,
+    grid: np.ndarray,
+) -> np.ndarray:
+    """The Table 1 comparator: true latent factors plus the correct model form.
+
+    ``covariates`` stacks the true [V_n, U_p] for each observed cohort, and the
+    fitted model is the same parametric family that generated the data, so this
+    is the correctly-specified oracle the paper compares SSC against.
+    """
+    flat_x = np.concatenate([
+        np.repeat(covariates[i][None, :], times[i].size, axis=0)
+        for i in range(len(times))
+    ])
+    flat_t = np.concatenate(times)
+    flat_d = np.concatenate(events)
+    design = np.column_stack([np.ones(flat_x.shape[0]), flat_x])
+
+    if dgp == "cox":
+        def negll(theta: np.ndarray) -> float:
+            return -_exponential_loglik(np.exp(design @ theta), flat_t, flat_d)
+
+        theta0 = np.zeros(design.shape[1])
+        theta0[0] = np.log(max(flat_d.sum(), 1.0) / max(flat_t.sum(), 1e-12))
+        fit = minimize(negll, theta0, method="L-BFGS-B")
+        rate = float(np.exp(np.concatenate([[1.0], target_covariate]) @ fit.x))
+    else:
+        def negll(theta: np.ndarray) -> float:
+            lin = design @ theta
+            if np.any(lin <= 0):
+                return 1e12
+            return -_exponential_loglik(lin, flat_t, flat_d)
+
+        theta0 = np.zeros(design.shape[1])
+        theta0[0] = max(flat_d.sum(), 1.0) / max(flat_t.sum(), 1e-12)
+        fit = minimize(negll, theta0, method="Nelder-Mead",
+                       options={"maxiter": 20000, "fatol": 1e-10, "xatol": 1e-10})
+        rate = float(np.concatenate([[1.0], target_covariate]) @ fit.x)
+        rate = max(rate, 1e-12)
+
+    return np.exp(-rate * grid)
+
+
+def replication(
+    dgp: str,
+    K: int,
+    seed: int,
+    rank_rule: str = "cumvar",
+    fixed_rank: int | None = None,
+    run_oracle: bool = True,
+    horizon_mode: str = "pooled",
+    design_seed: int | None = None,
+    weight_mode: str = "pcr",
+) -> dict:
+    """One Monte-Carlo replication; returns sup-norm errors.
+
+    ``design_seed`` separates the latent draw from the patient draw. Holding it
+    fixed across ``K`` gives common random numbers, so the K-comparison in
+    Figure 4 is not swamped by design variability -- under this DGP the latent
+    draw moves the evaluation horizon over two orders of magnitude, which is
+    far larger than the effect of K.
+    """
+    design_rng = np.random.default_rng(seed if design_seed is None else design_seed)
+    rng = np.random.default_rng(seed)
+    design = draw_design(design_rng, dgp)
+    nu = solve_censoring_rate(design.rate)
+
+    donors = [n for n in range(N_UNITS) if n != TREATED]
+
+    # Cohorts the estimator may see: every donor in both periods, and the
+    # treated unit in the pre-period only. The treated unit's post-period is
+    # the counterfactual, so it is never generated.
+    times: dict[tuple[int, int], np.ndarray] = {}
+    events: dict[tuple[int, int], np.ndarray] = {}
+    for p in range(N_PERIODS):
+        for n in range(N_UNITS):
+            if p == 1 and n == TREATED:
+                continue
+            t, d = sample_cell(design.rate[p, n], nu, K, rng)
+            times[(p, n)] = t
+            events[(p, n)] = d
+
+    # tau_tilde. The paper writes quantile_0.90({T_{p,n,i}}) with all three
+    # indices free, which reads as the pooled sample ("pooled" below). Under
+    # the Cox design that quantile is set by the slowest cells and ranges over
+    # two orders of magnitude across draws, so the alternative reading -- the
+    # treated unit's own observed times -- is carried as a sensitivity.
+    if horizon_mode == "pooled":
+        reference = np.concatenate(list(times.values()))
+    elif horizon_mode == "treated":
+        reference = times[(0, TREATED)]
+    else:  # pragma: no cover - guarded by the caller
+        raise ValueError(f"unknown horizon_mode {horizon_mode!r}")
+    horizon = float(np.quantile(reference, HORIZON_Q))
+    grid = np.linspace(0.0, horizon, GRID_POINTS)
+
+    curves = {key: kaplan_meier(times[key], events[key], grid) for key in times}
+
+    donors_pre = np.column_stack([curves[(0, n)] for n in donors])    # (T0, N0)
+    donors_post = np.column_stack([curves[(1, n)] for n in donors])
+    treated_pre = curves[(0, TREATED)]
+
+    if fixed_rank is not None:
+        rank = min(fixed_rank, min(donors_pre.shape))
+    elif rank_rule == "spectral":
+        rank = spectral_rank(np.linalg.svd(donors_pre, compute_uv=False))
+    else:
+        rank = select_rank(donors_pre, method=rank_rule)
+    # Numerical-rank cap. mlsynth's pcr_weights divides by s_r unguarded, so a
+    # rule that asks for more directions than the donor matrix numerically has
+    # returns NaN. The dispersion in the Cox design makes that reachable.
+    singular = np.linalg.svd(donors_pre, compute_uv=False)
+    tol = singular[0] * max(donors_pre.shape) * np.finfo(float).eps
+    numerical_rank = int(np.sum(singular > max(tol, 1e-10)))
+    rank = max(1, min(int(rank), numerical_rank))
+
+    if weight_mode == "pcr":
+        estimate = ssc_counterfactual(donors_pre, treated_pre, donors_post, rank)
+    elif weight_mode == "simplex":
+        # Not the paper's estimator. Assumption 6 asks only for a linear span,
+        # but Abadie's convex-hull condition makes the output a survival
+        # function by construction: a convex combination of monotone [0, 1]
+        # curves is monotone in [0, 1].
+        from mlsynth.utils.inferutils import _outcome_only_simplex
+
+        weights = _outcome_only_simplex(treated_pre, donors_pre)
+        estimate = donors_post @ weights
+    else:  # pragma: no cover - guarded by the caller
+        raise ValueError(f"unknown weight_mode {weight_mode!r}")
+    truth = np.exp(-design.rate[1, TREATED] * grid)
+
+    out = {
+        "ssc": float(np.max(np.abs(estimate - truth))),
+        "rank": float(rank),
+        "censored_share": float(1.0 - np.concatenate(list(events.values())).mean()),
+        "horizon": horizon,
+        "monotone": float(np.all(np.diff(estimate) <= 1e-12)),
+        "in_unit_range": float(np.all((estimate >= -1e-12) & (estimate <= 1 + 1e-12))),
+    }
+
+    if run_oracle:
+        keys = list(times.keys())
+        oracle = confounder_aware_parametric(
+            dgp,
+            [design.covariates[p, n] for (p, n) in keys],
+            [times[k] for k in keys],
+            [events[k] for k in keys],
+            design.covariates[1, TREATED],
+            grid,
+        )
+        out["oracle"] = float(np.max(np.abs(oracle - truth)))
+    return out

--- a/mlsynth/tests/test_pcr.py
+++ b/mlsynth/tests/test_pcr.py
@@ -1,0 +1,200 @@
+"""Tests for the shared PCR kernel (:mod:`mlsynth.utils.pcr.core`).
+
+``pcr_weights`` is reached by SI, ClusterSC, RSC and SCMO, but until now only
+transitively and only on well-conditioned panels. The degenerate half of its
+input domain -- a design whose numerical rank falls below the requested rank --
+was untested, which is where the pseudo-inverse divides by a singular value at
+or near zero.
+"""
+
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthEstimationError
+from mlsynth.utils.pcr import hsvt, pcr_weights
+
+
+def _well_conditioned(m=40, n=6, seed=0):
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((m, n)), rng.standard_normal(m)
+
+
+def _rank_deficient(m=40, n=12, true_rank=3, seed=0, exact_zeros=False):
+    """A design whose numerical rank is ``true_rank`` but which has ``n`` columns."""
+    rng = np.random.default_rng(seed)
+    if exact_zeros:
+        design = rng.standard_normal((m, n))
+        design[:, true_rank:] = 0.0
+        return design
+    basis = rng.standard_normal((m, true_rank))
+    return basis @ rng.standard_normal((true_rank, n))
+
+
+# --- smoke -----------------------------------------------------------------
+
+
+def test_pcr_weights_smoke():
+    """Runs end to end on a minimal valid input and returns a finite vector."""
+    design, target = _well_conditioned()
+    weights = pcr_weights(design, target, rank=3)
+    assert weights.shape == (design.shape[1],)
+    assert np.all(np.isfinite(weights))
+
+
+# --- unit ------------------------------------------------------------------
+
+
+def test_pcr_weights_matches_closed_form():
+    """w = sum_{i<=r} (1/s_i) v_i u_i' y, the definition in the docstring."""
+    design, target = _well_conditioned()
+    U, s, Vt = np.linalg.svd(design, full_matrices=False)
+    for rank in (1, 2, 4, 6):
+        expected = sum((1.0 / s[i]) * Vt[i] * (U[:, i] @ target) for i in range(rank))
+        np.testing.assert_allclose(pcr_weights(design, target, rank), expected,
+                                   rtol=0, atol=1e-12)
+
+
+def test_pcr_weights_at_full_rank_is_the_pseudo_inverse():
+    """At full rank the truncation is vacuous, so PCR is the least-squares fit."""
+    design, target = _well_conditioned()
+    np.testing.assert_allclose(pcr_weights(design, target, rank=design.shape[1]),
+                               np.linalg.pinv(design) @ target, rtol=1e-10, atol=1e-12)
+
+
+def test_pcr_weights_reconstructs_a_target_in_the_donor_span():
+    """A target that is exactly a donor combination is reproduced by the fit."""
+    design, _ = _well_conditioned()
+    truth = np.array([0.3, -0.7, 1.1, 0.0, 0.5, -0.2])
+    target = design @ truth
+    weights = pcr_weights(design, target, rank=design.shape[1])
+    np.testing.assert_allclose(design @ weights, target, rtol=1e-8, atol=1e-8)
+
+
+def test_pcr_weights_is_scale_equivariant_in_the_target():
+    """Doubling the target doubles the weights -- the map is linear in y."""
+    design, target = _well_conditioned()
+    np.testing.assert_allclose(pcr_weights(design, 2.5 * target, rank=4),
+                               2.5 * pcr_weights(design, target, rank=4),
+                               rtol=1e-10, atol=1e-12)
+
+
+def test_pcr_weights_accepts_a_column_vector_target():
+    """``target`` is ravelled, so an (m, 1) column behaves like an (m,) vector."""
+    design, target = _well_conditioned()
+    np.testing.assert_allclose(pcr_weights(design, target.reshape(-1, 1), rank=3),
+                               pcr_weights(design, target, rank=3),
+                               rtol=0, atol=0)
+
+
+# --- edge ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("exact_zeros", [False, True])
+def test_pcr_weights_bounded_when_rank_exceeds_numerical_rank(exact_zeros):
+    """The degenerate case: more directions requested than the design carries.
+
+    With ``exact_zeros`` the spare columns are identically zero, so the spare
+    singular values are exactly 0 and the unguarded quotient is 0/0. Without
+    it they are ~1e-16 and the unguarded quotient explodes instead. Both must
+    stay finite and bounded.
+    """
+    design = _rank_deficient(true_rank=3, exact_zeros=exact_zeros)
+    rng = np.random.default_rng(1)
+    target = rng.standard_normal(design.shape[0])
+
+    reference = pcr_weights(design, target, rank=3)
+    for rank in (4, 6, 9, 12):
+        weights = pcr_weights(design, target, rank=rank)
+        assert np.all(np.isfinite(weights))
+        assert np.max(np.abs(weights)) <= 1e3 * max(np.max(np.abs(reference)), 1.0)
+
+
+def test_pcr_weights_truncates_to_the_numerical_rank():
+    """Asking beyond the numerical rank adds no directions, so the fit is stable."""
+    design = _rank_deficient(true_rank=3)
+    rng = np.random.default_rng(2)
+    target = rng.standard_normal(design.shape[0])
+    at_rank = pcr_weights(design, target, rank=3)
+    for rank in (5, 8, 12):
+        np.testing.assert_allclose(design @ pcr_weights(design, target, rank=rank),
+                                   design @ at_rank, rtol=1e-6, atol=1e-6)
+
+
+def test_pcr_weights_collinear_donors_stay_bounded():
+    """Two exactly duplicated donors -- the classic collinear donor pool."""
+    rng = np.random.default_rng(3)
+    design = rng.standard_normal((30, 4))
+    design = np.column_stack([design, design[:, 0]])       # donor 4 duplicates donor 0
+    target = rng.standard_normal(30)
+    weights = pcr_weights(design, target, rank=5)
+    assert np.all(np.isfinite(weights))
+    assert np.max(np.abs(weights)) < 1e3
+
+
+def test_pcr_weights_single_donor():
+    """A one-column design is a scalar projection, not a degenerate case."""
+    rng = np.random.default_rng(4)
+    design = rng.standard_normal((20, 1))
+    target = rng.standard_normal(20)
+    weights = pcr_weights(design, target, rank=1)
+    assert weights.shape == (1,)
+    np.testing.assert_allclose(weights, np.linalg.lstsq(design, target, rcond=None)[0],
+                               rtol=1e-10, atol=1e-12)
+
+
+def test_pcr_weights_rank_above_matrix_dimensions_is_clamped():
+    """``hsvt`` already clamps to min(m, n); asking for more is not an error."""
+    design, target = _well_conditioned(m=10, n=3)
+    np.testing.assert_allclose(pcr_weights(design, target, rank=99),
+                               pcr_weights(design, target, rank=3),
+                               rtol=0, atol=0)
+
+
+def test_pcr_weights_rank_below_one_is_clamped():
+    """``hsvt`` floors the rank at 1, so a zero or negative rank is not an error."""
+    design, target = _well_conditioned()
+    for rank in (0, -5):
+        np.testing.assert_allclose(pcr_weights(design, target, rank=rank),
+                                   pcr_weights(design, target, rank=1),
+                                   rtol=0, atol=0)
+
+
+# --- failure ---------------------------------------------------------------
+
+
+def test_pcr_weights_all_zero_design_raises_translated_error():
+    """No direction survives thresholding, so the fit is reported, not returned."""
+    design = np.zeros((15, 4))
+    target = np.random.default_rng(5).standard_normal(15)
+    with pytest.raises(MlsynthEstimationError, match="rank"):
+        pcr_weights(design, target, rank=2)
+
+
+def test_pcr_weights_non_2d_design_raises_translated_error():
+    """A 1-D design is a caller error and surfaces as an mlsynth exception."""
+    target = np.random.default_rng(6).standard_normal(10)
+    with pytest.raises(MlsynthEstimationError):
+        pcr_weights(np.arange(10.0), target, rank=1)
+
+
+def test_hsvt_non_2d_raises_translated_error():
+    with pytest.raises(MlsynthEstimationError, match="2D"):
+        hsvt(np.arange(10.0), rank=1)
+
+
+# --- regression guard ------------------------------------------------------
+
+
+def test_well_conditioned_weights_are_unchanged_by_the_rank_guard():
+    """The guard must be inert whenever every retained direction carries signal.
+
+    Pins the exact closed-form value so a future change to the thresholding
+    cannot silently move results for SI / ClusterSC / RSC / SCMO.
+    """
+    design, target = _well_conditioned(m=50, n=8, seed=11)
+    U, s, Vt = np.linalg.svd(design, full_matrices=False)
+    assert s[-1] / s[0] > 1e-6, "fixture must be well conditioned"
+    for rank in range(1, 9):
+        expected = sum((1.0 / s[i]) * Vt[i] * (U[:, i] @ target) for i in range(rank))
+        np.testing.assert_allclose(pcr_weights(design, target, rank), expected,
+                                   rtol=0, atol=1e-13)

--- a/mlsynth/utils/pcr/core.py
+++ b/mlsynth/utils/pcr/core.py
@@ -46,6 +46,7 @@ def pcr_weights(
     design: np.ndarray,
     target: np.ndarray,
     rank: int,
+    rcond: float | None = None,
 ) -> np.ndarray:
     """Principal-component-regression weights over the columns of ``design``.
 
@@ -67,12 +68,43 @@ def pcr_weights(
         Response vector, shape ``(m,)``.
     rank : int
         Spectral truncation rank.
+    rcond : float, optional
+        Relative cutoff for the retained singular values. Directions with
+        ``s_i <= rcond * s_0`` carry no signal and are dropped before the
+        inversion, so the effective rank is the smaller of ``rank`` and the
+        design's numerical rank -- the same convention as
+        :func:`numpy.linalg.pinv`. Defaults to ``max(design.shape) * eps``,
+        which is inert on a well-conditioned design: when every retained
+        direction clears the cutoff the returned weights are bit-for-bit the
+        untruncated closed form.
 
     Returns
     -------
     np.ndarray
         Weight vector, shape ``(p,)``.
+
+    Raises
+    ------
+    MlsynthEstimationError
+        If no direction clears the cutoff, i.e. the design is numerically the
+        zero matrix and no weight vector is identified.
     """
     target = np.ravel(target)
     _, U_r, s_r, Vt_r = hsvt(design, rank)
+
+    # Without this, a design whose numerical rank falls below ``rank`` divides
+    # by a singular value at or near zero: exactly zero gives 0/0 and NaN,
+    # near zero gives weights of order 1e14 and no warning at all. Collinear
+    # donors and a donor matrix collapsed by a long evaluation horizon both
+    # reach it.
+    if rcond is None:
+        rcond = max(design.shape) * np.finfo(float).eps
+    keep = s_r > rcond * s_r[0]
+    if not np.any(keep):
+        raise MlsynthEstimationError(
+            "PCR design has numerical rank 0: every singular value is at or "
+            "below the cutoff, so no weight vector is identified. Check that "
+            "the donor matrix is not empty or identically zero."
+        )
+    U_r, s_r, Vt_r = U_r[:, keep], s_r[keep], Vt_r[keep, :]
     return Vt_r.T @ ((U_r.T @ target) / s_r)


### PR DESCRIPTION
## Related Links

- Testing reference: Jorgensen, P. C. (2013). *Software Testing: A Craftsman's Approach*, 4th ed. CRC Press.
- Replication source: Han, J. X. & Shah, D. (2025), "Synthetic Survival Control: Extending Synthetic Controls for 'When-If' Decision", [arXiv:2511.14133v1](https://arxiv.org/abs/2511.14133).
- Staged bundle: `benchmarks/reference/survsc_mc/README.md`.
- Merge order: second of three. #383 (hypothesis) is first. The instrument contract added here is cited by #383 and by the third PR, so landing it before the last one makes those references resolve.

## What

Three related but separable pieces. Flagged up front because `CLAUDE.md` asks for one scope per branch and this carries three — see Other Notes.

- `agents/agents_tests.md` — a vocabulary and framework section, an oracle-problem section, the four levels named in the classical vocabulary, and how to read mutation and coverage numbers. `CLAUDE.md` pointer updated.
- `mlsynth/utils/pcr/core.py` — `pcr_weights` now drops singular directions below a relative cutoff instead of dividing by them. New `mlsynth/tests/test_pcr.py`.
- `benchmarks/reference/survsc_mc/` — a pre-build replication spike for Synthetic Survival Control, plus a parking entry as future integration 18.

## Why

The document asserted a layered architecture and a four-level checklist without a principle for either, and never addressed the problem at the centre of this library: for most estimators nobody knows the true counterfactual, so a test on real data has no expected output. Jorgensen names that (the oracle problem) and names the answer already in use here — reference testing, with the paper and the authors' code as the expert. That reframes `benchmarks/` from validation-we-also-do into the source of expected values for an entire estimator.

The PCR bug was found while running the SSC spike. `pcr_weights` divided by `s_r` with no cutoff, so a design whose numerical rank fell below the requested rank produced garbage two ways: an exactly-zero singular value gives `0/0` and NaN with a RuntimeWarning, and a near-zero one gives weights of order 1e14 with no warning at all. The second is worse because nothing surfaces it, and ordinary collinear donors reach it. `SI`, `ClusterSC`, `RSC` and `SCMO` all share the exposure.

## How

The framework section uses the specified/programmed/tested sets, which settle by definition what was previously argued from one example. Mutation runs construct mutants of the program, so every mutant is a fault of commission; a missing guard has nothing to mutate. Property tests generate inside the specification, which is where omission lives. `pcr_weights` is the worked case: three mutants on the offending line were all killed by the suite of the day, giving that line a perfect mutation score while the defect stood.

Naming the four levels as weak normal equivalence class, invariant, boundary value and robustness testing exposes what they share — the single-fault assumption — and two gaps are recorded as open rather than fixed: no worst-case testing of interacting boundaries anywhere, and config validators that form a decision table nobody has written down.

The guard uses `numpy.linalg.pinv` semantics: directions with `s_i <= rcond * s_0` are dropped, `rcond` defaulting to `max(design.shape) * eps`. A design where nothing clears the cutoff raises `MlsynthEstimationError` instead of returning NaN.

## Verification

- Path: B for the replication spike; not applicable for the doctrine; bug fix for the PCR guard.
- SSC Path B reproduces. All six cells of the paper's Table 1 land within 1.5x of the published sup-norm error, two of them on top of it, and the Figure 4 claim that error falls in `K` holds in both DGPs. Regenerate with `python benchmarks/reference/survsc_mc/dump_results.py`; every number in that README is in the committed `results.json`.
- Recorded and not fixed: the confounder-aware comparator in the spike is 2–6x more accurate than the paper's, which makes SSC look worse in the port than in the paper. The likely cause (Breslow nonparametric baseline vs the parametric fit here) is documented.
- PCR guard: the cutoff is inert on a well-conditioned design — a test pins that the returned weights are bit-for-bit the untruncated closed form. Every module importing the kernel passes unchanged (117 tests across `test_si`, `test_si_replication`, `test_clustersc`, `test_scmo`, `test_snn`).
- Full suite: 6769 passed, 290 skipped, 0 failed.

## Scope checks

BUG FIX (for the `pcr_weights` half):

- [x] A test reproduces the defect and fails without the fix — five of the seventeen in `test_pcr.py` were red before the guard
- [x] It asserts the correct behaviour, not merely the absence of a crash — both failure modes are covered, including the silent 1e14 one that stays finite
- [x] No docs page, docstring, or comment still states the old behaviour — the docstring documents the cutoff and the raise
- [x] Any pinned value that moved is justified — none moved; a regression test pins that

The other two pieces are docs/tooling and a benchmark-reference bundle with no registered case.

## Designs

No visual output.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_pcr.py -q` — 17 passed
- [x] `pytest mlsynth/tests/` — 6769 passed, 290 skipped, 0 failed
- [x] `python benchmarks/reference/survsc_mc/dump_results.py`
- [x] `python benchmarks/reference/survsc_mc/km_floor.py`
- [ ] `python benchmarks/run_benchmarks.py --all` — not run; this branch registers no benchmark case

## Other Notes

- This branch carries three scopes, against the one-scope rule. It happened because the PCR bug and the doctrine both fell out of running the SSC spike. Happy to split into three PRs if you would prefer to review them separately — the commits are already clean along those lines (`f3d5426` spike, `e52c54f` guard + tests, `51b1573` + `47997d4` doctrine).
- The PCR guard belongs upstream of every caller, so it is the piece most worth reviewing on its own terms.
- `SURVSC` is parked, not proposed. Nothing in `mlsynth/` implements it; the entry records that Path B reproduces, the two settled build decisions (simplex weights as the defensible default, RMST difference as the scalar ATT), and that `SSC` is already taken by Staggered Synthetic Control.
- Four pre-existing uses of "rather" in `agents_tests.md` violate the repo's own grep rule, one inside the stated guiding principle. Left alone — changing that text felt like an author call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbWZFe1K2ewxJ4RMgEf5Zb)_