### PR TITLE
Let the augsynth engine read out a realized experiment

### DIFF
--- a/docs/geox.rst
+++ b/docs/geox.rst
@@ -463,6 +463,12 @@ at all. For the same reason the readout inherits the design's donor
 pool: where a spillover constraint barred a treated market's
 conflict-neighbours, they stay barred here.
 
+``report.weights.summary_stats`` carries whatever the engine has to say
+about its own fit alongside the shared keys: SDID's ridge and bias
+correction, augsynth's intercept, its penalty and the augmentation by
+name. Under ``augment=None`` there is no penalty and ``lambda_`` is
+``None``, which is the answer and not a missing value.
+
 .. code-block:: python
 
     design = GEOX(GEOXConfig(

--- a/mlsynth/tests/test_geox_realize.py
+++ b/mlsynth/tests/test_geox_realize.py
@@ -274,3 +274,183 @@ class TestFitPopulatesTheReport:
             n_validation_backtests=0, seed=0)).fit()
         donors = set(res.report.weights.donor_weights)
         assert not (donors & set(res.selected_units))
+
+
+# ---------------------------------------------------------------------------
+# The readout across engines
+#
+# `realize_design` was written when SDID was the only engine, whose `extras`
+# happen to be all floats (`zeta`, `bias_correction`, `pre_rmspe_lambda`). The
+# augsynth engine carries what its estimator has: a penalty that may be absent,
+# an augmentation named by string, a flag. `extras` is the engine's own slot and
+# the readout does not get to assume a type for it -- the pipeline's premise is
+# that everything outside the fit is engine-independent, and a readout that
+# runs on one engine and raises on the other is that premise failing.
+#
+# These parametrize over both engines so the whole readout, not one field, is
+# held to it.
+# ---------------------------------------------------------------------------
+
+_ENGINE_KWARGS = {
+    "sdid": {"engine": "sdid"},
+    "augsynth": {"engine": "augsynth", "inference": "placebo"},
+    "augsynth-conformal": {"engine": "augsynth", "inference": "conformal",
+                           "ns": 40},
+    "augsynth-plain": {"engine": "augsynth", "inference": "placebo",
+                       "augment": None},
+    "augsynth-nofe": {"engine": "augsynth", "inference": "placebo",
+                      "fixed_effects": False},
+}
+
+
+def _post_panel(panel):
+    df = panel.copy()
+    cutoff = df["date"].sort_values().unique()[-14]
+    df["post"] = (df["date"] >= cutoff).astype(int)
+    return df
+
+
+def _design(panel, **over):
+    kwargs = dict(
+        df=_post_panel(panel), unitid="location", time="date", outcome="Y",
+        post_col="post", treatment_size=2, durations=[7],
+        effect_sizes=[0.0, 0.2], n_backtests=2, n_draws=5,
+        n_validation_backtests=0, seed=0)
+    kwargs.update(over)
+    return GEOX(GEOXConfig(**kwargs)).fit()
+
+
+class TestReadoutRunsOnEveryEngine:
+    @pytest.mark.parametrize("label", sorted(_ENGINE_KWARGS))
+    def test_the_report_is_produced(self, panel, label):
+        """Smoke: every engine and inference pairing reads out."""
+        res = _design(panel, **_ENGINE_KWARGS[label])
+        assert res.report is not None
+        assert np.isfinite(res.report.effects.att)
+
+    @pytest.mark.parametrize("label", sorted(_ENGINE_KWARGS))
+    def test_the_paths_are_finite_and_panel_length(self, panel, label):
+        res = _design(panel, **_ENGINE_KWARGS[label])
+        ts = res.report.time_series
+        n = len(ts.time_periods)
+        for path in (ts.observed_outcome, ts.counterfactual_outcome,
+                     ts.estimated_gap):
+            assert len(path) == n
+            assert np.all(np.isfinite(path))
+
+    @pytest.mark.parametrize("label", sorted(_ENGINE_KWARGS))
+    def test_the_p_value_is_a_probability(self, panel, label):
+        res = _design(panel, **_ENGINE_KWARGS[label])
+        assert 0.0 <= res.report.inference.p_value <= 1.0
+
+
+class TestEngineExtrasSurviveTheReadout:
+    """`extras` reach `summary_stats` with their own types intact.
+
+    The readout reports what the engine fitted, so a penalty that was absent
+    has to arrive as absent and not as a number standing in for it. Coercing
+    the slot to float is what made the augsynth readout unreachable.
+    """
+
+    def test_sdid_extras_are_reported(self, panel):
+        stats = _design(panel, engine="sdid").report.weights.summary_stats
+        for key in ("zeta", "bias_correction", "pre_rmspe_lambda"):
+            assert key in stats
+            assert isinstance(stats[key], float)
+
+    def test_augsynth_string_extra_is_reported_as_itself(self, panel):
+        stats = _design(panel, **_ENGINE_KWARGS["augsynth"]).report.weights.summary_stats
+        assert stats["augment"] == "ridge"
+
+    def test_augsynth_flag_extra_stays_a_bool(self, panel):
+        stats = _design(panel, **_ENGINE_KWARGS["augsynth"]).report.weights.summary_stats
+        assert stats["fixed_effects"] is True
+
+    def test_a_flag_turned_off_is_reported_off(self, panel):
+        stats = _design(panel, **_ENGINE_KWARGS["augsynth-nofe"]).report.weights.summary_stats
+        assert stats["fixed_effects"] is False
+
+    def test_an_absent_penalty_is_reported_absent(self, panel):
+        """`augment=None` is plain SCM, which has no ridge penalty.
+
+        `float(None)` raises, and any stand-in value would report a penalty
+        that was never applied.
+        """
+        stats = _design(panel, **_ENGINE_KWARGS["augsynth-plain"]).report.weights.summary_stats
+        assert stats["augment"] is None
+        assert stats["lambda_"] is None
+
+    def test_a_present_penalty_is_a_number(self, panel):
+        stats = _design(panel, **_ENGINE_KWARGS["augsynth"]).report.weights.summary_stats
+        assert isinstance(stats["lambda_"], float)
+        assert np.isfinite(stats["lambda_"])
+
+    @pytest.mark.parametrize("label", sorted(_ENGINE_KWARGS))
+    def test_the_shared_summary_keys_are_present_whichever_engine(self, panel, label):
+        stats = _design(panel, **_ENGINE_KWARGS[label]).report.weights.summary_stats
+        for key in ("how", "treated_markets", "engine", "cpic", "cost"):
+            assert key in stats
+
+    @pytest.mark.parametrize("label", sorted(_ENGINE_KWARGS))
+    def test_no_numpy_scalars_leak_into_the_summary(self, panel, label):
+        """Plain Python scalars, so the report pickles and serialises.
+
+        Every other numeric field in the result models is cast on the way in;
+        `extras` is the one slot fed straight from an engine, so it is the one
+        that can carry a `np.float64` out.
+        """
+        stats = _design(panel, **_ENGINE_KWARGS[label]).report.weights.summary_stats
+        leaked = {k: type(v).__name__ for k, v in stats.items()
+                  if isinstance(v, np.generic)}
+        assert leaked == {}
+
+
+class TestExtrasNormalisationUnit:
+    """The conversion itself, away from a fit."""
+
+    def test_numpy_scalars_become_python_scalars(self):
+        from mlsynth.utils.geox_helpers.realize import _report_extras
+
+        out = _report_extras({"a": np.float64(1.5), "b": np.int64(3),
+                              "c": np.bool_(True)})
+        assert out == {"a": 1.5, "b": 3, "c": True}
+        assert all(not isinstance(v, np.generic) for v in out.values())
+
+    def test_strings_none_and_bools_pass_through(self):
+        from mlsynth.utils.geox_helpers.realize import _report_extras
+
+        out = _report_extras({"augment": "ridge", "lambda_": None,
+                              "fixed_effects": False})
+        assert out == {"augment": "ridge", "lambda_": None,
+                       "fixed_effects": False}
+        assert out["fixed_effects"] is False
+
+    def test_an_empty_slot_is_an_empty_dict(self):
+        from mlsynth.utils.geox_helpers.realize import _report_extras
+
+        assert _report_extras({}) == {}
+
+    def test_nan_survives(self):
+        """augsynth reports `pre_rmspe_lambda` as nan: it weights donors only."""
+        from mlsynth.utils.geox_helpers.realize import _report_extras
+
+        assert np.isnan(_report_extras({"x": float("nan")})["x"])
+
+
+class TestTheTwoEnginesDisagree:
+    """A guard on the parametrization above.
+
+    If both engines produced the same report the tests would pass while
+    testing one estimator twice.
+    """
+
+    def test_the_engines_give_different_answers(self, panel):
+        sdid = _design(panel, **_ENGINE_KWARGS["sdid"]).report
+        aug = _design(panel, **_ENGINE_KWARGS["augsynth"]).report
+        assert sdid.effects.att != aug.effects.att
+
+    def test_only_sdid_reports_time_weights(self, panel):
+        sdid = _design(panel, **_ENGINE_KWARGS["sdid"]).report
+        aug = _design(panel, **_ENGINE_KWARGS["augsynth"]).report
+        assert sdid.weights.time_weights is not None
+        assert aug.weights.time_weights is None

