### PR TITLE
Realize an SDIDGEO design, and expose the reporting scale

### DIFF
--- a/docs/sdidgeo.rst
+++ b/docs/sdidgeo.rst
@@ -133,9 +133,12 @@ Assumptions
    metros that share media markets or commuters violate this, and the
    donor pool then contains partially treated units.
 
-   *Remark.* SDIDGEO does not model spillover. Exclude the markets you
-   suspect with ``not_to_be_treated``, which keeps them out of candidate
-   regions while leaving them as donors.
+   *Remark.* Where the interference is known, declare it: ``cluster_col``
+   or ``adjacency`` makes the affected pairs conflict, which keeps them
+   out of the same test region and out of each other's donor pool. Where
+   it is only suspected, ``not_to_be_treated`` bars a market from
+   treatment while leaving it a donor. Neither detects interference the
+   panel does not declare.
 
 4. The pre-period relationship persists into the test.
 
@@ -344,6 +347,50 @@ design that cannot be run says why:
 
 Every constraint is off by default, and with none configured the search
 runs exactly as it does above.
+
+Reading out the experiment
+--------------------------
+
+``fit()`` chooses a region before the experiment runs, so ``report`` is
+``None`` on the returned design. Once outcomes exist, name the
+post-treatment periods with ``post_col`` and the same call fills it with
+the realized effect: the ATT over the post window, the observed,
+counterfactual and gap paths across the whole panel, both weight
+vectors, and the pre-period fit diagnostics.
+
+The readout uses synthetic DiD and the placebo standard error, the same
+estimator and the same null the design scored itself with. A minimum
+detectable effect computed one way and a readout computed another would
+leave the reported power describing a test nobody ran, and the promise
+that the design is chosen by the estimator that will analyse the result
+is the reason to use SDIDGEO at all. For the same reason the readout
+inherits the design's donor pool: where a spillover constraint barred a
+treated market's conflict-neighbours, they stay barred here.
+
+.. code-block:: python
+
+    design = SDIDGEO(SDIDGEOConfig(
+        df=df, unitid="location", time="date", outcome="Y",
+        post_col="post",              # 1 on the periods the campaign ran
+        treatment_size=2, durations=[14],
+        effect_sizes=[0.05, 0.10, 0.15],
+    )).fit()
+
+    design.report.effects.att          # realized effect
+    design.report.inference.p_value    # placebo test against the same null
+
+The design itself is unaffected by ``post_col``: ingestion truncates to
+the pre-period before any candidate is scored, so a design fit on a
+pre-only panel and one fit on the full panel choose the same region. Only
+the readout sees the post periods.
+
+``how`` sets the scale the readout is written in. The fit always runs on
+the per-market mean, which keeps the target at donor scale, so ``how``
+changes reported units and neither the region chosen nor the p-value:
+``"mean"`` gives the per-market effect, ``"sum"`` the summed incremental
+across the treated markets, which is GeoLift's convention and the one to
+use when the number is going next to a spend figure. Cost from ``cpic``
+is computed off the summed incremental either way.
 
 Plots
 -----

