### PR TITLE
Give ridge augmentation an answer when the donor matrix has no rank

### DIFF
--- a/mlsynth/tests/test_bilevel_ridge_degenerate.py
+++ b/mlsynth/tests/test_bilevel_ridge_degenerate.py
@@ -1,0 +1,140 @@
+"""Ridge augmentation when the centred donor matrix carries no information.
+
+Augmented SCM (Ben-Michael, Feller & Rothstein 2021) centres the outcomes each
+period by the donor mean and fits a ridge correction on what is left. With a
+single donor the donor mean per period *is* that donor, so the centred matrix is
+identically zero: there is no cross-donor variation for the correction to act
+on, and the augmentation is mathematically zero whatever penalty is chosen.
+
+Before this, that case crashed. ``generate_lambdas`` takes the squared largest
+singular value of the centred matrix as ``lambda_max``, which is zero, so every
+penalty on the grid is zero; the ridge path then divides zero by zero and the
+whole cross-validation curve is NaN; ``best_lambda`` compares against a NaN
+threshold, selects nothing, and calls ``.max()`` on an empty array. The user saw
+``ValueError: zero-size array to reduction operation maximum which has no
+identity`` from inside numpy, with nothing naming the cause.
+
+The claim tested here is that a rank-zero matching matrix is a degeneracy with a
+known answer, not an error: the augmentation contributes nothing, so the
+result is the base simplex fit, reported as such.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.engine import BilevelSCM
+from mlsynth.utils.bilevel.ridge_augment import (
+    best_lambda,
+    build_matching,
+    generate_lambdas,
+    ridge_augment_weights,
+)
+
+
+def _panel(n_pre=15, n_donors=1, seed=0):
+    rng = np.random.default_rng(seed)
+    Y0 = rng.normal(100.0, 5.0, size=(n_pre, n_donors))
+    y = Y0[:, 0] + rng.normal(0.0, 1.0, size=n_pre)
+    return y, Y0
+
+
+# ---------------------------------------------------------------------------
+# The premise
+# ---------------------------------------------------------------------------
+
+class TestPremise:
+    def test_single_donor_centres_to_exactly_zero(self):
+        y, Y0 = _panel()
+        B, _ = build_matching(y, Y0)
+        assert np.abs(B).max() == 0.0
+
+    def test_zero_matrix_gives_a_zero_lambda_grid(self):
+        grid = generate_lambdas(np.zeros((15, 1)))
+        assert np.all(grid == 0.0)
+
+    def test_two_donors_are_not_degenerate(self):
+        y, Y0 = _panel(n_donors=2)
+        B, _ = build_matching(y, Y0)
+        assert np.abs(B).max() > 0.0
+
+
+# ---------------------------------------------------------------------------
+# The fix: a known answer, not a crash
+# ---------------------------------------------------------------------------
+
+class TestSingleDonorAugmentation:
+    def test_ridge_augment_returns_the_base_fit(self):
+        y, Y0 = _panel()
+        res = ridge_augment_weights(y, Y0)
+        np.testing.assert_allclose(res.W, res.W_base, atol=1e-12)
+        np.testing.assert_allclose(res.W_ridge, 0.0, atol=1e-12)
+
+    def test_lambda_is_zero_and_finite(self):
+        y, Y0 = _panel()
+        res = ridge_augment_weights(y, Y0)
+        assert np.isfinite(res.lambda_) and res.lambda_ == 0.0
+
+    def test_weights_are_finite_and_sum_to_one(self):
+        y, Y0 = _panel()
+        res = ridge_augment_weights(y, Y0)
+        assert np.all(np.isfinite(res.W))
+        assert float(np.sum(res.W)) == pytest.approx(1.0, abs=1e-8)
+
+    def test_through_the_public_engine(self):
+        y, Y0 = _panel()
+        A, B = y - y.mean(), Y0 - Y0.mean(axis=0)
+        res = BilevelSCM(augment="ridge").fit(A, B)
+        assert np.all(np.isfinite(np.asarray(res.W)))
+        assert np.isfinite(res.pre_rmspe)
+
+    @pytest.mark.parametrize("n_donors", [1, 2, 3, 5])
+    def test_donor_counts_around_the_degeneracy(self, n_donors):
+        # The guard must bite at J=1 and nowhere else.
+        y, Y0 = _panel(n_donors=n_donors, seed=n_donors)
+        res = ridge_augment_weights(y, Y0)
+        assert np.all(np.isfinite(res.W))
+        if n_donors == 1:
+            assert res.lambda_ == 0.0
+        else:
+            assert res.lambda_ > 0.0
+
+    def test_duplicated_donor_is_also_degenerate(self):
+        # Two identical donors centre to zero as surely as one does, so the
+        # guard has to key on the matrix and not on the column count.
+        rng = np.random.default_rng(3)
+        col = rng.normal(100.0, 5.0, size=(15, 1))
+        Y0 = np.hstack([col, col])
+        y = col[:, 0] + rng.normal(0.0, 1.0, size=15)
+        res = ridge_augment_weights(y, Y0)
+        assert np.all(np.isfinite(res.W))
+        assert res.lambda_ == 0.0
+
+
+# ---------------------------------------------------------------------------
+# best_lambda's own contract
+# ---------------------------------------------------------------------------
+
+class TestBestLambda:
+    def test_selects_among_finite_entries(self):
+        lambdas = np.array([10.0, 5.0, 1.0])
+        mean = np.array([np.nan, 2.0, 3.0])
+        se = np.array([0.0, 0.5, 0.5])
+        assert best_lambda(lambdas, mean, se, min_1se=False) == 5.0
+
+    def test_all_non_finite_raises_a_translated_error(self):
+        from mlsynth.exceptions import MlsynthEstimationError
+        lambdas = np.array([1.0, 2.0])
+        nan = np.array([np.nan, np.nan])
+        with pytest.raises(MlsynthEstimationError, match="cross-validation"):
+            best_lambda(lambdas, nan, nan)
+
+    def test_ordinary_curve_is_unchanged(self):
+        # The 1-SE rule: the largest lambda within one standard error of the
+        # minimum. This must not move.
+        lambdas = np.array([100.0, 10.0, 1.0])
+        mean = np.array([1.2, 1.0, 1.15])
+        se = np.array([0.3, 0.3, 0.3])
+        assert best_lambda(lambdas, mean, se, min_1se=True) == 100.0
+        assert best_lambda(lambdas, mean, se, min_1se=False) == 10.0

--- a/mlsynth/utils/bilevel/ridge_augment.py
+++ b/mlsynth/utils/bilevel/ridge_augment.py
@@ -43,6 +43,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 
+from ...exceptions import MlsynthEstimationError
 from .accelerate import ACCEL_MIN_DONORS, fista_warm_start
 
 _EPS = 1e-12
@@ -145,7 +146,7 @@ def solve_ridge(
     W = np.asarray(W, dtype=float).ravel()
     M = A - B @ W
     # Solve (B B^T + lambda I) X = B instead of forming the inverse: same result,
-    # one LAPACK solve rather than a full inversion plus a matmul.
+    # one LAPACK solve instead of a full inversion plus a matmul.
     X = np.linalg.solve(B @ B.T + lambda_ * np.identity(B.shape[0]), B)
     return M @ X
 
@@ -168,7 +169,7 @@ def solve_ridge_path(
 
       so ``M @ inv(...) @ B = (a * S / (S^2 + lambda)) @ V^T`` with
       ``a = M U``. This factors the ``m x J`` matrix (cost ``O(m J^2)``) and
-      works in ``r`` components rather than eigendecomposing the ``m x m``
+      works in ``r`` components instead of eigendecomposing the ``m x m``
       ``B B^T`` (cost ``O(m^3)``) -- a large saving when ``m >> J``.
     * ``m <= J``: the symmetric eigendecomposition ``B B^T = V diag(d) V^T``
       (the smaller, ``m x m``, matrix here), giving
@@ -358,10 +359,24 @@ def best_lambda(
     errors_mean = np.asarray(errors_mean, dtype=float)
     errors_se = np.asarray(errors_se, dtype=float)
     lambdas = np.asarray(lambdas, dtype=float)
+    # A fold can leave a penalty with no finite error -- a near-singular ridge
+    # solve, or a matching matrix with no rank left. Those penalties carry no
+    # information about fit, so they take no part in the choice; comparing
+    # against them makes the threshold NaN and selects nothing.
+    finite = np.isfinite(errors_mean)
+    if not finite.any():
+        raise MlsynthEstimationError(
+            "the ridge cross-validation curve is entirely non-finite, so no "
+            "penalty can be selected. This happens when the centered donor "
+            "matrix has no rank left -- a single donor, or donors identical to "
+            "each other -- and the augmentation is zero for every penalty.")
+    lambdas_f = lambdas[finite]
+    mean_f = errors_mean[finite]
+    se_f = errors_se[finite]
     if min_1se:
-        threshold = errors_mean.min() + errors_se[int(errors_mean.argmin())]
-        return float(lambdas[errors_mean <= threshold].max())
-    return float(lambdas[int(errors_mean.argmin())])
+        threshold = mean_f.min() + se_f[int(mean_f.argmin())]
+        return float(lambdas_f[mean_f <= threshold].max())
+    return float(lambdas_f[int(mean_f.argmin())])
 
 
 @dataclass
@@ -562,13 +577,24 @@ def ridge_augment_weights(
     if lambda_ is None:
         lambdas = generate_lambdas(B, lambda_min_ratio=lambda_min_ratio,
                                    n_lambda=n_lambda)
-        lambdas, mean, se = cross_validate(
-            base_weights_fn, B, A, lambdas, holdout_len=holdout_length
-        )
-        lambda_ = best_lambda(lambdas, mean, se, min_1se=min_1se)
-        cv = {"lambdas": lambdas, "errors_mean": mean, "errors_se": se}
+        if not np.any(lambdas > 0.0):
+            # The centered matching matrix has no rank: augsynth centers each
+            # period by the donor mean, so a single donor (or donors identical
+            # to one another) leaves exactly zero. The ridge correction is then
+            # zero for every penalty, so there is nothing to cross-validate and
+            # the augmented fit is the base fit.
+            lambda_ = 0.0
+        else:
+            lambdas, mean, se = cross_validate(
+                base_weights_fn, B, A, lambdas, holdout_len=holdout_length
+            )
+            lambda_ = best_lambda(lambdas, mean, se, min_1se=min_1se)
+            cv = {"lambdas": lambdas, "errors_mean": mean, "errors_se": se}
 
-    W_ridge = solve_ridge(A, B, W_base, float(lambda_))
+    if float(lambda_) == 0.0 and not np.any(np.asarray(B) != 0.0):
+        W_ridge = np.zeros_like(W_base)   # no rank to correct on; see above
+    else:
+        W_ridge = solve_ridge(A, B, W_base, float(lambda_))
     W = W_base + W_ridge
     if add_back is not None:                 # residualize: restore covariate balance
         W = W + add_back(W)


### PR DESCRIPTION
## Related Links

- `mlsynth/utils/bilevel/ridge_augment.py` — `best_lambda`, `ridge_augment_weights`
- Reached from `VanillaSC(augment="ridge")` and the other ASCM paths
- Found while adding a second scoring engine to SDIDGEO; that work waits on this

## What

- `best_lambda` selects among the finite entries of the CV curve, and raises a translated `MlsynthEstimationError` when none are finite
- `ridge_augment_weights` short-circuits when the penalty grid is entirely zero
- The final solve skips the ridge path when there is no rank to correct on
- New `mlsynth/tests/test_bilevel_ridge_degenerate.py` (15 tests)

## Why

Augmented SCM centres the outcomes each period by the donor mean, so a single
donor leaves a matching matrix of exactly zero (`|B|max == 0.0`, pinned as a
test). `generate_lambdas` then takes the squared largest singular value as
`lambda_max`, which is zero, so every penalty on the grid is zero; the ridge
path divides zero by zero and the whole cross-validation curve is NaN;
`best_lambda` compares against a NaN threshold, selects nothing, and calls
`.max()` on an empty array.

What reached the caller was:

```
ValueError: zero-size array to reduction operation maximum which has no identity
```

from inside numpy, naming none of the cause.

## How

The case has a known answer instead of an error. With no cross-donor variation
the ridge correction is identically zero for every penalty, so there is nothing
to cross-validate and the augmented fit is the base simplex fit — which is what
the code now returns, with `lambda_ = 0.0` and `W_ridge = 0`.

The guard keys on the matrix and not the column count, because two identical
donors centre to zero as surely as one does; that case is tested.

`best_lambda`'s change is inert on a fully finite curve, which is every normal
case, and a test pins the 1-SE rule and the plain minimum at unchanged values.

## Verification

- Path: not applicable — a crash fix in a shared helper, no numerical result changes.
- The premise is pinned by measurement, not assumed: `build_matching` returns a
  matrix whose largest absolute entry is exactly `0.0` at J=1, and `> 0` at J=2.
- Donor counts 1, 2, 3, 5 are parametrized so the guard is shown to bite at J=1
  and nowhere else (`lambda_ == 0.0` at J=1, `> 0` otherwise).
- Nothing existing moved: `pytest mlsynth/tests/test_vanillasc.py` — 36 passed,
  1 skipped, against the same counts before the change.

## Scope checks

BUG FIX
- [x] A test reproduces the defect and fails without the fix (8 of the 15 were red before it)
- [x] It asserts the correct behaviour — the base fit is returned, weights finite and summing to one — not merely the absence of a crash
- [x] No docstring or comment still states the old behaviour
- [x] No pinned value moved

## Test Steps

- [x] `pytest mlsynth/tests/test_bilevel_ridge_degenerate.py -q` — 15 passed
- [x] `pytest mlsynth/tests/test_vanillasc.py -q` — 36 passed, 1 skipped
- [x] `coverage run --timid -m pytest mlsynth/tests/test_bilevel_ridge_degenerate.py` — the new lines are covered; the remaining gaps in the file are pre-existing paths (warm start, covariate add-back) exercised elsewhere

## Other Notes

Two pre-existing uses of a banned word were corrected in the file while it was
open, so the repo-wide grep stays clean.

The wider ridge-adjacent sweep (ClusterSC, SPSC) was still running when this went
up; VanillaSC is the closest dependent and is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_