### PR TITLE
Property-test dataprep and the effect primitives, and fix an R-squared guard they exposed

### DIFF
--- a/mlsynth/tests/test_datautils_properties.py
+++ b/mlsynth/tests/test_datautils_properties.py
@@ -1,0 +1,203 @@
+"""Property tests for ``dataprep``, the ingestion contract every estimator uses.
+
+Architecture invariant 2 in ``CLAUDE.md`` routes every estimator through
+``mlsynth.utils.datautils.dataprep``, so its output contract -- ``y``,
+``donor_matrix``, ``pre_periods``, ``post_periods``, ``Ywide`` -- is the one
+piece of shared state the whole library depends on. A defect here misreports
+every estimator at once, and it would do so silently: a donor column in the
+wrong order or an off-by-one in ``pre_periods`` produces numbers, not errors.
+
+What the contract promises, and what is asserted below over generated panels:
+
+* the period counts partition the panel, ``pre + post == total``;
+* ``y`` is the treated unit's own series, and ``donor_matrix`` is the wide
+  frame with exactly that column removed, in column order matching
+  ``donor_names``;
+* nothing is invented or dropped -- every value round-trips back to the long
+  input frame;
+* ingestion is a set operation on rows, so shuffling the input frame cannot
+  move a number, and relabelling the units permutes the donor columns instead
+  of changing their contents;
+* the two documented failures raise ``MlsynthDataError``.
+
+The row-order and relabelling properties are the ones generation earns most.
+Both are the kind of assumption a pivot silently violates, and neither is
+visible in an estimator's output until two runs of the same data disagree.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.exceptions import MlsynthDataError
+from mlsynth.utils.datautils import dataprep
+
+_VALUE = st.floats(min_value=-1e4, max_value=1e4,
+                   allow_nan=False, allow_infinity=False, width=64)
+
+
+@st.composite
+def panels(draw, min_units: int = 2, max_units: int = 6):
+    """A balanced long panel with one absorbing-treated unit.
+
+    Returns ``(df, n_units, n_periods, treat_start)`` where ``treat_start`` is
+    the index of the first treated period, so ``pre_periods`` should equal it.
+    """
+    n_units = draw(st.integers(min_value=min_units, max_value=max_units))
+    n_periods = draw(st.integers(min_value=3, max_value=18))
+    treat_start = draw(st.integers(min_value=1, max_value=n_periods - 1))
+    values = draw(st.lists(_VALUE, min_size=n_units * n_periods,
+                           max_size=n_units * n_periods))
+    grid = np.asarray(values).reshape(n_units, n_periods)
+
+    rows = [
+        {"unit": f"u{u}", "time": 2000 + t, "y": float(grid[u, t]),
+         "treated": int(u == 0 and t >= treat_start)}
+        for u in range(n_units) for t in range(n_periods)
+    ]
+    return pd.DataFrame(rows), n_units, n_periods, treat_start
+
+
+def _prep(df):
+    return dataprep(df, "unit", "time", "y", "treated")
+
+
+# ---------------------------------------------------------------------------
+# The shape contract
+# ---------------------------------------------------------------------------
+
+@given(panel=panels())
+@settings(max_examples=150)
+def test_period_counts_partition_the_panel(panel):
+    df, n_units, n_periods, treat_start = panel
+    out = _prep(df)
+    assert out["pre_periods"] + out["post_periods"] == out["total_periods"]
+    assert out["total_periods"] == n_periods
+    assert out["pre_periods"] == treat_start
+
+
+@given(panel=panels())
+@settings(max_examples=150)
+def test_donor_matrix_is_the_wide_frame_without_the_treated_column(panel):
+    df, n_units, n_periods, _ = panel
+    out = _prep(df)
+
+    assert out["treated_unit_name"] == "u0"
+    assert out["donor_matrix"].shape == (n_periods, n_units - 1)
+    assert list(out["donor_names"]) == [f"u{u}" for u in range(1, n_units)]
+
+    wide = out["Ywide"]
+    np.testing.assert_allclose(out["y"], wide["u0"].to_numpy(), atol=0)
+    np.testing.assert_allclose(
+        out["donor_matrix"], wide.drop(columns=["u0"]).to_numpy(), atol=0
+    )
+
+
+@given(panel=panels())
+@settings(max_examples=150)
+def test_every_value_round_trips_back_to_the_long_frame(panel):
+    """Nothing is invented, dropped or transposed by the pivot."""
+    df, _, _, _ = panel
+    out = _prep(df)
+    wide = out["Ywide"]
+
+    for _, row in df.iterrows():
+        assert wide.loc[row["time"], row["unit"]] == pytest.approx(row["y"], abs=0)
+
+
+# ---------------------------------------------------------------------------
+# Invariances
+# ---------------------------------------------------------------------------
+
+@given(panel=panels(), seed=st.integers(0, 2**31 - 1))
+@settings(max_examples=100)
+def test_row_order_of_the_long_frame_is_irrelevant(panel, seed):
+    """A long frame is a set of rows; the pivot must not depend on their order."""
+    df, _, _, _ = panel
+    shuffled = df.sample(frac=1.0, random_state=seed % (2**31)).reset_index(drop=True)
+
+    base, other = _prep(df), _prep(shuffled)
+    np.testing.assert_allclose(other["y"], base["y"], atol=0)
+    np.testing.assert_allclose(other["donor_matrix"], base["donor_matrix"], atol=0)
+    assert other["pre_periods"] == base["pre_periods"]
+    assert other["treated_unit_name"] == base["treated_unit_name"]
+
+
+@given(panel=panels(min_units=3))
+@settings(max_examples=100)
+def test_relabelling_donors_permutes_the_columns_and_keeps_their_contents(panel):
+    """Unit labels are identifiers, not data.
+
+    Renaming the donors so their sort order reverses must reorder the donor
+    columns to match ``donor_names`` and leave the set of series unchanged.
+    """
+    df, n_units, _, _ = panel
+    base = _prep(df)
+
+    # u1..u{n-1} -> reversed alphabetical order, treated unit untouched.
+    mapping = {f"u{u}": f"z{n_units - u}" for u in range(1, n_units)}
+    renamed = df.copy()
+    renamed["unit"] = renamed["unit"].map(lambda u: mapping.get(u, u))
+    other = _prep(renamed)
+
+    assert list(other["donor_names"]) == sorted(mapping.values())
+    for label, original in zip(base["donor_names"], base["donor_matrix"].T):
+        column = other["donor_matrix"][:, list(other["donor_names"]).index(mapping[label])]
+        np.testing.assert_allclose(column, original, atol=0)
+
+
+@given(panel=panels(), shift=st.floats(min_value=-1e3, max_value=1e3,
+                                       allow_nan=False, allow_infinity=False))
+@settings(max_examples=100)
+def test_shifting_the_outcome_shifts_every_series_and_nothing_else(panel, shift):
+    """A units change touches the outcome arrays and no structural field."""
+    df, _, _, _ = panel
+    shifted = df.copy()
+    shifted["y"] += shift
+
+    base, other = _prep(df), _prep(shifted)
+    np.testing.assert_allclose(other["y"], base["y"] + shift, rtol=1e-9, atol=1e-6)
+    np.testing.assert_allclose(other["donor_matrix"], base["donor_matrix"] + shift,
+                               rtol=1e-9, atol=1e-6)
+    assert other["pre_periods"] == base["pre_periods"]
+    assert other["post_periods"] == base["post_periods"]
+
+
+# ---------------------------------------------------------------------------
+# Documented failures
+# ---------------------------------------------------------------------------
+
+@given(panel=panels())
+@settings(max_examples=50)
+def test_a_panel_with_no_donors_is_reported(panel):
+    df, _, _, _ = panel
+    only_treated = df[df["unit"] == "u0"]
+    with pytest.raises(MlsynthDataError, match="donor"):
+        _prep(only_treated)
+
+
+@given(panel=panels())
+@settings(max_examples=50)
+def test_treatment_from_the_first_period_leaves_no_pre_period_and_is_reported(panel):
+    """Zero pre-periods is unusable for a synthetic control and must raise."""
+    df, _, _, _ = panel
+    always_treated = df.copy()
+    always_treated["treated"] = (always_treated["unit"] == "u0").astype(int)
+    with pytest.raises(MlsynthDataError, match="pre-treatment"):
+        _prep(always_treated)
+
+
+@given(panel=panels())
+@settings(max_examples=50)
+def test_no_donors_is_allowed_when_the_caller_opts_in(panel):
+    """``allow_no_donors`` exists for estimators with no control pool (SHC)."""
+    df, _, _, _ = panel
+    only_treated = df[df["unit"] == "u0"]
+    out = dataprep(only_treated, "unit", "time", "y", "treated",
+                   allow_no_donors=True)
+    assert out["donor_matrix"].shape[1] == 0
+    assert out["pre_periods"] >= 1

--- a/mlsynth/tests/test_effect_primitives_properties.py
+++ b/mlsynth/tests/test_effect_primitives_properties.py
@@ -1,0 +1,405 @@
+"""Property tests for the effect and fit primitives every estimator reports through.
+
+``mlsynth.utils.effectutils`` and ``mlsynth.utils.fitutils`` are the bedrock of
+estimator reporting: ATT, total effect, percent ATT, standardized ATT, the
+per-period gap, RMSE and R-squared. Every estimator's headline numbers come out
+of these ten functions, and ``resultutils.effects.calculate`` composes them into
+the display dictionaries. A defect here is a defect in every estimator at once,
+which is why they are asserted over their domain instead of at a fixture.
+
+Coverage before this file: the primitives had no direct tests at all, and
+``effects.calculate`` had three (a smoke test and the two empty-segment cases).
+
+Most of what these functions promise is metamorphic -- how an output must
+respond to rescaling or shifting the input -- which needs no oracle and is
+exactly the shape that survives generation. Three of the relations are the ones
+a reader should care about most:
+
+* ``percent_att`` and ``standardized_att`` are scale invariant. They are ratios,
+  so changing the outcome's units must not move them; if either picked up a
+  dimension the estimator would report a different number for the same study
+  measured in cents instead of dollars.
+* ``rmse`` and ``std`` are linked by an exact identity, ``rmse^2 = mean^2 +
+  std^2``. ``effects.calculate`` reports ``std(post_gap)`` under the label
+  "T1 RMSE", so the two are not interchangeable and the identity is what says
+  by how much they differ.
+* ``total_effect == att * T1`` exactly. Both are reported, and a reader who
+  divides one by the other is entitled to get the post-period count back.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from hypothesis import assume, example, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils import effectutils as eff
+from mlsynth.utils import fitutils as fit
+from mlsynth.utils.resultutils import effects
+
+_FINITE = dict(allow_nan=False, allow_infinity=False,
+               min_value=-1e6, max_value=1e6, width=64)
+
+
+def _series(min_size: int = 1, max_size: int = 60):
+    return st.lists(st.floats(**_FINITE), min_size=min_size, max_size=max_size
+                    ).map(np.asarray)
+
+
+def _approx(expected, rel=1e-9, abs=1e-9):
+    """`pytest.approx` under a shorter name; used throughout this module."""
+    return pytest.approx(expected, rel=rel, abs=abs)
+
+
+_nonzero_scale = st.floats(min_value=0.01, max_value=1e3,
+                           allow_nan=False, allow_infinity=False)
+_shift = st.floats(min_value=-1e4, max_value=1e4,
+                   allow_nan=False, allow_infinity=False)
+
+
+# ---------------------------------------------------------------------------
+# gap
+# ---------------------------------------------------------------------------
+
+@given(obs=_series(), shift=_shift)
+def test_gap_is_invariant_to_a_common_level_shift(obs, shift):
+    """Moving observed and counterfactual together cannot change the effect."""
+    cf = obs * 0.5 + 1.0
+    np.testing.assert_allclose(eff.gap(obs + shift, cf + shift), eff.gap(obs, cf),
+                               atol=1e-9, rtol=1e-9)
+
+
+@given(obs=_series(), scale=_nonzero_scale)
+def test_gap_scales_with_the_outcome(obs, scale):
+    cf = obs * 0.5 + 1.0
+    np.testing.assert_allclose(eff.gap(scale * obs, scale * cf),
+                               scale * eff.gap(obs, cf), rtol=1e-9, atol=1e-9)
+
+
+@given(obs=_series(), cf=_series())
+def test_gap_is_antisymmetric_and_length_preserving(obs, cf):
+    assume(obs.size == cf.size)
+    np.testing.assert_allclose(eff.gap(cf, obs), -eff.gap(obs, cf), atol=0)
+    assert eff.gap(obs, cf).shape == (obs.size,)
+
+
+# ---------------------------------------------------------------------------
+# split_pre_post
+# ---------------------------------------------------------------------------
+
+@given(arr=_series(min_size=0), n_pre=st.integers(0, 70), n_post=st.integers(0, 70))
+@example(arr=np.array([1.0, 2.0, 3.0]), n_pre=0, n_post=3)
+@example(arr=np.array([1.0, 2.0, 3.0]), n_pre=3, n_post=0)
+def test_split_partitions_without_overlap_or_gap(arr, n_pre, n_post):
+    """The two segments are adjacent, in order, and never share an element."""
+    pre, post = eff.split_pre_post(arr, n_pre, n_post)
+    assert pre.size == min(n_pre, arr.size)
+    assert post.size == max(0, min(n_pre + n_post, arr.size) - n_pre)
+    np.testing.assert_allclose(np.concatenate([pre, post]),
+                               arr[: n_pre + n_post], atol=0)
+
+
+# ---------------------------------------------------------------------------
+# att / total_effect
+# ---------------------------------------------------------------------------
+
+@given(post_gap=_series())
+def test_total_effect_is_att_times_the_post_period_count(post_gap):
+    """Both are reported; dividing one by the other must give T1 back."""
+    assert eff.total_effect(post_gap) == \
+        _approx(eff.att(post_gap) * post_gap.size)
+
+
+@given(value=st.floats(**_FINITE), size=st.integers(1, 40))
+def test_att_of_a_constant_gap_is_that_constant(value, size):
+    assert eff.att(np.full(size, value)) == _approx(value)
+
+
+@given(post_gap=_series(), scale=_nonzero_scale)
+def test_att_and_total_effect_scale_with_the_gap(post_gap, scale):
+    assert eff.att(scale * post_gap) == _approx(scale * eff.att(post_gap))
+    assert eff.total_effect(scale * post_gap) == \
+        _approx(scale * eff.total_effect(post_gap))
+
+
+def test_att_and_total_effect_are_nan_on_an_empty_post_period():
+    assert np.isnan(eff.att(np.array([])))
+    assert np.isnan(eff.total_effect(np.array([])))
+
+
+# ---------------------------------------------------------------------------
+# percent_att / percent_gap -- the ratios
+# ---------------------------------------------------------------------------
+
+@given(post_gap=_series(), cf=_series(), scale=_nonzero_scale)
+def test_percent_att_is_scale_invariant(post_gap, cf, scale):
+    """A percent is dimensionless: the same study in cents and in dollars must
+    report the same number."""
+    assume(cf.size > 0 and abs(float(cf.mean())) > 1e-3)
+    base = eff.percent_att(eff.att(post_gap), cf)
+    scaled = eff.percent_att(eff.att(scale * post_gap), scale * cf)
+    assume(np.isfinite(base))
+    assert scaled == _approx(base, rel=1e-6)
+
+
+@given(att_value=st.floats(min_value=0.1, max_value=1e4,
+                           allow_nan=False, allow_infinity=False),
+       cf=_series())
+def test_percent_att_keeps_the_sign_of_the_counterfactual_denominator(att_value, cf):
+    """A negative counterfactual level flips the sign of the percent effect.
+
+    Scale invariance alone does not pin this: taking the absolute value of the
+    denominator preserves it, and that mutation survives every other test here.
+    A treated series whose counterfactual sits below zero -- a net balance, a
+    deficit, a temperature anomaly -- is where the two differ.
+    """
+    assume(cf.size > 0 and float(cf.mean()) < -1e-3)
+    assert eff.percent_att(att_value, cf) < 0.0
+    assert eff.percent_att(-att_value, cf) > 0.0
+
+
+@given(post_gap=_series())
+def test_percent_att_is_nan_when_the_counterfactual_averages_to_zero(post_gap):
+    assert np.isnan(eff.percent_att(eff.att(post_gap), np.array([-1.0, 1.0])))
+    assert np.isnan(eff.percent_att(eff.att(post_gap), np.array([])))
+
+
+@given(post_gap=_series(), cf=_series())
+def test_percent_gap_is_nan_exactly_where_the_counterfactual_is_zero(post_gap, cf):
+    assume(post_gap.size == cf.size)
+    out = eff.percent_gap(post_gap, cf)
+    np.testing.assert_array_equal(np.isnan(out), cf == 0)
+
+
+# ---------------------------------------------------------------------------
+# standardized_att
+# ---------------------------------------------------------------------------
+
+@given(pre_gap=_series(), post_gap=_series(), scale=_nonzero_scale)
+def test_standardized_att_is_scale_invariant(pre_gap, post_gap, scale):
+    """Numerator and denominator carry the same units, so the ratio is free of
+    them -- the property that makes SATT comparable across studies."""
+    base = eff.standardized_att(pre_gap, post_gap)
+    assume(np.isfinite(base))
+    scaled = eff.standardized_att(scale * pre_gap, scale * post_gap)
+    assert scaled == _approx(base, rel=1e-6)
+
+
+@given(pre_gap=_series(), post_gap=_series())
+def test_standardized_att_carries_the_sign_of_the_att(pre_gap, post_gap):
+    satt = eff.standardized_att(pre_gap, post_gap)
+    assume(np.isfinite(satt) and satt != 0.0)
+    assert np.sign(satt) == np.sign(eff.att(post_gap))
+
+
+def test_standardized_att_is_nan_when_either_segment_is_empty():
+    assert np.isnan(eff.standardized_att(np.array([]), np.array([1.0])))
+    assert np.isnan(eff.standardized_att(np.array([1.0]), np.array([])))
+
+
+@given(pre_gap=_series(min_size=2), post_gap=_series(min_size=2))
+def test_standardized_att_matches_the_documented_formula(pre_gap, post_gap):
+    """``sqrt(T1) * att / sqrt((T1/T0) * s^2 + s^2)``, transcribed independently.
+
+    Scale invariance and the sign both survive swapping ``sqrt(T1)`` for
+    ``sqrt(T0)`` in the numerator, so neither pins the statistic's magnitude.
+    Writing the docstring's formula out is what does, and it is the quantity a
+    reader compares across studies with different post-period lengths.
+    """
+    t0, t1 = pre_gap.size, post_gap.size
+    mean_sq_resid = float(pre_gap @ pre_gap) / t0
+    denom = np.sqrt((t1 / t0) * mean_sq_resid + mean_sq_resid)
+    assume(denom > 1e-8)
+
+    expected = float(np.sqrt(t1) * post_gap.mean() / denom)
+    assume(np.isfinite(expected))
+    assert eff.standardized_att(pre_gap, post_gap) == _approx(expected, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# fitutils
+# ---------------------------------------------------------------------------
+
+@given(residuals=_series())
+def test_rmse_and_std_satisfy_the_bias_variance_identity(residuals):
+    """``rmse^2 = mean^2 + std^2``.
+
+    ``effects.calculate`` labels ``std(post_gap)`` as "T1 RMSE", so the two are
+    not the same quantity; this pins the exact amount by which they differ.
+    """
+    r = residuals
+    assert fit.rmse(r) ** 2 == _approx(
+        float(r.mean()) ** 2 + fit.std(r) ** 2, rel=1e-8, abs=1e-8
+    )
+
+
+@given(residuals=_series(), scale=_nonzero_scale)
+def test_rmse_and_std_are_non_negative_and_scale_by_the_magnitude(residuals, scale):
+    assert fit.rmse(residuals) >= 0.0
+    assert fit.std(residuals) >= 0.0
+    assert fit.rmse(scale * residuals) == _approx(scale * fit.rmse(residuals))
+    assert fit.std(scale * residuals) == _approx(scale * fit.std(residuals))
+
+
+@given(residuals=_series(), shift=_shift)
+def test_std_is_shift_invariant_and_rmse_is_not(residuals, shift):
+    assert fit.std(residuals + shift) == _approx(fit.std(residuals), abs=1e-6)
+
+
+@given(size=st.integers(1, 40))
+def test_rmse_of_a_perfect_fit_is_zero(size):
+    assert fit.rmse(np.zeros(size)) == 0.0
+
+
+@given(observed=_series(min_size=2), residuals=_series(min_size=2))
+def test_r_squared_never_exceeds_one(observed, residuals):
+    assume(observed.size == residuals.size)
+    value = fit.r_squared(observed, residuals)
+    assume(np.isfinite(value))
+    assert value <= 1.0 + 1e-9
+
+
+@given(
+    observed=st.lists(st.floats(min_value=-1e3, max_value=1e3, allow_nan=False,
+                                allow_infinity=False, width=64),
+                      min_size=2, max_size=60).map(np.asarray),
+    scale=_nonzero_scale,
+    shift=st.floats(min_value=-1e3, max_value=1e3,
+                    allow_nan=False, allow_infinity=False),
+)
+def test_r_squared_is_invariant_to_the_units_of_the_outcome(observed, scale, shift):
+    """R-squared is a variance ratio, so rescaling and shifting the observed
+    series (with the residuals rescaled to match) cannot move it.
+
+    The spread has to survive the shift in float64 for the claim to mean
+    anything -- adding 1.0 to a series whose spread is 1e-70 leaves a constant
+    array, and comparing a ratio computed on that against one computed on the
+    original is a statement about floating point, not about R-squared.
+    """
+    assume(float(np.std(observed)) > 1e-6 * (1.0 + abs(shift)))
+    residuals = observed * 0.1 - 0.3
+    base = fit.r_squared(observed, residuals)
+    assume(np.isfinite(base))
+    moved = fit.r_squared(scale * observed + shift, scale * residuals)
+    assert moved == _approx(base, rel=1e-6, abs=1e-9)
+
+
+@given(observed=_series(min_size=2))
+def test_r_squared_of_a_zero_residual_fit_is_one(observed):
+    assume(float(np.var(observed)) > 1e-6)
+    assert fit.r_squared(observed, np.zeros(observed.size)) == _approx(1.0)
+
+
+@given(size=st.integers(2, 20), value=st.floats(**_FINITE))
+def test_r_squared_is_nan_when_the_observed_series_has_no_variance(size, value):
+    assert np.isnan(fit.r_squared(np.full(size, value), np.zeros(size)))
+
+
+@pytest.mark.parametrize("residuals_value", [0.0, 1e-6, 0.5])
+def test_r_squared_on_a_flat_series_that_does_not_center_to_exactly_zero(
+    residuals_value,
+):
+    """Regression: the exact case the generated tests turned up.
+
+    ``np.full(17, 493447.830355742)`` is constant, but subtracting its mean
+    leaves residue with a centered sum of squares of 5.8e-20 instead of 0. An
+    exact ``denom != 0`` guard admitted that, and the reported R-squared was
+    1.0, -2.9e8 or -7.4e19 depending only on the residuals -- a silent wrong
+    answer with no warning. A flat pre-period is an ordinary panel, so the
+    guard now compares against the noise floor of the centering.
+    """
+    y = np.full(17, 493447.830355742)
+    assert 0.0 < float((y - y.mean()) @ (y - y.mean())) < 1e-15   # not exactly flat
+    assert np.isnan(fit.r_squared(y, np.full(17, residuals_value)))
+
+
+def test_r_squared_still_reports_a_series_with_real_but_small_variance():
+    """The guard must not swallow a genuinely varying series.
+
+    A spread of 1 on a level of 1e6 is a ratio of 1e-13 -- far below anything a
+    naive relative tolerance would keep, and far above the 1e-32 floor that
+    centering noise sits at.
+    """
+    y = 1e6 + np.arange(20.0)
+    value = fit.r_squared(y, np.full(20, 0.1))
+    assert np.isfinite(value) and value < 1.0
+
+
+# ---------------------------------------------------------------------------
+# effects.calculate -- the composition
+# ---------------------------------------------------------------------------
+
+@st.composite
+def _panels(draw):
+    n_pre = draw(st.integers(min_value=1, max_value=25))
+    n_post = draw(st.integers(min_value=1, max_value=25))
+    total = n_pre + n_post
+    obs = np.asarray(draw(st.lists(st.floats(**_FINITE),
+                                   min_size=total, max_size=total)))
+    cf = np.asarray(draw(st.lists(st.floats(**_FINITE),
+                                  min_size=total, max_size=total)))
+    return obs, cf, n_pre, n_post
+
+
+@given(panel=_panels())
+@settings(max_examples=150)
+def test_calculate_reports_the_primitives_it_delegates_to(panel):
+    """The display dictionaries must agree with the functions underneath."""
+    obs, cf, n_pre, n_post = panel
+    eff_dict, fit_dict, _ = effects.calculate(obs, cf, n_pre, n_post)
+
+    gap_series = eff.gap(obs, cf)
+    pre_gap, post_gap = eff.split_pre_post(gap_series, n_pre, n_post)
+
+    assert eff_dict["ATT"] == _approx(round(eff.att(post_gap), 3))
+    assert eff_dict["TTE"] == _approx(round(eff.total_effect(post_gap), 3))
+    assert fit_dict["T0 RMSE"] == _approx(round(fit.rmse(pre_gap), 3))
+    assert fit_dict["T1 RMSE"] == _approx(round(fit.std(post_gap), 3))
+    assert fit_dict["Pre-Periods"] == n_pre
+    assert fit_dict["Post-Periods"] == n_post
+
+
+@given(panel=_panels(), shift=_shift)
+@settings(max_examples=150)
+def test_calculate_att_is_invariant_to_a_common_level_shift(panel, shift):
+    """Shifting observed and counterfactual together leaves the effect alone."""
+    obs, cf, n_pre, n_post = panel
+    base, _, _ = effects.calculate(obs, cf, n_pre, n_post)
+    moved, _, _ = effects.calculate(obs + shift, cf + shift, n_pre, n_post)
+    assert moved["ATT"] == _approx(base["ATT"], abs=1e-3)
+
+
+@given(panel=_panels())
+@settings(max_examples=150)
+def test_calculate_relative_time_column_puts_zero_on_the_last_pre_period(panel):
+    """Pins the convention the gap plots depend on.
+
+    ``relative_time = arange(T) - n_pre + 1``, so index ``n_pre - 1`` -- the
+    last pre-treatment period -- carries 0 and the first post-treatment period
+    carries 1. The comment above that line in ``resultutils`` reads "0 at
+    treatment start", which is off by one against this if "treatment start"
+    means the first treated period. The behaviour is pinned here as-is because
+    every gap plot in the library is drawn on it; the comment is the thing that
+    disagrees.
+    """
+    obs, cf, n_pre, n_post = panel
+    _, _, vectors = effects.calculate(obs, cf, n_pre, n_post)
+    rel = vectors["Gap"][:, 1]
+
+    assert rel[n_pre - 1] == 0.0
+    assert rel[n_pre] == 1.0
+    assert rel.shape[0] == obs.size
+    np.testing.assert_allclose(np.diff(rel), 1.0, atol=0)
+
+
+@given(panel=_panels())
+@settings(max_examples=100)
+def test_calculate_time_series_vectors_keep_the_input_length(panel):
+    obs, cf, n_pre, n_post = panel
+    _, _, vectors = effects.calculate(obs, cf, n_pre, n_post)
+    assert vectors["Observed Unit"].shape == (obs.size, 1)
+    assert vectors["Counterfactual"].shape == (obs.size, 1)
+    assert vectors["Gap"].shape == (obs.size, 2)
+
+

--- a/mlsynth/utils/fitutils.py
+++ b/mlsynth/utils/fitutils.py
@@ -43,4 +43,14 @@ def r_squared(observed: np.ndarray, residuals: np.ndarray) -> float:
         return float("nan")
     y_c = y - y.mean()
     denom = float(y_c @ y_c)
-    return float(1.0 - (r @ r) / denom) if denom != 0 else float("nan")
+    # A series that is constant to machine precision does not center to
+    # exactly zero: subtracting the mean leaves rounding residue of order
+    # eps*|y| per element, so `denom != 0` lets a flat series through and
+    # divides by ~1e-20. A flat pre-period is an ordinary panel -- a count
+    # that stays at zero, a rate that does not move -- and the result was a
+    # silent 1.0 or a value of order -1e19 depending on the residuals. Compare
+    # against the noise floor of the centering itself instead.
+    noise_floor = y.size * np.finfo(float).eps ** 2 * float(y @ y)
+    if denom <= noise_floor:
+        return float("nan")
+    return float(1.0 - (r @ r) / denom)


### PR DESCRIPTION
## Related Links

- Follows #383, which added `hypothesis` and the profiles these tests run under. Rebased onto `main` after that merged, so this branch carries one commit.
- The instrument contract these follow is in `agents/agents_tests.md` (#384).
- Targets: `mlsynth/utils/datautils.py::dataprep`, `mlsynth/utils/effectutils.py`, `mlsynth/utils/fitutils.py`, `mlsynth/utils/resultutils.py::effects.calculate`.

## What

- Added `mlsynth/tests/test_effect_primitives_properties.py` — 32 tests over the ten effect/fit primitives and `effects.calculate`.
- Added `mlsynth/tests/test_datautils_properties.py` — 9 tests over the `dataprep` output contract.
- Fixed the zero-variance guard in `fitutils.r_squared`.

## Why

Architecture invariant 2 routes every estimator through `dataprep`, and every headline number an estimator reports comes out of the ten functions in `effectutils` and `fitutils`, composed by `effects.calculate`. Before this the primitives had no direct tests at all and `effects.calculate` had three. A defect there misreports every estimator at once, and does it silently — a donor column in the wrong order or an off-by-one in `pre_periods` produces numbers, not errors.

## How

Metamorphic relations carry most of the load, because they need no oracle: `percent_att` and `standardized_att` are scale invariant, `gap` and `std` are shift invariant, `att` and `total_effect` scale with the gap, and `dataprep` is invariant to row order and to relabelling the donors. Three exact identities are pinned as well — `total_effect == att * T1`, `rmse^2 == mean^2 + std^2` (which matters because `effects.calculate` labels `std(post_gap)` as "T1 RMSE", so the two are not the same quantity), and `standardized_att` against its documented formula.

## Verification

- Path: bug fix, plus tests. No estimator's numerical path changes except through the `r_squared` guard below, which only fires where the old answer was garbage.

The defect the generated tests found. `r_squared` guarded zero variance with an exact `denom != 0`, but centering a constant series does not give exactly zero. `np.full(17, 493447.830355742)` leaves a centered sum of squares of 5.8e-20, so the guard admitted it and the function divided by that:

| residuals | reported R-squared | contract |
| --- | --- | --- |
| all zero | 1.0 | nan |
| 1e-6 | -2.9e8 | nan |
| 0.5 | -7.4e19 | nan |

No exception and no NaN — just a number, and which one depended on whether the constant happened to divide evenly by the series length (`np.full(3, 1.0)` centers exactly and correctly returns nan). A flat pre-period is an ordinary panel: a count that stays at zero, a rate that does not move. The guard now compares the centered sum of squares against the noise floor of the centering itself, and a test pins that a spread of 1 on a level of 1e6 — a ratio of 1e-13, far below what a naive relative tolerance would keep — still reports normally.

The audit changed the tests three times, none of which the green run showed:

1. `percent_att` taking the absolute value of its denominator survived everything. Scale invariance holds under it, and no test used a negative counterfactual level — so a deficit or a temperature anomaly would have reported a sign-flipped percent effect undetected.
2. `standardized_att` using `sqrt(T0)` for `sqrt(T1)` survived for the same reason: invariance and sign both hold under it. Only transcribing the documented formula independently kills it.
3. A `dataprep` mutant appeared to survive but had never applied — the `sed` range address did not match. The audit now asserts the mutant is present before reading the result, which is the difference between a finding and a false one.

Mutants killed after those fixes: `split_pre_post` off by one, `att` returning a sum, `percent_att` absolute denominator, `standardized_att` using T0, `standardized_att` dropping a denominator term, `rmse` using `n-1`, `std` using `ddof=1`, `y` reversed in time, `y` scaled by 1.0001.

One convention is pinned as-is and flagged rather than changed. The gap matrix's relative-time column puts 0 on the last pre-treatment period and 1 on the first post period, while the comment above it in `resultutils` says "0 at treatment start". Every gap plot in the library is drawn on the current behaviour, so the comment is what disagrees; a test now records which is which.

## Scope checks

BUG FIX:

- [x] A test reproduces the defect and fails without the fix — `test_r_squared_is_nan_when_the_observed_series_has_no_variance` was red, and the exact discovered case is pinned as a named regression test
- [x] It asserts the correct behaviour, not merely the absence of a crash — all three residual regimes are asserted to be nan, and a companion test asserts a genuinely small-variance series still reports
- [x] No docs page, docstring, or comment still states the old behaviour — the docstring already promised nan on zero variance; the code now matches it
- [x] Any pinned value that moved is justified — none moved

## Designs

No visual output.

## Test Steps

- [x] `pip install -e ".[test]"`
- [x] `pytest mlsynth/tests/test_effect_primitives_properties.py -q` — 32 passed
- [x] `pytest mlsynth/tests/test_datautils_properties.py -q` — 9 passed
- [x] `MLSYNTH_HYPOTHESIS_PROFILE=dev` on both — passed at 1000 examples
- [ ] `pytest mlsynth/tests/` — **not completed locally.** Two attempts were killed by container restarts before finishing, so the full-suite check for the `r_squared` change is delegated to this PR's CI across 3.10/3.12/3.13. Flagging it rather than implying a green I did not see. The change is inert wherever the centered sum of squares is above the centering noise floor, which is every non-degenerate series, so the expected blast radius is nil — but that is an argument, not a run.
- [ ] `python benchmarks/run_benchmarks.py --all` — not run; no benchmark case changes

## Other Notes

- `effects.calculate` rounds to 3 decimals for display, so the composition tests compare against `round(primitive(...), 3)` instead of the raw value. That is the existing contract, not something this PR changes.
- The primitives are now the best-covered part of the library and the natural place to point a future cosmic-ray run, since they are pure, fast and deterministic — the constraints Phase 3 in `agents/agents_tests.md` puts on mutation targets.
- Still untested at this layer: the cohort (multiple-treated) branch of `dataprep`, and the covariate and `marex` opt-in paths. Each has a different return contract and deserves its own generated panels.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbWZFe1K2ewxJ4RMgEf5Zb)_