--- a/mlsynth/tests/test_sdidgeo_realize.py
+++ b/mlsynth/tests/test_sdidgeo_realize.py
@@ -1,0 +1,276 @@
+"""SDIDGEO realization: reading out the experiment the design chose.
+
+``SDIDGEO.fit()`` returns a :class:`DesignResult` whose ``report`` slot stays
+``None`` until outcomes exist. ``realize_design`` fills it: apply the chosen
+region's pre-period SDID fit across the full panel and package the realized
+effect into the standardized result models.
+
+The realization has to use the same estimator and the same null the design
+scored itself with, because SDIDGEO's whole claim is that the design is chosen
+by the estimator that will analyse the result. So the readout is SDID plus the
+placebo standard error, not a different model that happens to be available. It
+also has to inherit the design's donor pool: with a spillover constraint active
+the design excluded a treated market's conflict-neighbours, and reading out
+against the full complement would answer a different question than the MDE
+promised.
+
+``how`` is tested alongside, since it sets the scale everything here reports in.
+
+Tests are TDD-first and layered: premise, invariants of the readout, edge cases
+(no post period, single post period, constrained donor pool), and failures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SDIDGEO
+from mlsynth.config_models import BaseEstimatorResults, SDIDGEOConfig
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.datautils import geoex_dataprep
+from mlsynth.utils.sdidgeo_helpers.realize import realize_design
+from mlsynth.utils.sdidgeo_helpers.shaping import aggregate_treated
+
+DATA = Path(__file__).resolve().parents[2] / "basedata" / "geolift_test_data.csv"
+
+
+@pytest.fixture(scope="module")
+def panel():
+    df = pd.read_csv(DATA)
+    df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+@pytest.fixture(scope="module")
+def wide(panel):
+    return geoex_dataprep(panel, "location", "date", "Y")["Ywide"]
+
+
+@pytest.fixture(scope="module")
+def region(wide):
+    return frozenset(list(wide.columns)[:2])
+
+
+# ---------------------------------------------------------------------------
+# Structure of the realized report
+# ---------------------------------------------------------------------------
+
+class TestRealizedReport:
+    @pytest.fixture(scope="class")
+    def report(self, wide, region):
+        n_pre = wide.shape[0] - 14
+        return realize_design(wide, region, n_pre, n_draws=25, seed=0)
+
+    def test_is_an_effect_result(self, report):
+        assert isinstance(report, BaseEstimatorResults)
+
+    def test_series_span_the_whole_panel(self, report, wide):
+        ts = report.time_series
+        for arr in (ts.observed_outcome, ts.counterfactual_outcome,
+                    ts.estimated_gap):
+            assert np.asarray(arr).shape[0] == wide.shape[0]
+        assert len(ts.time_periods) == wide.shape[0]
+
+    def test_gap_is_observed_minus_counterfactual(self, report):
+        ts = report.time_series
+        np.testing.assert_allclose(
+            np.asarray(ts.estimated_gap),
+            np.asarray(ts.observed_outcome) - np.asarray(ts.counterfactual_outcome),
+            atol=1e-9)
+
+    def test_att_is_the_post_period_mean_gap(self, report, wide):
+        n_pre = wide.shape[0] - 14
+        gap = np.asarray(report.time_series.estimated_gap)
+        assert report.effects.att == pytest.approx(float(gap[n_pre:].mean()),
+                                                   abs=1e-9)
+
+    def test_intervention_time_is_the_split(self, report, wide):
+        n_pre = wide.shape[0] - 14
+        assert report.time_series.intervention_time == wide.index[n_pre]
+
+    def test_carries_both_sdid_weight_vectors(self, report):
+        w = report.weights
+        assert w.donor_weights and w.time_weights
+
+    def test_fit_diagnostics_are_finite(self, report):
+        fd = report.fit_diagnostics
+        assert np.isfinite(fd.rmse_pre)
+        assert np.isfinite(fd.additional_metrics["scaled_l2"])
+
+    def test_inference_uses_the_designs_own_null(self, report):
+        inf = report.inference
+        assert inf.method == "placebo"
+        assert 0.0 <= inf.p_value <= 1.0
+        assert np.isfinite(inf.details["sigma"])
+
+
+# ---------------------------------------------------------------------------
+# The readout must match the estimator the design scored with
+# ---------------------------------------------------------------------------
+
+class TestConsistencyWithTheDesign:
+    def test_counterfactual_matches_a_direct_sdid_fit(self, wide, region):
+        from mlsynth.utils.sdidgeo_helpers.engine import sdid_fit_once
+        from mlsynth.utils.sdidgeo_helpers.shaping import donor_matrix
+
+        n_pre = wide.shape[0] - 14
+        report = realize_design(wide, region, n_pre, n_draws=10, seed=0)
+        treated = aggregate_treated(wide, region, how="mean").to_numpy()
+        donors = donor_matrix(wide, region).to_numpy()
+        fit = sdid_fit_once(treated, donors, n_pre, n_pre, wide.shape[0] - 1,
+                            n_tr=len(region))
+        np.testing.assert_allclose(
+            np.asarray(report.time_series.counterfactual_outcome),
+            fit.counterfactual, atol=1e-9)
+
+    def test_p_value_is_reproducible_at_a_fixed_seed(self, wide, region):
+        n_pre = wide.shape[0] - 14
+        kw = dict(n_draws=15, seed=7)
+        a = realize_design(wide, region, n_pre, **kw)
+        b = realize_design(wide, region, n_pre, **kw)
+        assert a.inference.p_value == b.inference.p_value
+
+    def test_excluded_markets_stay_out_of_the_donor_pool(self, wide, region):
+        units = [u for u in wide.columns if u not in region]
+        drop = units[0]
+        n_pre = wide.shape[0] - 14
+        report = realize_design(wide, region, n_pre, exclude=[drop],
+                                n_draws=10, seed=0)
+        assert str(drop) not in report.weights.donor_weights
+
+
+# ---------------------------------------------------------------------------
+# how: the reporting scale
+# ---------------------------------------------------------------------------
+
+class TestHow:
+    def test_sum_scales_the_paths_by_the_region_size(self, wide, region):
+        n_pre = wide.shape[0] - 14
+        mean = realize_design(wide, region, n_pre, how="mean", n_draws=10, seed=0)
+        summed = realize_design(wide, region, n_pre, how="sum", n_draws=10, seed=0)
+        k = len(region)
+        np.testing.assert_allclose(
+            np.asarray(summed.time_series.observed_outcome),
+            np.asarray(mean.time_series.observed_outcome) * k, rtol=1e-9)
+        assert summed.effects.att == pytest.approx(mean.effects.att * k, rel=1e-9)
+
+    def test_scale_does_not_move_the_p_value(self, wide, region):
+        # The test statistic is scale-free, so reporting units must not decide
+        # significance.
+        n_pre = wide.shape[0] - 14
+        mean = realize_design(wide, region, n_pre, how="mean", n_draws=15, seed=3)
+        summed = realize_design(wide, region, n_pre, how="sum", n_draws=15, seed=3)
+        assert summed.inference.p_value == pytest.approx(mean.inference.p_value)
+
+    def test_bad_how_raises(self, wide, region):
+        with pytest.raises(MlsynthConfigError, match="how"):
+            realize_design(wide, region, wide.shape[0] - 14, how="median")
+
+
+class TestHowOnTheConfig:
+    def _cfg(self, panel, **kw):
+        base = dict(df=panel, unitid="location", time="date", outcome="Y",
+                    treatment_size=2, durations=[14], effect_sizes=[0.0, 0.2],
+                    n_backtests=2, n_draws=5, n_validation_backtests=0, seed=0)
+        base.update(kw)
+        return SDIDGEOConfig(**base)
+
+    def test_defaults_to_mean(self, panel):
+        assert self._cfg(panel).how == "mean"
+
+    def test_rejects_anything_else(self, panel):
+        with pytest.raises(MlsynthConfigError, match="how"):
+            self._cfg(panel, how="median")
+
+    def test_sum_scales_the_deployable_design(self, panel):
+        a = SDIDGEO(self._cfg(panel, how="mean")).fit()
+        b = SDIDGEO(self._cfg(panel, how="sum")).fit()
+        # Same region chosen; SDID differences out the level, so the scale
+        # changes what is reported and not which markets win.
+        assert a.selected_units == b.selected_units
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_single_post_period(self, wide, region):
+        n_pre = wide.shape[0] - 1
+        report = realize_design(wide, region, n_pre, n_draws=10, seed=0)
+        assert np.isfinite(report.effects.att)
+        assert len(report.time_series.observed_outcome) == wide.shape[0]
+
+    def test_no_post_period_raises(self, wide, region):
+        with pytest.raises(MlsynthConfigError, match="post"):
+            realize_design(wide, region, wide.shape[0], n_draws=10, seed=0)
+
+    def test_pre_periods_out_of_range_raises(self, wide, region):
+        with pytest.raises(MlsynthConfigError, match="pre_periods"):
+            realize_design(wide, region, 0, n_draws=10, seed=0)
+
+    def test_unknown_market_raises(self, wide):
+        with pytest.raises(MlsynthDataError):
+            realize_design(wide, frozenset({"atlantis"}), wide.shape[0] - 14,
+                           n_draws=10, seed=0)
+
+    def test_excluding_every_donor_raises(self, wide, region):
+        others = [u for u in wide.columns if u not in region]
+        with pytest.raises(MlsynthDataError, match="No donor units remain"):
+            realize_design(wide, region, wide.shape[0] - 14, exclude=others,
+                           n_draws=10, seed=0)
+
+    def test_cpic_reports_the_realized_spend(self, wide, region):
+        n_pre = wide.shape[0] - 14
+        report = realize_design(wide, region, n_pre, cpic=7.5, n_draws=10, seed=0)
+        gap = np.asarray(report.time_series.estimated_gap)
+        expected = 7.5 * float(gap[n_pre:].sum()) * len(region)
+        assert report.weights.summary_stats["cost"] == pytest.approx(expected)
+
+    def test_cost_absent_without_cpic(self, wide, region):
+        report = realize_design(wide, region, wide.shape[0] - 14, n_draws=10,
+                                seed=0)
+        assert report.weights.summary_stats["cost"] is None
+
+
+# ---------------------------------------------------------------------------
+# Wiring: SDIDGEO fills report when the panel carries a post period
+# ---------------------------------------------------------------------------
+
+class TestFitPopulatesTheReport:
+    def _post_panel(self, panel):
+        df = panel.copy()
+        cutoff = df["date"].sort_values().unique()[-14]
+        df["post"] = (df["date"] >= cutoff).astype(int)
+        return df
+
+    def test_report_is_none_without_a_post_period(self, panel):
+        res = SDIDGEO(SDIDGEOConfig(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14], effect_sizes=[0.0, 0.2],
+            n_backtests=2, n_draws=5, n_validation_backtests=0, seed=0)).fit()
+        assert res.report is None
+
+    def test_report_is_filled_when_post_periods_exist(self, panel):
+        res = SDIDGEO(SDIDGEOConfig(
+            df=self._post_panel(panel), unitid="location", time="date",
+            outcome="Y", post_col="post", treatment_size=2, durations=[7],
+            effect_sizes=[0.0, 0.2], n_backtests=2, n_draws=5,
+            n_validation_backtests=0, seed=0)).fit()
+        assert res.report is not None
+        assert isinstance(res.report, BaseEstimatorResults)
+        assert np.isfinite(res.report.effects.att)
+        assert res.report.inference.method == "placebo"
+
+    def test_realized_region_is_the_selected_one(self, panel):
+        res = SDIDGEO(SDIDGEOConfig(
+            df=self._post_panel(panel), unitid="location", time="date",
+            outcome="Y", post_col="post", treatment_size=2, durations=[7],
+            effect_sizes=[0.0, 0.2], n_backtests=2, n_draws=5,
+            n_validation_backtests=0, seed=0)).fit()
+        donors = set(res.report.weights.donor_weights)
+        assert not (donors & set(res.selected_units))

--- a/mlsynth/utils/sdidgeo_helpers/config.py
+++ b/mlsynth/utils/sdidgeo_helpers/config.py
@@ -95,6 +95,15 @@ class SDIDGEOConfig(BaseMAREXConfig):
         description="'global' draws one tier pattern for every anchor; "
         "'per_anchor' draws a fresh one per anchor.",
     )
+    how: str = Field(
+        default="mean",
+        description="Treated aggregation. The SDID fit always runs on the "
+        "per-market mean, which keeps the target at donor scale; this sets the "
+        "scale the realized report is written in. 'sum' gives the summed "
+        "incremental across the treated markets (GeoLift's reporting "
+        "convention), 'mean' the per-market effect. Cost is computed from the "
+        "summed incremental either way.",
+    )
     post_col: Optional[str] = Field(
         default=None,
         description="Column flagging post-treatment periods. Absent, the whole "
@@ -214,6 +223,9 @@ class SDIDGEOConfig(BaseMAREXConfig):
             raise MlsynthConfigError(
                 "stochastic_mode must be 'global' or 'per_anchor'; got "
                 f"{self.stochastic_mode!r}.")
+        if self.how not in ("sum", "mean"):
+            raise MlsynthConfigError(
+                f"how must be 'sum' or 'mean'; got {self.how!r}.")
         if self.spillover_threshold < 0.0:
             raise MlsynthConfigError(
                 "spillover_threshold must be >= 0; got "

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -30,12 +30,13 @@ from .feasibility import audit_sdidgeo_feasibility
 from .engine import sdid_fit_once
 from .shaping import aggregate_treated, donor_matrix
 from .simulate import simulate_backtest
+from .realize import realize_design
 from .similarity import rank_markets_by_correlation
 from .structures import CandidateDesign, MarketSearch, SDIDGEOResults
 
 
 def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
-               duration: int, exclude=None) -> CandidateDesign:
+               duration: int, exclude=None, how: str = "mean") -> CandidateDesign:
     """Deployable SDID design for one candidate, fit on the full pre-period.
 
     The scoring stage fits each backtest; this fits the design the
