### PR TITLE
Raise the CI job cap to 75 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # The cap exists to kill a genuinely hung suite, not to bound a healthy one.
-    # The full run has measured 30-38 min across the matrix, so 40 left under 10%
-    # headroom and ordinary runner variance was tipping jobs into a timeout that
-    # reads as 'cancelled' rather than a clear failure. 55 keeps the hang guard
-    # while leaving room for a slow runner.
-    timeout-minutes: 55
+    # It has been raised twice for the same reason: the suite grows, a slow
+    # runner lands within a few minutes of the cap, and a healthy run is killed
+    # at 99% -- which GitHub reports as 'cancelled', so it reads as neither a
+    # pass nor a failure and costs a full re-run to diagnose. Measured on
+    # 2026-08-09 across one matrix: build 33-49 min, 3.10 44-49 min, and 3.12 and
+    # 3.13 both past 55. 75 restores the headroom 55 was meant to give. A cap
+    # only bites on a hang, so a job that finishes in 50 minutes is unaffected.
+    timeout-minutes: 75
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -133,7 +136,10 @@ jobs:
   # avoid duplicating `build`.
   pyversions:
     runs-on: ubuntu-latest
-    timeout-minutes: 55
+    # Same cap and the same reasoning as `build` above. These are the jobs that
+    # hit it: 3.12 and 3.13 run slower than the 3.11 `build` job on identical
+    # work, so they reach the cap first.
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Related Links

- `.github/workflows/build.yml`
- Blocking #399 and #400, both of which have `build` and `3.10` green and
  `3.12`/`3.13` killed at the cap

## What

- `timeout-minutes: 55` → `75` on both the `build` job and the `pyversions` matrix
- Recorded the measurements in the comment, since this is the second raise for
  the same reason

## Why

Two consecutive runs had `pyversions (3.12)` and `(3.13)` killed at 55 minutes
with no test having failed. GitHub reports a `timeout-minutes` kill as
`cancelled`, so the run reads as neither a pass nor a failure — it takes a log
read to tell a timeout from a genuine cancellation, and a full re-run to
distinguish either from a flake.

The job logs show a clean run of dots and then:

```
##[error]The operation was canceled.
Terminate orphan process: pid (2755) (pytest)
```

The second run reached 99% and was killed 102 seconds short of finishing.

The suite is healthy and sitting on the cap. Measured across one matrix on
2026-08-09:

| Job | Time |
|---|---|
| `build` | 33–49 min |
| `3.10` | 44–49 min |
| `3.12` | > 55 (killed) |
| `3.13` | > 55 (killed) |

On the last green run before this (#397) `3.13` took 50 minutes against the same
cap, so the gate already had only five minutes of slack and which runner it drew
decided the outcome.

The workflow's own comment states the intent: the cap "exists to kill a
genuinely hung suite, not to bound a healthy one." This is a healthy suite being
bounded, and the same thing that prompted the earlier 40 → 55 raise.

## How

A cap only bites on a hang, so a job that finishes in 50 minutes finishes in 50
minutes either way — no green run costs more, and the hang guard is intact at a
threshold no healthy run has approached.

This does not paper over a slow suite that I made slower. The PR that surfaced
it (#399) had a real inefficiency — 31 new tests rebuilding the same GEOX design
~35 times — and that is fixed on its own branch by a shared fixture, taking the
file from 217s back to 39s against a 15s baseline. With that fix in, `3.13` still
reached only 99% before the cap. The remaining gap is the suite's own growth, not
that PR's.

## Verification

- Path: not applicable. This is CI configuration; no numerical code, no
  estimator, no result contract.
- `yaml.safe_load` parses the edited workflow.
- The change is self-verifying: this PR's own run executes under the new cap, so
  four green checks here are the evidence it is sufficient.

## Scope checks

None of the four blocks fits — this is CI configuration. Per CLAUDE.md it is on
its own branch, separate from the estimator fix (#399) and the benchmark (#400)
it unblocks.

## Test Steps

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"`
- [ ] This PR's four checks pass — which is the actual test of the change

## Other Notes

75 buys headroom, it does not fix the trend. The suite has now outgrown its cap
twice. The durable options are sharding the matrix across parallel jobs or
profiling the full run for the files that dominate it; both are larger changes
than this and neither should hold up two finished PRs. Happy to take either on
if you want it queued.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_