### PR TITLE
Report the effect a design actually detects, not the nearest grid point

### DIFF
--- a/mlsynth/tests/test_sdidgeo_exact_mde.py
+++ b/mlsynth/tests/test_sdidgeo_exact_mde.py
@@ -1,0 +1,277 @@
+"""The effect a design actually detects, instead of the nearest grid point.
+
+``mde`` is the smallest simulated effect whose power clears the threshold, so
+its resolution is the effect grid's step. On a 0.05 grid a design that truly
+detects 0.1014 reports 0.150, because 0.1014 misses the 0.10 point and rounds to
+the next one -- a 48% overstatement of the lift the experiment needs.
+
+Under placebo inference the detection condition is closed form in the effect
+size. Detection is ``2(1 - Phi(|tau| / sigma)) < alpha``, and the analytic
+shortcut gives ``tau = tau_0 + e * mean(y_post)``, linear in ``e``. So the
+effect where a backtest starts detecting solves directly:
+
+    e_up   = ( z * sigma - tau_0) / mean(y_post)
+    e_down = (-z * sigma - tau_0) / mean(y_post)
+
+Two directions, not one, and they are not a symmetric pair. The test rejects
+when ``tau`` leaves ``[-z sigma, z sigma]``, so the detection region is
+``e < down`` or ``e > up`` with ``down < up`` always -- but nothing forces
+``down < 0 < up``. When a backtest's own placebo effect ``tau_0`` is large and
+negative, both crossings land positive, and ``down > 0`` says the design rejects
+at zero injected effect: it is firing on its own drift. The grid hides that
+behind a plausible-looking number, because a small positive effect still sits
+inside the rejection region.
+
+With several backtests, power above the threshold means at least
+``k = floor(threshold * n_sims) + 1`` of them detect, so the design's boundary
+is the k-th smallest per-backtest boundary -- an order statistic, not a mean.
+That is why this cannot ride through ``compute_power``, which averages.
+
+``mde`` and every rank column are untouched. They are what the GeoLift
+cross-validation pins, and the exact boundary is reported beside them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.stats import norm
+
+from mlsynth import SDIDGEO
+from mlsynth.config_models import SDIDGEOConfig
+from mlsynth.utils.datautils import geoex_dataprep
+from mlsynth.utils.sdidgeo_helpers.aggregate import compute_exact_mde
+from mlsynth.utils.sdidgeo_helpers.engines import resolve_engine
+from mlsynth.utils.sdidgeo_helpers.shaping import aggregate_treated, donor_matrix
+
+DATA = Path(__file__).resolve().parents[2] / "basedata" / "geolift_test_data.csv"
+ALPHA = 0.1
+
+
+@pytest.fixture(scope="module")
+def panel():
+    df = pd.read_csv(DATA)
+    df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+@pytest.fixture(scope="module")
+def wide(panel):
+    return geoex_dataprep(panel, "location", "date", "Y")["Ywide"]
+
+
+@pytest.fixture(scope="module")
+def arrays(wide):
+    region = frozenset(list(wide.columns)[:2])
+    y = aggregate_treated(wide, region, how="mean").to_numpy()
+    Y0 = donor_matrix(wide, region).to_numpy()
+    n_pre = wide.shape[0] - 14
+    return y, Y0, n_pre, n_pre, wide.shape[0] - 1, len(region)
+
+
+# ---------------------------------------------------------------------------
+# The engine's boundary
+# ---------------------------------------------------------------------------
+
+class TestBoundary:
+    def test_matches_a_brute_force_search(self, arrays):
+        # The claim the closed form makes: it is the effect at which a fine
+        # search would first find the p-value crossing alpha.
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("sdid")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        kw = dict(n_draws=15, n_tr=n_tr, seed=1)
+        up, down = eng.detection_boundary(fit, y, Y0, n_pre, start, end,
+                                          alpha=ALPHA, **kw)
+
+        grid = np.round(np.arange(0.0, 0.6, 0.0005), 6)
+        swept = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, list(grid),
+                                   **kw)
+        detected = grid[np.asarray(swept["p_value"]) < ALPHA]
+        assert detected.size, "no effect on the search grid detected"
+        assert up == pytest.approx(float(detected.min()), abs=0.001)
+
+    def test_down_boundary_matches_a_brute_force_search(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("sdid")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        kw = dict(n_draws=15, n_tr=n_tr, seed=1)
+        _, down = eng.detection_boundary(fit, y, Y0, n_pre, start, end,
+                                         alpha=ALPHA, **kw)
+        grid = np.round(np.arange(-0.6, 0.0, 0.0005), 6)
+        swept = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, list(grid),
+                                   **kw)
+        detected = grid[np.asarray(swept["p_value"]) < ALPHA]
+        assert detected.size
+        assert down == pytest.approx(float(detected.max()), abs=0.001)
+
+    def test_down_is_below_up(self, arrays):
+        # The invariant that always holds: the rejection region is the outside
+        # of an interval, so the lower crossing sits below the upper one. Their
+        # signs are not guaranteed -- a backtest drifting hard enough puts both
+        # on the same side, which is what a rejected null at zero effect looks
+        # like.
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("sdid")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        up, down = eng.detection_boundary(fit, y, Y0, n_pre, start, end,
+                                          alpha=ALPHA, n_draws=15, n_tr=n_tr,
+                                          seed=1)
+        assert down < up
+        assert abs(up) != pytest.approx(abs(down), rel=1e-6)
+
+    def test_a_tighter_alpha_needs_a_bigger_effect(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("sdid")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        kw = dict(n_draws=15, n_tr=n_tr, seed=1)
+        lax, _ = eng.detection_boundary(fit, y, Y0, n_pre, start, end,
+                                        alpha=0.20, **kw)
+        strict, _ = eng.detection_boundary(fit, y, Y0, n_pre, start, end,
+                                           alpha=0.01, **kw)
+        assert strict > lax
+
+    def test_conformal_reports_no_boundary(self, arrays):
+        # The conformal p-value re-permutes against the injected series, so it
+        # is not analytic in the effect size. Reported absent instead of guessed.
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("augsynth")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        up, down = eng.detection_boundary(fit, y, Y0, n_pre, start, end,
+                                          alpha=ALPHA, inference="conformal",
+                                          ns=40, n_tr=n_tr, seed=0)
+        assert np.isnan(up) and np.isnan(down)
+
+    def test_augsynth_under_placebo_has_one(self, arrays):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine("augsynth")
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        up, down = eng.detection_boundary(fit, y, Y0, n_pre, start, end,
+                                          alpha=ALPHA, inference="placebo",
+                                          n_draws=12, n_tr=n_tr, seed=0)
+        assert np.isfinite(up) and np.isfinite(down)
+        assert up > 0 > down
+
+
+# ---------------------------------------------------------------------------
+# Aggregating over backtests
+# ---------------------------------------------------------------------------
+
+class TestOrderStatistic:
+    def _cube(self, ups, downs, duration=7):
+        rows = []
+        for sim, (u, d) in enumerate(zip(ups, downs), start=1):
+            rows.append({"candidate": frozenset({"a"}), "duration": duration,
+                         "sim": sim, "boundary_up": u, "boundary_down": d})
+        return pd.DataFrame(rows)
+
+    def test_takes_the_kth_smallest_not_the_mean(self):
+        # Four backtests at a 0.8 threshold: k = floor(0.8*4)+1 = 4, so every
+        # backtest must detect and the boundary is the largest of them.
+        cube = self._cube([0.05, 0.08, 0.11, 0.20], [-0.06, -0.09, -0.12, -0.30])
+        out = compute_exact_mde(cube, power_threshold=0.8)
+        row = out.iloc[0]
+        assert row["mde_exact_up"] == pytest.approx(0.20)
+        assert row["mde_exact_down"] == pytest.approx(-0.30)
+
+    def test_a_lower_threshold_needs_fewer_backtests(self):
+        # k = floor(0.5*4)+1 = 3 -> the third smallest.
+        cube = self._cube([0.05, 0.08, 0.11, 0.20], [-0.06, -0.09, -0.12, -0.30])
+        out = compute_exact_mde(cube, power_threshold=0.5)
+        assert out.iloc[0]["mde_exact_up"] == pytest.approx(0.11)
+        assert out.iloc[0]["mde_exact_down"] == pytest.approx(-0.12)
+
+    def test_single_backtest_is_its_own_boundary(self):
+        out = compute_exact_mde(self._cube([0.09], [-0.07]),
+                                power_threshold=0.8)
+        assert out.iloc[0]["mde_exact_up"] == pytest.approx(0.09)
+        assert out.iloc[0]["mde_exact_down"] == pytest.approx(-0.07)
+
+    def test_non_finite_boundaries_give_nan(self):
+        cube = self._cube([np.nan, np.nan], [np.nan, np.nan])
+        out = compute_exact_mde(cube, power_threshold=0.8)
+        assert np.isnan(out.iloc[0]["mde_exact_up"])
+
+    def test_empty_cube(self):
+        out = compute_exact_mde(pd.DataFrame(), power_threshold=0.8)
+        assert out.empty
+
+
+# ---------------------------------------------------------------------------
+# End to end
+# ---------------------------------------------------------------------------
+
+class TestShortlist:
+    @pytest.fixture(scope="class")
+    def result(self, panel):
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return SDIDGEO(SDIDGEOConfig(
+                df=panel, unitid="location", time="date", outcome="Y",
+                treatment_size=2, durations=[14],
+                effect_sizes=[-0.2, -0.1, 0.0, 0.1, 0.2], n_backtests=3,
+                n_draws=25, n_validation_backtests=0, alpha=ALPHA,
+                seed=0)).fit()
+
+    def test_columns_present(self, result):
+        for col in ("mde_exact_up", "mde_exact_down", "pre_rmspe_lambda"):
+            assert col in result.power.columns, col
+
+    def test_boundaries_are_ordered(self, result):
+        s = result.power.dropna(subset=["mde_exact_up", "mde_exact_down"])
+        assert not s.empty
+        assert (s["mde_exact_down"] < s["mde_exact_up"]).all()
+
+    def test_grid_overstates_where_the_null_is_not_already_rejected(self, result):
+        # Restricted to designs that straddle zero, which is the case the grid
+        # is meant to describe. There the grid rounds up to its next point, so
+        # the exact crossing is at or below it -- and strictly below somewhere,
+        # which is the resolution the grid loses.
+        s = result.power.dropna(subset=["mde", "mde_exact_up", "mde_exact_down"])
+        healthy = s[(s["mde_exact_down"] < 0) & (s["mde_exact_up"] > 0)]
+        assert not healthy.empty
+        smallest = np.minimum(healthy["mde_exact_up"].abs(),
+                              healthy["mde_exact_down"].abs())
+        assert (healthy["mde"].abs() + 1e-9 >= smallest).all()
+        assert (healthy["mde"].abs() - smallest > 1e-6).any()
+
+    def test_a_rejected_null_shows_as_a_positive_lower_crossing(self, result):
+        # down > 0 means zero injected effect already rejects. The grid reports
+        # an ordinary-looking MDE for these, so the boundary is the only column
+        # that says so.
+        s = result.power.dropna(subset=["mde_exact_down"])
+        broken = s[s["mde_exact_down"] > 0]
+        if not broken.empty:
+            assert (broken["mde"].abs() > 0).all()
+
+    def test_lambda_rmse_is_reported_and_usually_lower(self, result):
+        # Usually, not always. SDID's time weights solve a problem the treated
+        # unit takes no part in: lambda is chosen so a convex combination of the
+        # donors' pre-period rows reproduces each donor's post-period mean. The
+        # treated unit's lambda-weighted pre-period dispersion is a by-product
+        # of that, not a quantity anything optimises, so nothing orders it
+        # against the unweighted RMSE. On this panel the ratio runs about 0.72
+        # at the median and exceeds 1 for a few designs.
+        s = result.power.dropna(subset=["pre_rmspe", "pre_rmspe_lambda"])
+        assert not s.empty
+        assert (s["pre_rmspe_lambda"] >= 0).all()
+        ratio = s["pre_rmspe_lambda"] / s["pre_rmspe"]
+        assert ratio.median() < 1.0
+
+    def test_mde_and_ranks_are_unchanged(self, result):
+        # Pinned from the run before these columns existed. The GeoLift
+        # cross-validation depends on every one of them.
+        top = result.power.sort_values("rank").head(5)
+        got = [(float(r["rank"]), float(r["mde"]),
+                sorted(map(str, r["candidate"]))) for _, r in top.iterrows()]
+        assert got == [
+            (1.0, 0.2, ["jacksonville", "minneapolis"]),
+            (2.0, 0.2, ["atlanta", "nashville"]),
+            (3.0, 0.1, ["cleveland", "san francisco"]),
+            (3.0, 0.2, ["milwaukee", "orlando"]),
+            (5.0, 0.2, ["detroit", "new orleans"]),
+        ]

--- a/mlsynth/utils/sdidgeo_helpers/aggregate.py
+++ b/mlsynth/utils/sdidgeo_helpers/aggregate.py
@@ -19,7 +19,7 @@ import pandas as pd
 _POWER_COLUMNS = [
     "candidate", "duration", "effect_size",
     "power", "placebo_mean_effect", "detected_lift", "scaled_l2", "pre_rmspe",
-    "investment",
+    "pre_rmspe_lambda", "investment",
 ]
 
 
@@ -54,6 +54,7 @@ def compute_power(cube: pd.DataFrame, *, alpha: float = 0.1) -> pd.DataFrame:
         detected_lift=("detected_lift", "mean"),
         scaled_l2=("scaled_l2", "mean"),
         pre_rmspe=("pre_rmspe", "mean"),
+        pre_rmspe_lambda=("pre_rmspe_lambda", "mean"),
     )
     if has_investment:
         # investment = cpic * es * volume is constant across backtests.
@@ -111,9 +112,57 @@ def compute_mde(power_table: pd.DataFrame, *, power_threshold: float = 0.8) -> p
     return pd.DataFrame(rows)
 
 
+def compute_exact_mde(cube: pd.DataFrame, *,
+                      power_threshold: float = 0.8) -> pd.DataFrame:
+    """The effect a design actually detects, per (candidate, duration).
+
+    ``compute_mde`` reports the smallest simulated effect whose power clears the
+    threshold, so its resolution is the effect grid's step: a design that truly
+    detects 0.1014 reports 0.150 on a 0.05 grid, because 0.1014 misses the 0.10
+    point. This reports the crossing itself.
+
+    The per-backtest boundaries come from the engine (closed form where the
+    p-value is analytic in the effect). Power above the threshold means at least
+    ``k = floor(power_threshold * n_sims) + 1`` backtests detect, so the design's
+    boundary is the k-th smallest of them -- an order statistic, which is why
+    this works on the pre-aggregation cube instead of riding through
+    :func:`compute_power`, which averages.
+
+    Both directions are kept. The backtest's own placebo effect is generally
+    nonzero, so the detection interval sits off centre and a design can need
+    less of a push downward than upward.
+
+    Returns ``nan`` for a design whose boundaries are not finite, which is what
+    an engine reports when its p-value is not analytic in the effect.
+    """
+    if cube.empty or "boundary_up" not in cube.columns:
+        return pd.DataFrame(columns=["candidate", "duration",
+                                     "mde_exact_up", "mde_exact_down"])
+
+    rows: List[dict] = []
+    per_sim = cube.drop_duplicates(subset=["candidate", "duration", "sim"])
+    for (candidate, duration), group in per_sim.groupby(
+        ["candidate", "duration"], sort=False
+    ):
+        ups = group["boundary_up"].to_numpy(dtype=float)
+        downs = group["boundary_down"].to_numpy(dtype=float)
+        n_sims = ups.shape[0]
+        k = int(np.floor(power_threshold * n_sims)) + 1
+        up = down = float("nan")
+        finite_up = np.sort(ups[np.isfinite(ups)])
+        finite_down = np.sort(downs[np.isfinite(downs)])[::-1]
+        if finite_up.size >= k:
+            up = float(finite_up[k - 1])
+        if finite_down.size >= k:
+            down = float(finite_down[k - 1])
+        rows.append({"candidate": candidate, "duration": duration,
+                     "mde_exact_up": up, "mde_exact_down": down})
+    return pd.DataFrame(rows)
+
+
 _RANK_COLUMNS = [
     "candidate", "duration", "mde", "power", "detected_lift", "abs_lift_in_zero",
-    "scaled_l2", "pre_rmspe", "investment",
+    "scaled_l2", "pre_rmspe", "pre_rmspe_lambda", "investment",
     "rank_mde", "rank_pvalue", "rank_abszero", "rank",
 ]
 

--- a/mlsynth/utils/sdidgeo_helpers/batch.py
+++ b/mlsynth/utils/sdidgeo_helpers/batch.py
@@ -17,13 +17,14 @@ from .simulate import simulate_backtest
 _COLUMNS = [
     "candidate", "duration", "sim", "effect_size",
     "p_value", "placebo_mean_effect", "detected_lift", "scaled_l2", "pre_rmspe",
-    "investment",
+    "pre_rmspe_lambda", "boundary_up", "boundary_down", "investment",
 ]
 
 
 def _simulate_candidate(candidate, Ywide, durations, n_backtests,
                         effect_sizes, *, n_periods, n_draws, seed, cpic,
-                        exclude=None, engine="sdid", engine_kwargs=None):
+                        exclude=None, engine="sdid", engine_kwargs=None,
+                        alpha=0.1):
     """Every row for one candidate.
 
     Pure and deterministic given a fixed ``seed``, and defined at module level so