@@ -45,6 +46,8 @@ def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
     ``exclude`` drops the candidate's conflict-neighbours from its donor pool
     (the spillover exclusion restriction).
     """
+    # The fit runs on the mean whatever the reporting scale, so every candidate
+    # is scored on the series the MDE describes.
     treated = aggregate_treated(Ywide, candidate, how="mean").to_numpy()
     donors_df = donor_matrix(Ywide, candidate, exclude=exclude)
     donors = donors_df.to_numpy()
@@ -263,7 +266,7 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
     n_pre_deploy = n_periods - deploy_duration
     designs: Dict[frozenset, CandidateDesign] = {
         c: design_fit(Ywide, c, n_pre_deploy, deploy_duration,
-                      exclude=excluded.get(c))
+                      exclude=excluded.get(c), how=config.how)
         for c in candidates
     }
 
@@ -295,8 +298,22 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
     search = MarketSearch(shortlist=shortlist, power_table=power_table,
                           candidates=list(designs.values()), winner=winner)
 
+    # A genuine post period means the experiment has run, so the design can be
+    # read out. geoex_dataprep truncates to the pre-period when post_col is set,
+    # so the design reproduces identically on a pre-only or a full panel; the
+    # readout needs the periods that truncation removed, and re-preps without it.
+    report = None
+    if winner_units is not None and config.post_col is not None:
+        full = geoex_dataprep(config.df, config.unitid, config.time,
+                              config.outcome)["Ywide"]
+        if full.shape[0] > n_periods:
+            report = realize_design(
+                full, winning, n_periods, how=config.how,
+                exclude=excluded.get(winning), alpha=config.alpha,
+                n_draws=config.n_draws, seed=config.seed, cpic=config.cpic)
+
     return SDIDGEOResults(
-        report=None,  # realized once post-treatment outcomes are observed
+        report=report,
         power=shortlist,
         selected_units=winner_units,
         assignment=({"treated": winner_units}

--- a/mlsynth/utils/sdidgeo_helpers/realize.py
+++ b/mlsynth/utils/sdidgeo_helpers/realize.py
@@ -1,0 +1,173 @@
+"""Realize an SDIDGEO design once post-treatment outcomes exist.
+
+:meth:`mlsynth.SDIDGEO.fit` chooses a test region before the experiment runs, so
+its result is a design with an empty ``report`` slot. This module fills that
+slot: apply the chosen region's pre-period SDID fit across the full panel and
+package the realized effect into the standardized result models.
+
+The readout uses the estimator and the null the design scored itself with --
+synthetic DiD plus the placebo standard error of Arkhangelsky et al.'s Algorithm
+4 -- because SDIDGEO's claim is that the design is chosen by the estimator that
+will analyse the result. A minimum detectable effect computed one way and a
+readout computed another would leave the reported power describing a test nobody
+ran.
+
+For the same reason the readout inherits the design's donor pool. Where a
+spillover constraint barred a treated market's conflict-neighbours from its
+synthetic control, ``exclude`` carries that restriction through, so the realized
+effect is measured against the comparison the MDE was promised for.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+from ...config_models import (
+    BaseEstimatorResults,
+    EffectsResults,
+    FitDiagnosticsResults,
+    InferenceResults,
+    TimeSeriesResults,
+    WeightsResults,
+)
+from ...exceptions import MlsynthConfigError
+from .engine import normal_p_value, placebo_sigma, sdid_att, sdid_fit_once
+from .shaping import aggregate_treated, donor_matrix
+
+
+def realize_design(
+    Ywide_full: pd.DataFrame,
+    candidate: Iterable,
+    pre_periods: int,
+    *,
+    how: str = "mean",
+    exclude: Optional[Iterable] = None,
+    alpha: float = 0.1,
+    n_draws: int = 200,
+    seed: int = 0,
+    cpic: Optional[float] = None,
+) -> BaseEstimatorResults:
+    """Realize one candidate design on the full (pre + post) panel.
+
+    Parameters
+    ----------
+    Ywide_full : pandas.DataFrame
+        The full wide panel, pre and post, as ``geoex_dataprep(...)["Ywide"]``.
+    candidate : iterable
+        The treated markets, normally the design's winning region.
+    pre_periods : int
+        Periods before the intervention; the split point.
+    how : {"mean", "sum"}, default "mean"
+        Reporting scale. The fit runs on the per-market mean either way, since
+        that is the series the design was scored on; ``"sum"`` multiplies the
+        reported paths by the region size to give the summed incremental.
+    exclude : iterable, optional
+        Markets barred from the donor pool beyond the treated region itself
+        (the spillover exclusion). ``None`` leaves the candidate complement.
+    alpha : float, default 0.1
+        Significance level carried into the reported confidence level.
+    n_draws : int, default 200
+        Placebo draws behind the standard error.
+    seed : int, default 0
+        Seed for the placebo draws.
+    cpic : float, optional
+        Cost per incremental conversion. When set, the realized spend
+        ``cpic x summed incremental outcome`` is reported.
+
+    Returns
+    -------
+    BaseEstimatorResults
+        ATT over the post window, the observed / counterfactual / gap paths over
+        the whole panel, placebo inference, both SDID weight vectors, and the
+        pre-period fit diagnostics.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``how`` is not ``"mean"``/``"sum"``, or ``pre_periods`` leaves no
+        pre-period or no post-period.
+    MlsynthDataError
+        If a candidate market is absent, or no donors remain.
+    """
+    if how not in ("mean", "sum"):
+        raise MlsynthConfigError(f"how must be 'sum' or 'mean'; got {how!r}.")
+    n_periods = Ywide_full.shape[0]
+    if not 0 < pre_periods < n_periods:
+        if pre_periods >= n_periods:
+            raise MlsynthConfigError(
+                f"pre_periods={pre_periods} leaves no post-treatment period in "
+                f"a panel of {n_periods}. The design cannot be realized until "
+                "outcomes are observed.")
+        raise MlsynthConfigError(
+            f"pre_periods must be in (0, {n_periods}); got {pre_periods}.")
+
+    members = sorted(map(str, candidate))
+    # The fit runs on the mean regardless of the reporting scale: that is the
+    # series every backtest was scored on, so realizing on the sum would answer
+    # with a different fit than the one the MDE describes.
+    treated = aggregate_treated(Ywide_full, candidate, how="mean").to_numpy()
+    donors_df = donor_matrix(Ywide_full, candidate, exclude=exclude)
+    donors = donors_df.to_numpy()
+
+    start, end = pre_periods, n_periods - 1
+    fit = sdid_fit_once(treated, donors, pre_periods, start, end,
+                        n_tr=len(members))
+    tau = sdid_att(fit, treated, start, end)
+    sigma = placebo_sigma(treated, donors, pre_periods, start, end,
+                          n_draws=n_draws, n_tr=len(members), seed=seed)
+    p_value = normal_p_value(tau, sigma)
+
+    # Reporting scale. The statistic is a ratio, so it is scale-free and the
+    # p-value is unmoved; only the reported paths change units.
+    k = float(len(members)) if how == "sum" else 1.0
+    observed = treated * k
+    counterfactual = fit.counterfactual * k
+    gap = observed - counterfactual
+
+    # Cost tracks the summed incremental outcome across the treated markets,
+    # whatever scale the paths are reported in.
+    incremental = float(np.sum(fit.tau_path(treated)[pre_periods:])) * len(members)
+    cost = float(cpic) * incremental if cpic is not None else None
+
+    return BaseEstimatorResults(
+        effects=EffectsResults(att=float(np.mean(gap[pre_periods:]))),
+        time_series=TimeSeriesResults(
+            observed_outcome=observed,
+            counterfactual_outcome=counterfactual,
+            estimated_gap=gap,
+            time_periods=np.asarray(Ywide_full.index),
+            intervention_time=Ywide_full.index[pre_periods],
+        ),
+        inference=InferenceResults(
+            p_value=float(p_value),
+            method="placebo",
+            confidence_level=1.0 - alpha,
+            details={
+                "sigma": float(sigma) if sigma is not None else float("nan"),
+                "att_mean_scale": float(tau),
+                "n_draws": int(n_draws),
+            },
+        ),
+        weights=WeightsResults(
+            donor_weights={str(name): float(w)
+                           for name, w in zip(donors_df.columns, fit.omega)},
+            time_weights={period: float(w)
+                          for period, w in zip(Ywide_full.index[:pre_periods],
+                                               fit.lam)},
+            summary_stats={
+                "how": how,
+                "treated_markets": members,
+                "zeta": float(fit.zeta),
+                "bias_correction": float(fit.bias_correction),
+                "cpic": cpic,
+                "cost": cost,
+            },
+        ),
+        fit_diagnostics=FitDiagnosticsResults(
+            rmse_pre=float(fit.pre_rmspe),
+            additional_metrics={"scaled_l2": float(fit.scaled_l2)},
+        ),
+    )


