### PR TITLE
Close the two open method gaps: worst-case and decision-table testing

### DIFF
--- a/mlsynth/estimators/vanillasc.py
+++ b/mlsynth/estimators/vanillasc.py
@@ -56,7 +56,7 @@ class VanillaSC:
         if isinstance(config, dict):
             try:
                 config = VanillaSCConfig(**config)
-            except ValidationError as exc:  # pragma: no cover - passthrough
+            except ValidationError as exc:
                 raise MlsynthConfigError(str(exc)) from exc
         if not isinstance(config, VanillaSCConfig):
             raise MlsynthConfigError(

--- a/mlsynth/tests/test_dataprep_worst_case.py
+++ b/mlsynth/tests/test_dataprep_worst_case.py
@@ -1,0 +1,163 @@
+"""Worst-case boundary testing for ``dataprep``.
+
+``agents/agents_tests.md`` records two gaps as open. This file closes one of
+them for the ingestion layer.
+
+The four test levels there -- smoke, unit, edge, failure -- are all
+single-fault: each varies one input to a boundary and holds the others
+nominal. That is what makes them affordable (``4n + 1`` cases for ``n`` inputs
+instead of ``5^n``), and it is sound when failures arise from one variable
+being extreme. ``dataprep``'s inputs are not independent. The number of units,
+the number of periods and the treatment date interact: one unit means no
+donors, a treatment date of zero means no pre-periods, and a panel can be both
+at once. Which error a caller sees then depends on a precedence between checks
+that no single-fault test exercises, because no single-fault test ever makes
+two conditions true together.
+
+Worst-case testing is the classical answer (Jorgensen §5.4): take the
+boundary values of each input and test their cross product, not one axis at
+a time. The grid below is ``min``, ``min+``, ``nom``, ``max-``,
+``max`` on each of the three panel-shape inputs.
+
+The expected outcome is a decision table, and its content is the precedence:
+
+===========================  ===========================================
+condition (first that holds)  outcome
+===========================  ===========================================
+no treated observations       ``MlsynthDataError`` -- "No treated units"
+exactly one unit              ``MlsynthDataError`` -- "No donor units"
+treatment from period zero    ``MlsynthDataError`` -- "pre-treatment"
+otherwise                     a valid contract, ``pre == treat_start``
+===========================  ===========================================
+
+The ordering is the finding. A panel with one unit treated from the first
+period trips the donor rule and the pre-period rule simultaneously, and
+reports the donor one; a caller who fixes only what the message names is sent
+back for a second round. That is a property of the code as written, pinned
+here so a reordering of the checks is a visible change and not a silent one.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Optional
+
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthDataError
+from mlsynth.utils.datautils import dataprep
+
+# Boundary values per input: min, min+, nom, max-, max.
+_UNIT_COUNTS = (1, 2, 4, 7, 8)
+_PERIOD_COUNTS = (1, 2, 6, 11, 12)
+# Treatment dates are expressed relative to the panel length and resolved per
+# case, since the upper boundary depends on the number of periods.
+_TREAT_POSITIONS = ("none", "first", "second", "penultimate", "last")
+
+
+def _panel(n_units: int, n_periods: int, treat_start: Optional[int]) -> pd.DataFrame:
+    return pd.DataFrame([
+        {"unit": f"u{u}", "time": 2000 + t, "y": float(10 * u + t),
+         "treated": int(u == 0 and treat_start is not None and t >= treat_start)}
+        for u in range(n_units) for t in range(n_periods)
+    ])
+
+
+def _resolve(position: str, n_periods: int) -> Optional[int]:
+    """Map a boundary position onto an index, or ``None`` for no treatment."""
+    return {
+        "none": None,
+        "first": 0,
+        "second": min(1, n_periods - 1),
+        "penultimate": max(n_periods - 2, 0),
+        "last": n_periods - 1,
+    }[position]
+
+
+def _expected(n_units: int, n_periods: int, treat_start: Optional[int]) -> Optional[str]:
+    """The decision table: the message fragment expected, or ``None`` if valid."""
+    if treat_start is None:
+        return "No treated units"
+    if n_units == 1:
+        return "No donor units"
+    if treat_start == 0:
+        return "pre-treatment"
+    return None
+
+
+_GRID = list(itertools.product(_UNIT_COUNTS, _PERIOD_COUNTS, _TREAT_POSITIONS))
+
+
+@pytest.mark.parametrize("n_units,n_periods,position", _GRID)
+def test_worst_case_panel_shapes(n_units, n_periods, position):
+    """Every corner of the boundary cross product, against the decision table."""
+    treat_start = _resolve(position, n_periods)
+    df = _panel(n_units, n_periods, treat_start)
+    expected = _expected(n_units, n_periods, treat_start)
+
+    if expected is not None:
+        with pytest.raises(MlsynthDataError, match=expected):
+            dataprep(df, "unit", "time", "y", "treated")
+        return
+
+    out = dataprep(df, "unit", "time", "y", "treated")
+    assert out["pre_periods"] == treat_start
+    assert out["post_periods"] == n_periods - treat_start
+    assert out["total_periods"] == n_periods
+    assert out["donor_matrix"].shape == (n_periods, n_units - 1)
+
+
+def test_the_grid_covers_every_row_of_the_decision_table():
+    """A cross product earns its cost only by reaching every outcome.
+
+    Guards against the grid drifting until some rule is never exercised --
+    which is how a worst-case suite decays into an expensive smoke test.
+    """
+    reached = {
+        _expected(nu, npd, _resolve(pos, npd)) for nu, npd, pos in _GRID
+    }
+    assert reached == {None, "No treated units", "No donor units", "pre-treatment"}
+
+
+# ---------------------------------------------------------------------------
+# The multiple-fault cases, named
+# ---------------------------------------------------------------------------
+
+def test_one_unit_treated_from_the_first_period_reports_the_donor_rule_first():
+    """Both the donor rule and the pre-period rule are violated at once.
+
+    Single-fault testing cannot reach this: it holds every other input
+    nominal, so the two conditions never hold together and the precedence is
+    never observed. The donor check runs first.
+    """
+    df = _panel(n_units=1, n_periods=4, treat_start=0)
+    with pytest.raises(MlsynthDataError, match="No donor units"):
+        dataprep(df, "unit", "time", "y", "treated")
+
+
+def test_one_unit_with_no_treatment_reports_the_treated_rule_first():
+    """Three-way: no treated unit, no donors, and nothing to split on."""
+    df = _panel(n_units=1, n_periods=4, treat_start=None)
+    with pytest.raises(MlsynthDataError, match="No treated units"):
+        dataprep(df, "unit", "time", "y", "treated")
+
+
+def test_allowing_no_donors_does_not_also_waive_the_pre_period_rule():
+    """``allow_no_donors`` waives exactly one rule of the table.
+
+    With the donor rule opted out, a panel that also has no pre-periods must
+    still fail -- on the next rule down. An opt-out that swallowed both would
+    return a contract with nothing to fit on.
+    """
+    df = _panel(n_units=1, n_periods=4, treat_start=0)
+    with pytest.raises(MlsynthDataError, match="pre-treatment"):
+        dataprep(df, "unit", "time", "y", "treated", allow_no_donors=True)
+
+
+def test_treatment_in_the_final_period_leaves_exactly_one_post_period():
+    """The upper boundary of the treatment date, where ``post_periods == 1``."""
+    df = _panel(n_units=3, n_periods=6, treat_start=5)
+    out = dataprep(df, "unit", "time", "y", "treated")
+    assert out["pre_periods"] == 5
+    assert out["post_periods"] == 1

--- a/mlsynth/tests/test_vanillasc_config_decision_table.py
+++ b/mlsynth/tests/test_vanillasc_config_decision_table.py
@@ -1,0 +1,199 @@
+"""Decision-table tests for ``VanillaSCConfig``'s cross-field rules.
+
+``agents/agents_tests.md`` records two gaps as open; this file closes the
+second one. Config validators are the place where a decision table earns its
+keep: their conditions are *dependent*, and the classical selection guidance
+(Jorgensen §10.5, Table 10.13) puts dependent variables straight at decision
+tables, not at boundary or equivalence-class testing. Writing the table
+out makes the impossible rule combinations explicit and shows which rows no
+test reaches.
+
+``VanillaSCConfig`` has the most cross-field rules in the library (nine
+validators), and two of them are genuinely multi-condition.
+
+Rule 1 -- ``_w_constr_is_exclusive``. ``w_constr`` routes the fit through
+scpi's constrained program, which is a different estimator from the bilevel
+predictor-weight engine and from user-supplied weights, so it clashes with
+four other options:
+
+======  ==========================  =========================================
+symbol  condition                   set by
+======  ==========================  =========================================
+c1      ``w_constr`` is not None    ``w_constr={"name": "simplex"}``
+c2      ``covariates`` truthy       ``covariates=["x"]``
+c3      ``backend != "auto"``       ``backend="malo"``
+c4      ``oracle_weights`` given    ``oracle_weights={"u1": 0.5, "u2": 0.5}``
+c5      ``staggered_spec`` given    ``StaggeredSCMSpec(features=["y"])``
+======  ==========================  =========================================
+
+The action is to raise iff ``c1 and (c2 or c3 or c4 or c5)``, and -- the part
+single-fault testing cannot reach -- the message must name *every* clash that
+holds, not the first one found. Sixteen combinations of c2..c5 are tested
+under c1, and the same sixteen with c1 false as the control half of the table:
+without ``w_constr`` none of the four is a clash at all, which is what makes
+the rule about ``w_constr`` and not about the four options individually.
+
+Rule 2 -- ``_bias_correction_needs_predictors``. Two conditions, four rows,
+one of which raises.
+
+Exception surface. Constructing the config object directly raises pydantic's
+``ValidationError``; the public path -- handing a dict to the estimator --
+translates it to ``MlsynthConfigError`` in ``VanillaSC.__init__``. Both are
+asserted, because the translation is what a user actually meets and it had no
+test: the ``except ValidationError`` arm carried ``# pragma: no cover`` even
+though any invalid dict config reaches it.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+from mlsynth import VanillaSC
+from mlsynth.config_models import VanillaSCConfig
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.vanillasc_helpers.config import StaggeredSCMSpec
+
+
+@pytest.fixture(scope="module")
+def panel() -> pd.DataFrame:
+    return pd.DataFrame([
+        {"unit": f"u{u}", "time": 2000 + t, "y": float(10 * u + t), "x": float(t),
+         "treated": int(u == 0 and t >= 4)}
+        for u in range(3) for t in range(8)
+    ])
+
+
+def _base(panel: pd.DataFrame) -> dict:
+    return dict(df=panel, outcome="y", treat="treated", unitid="unit",
+                time="time", display_graphs=False)
+
+
+# Each clash condition: the kwargs that switch it on, and the fragment the
+# message must contain when it does.
+_CLASHES = {
+    "covariates": (dict(covariates=["x"]), "covariates"),
+    "backend": (dict(backend="malo"), "backend"),
+    "oracle_weights": (dict(oracle_weights={"u1": 0.5, "u2": 0.5}), "oracle_weights"),
+    "staggered_spec": (dict(staggered_spec=StaggeredSCMSpec(features=["y"])),
+                       "staggered_spec"),
+}
+
+# All 2^4 combinations of the clash conditions.
+_COMBOS = [
+    combo
+    for r in range(len(_CLASHES) + 1)
+    for combo in itertools.combinations(sorted(_CLASHES), r)
+]
+
+
+def _kwargs_for(combo) -> dict:
+    merged: dict = {}
+    for name in combo:
+        merged.update(_CLASHES[name][0])
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 -- w_constr exclusivity, both halves of the table
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("combo", _COMBOS, ids=lambda c: "+".join(c) or "none")
+def test_w_constr_clashes_name_every_condition_that_holds(panel, combo):
+    """c1 true: raise iff any clash holds, and name all of them.
+
+    The multiple-fault half. A validator that stopped at the first clash would
+    pass every single-fault test and fail here, and a user acting on such a
+    message would be sent back for a second and third round.
+    """
+    kwargs = dict(_base(panel), w_constr={"name": "simplex"}, **_kwargs_for(combo))
+
+    if not combo:
+        VanillaSCConfig(**kwargs)          # no clash: the rule permits it
+        return
+
+    with pytest.raises(ValidationError) as excinfo:
+        VanillaSCConfig(**kwargs)
+    message = str(excinfo.value)
+    for name in combo:
+        assert _CLASHES[name][1] in message, (
+            f"{name} holds but is not named; the message reports only "
+            f"a subset of the clashes: {message}"
+        )
+
+
+@pytest.mark.parametrize("combo", _COMBOS, ids=lambda c: "+".join(c) or "none")
+def test_without_w_constr_none_of_the_four_is_a_clash(panel, combo):
+    """c1 false: the control half.
+
+    Every one of the sixteen combinations must construct. This is what makes
+    the rule a statement about ``w_constr`` and not about the four options,
+    and it is the half a test suite usually omits.
+    """
+    VanillaSCConfig(**dict(_base(panel), **_kwargs_for(combo)))
+
+
+def test_w_constr_alone_is_permitted(panel):
+    """The row where c1 holds and nothing else does."""
+    VanillaSCConfig(**_base(panel), w_constr={"name": "simplex"})
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 -- bias correction needs predictors, all four rows
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "bias_correct,with_covariates,raises",
+    [
+        (False, False, False),
+        (False, True, False),
+        (True, True, False),
+        (True, False, True),      # the only row that raises
+    ],
+)
+def test_bias_correction_decision_table(panel, bias_correct, with_covariates, raises):
+    kwargs = dict(_base(panel), bias_correct=bias_correct)
+    if with_covariates:
+        kwargs["covariates"] = ["x"]
+
+    if raises:
+        with pytest.raises(ValidationError, match="needs covariates"):
+            VanillaSCConfig(**kwargs)
+    else:
+        VanillaSCConfig(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The exception surface a user actually meets
+# ---------------------------------------------------------------------------
+
+def test_dict_config_translates_validation_errors_to_mlsynth_config_error(panel):
+    """The public path, and the arm that carried an unearned ``no cover``.
+
+    ``VanillaSC(config_dict)`` funnels pydantic's ``ValidationError`` into
+    ``MlsynthConfigError`` so callers catch one exception family. That arm is
+    reachable from any invalid dict, so it is behaviour, not a defensive
+    branch, and the original message has to survive the translation or the
+    user loses the reason.
+    """
+    bad = dict(_base(panel), bias_correct=True)
+    with pytest.raises(MlsynthConfigError, match="needs covariates"):
+        VanillaSC(bad)
+
+
+def test_dict_config_translation_covers_the_multi_clash_message(panel):
+    """The translated error keeps every clash the validator named."""
+    bad = dict(_base(panel), w_constr={"name": "simplex"},
+               covariates=["x"], backend="malo")
+    with pytest.raises(MlsynthConfigError) as excinfo:
+        VanillaSC(bad)
+    message = str(excinfo.value)
+    assert "covariates" in message and "backend" in message
+
+
+def test_a_valid_dict_config_is_accepted_by_the_same_path(panel):
+    """The translation must not swallow a config that is simply fine."""
+    assert VanillaSC(dict(_base(panel))) is not None


### PR DESCRIPTION
## Related Links

- Closes the two gaps `agents/agents_tests.md` records as open after naming the four test levels in the classical vocabulary (added in #384).
- Method selection follows Jorgensen, *Software Testing: A Craftsman's Approach*, 4th ed. — §5.4 worst-case testing, §10.5 and Table 10.13 for choosing by variable attributes.
- Targets: `mlsynth/utils/datautils.py::dataprep` and `mlsynth/utils/vanillasc_helpers/config.py`.

## What

- Added `mlsynth/tests/test_dataprep_worst_case.py` — the 125-cell boundary cross product, scored against a decision table.
- Added `mlsynth/tests/test_vanillasc_config_decision_table.py` — both cross-field rules of `VanillaSCConfig`, all rows.
- Removed a `# pragma: no cover - passthrough` from `VanillaSC.__init__`.

## Why

The four levels are all single-fault: each varies one input to a boundary and holds the others nominal. That is what makes them affordable — `4n + 1` cases instead of `5^n` — and it is sound when failures arise from one variable being extreme.

`dataprep`'s inputs are not independent. One unit means no donors, a treatment date of zero means no pre-periods, and a panel can be both at once. Which error a caller sees then depends on a precedence between checks that no single-fault test can reach, because no single-fault test ever makes two conditions true together.

Config validators are the other half. Their conditions are dependent, which Table 10.13 routes straight to decision tables, and `VanillaSCConfig` has the most cross-field rules in the library.

## How

Worst-case testing takes `min`, `min+`, `nom`, `max-`, `max` on each of the three panel-shape inputs and tests the cross product. The expected outcome is a decision table whose content is the precedence:

| condition (first that holds) | outcome |
| --- | --- |
| no treated observations | `MlsynthDataError` — "No treated units" |
| exactly one unit | `MlsynthDataError` — "No donor units" |
| treatment from period zero | `MlsynthDataError` — "pre-treatment" |
| otherwise | a valid contract, `pre == treat_start` |

A guard test asserts the grid still reaches every row, since a cross product that drifts until some rule is never exercised is an expensive smoke test.

For the config, `w_constr` clashes with four other options: 16 combinations that must raise and name *every* clash that holds, and 16 more with `w_constr` absent that must all construct. The control half is what makes the rule a statement about `w_constr` and not about the four options individually. `bias_correct` against `covariates` is a second, four-row table.

## Verification

- Path: not applicable — tests plus one `# pragma` removal; no numerical code changes and no pinned benchmark value moves.
- 170 tests added; `pytest mlsynth/tests/ -k "vanillasc or datautils or dataprep"` — 249 passed, 1 skipped.

The precedence is the finding. A one-unit panel treated from the first period violates the donor rule and the pre-period rule simultaneously and reports only the donor one, so a caller who fixes what the message names is sent back for a second round. That is pinned as behaviour so reordering the checks becomes a visible change, not silently altered.

Mutation-audited. The mutant that earns the multiple-fault half is a validator that stops at the first clash: it passes every single-fault test and fails ten of these. Dropping the `oracle_weights` clash fails eight; dropping the bias-correction rule fails two.

## Scope checks

None of the four blocks fits cleanly — this is test authoring plus one coverage-pragma removal. The `# pragma: no cover - passthrough` sat on the arm of `VanillaSC.__init__` that translates pydantic's `ValidationError` into `MlsynthConfigError`. That arm is reachable from any invalid dict config, so it is behaviour and not a defensive branch; tests now exercise it and `coverage json` confirms both lines execute.

## Designs

No visual output.

## Test Steps

- [x] `pytest mlsynth/tests/test_dataprep_worst_case.py -q` — 130 passed
- [x] `pytest mlsynth/tests/test_vanillasc_config_decision_table.py -q` — 40 passed
- [x] `pytest mlsynth/tests/ -k "vanillasc or datautils or dataprep"` — 249 passed, 1 skipped
- [x] `coverage run --timid -m pytest mlsynth/tests/test_vanillasc_config_decision_table.py && coverage report` — the previously-pragma'd lines execute
- [ ] `python benchmarks/run_benchmarks.py --all` — not run; no benchmark case changes

## Other Notes

- The worst-case grid is 125 cells and runs in about five seconds, because `dataprep` is cheap. The same technique on an estimator's `fit()` would not be, so this is not a pattern to apply everywhere — apply it where the inputs genuinely interact.
- `VanillaSCConfig` has nine validators; two are cross-field and are tabled here. The remaining seven are single-field and already covered by the existing suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbWZFe1K2ewxJ4RMgEf5Zb)_