@@ -47,7 +48,7 @@ def _simulate_candidate(candidate, Ywide, durations, n_backtests,
                 treated, donors, n_periods, duration, sim, effect_sizes,
                 n_draws=n_draws, n_tr=n_tr, seed=seed, cpic=cpic,
                 treated_total=treated_total, engine=engine,
-                engine_kwargs=engine_kwargs,
+                engine_kwargs=engine_kwargs, alpha=alpha,
             ):
                 row["candidate"] = candidate
                 rows.append(row)
@@ -68,6 +69,7 @@ def run_simulations(
     excluded: Optional[Mapping[frozenset, Iterable]] = None,
     engine: str = "sdid",
     engine_kwargs: Optional[Mapping[str, object]] = None,
+    alpha: float = 0.1,
 ) -> pd.DataFrame:
     """Run the simulation grid and stack the results into one long table.
 
@@ -101,7 +103,8 @@ def run_simulations(
     n_periods = Ywide.shape[0]
     candidates = list(candidates)
     work = dict(n_periods=n_periods, n_draws=n_draws, seed=seed, cpic=cpic,
-                engine=engine, engine_kwargs=dict(engine_kwargs or {}))
+                engine=engine, engine_kwargs=dict(engine_kwargs or {}),
+                alpha=alpha)
     excluded = excluded or {}
 
     if n_jobs == 1 or len(candidates) <= 1:

--- a/mlsynth/utils/sdidgeo_helpers/engines/__init__.py
+++ b/mlsynth/utils/sdidgeo_helpers/engines/__init__.py
@@ -26,6 +26,11 @@ An engine supplies four things.
 
 ``point_inference(fit, y, Y0, n_pre, start, end, ...) -> (p_value, details)``
     A single window's test, for the realized readout.
+
+``detection_boundary(fit, y, Y0, n_pre, start, end, *, alpha, ...) -> (up, down)``
+    The effect sizes at which this backtest starts detecting, in each
+    direction. Closed form where the p-value is analytic in the effect, and
+    ``(nan, nan)`` where it is not -- reported absent instead of guessed.
 """
 
 from __future__ import annotations
