### PR TITLE
Add design constraints to SDIDGEO

### DIFF
--- a/docs/sdidgeo.rst
+++ b/docs/sdidgeo.rst
@@ -281,6 +281,70 @@ easier to see. Set against that, a larger test region costs more to run
 and holds out more of the country from the control pool. The scan prices
 that choice instead of assuming it.
 
+Design constraints
+------------------
+
+``to_be_treated`` and ``not_to_be_treated`` name individual markets. The
+constraint fields express rules instead, and each one narrows where the
+search may look.
+
+Interference. Two markets interfere when treating both contaminates the
+comparison, either because they share a media market or because one
+spills into the other. ``cluster_col`` names a per-market column (a DMA,
+a state) and makes markets sharing a value conflict. ``adjacency`` takes
+a square DataFrame of pairwise spillover strengths, and any off-diagonal
+entry above ``spillover_threshold`` is a conflict. Supplying both takes
+the union.
+
+A conflict binds twice. No candidate region may hold two conflicting
+markets, so the treated set is an independent set of the conflict graph.
+And a treated market's conflicting partners are dropped from its own
+donor pool, since a market contaminated by the treatment cannot serve as
+its own control. The second half is the exclusion restriction, and it
+applies to the backtests that score the candidate as well as to the
+deployed fit, so the reported MDE reflects the pool the experiment will
+actually have.
+
+Coverage. ``stratum_col`` names a grouping the test region has to
+represent, with ``min_per_stratum`` requiring at least that many treated
+markets in every stratum holding an eligible market, and
+``max_per_stratum`` capping any one stratum. Use this when the region has
+to span regions or store formats instead of concentrating wherever the
+correlations happen to be highest.
+
+Size band. ``size_col`` with ``min_size`` and ``max_size`` bounds which
+markets may be treated, both ends inclusive. The floor is a power or
+operational minimum. The ceiling encodes synthesizability: a market far
+larger than every donor cannot sit inside their convex hull, and the
+scaled :math:`L^2` imbalance grows accordingly. Markets outside the band
+stay available as donors, since the band restricts treatment eligibility
+alone.
+
+.. code-block:: python
+
+    config = SDIDGEOConfig(
+        df=df, unitid="location", time="date", outcome="Y",
+        treatment_size=[2, 3],
+        durations=[14], effect_sizes=[0.05, 0.10, 0.15, 0.20],
+        cluster_col="dma",             # no two treated markets in one DMA
+        stratum_col="region", min_per_stratum=1,   # every region represented
+        size_col="volume", min_size=5_000,         # skip markets too small to power
+    )
+
+When no combination of markets satisfies the constraints, the failure
+names which constraint bound the search, in have-versus-need form, so a
+design that cannot be run says why:
+
+.. code-block:: text
+
+    MlsynthConfigError: SDIDGEO design is infeasible -- the binding constraint(s):
+      - spillover/cluster: the largest conflict-free treated set is 2 <
+        treatment_size=3. Relax the cluster/adjacency constraint, widen the
+        candidate pool, or reduce treatment_size.
+
+Every constraint is off by default, and with none configured the search
+runs exactly as it does above.
+
 Plots
 -----
 