### PR DESCRIPTION
## Related Links

- Docs page: `docs/sdidgeo.rst` (new "Reading out the experiment" section)
- Follows #392, whose donor exclusion this readout has to inherit
- The estimator was added in #372

## What

- Added `mlsynth/utils/sdidgeo_helpers/realize.py` — applies the chosen region's pre-period fit across the full panel and builds the realized effect report
- `fit()` now fills `DesignResult.report` when `post_col` marks post-treatment periods
- Added `how` to the config: the scale the readout is written in
- 27 new tests
- Corrected assumption 3's remark, which still said SDIDGEO does not model spillover

## Why

SDIDGEO chose a test region and then could not read out the experiment it
designed. `report` stayed `None` with a comment saying it happens once outcomes
are observed, and that code did not exist — so the estimator designed an
experiment you then had to analyse by hand.

## How

The readout uses synthetic DiD and the placebo standard error, the same
estimator and the same null every candidate was scored with. A minimum
detectable effect computed one way and a readout computed another would leave
the reported power describing a test nobody ran, and choosing the design with
the estimator that will analyse the result is the reason to reach for SDIDGEO.
For the same reason the readout inherits the design's donor pool: where a
spillover constraint barred a treated market's conflict-neighbours, they stay
barred.

One wrinkle. `geoex_dataprep` truncates to the pre-period when `post_col` is
set, on purpose, so a design fit on a pre-only panel and one fit on a full panel
choose the same region. That meant `run_design` never saw the post periods, so
the readout re-preps without `post_col` to get them. The selection path is
untouched, and a test pins that.