@@ -65,6 +70,30 @@ class Engine:
     att: Callable[..., float]
     sweep_p_values: Callable[..., Dict[str, Any]]
     point_inference: Callable[..., Any]
+    detection_boundary: Callable[..., Any]
+
+
+def placebo_detection_boundary(att_0: float, baseline: float, sigma, alpha: float):
+    """Effects at which a placebo-tested backtest starts detecting.
+
+    Detection is ``2(1 - Phi(|tau| / sigma)) < alpha`` and the analytic shortcut
+    gives ``tau = att_0 + e * baseline``, linear in the effect, so the crossings
+    solve directly:
+
+        up   = ( z * sigma - att_0) / baseline
+        down = (-z * sigma - att_0) / baseline
+
+    with ``z`` the two-sided normal critical value. ``att_0`` is the backtest's
+    own placebo effect and is generally nonzero, so the interval sits off centre
+    and the two directions differ -- a design already drifting negative needs
+    less of a push downward than upward.
+    """
+    from scipy.stats import norm
+
+    if sigma is None or not np.isfinite(sigma) or sigma <= 0 or baseline == 0:
+        return float("nan"), float("nan")
+    z = float(norm.ppf(1.0 - alpha / 2.0))
+    return ((z * sigma - att_0) / baseline, (-z * sigma - att_0) / baseline)
 
 
 def resolve_engine(name: str) -> Engine:

--- a/mlsynth/utils/sdidgeo_helpers/engines/augsynth/__init__.py
+++ b/mlsynth/utils/sdidgeo_helpers/engines/augsynth/__init__.py
@@ -38,7 +38,7 @@ import numpy as np
 from .....exceptions import MlsynthConfigError
 from .....utils.bilevel.engine import BilevelSCM
 from .....utils.bilevel.ridge_inference import conformal_pvalue
-from .. import Engine, EngineFit
+from .. import Engine, EngineFit, placebo_detection_boundary
 from ...engine import normal_p_value, placebo_sigma
 
 
@@ -86,6 +86,7 @@ def fit_once(y, Y0, n_pre: int, start: int, end: int, n_tr: int, *,
         pre_rmspe=float(res.pre_rmspe),
         scaled_l2=_scaled_l2(A, B, w),
         extras={
+            "pre_rmspe_lambda": float("nan"),   # augsynth weights donors only
             "intercept": intercept,
             "augment": augment,
             "fixed_effects": bool(fixed_effects),
@@ -104,7 +105,7 @@ def sweep_p_values(
     fit: EngineFit, y, Y0, n_pre: int, start: int, end: int,
     effect_sizes: Iterable[float], *, inference: str = "conformal",
     ns: int = 1000, n_draws: int = 200, n_tr: int = 1, seed: int = 0,
-    conformal_type: str = "iid", analytic: bool = True,
+    conformal_type: str = "iid", analytic: bool = True, alpha: float = 0.1,
     **_ignored: Any,
 ) -> Dict[str, Any]:
     """Test every effect size on one backtest.
@@ -144,7 +145,10 @@ def sweep_p_values(
             ps.append(float(conformal_pvalue(
                 injected, Y0, n_pre, lambda_=lam, ns=ns, seed=seed,
                 conformal_type=conformal_type, fixed_effects=fixed_effects)))
-    return {"tau": taus, "p_value": ps, "sigma": sigma}
+    up, down = (placebo_detection_boundary(tau0, baseline, sigma, alpha)
+                if inference == "placebo" else (float("nan"), float("nan")))
+    return {"tau": taus, "p_value": ps, "sigma": sigma,
+            "boundary_up": up, "boundary_down": down}
 
 
 def point_inference(
@@ -174,7 +178,31 @@ def point_inference(
                "conformal_type": conformal_type}
 
 
-ENGINE = Engine(name="augsynth", fit_once=fit_once, att=att,
-                sweep_p_values=sweep_p_values, point_inference=point_inference)
+def detection_boundary(
+    fit: EngineFit, y, Y0, n_pre: int, start: int, end: int, *,
+    alpha: float = 0.1, inference: str = "conformal", n_draws: int = 200,
+    n_tr: int = 1, seed: int = 0, **_ignored: Any,
+):
+    """Effects at which this backtest starts detecting, in each direction.
 
-__all__ = ["ENGINE", "fit_once", "att", "sweep_p_values", "point_inference"]
+    Only defined under placebo inference. A conformal p-value re-permutes
+    against the injected series, so it is not analytic in the effect size and
+    the crossing would have to be searched for; absent is reported instead of a
+    number that is not what it claims.
+    """
+    if inference != "placebo":
+        return float("nan"), float("nan")
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    sigma = placebo_sigma(y, Y0, n_pre, start, end, n_draws=n_draws,
+                          n_tr=n_tr, seed=seed)
+    return placebo_detection_boundary(
+        att(fit, y, start, end), float(np.mean(y[start:end + 1])), sigma, alpha)
+
+
+ENGINE = Engine(name="augsynth", fit_once=fit_once, att=att,
+                sweep_p_values=sweep_p_values, point_inference=point_inference,
+                detection_boundary=detection_boundary)
+
+__all__ = ["ENGINE", "fit_once", "att", "sweep_p_values",
+           "point_inference", "detection_boundary"]

--- a/mlsynth/utils/sdidgeo_helpers/engines/sdid/__init__.py
+++ b/mlsynth/utils/sdidgeo_helpers/engines/sdid/__init__.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Iterable, Optional, Tuple
 
 import numpy as np
 
-from .. import Engine, EngineFit
+from .. import Engine, EngineFit, placebo_detection_boundary
 from .....exceptions import MlsynthConfigError
 from ...engine import (
     normal_p_value,
@@ -26,6 +26,23 @@ from ...engine import (
     sdid_att,
     sdid_fit_once,
 )
+
+
+def _lambda_dispersion(y, fit, n_pre: int) -> float:
+    """Pre-period gap dispersion under the fit's own time weights.
+
+    SDID matches a lambda-weighted average of pre-periods, so the unweighted
+    RMSE covers periods the fit set aside. The gap is centred on its
+    lambda-weighted mean, which the level term absorbs, so this measures what
+    the fit leaves once the level is out.
+    """
+    lam = np.asarray(fit.lam, dtype=float).ravel()
+    y = np.asarray(y, dtype=float).ravel()
+    gap = y[:n_pre] - fit.counterfactual[:n_pre]
+    if lam.shape[0] != n_pre or not np.isfinite(gap).all():
+        return float("nan")
+    centred = gap - float(lam @ gap)
+    return float(np.sqrt(lam @ (centred ** 2)))
 
 
 def fit_once(y, Y0, n_pre: int, start: int, end: int, n_tr: int,
@@ -42,7 +59,8 @@ def fit_once(y, Y0, n_pre: int, start: int, end: int, n_tr: int,
         time_weights=fit.lam,
         pre_rmspe=fit.pre_rmspe,
         scaled_l2=fit.scaled_l2,
-        extras={"zeta": fit.zeta, "bias_correction": fit.bias_correction},
+        extras={"zeta": fit.zeta, "bias_correction": fit.bias_correction,
+                "pre_rmspe_lambda": _lambda_dispersion(y, fit, n_pre)},
     )
 
 
@@ -56,7 +74,7 @@ def sweep_p_values(
     fit: EngineFit, y, Y0, n_pre: int, start: int, end: int,
     effect_sizes: Iterable[float], *, n_draws: int = 200, n_tr: int = 1,
     seed: int = 0, analytic: bool = True, inference: str = "placebo",
-    **_ignored: Any,
+    alpha: float = 0.1, **_ignored: Any,
 ) -> Dict[str, Any]:
     """Test every effect size on one backtest.
 
@@ -91,7 +109,9 @@ def sweep_p_values(
             tau = att(fit, inject_effect(y, start, end, es), start, end)
         taus.append(tau)
         ps.append(normal_p_value(tau, sigma))
-    return {"tau": taus, "p_value": ps, "sigma": sigma}
+    up, down = placebo_detection_boundary(tau0, baseline, sigma, alpha)
+    return {"tau": taus, "p_value": ps, "sigma": sigma,
+            "boundary_up": up, "boundary_down": down}
 
 
 def point_inference(
@@ -113,7 +133,23 @@ def point_inference(
     }
 
 
-ENGINE = Engine(name="sdid", fit_once=fit_once, att=att,
-                sweep_p_values=sweep_p_values, point_inference=point_inference)
+def detection_boundary(
+    fit: EngineFit, y, Y0, n_pre: int, start: int, end: int, *,
+    alpha: float = 0.1, n_draws: int = 200, n_tr: int = 1, seed: int = 0,
+    **_ignored: Any,
+):
+    """Effects at which this backtest starts detecting, in each direction."""
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    sigma = placebo_sigma(y, Y0, n_pre, start, end, n_draws=n_draws,
+                          n_tr=n_tr, seed=seed)
+    return placebo_detection_boundary(
+        att(fit, y, start, end), float(np.mean(y[start:end + 1])), sigma, alpha)
 
-__all__ = ["ENGINE", "fit_once", "att", "sweep_p_values", "point_inference"]
+
+ENGINE = Engine(name="sdid", fit_once=fit_once, att=att,
+                sweep_p_values=sweep_p_values, point_inference=point_inference,
+                detection_boundary=detection_boundary)
+
+__all__ = ["ENGINE", "fit_once", "att", "sweep_p_values",
+           "point_inference", "detection_boundary"]

--- a/mlsynth/utils/sdidgeo_helpers/orchestration.py
+++ b/mlsynth/utils/sdidgeo_helpers/orchestration.py
@@ -15,7 +15,8 @@ import pandas as pd
 from ...config_models import WeightsResults
 from ...exceptions import MlsynthConfigError, MlsynthDataError
 from ..datautils import geoex_dataprep
-from .aggregate import compute_mde, compute_power, compute_rank
+from .aggregate import (compute_exact_mde, compute_mde,
+                        compute_power, compute_rank)
 from .batch import run_simulations
 from .candidates import generate_candidate_markets
 from .config import SDIDGEOConfig
@@ -274,12 +275,19 @@ def run_design(config: SDIDGEOConfig) -> SDIDGEOResults:
         Ywide, candidates, config.durations, config.n_backtests,
         config.effect_sizes, n_draws=config.n_draws, seed=config.seed,
         cpic=config.cpic, n_jobs=config.n_jobs, excluded=excluded,
-        engine=config.engine, engine_kwargs=ekw,
+        engine=config.engine, engine_kwargs=ekw, alpha=config.alpha,
     )
     power_table = compute_power(cube, alpha=config.alpha)
+    # The effect the design actually detects, solved instead of read off the
+    # grid. Reported beside mde, which the ranking and the GeoLift
+    # cross-validation both depend on and which is left alone.
+    exact = compute_exact_mde(cube, power_threshold=config.power_threshold)
     shortlist = compute_rank(power_table,
                              power_threshold=config.power_threshold,
                              budget=config.budget)
+    if not shortlist.empty and not exact.empty:
+        shortlist = shortlist.merge(exact, on=["candidate", "duration"],
+                                    how="left")
     if not shortlist.empty:
         # Surface the region size next to its MDE, so a size scan is readable
         # without unpacking the candidate frozensets.

--- a/mlsynth/utils/sdidgeo_helpers/simulate.py
+++ b/mlsynth/utils/sdidgeo_helpers/simulate.py
@@ -48,7 +48,7 @@ def simulate_backtest(
     *, n_draws: int = 200, n_tr: int = 1, seed: int = 0,
     cpic: Optional[float] = None, treated_total: Optional[np.ndarray] = None,
     analytic: bool = True, engine: str = "sdid",
-    engine_kwargs: Optional[dict] = None,
+    engine_kwargs: Optional[dict] = None, alpha: float = 0.1,
 ) -> List[dict]:
     """Simulate one backtest across a grid of effect sizes.
 
@@ -110,7 +110,8 @@ def simulate_backtest(
     # draw) and what cannot (a conformal permutation) differs by procedure.
     swept = eng.sweep_p_values(fit, treated_arr, donors_arr, n_pre, start, end,
                                list(effect_sizes), n_draws=n_draws, n_tr=n_tr,
-                               seed=seed, analytic=analytic, **ekw)
+                               seed=seed, analytic=analytic, alpha=alpha,
+                               **ekw)
 
     total_arr = (np.asarray(treated_total, dtype=float).ravel()
                  if treated_total is not None else treated_arr)
@@ -128,6 +129,10 @@ def simulate_backtest(
                               else float("nan")),
             "scaled_l2": fit.scaled_l2,
             "pre_rmspe": fit.pre_rmspe,
+            "pre_rmspe_lambda": float(fit.extras.get("pre_rmspe_lambda",
+                                                     float("nan"))),
+            "boundary_up": swept.get("boundary_up", float("nan")),
+            "boundary_down": swept.get("boundary_down", float("nan")),
             "investment": (cpic * float(es) * window_volume
                            if cpic is not None else float("nan")),
         })


### PR DESCRIPTION
## Related Links

- Docs page: `docs/sdidgeo.rst`
- Companion: #396, whose statistic this surfaces as a shortlist column
- The cross-validation this must not disturb: `benchmarks/cases/sdidgeo_augsynth_geolift.py` (#395)

## What

- `detection_boundary` on the engine contract, implemented for both engines
- `compute_exact_mde` in `aggregate.py` — the k-th order statistic over backtests
- New shortlist columns `mde_exact_up`, `mde_exact_down`, `pre_rmspe_lambda`
- 17 new tests

## Why

`mde` is the smallest simulated effect whose power clears the threshold, so its
resolution is the effect grid's step. A design that truly detects 0.1014 reports
0.150 on a 0.05 grid — a 48% overstatement of the lift the experiment needs.

## How

Under placebo inference the crossing solves in closed form: detection is
`2(1 - Phi(|tau| / sigma)) < alpha` and the analytic shortcut gives
`tau = tau_0 + e * mean(y_post)`, linear in `e`. Conformal reports `nan`, since
its p-value re-permutes against the injected series and is not analytic in `e`.

Aggregation is an order statistic, not a mean. Power above the threshold means
at least `floor(threshold * n_sims) + 1` backtests detect, so the design's
boundary is the k-th smallest of theirs — which is why it works on the
pre-aggregation cube instead of riding through `compute_power`.

The sweep already draws `sigma`, so the boundary comes back with it rather than
redrawing placebos.

## Verification

- Path: not applicable — a new diagnostic, no external referent. The
  cross-validation in #395 is what constrains this PR, and it constrains it by
  requiring nothing move.
- The closed form is checked against a brute-force search over a 0.0005 grid, in
  both directions.
- `mde` and all four rank columns are pinned unchanged by a test.

Two claims I asserted while designing this turned out to be false, and the tests
now assert what holds instead:

1. I expected the grid to always overstate. It does not. The rejection region is
   `e < down` or `e > up` with `down < up`, but nothing forces `down < 0 < up`.
   Two designs come back with both crossings positive — `down = 0.148` means zero
   injected effect already rejects, so the design is firing on its own drift.
   The grid reports an ordinary-looking 0.100 for those. That makes the columns
   a design-validity signal, not only a resolution gain.
2. I expected `pre_rmspe_lambda` to sit below `pre_rmspe` always. It is lower in
   26 of 31 designs (median ratio 0.72) and exceeds it in 5. `lambda` solves a
   problem the treated unit takes no part in — it reproduces the donors'
   post-period means — so the treated unit's weighted pre-period dispersion is a
   by-product and nothing orders the two.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR
- [x] The default preserves existing behaviour, including reported units
- [x] Existing pinned benchmark values unchanged
- [x] A test pins `mde` and every rank column
- [x] No new config field

## Test Steps

- [x] `pytest mlsynth/tests/test_sdidgeo_exact_mde.py -q` — 17 passed
- [x] All seven SDIDGEO suites together — 236 passed
- [x] `pytest mlsynth/tests/test_result_contract.py -q` — 174 passed
- [ ] `python benchmarks/run_benchmarks.py sdidgeo_augsynth_geolift` — not rerun; the rank/mde pin covers what it depends on

## Other Notes

Coverage of the new code is uneven measured from this file alone
(`aggregate.py` 88%, `engines/sdid` 82%, `engines/augsynth` 53%) because the
augsynth conformal paths are covered by `test_sdidgeo_augsynth_engine.py`
instead. I have not measured the union.

`SDIDGEO` is becoming a misnomer now that the engine is pluggable; a rename is
worth doing separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_