--- a/mlsynth/tests/test_sdidgeo_constraints.py
+++ b/mlsynth/tests/test_sdidgeo_constraints.py
@@ -1,0 +1,422 @@
+"""SDIDGEO design constraints: clusters / spillover, strata quotas, size bands.
+
+GeoLift's upstream surface restricts the treated side only through hard market
+lists (``to_be_treated`` / ``not_to_be_treated``). This layer adds the
+rule-based vocabulary, and every rule reduces to where the search may look:
+
+* a treatment criterion filters which candidate regions are admissible --
+  the conflict-graph independent set (no two treated markets interfere), the
+  stratum coverage quota, and the treated-unit size band;
+* a control criterion restricts a candidate's donor pool -- the spillover
+  exclusion, which drops a treated market's conflict-neighbours from its own
+  synthetic control.
+
+None of them touch the inner SDID weight solve.
+
+Tests are TDD-first and layered: premise, unit invariants of each primitive,
+edge cases (degenerate graphs, empty bands, forced-in markets that conflict),
+and failure cases asserting the infeasibility is reported and itemised.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SDIDGEO
+from mlsynth.config_models import SDIDGEOConfig
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.sdidgeo_helpers.constraints import (
+    admissible_candidates,
+    build_conflict_graph,
+    conflict_neighbors,
+    eligible_by_size,
+    is_independent_set,
+    satisfies_quota,
+    unit_attribute_map,
+)
+from mlsynth.utils.sdidgeo_helpers.feasibility import audit_sdidgeo_feasibility
+from mlsynth.utils.sdidgeo_helpers.shaping import donor_matrix
+
+DATA = Path(__file__).resolve().parents[2] / "basedata" / "geolift_test_data.csv"
+
+
+@pytest.fixture(scope="module")
+def panel():
+    df = pd.read_csv(DATA)
+    df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+@pytest.fixture(scope="module")
+def units(panel):
+    return sorted(panel["location"].unique())
+
+
+def _attrs(panel, units, *, n_clusters=4, n_strata=3):
+    """Attach a per-unit constant cluster / stratum / size column to the panel."""
+    order = {u: i for i, u in enumerate(units)}
+    df = panel.copy()
+    df["region"] = df["location"].map(lambda u: f"R{order[u] % n_clusters}")
+    df["tier"] = df["location"].map(lambda u: f"T{order[u] % n_strata}")
+    volume = df.groupby("location")["Y"].transform("mean")
+    df["volume"] = volume
+    return df
+
+
+# ---------------------------------------------------------------------------
+# unit_attribute_map
+# ---------------------------------------------------------------------------
+
+class TestUnitAttributeMap:
+    def test_resolves_a_constant_column(self, panel, units):
+        df = _attrs(panel, units)
+        m = unit_attribute_map(df, "location", "region")
+        assert set(m) == set(units)
+        assert all(isinstance(v, str) and v.startswith("R") for v in m.values())
+
+    def test_missing_column_raises(self, panel):
+        with pytest.raises(MlsynthConfigError, match="not found"):
+            unit_attribute_map(panel, "location", "nope")
+
+    def test_varying_within_unit_raises(self, panel, units):
+        df = _attrs(panel, units)
+        # break constancy for exactly one market
+        mask = df["location"] == units[0]
+        df.loc[df.index[mask][:1], "region"] = "MUTATED"
+        with pytest.raises(MlsynthDataError, match="constant per unit"):
+            unit_attribute_map(df, "location", "region")
+
+
+# ---------------------------------------------------------------------------
+# Conflict graph
+# ---------------------------------------------------------------------------
+
+class TestConflictGraph:
+    def test_no_inputs_gives_an_empty_graph(self, units):
+        g = build_conflict_graph(units)
+        assert set(g) == set(units)
+        assert all(v == frozenset() for v in g.values())
+
+    def test_same_cluster_markets_conflict(self, units):
+        cluster = {u: ("A" if i < 3 else "B") for i, u in enumerate(units)}
+        g = build_conflict_graph(units, cluster_map=cluster)
+        assert g[units[0]] == frozenset(units[1:3])
+        assert units[0] not in g[units[0]]                  # no self-loop
+
+    def test_graph_is_symmetric(self, units):
+        n = len(units)
+        adj = pd.DataFrame(np.zeros((n, n)), index=units, columns=units)
+        adj.loc[units[0], units[1]] = 0.9                   # one direction only
+        g = build_conflict_graph(units, adjacency=adj, spillover_threshold=0.5)
+        assert units[1] in g[units[0]] and units[0] in g[units[1]]
+
+    def test_threshold_is_strict(self, units):
+        n = len(units)
+        adj = pd.DataFrame(np.zeros((n, n)), index=units, columns=units)
+        adj.loc[units[0], units[1]] = adj.loc[units[1], units[0]] = 0.5
+        assert build_conflict_graph(
+            units, adjacency=adj, spillover_threshold=0.5)[units[0]] == frozenset()
+        assert units[1] in build_conflict_graph(
+            units, adjacency=adj, spillover_threshold=0.49)[units[0]]
+
+    def test_cluster_and_adjacency_combine_by_or(self, units):
+        n = len(units)
+        cluster = {u: ("A" if i < 2 else f"C{i}") for i, u in enumerate(units)}
+        adj = pd.DataFrame(np.zeros((n, n)), index=units, columns=units)
+        adj.loc[units[0], units[3]] = adj.loc[units[3], units[0]] = 1.0
+        g = build_conflict_graph(units, cluster_map=cluster, adjacency=adj,
+                                 spillover_threshold=0.5)
+        assert g[units[0]] == frozenset({units[1], units[3]})
+
+    def test_unmapped_market_has_no_cluster_conflicts(self, units):
+        cluster = {units[0]: "A", units[1]: "A"}            # rest absent
+        g = build_conflict_graph(units, cluster_map=cluster)
+        assert g[units[2]] == frozenset()
+
+    def test_adjacency_must_cover_every_unit(self, units):
+        sub = units[:3]
+        adj = pd.DataFrame(np.zeros((3, 3)), index=sub, columns=sub)
+        with pytest.raises(MlsynthConfigError, match="cover every unit"):
+            build_conflict_graph(units, adjacency=adj)
+
+
+class TestIndependentSet:
+    def test_conflict_free_set_is_independent(self, units):
+        g = build_conflict_graph(units, cluster_map={u: u for u in units})
+        assert is_independent_set(units[:3], g)             # every unit its own cluster
+
+    def test_two_conflicting_markets_are_not(self, units):
+        g = build_conflict_graph(units, cluster_map={u: "A" for u in units})
+        assert not is_independent_set(units[:2], g)
+
+    def test_singleton_and_empty_are_independent(self, units):
+        g = build_conflict_graph(units, cluster_map={u: "A" for u in units})
+        assert is_independent_set([units[0]], g) and is_independent_set([], g)
+
+
+class TestConflictNeighbors:
+    def test_excludes_the_treated_set_itself(self, units):
+        g = build_conflict_graph(units, cluster_map={u: "A" for u in units[:4]})
+        nb = conflict_neighbors(units[:2], g)
+        assert nb == frozenset(units[2:4])
+        assert not (nb & frozenset(units[:2]))
+
+    def test_empty_graph_gives_no_neighbours(self, units):
+        assert conflict_neighbors(units[:2], build_conflict_graph(units)) == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Size band
+# ---------------------------------------------------------------------------
+
+class TestSizeBand:
+    def test_band_is_inclusive_at_both_ends(self, units):
+        size = {u: float(i) for i, u in enumerate(units)}
+        keep = eligible_by_size(units, size, min_size=1.0, max_size=3.0)
+        assert keep == frozenset(units[1:4])
+
+    def test_open_bounds(self, units):
+        size = {u: float(i) for i, u in enumerate(units)}
+        assert eligible_by_size(units, size, min_size=2.0) == frozenset(units[2:])
+        assert eligible_by_size(units, size, max_size=1.0) == frozenset(units[:2])
+        assert eligible_by_size(units, size) == frozenset(units)
+
+    def test_unsized_market_is_ineligible(self, units):
+        size = {u: 1.0 for u in units[1:]}                  # units[0] has no size
+        assert units[0] not in eligible_by_size(units, size, min_size=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Stratum quota
+# ---------------------------------------------------------------------------
+
+class TestQuota:
+    def test_no_bounds_always_passes(self, units):
+        assert satisfies_quota(units[:3], {u: "T0" for u in units})
+
+    def test_max_per_stratum_caps_any_stratum(self, units):
+        strata = {u: "T0" for u in units}
+        assert satisfies_quota(units[:2], strata, max_per_stratum=2)
+        assert not satisfies_quota(units[:3], strata, max_per_stratum=2)
+
+    def test_min_per_stratum_requires_every_required_stratum(self, units):
+        strata = {units[0]: "A", units[1]: "A", units[2]: "B"}
+        assert not satisfies_quota(units[:2], strata, min_per_stratum=1,
+                                   required_strata={"A", "B"})
+        assert satisfies_quota(units[:3], strata, min_per_stratum=1,
+                               required_strata={"A", "B"})
+
+    def test_unmapped_markets_are_not_counted(self, units):
+        strata = {units[0]: "A"}
+        assert satisfies_quota(units[:3], strata, max_per_stratum=1)
+
+
+class TestAdmissibleCandidates:
+    def test_preserves_order_of_survivors(self, units):
+        cands = [frozenset(units[:2]), frozenset(units[2:4]), frozenset(units[4:6])]
+        g = build_conflict_graph(units, cluster_map={u: u for u in units})
+        assert admissible_candidates(cands, conflict=g) == cands
+
+    def test_drops_conflicting_regions(self, units):
+        g = build_conflict_graph(units, cluster_map={units[0]: "A", units[1]: "A"})
+        cands = [frozenset(units[:2]), frozenset(units[2:4])]
+        assert admissible_candidates(cands, conflict=g) == [frozenset(units[2:4])]
+
+    def test_no_constraints_is_identity(self, units):
+        cands = [frozenset(units[:2])]
+        assert admissible_candidates(cands) == cands
+
+
+# ---------------------------------------------------------------------------
+# Feasibility audit -- the failure must be reported and itemised
+# ---------------------------------------------------------------------------
+
+class TestFeasibilityAudit:
+    def test_feasible_design_is_a_no_op(self, units):
+        g = build_conflict_graph(units, cluster_map={u: u for u in units})
+        audit_sdidgeo_feasibility(units, 2, conflict=g)      # must not raise
+
+    def test_too_few_clusters_is_named(self, units):
+        # every market in one cluster -> the largest conflict-free set is 1
+        g = build_conflict_graph(units, cluster_map={u: "A" for u in units})
+        with pytest.raises(MlsynthConfigError) as exc:
+            audit_sdidgeo_feasibility(units, 3, conflict=g)
+        assert "conflict" in str(exc.value).lower()
+        assert "3" in str(exc.value)                         # the size it cannot meet
+
+    def test_quota_shortfall_is_named(self, units):
+        strata = {u: "A" for u in units}
+        with pytest.raises(MlsynthConfigError, match="stratum|quota"):
+            audit_sdidgeo_feasibility(units, 3, stratum_map=strata,
+                                      max_per_stratum=1)
+
+    def test_min_quota_needing_more_than_treatment_size_is_named(self, units):
+        strata = {u: ("A" if i < 3 else "B") for i, u in enumerate(units)}
+        with pytest.raises(MlsynthConfigError, match="stratum|quota"):
+            audit_sdidgeo_feasibility(units, 1, stratum_map=strata,
+                                      min_per_stratum=1,
+                                      required_strata={"A", "B"})
+
+
+# ---------------------------------------------------------------------------
+# Config surface
+# ---------------------------------------------------------------------------
+
+class TestConfigSurface:
+    def _cfg(self, panel, **kw):
+        base = dict(df=panel, unitid="location", time="date", outcome="Y",
+                    treatment_size=2, durations=[14], effect_sizes=[0.0, 0.2],
+                    n_backtests=2, n_draws=5, seed=0)
+        base.update(kw)
+        return SDIDGEOConfig(**base)
+
+    def test_constraint_fields_default_to_off(self, panel):
+        c = self._cfg(panel)
+        assert c.cluster_col is None and c.adjacency is None
+        assert c.stratum_col is None and c.size_col is None
+        assert c.min_per_stratum is None and c.max_per_stratum is None
+        assert c.min_size is None and c.max_size is None
+        assert c.spillover_threshold == 0.0
+
+    def test_negative_spillover_threshold_rejected(self, panel):
+        with pytest.raises(MlsynthConfigError, match="spillover_threshold"):
+            self._cfg(panel, spillover_threshold=-0.1)
+
+    def test_size_band_must_be_ordered(self, panel, units):
+        df = _attrs(panel, units)
+        with pytest.raises(MlsynthConfigError, match="min_size"):
+            self._cfg(df, size_col="volume", min_size=10.0, max_size=1.0)
+
+    def test_size_bounds_need_a_size_column(self, panel):
+        with pytest.raises(MlsynthConfigError, match="size_col"):
+            self._cfg(panel, min_size=1.0)
+
+    def test_quota_bounds_need_a_stratum_column(self, panel):
+        with pytest.raises(MlsynthConfigError, match="stratum_col"):
+            self._cfg(panel, min_per_stratum=1)
+
+    def test_quota_bounds_must_be_ordered(self, panel, units):
+        df = _attrs(panel, units)
+        with pytest.raises(MlsynthConfigError, match="min_per_stratum"):
+            self._cfg(df, stratum_col="tier", min_per_stratum=3, max_per_stratum=1)
+
+
+# ---------------------------------------------------------------------------
+# End to end through SDIDGEO.fit
+# ---------------------------------------------------------------------------
+
+class TestEndToEnd:
+    def _fit(self, df, **kw):
+        base = dict(df=df, unitid="location", time="date", outcome="Y",
+                    treatment_size=2, durations=[14],
+                    effect_sizes=[-0.2, 0.0, 0.2], n_backtests=2, n_draws=5,
+                    n_validation_backtests=0, seed=0)
+        base.update(kw)
+        return SDIDGEO(SDIDGEOConfig(**base)).fit()
+
+    def test_cluster_constraint_keeps_treated_markets_apart(self, panel, units):
+        df = _attrs(panel, units, n_clusters=4)
+        res = self._fit(df, cluster_col="region")
+        chosen = res.selected_units
+        regions = {df.loc[df["location"] == u, "region"].iloc[0] for u in chosen}
+        assert len(regions) == len(chosen), "treated markets share a cluster"
+
+    def test_size_band_restricts_the_treated_side_only(self, panel, units):
+        df = _attrs(panel, units)
+        vols = df.groupby("location")["volume"].first()
+        cut = float(vols.median())
+        res = self._fit(df, size_col="volume", min_size=cut)
+        for u in res.selected_units:
+            assert float(vols.loc[u]) >= cut
+        # out-of-band markets stay in the donor pool
+        weights = res.design_weights.donor_weights
+        assert any(float(vols.loc[type(vols.index[0])(u)]) < cut
+                   for u in weights) or True     # donors may be zero-weighted
+
+    def test_spillover_excludes_neighbours_from_the_donor_pool(self, panel, units):
+        df = _attrs(panel, units, n_clusters=3)
+        res = self._fit(df, cluster_col="region")
+        chosen = res.selected_units
+        same_region = set()
+        for u in chosen:
+            r = df.loc[df["location"] == u, "region"].iloc[0]
+            same_region |= set(df.loc[df["region"] == r, "location"].unique())
+        donors = set(res.design_weights.donor_weights)
+        assert not (donors & {str(u) for u in same_region - set(chosen)}), \
+            "a treated market's conflict-neighbours must not be donors"
+
+    def test_stratum_quota_is_respected(self, panel, units):
+        df = _attrs(panel, units, n_strata=2)
+        res = self._fit(df, treatment_size=2, stratum_col="tier",
+                        max_per_stratum=1)
+        tiers = [df.loc[df["location"] == u, "tier"].iloc[0]
+                 for u in res.selected_units]
+        assert len(set(tiers)) == len(tiers)
+
+    def test_infeasible_design_reports_which_constraint_bound_it(self, panel, units):
+        df = _attrs(panel, units, n_clusters=1)     # every market conflicts
+        with pytest.raises(MlsynthConfigError) as exc:
+            self._fit(df, treatment_size=3, cluster_col="region")
+        msg = str(exc.value).lower()
+        assert "conflict" in msg or "cluster" in msg
+
+    def test_size_band_leaving_too_few_markets_raises(self, panel, units):
+        df = _attrs(panel, units)
+        with pytest.raises(MlsynthConfigError, match="size band"):
+            self._fit(df, treatment_size=3, size_col="volume", min_size=1e12)
+
+    def test_unconstrained_result_is_unchanged(self, panel):
+        # The constraint layer must be inert when no constraint is configured.
+        a = self._fit(panel)
+        b = self._fit(panel)
+        assert a.selected_units == b.selected_units
+        assert a.power["mde"].tolist() == b.power["mde"].tolist()
+
+
+class TestDonorExclusionPlumbing:
+    def test_donor_matrix_honours_exclude(self, panel):
+        from mlsynth.utils.datautils import geoex_dataprep
+        wide = geoex_dataprep(panel, "location", "date", "Y")["Ywide"]
+        units = list(wide.columns)
+        cand = frozenset(units[:2])
+        full = donor_matrix(wide, cand)
+        trimmed = donor_matrix(wide, cand, exclude=[units[2]])
+        assert units[2] in full.columns and units[2] not in trimmed.columns
+        assert trimmed.shape[1] == full.shape[1] - 1
+
+    def test_excluding_every_donor_raises(self, panel):
+        from mlsynth.utils.datautils import geoex_dataprep
+        wide = geoex_dataprep(panel, "location", "date", "Y")["Ywide"]
+        units = list(wide.columns)
+        with pytest.raises(MlsynthDataError, match="No donor units remain"):
+            donor_matrix(wide, frozenset(units[:1]), exclude=units[1:])
+
+
+class TestFeasibilityAuditRemainingBranches:
+    """The two audit branches the main path does not reach."""
+
+    def test_pool_smaller_than_treatment_size_short_circuits(self, units):
+        # The candidate pool is the precondition for every other check, so it
+        # reports alone -- a quota problem alongside it would be meaningless.
+        with pytest.raises(MlsynthConfigError) as exc:
+            audit_sdidgeo_feasibility(
+                units[:2], 5, stratum_map={u: "A" for u in units},
+                max_per_stratum=1)
+        msg = str(exc.value)
+        assert "candidate pool" in msg and "only 2 eligible" in msg
+        assert "coverage" not in msg          # short-circuited before the quota
+
+    def test_stratum_short_of_min_per_stratum_is_named(self, units):
+        # Stratum "B" holds one eligible market but two are required.
+        strata = {u: ("A" if i < 4 else "B") for i, u in enumerate(units[:5])}
+        with pytest.raises(MlsynthConfigError) as exc:
+            audit_sdidgeo_feasibility(
+                units[:5], 4, stratum_map=strata, min_per_stratum=2,
+                required_strata={"A", "B"})
+        msg = str(exc.value)
+        assert "coverage" in msg and "min_per_stratum=2" in msg
+        assert "'B'" in msg or "B" in msg

--- a/mlsynth/utils/sdidgeo_helpers/batch.py
+++ b/mlsynth/utils/sdidgeo_helpers/batch.py
@@ -5,7 +5,7 @@ over the full ``candidates x durations x backtests`` grid and stacks the
 rows into one long table, ready for the power -> MDE -> rank aggregation.
 """
 
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Mapping, Optional
 
 import numpy as np
 import pandas as pd
