### PR TITLE
Pin the mlSC nesting, recovery and scale claims by value

### DIFF
--- a/mlsynth/tests/test_mlsc_nesting.py
+++ b/mlsynth/tests/test_mlsc_nesting.py
@@ -1,0 +1,351 @@
+"""Nesting and recovery claims of the mlSC estimator, asserted by value.
+
+Reference: Bottmer, L., "Synthetic Control with Disaggregated Data" (JMP,
+Stanford). mlsynth implements the paper's preferred specification, Equation
+5.2 -- the ``lambda_2 = infinity`` case in which the treated unit stays
+aggregated and the weight matrix collapses to the vector ``omega``:
+
+    argmin_omega  sum_{t<=T0} (Y_0t - sum_s sum_c omega_sc Y_sct)^2
+                  + lambda * sigma_y^2 * sum_s sum_c (omega_sc - v_sc w_s)^2
+    s.t.          sum omega = 1,  omega >= 0,  w_s = sum_c omega_sc
+
+Section 5.1 states that this nests two named estimators as limiting cases,
+and Proposition 3 states a recovery result. `test_mlsc.py` asserts the first
+limit structurally and the second not at all, so the claims are pinned here
+by value against estimators mlsynth already has -- differential testing in
+the sense of ``agents/agents_tests.md``, which is the strongest instrument
+available where no oracle exists.
+
+The three claims:
+
+* C1 -- as ``lambda -> infinity`` the estimator reduces to the classical SC
+  (dGSC-AA) estimator computed on the aggregated panel.
+* C2 -- at ``lambda = 0`` it recovers dGSC-AD, which Proposition 1 shows is
+  the classical SC problem over the disaggregated donor pool, "differing only
+  in the selection of units included in the donor pool".
+* C3 -- Proposition 3: under Assumption 3 (perfect pre-treatment fit for
+  classical SC) the mlSC and classical SC problems have identical solutions,
+  at every penalty.
+
+C3 is the one case in this file with a genuine oracle: Assumption 3 is
+satisfiable by construction, so the fixture is built to satisfy it and the
+expected weights are known before the estimator runs.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import MLSC
+from mlsynth.utils.inferutils import _outcome_only_simplex
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _panels(
+    Y_sct: np.ndarray,
+    Y_st: np.ndarray,
+    T0: int,
+    treated: int = 0,
+    pops: np.ndarray | None = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Long-form aggregate and disaggregate frames from explicit arrays."""
+    S, C, T = Y_sct.shape
+    states = [f"state_{s}" for s in range(S)]
+    agg = pd.DataFrame([
+        {"state": states[s], "year": 2000 + t, "y": float(Y_st[s, t]),
+         "treated": int(s == treated and t >= T0)}
+        for s in range(S) for t in range(T)
+    ])
+    disagg = pd.DataFrame([
+        {"county": f"county_{s}_{c}", "state": states[s], "year": 2000 + t,
+         "y": float(Y_sct[s, c, t]),
+         "treated": int(s == treated and t >= T0),
+         "pop": 1.0 if pops is None else float(pops[s, c])}
+        for s in range(S) for c in range(C) for t in range(T)
+    ])
+    return agg, disagg
+
+
+def _factor_panel(seed=0, S=5, C=4, T=24, T0=18):
+    """A panel whose two nesting limits give genuinely different answers.
+
+    Deliberately not the rank-2 hierarchical factor panel `test_mlsc.py` uses.
+    Under that design the aggregate donor series are close to collinear, and
+    the aggregate weights come out the same at every penalty -- so an
+    assertion about the large-penalty limit passes on a panel where it could
+    not have failed. Independent county draws with a state-level offset keep
+    the donors separated, and `_assert_limits_differ` below checks that on
+    every fixture before the nesting claim is asserted.
+
+    The aggregate series is the population-weighted mean of its counties, so
+    aggregating the disaggregate panel with ``v`` reproduces it exactly and
+    C1's comparator is the panel the estimator actually sees.
+    """
+    rng = np.random.default_rng(seed)
+    Y_sct = rng.standard_normal((S, C, T)) + rng.standard_normal((S, 1, 1)) * 2.0
+    pops = rng.uniform(0.5, 2.0, size=(S, C))
+    v = pops / pops.sum(axis=1, keepdims=True)
+    Y_st = np.einsum("sc,sct->st", v, Y_sct)
+    return _panels(Y_sct, Y_st, T0, pops=pops), T0
+
+
+def _config(df_agg, df_disagg, **overrides):
+    cfg = dict(
+        df_agg=df_agg, df_disagg=df_disagg, outcome="y", time="year",
+        treat="treated", unitid_agg="state", unitid_disagg="county",
+        agg_id="state", weight_col="pop", lambda_est="heuristic",
+        display_graphs=False,
+    )
+    cfg.update(overrides)
+    return cfg
+
+
+def _aggregate_donor_matrix(res) -> np.ndarray:
+    """Donor series at the aggregate level, in block order, shape ``(T, S)``."""
+    v, idx = res.inputs.v_population, res.inputs.disagg_to_agg
+    blocks = [
+        res.inputs.X_disagg[:, idx == s] @ v[idx == s]
+        for s in range(len(res.inputs.agg_labels))
+    ]
+    return np.column_stack(blocks)
+
+
+def _assert_limits_differ(df_agg, df_disagg, attr: str, margin: float = 1e-2):
+    """Guard: the two limits must give different answers on this fixture.
+
+    A nesting claim asserted on a panel where every penalty returns the same
+    thing is vacuous -- it passes whatever the estimator does. This ran green
+    on a rank-2 factor panel whose aggregate weights were penalty-invariant,
+    which is why it is now checked, not assumed.
+    """
+    lo = MLSC(_config(df_agg, df_disagg, lambda_est="fixed", lambda_val=0.0)).fit()
+    hi = MLSC(_config(df_agg, df_disagg, lambda_est="fixed", lambda_val=1e10)).fit()
+    spread = np.max(np.abs(getattr(lo.design, attr) - getattr(hi.design, attr)))
+    assert spread > margin, (
+        f"fixture is degenerate for {attr}: the two limits agree to {spread:.2e}, "
+        "so the nesting assertion below cannot fail"
+    )
+    return lo, hi
+
+
+# ---------------------------------------------------------------------------
+# C2 -- lambda = 0 recovers the disaggregated-donor SC (dGSC-AD)
+# ---------------------------------------------------------------------------
+
+def test_lambda_zero_is_classical_sc_over_the_disaggregated_donor_pool():
+    """Section 5.1 plus Proposition 1.
+
+    With the aggregation pull switched off, Equation 5.2 is the classical SC
+    program whose donor pool happens to be the disaggregated units. Agreement
+    is limited by the 1e-8 uniqueness ridge, not by solver tolerance.
+    """
+    (df_agg, df_disagg), T0 = _factor_panel()
+    res = MLSC(_config(df_agg, df_disagg, lambda_est="fixed", lambda_val=0.0)).fit()
+
+    reference = _outcome_only_simplex(
+        res.inputs.Y_agg_treated[:T0], res.inputs.X_disagg[:T0, :]
+    )
+    np.testing.assert_allclose(res.design.omega, reference, atol=1e-5)
+
+
+def test_lambda_zero_matches_the_disaggregated_sc_counterfactual():
+    """The weights are what nests; the counterfactual is what a user reads."""
+    (df_agg, df_disagg), T0 = _factor_panel(seed=3)
+    res = MLSC(_config(df_agg, df_disagg, lambda_est="fixed", lambda_val=0.0)).fit()
+
+    reference = _outcome_only_simplex(
+        res.inputs.Y_agg_treated[:T0], res.inputs.X_disagg[:T0, :]
+    )
+    np.testing.assert_allclose(
+        res.paths.counterfactual, res.inputs.X_disagg @ reference, atol=1e-5
+    )
+
+
+# ---------------------------------------------------------------------------
+# C1 -- lambda -> infinity recovers classical SC on the aggregated panel
+# ---------------------------------------------------------------------------
+
+def test_high_lambda_aggregate_weights_equal_classical_sc():
+    """Section 5.1: the large-penalty limit is the dGSC-AA (classical SC)
+    estimator on aggregated data.
+
+    `test_mlsc.py` asserts only that omega/v is flat within each block, which
+    would hold even if the aggregate weights themselves were wrong. This pins
+    the value.
+    """
+    (df_agg, df_disagg), T0 = _factor_panel()
+    lo, res = _assert_limits_differ(df_agg, df_disagg, "aggregate_weights")
+
+    agg_donors = _aggregate_donor_matrix(res)
+    reference = _outcome_only_simplex(res.inputs.Y_agg_treated[:T0], agg_donors[:T0, :])
+    np.testing.assert_allclose(res.design.aggregate_weights, reference, atol=1e-4)
+    # ... and the small-penalty end is genuinely somewhere else, so the
+    # assertion above is about the limit and not about the estimator's only
+    # possible answer.
+    assert np.max(np.abs(lo.design.aggregate_weights - reference)) > 1e-2
+
+
+def test_high_lambda_omega_is_the_classical_solution_spread_by_population():
+    """The disaggregate weights in the limit are ``omega_sc = v_sc * w_s``
+    with ``w`` the classical SC solution -- structure and value together."""
+    (df_agg, df_disagg), T0 = _factor_panel()
+    res = MLSC(_config(df_agg, df_disagg, lambda_est="fixed", lambda_val=1e10)).fit()
+
+    agg_donors = _aggregate_donor_matrix(res)
+    w = _outcome_only_simplex(res.inputs.Y_agg_treated[:T0], agg_donors[:T0, :])
+    expected = res.inputs.v_population * w[res.inputs.disagg_to_agg]
+    np.testing.assert_allclose(res.design.omega, expected, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# C3 -- Proposition 3, recovery of classical SC under perfect pre-treatment fit
+# ---------------------------------------------------------------------------
+
+def _perfect_fit_panel(seed=0, S=5, C=4, T=24, T0=18):
+    """A panel satisfying Assumption 3 by construction.
+
+    The treated aggregate's pre-treatment series is an exact convex
+    combination of the donor aggregates, so the classical SC problem attains
+    zero pre-treatment loss and its solution is the constructed weight vector.
+    With T0 = 18 periods and 4 donors the representation is generically
+    unique, so the comparison is well posed.
+    """
+    rng = np.random.default_rng(seed)
+    Y_sct = rng.standard_normal((S, C, T)) * 0.8 + rng.standard_normal((S, 1, 1)) * 2.0
+    pops = rng.uniform(0.5, 2.0, size=(S, C))
+    v = pops / pops.sum(axis=1, keepdims=True)
+    Y_st = np.einsum("sc,sct->st", v, Y_sct)
+
+    w = np.array([0.5, 0.2, 0.2, 0.1])          # on the simplex, S - 1 donors
+    Y_st[0, :] = w @ Y_st[1:, :]                # exact at every t, pre and post
+    Y_sct[0, :, :] = Y_st[0, :]                 # treated counties consistent
+
+    panels = _panels(Y_sct, Y_st, T0, pops=pops)
+    return panels, T0, w
+
+
+@pytest.mark.parametrize("lambda_val", [0.0, 1e-4, 0.1, 1.0, 25.0, 1e4, 1e10])
+def test_proposition_3_recovers_classical_sc_at_every_penalty(lambda_val):
+    """Proposition 3: under Assumption 3 the mlSC and classical SC problems
+    have identical solutions, so the penalty cannot move the answer."""
+    (df_agg, df_disagg), T0, w_true = _perfect_fit_panel()
+    res = MLSC(_config(df_agg, df_disagg,
+                       lambda_est="fixed", lambda_val=lambda_val)).fit()
+
+    np.testing.assert_allclose(res.design.aggregate_weights, w_true, atol=1e-4)
+
+
+def test_proposition_3_att_matches_classical_sc():
+    """The estimand form of Proposition 3: tau_mlSC = tau_SC."""
+    (df_agg, df_disagg), T0, w_true = _perfect_fit_panel()
+    atts = [
+        MLSC(_config(df_agg, df_disagg, lambda_est="fixed", lambda_val=lam)).fit().att
+        for lam in (0.0, 1.0, 1e10)
+    ]
+    assert np.allclose(atts, atts[0], atol=1e-6)
+
+
+def test_proposition_3_fit_is_exact():
+    """Assumption 3 holds by construction, so the pre-period fit is zero."""
+    (df_agg, df_disagg), T0, _ = _perfect_fit_panel()
+    res = MLSC(_config(df_agg, df_disagg, lambda_est="fixed", lambda_val=1.0)).fit()
+    assert res.pre_rmse < 1e-6
+
+
+def test_proposition_3_is_a_property_of_assumption_3_not_of_the_estimator():
+    """The contrast that gives Proposition 3 its content.
+
+    Penalty-invariance of the solution is what Proposition 3 claims, so the
+    claim only says something if the solution is penalty-*dependent* when
+    Assumption 3 fails. It is: on a panel without perfect pre-treatment fit
+    the aggregate weights and the ATT both move with the penalty.
+    """
+    (perfect_agg, perfect_disagg), _, _ = _perfect_fit_panel()
+    (generic_agg, generic_disagg), _ = _factor_panel()
+
+    def spread(df_agg, df_disagg):
+        fits = [
+            MLSC(_config(df_agg, df_disagg, lambda_est="fixed", lambda_val=lam)).fit()
+            for lam in (0.0, 1e10)
+        ]
+        return (
+            np.max(np.abs(fits[0].design.aggregate_weights
+                          - fits[1].design.aggregate_weights)),
+            abs(fits[0].att - fits[1].att),
+        )
+
+    w_perfect, att_perfect = spread(perfect_agg, perfect_disagg)
+    w_generic, att_generic = spread(generic_agg, generic_disagg)
+
+    assert w_perfect < 1e-6 and att_perfect < 1e-6
+    assert w_generic > 1e-2 and att_generic > 1e-4
+
+
+# ---------------------------------------------------------------------------
+# The interior of the trade-off
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("lambda_val", [0.05, 1.0, 20.0])
+def test_interior_penalty_solves_equation_5_2_as_written(lambda_val):
+    """The endpoints do not pin how ``lambda`` enters the objective.
+
+    Halving the penalty's square-root factor only reparametrizes the penalty
+    (``lambda -> lambda / 4``), which leaves both limits and the monotonicity
+    of the fit untouched -- a mutation of exactly that form survives every
+    other test in this file. This transcribes Equation 5.2 directly, with the
+    estimator's own reported ``lambda_used`` and ``sigma_y2``, and solves it
+    independently, so the penalty's scale is pinned at interior penalties
+    where the estimator actually operates.
+
+        penalty(omega) = sum_s sum_c (omega_sc - v_sc * w_s)^2 = ||(I - B) omega||^2
+
+    with ``B[i, j] = v_i`` when columns ``i`` and ``j`` share an aggregate.
+    """
+    cp = pytest.importorskip("cvxpy")
+    (df_agg, df_disagg), T0 = _factor_panel()
+    res = MLSC(_config(df_agg, df_disagg,
+                       lambda_est="fixed", lambda_val=lambda_val)).fit()
+
+    X = res.inputs.X_disagg[:T0, :]
+    y = res.inputs.Y_agg_treated[:T0]
+    v, idx = res.inputs.v_population, res.inputs.disagg_to_agg
+    M = X.shape[1]
+
+    B = np.where(idx[:, None] == idx[None, :], v[:, None], 0.0)
+    R = np.eye(M) - B
+
+    omega = cp.Variable(M)
+    cp.Problem(
+        cp.Minimize(cp.sum_squares(X @ omega - y)
+                    + res.design.lambda_used * res.design.sigma_y2
+                    * cp.sum_squares(R @ omega)),
+        [cp.sum(omega) == 1, omega >= 0],
+    ).solve(solver=cp.OSQP, eps_abs=1e-10, eps_rel=1e-10, max_iter=400_000)
+
+    np.testing.assert_allclose(res.design.omega, omega.value, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# The trade-off between the two limits
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_pre_period_fit_is_monotone_in_the_penalty(seed):
+    """The penalty only ever constrains the feasible set, so the attained
+    pre-treatment loss cannot improve as it grows. Asserted across the grid,
+    not at two points."""
+    (df_agg, df_disagg), _ = _factor_panel(seed=seed)
+    grid = [0.0, 1e-3, 0.1, 1.0, 10.0, 1e3, 1e6]
+    rmses = [
+        MLSC(_config(df_agg, df_disagg, lambda_est="fixed", lambda_val=lam)).fit().pre_rmse
+        for lam in grid
+    ]
+    for lo, hi in zip(rmses, rmses[1:]):
+        assert hi >= lo - 1e-8, f"fit improved as the penalty grew: {rmses}"

--- a/mlsynth/tests/test_mlsc_properties.py
+++ b/mlsynth/tests/test_mlsc_properties.py
@@ -11,18 +11,14 @@ Two families, neither of which needs an oracle:
   claim about how the output must respond to rescaling the outcome. Location
   and row-order invariance follow from the simplex constraint and from the
   ingestion contract respectively.
-* C5 -- algebra of the block penalty matrix. ``build_block`` returns
-  ``Q = I - v 1' - 1 v' + (v'v) J``, so for any ``v`` on the simplex it is
-  symmetric, positive semi-definite, annihilates ``v``, and has rank
-  ``C - 1``. `test_mlsc.py` asserts the first three at a single hand-picked
-  ``v = [0.3, 0.2, 0.5]``; asserting them over the domain is what makes them
-  claims about the estimator instead of claims about one vector.
-
-The C5 sweeps are deterministic draws, not generated inputs. Adding
-``hypothesis`` is a dependency decision (Phase 1 of the plan in
-``agents/agents_tests.md``) and belongs on its own branch; each sweep here is
-written as a single-draw property function so the conversion is a decorator
-swap.
+* C5 -- the degenerate corners of the block penalty matrix. ``build_block``
+  returns ``Q = I - v 1' - 1 v' + (v'v) J``, so for any ``v`` on the simplex it
+  is symmetric, positive semi-definite, annihilates ``v``, and has rank
+  ``C - 1``. The generative coverage of that claim lives in
+  ``test_mlsc_penalty_properties.py``; what stays here are the named shares a
+  real panel produces, which the instrument contract in
+  ``agents/agents_tests.md`` keeps as examples because named edges are
+  documentation.
 """
 
 from __future__ import annotations
@@ -34,11 +30,7 @@ import pandas as pd
 import pytest
 
 from mlsynth import MLSC
-from mlsynth.utils.mlsc_helpers.penalty import (
-    build_block,
-    build_penalty_matrix,
-    build_sqrt_factor,
-)
+from mlsynth.utils.mlsc_helpers.penalty import build_block
 
 _TOL = 1e-10
 
@@ -77,12 +69,6 @@ def _config(df_agg, df_disagg, **overrides):
     )
     cfg.update(overrides)
     return cfg
-
-
-def _simplex(rng: np.random.Generator, size: int) -> np.ndarray:
-    """A draw from the interior of the simplex in ``size`` dimensions."""
-    x = rng.gamma(shape=1.0, size=size)
-    return x / x.sum()
 
 
 # ===========================================================================
@@ -199,13 +185,6 @@ def _check_block_properties(v: np.ndarray) -> None:
             assert float(probe @ Q @ probe) > 1e-9
 
 
-@pytest.mark.parametrize("size", [1, 2, 3, 5, 12, 40])
-def test_block_properties_across_block_sizes(size):
-    rng = np.random.default_rng(1000 + size)
-    for _ in range(25):
-        _check_block_properties(_simplex(rng, size))
-
-
 def test_block_properties_on_degenerate_population_shares():
     """Boundary of the simplex: a share at zero, and all mass on one unit."""
     for v in (
@@ -216,52 +195,3 @@ def test_block_properties_on_degenerate_population_shares():
         np.full(6, 1.0 / 6.0),                 # exactly uniform
     ):
         _check_block_properties(v)
-
-
-@pytest.mark.parametrize("size", [2, 4, 9])
-def test_uniform_shares_give_the_centering_matrix(size):
-    """`v = 1/C` collapses Q to `I - J/C`, the centering matrix."""
-    Q = build_block(np.full(size, 1.0 / size))
-    np.testing.assert_allclose(Q, np.eye(size) - np.full((size, size), 1.0 / size),
-                               atol=_TOL)
-
-
-@pytest.mark.parametrize("seed", range(6))
-def test_assembly_is_block_diagonal_for_arbitrary_block_structures(seed):
-    """`build_penalty_matrix` glues per-block matrices with nothing across."""
-    rng = np.random.default_rng(seed)
-    sizes = rng.integers(1, 6, size=int(rng.integers(2, 6)))
-    v = np.concatenate([_simplex(rng, int(n)) for n in sizes])
-    idx = np.repeat(np.arange(len(sizes)), sizes)
-
-    Q = build_penalty_matrix(v, idx)
-    assert Q.shape == (v.size, v.size)
-
-    start = 0
-    for block, n in enumerate(sizes):
-        stop = start + int(n)
-        np.testing.assert_allclose(Q[start:stop, start:stop],
-                                   build_block(v[start:stop]), atol=_TOL)
-        off_block = idx[None, :] != idx[:, None]
-        np.testing.assert_allclose(Q[off_block], 0.0, atol=_TOL)
-        start = stop
-
-    # The full penalty still annihilates the population vector blockwise.
-    np.testing.assert_allclose(Q @ v, 0.0, atol=1e-12)
-
-
-@pytest.mark.parametrize("seed", range(6))
-def test_square_root_factor_reproduces_the_penalty(seed):
-    """`R' R == Q` over arbitrary block structures, not one fixture.
-
-    The solver augments the design with ``sqrt(lambda) R`` instead of forming
-    ``Q``, so the two representations agreeing is what makes the augmented
-    least-squares path equal the penalised program.
-    """
-    rng = np.random.default_rng(100 + seed)
-    sizes = rng.integers(1, 7, size=int(rng.integers(2, 5)))
-    v = np.concatenate([_simplex(rng, int(n)) for n in sizes])
-    idx = np.repeat(np.arange(len(sizes)), sizes)
-
-    R = build_sqrt_factor(v, idx)
-    np.testing.assert_allclose(R.T @ R, build_penalty_matrix(v, idx), atol=1e-10)

--- a/mlsynth/tests/test_mlsc_properties.py
+++ b/mlsynth/tests/test_mlsc_properties.py
@@ -1,0 +1,267 @@
+"""Metamorphic and algebraic properties of the mlSC estimator.
+
+Reference: Bottmer, L., "Synthetic Control with Disaggregated Data" (JMP,
+Stanford), Equation 5.2 and the discussion following it.
+
+Two families, neither of which needs an oracle:
+
+* C4 -- metamorphic relations on ``MLSC.fit()``. The paper states that the
+  ``sigma_y^2`` factor "ensures the penalty is on the same scale as the loss
+  function while the penalty parameter lambda is scale invariant", which is a
+  claim about how the output must respond to rescaling the outcome. Location
+  and row-order invariance follow from the simplex constraint and from the
+  ingestion contract respectively.
+* C5 -- algebra of the block penalty matrix. ``build_block`` returns
+  ``Q = I - v 1' - 1 v' + (v'v) J``, so for any ``v`` on the simplex it is
+  symmetric, positive semi-definite, annihilates ``v``, and has rank
+  ``C - 1``. `test_mlsc.py` asserts the first three at a single hand-picked
+  ``v = [0.3, 0.2, 0.5]``; asserting them over the domain is what makes them
+  claims about the estimator instead of claims about one vector.
+
+The C5 sweeps are deterministic draws, not generated inputs. Adding
+``hypothesis`` is a dependency decision (Phase 1 of the plan in
+``agents/agents_tests.md``) and belongs on its own branch; each sweep here is
+written as a single-draw property function so the conversion is a decorator
+swap.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import MLSC
+from mlsynth.utils.mlsc_helpers.penalty import (
+    build_block,
+    build_penalty_matrix,
+    build_sqrt_factor,
+)
+
+_TOL = 1e-10
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _panel(seed=0, S=5, C=4, T=24, T0=18) -> Tuple[pd.DataFrame, pd.DataFrame, int]:
+    rng = np.random.default_rng(seed)
+    Y_sct = rng.standard_normal((S, C, T)) + rng.standard_normal((S, 1, 1)) * 2.0
+    pops = rng.uniform(0.5, 2.0, size=(S, C))
+    v = pops / pops.sum(axis=1, keepdims=True)
+    Y_st = np.einsum("sc,sct->st", v, Y_sct)
+    states = [f"state_{s}" for s in range(S)]
+    agg = pd.DataFrame([
+        {"state": states[s], "year": 2000 + t, "y": float(Y_st[s, t]),
+         "treated": int(s == 0 and t >= T0)}
+        for s in range(S) for t in range(T)
+    ])
+    disagg = pd.DataFrame([
+        {"county": f"county_{s}_{c}", "state": states[s], "year": 2000 + t,
+         "y": float(Y_sct[s, c, t]), "treated": int(s == 0 and t >= T0),
+         "pop": float(pops[s, c])}
+        for s in range(S) for c in range(C) for t in range(T)
+    ])
+    return agg, disagg, T0
+
+
+def _config(df_agg, df_disagg, **overrides):
+    cfg = dict(
+        df_agg=df_agg, df_disagg=df_disagg, outcome="y", time="year",
+        treat="treated", unitid_agg="state", unitid_disagg="county",
+        agg_id="state", weight_col="pop", lambda_est="heuristic",
+        display_graphs=False,
+    )
+    cfg.update(overrides)
+    return cfg
+
+
+def _simplex(rng: np.random.Generator, size: int) -> np.ndarray:
+    """A draw from the interior of the simplex in ``size`` dimensions."""
+    x = rng.gamma(shape=1.0, size=size)
+    return x / x.sum()
+
+
+# ===========================================================================
+# C4 -- metamorphic relations on the estimator
+# ===========================================================================
+
+@pytest.mark.parametrize("scale", [0.01, 3.0, 250.0])
+def test_outcome_rescaling_leaves_the_penalty_parameter_and_weights_fixed(scale):
+    """The sigma_y^2 claim, stated as a response to rescaling.
+
+    Multiplying every outcome by ``c`` multiplies the loss by ``c^2`` and,
+    because the penalty carries ``sigma_y^2``, multiplies the penalty term by
+    ``c^2`` as well. The minimiser is therefore unchanged and the selected
+    penalty is scale free, while everything measured in outcome units moves by
+    ``c``. Drop ``sigma_y^2`` from the penalty and this breaks.
+    """
+    agg, disagg, _ = _panel()
+    scaled_agg, scaled_disagg = agg.copy(), disagg.copy()
+    scaled_agg["y"] *= scale
+    scaled_disagg["y"] *= scale
+
+    base = MLSC(_config(agg, disagg)).fit()
+    other = MLSC(_config(scaled_agg, scaled_disagg)).fit()
+
+    # Scale free
+    np.testing.assert_allclose(other.design.omega, base.design.omega, atol=1e-6)
+    np.testing.assert_allclose(other.design.aggregate_weights,
+                               base.design.aggregate_weights, atol=1e-6)
+    assert other.design.lambda_used == pytest.approx(base.design.lambda_used, rel=1e-8)
+
+    # Carried in outcome units
+    assert other.att == pytest.approx(base.att * scale, rel=1e-6)
+    assert other.pre_rmse == pytest.approx(base.pre_rmse * scale, rel=1e-6)
+    np.testing.assert_allclose(other.paths.counterfactual,
+                               base.paths.counterfactual * scale, rtol=1e-6)
+
+    # Variance components are second moments of the outcome
+    assert other.design.sigma_y2 == pytest.approx(base.design.sigma_y2 * scale**2, rel=1e-6)
+    assert other.design.sigma_eps2 == pytest.approx(base.design.sigma_eps2 * scale**2, rel=1e-6)
+
+
+@pytest.mark.parametrize("shift", [-40.0, 7.5])
+def test_outcome_shifting_leaves_the_weights_and_the_effect_fixed(shift):
+    """Adding a constant to every outcome changes nothing that matters.
+
+    The simplex constraint makes the loss shift-invariant: with ``sum omega =
+    1`` the constant cancels out of ``Y - X omega``. So the weights, the
+    penalty parameter and the ATT are all unchanged, and only the level of the
+    counterfactual moves.
+    """
+    agg, disagg, _ = _panel()
+    shifted_agg, shifted_disagg = agg.copy(), disagg.copy()
+    shifted_agg["y"] += shift
+    shifted_disagg["y"] += shift
+
+    base = MLSC(_config(agg, disagg)).fit()
+    other = MLSC(_config(shifted_agg, shifted_disagg)).fit()
+
+    np.testing.assert_allclose(other.design.omega, base.design.omega, atol=1e-6)
+    assert other.design.lambda_used == pytest.approx(base.design.lambda_used, rel=1e-8)
+    assert other.att == pytest.approx(base.att, abs=1e-6)
+    assert other.pre_rmse == pytest.approx(base.pre_rmse, abs=1e-6)
+    np.testing.assert_allclose(other.paths.counterfactual,
+                               base.paths.counterfactual + shift, atol=1e-6)
+
+
+@pytest.mark.parametrize("seed", [0, 1])
+def test_row_order_of_the_input_frames_is_irrelevant(seed):
+    """Ingestion goes through ``dataprep``, so the long frames are sets of
+    rows and shuffling them cannot move a single number."""
+    agg, disagg, _ = _panel()
+    rng = np.random.default_rng(seed)
+    shuffled_agg = agg.sample(frac=1.0, random_state=int(rng.integers(1 << 31)))
+    shuffled_disagg = disagg.sample(frac=1.0, random_state=int(rng.integers(1 << 31)))
+
+    base = MLSC(_config(agg, disagg)).fit()
+    other = MLSC(_config(shuffled_agg, shuffled_disagg)).fit()
+
+    np.testing.assert_allclose(other.design.omega, base.design.omega, atol=1e-8)
+    assert other.att == pytest.approx(base.att, abs=1e-8)
+    assert other.donor_weights == pytest.approx(base.donor_weights, abs=1e-8)
+
+
+# ===========================================================================
+# C5 -- algebra of the block penalty matrix
+# ===========================================================================
+
+def _check_block_properties(v: np.ndarray) -> None:
+    """Every claim `build_block` makes, for one draw of ``v``."""
+    C = v.shape[0]
+    Q = build_block(v)
+
+    assert Q.shape == (C, C)
+    np.testing.assert_allclose(Q, Q.T, atol=_TOL)                    # symmetric
+    assert np.linalg.eigvalsh(Q).min() >= -_TOL                      # PSD
+    np.testing.assert_allclose(Q @ v, 0.0, atol=1e-12)               # v in kernel
+
+    # The kernel is exactly span{v}: R = I - v 1' drops one dimension, so a
+    # weight vector is unpenalised only when it is proportional to population.
+    expected_rank = max(C - 1, 0)
+    assert np.linalg.matrix_rank(Q, tol=1e-9) == expected_rank
+
+    # Stated as the estimator reads it: the penalty vanishes on proportional
+    # weights and is strictly positive off that ray. The probe has to be built
+    # by projecting v out, not picked as a basis vector -- at a corner of the
+    # simplex such as v = [1, 0] the basis vector *is* v and the assertion
+    # would be testing the kernel it meant to avoid.
+    for c in (0.3, 1.0, 7.0):
+        assert abs(float(c * v @ Q @ (c * v))) < 1e-12
+    if C >= 2:
+        probe = np.arange(1.0, C + 1.0)
+        probe = probe - (probe @ v / (v @ v)) * v          # orthogonal to v
+        if np.linalg.norm(probe) > 1e-8:
+            assert float(probe @ Q @ probe) > 1e-9
+
+
+@pytest.mark.parametrize("size", [1, 2, 3, 5, 12, 40])
+def test_block_properties_across_block_sizes(size):
+    rng = np.random.default_rng(1000 + size)
+    for _ in range(25):
+        _check_block_properties(_simplex(rng, size))
+
+
+def test_block_properties_on_degenerate_population_shares():
+    """Boundary of the simplex: a share at zero, and all mass on one unit."""
+    for v in (
+        np.array([1.0]),                       # a block with one disaggregate
+        np.array([1.0, 0.0]),                  # a county with no population
+        np.array([0.0, 0.0, 1.0]),             # all mass on one county
+        np.array([1e-12, 1.0 - 1e-12]),        # near-degenerate
+        np.full(6, 1.0 / 6.0),                 # exactly uniform
+    ):
+        _check_block_properties(v)
+
+
+@pytest.mark.parametrize("size", [2, 4, 9])
+def test_uniform_shares_give_the_centering_matrix(size):
+    """`v = 1/C` collapses Q to `I - J/C`, the centering matrix."""
+    Q = build_block(np.full(size, 1.0 / size))
+    np.testing.assert_allclose(Q, np.eye(size) - np.full((size, size), 1.0 / size),
+                               atol=_TOL)
+
+
+@pytest.mark.parametrize("seed", range(6))
+def test_assembly_is_block_diagonal_for_arbitrary_block_structures(seed):
+    """`build_penalty_matrix` glues per-block matrices with nothing across."""
+    rng = np.random.default_rng(seed)
+    sizes = rng.integers(1, 6, size=int(rng.integers(2, 6)))
+    v = np.concatenate([_simplex(rng, int(n)) for n in sizes])
+    idx = np.repeat(np.arange(len(sizes)), sizes)
+
+    Q = build_penalty_matrix(v, idx)
+    assert Q.shape == (v.size, v.size)
+
+    start = 0
+    for block, n in enumerate(sizes):
+        stop = start + int(n)
+        np.testing.assert_allclose(Q[start:stop, start:stop],
+                                   build_block(v[start:stop]), atol=_TOL)
+        off_block = idx[None, :] != idx[:, None]
+        np.testing.assert_allclose(Q[off_block], 0.0, atol=_TOL)
+        start = stop
+
+    # The full penalty still annihilates the population vector blockwise.
+    np.testing.assert_allclose(Q @ v, 0.0, atol=1e-12)
+
+
+@pytest.mark.parametrize("seed", range(6))
+def test_square_root_factor_reproduces_the_penalty(seed):
+    """`R' R == Q` over arbitrary block structures, not one fixture.
+
+    The solver augments the design with ``sqrt(lambda) R`` instead of forming
+    ``Q``, so the two representations agreeing is what makes the augmented
+    least-squares path equal the penalised program.
+    """
+    rng = np.random.default_rng(100 + seed)
+    sizes = rng.integers(1, 7, size=int(rng.integers(2, 5)))
+    v = np.concatenate([_simplex(rng, int(n)) for n in sizes])
+    idx = np.repeat(np.arange(len(sizes)), sizes)
+
+    R = build_sqrt_factor(v, idx)
+    np.testing.assert_allclose(R.T @ R, build_penalty_matrix(v, idx), atol=1e-10)


### PR DESCRIPTION
## Related Links

- Source paper: Bottmer, L., "Synthetic Control with Disaggregated Data" (JMP, Stanford) — Section 5.1 for the nesting claims, Proposition 1 for what dGSC-AD is, Proposition 3 for the recovery result.
- Existing validation: `benchmarks/cases/mlsc_bottmer.py`, cross-validated against the author's `multi-level-sc-estimator` at commit `0fb2639`.
- Depends on #383. The final commit here trims sweeps that #383 supersedes generatively, so merging this alone loses that coverage rather than relocating it.
- Follows #384, whose instrument contract this PR's docstrings cite.

## What

- Added `mlsynth/tests/test_mlsc_nesting.py` — the two nesting limits and Proposition 3, asserted by value.
- Added `mlsynth/tests/test_mlsc_properties.py` — metamorphic relations on `fit()`, plus the degenerate corners of the penalty matrix.
- Trimmed the randomized penalty sweeps from that second file once #383 covered the same claims generatively.

## Why

mlsynth implements the paper's preferred specification, Equation 5.2 — the `lambda_2 = infinity` case where the treated unit stays aggregated and the weight matrix collapses to `omega`. The paper makes six checkable claims about it. `test_mlsc.py` covered two properly:

| Claim | Before |
| --- | --- |
| `lambda -> infinity` reduces to classical SC on aggregated data | structure only — `omega/v` flat within block, which holds even if the aggregate weights are wrong |
| `lambda = 0` recovers dGSC-AD | not tested — only `pre_rmse(0) <= pre_rmse(1e6)` |
| Proposition 3: recovery under perfect pre-treatment fit | not tested, despite the test file's own docstring claiming it |
| `sigma_y^2` makes `lambda` scale invariant | not tested |
| Penalty vanishes iff weights are population-proportional | one hand-picked `v` |
| Simplex feasibility | tested |

A method whose contribution is interpolating between two named estimators should be tested against both endpoints.

## How

C1–C3 are differential tests against estimators already in the library, which the oracle-problem section of `agents_tests.md` identifies as the strongest instrument where no truth exists. At `lambda = 0` the weights and counterfactual equal classical SC over the disaggregated donor pool (Proposition 1). At `lambda -> infinity` the aggregate weights equal classical SC on the aggregated panel. Under Assumption 3, satisfiable by construction, the solution is the constructed weight vector at every penalty — that one is the rare case with a genuine oracle.

C4 is metamorphic and needs no oracle: rescaling every outcome by `c` must leave `omega`, the aggregate weights and `lambda_used` untouched while moving the ATT, the fit and the counterfactual by `c` and the variance components by `c^2`. Shifting by a constant must change nothing but the counterfactual's level. Row order of the input frames cannot matter.

## Verification

- Path: cross-validation against estimators already in this library — `_outcome_only_simplex` for the classical SC comparators — plus one constructed-oracle case.
- Tolerances: `atol=1e-5` at `lambda = 0` (limited by the 1e-8 uniqueness ridge, not solver tolerance), `atol=1e-4` at the large-penalty limit, `atol=1e-4` on the Proposition 3 weights.
- Pinned durably as unit tests; `benchmarks/cases/mlsc_bottmer.py` continues to carry the end-to-end cross-validation.
- Everything matches. Nothing is recorded-but-unfixed.

Three things the audit changed that a green run did not show, since this PR is as much about the tests being strong as about them passing:

1. **The first fixture was degenerate.** On the rank-2 hierarchical factor panel `test_mlsc.py` uses, the aggregate donor series are near-collinear and the aggregate weights come out identical at every penalty — so the large-penalty assertion passed on a panel where it could not have failed. The fixture now uses independent county draws where the two limits sit 0.19 apart, and `_assert_limits_differ` checks that before the nesting claim is asserted.
2. **Proposition 3 needed its converse.** Penalty-invariance of the solution is the claim, so it says something only if the solution is penalty-dependent when Assumption 3 fails. A companion test shows it is.
3. **Mutation-auditing found the endpoints do not pin the objective.** Halving the penalty's square-root factor only reparametrizes `lambda`, leaving both limits and the monotonicity of the fit untouched — that mutant survived everything. Equation 5.2 is now transcribed and solved independently at interior penalties, which kills it and catches a 2% perturbation of the penalty scale.

Mutants killed, after those fixes: penalty never applied (6 tests fail), `R` replaced by identity (10), penalty scaled by 1/2 (3), penalty scaled by 1.02 (2), `sigma_y2` dropped from the penalty scale (3).

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR — closest fit, though this adds only tests:

- [x] The default preserves existing behaviour exactly — no estimator code is touched
- [x] Existing pinned benchmark values unchanged
- [x] A test pins that the default is unchanged — the whole PR is that
- [ ] New config field — none added

## Designs

No visual output.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_mlsc_nesting.py -q` — 20 passed
- [x] `pytest mlsynth/tests/test_mlsc_properties.py -q` — 8 passed after the trim
- [x] `pytest mlsynth/tests/ -k mlsc` — 132 passed, 1 skipped (the skip is `pyscipopt`, unrelated)
- [ ] `python benchmarks/run_benchmarks.py --all` — not run; no benchmark case changes

## Other Notes

- Untested from the paper: the Section 7 theory — the MSE decomposition and the dGSC-AA versus dGSC-AD comparison. That is a Path B benchmark case rather than unit tests, and belongs on its own branch under the replication contract.
- The trim keeps the named corners as examples per the instrument contract, including the one that broke the first draft: at `v = [1, 0]` the penalty is `diag(0, 2)`, so an off-ray probe built as a basis vector tests the kernel it meant to avoid.
- The two-penalty `lambda_1`/`lambda_2` framework in Section 5.1 is not a gap — the paper itself focuses on `lambda_2 = infinity`, which is what mlsynth implements.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbWZFe1K2ewxJ4RMgEf5Zb)_