### PR TITLE
Label SDIDGEO's validation for what it is

### DIFF
--- a/benchmarks/cases/sdidgeo_mc.py
+++ b/benchmarks/cases/sdidgeo_mc.py
@@ -1,4 +1,22 @@
-"""SDIDGEO Path B: does the design's minimum detectable effect mean what it says?
+"""SDIDGEO design calibration: does the minimum detectable effect mean what it says?
+
+This is not a replication. SDIDGEO is an original construction -- GeoLift's
+market-selection loop with Arkhangelsky et al.'s estimator doing the scoring --
+and no paper publishes that pairing, so there is no empirical result to
+reproduce (Path A), no simulation table to match (Path B), and no reference
+implementation to agree with (cross-validation). The case imposes ground truth
+on a data-generating process defined here and asks whether SDIDGEO's own claim
+survives contact with it. That is weaker than a replication and is labelled as
+such.
+
+What external validation exists sits on either side of this case, not in it.
+The engine is cross-validated: ``sdid_prop99`` against the authors' synthdid R,
+``sdid_euets`` and ``sdid_ddd_hpv`` against Stata ``sdid``. The nomination stage
+is estimator-independent -- correlation ranking and anchor-plus-neighbours do
+not depend on what scores the candidates -- so it can be checked against live R
+``GeoLiftMarketSelection`` on ``basedata/geolift_test_data.csv``; that case is
+not yet written. What remains is the composition, and the composition is what
+this case measures.
 
 SDIDGEO's output is a falsifiable claim -- "region R detects a lift of size m
 with probability ``power_threshold`` at level ``alpha``" -- estimated by

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -25,7 +25,7 @@ CASES = {
     "spsydid_state_mc": "benchmarks.cases.spsydid_state_mc",  # cross-val vs authors' repo
     "spsydid_lawa_diff": "benchmarks.cases.spsydid_lawa_diff",  # differential cross-val vs authors' functions_ssdid on the real Arizona LAWA CPS panel (SpSyDiD.fit() ATT + spillover agree to solver tolerance under canonical convention)
     "seq_sdid_mc": "benchmarks.cases.seq_sdid_mc",
-    "sdidgeo_mc": "benchmarks.cases.sdidgeo_mc",              # Path B: SDIDGEO design calibration on a known factor DGP -- size at the null, out-of-sample power at the reported MDE, and the shallow-lookback MDE bias            # Path B: SSDiD vs DiD coverage/RMSE
+    "sdidgeo_mc": "benchmarks.cases.sdidgeo_mc",              # design calibration (original method, no external referent): size at the null, out-of-sample power at the reported MDE, and the winner's-curse gap on the selected region
     "clustersc_subgroups": "benchmarks.cases.clustersc_subgroups",      # Path B: ClusterSC vs RSC
     "clustersc_subgroups_ref": "benchmarks.cases.clustersc_subgroups_ref",  # cross-val vs authors' repo
     "clustersc_rpca_germany": "benchmarks.cases.clustersc_rpca_germany",  # cross-val vs Bayani's RPCA-SC code (West Germany reunification, value-for-value)

--- a/docs/replications/sdidgeo.rst
+++ b/docs/replications/sdidgeo.rst
@@ -9,8 +9,26 @@ transfers to an experiment that has not happened yet is a separate
 question, and it cannot be answered on the panel the design was fit on,
 because the backtests reuse those very periods.
 
-Path B, on a constructed data-generating process. The case is
-`benchmarks/cases/sdidgeo_mc.py
+This page is not a replication, and the distinction matters for how the
+numbers below should be read. SDIDGEO is an original construction:
+GeoLift's market-selection loop with Arkhangelsky et al.'s estimator
+doing the scoring. No paper publishes that pairing, so there is no
+empirical result to reproduce, no simulation table to match, and no
+reference implementation to agree with. What follows imposes ground
+truth on a data-generating process defined in the case itself and asks
+whether SDIDGEO's own claim survives it.
+
+The external validation SDIDGEO does have sits on either side of this
+study. The engine is cross-validated against the authors' ``synthdid``
+R package on Proposition 99 (:doc:`sdid`) and against Stata ``sdid`` on
+the EU ETS panel (:doc:`sdid_euets`). The nomination stage is
+estimator-independent -- correlation ranking and anchor-plus-neighbours
+do not depend on what scores the candidates -- so it can be checked
+against live R ``GeoLiftMarketSelection`` on the GeoLift walkthrough
+panel; that case is not yet written. Neither covers the composition,
+which is what this study measures.
+
+The case is `benchmarks/cases/sdidgeo_mc.py
 <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/sdidgeo_mc.py>`_.
 
 Design
@@ -67,7 +85,7 @@ At a backtest count of 16 the design's claim holds out of sample: it
 promises 0.80 and delivers 0.77, on periods it never saw.
 
 The winner's curse on the selected region
-----------------------------------------
+-----------------------------------------
 
 The design reports the smallest MDE in a field of candidates, and the
 smallest of many noisy estimates is optimistic. Sweeping the backtests
@@ -123,9 +141,9 @@ Size sits above nominal
 The realized size of 0.135 exceeds the nominal 0.10, and the benchmark
 pins the realized value. The placebo draws reassign two of 28 donors per
 draw, so they overlap heavily and the resulting standard error is
-slightly optimistic. This is recorded and not tuned away: it is a
-property of the placebo procedure on a thin donor pool, and it is the
-same caution the estimator's fifth assumption states. A design with a
-donor pool comfortably larger than its test region will not see it as
-sharply. Pinning 0.135 with a band of 0.055 means a regression that
+slightly optimistic. This is a property of the placebo procedure on a
+thin donor pool, and it is the same caution the estimator's fifth
+assumption states. A design with a donor pool comfortably larger than
+its test region will not see it as sharply. Pinning 0.135 with a band
+of 0.055 means a regression that
 pushed size to 0.20 fails here.

--- a/docs/sdidgeo.rst
+++ b/docs/sdidgeo.rst
@@ -312,11 +312,36 @@ window. The two structural properties the effect sweep relies on are
 checked against brute-force recomputation in the same file, so the
 shortcut is proved and not assumed.
 
-A durable benchmark case is not yet attached. Ranking a design against an
-external reference needs known ground truth, since no published
-implementation pairs synthetic DiD with GeoLift's market-selection loop;
-the natural route is a Path B simulation that injects a known lift and
-scores recovery.
+No published implementation pairs synthetic DiD with GeoLift's
+market-selection loop, so SDIDGEO has no replication path in the sense
+the other estimators do: nothing to reproduce, no simulation table to
+match, no reference to agree with. Its validation is assembled from
+three pieces instead, and they are not equally strong.
+
+The engine is cross-validated. mlsynth's synthetic DiD matches the
+authors' ``synthdid`` R package on Proposition 99 and Stata ``sdid`` on
+the EU ETS panel, and ``tests/test_sdidgeo.py`` asserts that the ATT
+SDIDGEO scores a backtest with matches ``SDID(...).fit()`` on the same
+panel and window. The two structural properties the effect sweep relies
+on are checked against brute-force recomputation in the same file, so
+the shortcut is proved and not assumed.
+
+The nomination stage could be cross-validated and is not yet. Which
+candidate regions get nominated depends on correlation ranking and
+anchor-plus-neighbours, not on what scores them, so the stage is
+estimator-independent and comparable against live R
+``GeoLiftMarketSelection`` on ``basedata/geolift_test_data.csv``. That
+case is not written.
+
+The composition is self-validated. Whether an MDE from SDID-scored
+backtests means what it claims has no external referent, so
+`benchmarks/cases/sdidgeo_mc.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/sdidgeo_mc.py>`_
+imposes ground truth on a constructed factor DGP and measures size at
+the null, out-of-sample power at the reported MDE, and the gap between
+the selected winner's MDE and a region fixed in advance. See
+:doc:`replications/sdidgeo`. This is the weakest of the three, because
+the DGP and the claim come from the same place.
 
 Core API
 --------


### PR DESCRIPTION
## Related Links

- Docs: `docs/sdidgeo.rst`, `docs/replications/sdidgeo.rst`, `benchmarks/cases/sdidgeo_mc.py`
- The case this relabels was added in #373

## What

- Relabelled `benchmarks/cases/sdidgeo_mc.py` and its docs page from "Path B" to a design calibration study
- Stated the validation decomposition explicitly on both pages
- Corrected `docs/sdidgeo.rst`, which still said no benchmark case was attached
- Removed a duplicated registry comment left by a sed
- Fixed a heading underline one character short of its title

## Why

The case called itself Path B. The contract defines Path B as the paper's Monte
Carlo table, and SDIDGEO has no paper: it pairs GeoLift's market-selection loop
with Arkhangelsky et al.'s estimator, and nobody publishes that combination.
There is no empirical result to reproduce, no table to match, and no reference
implementation to agree with. The case imposes ground truth on a DGP defined in
the case itself and checks our own claim against it, which is weaker than a
replication and should say so.

## How

The validation SDIDGEO does have decomposes into three pieces of unequal
strength, and both pages now state which is which:

- the engine is cross-validated against the authors' `synthdid` R package on
  Proposition 99 and Stata `sdid` on the EU ETS panel;
- the nomination stage is estimator-independent, so it is comparable against
  live R `GeoLiftMarketSelection` on the walkthrough panel — that case is not
  written;
- the composition has no external referent, and the calibration study covers it.

## Verification

- Path: not applicable. No numerical code changes; this corrects how existing
  numbers are labelled.
- The pinned quantities are untouched: the case still imports with all 15
  `EXPECTED` entries, and `mlsynth/tests/test_benchmark_reference.py` passes
  (21 tests).
- Neither sphinx nor docutils is installed in this environment, so the RST was
  checked by script — heading underline lengths, line lengths, absence of bold
  in prose, and the banned-word sweep from `CLAUDE.md`. The changes are prose
  and one comment, so the residual risk is rendering, not behaviour.

## Scope checks

Docs and labelling only — none of the four blocks applies.

## Test Steps

- [x] `pytest mlsynth/tests/test_benchmark_reference.py -q` — 21 passed
- [x] Case imports; `EXPECTED` unchanged at 15 entries
- [x] Section underlines at least as long as their titles (checked by script)
- [ ] Docs build — sphinx unavailable here

## Other Notes

The nomination cross-check against live R is the piece that would earn a real
cross-validation label. It needs either R in the environment or R's
`BestMarkets` output vendored: the existing reference bundle stores only
rank/investment/MDE values from the augsynth-scored run, with no market names,
so the nominated candidate set is not recoverable from it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_