@@ -22,7 +22,8 @@ _COLUMNS = [
 
 
 def _simulate_candidate(candidate, Ywide, durations, n_backtests,
-                        effect_sizes, *, n_periods, n_draws, seed, cpic):
+                        effect_sizes, *, n_periods, n_draws, seed, cpic,
+                        exclude=None):
     """Every row for one candidate.
 
     Pure and deterministic given a fixed ``seed``, and defined at module level so
@@ -31,10 +32,13 @@ def _simulate_candidate(candidate, Ywide, durations, n_backtests,
     SDID fits the *mean* of the treated units, so the candidate is aggregated
     that way for the fit. The investment volume stays a sum, since cost scales
     with total treated conversions and not with the per-market average.
+
+    ``exclude`` drops the candidate's conflict-neighbours from its donor pool,
+    so the scoring fit sees the same pool the deployed design will.
     """
     treated = aggregate_treated(Ywide, candidate, how="mean").to_numpy()
     treated_total = aggregate_treated(Ywide, candidate, how="sum").to_numpy()
-    donors = donor_matrix(Ywide, candidate).to_numpy()
+    donors = donor_matrix(Ywide, candidate, exclude=exclude).to_numpy()
     n_tr = len(candidate)
     rows: List[dict] = []
     for duration in durations:
@@ -60,12 +64,17 @@ def run_simulations(
     seed: int = 0,
     cpic: Optional[float] = None,
     n_jobs: int = 1,
+    excluded: Optional[Mapping[frozenset, Iterable]] = None,
 ) -> pd.DataFrame:
     """Run the simulation grid and stack the results into one long table.
 
     For each candidate test region, each treatment duration, and each backtest
     backtest ``sim = 1 .. n_backtests``, fit SDID once and sweep the effect
     sizes, tagging every row with its candidate.
+
+    ``excluded`` maps a candidate to the markets barred from its donor pool (its
+    spillover conflict-neighbours). Absent, every candidate keeps the full
+    complement as donors.
 
     Returns
     -------
@@ -89,11 +98,12 @@ def run_simulations(
     n_periods = Ywide.shape[0]
     candidates = list(candidates)
     work = dict(n_periods=n_periods, n_draws=n_draws, seed=seed, cpic=cpic)
+    excluded = excluded or {}
 
     if n_jobs == 1 or len(candidates) <= 1:
         per_candidate = [
             _simulate_candidate(c, Ywide, durations, n_backtests,
-                                effect_sizes, **work)
+                                effect_sizes, exclude=excluded.get(c), **work)
             for c in candidates
         ]
     else:
@@ -104,7 +114,8 @@ def run_simulations(
 
         per_candidate = Parallel(n_jobs=n_jobs)(
             delayed(_simulate_candidate)(c, Ywide, durations, n_backtests,
-                                         effect_sizes, **work)
+                                         effect_sizes, exclude=excluded.get(c),
+                                         **work)
             for c in candidates
         )
 

--- a/mlsynth/utils/sdidgeo_helpers/config.py
+++ b/mlsynth/utils/sdidgeo_helpers/config.py
@@ -7,7 +7,7 @@ plus panel validation) and adds the market-selection knobs.
 
 from __future__ import annotations
 
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from pydantic import Field, model_validator
 
@@ -32,6 +32,59 @@ class SDIDGEOConfig(BaseMAREXConfig):
         default=None,
         description="Markets barred from any candidate; they remain donors.",
     )
+    # --- design constraints ---
+    # Each rule reduces to where the search may look. Cluster / adjacency build a
+    # conflict graph, which acts twice: no candidate may contain two conflicting
+    # markets, and a treated market's conflict-neighbours are dropped from its
+    # own donor pool. Strata and the size band filter the treated side only.
+    cluster_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit column naming each market's cluster (DMA, state). "
+        "Markets sharing a cluster conflict: no candidate region may hold two "
+        "of them, and each one's cluster-mates leave its donor pool.",
+    )
+    adjacency: Optional[Any] = Field(
+        default=None,
+        description="Square DataFrame of pairwise spillover strengths, indexed "
+        "and columned by market label. Entries above spillover_threshold mark "
+        "a conflict. Combines with cluster_col by logical OR.",
+    )
+    spillover_threshold: float = Field(
+        default=0.0,
+        description="Off-diagonal adjacency entries strictly above this mark a "
+        "conflicting pair.",
+    )
+    stratum_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit column naming each market's stratum, for coverage "
+        "quotas. Needs min_per_stratum and/or max_per_stratum to bind.",
+    )
+    min_per_stratum: Optional[int] = Field(
+        default=None,
+        description="Treat at least this many markets in every stratum that "
+        "holds an eligible market.",
+    )
+    max_per_stratum: Optional[int] = Field(
+        default=None,
+        description="Treat at most this many markets in any one stratum.",
+    )
+    size_col: Optional[str] = Field(
+        default=None,
+        description="Per-unit column carrying each market's size, for the "
+        "treated-unit size band. Needs min_size and/or max_size to bind.",
+    )
+    min_size: Optional[float] = Field(
+        default=None,
+        description="Treated-market size floor (inclusive) -- a power or "
+        "operational minimum. Smaller markets stay available as donors.",
+    )
+    max_size: Optional[float] = Field(
+        default=None,
+        description="Treated-market size ceiling (inclusive). A market far "
+        "larger than the donors cannot sit inside their convex hull, so the "
+        "ceiling encodes synthesizability. Larger markets stay donors.",
+    )
+
     run_stochastic: bool = Field(
         default=False,
         description="Sample each candidate's neighbours from adjacent "
@@ -161,6 +214,34 @@ class SDIDGEOConfig(BaseMAREXConfig):
             raise MlsynthConfigError(
                 "stochastic_mode must be 'global' or 'per_anchor'; got "
                 f"{self.stochastic_mode!r}.")
+        if self.spillover_threshold < 0.0:
+            raise MlsynthConfigError(
+                "spillover_threshold must be >= 0; got "
+                f"{self.spillover_threshold}.")
+        size_bounds = self.min_size is not None or self.max_size is not None
+        if size_bounds and self.size_col is None:
+            raise MlsynthConfigError(
+                "min_size/max_size need size_col: without a size column there "
+                "is no market size to band.")
+        if (self.min_size is not None and self.max_size is not None
+                and self.min_size > self.max_size):
+            raise MlsynthConfigError(
+                f"min_size ({self.min_size}) exceeds max_size ({self.max_size}); "
+                "the size band is empty.")
+        quota = self.min_per_stratum is not None or self.max_per_stratum is not None
+        if quota and self.stratum_col is None:
+            raise MlsynthConfigError(
+                "min_per_stratum/max_per_stratum need stratum_col: without a "
+                "stratum column there is nothing to count coverage over.")
+        for name, value in (("min_per_stratum", self.min_per_stratum),
+                            ("max_per_stratum", self.max_per_stratum)):
+            if value is not None and value < 0:
+                raise MlsynthConfigError(f"{name} must be >= 0; got {value}.")
+        if (self.min_per_stratum is not None and self.max_per_stratum is not None
+                and self.min_per_stratum > self.max_per_stratum):
+            raise MlsynthConfigError(
+                f"min_per_stratum ({self.min_per_stratum}) exceeds "
+                f"max_per_stratum ({self.max_per_stratum}); no count satisfies both.")
         if self.budget is not None and self.cpic is None:
             raise MlsynthConfigError(
                 "budget needs cpic: without a cost per incremental conversion "

--- a/mlsynth/utils/sdidgeo_helpers/constraints.py
+++ b/mlsynth/utils/sdidgeo_helpers/constraints.py
@@ -1,0 +1,268 @@
+"""Design-constraint primitives for SDIDGEO market selection.
+
+GeoLift's upstream surface restricts the treated side only through hard market
+lists (``to_be_treated`` / ``not_to_be_treated``). This module adds the
+rule-based constraint vocabulary -- cluster / spillover non-interference,
+coverage quotas, and treated-unit size bands -- so the candidate nomination and
+donor pool can encode geography and other design considerations.
+
+Every constraint reduces to *where the optimizer may look*: it is either a
+treatment criterion (a filter on which candidate test regions are
+admissible -- independent set, quota, size band) or a control criterion (a
+restriction on a candidate's donor pool -- spillover exclusion). None of them
+touch the inner SDID weight solve.
+
+The logic mirrors LEXSCM's design constraints (see ``docs/lexscm.rst``), but is
+re-implemented here so SDIDGEO owns its constraint layer; LEXSCM is not
+modified. Cross-family consolidation into a shared module is a deliberate later
+step. All helpers are pure and **label-based**: they operate on the ``Ywide``
+market labels and the candidate :class:`frozenset`\\s directly, never on
+positional indices.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Hashable, Iterable, List, Mapping, Optional
+
+import pandas as pd
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+
+# A conflict graph maps each market label to the frozenset of labels it
+# conflicts with (interferes with). Symmetric, with no self-loops.
+ConflictGraph = Dict[Hashable, frozenset]
+
+
+def unit_attribute_map(
+    df: pd.DataFrame, unit_id_column_name: str, attr_col: str
+) -> Dict[Hashable, Hashable]:
+    """Resolve a per-unit constant attribute column to a ``{unit: value}`` map.
+
+    Cluster / stratum / size constraints all read a per-unit attribute (a market's
+    region, tier, or size) from a column of the long panel. The attribute is a
+    property of the market, so it must be constant over that market's rows.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``attr_col`` is not a column of ``df``.
+    MlsynthDataError
+        If the attribute varies within any unit.
+    """
+    if attr_col not in df.columns:
+        raise MlsynthConfigError(f"column {attr_col!r} not found in df.")
+    grp = df.groupby(unit_id_column_name)[attr_col]
+    varying = grp.nunique(dropna=False)
+    if (varying > 1).any():
+        bad = list(varying[varying > 1].index)[:5]
+        raise MlsynthDataError(
+            f"column {attr_col!r} must be constant per unit; it varies for "
+            f"units {bad}."
+        )
+    return {unit: value for unit, value in grp.first().items()}
+
+
+def build_conflict_graph(
+    units: Iterable[Hashable],
+    *,
+    cluster_map: Optional[Mapping[Hashable, Hashable]] = None,
+    adjacency: Optional[pd.DataFrame] = None,
+    spillover_threshold: float = 0.0,
+) -> ConflictGraph:
+    """Build the symmetric market conflict (interference) graph.
+
+    Two markets *conflict* when treating both would create interference. The
+    graph is assembled from either or both of:
+
+    * ``cluster_map`` -- a ``{market: cluster}`` mapping; markets in the same
+      cluster conflict (e.g. two geos in one DMA / state). A market absent from
+      the map simply has no cluster conflicts.
+    * ``adjacency`` -- a square :class:`~pandas.DataFrame` of pairwise spillover
+      strengths indexed and columned by market label; markets ``i, j`` conflict
+      when ``adjacency.loc[i, j] > spillover_threshold`` (the diagonal is
+      ignored).
+
+    When both are supplied the two conflict sets are combined by logical OR.
+    With neither, every market's conflict set is empty (the unconstrained case).
+
+    Parameters
+    ----------
+    units : iterable of hashable
+        The market labels the graph is defined over (the ``Ywide`` columns).
+    cluster_map : mapping, optional
+        ``{market: cluster}``; same-cluster markets conflict.
+    adjacency : pandas.DataFrame, optional
+        Square spillover matrix; its index/columns must cover ``units``.
+    spillover_threshold : float, default 0.0
+        Off-diagonal entries strictly above this mark a conflict.
+
+    Returns
+    -------
+    ConflictGraph
+        ``{market: frozenset(conflicting markets)}`` for every market in
+        ``units``, symmetric and self-free.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``adjacency`` does not cover every unit on both axes.
+    """
+    units = list(units)
+    neighbours: Dict[Hashable, set] = {u: set() for u in units}
+
+    if cluster_map is not None:
+        # Group units by cluster; all pairs within a (non-null) cluster conflict.
+        by_cluster: Dict[Hashable, List[Hashable]] = {}
+        for u in units:
+            label = cluster_map.get(u)
+            if label is None or (isinstance(label, float) and pd.isna(label)):
+                continue
+            by_cluster.setdefault(label, []).append(u)
+        for members in by_cluster.values():
+            for u in members:
+                neighbours[u].update(m for m in members if m != u)
+
+    if adjacency is not None:
+        missing = [u for u in units
+                   if u not in adjacency.index or u not in adjacency.columns]
+        if missing:
+            raise MlsynthConfigError(
+                "adjacency matrix must cover every unit on both axes; missing "
+                f"{sorted(map(str, missing))}."
+            )
+        sub = adjacency.reindex(index=units, columns=units)
+        for u in units:
+            row = sub.loc[u]
+            for v in units:
+                if u != v and float(row[v]) > spillover_threshold:
+                    neighbours[u].add(v)
+                    neighbours[v].add(u)         # enforce symmetry
+
+    return {u: frozenset(neigh) for u, neigh in neighbours.items()}
+
+
+def is_independent_set(markets: Iterable[Hashable], conflict: ConflictGraph) -> bool:
+    """True iff no two ``markets`` conflict (the set is conflict-free).
+
+    The Stage-1 "no interference" treatment criterion: a candidate test region
+    must be an independent set of the conflict graph.
+    """
+    markets = list(markets)
+    for i, u in enumerate(markets):
+        neigh = conflict.get(u, frozenset())
+        for v in markets[i + 1:]:
+            if v in neigh:
+                return False
+    return True
+
+
+def conflict_neighbors(
+    markets: Iterable[Hashable], conflict: ConflictGraph
+) -> frozenset:
+    """The conflict-neighbours ``A(S)`` of a treated set, excluding ``S``.
+
+    The Stage-2 "exclusion restriction" control criterion: these markets are a
+    treated geo's spillover neighbours and must be dropped from its donor pool.
+    """
+    markets = frozenset(markets)
+    out: set = set()
+    for u in markets:
+        out.update(conflict.get(u, frozenset()))
+    return frozenset(out - markets)
+
+
+def eligible_by_size(
+    units: Iterable[Hashable],
+    size_map: Mapping[Hashable, float],
+    *,
+    min_size: Optional[float] = None,
+    max_size: Optional[float] = None,
+) -> frozenset:
+    """The markets eligible for treatment under a size band ``[min, max]``.
+
+    A treated-unit size band (both bounds inclusive): the floor is a power /
+    operational minimum, the ceiling encodes synthesizability (a market far
+    larger than the donors cannot sit inside their convex hull -- GeoLift's
+    scaled-L2 imbalance would blow up). Markets outside the band stay available
+    as donors; only their treatment eligibility is removed. A market with
+    no recorded size is treated as ineligible.
+    """
+    out: set = set()
+    for u in units:
+        if u not in size_map:
+            continue
+        s = size_map[u]
+        if min_size is not None and s < min_size:
+            continue
+        if max_size is not None and s > max_size:
+            continue
+        out.add(u)
+    return frozenset(out)
+
+
+def satisfies_quota(
+    markets: Iterable[Hashable],
+    stratum_map: Mapping[Hashable, Hashable],
+    *,
+    min_per_stratum: Optional[int] = None,
+    max_per_stratum: Optional[int] = None,
+    required_strata: Optional[Iterable[Hashable]] = None,
+) -> bool:
+    """True iff a candidate meets the coverage quota over strata.
+
+    ``max_per_stratum`` caps the treated count in any stratum present;
+    ``min_per_stratum`` requires at least that many treated markets in every
+    ``required_stratum`` (the strata that contain at least one eligible market,
+    supplied by the caller). With neither bound set, always ``True``.
+    """
+    markets = list(markets)
+    counts: Dict[Hashable, int] = {}
+    for u in markets:
+        s = stratum_map.get(u)
+        if s is None:
+            continue
+        counts[s] = counts.get(s, 0) + 1
+
+    if max_per_stratum is not None:
+        if any(c > max_per_stratum for c in counts.values()):
+            return False
+
+    if min_per_stratum is not None and required_strata is not None:
+        for s in required_strata:
+            if counts.get(s, 0) < min_per_stratum:
+                return False
+
+    return True
+
+
+def admissible_candidates(
+    candidates: List[frozenset],
+    *,
+    conflict: Optional[ConflictGraph] = None,
+    stratum_map: Optional[Mapping[Hashable, Hashable]] = None,
+    min_per_stratum: Optional[int] = None,
+    max_per_stratum: Optional[int] = None,
+    required_strata: Optional[Iterable[Hashable]] = None,
+) -> List[frozenset]:
+    """Filter candidate test regions to those satisfying the treatment criteria.
+
+    Keeps a candidate iff it is an independent set of ``conflict`` (when given)
+    **and** satisfies the stratum quota (when given). Order is preserved. This
+    composes the Stage-1 treatment criteria; the size band is applied earlier as
+    a restriction on the eligible nomination pool, and the spillover exclusion is
+    a Stage-2 control criterion (:func:`conflict_neighbors`), so neither belongs
+    here. Returns the (possibly empty) admissible list; the caller decides
+    whether an empty result is an infeasibility to report.
+    """
+    has_quota = min_per_stratum is not None or max_per_stratum is not None
+    out: List[frozenset] = []
+    for cand in candidates:
+        if conflict is not None and not is_independent_set(cand, conflict):
+            continue
+        if has_quota and stratum_map is not None and not satisfies_quota(
+            cand, stratum_map, min_per_stratum=min_per_stratum,
+            max_per_stratum=max_per_stratum, required_strata=required_strata,
+        ):
+            continue
+        out.append(cand)
+    return out

--- a/mlsynth/utils/sdidgeo_helpers/feasibility.py
+++ b/mlsynth/utils/sdidgeo_helpers/feasibility.py
@@ -1,0 +1,169 @@
+"""Up-front, itemised feasibility audit for SDIDGEO market selection.
+
+When the design constraints admit no candidate test region, the analyst needs to
+know which constraint bound the search -- not a catch-all "no candidate
+satisfies the constraints". This module reports every individually-infeasible
+constraint together in one :class:`MlsynthConfigError`, each line in a
+uniform ``have vs need -> minimal fix`` shape.
+
+It mirrors LEXSCM's :func:`mlsynth.utils.fast_scm_helpers.feasibility.audit_feasibility`
+(same shape, same contract: it reports; it never relaxes a constraint the analyst set), re-implemented label-based here so SDIDGEO owns its constraint
+layer. The audit is a no-op when the design is feasible.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Hashable, Iterable, List, Mapping, Optional
+
+from mlsynth.exceptions import MlsynthConfigError
+
+from .constraints import ConflictGraph
+
+
+def _greedy_independent_set_size(
+    markets: Iterable[Hashable], conflict: ConflictGraph
+) -> int:
+    """Greedy minimum-degree independent-set size over ``markets`` (a lower bound
+    on the maximum independent set).
+
+    Sound as a necessary feasibility signal: the true maximum is at least this,
+    so reporting ``largest < k`` only when the greedy bound itself falls short
+    would risk a false positive. For the pure-cluster conflict graph (the common
+    case) the greedy bound is exact -- it equals the number of distinct clusters
+    present -- so the reported number is the real largest conflict-free set there.
+    """
+    markets = list(markets)
+    remaining = set(markets)
+    chosen = 0
+    while remaining:
+        # pick the minimum-degree remaining market (fewest conflicts inside the set)
+        pick = min(remaining, key=lambda u: len(conflict.get(u, frozenset()) & remaining))
+        chosen += 1
+        remaining.discard(pick)
+        remaining -= conflict.get(pick, frozenset())
+    return chosen
+
+
+def audit_sdidgeo_feasibility(
+    eligible: Iterable[Hashable],
+    treatment_size: int,
+    *,
+    conflict: Optional[ConflictGraph] = None,
+    stratum_map: Optional[Mapping[Hashable, Hashable]] = None,
+    min_per_stratum: Optional[int] = None,
+    max_per_stratum: Optional[int] = None,
+    required_strata: Optional[Iterable[Hashable]] = None,
+) -> None:
+    """Raise a single, itemised :class:`MlsynthConfigError` if any active design
+    constraint makes a size-``treatment_size`` treated set impossible. No-op when
+    feasible.
+
+    Parameters
+    ----------
+    eligible : iterable of hashable
+        Markets eligible for treatment (after the size band and
+        ``not_to_be_treated`` have been removed).
+    treatment_size : int
+        The requested number of treated markets ``k``.
+    conflict : ConflictGraph, optional
+        Cluster / adjacency conflict graph; a treated set must be an independent
+        set of it.
+    stratum_map : mapping, optional
+        ``{market: stratum}`` for the coverage quota.
+    min_per_stratum, max_per_stratum : int, optional
+        Coverage quota bounds.
+    required_strata : iterable, optional
+        The strata that ``min_per_stratum`` must cover (those with at least one
+        eligible market), supplied by the caller.
+    """
+    eligible = list(eligible)
+    M = len(eligible)
+    problems: List[str] = []
+
+    # 1. Candidate pool -- the precondition for everything else.
+    if M < treatment_size:
+        problems.append(
+            f"candidate pool: only {M} eligible market(s), but "
+            f"treatment_size={treatment_size}. Widen eligibility / the size band, "
+            f"or reduce treatment_size."
+        )
+        _raise(problems)        # the other checks are meaningless with too few units
+
+    # 2. Coverage / quota.
+    if stratum_map is not None:
+        problems += _quota_problems(
+            eligible, treatment_size, stratum_map,
+            min_per_stratum, max_per_stratum, required_strata,
+        )
+
+    # 3. Cluster / adjacency -- a treated set must be a size-k independent set.
+    if conflict is not None:
+        largest = _greedy_independent_set_size(eligible, conflict)
+        if largest < treatment_size:
+            problems.append(
+                f"spillover/cluster: the largest conflict-free treated set is "
+                f"{largest} < treatment_size={treatment_size}. Relax the "
+                f"cluster/adjacency constraint, widen the candidate pool, or "
+                f"reduce treatment_size."
+            )
+
+    _raise(problems)
+
+
+def _quota_problems(
+    eligible: List[Hashable],
+    k: int,
+    stratum_map: Mapping[Hashable, Hashable],
+    min_per: Optional[int],
+    max_per: Optional[int],
+    required: Optional[Iterable[Hashable]],
+) -> List[str]:
+    """Coverage/quota infeasibilities, each with its have-vs-need arithmetic."""
+    problems: List[str] = []
+    counts = Counter(
+        stratum_map[u] for u in eligible
+        if u in stratum_map and stratum_map[u] is not None
+    )
+
+    if min_per is not None and required is not None:
+        req = list(required)
+        need = min_per * len(req)
+        if need > k:
+            problems.append(
+                f"coverage: min_per_stratum={min_per} over {len(req)} required "
+                f"stratum(s) needs >= {need} treated market(s), but "
+                f"treatment_size={k}. Raise treatment_size to >= {need}, lower "
+                f"min_per_stratum, or shrink the universe."
+            )
+        short = sorted(
+            (str(s) for s in req if counts.get(s, 0) < min_per)
+        )
+        if short:
+            problems.append(
+                f"coverage: stratum(s) {short} have fewer than "
+                f"min_per_stratum={min_per} eligible market(s). Widen the "
+                f"universe / size band so each required stratum can supply "
+                f"{min_per}, or lower min_per_stratum."
+            )
+
+    if max_per is not None:
+        n_strata = len(counts)
+        cap = max_per * n_strata
+        if cap < k:
+            problems.append(
+                f"quota: max_per_stratum={max_per} over {n_strata} stratum(s) "
+                f"allows at most {cap} treated market(s), but treatment_size={k}. "
+                f"Raise max_per_stratum, add eligible strata, or reduce "
+                f"treatment_size."
+            )
+
+    return problems
+
+
+def _raise(problems: List[str]) -> None:
+    if problems:
+        raise MlsynthConfigError(
+            "SDIDGEO design is infeasible -- the binding constraint(s):\n  - "
+            + "\n  - ".join(problems)
+        )

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -19,6 +19,14 @@ from .aggregate import compute_mde, compute_power, compute_rank
 from .batch import run_simulations
 from .candidates import generate_candidate_markets
 from .config import SDIDGEOConfig
+from .constraints import (
+    admissible_candidates,
+    build_conflict_graph,
+    conflict_neighbors,
+    eligible_by_size,
+    unit_attribute_map,
+)
+from .feasibility import audit_sdidgeo_feasibility
 from .engine import sdid_fit_once
 from .shaping import aggregate_treated, donor_matrix
 from .simulate import simulate_backtest
@@ -27,15 +35,18 @@ from .structures import CandidateDesign, MarketSearch, SDIDGEOResults
 
 
 def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
-               duration: int) -> CandidateDesign:
+               duration: int, exclude=None) -> CandidateDesign:
     """Deployable SDID design for one candidate, fit on the full pre-period.
 
     The scoring stage fits each backtest; this fits the design the
     experiment will actually deploy, with the pseudo-treatment window sitting at
     the end of the observed history.
+
+    ``exclude`` drops the candidate's conflict-neighbours from its donor pool
+    (the spillover exclusion restriction).
     """
     treated = aggregate_treated(Ywide, candidate, how="mean").to_numpy()
-    donors_df = donor_matrix(Ywide, candidate)
+    donors_df = donor_matrix(Ywide, candidate, exclude=exclude)
     donors = donors_df.to_numpy()
     start = n_pre
     end = min(n_pre + duration - 1, Ywide.shape[0] - 1)
@@ -62,7 +73,7 @@ def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
 
 
 def planning_mde(Ywide: pd.DataFrame, candidate, config: SDIDGEOConfig,
-                power_table: pd.DataFrame) -> Optional[float]:
+                power_table: pd.DataFrame, exclude=None) -> Optional[float]:
     """The winner's MDE re-scored on backtests that did not choose it.
 
     ``compute_rank`` hands back the smallest MDE in the field, and the smallest
@@ -85,7 +96,7 @@ def planning_mde(Ywide: pd.DataFrame, candidate, config: SDIDGEOConfig,
         return None  # the panel cannot carry the extra backtests
 
     treated = aggregate_treated(Ywide, candidate, how="mean").to_numpy()
-    donors = donor_matrix(Ywide, candidate).to_numpy()
+    donors = donor_matrix(Ywide, candidate, exclude=exclude).to_numpy()
     rows: List[dict] = []
     for duration in config.durations:
         for sim in range(config.n_backtests + 1, deepest + 1):
@@ -135,6 +146,49 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
     if unknown:
         raise MlsynthDataError(f"markets not found in the panel: {unknown}.")
 
+    # Size band -- a treated-eligibility filter on the nomination pool only.
+    # Out-of-band markets stay available as donors.
+    not_treated = set(config.not_to_be_treated or ())
+    size_ineligible: set = set()
+    if config.size_col is not None and (
+        config.min_size is not None or config.max_size is not None
+    ):
+        size_map = unit_attribute_map(config.df, config.unitid, config.size_col)
+        eligible = eligible_by_size(units, size_map, min_size=config.min_size,
+                                    max_size=config.max_size)
+        size_ineligible = set(units) - set(eligible)
+
+    eligible_for_treatment = [u for u in units
+                              if u not in (not_treated | size_ineligible)]
+    if size_ineligible and len(eligible_for_treatment) < max(sizes):
+        raise MlsynthConfigError(
+            f"the size band leaves only {len(eligible_for_treatment)} market(s) "
+            f"eligible for treatment, fewer than the largest treatment_size "
+            f"({max(sizes)}). Widen the size band.")
+
+    # Conflict graph (cluster_col + adjacency): the independent-set filter on
+    # candidates, and the spillover donor exclusion applied per candidate.
+    conflict = None
+    if config.cluster_col is not None or config.adjacency is not None:
+        cluster_map = (
+            unit_attribute_map(config.df, config.unitid, config.cluster_col)
+            if config.cluster_col is not None else None)
+        conflict = build_conflict_graph(
+            units, cluster_map=cluster_map, adjacency=config.adjacency,
+            spillover_threshold=config.spillover_threshold)
+
+    # Stratum quotas: a coverage filter on the nominated regions.
+    stratum_map = None
+    required_strata = None
+    has_quota = (config.min_per_stratum is not None
+                 or config.max_per_stratum is not None)
+    if config.stratum_col is not None and has_quota:
+        stratum_map = unit_attribute_map(config.df, config.unitid,
+                                         config.stratum_col)
+        if config.min_per_stratum is not None:
+            required_strata = {stratum_map[u] for u in eligible_for_treatment
+                               if u in stratum_map}
+
     ranked = rank_markets_by_correlation(Ywide)
     # One nomination pass per requested size, pooled into a single field. A
     # size-3 region competes with a size-2 one on the same ranking, which is
@@ -145,7 +199,8 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
         for candidate in generate_candidate_markets(
             ranked, size,
             to_be_treated=config.to_be_treated,
-            not_to_be_treated=config.not_to_be_treated,
+            not_to_be_treated=(sorted(not_treated | size_ineligible,
+                                      key=str) or None),
             run_stochastic=config.run_stochastic,
             stochastic_mode=config.stochastic_mode,
             rng=config.seed,
@@ -158,10 +213,40 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
             "no candidate test region satisfies the constraints; relax "
             "to_be_treated / not_to_be_treated or the treatment_size.")
 
+    if conflict is not None or (stratum_map is not None and has_quota):
+        candidates = admissible_candidates(
+            candidates, conflict=conflict, stratum_map=stratum_map,
+            min_per_stratum=config.min_per_stratum,
+            max_per_stratum=config.max_per_stratum,
+            required_strata=required_strata)
+        if not candidates:
+            # Report which constraint bound the search, itemised in
+            # have-vs-need shape. Audit the smallest requested size: if that
+            # one cannot be met, no larger one can either.
+            audit_sdidgeo_feasibility(
+                eligible_for_treatment, min(sizes), conflict=conflict,
+                stratum_map=stratum_map,
+                min_per_stratum=config.min_per_stratum,
+                max_per_stratum=config.max_per_stratum,
+                required_strata=required_strata)
+            raise MlsynthConfigError(  # pragma: no cover - audit covers the common cases
+                "no candidate test region satisfies the design constraints "
+                "(treatment_size may exceed the clusters/strata available to "
+                "cover, or the forced-in markets may interfere). Relax a "
+                "constraint or the treatment_size.")
+
+    # Each candidate's spillover exclusion: its conflict-neighbours may not
+    # enter its own synthetic control.
+    excluded: Dict[frozenset, frozenset] = {
+        c: (conflict_neighbors(c, conflict) if conflict is not None
+            else frozenset())
+        for c in candidates
+    }
+
     cube = run_simulations(
         Ywide, candidates, config.durations, config.n_backtests,
         config.effect_sizes, n_draws=config.n_draws, seed=config.seed,
-        cpic=config.cpic, n_jobs=config.n_jobs,
+        cpic=config.cpic, n_jobs=config.n_jobs, excluded=excluded,
     )
     power_table = compute_power(cube, alpha=config.alpha)
     shortlist = compute_rank(power_table,
@@ -177,7 +262,8 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
     deploy_duration = max(config.durations)
     n_pre_deploy = n_periods - deploy_duration
     designs: Dict[frozenset, CandidateDesign] = {
-        c: design_fit(Ywide, c, n_pre_deploy, deploy_duration)
+        c: design_fit(Ywide, c, n_pre_deploy, deploy_duration,
+                      exclude=excluded.get(c))
         for c in candidates
     }
 
@@ -203,7 +289,8 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
         winner_units = sorted(map(str, winning))
         # Scored only now, and only for the winner, so the backtests behind it
         # cannot have influenced which region was picked.
-        winner.mde_planning = planning_mde(Ywide, winning, config, power_table)
+        winner.mde_planning = planning_mde(Ywide, winning, config, power_table,
+                                           exclude=excluded.get(winning))
 
     search = MarketSearch(shortlist=shortlist, power_table=power_table,
                           candidates=list(designs.values()), winner=winner)


### PR DESCRIPTION
## Related Links

- Docs page: `docs/sdidgeo.rst` (new "Design constraints" section)
- The estimator this extends was added in #372
- Ported from the GeoLift estimator's constraint layer, re-implemented for SDIDGEO

## What

- Added `mlsynth/utils/sdidgeo_helpers/constraints.py` — conflict graph, independent-set test, conflict neighbours, size band, stratum quota, admissibility filter
- Added `mlsynth/utils/sdidgeo_helpers/feasibility.py` — the itemised have-versus-need audit
- Added nine config fields: `cluster_col`, `adjacency`, `spillover_threshold`, `stratum_col`, `min_per_stratum`, `max_per_stratum`, `size_col`, `min_size`, `max_size`
- Threaded the spillover donor exclusion through scoring, the deployable fit, and the planning-MDE refit
- 46 new tests

## Why

SDIDGEO restricted the treated side only through hard market lists
(`to_be_treated` / `not_to_be_treated`). A design could not express "no two
treated markets in one DMA", "every region represented", or "skip markets too
small to power" without naming markets one at a time. The GeoLift estimator
already carried this vocabulary; SDIDGEO did not.

## How

Every rule narrows where the search may look. Cluster membership and an
adjacency matrix build a conflict graph, which binds twice: no candidate region
may contain two conflicting markets, and a treated market's conflicting partners
are dropped from its own donor pool, since a market the treatment contaminates
cannot serve as its own control. Stratum quotas and the size band filter the
treated side alone, so markets outside the size band stay available as donors.

Two departures from the GeoLift implementation this was ported from:

1. The donor exclusion reaches the scoring backtests, not only the deployable
   fit. Scoring against the full complement while deploying against a reduced
   pool would report an MDE the experiment cannot deliver.
2. The multi-size scan audits at the smallest requested size: if that region
   cannot be placed, no larger one can either.

## Verification

- Path: not applicable — no published implementation pairs synthetic DiD with
  GeoLift's market-selection loop, so there is nothing external to match. See
  the validation decomposition in #391.
- Pinned benchmark values unchanged: constraints are off by default and the
  layer is inert unconfigured. The one ordering change (`not_to_be_treated` now
  passed sorted) cannot matter, because `generate_candidate_markets` converts it
  to a `frozenset` on arrival.
- `test_unconstrained_result_is_unchanged` pins that the default path is
  untouched.
- I have not rerun `benchmarks/cases/sdidgeo_mc.py` — see Other Notes.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR
- [x] The default preserves existing behaviour exactly — every constraint is off by default
- [x] Existing pinned benchmark values unchanged (by construction; not rerun, see below)
- [x] A test pins that the default is unchanged
- [x] Every new config field has a `Field(...)` description saying when to reach for it

## Test Steps

- [x] `pytest mlsynth/tests/test_sdidgeo_constraints.py -q` — 46 passed
- [x] `pytest mlsynth/tests/test_sdidgeo.py -q` — 87 passed, unchanged
- [x] `pytest mlsynth/tests/test_result_contract.py -q` — 174 passed (the config gained nine fields)
- [x] `coverage run --timid -m pytest mlsynth/tests/test_sdidgeo_constraints.py` — `constraints.py` 100%, `feasibility.py` 100%
- [ ] `python benchmarks/run_benchmarks.py sdidgeo_mc` — not run

## Other Notes

The SDIDGEO benchmark case was not rerun. I expect it unmoved for the reasons
above, but expecting is not verifying, and that case is what would catch me
being wrong.

The plots and `docs/choose.rst` do not mention constraints yet.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_