### PR TITLE
Pin that GEOX's harness does not perturb the estimator it wraps

### DIFF
--- a/benchmarks/cases/geox_sdid_equivalence.py
+++ b/benchmarks/cases/geox_sdid_equivalence.py
@@ -1,0 +1,245 @@
+"""Differential benchmark: GEOX's readout against the SDID estimator it wraps.
+
+GEOX is a design harness -- candidate nomination, backtest windows, effect
+injection, power, MDE, ranking, constraints -- wrapped around a scoring engine.
+With ``engine="sdid"`` the engine is mlsynth's synthetic difference-in-
+differences, reached through ``mlsynth.utils.sdid_helpers.weights``, so the two
+estimators are not independent implementations. What is unverified is the
+harness *around* the fit: how GEOX aggregates the treated region, builds the
+donor pool, indexes the pre/post split, and packages the readout. Any of those
+can perturb the estimate without touching the estimator.
+
+This case fixes the design question and asks the harness to disappear. Force one
+market as the treated region (``treatment_size=1`` with ``to_be_treated``), hand
+GEOX the real post-period, and compare its realized readout to
+``SDID(...).fit()`` on the identical panel. Agreement to solver noise means the
+harness is a no-op on the estimate; any drift is the harness, since the engine
+is the same code.
+
+The panel is the Abadie-Diamond-Hainmueller Proposition 99 smoking panel
+(``basedata/smoking_data.csv``: 39 states x 31 years, 1970-2000, California
+treated from 1989), which is also what ``sdid_prop99`` cross-validates against
+the authors' ``synthdid`` R package. That gives the equivalence a second use:
+whatever external validation SDID carries on this panel, GEOX inherits, and the
+transitivity row measures it directly instead of asserting it.
+
+Path: differential cross-validation, mlsynth against mlsynth. Not Path A or B --
+no paper pairs GeoLift's market-selection loop with synthetic DiD, so there is
+no published number for the composition. What can be checked is that composing
+does not change the component, which is what this measures.
+
+Four things are pinned, and one of them is a guard.
+
+Equality. The realized ATT and every donor weight, against ``SDID(...).fit()``.
+
+Generality. Six (treated unit, post split) pairs, so the match is not a property
+of California in 1989.
+
+Invariance. The readout across seven design-knob settings. The design search
+chooses the region; once the region is fixed the readout must be a function of
+the panel, the region and the split alone. A knob that moved it would mean the
+search leaks into the answer.
+
+Contrast. ``engine="augsynth"`` on the same inputs, which must *not* match. A
+harness that collapsed every engine onto one number would pass every row above
+while testing one estimator repeatedly.
+
+Two quantities are reported that do not agree, because they are not the same
+object. SDID's reported ``counterfactual`` is ``Y0 @ omega``, carrying no level
+term, so it sits a constant below GEOX's and its ``pre_rmse`` is computed
+against that level-free path. The constant is pinned instead of the paths: the
+offset's standard deviation across the panel is a reported quantity, and zero
+means the two differ by a level and nothing else. GEOX's path is the one for
+which ``mean(observed - counterfactual)`` over the post window reproduces the
+ATT both estimators report.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from benchmarks.reference import load_reference
+
+_BASE = Path(__file__).resolve().parents[2] / "basedata"
+_REF = load_reference("sdid_prop99")["values"]
+
+# (treated market, first post period). California 1989 is the real experiment;
+# the rest are placebo assignments on the same panel, chosen to spread over the
+# window (1980-1995) and over market size, so the match is not a property of one
+# unit or one split.
+_CASES = [
+    ("California", 1989),
+    ("Texas", 1989),
+    ("Utah", 1985),
+    ("Montana", 1995),
+    ("Nevada", 1980),
+    ("Pennsylvania", 1992),
+]
+
+# Knob settings the readout must be invariant to. Each drives the design search
+# differently -- window length, how many backtests, the placebo draws, the
+# injected grid, the reporting scale, the detection level -- and none of them is
+# an input to the realized fit.
+_KNOBS = [
+    {},
+    {"durations": [4]},
+    {"durations": [6, 8]},
+    {"n_backtests": 4},
+    {"seed": 42, "n_draws": 30},
+    {"effect_sizes": [-0.9, 0.0, 0.9]},
+    {"how": "sum"},          # one treated market: sum and mean coincide
+    {"alpha": 0.05},
+]
+
+_GRID = [-0.6, -0.3, 0.0, 0.3, 0.6]
+
+
+def _panel(state: str, first_post: int) -> pd.DataFrame:
+    df = pd.read_csv(_BASE / "smoking_data.csv")
+    df["treat"] = ((df["state"] == state) & (df["year"] >= first_post)).astype(int)
+    df["post"] = (df["year"] >= first_post).astype(int)
+    return df
+
+
+def _sdid(df: pd.DataFrame):
+    from mlsynth import SDID
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return SDID({"df": df[["state", "year", "cigsale", "treat"]],
+                     "outcome": "cigsale", "treat": "treat", "unitid": "state",
+                     "time": "year", "display_graphs": False}).fit()
+
+
+def _geox(df: pd.DataFrame, state: str, **over):
+    from mlsynth import GEOX
+    from mlsynth.config_models import GEOXConfig
+
+    kwargs = dict(
+        df=df[["state", "year", "cigsale", "post"]], unitid="state",
+        time="year", outcome="cigsale", post_col="post",
+        treatment_size=1, to_be_treated=[state], durations=[6],
+        effect_sizes=_GRID, n_backtests=2, n_draws=10, seed=0, n_jobs=1,
+        n_validation_backtests=0)
+    kwargs.update(over)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        design = GEOX(GEOXConfig(**kwargs)).fit()
+    if design.report is None:      # pragma: no cover - the grid always clears
+        raise AssertionError(
+            f"no design realized for {state}: the effect grid did not clear "
+            "power_threshold, so there is nothing to compare.")
+    return design
+
+
+def run() -> dict:
+    # --- California 1989: the real experiment, every accessor ---------------
+    df = _panel("California", 1989)
+    sdid, design = _sdid(df), _geox(df, "California")
+    report = design.report
+
+    att_diff = abs(float(report.att) - float(sdid.att))
+    sw, gw = sdid.donor_weights, report.donor_weights
+    weight_diff = (max(abs(sw[k] - gw[k]) for k in sw)
+                   if set(sw) == set(gw) else float("inf"))
+
+    # The two reported counterfactuals differ by SDID's level term, which its
+    # own path omits. Zero spread means a level and nothing else.
+    offset = (np.asarray(report.counterfactual, dtype=float).ravel()
+              - np.asarray(sdid.counterfactual, dtype=float).ravel())
+    offset_spread = float(np.std(offset))
+
+    # GEOX's path is self-consistent: the post-window mean gap is the ATT.
+    obs = np.asarray(report.time_series.observed_outcome, dtype=float).ravel()
+    cf = np.asarray(report.counterfactual, dtype=float).ravel()
+    n_pre = int((df["post"] == 0).sum() / df["state"].nunique())
+    path_att_diff = abs(float(np.mean((obs - cf)[n_pre:])) - float(report.att))
+
+    # --- generality: six treated units and post splits ---------------------
+    worst = 0.0
+    for state, first_post in _CASES:
+        d = _panel(state, first_post)
+        worst = max(worst, abs(float(_geox(d, state).report.att)
+                               - float(_sdid(d).att)))
+
+    # --- invariance: the readout does not move with the design knobs -------
+    atts = [float(_geox(df, "California", **knob).report.att) for knob in _KNOBS]
+    knob_spread = float(max(atts) - min(atts))
+
+    # --- contrast: a different engine must give a different answer ---------
+    aug = float(_geox(df, "California", engine="augsynth",
+                      inference="placebo").report.att)
+    engine_gap = abs(aug - float(sdid.att))
+
+    return {
+        "att_diff_vs_sdid": att_diff,
+        "donor_weight_max_diff": weight_diff,
+        "generality_max_att_diff": worst,
+        "knob_invariance_spread": knob_spread,
+        "counterfactual_offset_spread": offset_spread,
+        "geox_path_att_consistency": path_att_diff,
+        "geox_att_vs_synthdid_R": abs(float(report.att) - float(_REF["sdid_att"])),
+        "augsynth_engine_gap": engine_gap,
+    }
+
+
+def comparison() -> dict:
+    """GEOX's realized readout beside the SDID estimator, on Prop 99."""
+    df = _panel("California", 1989)
+    sdid, report = _sdid(df), _geox(df, "California").report
+    aug = _geox(df, "California", engine="augsynth", inference="placebo").report
+    return {
+        "rows": [
+            {"quantity": "ATT (California, 1989-2000)",
+             "mlsynth": round(float(report.att), 9),
+             "reference": round(float(sdid.att), 9)},
+            {"quantity": "donor weights, max |difference|",
+             "mlsynth": round(
+                 max(abs(sdid.donor_weights[k] - report.donor_weights[k])
+                     for k in sdid.donor_weights), 12),
+             "reference": 0.0},
+            {"quantity": "ATT under engine='augsynth' (contrast)",
+             "mlsynth": round(float(aug.att), 9),
+             "reference": round(float(sdid.att), 9)},
+        ],
+        "mlsynth_call": {
+            "estimator": "GEOX",
+            "config": {"post_col": "post", "treatment_size": 1,
+                       "to_be_treated": ["California"], "engine": "sdid",
+                       "n_backtests": 2, "n_draws": 10, "seed": 0}},
+        "reference": {"impl": "mlsynth SDID (the engine GEOX wraps)",
+                      "version": "same tree; differential, not external"},
+    }
+
+
+# Tolerances.
+#
+# The four agreement rows compare two calls into the same weight programs on the
+# same arrays, so they are exactly zero on this tree, not merely close. 1e-9
+# records that the claim is bit-level agreement while leaving room for a BLAS
+# that reorders a reduction; it is four orders tighter than any real regression
+# in aggregation, donor-pool construction or pre/post indexing could hide under,
+# since those shift the ATT by whole packs.
+#
+# `geox_att_vs_synthdid_R` is inherited from `sdid_prop99` -- the same 1.6e-3
+# unit-weight ridge (zeta) solver gap against the authors' R, carried through an
+# equality that is exact -- so it takes that case's 0.02.
+#
+# `augsynth_engine_gap` is a guard, not a match: it fails if the two engines
+# converge, which would make every row above vacuous. 0.71 packs is the observed
+# separation and 0.35 is half of it, so the row fails only if the gap halves --
+# loose enough that ordinary augsynth solver drift does not trip it, tight
+# enough that a collapse to a single estimator does.
+EXPECTED = {
+    "att_diff_vs_sdid": (0.0, 1e-9),
+    "donor_weight_max_diff": (0.0, 1e-9),
+    "generality_max_att_diff": (0.0, 1e-9),
+    "knob_invariance_spread": (0.0, 1e-9),
+    "counterfactual_offset_spread": (0.0, 1e-9),
+    "geox_path_att_consistency": (0.0, 1e-9),
+    "geox_att_vs_synthdid_R": (0.0, 0.02),
+    "augsynth_engine_gap": (0.7135, 0.35),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -27,6 +27,7 @@ CASES = {
     "seq_sdid_mc": "benchmarks.cases.seq_sdid_mc",
     "geox_augsynth_geolift": "benchmarks.cases.geox_augsynth_geolift",  # cross-val vs R GeoLiftMarketSelection: the augsynth engine reproduces the published BestMarkets top five (rank, MDE, investment, abs_lift_in_zero)
     "geox_mc": "benchmarks.cases.geox_mc",              # design calibration (original method, no external referent): size at the null, out-of-sample power at the reported MDE, and the winner's-curse gap on the selected region
+    "geox_sdid_equivalence": "benchmarks.cases.geox_sdid_equivalence",  # differential cross-val, mlsynth vs mlsynth: with the region forced, GEOX's readout equals SDID(...).fit() on Prop 99 to solver noise -- ATT and every donor weight, over six treated units and seven design-knob settings
     "clustersc_subgroups": "benchmarks.cases.clustersc_subgroups",      # Path B: ClusterSC vs RSC
     "clustersc_subgroups_ref": "benchmarks.cases.clustersc_subgroups_ref",  # cross-val vs authors' repo
     "clustersc_rpca_germany": "benchmarks.cases.clustersc_rpca_germany",  # cross-val vs Bayani's RPCA-SC code (West Germany reunification, value-for-value)

--- a/docs/geox.rst
+++ b/docs/geox.rst
@@ -535,6 +535,16 @@ The two structural properties the effect sweep relies on are checked
 against brute-force recomputation in ``tests/test_geox.py``, so the
 shortcut is proved and not assumed.
 
+The harness does not perturb the engine. Force one market as the treated
+region and hand GEOX the real post-period, and its readout equals
+``SDID(...).fit()`` on Proposition 99 exactly -- the ATT and all 38 donor
+weights -- over six treated units and seven design-knob settings
+(`benchmarks/cases/geox_sdid_equivalence.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/geox_sdid_equivalence.py>`_).
+That is what makes the engine's validation the design's: mlsynth's SDID
+sits 1.6e-3 packs from the authors' ``synthdid`` R, and GEOX sits zero
+from mlsynth's SDID. See :doc:`replications/geox_sdid_equivalence`.
+
 The harness is cross-validated. With ``engine="augsynth"`` selected,
 GEOX reproduces the market selection GeoLift itself publishes: on the
 walkthrough panel, all five of its top-ranked designs come back with the

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -51,6 +51,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    :caption: Dedicated replication pages
 
    replications/geox
+   replications/geox_sdid_equivalence
    replications/drsc
    replications/fsc
    replications/fdid
@@ -795,8 +796,24 @@ Experimental design
   for the single-treated-unit design falling to :math:`\approx 0.16` at
   :math:`m=2` (Table-2 monotonicity).
   → dedicated page: :doc:`replications/lexscm`.
-  Coverage summary
-  ----------------
+* :doc:`geox` -- geo experiment design by simulated power
+  (GeoLift's market-selection loop; Arkhangelsky et al. 2021 or
+  Ben-Michael et al. 2021 scoring it). Cross-validation: under
+  ``engine="augsynth"`` the design reproduces the market selection
+  GeoLift publishes on its walkthrough panel, fourteen quantities
+  value for value. Differential: with the region forced, the readout
+  equals ``SDID(...).fit()`` on Proposition 99 exactly -- ATT and all
+  38 donor weights -- over six treated units and seven design-knob
+  settings, so the harness does not perturb the estimator it wraps and
+  the authors' ``synthdid`` agreement is inherited at 1.6e-3.
+  Calibration: an imposed-truth Monte Carlo measures size at the null
+  (0.135 against a nominal 0.10) and out-of-sample power at the
+  reported MDE (0.770 against a claimed 0.80).
+  → dedicated pages: :doc:`replications/geox`,
+  :doc:`replications/geox_sdid_equivalence`.
+
+Coverage summary
+----------------
 
 .. list-table:: Verification coverage by family
    :header-rows: 1

--- a/docs/replications/geox_sdid_equivalence.rst
+++ b/docs/replications/geox_sdid_equivalence.rst
@@ -1,0 +1,137 @@
+.. _replication-geox-sdid-equivalence:
+
+GEOX — does the harness change the estimator it wraps?
+======================================================
+
+:Estimator: :doc:`../geox` — :class:`mlsynth.GEOX`
+:Reference: mlsynth's own :doc:`../sdid` — the engine GEOX runs under
+   ``engine="sdid"``.
+:Replication type: differential cross-validation, mlsynth against mlsynth.
+   Not Path A or B: no paper pairs GeoLift's market-selection loop with
+   synthetic difference-in-differences, so the composition has no published
+   number. What can be checked is that composing does not change the
+   component.
+:Status: verified — agreement is exact on this tree, over six treated units
+   and seven design-knob settings.
+
+What is and is not in question
+------------------------------
+
+GEOX is a design harness around a scoring engine. Under ``engine="sdid"`` the
+engine reaches straight into ``mlsynth.utils.sdid_helpers.weights``, so the
+two estimators are not independent implementations and their agreement on the
+weight programs is not news.
+
+What surrounds the fit is unverified, and it is a lot: GEOX aggregates a
+candidate region into a treated series, builds a donor pool from the
+complement, indexes a pre/post split, applies a pre-period fit across the
+whole panel, and packages the readout into the standardized result models.
+Each of those can shift the estimate without touching a line of the
+estimator. An off-by-one on the split, a donor pool that keeps a treated
+market, an aggregation on the wrong axis — all produce a number, and all
+produce the wrong one.
+
+So this study fixes the design question and asks the harness to disappear.
+Force one market as the treated region, hand GEOX the real post-period, and
+compare its realized readout to ``SDID(...).fit()`` on the identical panel.
+
+The panel is the Abadie–Diamond–Hainmueller Proposition 99 smoking panel
+(``basedata/smoking_data.csv``: 39 states over 31 years, 1970–2000,
+California treated from 1989) — the same one :doc:`sdid` cross-validates
+against the authors' ``synthdid`` R package.
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import GEOX, SDID
+   from mlsynth.config_models import GEOXConfig
+
+   df = pd.read_csv("basedata/smoking_data.csv")
+   df["treat"] = ((df["state"] == "California") & (df["year"] >= 1989)).astype(int)
+   df["post"] = (df["year"] >= 1989).astype(int)
+
+   sdid = SDID({"df": df[["state", "year", "cigsale", "treat"]],
+                "outcome": "cigsale", "treat": "treat", "unitid": "state",
+                "time": "year", "display_graphs": False}).fit()
+
+   design = GEOX(GEOXConfig(
+       df=df[["state", "year", "cigsale", "post"]], unitid="state",
+       time="year", outcome="cigsale", post_col="post",
+       treatment_size=1, to_be_treated=["California"],
+       durations=[6], effect_sizes=[-0.6, -0.3, 0.0, 0.3, 0.6],
+       n_backtests=2, n_draws=10, seed=0, n_validation_backtests=0)).fit()
+
+   sdid.att, design.report.att      # -15.605399261018, -15.605399261018
+
+What it establishes
+-------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 18 42
+
+   * - Quantity
+     - Value
+     - Reading
+   * - ATT, GEOX vs SDID
+     - 0
+     - Exact, not close.
+   * - Donor weights, max difference
+     - 0
+     - All 38 states. The same fit, not two fits agreeing on a mean.
+   * - Six treated units and splits
+     - 0
+     - Not a property of California in 1989.
+   * - Seven design-knob settings
+     - 0
+     - The search does not leak into the readout.
+   * - GEOX vs the authors' ``synthdid`` R
+     - 0.00157
+     - Inherited whole from :doc:`sdid`.
+   * - ``engine="augsynth"`` gap
+     - 0.714
+     - A guard: the engines must disagree.
+
+The last row is what keeps the rest from being vacuous. If the harness
+collapsed every engine onto one number, every zero above would still be zero
+and the case would be testing one estimator six times. Under
+``engine="augsynth"`` the same call returns −14.892 against SDID's −15.605, so
+the equality is the engine's doing.
+
+The transitivity row is the practical payoff. mlsynth's SDID sits 1.6e-3 packs
+from the authors' ``synthdid`` R estimate of −15.603829, and GEOX sits 0 from
+mlsynth's SDID, so GEOX reaches the authors' number at the same distance. The
+external validation is inherited, and measured instead of asserted.
+
+Where the two reports differ
+----------------------------
+
+Two quantities do not agree, and they are not the same object.
+
+SDID's reported ``counterfactual`` is :math:`\mathbf{Y}_{0}\omega`, which
+carries no level term, so it sits a constant below GEOX's — on this panel
+25.260 packs — and its ``pre_rmse`` is computed against that level-free path.
+The case pins the constant instead of the paths: the standard deviation of the
+offset across all 31 periods is a reported quantity, and it comes back at
+7.1e-15, so the two differ by a level and nothing else.
+
+GEOX's path is the one for which ``mean(observed - counterfactual)`` over the
+post window reproduces the ATT, at −15.605399261018. Taking the same mean
+against SDID's own reported path gives −40.866, which is that path's level
+offset showing through. Both estimators report the same ATT; only one reports
+a path consistent with it.
+
+The case
+--------
+
+`benchmarks/cases/geox_sdid_equivalence.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/geox_sdid_equivalence.py>`_,
+seeded and deterministic — repeat runs give identical values — and it completes
+in about seven seconds.
+
+The four agreement rows carry a tolerance of 1e-9. They compare two calls into
+the same weight programs on the same arrays, so they are exactly zero on this
+tree; the tolerance records that the claim is bit-level agreement while leaving
+room for a BLAS that reorders a reduction. It is four orders tighter than any
+regression in aggregation, donor-pool construction or pre/post indexing could
+hide beneath, since those move the ATT by whole packs.

--- a/mlsynth/tests/test_geox_realize.py
+++ b/mlsynth/tests/test_geox_realize.py
@@ -276,6 +276,7 @@ class TestFitPopulatesTheReport:
         assert not (donors & set(res.selected_units))
 
 
+
 # ---------------------------------------------------------------------------
 # The readout across engines
 #
@@ -288,7 +289,9 @@ class TestFitPopulatesTheReport:
 # runs on one engine and raises on the other is that premise failing.
 #
 # These parametrize over both engines so the whole readout, not one field, is
-# held to it.
+# held to it. The five designs are built once and shared: a design on the
+# augsynth path costs about seven seconds, and rebuilding one per test put
+# thirty-five fits in a suite that needs five.
 # ---------------------------------------------------------------------------
 
 _ENGINE_KWARGS = {
@@ -320,18 +323,28 @@ def _design(panel, **over):
     return GEOX(GEOXConfig(**kwargs)).fit()
 
 
+@pytest.fixture(scope="module")
+def readouts(panel):
+    """One realized design per engine/inference pairing, built once.
+
+    Every test in this section reads the same five designs and none of them
+    mutates one, so the fits are shared. Seeds are fixed, so a shared design is
+    the same object a per-test build would have produced.
+    """
+    return {label: _design(panel, **over).report
+            for label, over in _ENGINE_KWARGS.items()}
+
+
 class TestReadoutRunsOnEveryEngine:
     @pytest.mark.parametrize("label", sorted(_ENGINE_KWARGS))
-    def test_the_report_is_produced(self, panel, label):
+    def test_the_report_is_produced(self, readouts, label):
         """Smoke: every engine and inference pairing reads out."""
-        res = _design(panel, **_ENGINE_KWARGS[label])
-        assert res.report is not None
-        assert np.isfinite(res.report.effects.att)
+        assert readouts[label] is not None
+        assert np.isfinite(readouts[label].effects.att)
 
     @pytest.mark.parametrize("label", sorted(_ENGINE_KWARGS))
-    def test_the_paths_are_finite_and_panel_length(self, panel, label):
-        res = _design(panel, **_ENGINE_KWARGS[label])
-        ts = res.report.time_series
+    def test_the_paths_are_finite_and_panel_length(self, readouts, label):
+        ts = readouts[label].time_series
         n = len(ts.time_periods)
         for path in (ts.observed_outcome, ts.counterfactual_outcome,
                      ts.estimated_gap):
@@ -339,9 +352,8 @@ class TestReadoutRunsOnEveryEngine:
             assert np.all(np.isfinite(path))
 
     @pytest.mark.parametrize("label", sorted(_ENGINE_KWARGS))
-    def test_the_p_value_is_a_probability(self, panel, label):
-        res = _design(panel, **_ENGINE_KWARGS[label])
-        assert 0.0 <= res.report.inference.p_value <= 1.0
+    def test_the_p_value_is_a_probability(self, readouts, label):
+        assert 0.0 <= readouts[label].inference.p_value <= 1.0
 
 
 class TestEngineExtrasSurviveTheReadout:
@@ -352,54 +364,53 @@ class TestEngineExtrasSurviveTheReadout:
     the slot to float is what made the augsynth readout unreachable.
     """
 
-    def test_sdid_extras_are_reported(self, panel):
-        stats = _design(panel, engine="sdid").report.weights.summary_stats
+    def test_sdid_extras_are_reported(self, readouts):
+        stats = readouts["sdid"].weights.summary_stats
         for key in ("zeta", "bias_correction", "pre_rmspe_lambda"):
             assert key in stats
             assert isinstance(stats[key], float)
 
-    def test_augsynth_string_extra_is_reported_as_itself(self, panel):
-        stats = _design(panel, **_ENGINE_KWARGS["augsynth"]).report.weights.summary_stats
-        assert stats["augment"] == "ridge"
+    def test_augsynth_string_extra_is_reported_as_itself(self, readouts):
+        assert readouts["augsynth"].weights.summary_stats["augment"] == "ridge"
 
-    def test_augsynth_flag_extra_stays_a_bool(self, panel):
-        stats = _design(panel, **_ENGINE_KWARGS["augsynth"]).report.weights.summary_stats
-        assert stats["fixed_effects"] is True
+    def test_augsynth_flag_extra_stays_a_bool(self, readouts):
+        assert readouts["augsynth"].weights.summary_stats["fixed_effects"] is True
 
-    def test_a_flag_turned_off_is_reported_off(self, panel):
-        stats = _design(panel, **_ENGINE_KWARGS["augsynth-nofe"]).report.weights.summary_stats
+    def test_a_flag_turned_off_is_reported_off(self, readouts):
+        stats = readouts["augsynth-nofe"].weights.summary_stats
         assert stats["fixed_effects"] is False
 
-    def test_an_absent_penalty_is_reported_absent(self, panel):
+    def test_an_absent_penalty_is_reported_absent(self, readouts):
         """`augment=None` is plain SCM, which has no ridge penalty.
 
         `float(None)` raises, and any stand-in value would report a penalty
         that was never applied.
         """
-        stats = _design(panel, **_ENGINE_KWARGS["augsynth-plain"]).report.weights.summary_stats
+        stats = readouts["augsynth-plain"].weights.summary_stats
         assert stats["augment"] is None
         assert stats["lambda_"] is None
 
-    def test_a_present_penalty_is_a_number(self, panel):
-        stats = _design(panel, **_ENGINE_KWARGS["augsynth"]).report.weights.summary_stats
+    def test_a_present_penalty_is_a_number(self, readouts):
+        stats = readouts["augsynth"].weights.summary_stats
         assert isinstance(stats["lambda_"], float)
         assert np.isfinite(stats["lambda_"])
 
     @pytest.mark.parametrize("label", sorted(_ENGINE_KWARGS))
-    def test_the_shared_summary_keys_are_present_whichever_engine(self, panel, label):
-        stats = _design(panel, **_ENGINE_KWARGS[label]).report.weights.summary_stats
+    def test_the_shared_summary_keys_are_present_whichever_engine(
+            self, readouts, label):
+        stats = readouts[label].weights.summary_stats
         for key in ("how", "treated_markets", "engine", "cpic", "cost"):
             assert key in stats
 
     @pytest.mark.parametrize("label", sorted(_ENGINE_KWARGS))
-    def test_no_numpy_scalars_leak_into_the_summary(self, panel, label):
+    def test_no_numpy_scalars_leak_into_the_summary(self, readouts, label):
         """Plain Python scalars, so the report pickles and serialises.
 
         Every other numeric field in the result models is cast on the way in;
         `extras` is the one slot fed straight from an engine, so it is the one
         that can carry a `np.float64` out.
         """
-        stats = _design(panel, **_ENGINE_KWARGS[label]).report.weights.summary_stats
+        stats = readouts[label].weights.summary_stats
         leaked = {k: type(v).__name__ for k, v in stats.items()
                   if isinstance(v, np.generic)}
         assert leaked == {}
@@ -444,13 +455,9 @@ class TestTheTwoEnginesDisagree:
     testing one estimator twice.
     """
 
-    def test_the_engines_give_different_answers(self, panel):
-        sdid = _design(panel, **_ENGINE_KWARGS["sdid"]).report
-        aug = _design(panel, **_ENGINE_KWARGS["augsynth"]).report
-        assert sdid.effects.att != aug.effects.att
+    def test_the_engines_give_different_answers(self, readouts):
+        assert readouts["sdid"].effects.att != readouts["augsynth"].effects.att
 
-    def test_only_sdid_reports_time_weights(self, panel):
-        sdid = _design(panel, **_ENGINE_KWARGS["sdid"]).report
-        aug = _design(panel, **_ENGINE_KWARGS["augsynth"]).report
-        assert sdid.weights.time_weights is not None
-        assert aug.weights.time_weights is None
+    def test_only_sdid_reports_time_weights(self, readouts):
+        assert readouts["sdid"].weights.time_weights is not None
+        assert readouts["augsynth"].weights.time_weights is None


### PR DESCRIPTION
## Related Links

- `benchmarks/cases/geox_sdid_equivalence.py`
- `docs/replications/geox_sdid_equivalence.rst`
- Stacked on #399 — the case's augsynth contrast row needs that fix to run

## What

- Added `benchmarks/cases/geox_sdid_equivalence.py` — 8 pinned quantities, 7s, deterministic
- Registered as `geox_sdid_equivalence`
- Added `docs/replications/geox_sdid_equivalence.rst`, linked from the toctree,
  the design catalogue, and the GEOX page's Verification pointer
- Added the GEOX entry to the experimental-design catalogue, which had none

## Why

GEOX is a design harness wrapped around a scoring engine. Under
`engine="sdid"` the engine reaches straight into
`mlsynth.utils.sdid_helpers.weights`, so agreement on the weight programs is not
the claim and would not be worth a case.

What was unverified is everything around the fit: GEOX aggregates a candidate
region into a treated series, builds a donor pool from the complement, indexes a
pre/post split, applies the pre-period fit across the whole panel, and packages
the readout into the standardized result models. Each of those can move the
estimate without touching a line of the estimator — an off-by-one on the split,
a donor pool that keeps a treated market, an aggregation on the wrong axis. All
of them produce a number, and all of them produce the wrong one.

So the case fixes the design question (`treatment_size=1` with `to_be_treated`),
hands GEOX the real post-period, and asks the harness to disappear.

## How

Eight quantities on the Proposition 99 panel — the same one `sdid_prop99`
cross-validates against the authors' `synthdid` R:

| Row | Value | Tol |
|---|---|---|
| ATT vs `SDID(...).fit()` | 0 | 1e-9 |
| Donor weights, max difference (38 states) | 0 | 1e-9 |
| Six treated units and post splits | 0 | 1e-9 |
| Seven design-knob settings | 0 | 1e-9 |
| Counterfactual offset spread | 7.1e-15 | 1e-9 |
| GEOX path ATT consistency | 0 | 1e-9 |
| GEOX vs the authors' `synthdid` R | 0.00157 | 0.02 |
| `engine="augsynth"` gap | 0.7135 | 0.35 |

The last row is a guard, not a match. A harness that collapsed every engine onto
one number would pass every row above while testing one estimator six times; the
row fails if the two engines converge.

The generality and invariance rows are what make this more than one number
agreeing once. Six (treated unit, post split) pairs spread over 1980–1995 rule
out a property of California in 1989. Seven knob settings — `durations`,
`n_backtests`, `seed`/`n_draws`, `effect_sizes`, `how`, `alpha` — establish that
once the region is fixed the readout is a function of the panel, the region and
the split alone, so the search does not leak into the answer.

Two reported quantities do not agree, and the case reports them rather than
omitting them. SDID's `counterfactual` is `Y0 @ omega`, carrying no level term,
so it sits a constant 25.260 packs below GEOX's and its `pre_rmse` is computed
against that level-free path. The constant is what gets pinned: the offset's
standard deviation across the panel is a reported row and comes back at 7.1e-15,
so the two differ by a level and nothing else. GEOX's path is the one whose
post-window mean gap reproduces the ATT — `-15.605399261018`, the number both
estimators report; the same mean against SDID's own path gives `-40.866`.

## Verification

- Path: differential cross-validation, mlsynth against mlsynth. Not Path A or B
  — no paper pairs GeoLift's market-selection loop with synthetic DiD, so the
  composition has no published number. What is checkable is that composing does
  not change the component.
- Deterministic: `seed=0`, `n_draws=10`; two consecutive runs give byte-identical
  values including the `7.105427357601002e-15` offset spread.
- Runtime 7s, well inside the per-case budget.
- Values read through the standardized accessors — `res.att`,
  `res.donor_weights`, `res.counterfactual`, `res.pre_rmse` — never
  estimator-private fields.
- Neighbouring cases unaffected: `sdid_prop99`, `geox_augsynth_geolift` (14/14)
  and `geox_mc` all still pass.

Tolerances. The agreement rows compare two calls into the same weight programs
on the same arrays, so they are exactly zero on this tree. 1e-9 records that the
claim is bit-level while leaving room for a BLAS that reorders a reduction, and
it is four orders tighter than any regression in aggregation, donor-pool
construction or pre/post indexing could hide beneath — those move the ATT by
whole packs. `geox_att_vs_synthdid_R` inherits `sdid_prop99`'s 0.02, since it is
the same zeta-solver gap carried through an exact equality. `augsynth_engine_gap`
takes half the observed separation, so it trips on a collapse to one estimator
but not on ordinary augsynth solver drift.

## Scope checks

BENCHMARK / VALIDATION
- [x] Path stated; the DoD this meets is the Universal one, since no scenario
      row applies to a differential case with no external source
- [x] Expected values come from this tree; no reference dump to regenerate
      beyond `sdid_prop99`'s already-committed bundle, which supplies the
      transitivity row
- [x] Each tolerance justified above
- [x] Determinism checked — identical values across repeat runs
- [x] Pinned quantities are the ones that actually move: a harness regression
      shifts the ATT and the weights, which is what the zeros hold
- [x] Branch is benchmark authoring only

## Test Steps

- [x] `python benchmarks/run_benchmarks.py --case geox_sdid_equivalence` — 8/8, 7s
- [x] Run twice — byte-identical
- [x] `--case sdid_prop99`, `--case geox_augsynth_geolift`, `--case geox_mc` — all pass
- [x] `python -m sphinx -b dummy docs <out>` — builds, no geox warning

## Other Notes

Stacked on #399. The augsynth contrast row calls the realized readout on that
engine, which raised `ValueError` before that fix — which is how the bug was
found in the first place.

Two things in `docs/replications.rst` this touches beyond adding a link. The
experimental-design catalogue had no GEOX entry at all, despite
`replications/geox` sitting in the toctree, so one is added covering all three
GEOX cases. And "Coverage summary" plus its underline were indented two spaces
inside the lexscm bullet, so RST read them as bullet text and the page had no
such heading; they are now un-indented.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_