### PR TITLE
Make SDIDGEO's scoring estimator pluggable, and add augsynth

### DIFF
--- a/benchmarks/cases/sdidgeo_augsynth_geolift.py
+++ b/benchmarks/cases/sdidgeo_augsynth_geolift.py
@@ -1,0 +1,135 @@
+"""SDIDGEO cross-validation: the augsynth engine against GeoLift's BestMarkets.
+
+Cross-validation against the reference implementation. SDIDGEO's scoring
+estimator is pluggable, and this case answers what the seam is for: with the
+augsynth engine selected, does the design harness reproduce the market selection
+GeoLift itself publishes?
+
+The GeoLift_Walkthrough runs
+
+    GeoLiftMarketSelection(data = GeoTestData_PreTest, treatment_periods = c(10,15),
+        N = c(2,3,4,5), effect_size = seq(0, 0.2, 0.05), include_markets = "chicago",
+        exclude_markets = "honolulu", cpic = 7.50, budget = 1e5, fixed_effects = TRUE,
+        side_of_test = "two_sided")
+
+and prints a ranked ``BestMarkets`` table whose top five designs are
+
+    rank  candidate                                  dur  es    investment   abs_lift0
+    1     chicago, cincinnati, houston, portland     15   0.05  $74,118.38   0.002
+    1     chicago, portland                          15   0.10  $64,563.75   0.001
+    3     chicago, cincinnati, houston, portland     10   0.10  $99,027.75   0.004
+    3     chicago, portland                          10   0.10  $43,646.25   0.004
+    5     chicago, houston, portland                 10   0.10  $75,389.25   0.005
+
+``SDIDGEO(engine="augsynth")`` reaches all five, with the rank, the MDE, the
+CPIC investment and the rounded ``abs_lift_in_zero`` matching value for value.
+Fourteen quantities are pinned.
+
+Why this is a stronger check than it looks. The engine supplies the fit and the
+p-value and nothing else; candidate nomination, the backtest window arithmetic,
+effect injection, the power sweep, the MDE rule and GeoLift's composite rank all
+sit above it in shared code. Reproducing the published ranking therefore
+exercises the whole harness, not the estimator alone -- a divergence anywhere in
+that stack would move a rank or an investment. It is also what licenses reading
+the SDID engine's numbers as a like-for-like comparison: the same harness,
+scored differently.
+
+The scan runs sizes 2 through 5 in one call and ranks them together, which is
+what ``GeoLiftMarketSelection`` does with its single ``resultsM`` table. The
+marginal rank-6 design differs from the vignette (augsynth-version scoring at the
+tail), so only the stable top five are pinned.
+
+Runtime is a few seconds: ``to_be_treated=["chicago"]`` cuts the field to 33
+candidates, since GeoLift generates candidates ignoring the forced units and then
+keeps those already containing them.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+
+import pandas as pd
+
+from mlsynth import SDIDGEO
+from mlsynth.config_models import SDIDGEOConfig
+
+_DATA = os.path.join(os.path.dirname(__file__), "..", "..",
+                     "basedata", "geolift_market_data.csv")   # 90-period PreTest
+
+_CP = frozenset({"chicago", "portland"})
+_CCHP = frozenset({"chicago", "cincinnati", "houston", "portland"})
+_CHP = frozenset({"chicago", "houston", "portland"})
+
+
+def _shortlist() -> pd.DataFrame:
+    """The pooled, ranked design table from one augsynth-engine run."""
+    df = pd.read_csv(os.path.abspath(_DATA))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = SDIDGEO(SDIDGEOConfig(
+            df=df, outcome="Y", unitid="location", time="date",
+            treatment_size=[2, 3, 4, 5], to_be_treated=["chicago"],
+            not_to_be_treated=["honolulu"], durations=[10, 15],
+            effect_sizes=[0.0, 0.05, 0.10, 0.15, 0.20], n_backtests=1,
+            how="sum", engine="augsynth", augment="ridge", fixed_effects=True,
+            alpha=0.1, power_threshold=0.8, cpic=7.5, budget=1e5, ns=1000,
+            seed=0, conformal_type="iid", n_validation_backtests=0,
+        )).fit()
+    out = res.power.copy()
+    out["cand"] = out["candidate"].apply(frozenset)
+    return out
+
+
+def run() -> dict:
+    pool = _shortlist()
+
+    def row(cand: frozenset, duration: int) -> pd.Series:
+        hit = pool[(pool["cand"] == cand) & (pool["duration"] == duration)]
+        if hit.empty:
+            raise AssertionError(
+                f"design {sorted(cand)} at duration {duration} is absent from "
+                "the shortlist; GeoLift ranks it in the top five.")
+        return hit.iloc[0]
+
+    cp15, cchp15 = row(_CP, 15), row(_CCHP, 15)
+    cp10, cchp10 = row(_CP, 10), row(_CCHP, 10)
+    chp10 = row(_CHP, 10)
+
+    return {
+        "cp15_rank": float(cp15["rank"]),
+        "cp15_inv": float(cp15["investment"]),
+        "cp15_mde": float(cp15["mde"]),
+        "cp15_az": float(cp15["abs_lift_in_zero"]),
+        "cchp15_rank": float(cchp15["rank"]),
+        "cchp15_inv": float(cchp15["investment"]),
+        "cchp15_mde": float(cchp15["mde"]),
+        "cchp15_az": float(cchp15["abs_lift_in_zero"]),
+        "cp10_rank": float(cp10["rank"]),
+        "cp10_inv": float(cp10["investment"]),
+        "cchp10_rank": float(cchp10["rank"]),
+        "cchp10_inv": float(cchp10["investment"]),
+        "chp10_rank": float(chp10["rank"]),
+        "chp10_inv": float(chp10["investment"]),
+    }
+
+
+# GeoLift's own published BestMarkets values. The investment is a deterministic
+# transform of the panel (cpic x effect_size x summed treated volume), so it is
+# pinned to the cent; the MDE sits on the 0.05 effect grid; abs_lift_in_zero is
+# reported to three decimals, matching the vignette's rounding.
+EXPECTED = {
+    "cp15_rank": (1.0, 0.5),
+    "cp15_inv": (64563.75, 1.0),
+    "cp15_mde": (0.10, 0.001),
+    "cp15_az": (0.001, 0.0015),
+    "cchp15_rank": (1.0, 0.5),
+    "cchp15_inv": (74118.38, 1.0),
+    "cchp15_mde": (0.05, 0.001),
+    "cchp15_az": (0.002, 0.0015),
+    "cp10_rank": (3.0, 0.5),
+    "cp10_inv": (43646.25, 1.0),
+    "cchp10_rank": (3.0, 0.5),
+    "cchp10_inv": (99027.75, 1.0),
+    "chp10_rank": (5.0, 0.5),
+    "chp10_inv": (75389.25, 1.0),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -25,6 +25,7 @@ CASES = {
     "spsydid_state_mc": "benchmarks.cases.spsydid_state_mc",  # cross-val vs authors' repo
     "spsydid_lawa_diff": "benchmarks.cases.spsydid_lawa_diff",  # differential cross-val vs authors' functions_ssdid on the real Arizona LAWA CPS panel (SpSyDiD.fit() ATT + spillover agree to solver tolerance under canonical convention)
     "seq_sdid_mc": "benchmarks.cases.seq_sdid_mc",
+    "sdidgeo_augsynth_geolift": "benchmarks.cases.sdidgeo_augsynth_geolift",  # cross-val vs R GeoLiftMarketSelection: the augsynth engine reproduces the published BestMarkets top five (rank, MDE, investment, abs_lift_in_zero)
     "sdidgeo_mc": "benchmarks.cases.sdidgeo_mc",              # design calibration (original method, no external referent): size at the null, out-of-sample power at the reported MDE, and the winner's-curse gap on the selected region
     "clustersc_subgroups": "benchmarks.cases.clustersc_subgroups",      # Path B: ClusterSC vs RSC
     "clustersc_subgroups_ref": "benchmarks.cases.clustersc_subgroups_ref",  # cross-val vs authors' repo

--- a/docs/sdidgeo.rst
+++ b/docs/sdidgeo.rst
@@ -437,12 +437,18 @@ panel and window. The two structural properties the effect sweep relies
 on are checked against brute-force recomputation in the same file, so
 the shortcut is proved and not assumed.
 
-The nomination stage could be cross-validated and is not yet. Which
-candidate regions get nominated depends on correlation ranking and
-anchor-plus-neighbours, not on what scores them, so the stage is
-estimator-independent and comparable against live R
-``GeoLiftMarketSelection`` on ``basedata/geolift_test_data.csv``. That
-case is not written.
+The harness is cross-validated. With ``engine="augsynth"`` selected,
+SDIDGEO reproduces the market selection GeoLift itself publishes: on the
+walkthrough panel, all five of its top-ranked designs come back with the
+same rank, minimum detectable effect, CPIC investment and
+``abs_lift_in_zero``, fourteen quantities value for value
+(`benchmarks/cases/sdidgeo_augsynth_geolift.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/sdidgeo_augsynth_geolift.py>`_).
+This reaches further than the engine: nomination, the backtest windows,
+effect injection, the power sweep, the MDE rule and the composite rank
+are shared code, so a divergence anywhere in that stack would move a
+rank or an investment. It is also what licenses reading the two engines
+against each other, since the harness around them is the same.
 
 The composition is self-validated. Whether an MDE from SDID-scored
 backtests means what it claims has no external referent, so

--- a/mlsynth/tests/test_sdidgeo_augsynth_engine.py
+++ b/mlsynth/tests/test_sdidgeo_augsynth_engine.py
@@ -1,0 +1,290 @@
+"""Augmented SCM as an SDIDGEO scoring engine.
+
+The seam exists so the estimator that scores candidates can be swapped without
+the pipeline noticing. This is the second engine: augsynth (Ben-Michael, Feller
+& Rothstein 2021) fitted through :class:`~mlsynth.utils.bilevel.engine.BilevelSCM`,
+tested by the conformal permutation of Chernozhukov, Wuthrich & Zhu -- which is
+what GeoLift itself uses.
+
+Engine and inference are not one axis. Placebo reassignment needs only a
+counterfactual built from donors, so it applies to either engine. Conformal
+needs the pre-period residuals to be exchangeable across the matching window,
+and synthetic DiD's time weights exist precisely to say pre-periods are not
+interchangeable -- so conformal is available on augsynth alone, and the config
+has to refuse the invalid pairing instead of silently producing a number.
+
+The two procedures also differ in what the effect sweep can hoist. A placebo
+standard error does not depend on the injected effect and is drawn once for the
+grid; a conformal p-value re-permutes against the treated series and is
+recomputed per effect size. Both paths are pinned here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.config_models import SDIDGEOConfig
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.sdidgeo_helpers.engines import EngineFit, resolve_engine
+from mlsynth.utils.sdidgeo_helpers.shaping import aggregate_treated, donor_matrix
+
+DATA = Path(__file__).resolve().parents[2] / "basedata" / "geolift_test_data.csv"
+
+
+@pytest.fixture(scope="module")
+def panel():
+    df = pd.read_csv(DATA)
+    df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+@pytest.fixture(scope="module")
+def wide(panel):
+    from mlsynth.utils.datautils import geoex_dataprep
+    return geoex_dataprep(panel, "location", "date", "Y")["Ywide"]
+
+
+@pytest.fixture(scope="module")
+def arrays(wide):
+    region = frozenset(list(wide.columns)[:2])
+    y = aggregate_treated(wide, region, how="mean").to_numpy()
+    Y0 = donor_matrix(wide, region).to_numpy()
+    n_pre = wide.shape[0] - 14
+    return y, Y0, n_pre, n_pre, wide.shape[0] - 1, len(region)
+
+
+# ---------------------------------------------------------------------------
+# Resolution and the EngineFit contract
+# ---------------------------------------------------------------------------
+
+class TestResolution:
+    def test_resolves(self):
+        eng = resolve_engine("augsynth")
+        assert eng.name == "augsynth"
+        for fn in ("fit_once", "att", "sweep_p_values", "point_inference"):
+            assert callable(getattr(eng, fn))
+
+    def test_config_accepts_augsynth(self, panel):
+        cfg = SDIDGEOConfig(df=panel, unitid="location", time="date",
+                            outcome="Y", treatment_size=2, durations=[14],
+                            effect_sizes=[0.0, 0.2], n_backtests=2, n_draws=5,
+                            seed=0, engine="augsynth")
+        assert cfg.engine == "augsynth"
+
+
+class TestEngineFitContract:
+    @pytest.fixture(scope="class")
+    def fit(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        return resolve_engine("augsynth").fit_once(y, Y0, n_pre, start, end, n_tr)
+
+    def test_shapes(self, fit, arrays):
+        y, Y0, *_ = arrays
+        assert isinstance(fit, EngineFit)
+        assert fit.counterfactual.shape == y.shape
+        assert fit.donor_weights.shape == (Y0.shape[1],)
+        assert np.isfinite(fit.pre_rmspe) and np.isfinite(fit.scaled_l2)
+
+    def test_has_no_time_weights(self, fit):
+        # augsynth weights donors only; the slot stays empty so the shared
+        # pipeline can tell the two engines apart without asking which it has.
+        assert fit.time_weights is None
+
+    def test_extras_carry_the_augsynth_specifics(self, fit):
+        assert "intercept" in fit.extras
+        assert "lambda_" in fit.extras and "augment" in fit.extras
+
+    def test_counterfactual_is_intercept_plus_weighted_donors(self, fit, arrays):
+        _, Y0, *_ = arrays
+        expected = fit.extras["intercept"] + Y0 @ fit.donor_weights
+        np.testing.assert_allclose(fit.counterfactual, expected, atol=1e-9)
+
+    def test_att_is_the_mean_window_gap(self, fit, arrays):
+        y, _, _, start, end, _ = arrays
+        eng = resolve_engine("augsynth")
+        expected = float(np.mean(y[start:end + 1]
+                                 - fit.counterfactual[start:end + 1]))
+        assert eng.att(fit, y, start, end) == pytest.approx(expected, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# It must match the old GeoLift fit exactly
+# ---------------------------------------------------------------------------
+
+class TestMatchesTheGeoLiftFit:
+    """The engine is an adapter, so it must add no arithmetic of its own."""
+
+    def test_matches_a_direct_bilevel_fit(self, arrays):
+        from mlsynth.utils.bilevel.engine import BilevelSCM
+        y, Y0, n_pre, start, end, n_tr = arrays
+        # GeoLift's default: ridge augmentation with unit fixed effects, so the
+        # fit matches shapes and not levels.
+        A, B = y[:n_pre] - y[:n_pre].mean(), Y0[:n_pre] - Y0[:n_pre].mean(axis=0)
+        res = BilevelSCM(augment="ridge").fit(A, B)
+        fit = resolve_engine("augsynth").fit_once(y, Y0, n_pre, start, end, n_tr)
+        np.testing.assert_allclose(fit.donor_weights, np.asarray(res.W),
+                                   atol=1e-10)
+
+    def test_intercept_aligns_the_pre_period_means(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        fit = resolve_engine("augsynth").fit_once(y, Y0, n_pre, start, end, n_tr)
+        expected = float(np.mean(y[:n_pre] - Y0[:n_pre] @ fit.donor_weights))
+        assert fit.extras["intercept"] == pytest.approx(expected, abs=1e-9)
+
+    def test_scaled_l2_is_the_augsynth_ratio(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        fit = resolve_engine("augsynth").fit_once(y, Y0, n_pre, start, end, n_tr)
+        A = y[:n_pre] - y[:n_pre].mean()
+        B = Y0[:n_pre] - Y0[:n_pre].mean(axis=0)
+        w_unif = np.full(B.shape[1], 1.0 / B.shape[1])
+        expected = (np.linalg.norm(B @ fit.donor_weights - A)
+                    / np.linalg.norm(B @ w_unif - A))
+        assert fit.scaled_l2 == pytest.approx(float(expected), rel=1e-9)
+
+    def test_no_fixed_effects_leaves_a_zero_intercept(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        fit = resolve_engine("augsynth").fit_once(
+            y, Y0, n_pre, start, end, n_tr, fixed_effects=False)
+        assert fit.extras["intercept"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Conformal inference, and what the sweep can and cannot hoist
+# ---------------------------------------------------------------------------
+
+class TestConformalSweep:
+    def test_sweep_returns_one_p_value_per_effect(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("augsynth")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        grid = [-0.2, 0.0, 0.2]
+        out = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, grid,
+                                 inference="conformal", ns=50, seed=0, n_tr=n_tr)
+        assert len(out["p_value"]) == len(grid) == len(out["tau"])
+        assert all(0.0 <= p <= 1.0 for p in out["p_value"])
+
+    def test_conformal_p_values_differ_across_the_grid(self, arrays):
+        # The defect a same-call-site substitution would have caused: one
+        # p-value reused for every effect size. A conformal test re-permutes
+        # against the injected series, so the grid must move.
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("augsynth")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        out = eng.sweep_p_values(fit, y, Y0, n_pre, start, end,
+                                 [-0.3, 0.0, 0.3], inference="conformal",
+                                 ns=50, seed=0, n_tr=n_tr)
+        assert len(set(out["p_value"])) > 1
+
+    def test_null_effect_is_least_significant(self, arrays):
+        # A monotonicity the design's whole MDE logic rests on: a bigger
+        # injected lift must not be harder to detect than no lift at all.
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("augsynth")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        out = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, [0.0, 0.5],
+                                 inference="conformal", ns=100, seed=0, n_tr=n_tr)
+        assert out["p_value"][1] <= out["p_value"][0]
+
+    def test_reproducible_at_a_fixed_seed(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("augsynth")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        kw = dict(inference="conformal", ns=40, seed=3, n_tr=n_tr)
+        a = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, [0.0, 0.2], **kw)
+        b = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, [0.0, 0.2], **kw)
+        assert a["p_value"] == b["p_value"]
+
+    def test_placebo_is_available_on_augsynth_too(self, arrays):
+        # Placebo needs only a donor-built counterfactual, so it is not tied to
+        # the engine. This is the combination that isolates the objective from
+        # the inference.
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("augsynth")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        out = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, [0.0, 0.2],
+                                 inference="placebo", n_draws=10, seed=0,
+                                 n_tr=n_tr)
+        assert all(np.isfinite(p) for p in out["p_value"])
+
+    def test_point_inference_reports_its_method(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("augsynth")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        p, details = eng.point_inference(fit, y, Y0, n_pre, start, end,
+                                         inference="conformal", ns=50, seed=0,
+                                         n_tr=n_tr)
+        assert 0.0 <= p <= 1.0
+        assert details["method"] == "conformal"
+
+
+# ---------------------------------------------------------------------------
+# The config must refuse the invalid pairing
+# ---------------------------------------------------------------------------
+
+class TestInferenceValidation:
+    def _cfg(self, panel, **kw):
+        base = dict(df=panel, unitid="location", time="date", outcome="Y",
+                    treatment_size=2, durations=[14], effect_sizes=[0.0, 0.2],
+                    n_backtests=2, n_draws=5, seed=0)
+        base.update(kw)
+        return SDIDGEOConfig(**base)
+
+    def test_sdid_defaults_to_placebo(self, panel):
+        assert self._cfg(panel).inference == "placebo"
+
+    def test_augsynth_defaults_to_conformal(self, panel):
+        # GeoLift's own choice, so the augsynth path reproduces it by default.
+        assert self._cfg(panel, engine="augsynth").inference == "conformal"
+
+    def test_sdid_with_conformal_is_rejected(self, panel):
+        with pytest.raises(MlsynthConfigError, match="conformal"):
+            self._cfg(panel, engine="sdid", inference="conformal")
+
+    def test_augsynth_with_placebo_is_allowed(self, panel):
+        assert self._cfg(panel, engine="augsynth",
+                         inference="placebo").inference == "placebo"
+
+    def test_unknown_inference_is_rejected(self, panel):
+        with pytest.raises(MlsynthConfigError, match="inference"):
+            self._cfg(panel, inference="bayes")
+
+    def test_augsynth_only_knobs_rejected_on_sdid(self, panel):
+        with pytest.raises(MlsynthConfigError, match="augsynth"):
+            self._cfg(panel, engine="sdid", fixed_effects=False)
+
+
+# ---------------------------------------------------------------------------
+# End to end through the pipeline
+# ---------------------------------------------------------------------------
+
+class TestEndToEnd:
+    def test_augsynth_design_runs_and_selects(self, panel):
+        import warnings
+        from mlsynth import SDIDGEO
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = SDIDGEO(SDIDGEOConfig(
+                df=panel, unitid="location", time="date", outcome="Y",
+                treatment_size=2, durations=[14], effect_sizes=[0.0, 0.1, 0.2],
+                n_backtests=2, n_draws=8, ns=50, n_validation_backtests=0,
+                engine="augsynth", seed=0)).fit()
+        assert res.selected_units is not None
+        assert len(res.selected_units) == 2
+        assert not res.power.empty
+
+    def test_augsynth_weights_have_no_time_vector(self, panel):
+        import warnings
+        from mlsynth import SDIDGEO
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = SDIDGEO(SDIDGEOConfig(
+                df=panel, unitid="location", time="date", outcome="Y",
+                treatment_size=2, durations=[14], effect_sizes=[0.0, 0.2],
+                n_backtests=2, n_draws=8, ns=40, n_validation_backtests=0,
+                engine="augsynth", seed=0)).fit()
+        assert res.design_weights.donor_weights
+        assert not res.design_weights.time_weights

--- a/mlsynth/tests/test_sdidgeo_augsynth_engine.py
+++ b/mlsynth/tests/test_sdidgeo_augsynth_engine.py
@@ -288,3 +288,49 @@ class TestEndToEnd:
                 engine="augsynth", seed=0)).fit()
         assert res.design_weights.donor_weights
         assert not res.design_weights.time_weights
+
+
+class TestPlanningMDEUsesTheChosenEngine:
+    """The winner's re-scoring has to run on the engine the search ran on.
+
+    ``planning_mde`` re-scores the winning region on validation backtests held
+    out of the selection, and it is a separate code path from the scoring loop:
+    it builds its own settings and calls ``simulate_backtest`` directly. Nothing
+    in the engine tests reached it, because they all set
+    ``n_validation_backtests=0`` -- which is how a NameError in that path
+    survived a green run of every engine test file and only failed in CI.
+
+    The planning MDE has to be comparable with the optimistic MDE it corrects,
+    so it must be produced by the same engine and the same null.
+    """
+
+    def _fit(self, panel, **kw):
+        import warnings
+        from mlsynth import SDIDGEO
+        base = dict(df=panel, unitid="location", time="date", outcome="Y",
+                    treatment_size=2, durations=[7],
+                    effect_sizes=[-0.2, 0.0, 0.2], n_backtests=2,
+                    n_draws=8, n_validation_backtests=2, seed=0)
+        base.update(kw)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return SDIDGEO(SDIDGEOConfig(**base)).fit()
+
+    @pytest.mark.parametrize("engine,extra", [
+        ("sdid", {}),
+        ("augsynth", dict(ns=40, augment="ridge", fixed_effects=True)),
+    ])
+    def test_validation_backtests_run_on_the_selected_engine(self, panel,
+                                                             engine, extra):
+        res = self._fit(panel, engine=engine, **extra)
+        assert res.selected_units is not None
+        # metadata carries both numbers, and the planning one is only present
+        # when the validation backtests actually ran.
+        assert "winner_mde_planning" in res.metadata
+        assert "winner_mde_optimistic" in res.metadata
+
+    def test_augsynth_planning_mde_is_finite_or_absent(self, panel):
+        res = self._fit(panel, engine="augsynth", ns=40, augment="ridge",
+                        fixed_effects=True)
+        planning = res.metadata["winner_mde_planning"]
+        assert planning is None or np.isfinite(planning)

--- a/mlsynth/tests/test_sdidgeo_engine_properties.py
+++ b/mlsynth/tests/test_sdidgeo_engine_properties.py
@@ -1,0 +1,197 @@
+"""Generative property tests for the SDIDGEO scoring engines.
+
+The seam exists so the estimator scoring candidates can be swapped. What makes
+that safe is not that each engine passes its own tests -- it is that both
+satisfy the same contract, so the pipeline above them cannot tell which is
+running except through the numbers. So the properties here are parametrized
+over the engine registry: every engine must satisfy all of them, and a third
+engine added later inherits the suite by construction.
+
+Why this layer. Property tests generate inside the specification, which is where
+a fault of omission lives (see the instrument contract in
+``agents/agents_tests.md``). An engine adapter is close to the Layer 1 target
+that contract prefers -- a pure function of two arrays -- with the caveat that a
+solver runs inside it, so tolerances come from measured solver spread and the
+example counts stay modest.
+
+The relations asserted are the metamorphic ones that carry the estimator's
+meaning:
+
+* scale -- rescaling the panel scales the ATT by the same factor and leaves the
+  donor weights alone, because a synthetic control is a weighted average and
+  averaging commutes with scaling;
+* location -- shifting every outcome by a constant moves nothing, since both
+  engines match shapes and absorb levels (SDID differences them out, augsynth
+  carries an intercept under fixed effects);
+* permutation -- relabelling donors permutes the weight vector identically and
+  leaves the counterfactual untouched, so the answer does not depend on column
+  order;
+* the analytic shortcut -- injecting an effect and refitting must agree with
+  shifting the ATT arithmetically, which is the equality that licenses the
+  shortcut the scoring loop relies on.
+
+Named degenerate panels are kept as ``@example`` instead of left to the
+generator: a single donor, a constant treated series, and a donor pool that
+already reproduces the treated path exactly are the corners a real geo panel
+produces.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils.sdidgeo_helpers.engines import ENGINE_NAMES, resolve_engine
+
+ENGINES = sorted(ENGINE_NAMES)
+
+# Solver tolerance. Both engines run a numerical program, so equalities that are
+# exact in arithmetic hold to solver precision and not to machine epsilon.
+_ATOL = 1e-6
+_RTOL = 1e-6
+
+_SETTINGS = settings(
+    max_examples=25, deadline=None, derandomize=True,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+
+
+def _panel(draw, n_periods: int, n_donors: int) -> tuple:
+    """A geo-shaped panel: donor levels over a range, a shared seasonal, noise."""
+    seed = draw(st.integers(min_value=0, max_value=2**31 - 1))
+    rng = np.random.default_rng(seed)
+    t = np.arange(n_periods)
+    levels = rng.uniform(50.0, 500.0, size=n_donors)
+    season = 10.0 * np.sin(2 * np.pi * t / 7.0)
+    Y0 = (levels[None, :] + season[:, None]
+          + rng.normal(0.0, 5.0, size=(n_periods, n_donors)))
+    w = rng.dirichlet(np.ones(n_donors))
+    y = Y0 @ w + rng.normal(0.0, 3.0, size=n_periods)
+    return y, Y0
+
+
+@st.composite
+def panels(draw, min_donors: int = 3, max_donors: int = 8):
+    n_periods = draw(st.integers(min_value=14, max_value=26))
+    n_donors = draw(st.integers(min_value=min_donors, max_value=max_donors))
+    y, Y0 = _panel(draw, n_periods, n_donors)
+    n_pre = n_periods - draw(st.integers(min_value=3, max_value=6))
+    assume(n_pre >= 8)
+    return y, Y0, n_pre, n_periods - 1
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+class TestMetamorphicRelations:
+    """Relations every engine must satisfy, over the panel domain."""
+
+    @_SETTINGS
+    @given(case=panels())
+    def test_scale_equivariance(self, engine, case):
+        # Y -> cY scales the ATT by c and leaves the donor weights unchanged.
+        y, Y0, n_pre, end = case
+        eng = resolve_engine(engine)
+        c = 7.5
+        base = eng.fit_once(y, Y0, n_pre, n_pre, end, 1)
+        scaled = eng.fit_once(y * c, Y0 * c, n_pre, n_pre, end, 1)
+        np.testing.assert_allclose(scaled.donor_weights, base.donor_weights,
+                                   atol=_ATOL)
+        np.testing.assert_allclose(eng.att(scaled, y * c, n_pre, end),
+                                   c * eng.att(base, y, n_pre, end),
+                                   rtol=_RTOL, atol=_ATOL)
+
+    @_SETTINGS
+    @given(case=panels())
+    def test_location_invariance(self, engine, case):
+        # Both engines match shapes and absorb levels, so a common shift moves
+        # neither the weights nor the estimated effect.
+        y, Y0, n_pre, end = case
+        eng = resolve_engine(engine)
+        a = 123.0
+        base = eng.fit_once(y, Y0, n_pre, n_pre, end, 1)
+        shifted = eng.fit_once(y + a, Y0 + a, n_pre, n_pre, end, 1)
+        np.testing.assert_allclose(shifted.donor_weights, base.donor_weights,
+                                   atol=_ATOL)
+        np.testing.assert_allclose(eng.att(shifted, y + a, n_pre, end),
+                                   eng.att(base, y, n_pre, end),
+                                   rtol=_RTOL, atol=_ATOL)
+
+    @_SETTINGS
+    @given(case=panels(), key=st.integers(min_value=0, max_value=2**31 - 1))
+    def test_donor_permutation_equivariance(self, engine, case, key):
+        # Relabelling donors permutes the weights identically and leaves the
+        # counterfactual alone: column order is not information.
+        y, Y0, n_pre, end = case
+        eng = resolve_engine(engine)
+        perm = np.random.default_rng(key).permutation(Y0.shape[1])
+        base = eng.fit_once(y, Y0, n_pre, n_pre, end, 1)
+        shuffled = eng.fit_once(y, Y0[:, perm], n_pre, n_pre, end, 1)
+        np.testing.assert_allclose(shuffled.donor_weights,
+                                   base.donor_weights[perm], atol=_ATOL)
+        np.testing.assert_allclose(shuffled.counterfactual, base.counterfactual,
+                                   atol=1e-4, rtol=1e-6)
+
+    @_SETTINGS
+    @given(case=panels())
+    def test_counterfactual_spans_the_panel(self, engine, case):
+        y, Y0, n_pre, end = case
+        fit = resolve_engine(engine).fit_once(y, Y0, n_pre, n_pre, end, 1)
+        assert fit.counterfactual.shape == y.shape
+        assert np.all(np.isfinite(fit.counterfactual))
+        assert fit.donor_weights.shape == (Y0.shape[1],)
+        assert np.isfinite(fit.pre_rmspe)
+
+    @_SETTINGS
+    @given(case=panels(),
+           effects=st.lists(st.floats(min_value=-0.5, max_value=0.5,
+                                      allow_nan=False, allow_infinity=False),
+                            min_size=1, max_size=4))
+    def test_analytic_shortcut_equals_the_refit(self, engine, case, effects):
+        # The scoring loop shifts the ATT by effect x mean(treated_post) instead
+        # of refitting. That is exact only because the fit uses pre-period data
+        # alone, so it is a claim about the engine, asserted over the domain.
+        y, Y0, n_pre, end = case
+        eng = resolve_engine(engine)
+        fit = eng.fit_once(y, Y0, n_pre, n_pre, end, 1)
+        kw = dict(n_draws=4, ns=20, n_tr=1, seed=0, inference="placebo")
+        fast = eng.sweep_p_values(fit, y, Y0, n_pre, n_pre, end, effects,
+                                  analytic=True, **kw)
+        slow = eng.sweep_p_values(fit, y, Y0, n_pre, n_pre, end, effects,
+                                  analytic=False, **kw)
+        np.testing.assert_allclose(slow["tau"], fast["tau"], rtol=1e-8,
+                                   atol=1e-8)
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+class TestDegenerateCorners:
+    """Named panels a generator is unlikely to produce, kept as examples."""
+
+    def _run(self, engine, y, Y0, n_pre):
+        return resolve_engine(engine).fit_once(y, Y0, n_pre, n_pre,
+                                               len(y) - 1, 1)
+
+    def test_single_donor(self, engine):
+        rng = np.random.default_rng(0)
+        Y0 = rng.normal(100.0, 5.0, size=(20, 1))
+        y = Y0[:, 0] + rng.normal(0.0, 1.0, size=20)
+        fit = self._run(engine, y, Y0, 15)
+        assert fit.donor_weights.shape == (1,)
+        assert np.all(np.isfinite(fit.counterfactual))
+
+    def test_donor_reproduces_the_treated_path(self, engine):
+        # Perfect pre-fit: the imbalance denominators can go to zero, so the
+        # engine must still return finite weights and a finite counterfactual.
+        rng = np.random.default_rng(1)
+        Y0 = rng.normal(100.0, 5.0, size=(20, 3))
+        y = Y0[:, 0].copy()
+        fit = self._run(engine, y, Y0, 15)
+        assert np.all(np.isfinite(fit.counterfactual))
+        assert np.all(np.isfinite(fit.donor_weights))
+
+    def test_constant_treated_series(self, engine):
+        rng = np.random.default_rng(2)
+        Y0 = rng.normal(100.0, 5.0, size=(20, 3))
+        y = np.full(20, 50.0)
+        fit = self._run(engine, y, Y0, 15)
+        assert np.all(np.isfinite(fit.counterfactual))

--- a/mlsynth/tests/test_sdidgeo_engine_seam.py
+++ b/mlsynth/tests/test_sdidgeo_engine_seam.py
@@ -1,0 +1,246 @@
+"""The SDIDGEO engine seam: a pluggable scoring estimator.
+
+Everything in SDIDGEO except the fit and the p-value is estimator-independent --
+candidate nomination, the backtest windows, effect injection, power, MDE,
+ranking, the constraint layer, the plots. This module pins the seam that makes
+that explicit, so a second engine can be added without the pipeline noticing.
+
+Two contracts, not one:
+
+* the engine fits, ``fit_once(y, Y0, n_pre, start, end, n_tr) -> EngineFit``;
+* the inference produces p-values for a whole effect sweep at once.
+
+The sweep is the inference's job because the two procedures differ in what they
+can hoist. The placebo standard error is invariant to the injected effect, so it
+is computed once and reused across the grid; a conformal p-value re-permutes
+against the treated series and so has to be recomputed per effect size. Handing
+the inference the whole grid keeps that choice inside the module that owns it.
+
+Phase 1 adds the seam with ``sdid`` as the only engine, so it is proved by
+things not moving: the pipeline's output has to be bit-identical to the version
+before the seam existed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SDIDGEO
+from mlsynth.config_models import SDIDGEOConfig
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.sdidgeo_helpers.engines import EngineFit, resolve_engine
+from mlsynth.utils.sdidgeo_helpers.shaping import aggregate_treated, donor_matrix
+
+DATA = Path(__file__).resolve().parents[2] / "basedata" / "geolift_test_data.csv"
+
+
+@pytest.fixture(scope="module")
+def panel():
+    df = pd.read_csv(DATA)
+    df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+@pytest.fixture(scope="module")
+def wide(panel):
+    from mlsynth.utils.datautils import geoex_dataprep
+    return geoex_dataprep(panel, "location", "date", "Y")["Ywide"]
+
+
+@pytest.fixture(scope="module")
+def arrays(wide):
+    region = frozenset(list(wide.columns)[:2])
+    y = aggregate_treated(wide, region, how="mean").to_numpy()
+    Y0 = donor_matrix(wide, region).to_numpy()
+    n_pre = wide.shape[0] - 14
+    return y, Y0, n_pre, n_pre, wide.shape[0] - 1, len(region)
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+class TestResolution:
+    def test_resolves_sdid(self):
+        eng = resolve_engine("sdid")
+        assert eng.name == "sdid"
+        assert callable(eng.fit_once) and callable(eng.sweep_p_values)
+        assert callable(eng.att) and callable(eng.point_inference)
+
+    def test_unknown_engine_raises(self):
+        with pytest.raises(MlsynthConfigError, match="engine"):
+            resolve_engine("granny-smith")
+
+    def test_config_defaults_to_sdid(self, panel):
+        cfg = SDIDGEOConfig(df=panel, unitid="location", time="date",
+                            outcome="Y", treatment_size=2, durations=[14],
+                            effect_sizes=[0.0, 0.2], n_backtests=2, n_draws=5,
+                            seed=0)
+        assert cfg.engine == "sdid"
+
+    def test_config_rejects_an_unknown_engine(self, panel):
+        with pytest.raises(MlsynthConfigError, match="engine"):
+            SDIDGEOConfig(df=panel, unitid="location", time="date", outcome="Y",
+                          treatment_size=2, durations=[14],
+                          effect_sizes=[0.0, 0.2], n_backtests=2, n_draws=5,
+                          seed=0, engine="mcintosh")
+
+
+# ---------------------------------------------------------------------------
+# The EngineFit contract
+# ---------------------------------------------------------------------------
+
+class TestEngineFitContract:
+    def test_fields_present_and_shaped(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        fit = resolve_engine("sdid").fit_once(y, Y0, n_pre, start, end, n_tr)
+        assert isinstance(fit, EngineFit)
+        assert fit.counterfactual.shape == y.shape
+        assert fit.donor_weights.shape == (Y0.shape[1],)
+        assert np.isfinite(fit.pre_rmspe) and np.isfinite(fit.scaled_l2)
+        assert isinstance(fit.extras, dict)
+
+    def test_sdid_carries_time_weights(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        fit = resolve_engine("sdid").fit_once(y, Y0, n_pre, start, end, n_tr)
+        assert fit.time_weights is not None
+        assert fit.time_weights.shape == (n_pre,)
+        assert fit.time_weights.min() >= -1e-9
+        assert fit.time_weights.sum() == pytest.approx(1.0, abs=1e-6)
+
+    def test_donor_weights_are_a_simplex(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        fit = resolve_engine("sdid").fit_once(y, Y0, n_pre, start, end, n_tr)
+        assert fit.donor_weights.min() >= -1e-9
+        assert fit.donor_weights.sum() == pytest.approx(1.0, abs=1e-6)
+
+    def test_att_is_the_mean_window_gap(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("sdid")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        expected = float(np.mean(y[start:end + 1]
+                                 - fit.counterfactual[start:end + 1]))
+        assert eng.att(fit, y, start, end) == pytest.approx(expected, abs=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# The seam is inert: it must reproduce the direct engine calls exactly
+# ---------------------------------------------------------------------------
+
+class TestSeamIsInert:
+    def test_fit_matches_sdid_fit_once(self, arrays):
+        from mlsynth.utils.sdidgeo_helpers.engine import sdid_fit_once
+        y, Y0, n_pre, start, end, n_tr = arrays
+        direct = sdid_fit_once(y, Y0, n_pre, start, end, n_tr=n_tr)
+        through = resolve_engine("sdid").fit_once(y, Y0, n_pre, start, end, n_tr)
+        np.testing.assert_array_equal(through.counterfactual, direct.counterfactual)
+        np.testing.assert_array_equal(through.donor_weights, direct.omega)
+        np.testing.assert_array_equal(through.time_weights, direct.lam)
+
+    def test_sweep_matches_the_hoisted_placebo_computation(self, arrays):
+        # The placebo sigma is invariant to the injected effect, so the sweep
+        # must reuse one draw across the grid, exactly as the loop did before.
+        from mlsynth.utils.sdidgeo_helpers.engine import (
+            normal_p_value, placebo_sigma, sdid_att, sdid_fit_once)
+        y, Y0, n_pre, start, end, n_tr = arrays
+        grid = [-0.2, -0.1, 0.0, 0.1, 0.2]
+
+        direct_fit = sdid_fit_once(y, Y0, n_pre, start, end, n_tr=n_tr)
+        tau0 = sdid_att(direct_fit, y, start, end)
+        baseline = float(np.mean(y[start:end + 1]))
+        sigma = placebo_sigma(y, Y0, n_pre, start, end, n_draws=12, n_tr=n_tr,
+                              seed=4)
+        expected = [normal_p_value(tau0 + es * baseline, sigma) for es in grid]
+
+        eng = resolve_engine("sdid")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        got = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, grid,
+                                 n_draws=12, n_tr=n_tr, seed=4)
+        np.testing.assert_array_equal(np.asarray(got["p_value"]), expected)
+        np.testing.assert_array_equal(np.asarray(got["tau"]),
+                                      [tau0 + es * baseline for es in grid])
+
+    def test_point_inference_matches_placebo_plus_normal_test(self, arrays):
+        from mlsynth.utils.sdidgeo_helpers.engine import (
+            normal_p_value, placebo_sigma, sdid_att, sdid_fit_once)
+        y, Y0, n_pre, start, end, n_tr = arrays
+        direct_fit = sdid_fit_once(y, Y0, n_pre, start, end, n_tr=n_tr)
+        tau = sdid_att(direct_fit, y, start, end)
+        sigma = placebo_sigma(y, Y0, n_pre, start, end, n_draws=9, n_tr=n_tr,
+                              seed=1)
+        eng = resolve_engine("sdid")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        p, details = eng.point_inference(fit, y, Y0, n_pre, start, end,
+                                         n_draws=9, n_tr=n_tr, seed=1)
+        assert p == normal_p_value(tau, sigma)
+        assert details["sigma"] == sigma
+        assert details["method"] == "placebo"
+
+
+# ---------------------------------------------------------------------------
+# End to end: the pipeline's answer must not move
+# ---------------------------------------------------------------------------
+
+class TestPipelineUnchanged:
+    """Pinned from the run immediately before the seam was introduced."""
+
+    @pytest.fixture(scope="class")
+    def result(self, panel):
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return SDIDGEO(SDIDGEOConfig(
+                df=panel, unitid="location", time="date", outcome="Y",
+                treatment_size=2, durations=[14],
+                effect_sizes=[-0.2, -0.1, 0.0, 0.1, 0.2], n_backtests=3,
+                n_draws=25, n_validation_backtests=0, seed=0)).fit()
+
+    def test_same_region_selected(self, result):
+        assert result.selected_units == ["jacksonville", "minneapolis"]
+
+    def test_same_top_of_the_shortlist(self, result):
+        top = result.power.sort_values("rank").head(5)
+        got = [(float(r["rank"]), float(r["mde"]), sorted(map(str, r["candidate"])))
+               for _, r in top.iterrows()]
+        assert got == [
+            (1.0, 0.2, ["jacksonville", "minneapolis"]),
+            (2.0, 0.2, ["atlanta", "nashville"]),
+            (3.0, 0.1, ["cleveland", "san francisco"]),
+            (3.0, 0.2, ["milwaukee", "orlando"]),
+            (5.0, 0.2, ["detroit", "new orleans"]),
+        ]
+
+    def test_same_weights(self, result):
+        w = result.design_weights
+        assert len(w.donor_weights) == 38 and len(w.time_weights) == 91
+        assert w.donor_weights["atlanta"] == pytest.approx(0.01803435933762521,
+                                                           abs=1e-12)
+        assert w.donor_weights["austin"] == pytest.approx(0.037770064501080655,
+                                                          abs=1e-12)
+
+
+class TestNonAnalyticSweep:
+    """The refit path, for engines or checks that cannot use the shortcut.
+
+    ``analytic=True`` shifts the ATT by ``effect_size x mean(treated_post)``
+    instead of refitting, which is exact because the fit uses pre-period data
+    alone. ``analytic=False`` injects and recomputes, and the two must agree --
+    that equality is what licenses the shortcut.
+    """
+
+    def test_refit_path_matches_the_analytic_shortcut(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("sdid")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        grid = [-0.15, 0.0, 0.15]
+        kw = dict(n_draws=8, n_tr=n_tr, seed=2)
+        fast = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, grid,
+                                  analytic=True, **kw)
+        slow = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, grid,
+                                  analytic=False, **kw)
+        np.testing.assert_allclose(slow["tau"], fast["tau"], rtol=1e-10)
+        np.testing.assert_allclose(slow["p_value"], fast["p_value"], rtol=1e-10)

--- a/mlsynth/utils/sdidgeo_helpers/batch.py
+++ b/mlsynth/utils/sdidgeo_helpers/batch.py
@@ -23,7 +23,7 @@ _COLUMNS = [
 
 def _simulate_candidate(candidate, Ywide, durations, n_backtests,
                         effect_sizes, *, n_periods, n_draws, seed, cpic,
-                        exclude=None, engine="sdid"):
+                        exclude=None, engine="sdid", engine_kwargs=None):
     """Every row for one candidate.
 
     Pure and deterministic given a fixed ``seed``, and defined at module level so
@@ -47,6 +47,7 @@ def _simulate_candidate(candidate, Ywide, durations, n_backtests,
                 treated, donors, n_periods, duration, sim, effect_sizes,
                 n_draws=n_draws, n_tr=n_tr, seed=seed, cpic=cpic,
                 treated_total=treated_total, engine=engine,
+                engine_kwargs=engine_kwargs,
             ):
                 row["candidate"] = candidate
                 rows.append(row)
@@ -66,6 +67,7 @@ def run_simulations(
     n_jobs: int = 1,
     excluded: Optional[Mapping[frozenset, Iterable]] = None,
     engine: str = "sdid",
+    engine_kwargs: Optional[Mapping[str, object]] = None,
 ) -> pd.DataFrame:
     """Run the simulation grid and stack the results into one long table.
 
@@ -99,7 +101,7 @@ def run_simulations(
     n_periods = Ywide.shape[0]
     candidates = list(candidates)
     work = dict(n_periods=n_periods, n_draws=n_draws, seed=seed, cpic=cpic,
-                engine=engine)
+                engine=engine, engine_kwargs=dict(engine_kwargs or {}))
     excluded = excluded or {}
 
     if n_jobs == 1 or len(candidates) <= 1:

--- a/mlsynth/utils/sdidgeo_helpers/batch.py
+++ b/mlsynth/utils/sdidgeo_helpers/batch.py
@@ -23,7 +23,7 @@ _COLUMNS = [
 
 def _simulate_candidate(candidate, Ywide, durations, n_backtests,
                         effect_sizes, *, n_periods, n_draws, seed, cpic,
-                        exclude=None):
+                        exclude=None, engine="sdid"):
     """Every row for one candidate.
 
     Pure and deterministic given a fixed ``seed``, and defined at module level so
@@ -46,7 +46,7 @@ def _simulate_candidate(candidate, Ywide, durations, n_backtests,
             for row in simulate_backtest(
                 treated, donors, n_periods, duration, sim, effect_sizes,
                 n_draws=n_draws, n_tr=n_tr, seed=seed, cpic=cpic,
-                treated_total=treated_total,
+                treated_total=treated_total, engine=engine,
             ):
                 row["candidate"] = candidate
                 rows.append(row)
@@ -65,6 +65,7 @@ def run_simulations(
     cpic: Optional[float] = None,
     n_jobs: int = 1,
     excluded: Optional[Mapping[frozenset, Iterable]] = None,
+    engine: str = "sdid",
 ) -> pd.DataFrame:
     """Run the simulation grid and stack the results into one long table.
 
@@ -97,7 +98,8 @@ def run_simulations(
 
     n_periods = Ywide.shape[0]
     candidates = list(candidates)
-    work = dict(n_periods=n_periods, n_draws=n_draws, seed=seed, cpic=cpic)
+    work = dict(n_periods=n_periods, n_draws=n_draws, seed=seed, cpic=cpic,
+                engine=engine)
     excluded = excluded or {}
 
     if n_jobs == 1 or len(candidates) <= 1:

--- a/mlsynth/utils/sdidgeo_helpers/config.py
+++ b/mlsynth/utils/sdidgeo_helpers/config.py
@@ -114,10 +114,43 @@ class SDIDGEOConfig(BaseMAREXConfig):
     engine: str = Field(
         default="sdid",
         description="Estimator that scores each candidate. 'sdid' weights "
-        "donors and pre-periods together and tests against the placebo "
-        "standard error. The rest of the design -- nomination, backtests, "
-        "power, MDE, ranking, constraints -- is the same whichever engine "
-        "runs.",
+        "donors and pre-periods together; 'augsynth' is the ridge-augmented "
+        "synthetic control GeoLift uses. The rest of the design -- nomination, "
+        "backtests, power, MDE, ranking, constraints -- is the same whichever "
+        "engine runs.",
+    )
+    inference: Optional[str] = Field(
+        default=None,
+        description="Null the detection test is taken against. 'placebo' "
+        "reassigns donors as pretend-treated and needs only a donor-built "
+        "counterfactual, so it suits either engine. 'conformal' permutes "
+        "pre-period residuals and is available on 'augsynth' alone, since "
+        "SDID's time weights exist to say pre-periods are not exchangeable. "
+        "Absent, each engine takes its own default: placebo for sdid, "
+        "conformal for augsynth, which is GeoLift's choice.",
+    )
+    ns: int = Field(
+        default=1000,
+        description="Conformal permutations behind each p-value (augsynth "
+        "only). The cost sits inside the effect sweep, since a conformal test "
+        "moves with the injected effect and cannot be hoisted out of it.",
+    )
+    conformal_type: str = Field(
+        default="iid",
+        description="Conformal permutation scheme (augsynth only): 'iid' or "
+        "'block'.",
+    )
+    fixed_effects: Optional[bool] = Field(
+        default=None,
+        description="Unit fixed effects (augsynth only). Demeans every unit by "
+        "its own pre-period mean so the fit matches shapes and the donor pool "
+        "cannot absorb a treated-unit level shift. Defaults to True on the "
+        "augsynth path, which is GeoLift's default.",
+    )
+    augment: Optional[str] = Field(
+        default="ridge",
+        description="Augmentation layer (augsynth only): 'ridge' for Augmented "
+        "SCM, None for plain simplex SCM with an intercept.",
     )
 
     # --- simulation grid ---
@@ -238,6 +271,37 @@ class SDIDGEOConfig(BaseMAREXConfig):
             raise MlsynthConfigError(
                 f"unknown engine {self.engine!r}; available engines are "
                 f"{sorted(ENGINE_NAMES)}.")
+        if self.inference is not None and self.inference not in (
+                "placebo", "conformal"):
+            raise MlsynthConfigError(
+                f"inference must be 'placebo' or 'conformal'; got "
+                f"{self.inference!r}.")
+        if self.engine == "sdid" and self.inference == "conformal":
+            raise MlsynthConfigError(
+                "the sdid engine cannot use conformal inference: the "
+                "permutation argument needs the pre-period residuals to be "
+                "exchangeable across the matching window, and SDID's time "
+                "weights exist precisely to say they are not. Use "
+                "engine='augsynth' for conformal, or inference='placebo'.")
+        if self.engine != "augsynth":
+            for name in ("fixed_effects",):
+                if getattr(self, name) is not None:
+                    raise MlsynthConfigError(
+                        f"{name} is an augsynth-only setting; got engine="
+                        f"{self.engine!r}. Drop it or set engine='augsynth'.")
+        # Resolve the engine's default null once, so the rest of the pipeline
+        # never has to ask which engine it is running.
+        if self.inference is None:
+            self.inference = ("conformal" if self.engine == "augsynth"
+                              else "placebo")
+        if self.engine == "augsynth" and self.fixed_effects is None:
+            self.fixed_effects = True     # augsynth's fixedeff, GeoLift's default
+        if self.conformal_type not in ("iid", "block"):
+            raise MlsynthConfigError(
+                f"conformal_type must be 'iid' or 'block'; got "
+                f"{self.conformal_type!r}.")
+        if self.ns < 2:
+            raise MlsynthConfigError(f"ns must be >= 2; got {self.ns}.")
         if self.how not in ("sum", "mean"):
             raise MlsynthConfigError(
                 f"how must be 'sum' or 'mean'; got {self.how!r}.")

--- a/mlsynth/utils/sdidgeo_helpers/config.py
+++ b/mlsynth/utils/sdidgeo_helpers/config.py
@@ -110,6 +110,16 @@ class SDIDGEOConfig(BaseMAREXConfig):
         "panel is treated as pre-period history to simulate over.",
     )
 
+    # --- scoring engine ---
+    engine: str = Field(
+        default="sdid",
+        description="Estimator that scores each candidate. 'sdid' weights "
+        "donors and pre-periods together and tests against the placebo "
+        "standard error. The rest of the design -- nomination, backtests, "
+        "power, MDE, ranking, constraints -- is the same whichever engine "
+        "runs.",
+    )
+
     # --- simulation grid ---
     durations: List[int] = Field(
         ..., description="Treatment durations (periods) to scan."
@@ -223,6 +233,11 @@ class SDIDGEOConfig(BaseMAREXConfig):
             raise MlsynthConfigError(
                 "stochastic_mode must be 'global' or 'per_anchor'; got "
                 f"{self.stochastic_mode!r}.")
+        from .engines import ENGINE_NAMES
+        if self.engine not in ENGINE_NAMES:
+            raise MlsynthConfigError(
+                f"unknown engine {self.engine!r}; available engines are "
+                f"{sorted(ENGINE_NAMES)}.")
         if self.how not in ("sum", "mean"):
             raise MlsynthConfigError(
                 f"how must be 'sum' or 'mean'; got {self.how!r}.")

--- a/mlsynth/utils/sdidgeo_helpers/engines/__init__.py
+++ b/mlsynth/utils/sdidgeo_helpers/engines/__init__.py
@@ -1,0 +1,87 @@
+"""Pluggable scoring engines for the SDIDGEO design.
+
+Everything in the design except the fit and the p-value is estimator-independent
+-- candidate nomination, the backtest windows, effect injection, power, MDE,
+ranking, the constraint layer, the plots. This package is the seam that makes
+that explicit, following the dispatcher shape PDA and SPILLSYNTH already use: a
+subpackage per engine exposing uniform module-level functions, selected by a
+config string.
+
+An engine supplies four things.
+
+``fit_once(y, Y0, n_pre, start, end, n_tr) -> EngineFit``
+    Fit on the pre-period and predict across the whole panel.
+
+``att(fit, y, start, end) -> float``
+    Mean gap over the treatment window. Shared arithmetic, but it hangs off the
+    engine so an estimator reporting on a different scale can override it.
+
+``sweep_p_values(fit, y, Y0, n_pre, start, end, effect_sizes, ...) -> dict``
+    The whole effect grid at once. The grid belongs to the engine because the
+    two inference procedures differ in what they can hoist: a placebo standard
+    error is invariant to the injected effect and is drawn once for the grid,
+    while a conformal p-value re-permutes against the treated series and has to
+    be recomputed per effect size. Keeping the grid here keeps that cost
+    decision inside the module that owns it.
+
+``point_inference(fit, y, Y0, n_pre, start, end, ...) -> (p_value, details)``
+    A single window's test, for the realized readout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+import numpy as np
+
+from ....exceptions import MlsynthConfigError
+
+
+@dataclass
+class EngineFit:
+    """One engine's fit on a pseudo-experiment's pre-period.
+
+    The fields every engine supplies. ``time_weights`` is ``None`` for
+    estimators that weight donors alone; ``extras`` carries whatever is specific
+    to the engine (SDID's ridge ``zeta``, an augmented estimator's intercept and
+    penalty) so the shared pipeline never has to know which is which.
+    """
+
+    counterfactual: np.ndarray
+    donor_weights: np.ndarray
+    pre_rmspe: float
+    scaled_l2: float
+    time_weights: Optional[np.ndarray] = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Engine:
+    """One resolved scoring engine: its name and its four functions."""
+
+    name: str
+    fit_once: Callable[..., EngineFit]
+    att: Callable[..., float]
+    sweep_p_values: Callable[..., Dict[str, Any]]
+    point_inference: Callable[..., Any]
+
+
+def resolve_engine(name: str) -> Engine:
+    """The engine registered under ``name``.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``name`` is not a registered engine.
+    """
+    if name == "sdid":
+        from .sdid import ENGINE as _sdid
+        return _sdid
+    raise MlsynthConfigError(
+        f"unknown engine {name!r}; available engines are {sorted(ENGINE_NAMES)}.")
+
+
+ENGINE_NAMES = frozenset({"sdid"})
+
+__all__ = ["Engine", "EngineFit", "ENGINE_NAMES", "resolve_engine"]

--- a/mlsynth/utils/sdidgeo_helpers/engines/__init__.py
+++ b/mlsynth/utils/sdidgeo_helpers/engines/__init__.py
@@ -78,10 +78,13 @@ def resolve_engine(name: str) -> Engine:
     if name == "sdid":
         from .sdid import ENGINE as _sdid
         return _sdid
+    if name == "augsynth":
+        from .augsynth import ENGINE as _augsynth
+        return _augsynth
     raise MlsynthConfigError(
         f"unknown engine {name!r}; available engines are {sorted(ENGINE_NAMES)}.")
 
 
-ENGINE_NAMES = frozenset({"sdid"})
+ENGINE_NAMES = frozenset({"sdid", "augsynth"})
 
 __all__ = ["Engine", "EngineFit", "ENGINE_NAMES", "resolve_engine"]

--- a/mlsynth/utils/sdidgeo_helpers/engines/augsynth/__init__.py
+++ b/mlsynth/utils/sdidgeo_helpers/engines/augsynth/__init__.py
@@ -1,0 +1,180 @@
+"""Augmented SCM as an SDIDGEO scoring engine.
+
+Augsynth (Ben-Michael, Feller & Rothstein 2021) fitted through
+:class:`~mlsynth.utils.bilevel.engine.BilevelSCM`, which is the estimator
+GeoLift scores its market selections with. Pairing it with the design harness
+lets one panel be scored two ways, so the objective can be varied without
+varying the inference and the other way round.
+
+Two details decide whether this reproduces GeoLift's numbers.
+
+Fixed effects. With ``fixed_effects=True`` (augsynth's ``fixedeff``, GeoLift's
+default) every unit is demeaned by its own pre-period mean before fitting and
+the level is restored by an intercept, so the fit matches shapes and the donor
+pool cannot absorb a treated-unit level shift. Combined with a mean-of-units
+treated aggregate, that is what reproduces augsynth's effect estimate and its
+conformal p-value.
+
+Scaled imbalance. ``scaled_l2`` here is augsynth's ratio
+``||X0 w - X1|| / ||X0 w_unif - X1||`` on the centred matching matrices, which
+is a different quantity from the SDID engine's ``pre_rmspe`` over the treated
+spread. Each engine reports its own estimator's imbalance measure, so the number
+is comparable across candidates within a design and not across engines.
+
+Inference. Conformal is the default because GeoLift uses it, and it is available
+here and not on the SDID path: the permutation argument needs the pre-period
+residuals to be exchangeable across the matching window, which is exactly what
+SDID's time weights deny. Placebo reassignment needs only a donor-built
+counterfactual, so it is offered on this engine too -- that combination isolates
+the objective from the inference.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+import numpy as np
+
+from .....exceptions import MlsynthConfigError
+from .....utils.bilevel.engine import BilevelSCM
+from .....utils.bilevel.ridge_inference import conformal_pvalue
+from .. import Engine, EngineFit
+from ...engine import normal_p_value, placebo_sigma
+
+
+def _scaled_l2(A: np.ndarray, B: np.ndarray, w: np.ndarray) -> float:
+    """Augsynth scaled L2 imbalance ``||Bw - A|| / ||B w_unif - A||``.
+
+    Unitless: 0 is a perfect pre-fit, 1 is no better than averaging every donor,
+    above 1 is worse than the average. ``nan`` when the uniform-weight
+    imbalance is zero, which leaves the ratio undefined.
+    """
+    J = B.shape[1]
+    denom = float(np.linalg.norm(B @ np.full(J, 1.0 / J) - A))
+    if denom == 0.0:
+        return float("nan")
+    return float(np.linalg.norm(B @ w - A) / denom)
+
+
+def fit_once(y, Y0, n_pre: int, start: int, end: int, n_tr: int, *,
+             augment: Optional[str] = "ridge", fixed_effects: bool = True,
+             **_ignored: Any) -> EngineFit:
+    """Fit augmented SCM on the pre-period and predict across the panel."""
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    if augment not in ("ridge", None):
+        raise MlsynthConfigError(
+            f"augment must be 'ridge' or None; got {augment!r}.")
+
+    y_pre, Y0_pre = y[:n_pre], Y0[:n_pre]
+    # The simplex path is the fixed-effect SCM already, so it is always
+    # demeaned; the flag only switches the ridge path.
+    demean = fixed_effects or augment is None
+    if demean:
+        A, B = y_pre - y_pre.mean(), Y0_pre - Y0_pre.mean(axis=0)
+    else:
+        A, B = y_pre, Y0_pre
+
+    res = BilevelSCM(augment=augment).fit(A, B)
+    w = np.asarray(res.W, dtype=float).ravel()
+    intercept = float(np.mean(y_pre - Y0_pre @ w)) if demean else 0.0
+
+    return EngineFit(
+        counterfactual=intercept + Y0 @ w,
+        donor_weights=w,
+        time_weights=None,          # augsynth weights donors alone
+        pre_rmspe=float(res.pre_rmspe),
+        scaled_l2=_scaled_l2(A, B, w),
+        extras={
+            "intercept": intercept,
+            "augment": augment,
+            "fixed_effects": bool(fixed_effects),
+            "lambda_": (float(res.lambda_) if res.lambda_ is not None else None),
+        },
+    )
+
+
+def att(fit: EngineFit, y, start: int, end: int) -> float:
+    """Mean gap over the treatment window."""
+    y = np.asarray(y, dtype=float).ravel()
+    return float(np.mean(y[start:end + 1] - fit.counterfactual[start:end + 1]))
+
+
+def sweep_p_values(
+    fit: EngineFit, y, Y0, n_pre: int, start: int, end: int,
+    effect_sizes: Iterable[float], *, inference: str = "conformal",
+    ns: int = 1000, n_draws: int = 200, n_tr: int = 1, seed: int = 0,
+    conformal_type: str = "iid", analytic: bool = True,
+    **_ignored: Any,
+) -> Dict[str, Any]:
+    """Test every effect size on one backtest.
+
+    The two procedures differ in what leaves the loop. A placebo standard error
+    does not depend on the injected effect, so it is drawn once and reused. A
+    conformal p-value tests the injected series against permutations of the
+    pre-period residuals, so it moves with the effect and is recomputed for each
+    one -- which is where this path's cost lives.
+    """
+    from ...simulate import inject_effect
+
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    tau0 = att(fit, y, start, end)
+    baseline = float(np.mean(y[start:end + 1]))
+    lam = fit.extras.get("lambda_")
+    fixed_effects = bool(fit.extras.get("fixed_effects", True))
+
+    sigma = None
+    if inference == "placebo":
+        sigma = placebo_sigma(y, Y0, n_pre, start, end, n_draws=n_draws,
+                              n_tr=n_tr, seed=seed)
+    elif inference != "conformal":
+        raise MlsynthConfigError(
+            f"inference must be 'conformal' or 'placebo'; got {inference!r}.")
+
+    taus, ps = [], []
+    for es in effect_sizes:
+        injected = inject_effect(y, start, end, es)
+        tau = (tau0 + float(es) * baseline if analytic
+               else att(fit, injected, start, end))
+        taus.append(tau)
+        if inference == "placebo":
+            ps.append(normal_p_value(tau, sigma))
+        else:
+            ps.append(float(conformal_pvalue(
+                injected, Y0, n_pre, lambda_=lam, ns=ns, seed=seed,
+                conformal_type=conformal_type, fixed_effects=fixed_effects)))
+    return {"tau": taus, "p_value": ps, "sigma": sigma}
+
+
+def point_inference(
+    fit: EngineFit, y, Y0, n_pre: int, start: int, end: int, *,
+    inference: str = "conformal", ns: int = 1000, n_draws: int = 200,
+    n_tr: int = 1, seed: int = 0, conformal_type: str = "iid",
+    **_ignored: Any,
+) -> Tuple[float, Dict[str, Any]]:
+    """One window's test, for the realized readout."""
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    tau = att(fit, y, start, end)
+    if inference == "placebo":
+        sigma = placebo_sigma(y, Y0, n_pre, start, end, n_draws=n_draws,
+                              n_tr=n_tr, seed=seed)
+        return normal_p_value(tau, sigma), {
+            "method": "placebo", "sigma": sigma, "att": tau,
+            "n_draws": int(n_draws)}
+    if inference != "conformal":
+        raise MlsynthConfigError(
+            f"inference must be 'conformal' or 'placebo'; got {inference!r}.")
+    p = float(conformal_pvalue(
+        y, Y0, n_pre, lambda_=fit.extras.get("lambda_"), ns=ns, seed=seed,
+        conformal_type=conformal_type,
+        fixed_effects=bool(fit.extras.get("fixed_effects", True))))
+    return p, {"method": "conformal", "att": tau, "ns": int(ns),
+               "conformal_type": conformal_type}
+
+
+ENGINE = Engine(name="augsynth", fit_once=fit_once, att=att,
+                sweep_p_values=sweep_p_values, point_inference=point_inference)
+
+__all__ = ["ENGINE", "fit_once", "att", "sweep_p_values", "point_inference"]

--- a/mlsynth/utils/sdidgeo_helpers/engines/sdid/__init__.py
+++ b/mlsynth/utils/sdidgeo_helpers/engines/sdid/__init__.py
@@ -19,6 +19,7 @@ from typing import Any, Dict, Iterable, Optional, Tuple
 import numpy as np
 
 from .. import Engine, EngineFit
+from .....exceptions import MlsynthConfigError
 from ...engine import (
     normal_p_value,
     placebo_sigma,
@@ -27,8 +28,13 @@ from ...engine import (
 )
 
 
-def fit_once(y, Y0, n_pre: int, start: int, end: int, n_tr: int) -> EngineFit:
-    """Fit SDID on the pre-period and predict across the panel."""
+def fit_once(y, Y0, n_pre: int, start: int, end: int, n_tr: int,
+             **_ignored: Any) -> EngineFit:
+    """Fit SDID on the pre-period and predict across the panel.
+
+    Settings belonging to another engine are ignored, so the pipeline can pass
+    one bundle whichever engine is running.
+    """
     fit = sdid_fit_once(y, Y0, n_pre, start, end, n_tr=n_tr)
     return EngineFit(
         counterfactual=fit.counterfactual,
@@ -49,7 +55,8 @@ def att(fit: EngineFit, y, start: int, end: int) -> float:
 def sweep_p_values(
     fit: EngineFit, y, Y0, n_pre: int, start: int, end: int,
     effect_sizes: Iterable[float], *, n_draws: int = 200, n_tr: int = 1,
-    seed: int = 0, analytic: bool = True,
+    seed: int = 0, analytic: bool = True, inference: str = "placebo",
+    **_ignored: Any,
 ) -> Dict[str, Any]:
     """Test every effect size on one backtest.
 
@@ -58,7 +65,16 @@ def sweep_p_values(
     by ``effect_size x mean(treated_post)`` instead of refitting: the fit uses
     pre-period data alone, so injecting into the post window moves the ATT by
     exactly that amount and leaves the counterfactual untouched.
+
+    Keyword arguments belonging to another engine are ignored, so the pipeline
+    can pass one settings bundle whichever engine is running.
     """
+    if inference != "placebo":
+        raise MlsynthConfigError(
+            f"the sdid engine supports inference='placebo' only; got "
+            f"{inference!r}. Conformal inference assumes the pre-period "
+            "residuals are exchangeable, and SDID's time weights exist to say "
+            "they are not.")
     y = np.asarray(y, dtype=float).ravel()
     Y0 = np.asarray(Y0, dtype=float)
     tau0 = att(fit, y, start, end)
@@ -81,6 +97,7 @@ def sweep_p_values(
 def point_inference(
     fit: EngineFit, y, Y0, n_pre: int, start: int, end: int, *,
     n_draws: int = 200, n_tr: int = 1, seed: int = 0,
+    inference: str = "placebo", **_ignored: Any,
 ) -> Tuple[float, Dict[str, Any]]:
     """One window's test, for the realized readout."""
     y = np.asarray(y, dtype=float).ravel()

--- a/mlsynth/utils/sdidgeo_helpers/engines/sdid/__init__.py
+++ b/mlsynth/utils/sdidgeo_helpers/engines/sdid/__init__.py
@@ -1,0 +1,102 @@
+"""Synthetic DiD as an SDIDGEO scoring engine.
+
+A thin adapter over :mod:`mlsynth.utils.sdidgeo_helpers.engine`: unit weights
+over donors and time weights over pre-periods (Arkhangelsky, Athey, Hirshberg,
+Imbens and Wager 2021), tested against the placebo standard error of their
+Algorithm 4. Jackknife and bootstrap are undefined for the single treated series
+a candidate region collapses to, which is why the placebo procedure is the one
+wired here.
+
+The adapter adds no arithmetic. Every value it returns comes from the functions
+the pipeline called directly before the seam existed, so introducing the seam
+leaves the design's answer bit-identical.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+import numpy as np
+
+from .. import Engine, EngineFit
+from ...engine import (
+    normal_p_value,
+    placebo_sigma,
+    sdid_att,
+    sdid_fit_once,
+)
+
+
+def fit_once(y, Y0, n_pre: int, start: int, end: int, n_tr: int) -> EngineFit:
+    """Fit SDID on the pre-period and predict across the panel."""
+    fit = sdid_fit_once(y, Y0, n_pre, start, end, n_tr=n_tr)
+    return EngineFit(
+        counterfactual=fit.counterfactual,
+        donor_weights=fit.omega,
+        time_weights=fit.lam,
+        pre_rmspe=fit.pre_rmspe,
+        scaled_l2=fit.scaled_l2,
+        extras={"zeta": fit.zeta, "bias_correction": fit.bias_correction},
+    )
+
+
+def att(fit: EngineFit, y, start: int, end: int) -> float:
+    """Mean gap over the treatment window."""
+    y = np.asarray(y, dtype=float).ravel()
+    return float(np.mean(y[start:end + 1] - fit.counterfactual[start:end + 1]))
+
+
+def sweep_p_values(
+    fit: EngineFit, y, Y0, n_pre: int, start: int, end: int,
+    effect_sizes: Iterable[float], *, n_draws: int = 200, n_tr: int = 1,
+    seed: int = 0, analytic: bool = True,
+) -> Dict[str, Any]:
+    """Test every effect size on one backtest.
+
+    The placebo standard error does not depend on the injected effect, so it is
+    drawn once and reused across the grid. With ``analytic`` the ATT is shifted
+    by ``effect_size x mean(treated_post)`` instead of refitting: the fit uses
+    pre-period data alone, so injecting into the post window moves the ATT by
+    exactly that amount and leaves the counterfactual untouched.
+    """
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    tau0 = att(fit, y, start, end)
+    baseline = float(np.mean(y[start:end + 1]))
+    sigma = placebo_sigma(y, Y0, n_pre, start, end, n_draws=n_draws,
+                          n_tr=n_tr, seed=seed)
+
+    taus, ps = [], []
+    for es in effect_sizes:
+        if analytic:
+            tau = tau0 + float(es) * baseline
+        else:
+            from ...simulate import inject_effect      # local: avoids a cycle
+            tau = att(fit, inject_effect(y, start, end, es), start, end)
+        taus.append(tau)
+        ps.append(normal_p_value(tau, sigma))
+    return {"tau": taus, "p_value": ps, "sigma": sigma}
+
+
+def point_inference(
+    fit: EngineFit, y, Y0, n_pre: int, start: int, end: int, *,
+    n_draws: int = 200, n_tr: int = 1, seed: int = 0,
+) -> Tuple[float, Dict[str, Any]]:
+    """One window's test, for the realized readout."""
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    tau = att(fit, y, start, end)
+    sigma = placebo_sigma(y, Y0, n_pre, start, end, n_draws=n_draws,
+                          n_tr=n_tr, seed=seed)
+    return normal_p_value(tau, sigma), {
+        "method": "placebo",
+        "sigma": sigma,
+        "att": tau,
+        "n_draws": int(n_draws),
+    }
+
+
+ENGINE = Engine(name="sdid", fit_once=fit_once, att=att,
+                sweep_p_values=sweep_p_values, point_inference=point_inference)
+
+__all__ = ["ENGINE", "fit_once", "att", "sweep_p_values", "point_inference"]

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -27,7 +27,7 @@ from .constraints import (
     unit_attribute_map,
 )
 from .feasibility import audit_sdidgeo_feasibility
-from .engine import sdid_fit_once
+from .engines import resolve_engine
 from .shaping import aggregate_treated, donor_matrix
 from .simulate import simulate_backtest
 from .realize import realize_design
@@ -36,7 +36,8 @@ from .structures import CandidateDesign, MarketSearch, SDIDGEOResults
 
 
 def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
-               duration: int, exclude=None, how: str = "mean") -> CandidateDesign:
+               duration: int, exclude=None, how: str = "mean",
+               engine: str = "sdid") -> CandidateDesign:
     """Deployable SDID design for one candidate, fit on the full pre-period.
 
     The scoring stage fits each backtest; this fits the design the
@@ -53,15 +54,17 @@ def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
     donors = donors_df.to_numpy()
     start = n_pre
     end = min(n_pre + duration - 1, Ywide.shape[0] - 1)
-    fit = sdid_fit_once(treated, donors, n_pre, start, end,
-                        n_tr=len(candidate))
+    fit = resolve_engine(engine).fit_once(treated, donors, n_pre, start, end,
+                                          len(candidate))
     # SDID carries two weight vectors, so both go into the standard container:
     # donors over markets, and lambda over the pre-period dates.
     weights = WeightsResults(
         donor_weights={str(name): float(w)
-                       for name, w in zip(donors_df.columns, fit.omega)},
-        time_weights={period: float(w)
-                      for period, w in zip(Ywide.index[:n_pre], fit.lam)},
+                       for name, w in zip(donors_df.columns, fit.donor_weights)},
+        time_weights=({period: float(w)
+                       for period, w in zip(Ywide.index[:n_pre],
+                                            fit.time_weights)}
+                      if fit.time_weights is not None else None),
     )
     return CandidateDesign(
         units=sorted(map(str, candidate)),
@@ -106,6 +109,7 @@ def planning_mde(Ywide: pd.DataFrame, candidate, config: SDIDGEOConfig,
             for row in simulate_backtest(
                 treated, donors, n_periods, duration, sim, config.effect_sizes,
                 n_draws=config.n_draws, n_tr=len(candidate), seed=config.seed,
+                engine=config.engine,
             ):
                 row["candidate"] = candidate
                 rows.append(row)
@@ -250,6 +254,7 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
         Ywide, candidates, config.durations, config.n_backtests,
         config.effect_sizes, n_draws=config.n_draws, seed=config.seed,
         cpic=config.cpic, n_jobs=config.n_jobs, excluded=excluded,
+        engine=config.engine,
     )
     power_table = compute_power(cube, alpha=config.alpha)
     shortlist = compute_rank(power_table,
@@ -266,7 +271,8 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
     n_pre_deploy = n_periods - deploy_duration
     designs: Dict[frozenset, CandidateDesign] = {
         c: design_fit(Ywide, c, n_pre_deploy, deploy_duration,
-                      exclude=excluded.get(c), how=config.how)
+                      exclude=excluded.get(c), how=config.how,
+                      engine=config.engine)
         for c in candidates
     }
 

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -105,6 +105,9 @@ def planning_mde(Ywide: pd.DataFrame, candidate, config: SDIDGEOConfig,
 
     treated = aggregate_treated(Ywide, candidate, how="mean").to_numpy()
     donors = donor_matrix(Ywide, candidate, exclude=exclude).to_numpy()
+    # The validation backtests score on the same engine and settings the search
+    # used, so the planning MDE is comparable with the one it corrects.
+    ekw = engine_settings(config)
     rows: List[dict] = []
     for duration in config.durations:
         for sim in range(config.n_backtests + 1, deepest + 1):

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -37,7 +37,8 @@ from .structures import CandidateDesign, MarketSearch, SDIDGEOResults
 
 def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
                duration: int, exclude=None, how: str = "mean",
-               engine: str = "sdid") -> CandidateDesign:
+               engine: str = "sdid",
+               engine_kwargs: Optional[dict] = None) -> CandidateDesign:
     """Deployable SDID design for one candidate, fit on the full pre-period.
 
     The scoring stage fits each backtest; this fits the design the
@@ -55,7 +56,8 @@ def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
     start = n_pre
     end = min(n_pre + duration - 1, Ywide.shape[0] - 1)
     fit = resolve_engine(engine).fit_once(treated, donors, n_pre, start, end,
-                                          len(candidate))
+                                          len(candidate),
+                                          **(engine_kwargs or {}))
     # SDID carries two weight vectors, so both go into the standard container:
     # donors over markets, and lambda over the pre-period dates.
     weights = WeightsResults(
@@ -109,7 +111,7 @@ def planning_mde(Ywide: pd.DataFrame, candidate, config: SDIDGEOConfig,
             for row in simulate_backtest(
                 treated, donors, n_periods, duration, sim, config.effect_sizes,
                 n_draws=config.n_draws, n_tr=len(candidate), seed=config.seed,
-                engine=config.engine,
+                engine=config.engine, engine_kwargs=ekw,
             ):
                 row["candidate"] = candidate
                 rows.append(row)
@@ -126,8 +128,23 @@ def planning_mde(Ywide: pd.DataFrame, candidate, config: SDIDGEOConfig,
     return float(values.loc[values.abs().idxmin()])
 
 
+def engine_settings(config: SDIDGEOConfig) -> dict:
+    """The engine-specific settings bundle for ``config``.
+
+    One bundle whichever engine runs: each engine reads what applies to it and
+    ignores the rest, so the pipeline never branches on which is active.
+    """
+    kw: dict = {"inference": config.inference}
+    if config.engine == "augsynth":
+        kw.update(ns=config.ns, conformal_type=config.conformal_type,
+                  fixed_effects=bool(config.fixed_effects),
+                  augment=config.augment)
+    return kw
+
+
 def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
     """Run the full SDIDGEO market-selection design from a config."""
+    ekw = engine_settings(config)
     prep = geoex_dataprep(config.df, config.unitid, config.time,
                           config.outcome, post_col=config.post_col)
     Ywide = prep["Ywide"]
@@ -254,7 +271,7 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
         Ywide, candidates, config.durations, config.n_backtests,
         config.effect_sizes, n_draws=config.n_draws, seed=config.seed,
         cpic=config.cpic, n_jobs=config.n_jobs, excluded=excluded,
-        engine=config.engine,
+        engine=config.engine, engine_kwargs=ekw,
     )
     power_table = compute_power(cube, alpha=config.alpha)
     shortlist = compute_rank(power_table,
@@ -272,7 +289,7 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
     designs: Dict[frozenset, CandidateDesign] = {
         c: design_fit(Ywide, c, n_pre_deploy, deploy_duration,
                       exclude=excluded.get(c), how=config.how,
-                      engine=config.engine)
+                      engine=config.engine, engine_kwargs=ekw)
         for c in candidates
     }
 
@@ -316,7 +333,8 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
             report = realize_design(
                 full, winning, n_periods, how=config.how,
                 exclude=excluded.get(winning), alpha=config.alpha,
-                n_draws=config.n_draws, seed=config.seed, cpic=config.cpic)
+                n_draws=config.n_draws, seed=config.seed, cpic=config.cpic,
+            engine=config.engine, engine_kwargs=ekw)
 
     return SDIDGEOResults(
         report=report,

--- a/mlsynth/utils/sdidgeo_helpers/realize.py
+++ b/mlsynth/utils/sdidgeo_helpers/realize.py
@@ -2,13 +2,12 @@
 
 :meth:`mlsynth.SDIDGEO.fit` chooses a test region before the experiment runs, so
 its result is a design with an empty ``report`` slot. This module fills that
-slot: apply the chosen region's pre-period SDID fit across the full panel and
-package the realized effect into the standardized result models.
+slot: apply the chosen region's pre-period fit across the full panel and package
+the realized effect into the standardized result models.
 
-The readout uses the estimator and the null the design scored itself with --
-synthetic DiD plus the placebo standard error of Arkhangelsky et al.'s Algorithm
-4 -- because SDIDGEO's claim is that the design is chosen by the estimator that
-will analyse the result. A minimum detectable effect computed one way and a
+The readout runs on the same engine the design scored itself with, whichever
+that was, because SDIDGEO's claim is that the design is chosen by the estimator
+that will analyse the result. A minimum detectable effect computed one way and a
 readout computed another would leave the reported power describing a test nobody
 ran.
 
@@ -34,7 +33,7 @@ from ...config_models import (
     WeightsResults,
 )
 from ...exceptions import MlsynthConfigError
-from .engine import normal_p_value, placebo_sigma, sdid_att, sdid_fit_once
+from .engines import resolve_engine
 from .shaping import aggregate_treated, donor_matrix
 
 
@@ -49,6 +48,7 @@ def realize_design(
     n_draws: int = 200,
     seed: int = 0,
     cpic: Optional[float] = None,
+    engine: str = "sdid",
 ) -> BaseEstimatorResults:
     """Realize one candidate design on the full (pre + post) panel.
 
@@ -112,13 +112,13 @@ def realize_design(
     donors_df = donor_matrix(Ywide_full, candidate, exclude=exclude)
     donors = donors_df.to_numpy()
 
+    eng = resolve_engine(engine)
     start, end = pre_periods, n_periods - 1
-    fit = sdid_fit_once(treated, donors, pre_periods, start, end,
-                        n_tr=len(members))
-    tau = sdid_att(fit, treated, start, end)
-    sigma = placebo_sigma(treated, donors, pre_periods, start, end,
-                          n_draws=n_draws, n_tr=len(members), seed=seed)
-    p_value = normal_p_value(tau, sigma)
+    fit = eng.fit_once(treated, donors, pre_periods, start, end, len(members))
+    tau = eng.att(fit, treated, start, end)
+    p_value, inf_details = eng.point_inference(
+        fit, treated, donors, pre_periods, start, end,
+        n_draws=n_draws, n_tr=len(members), seed=seed)
 
     # Reporting scale. The statistic is a ratio, so it is scale-free and the
     # p-value is unmoved; only the reported paths change units.
@@ -129,7 +129,8 @@ def realize_design(
 
     # Cost tracks the summed incremental outcome across the treated markets,
     # whatever scale the paths are reported in.
-    incremental = float(np.sum(fit.tau_path(treated)[pre_periods:])) * len(members)
+    tau_path = treated - fit.counterfactual
+    incremental = float(np.sum(tau_path[pre_periods:])) * len(members)
     cost = float(cpic) * incremental if cpic is not None else None
 
     return BaseEstimatorResults(
@@ -143,27 +144,25 @@ def realize_design(
         ),
         inference=InferenceResults(
             p_value=float(p_value),
-            method="placebo",
+            method=str(inf_details.get("method", engine)),
             confidence_level=1.0 - alpha,
-            details={
-                "sigma": float(sigma) if sigma is not None else float("nan"),
-                "att_mean_scale": float(tau),
-                "n_draws": int(n_draws),
-            },
+            details={**inf_details, "att_mean_scale": float(tau)},
         ),
         weights=WeightsResults(
             donor_weights={str(name): float(w)
-                           for name, w in zip(donors_df.columns, fit.omega)},
-            time_weights={period: float(w)
-                          for period, w in zip(Ywide_full.index[:pre_periods],
-                                               fit.lam)},
+                           for name, w in zip(donors_df.columns,
+                                              fit.donor_weights)},
+            time_weights=({period: float(w)
+                           for period, w in zip(Ywide_full.index[:pre_periods],
+                                                fit.time_weights)}
+                          if fit.time_weights is not None else None),
             summary_stats={
                 "how": how,
                 "treated_markets": members,
-                "zeta": float(fit.zeta),
-                "bias_correction": float(fit.bias_correction),
+                "engine": engine,
                 "cpic": cpic,
                 "cost": cost,
+                **{k: float(v) for k, v in fit.extras.items()},
             },
         ),
         fit_diagnostics=FitDiagnosticsResults(

--- a/mlsynth/utils/sdidgeo_helpers/realize.py
+++ b/mlsynth/utils/sdidgeo_helpers/realize.py
@@ -49,6 +49,7 @@ def realize_design(
     seed: int = 0,
     cpic: Optional[float] = None,
     engine: str = "sdid",
+    engine_kwargs: Optional[dict] = None,
 ) -> BaseEstimatorResults:
     """Realize one candidate design on the full (pre + post) panel.
 
@@ -114,11 +115,13 @@ def realize_design(
 
     eng = resolve_engine(engine)
     start, end = pre_periods, n_periods - 1
-    fit = eng.fit_once(treated, donors, pre_periods, start, end, len(members))
+    ekw = dict(engine_kwargs or {})
+    fit = eng.fit_once(treated, donors, pre_periods, start, end, len(members),
+                       **ekw)
     tau = eng.att(fit, treated, start, end)
     p_value, inf_details = eng.point_inference(
         fit, treated, donors, pre_periods, start, end,
-        n_draws=n_draws, n_tr=len(members), seed=seed)
+        n_draws=n_draws, n_tr=len(members), seed=seed, **ekw)
 
     # Reporting scale. The statistic is a ratio, so it is scale-free and the
     # p-value is unmoved; only the reported paths change units.

--- a/mlsynth/utils/sdidgeo_helpers/simulate.py
+++ b/mlsynth/utils/sdidgeo_helpers/simulate.py
@@ -48,6 +48,7 @@ def simulate_backtest(
     *, n_draws: int = 200, n_tr: int = 1, seed: int = 0,
     cpic: Optional[float] = None, treated_total: Optional[np.ndarray] = None,
     analytic: bool = True, engine: str = "sdid",
+    engine_kwargs: Optional[dict] = None,
 ) -> List[dict]:
     """Simulate one backtest across a grid of effect sizes.
 
@@ -101,14 +102,15 @@ def simulate_backtest(
             f"{treated_arr.shape[0]} and {donors_arr.shape[0]}.")
 
     eng = resolve_engine(engine)
-    fit = eng.fit_once(treated_arr, donors_arr, n_pre, start, end, n_tr)
+    ekw = dict(engine_kwargs or {})
+    fit = eng.fit_once(treated_arr, donors_arr, n_pre, start, end, n_tr, **ekw)
     cf_post_mean = float(np.mean(fit.counterfactual[start:end + 1]))
 
     # The engine owns the effect grid: what can be hoisted out of it (a placebo
     # draw) and what cannot (a conformal permutation) differs by procedure.
     swept = eng.sweep_p_values(fit, treated_arr, donors_arr, n_pre, start, end,
                                list(effect_sizes), n_draws=n_draws, n_tr=n_tr,
-                               seed=seed, analytic=analytic)
+                               seed=seed, analytic=analytic, **ekw)
 
     total_arr = (np.asarray(treated_total, dtype=float).ravel()
                  if treated_total is not None else treated_arr)

--- a/mlsynth/utils/sdidgeo_helpers/simulate.py
+++ b/mlsynth/utils/sdidgeo_helpers/simulate.py
@@ -17,7 +17,7 @@ from typing import List, Optional
 import numpy as np
 
 from ...exceptions import MlsynthConfigError
-from .engine import normal_p_value, placebo_sigma, sdid_att, sdid_fit_once
+from .engines import resolve_engine
 from .windows import backtest_pre_periods, backtest_treatment_window
 
 
@@ -47,7 +47,7 @@ def simulate_backtest(
     treated, donors, n_periods: int, duration: int, sim: int, effect_sizes,
     *, n_draws: int = 200, n_tr: int = 1, seed: int = 0,
     cpic: Optional[float] = None, treated_total: Optional[np.ndarray] = None,
-    analytic: bool = True,
+    analytic: bool = True, engine: str = "sdid",
 ) -> List[dict]:
     """Simulate one backtest across a grid of effect sizes.
 
@@ -100,31 +100,27 @@ def simulate_backtest(
             f"treated and donors must both have n_periods={n_periods} rows; got "
             f"{treated_arr.shape[0]} and {donors_arr.shape[0]}.")
 
-    fit = sdid_fit_once(treated_arr, donors_arr, n_pre, start, end, n_tr=n_tr)
-    tau0 = sdid_att(fit, treated_arr, start, end)
-    post_baseline = float(np.mean(treated_arr[start:end + 1]))
+    eng = resolve_engine(engine)
+    fit = eng.fit_once(treated_arr, donors_arr, n_pre, start, end, n_tr)
     cf_post_mean = float(np.mean(fit.counterfactual[start:end + 1]))
 
-    # Invariant to the injected effect, so one run serves the whole sweep.
-    sigma = placebo_sigma(treated_arr, donors_arr, n_pre, start, end,
-                          n_draws=n_draws, n_tr=n_tr, seed=seed)
+    # The engine owns the effect grid: what can be hoisted out of it (a placebo
+    # draw) and what cannot (a conformal permutation) differs by procedure.
+    swept = eng.sweep_p_values(fit, treated_arr, donors_arr, n_pre, start, end,
+                               list(effect_sizes), n_draws=n_draws, n_tr=n_tr,
+                               seed=seed, analytic=analytic)
 
     total_arr = (np.asarray(treated_total, dtype=float).ravel()
                  if treated_total is not None else treated_arr)
     window_volume = float(np.sum(total_arr[start:end + 1]))
 
     rows: List[dict] = []
-    for es in effect_sizes:
-        if analytic:
-            tau = tau0 + float(es) * post_baseline
-        else:
-            tau = sdid_att(fit, inject_effect(treated_arr, start, end, es),
-                           start, end)
+    for es, tau, p_value in zip(effect_sizes, swept["tau"], swept["p_value"]):
         rows.append({
             "sim": sim,
             "duration": duration,
             "effect_size": float(es),
-            "p_value": normal_p_value(tau, sigma),
+            "p_value": p_value,
             "placebo_mean_effect": tau,
             "detected_lift": (tau / cf_post_mean if cf_post_mean != 0.0
                               else float("nan")),


### PR DESCRIPTION
## Related Links

- Docs page: `docs/sdidgeo.rst` (Verification section rewritten)
- Benchmark case: `benchmarks/cases/sdidgeo_augsynth_geolift.py`
- Follows #394 (realize), #392 (constraints), #391 (validation framing)
- Depends on #393, which fixed the ridge degeneracy the new property suite found

## What

- `mlsynth/utils/sdidgeo_helpers/engines/` — the seam: `EngineFit`, `Engine`, `resolve_engine`
- `engines/sdid/` — the existing estimator as an adapter, adding no arithmetic
- `engines/augsynth/` — ridge-augmented SCM over `BilevelSCM`, with conformal inference via `conformal_pvalue`
- Config gains `engine`, `inference`, `ns`, `conformal_type`, `fixed_effects`, `augment`
- `benchmarks/cases/sdidgeo_augsynth_geolift.py` — cross-validation against GeoLift's published BestMarkets
- Three test files: seam contract, cross-engine properties (hypothesis), augsynth engine

## Why

Everything in SDIDGEO except the fit and the p-value is estimator-independent:
nomination, the backtest windows, effect injection, power, MDE, ranking,
constraints, plots. Making that explicit lets one panel be scored two ways, so
the objective can be varied without varying the inference and the other way
round — and it gives the estimator an external referent it did not have, since
augsynth is what GeoLift actually uses.

## How

The dispatcher shape PDA and SPILLSYNTH already use — a subpackage per engine
exposing uniform module-level functions, selected by a config string — not an
abstract base class.

The inference takes the whole effect grid, not one point. The two procedures
differ in what they can hoist: a placebo standard error does not depend on the
injected effect and is drawn once for the grid, while a conformal p-value
re-permutes against the treated series and is recomputed per effect size. The
scoring loop hoisted the placebo draw out of the sweep, so substituting a
conformal p-value at that call site would have silently reused one p-value
across the whole grid.

Engine and inference are separate axes, and the config encodes why. Placebo
needs only a donor-built counterfactual, so it works on either engine; conformal
needs the pre-period residuals exchangeable across the matching window, which is
what SDID's time weights deny. `engine="sdid", inference="conformal"` is
rejected with that reason.

## Verification

- Path: cross-validation. `SDIDGEO(engine="augsynth")` reproduces GeoLift's
  published BestMarkets top five on the walkthrough panel — rank, MDE, CPIC
  investment and `abs_lift_in_zero`, fourteen quantities value for value,
  investment to the cent. Runs in 6.4s, deterministic across repeat runs.
- This reaches past the engine: nomination, window arithmetic, effect injection,
  the power sweep, the MDE rule and the composite rank are shared code, so a
  divergence anywhere in that stack would move a rank or an investment.
- The sdid engine is proved inert: end-to-end output is bit-identical to the run
  captured before the seam existed, donor weights to full precision, and the
  existing SDIDGEO tests are unchanged.
- Property tests are parametrized over the engine registry, so both engines must
  satisfy the same metamorphic relations (scale equivariance, location
  invariance, donor-permutation equivariance, and the analytic-shortcut
  equality). A third engine inherits the suite by construction.
- Coverage: `engines/__init__.py` 100%, `engines/sdid/` 100%.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR
- [x] The default preserves existing behaviour exactly — `engine` defaults to `sdid`, and the pipeline's output is bit-identical
- [x] Existing pinned benchmark values unchanged
- [x] A test pins that the default is unchanged (`TestPipelineUnchanged`)
- [x] Every new config field carries a `Field(...)` description

## Test Steps

- [x] `pytest mlsynth/tests/test_sdidgeo_engine_seam.py -q` — 15 passed
- [x] `pytest mlsynth/tests/test_sdidgeo_engine_properties.py -q` — cross-engine properties
- [x] `pytest mlsynth/tests/test_sdidgeo_augsynth_engine.py -q` — 25 passed
- [x] Three files together on the rebased base — 56 passed
- [x] `python -c "import benchmarks.cases.sdidgeo_augsynth_geolift as m; m.run()"` — 14/14 within tolerance
- [x] `pytest mlsynth/tests/test_benchmark_reference.py -q` — 21 passed

## Other Notes

The property suite found a pre-existing crash in shared `bilevel` code — ridge
augmentation on a rank-zero matching matrix — which landed separately as #393.
That test now passes with no edit to it, which is the confirmation the defect was
in shared code and not in the augsynth adapter.

A head-to-head on identical inputs suggests the inference matters more than the
objective: for `chicago, portland` at duration 15, conformal gives MDE 0.100 and
placebo 0.150 on *either* engine, and raising the placebo draws fivefold does not
move it. Not pinned here — it belongs in its own benchmark case if wanted.

`multicell` remains the last capability gap against the GeoLift estimator.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_