--- a/mlsynth/utils/geox_helpers/realize.py
+++ b/mlsynth/utils/geox_helpers/realize.py
@@ -37,6 +37,25 @@ from .engines import resolve_engine
 from .shaping import aggregate_treated, donor_matrix
 
 
+def _report_extras(extras: dict) -> dict:
+    """An engine's ``extras`` in a form the report can carry.
+
+    ``extras`` is the engine's own slot, and what an estimator has to say about
+    its fit is not all numbers: SDID reports a ridge and a bias correction,
+    augsynth an intercept, a penalty that is absent under plain SCM, the
+    augmentation by name, and a flag. The readout reports what the engine
+    fitted, so an absent penalty arrives absent and the augmentation arrives as
+    its name.
+
+    The one thing changed on the way through is a numpy scalar, which becomes
+    the Python scalar it wraps. Every other numeric field in the result models
+    is cast as it is built; this slot is fed straight from an engine, so it is
+    where a ``np.float64`` would otherwise reach a caller pickling the report.
+    """
+    return {k: (v.item() if isinstance(v, np.generic) else v)
+            for k, v in extras.items()}
+
+
 def realize_design(
     Ywide_full: pd.DataFrame,
     candidate: Iterable,
@@ -165,7 +184,7 @@ def realize_design(
                 "engine": engine,
                 "cpic": cpic,
                 "cost": cost,
-                **{k: float(v) for k, v in fit.extras.items()},
+                **_report_extras(fit.extras),
             },
         ),
         fit_diagnostics=FitDiagnosticsResults(


### PR DESCRIPTION
## Related Links

- `mlsynth/utils/geox_helpers/realize.py`, `mlsynth/tests/test_geox_realize.py`
- `docs/geox.rst` — "Reading out the experiment"
- Introduced by #394 (`realize`) landing before #395 (the engine seam)

## What

- Added `_report_extras`, replacing `{k: float(v) for k, v in fit.extras.items()}`
- Parametrized the realize suite over five engine/inference pairings — 31 new tests
- Documented what `report.weights.summary_stats` carries per engine

## Why

`GEOX(engine="augsynth", post_col=...)` could not read out an experiment at all:

```
ValueError: could not convert string to float: 'ridge'
```

and `TypeError: float() argument must be a string or a real number, not 'NoneType'`
on the `augment=None` branch.

`extras` is the engine's own slot and its contents are the engine's business.
SDID puts three floats there (`zeta`, `bias_correction`, `pre_rmspe_lambda`), so
the coercion held while SDID was the only engine. Augsynth puts an intercept, a
penalty that is absent under plain SCM, the augmentation by name, and a flag.
The readout reports what the engine fitted, so an absent penalty has to arrive
absent — any stand-in would report a penalty that was never applied.

The engine this broke is the one someone reproducing GeoLift would pick, and the
pipeline's stated premise is that everything outside the fit is
engine-independent. A readout that runs on one engine and raises on the other is
that premise failing.

## How

`_report_extras` carries the slot through with its types intact and changes one
thing: a numpy scalar becomes the Python scalar it wraps. Every other numeric
field in the result models is cast as it is built; this is the one fed straight
from an engine, so it is where a `np.float64` would otherwise reach a caller
pickling the report. `WeightsResults.summary_stats` is already
`Optional[Dict[str, Any]]`, so nothing downstream wanted the floats.

The defect survived because the test matrix crossed `realize` with sdid and
`augsynth` with design-only — no test ran an engine other than the default
through the readout. That is the gap the new tests close, so the fix is a
parametrization as much as a function.

I found this while checking a separate question (whether the SDID Prop 99
benchmark is reproducible through GEOX with California forced treated — it is,
bit-identically). The augsynth arm of that comparison was meant to be the
contrast showing the equality is the engine's doing; it raised instead.

## Verification

- Path: not applicable — this fixes a crash. No estimate changes on any path
  that previously produced one.
- `sdid_prop99` passes unchanged: `sdid_att` |Δ|=0.001399 (tol 0.05),
  `sdid_att_vs_synthdid_R` 0.00157 (tol 0.02).
- `geox_augsynth_geolift` passes unchanged, all fourteen values.
- `realize.py` at 100% statement coverage, no `# pragma: no cover` added.
- On Prop 99 with California forced treated, GEOX reports -14.8918586 under
  augsynth against -15.6053993 under SDID, where before it raised.

Red first, for the right reasons. 31 tests failed before the fix, none of them
on the sdid path, and the failures were exactly `ValueError: 'ridge'` and
`TypeError: NoneType` — not a collateral error that would have masked the defect.

## Scope checks

BUG FIX
- [x] Tests reproduce the defect and fail without the fix — 31 red, 0 on sdid
- [x] They assert the correct behaviour, not the absence of a crash: the string
      extra arrives as `"ridge"`, the flag stays a `bool`, an absent penalty
      arrives as `None`, a present one as a finite `float`
- [x] No docs page, docstring, or comment stated the old behaviour — the page
      already promised the readout uses the configured engine, which is what the
      fix makes true
- [x] No pinned value moved

A guard class asserts the two engines disagree on the ATT and that only SDID
reports time weights, so the parametrization cannot pass by running one
estimator twice under two labels.

## Test Steps

- [x] `pytest mlsynth/tests/test_geox_realize.py -q` — 64 passed (33 before)
- [x] `pytest` over the other GEOX suites + the result contract — 424 passed, 4 skipped
- [x] `coverage run --timid -m pytest mlsynth/tests/test_geox_realize.py` — `realize.py` 100%
- [x] `python benchmarks/run_benchmarks.py --case sdid_prop99` — passed
- [x] `python benchmarks/run_benchmarks.py --case geox_augsynth_geolift` — 14/14
- [x] `python -m sphinx -b dummy docs <out>` — builds, no geox warning

## Other Notes

The GEOX-equals-SDID equivalence this came out of is not pinned anywhere. On
Prop 99 the realized ATT and all 38 donor weights match `SDID(...).fit()` to
`0.000e+00`, it holds for six different treated units and post splits, and it is
invariant to every design knob (`durations`, `n_backtests`, `seed`, `n_draws`,
`effect_sizes`, `how`, `alpha`). That belongs in a benchmark case, which
CLAUDE.md scopes to its own branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_