`how` sets reporting units only. The fit always runs on the per-market mean —
the series the MDE describes — so `how` moves neither the region chosen nor the
p-value, which is a scale-free ratio. Default `mean` preserves current
behaviour; `sum` gives GeoLift's summed incremental. Cost from `cpic` comes off
the summed incremental either way.

## Verification

- Path: not applicable — see the validation decomposition landed in #391. This
  adds a readout on the same engine, with no new numerical claim to match
  externally.
- A test pins that the p-value is identical across `how` scales, since a
  scale-free statistic deciding significance by reporting convention would be a
  defect.
- A test pins that the counterfactual matches a direct `sdid_fit_once` on the
  same panel and window, so the readout cannot drift from the engine.
- Rebased onto main after #392: replayed as a single commit onto the squashed
  constraints, then re-run.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR
- [x] The default preserves existing behaviour, including reporting units — `how` defaults to `mean`, which is what the fit already used
- [x] Existing pinned benchmark values unchanged; `report` was `None` before and is `None` still without `post_col`
- [x] A test pins that `report` stays `None` without a post period
- [x] Both new config fields carry `Field(...)` descriptions

## Test Steps

- [x] `pytest mlsynth/tests/test_sdidgeo_realize.py -q` — 27 passed
- [x] `pytest mlsynth/tests/test_sdidgeo_realize.py mlsynth/tests/test_sdidgeo_constraints.py -q` — 73 passed after the rebase onto merged constraints
- [x] `pytest mlsynth/tests/test_result_contract.py -q` — 174 passed
- [x] `coverage run --timid -m pytest mlsynth/tests/test_sdidgeo_realize.py` — `realize.py` 100%

## Other Notes

`multicell` remains the last capability gap against the GeoLift estimator. It
needs a modelling decision before it can be ported: its cross-cell winner rule
compares non-overlapping conformal intervals, and conformal is what does not
transfer to SDID.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_