### PR TITLE
Shard the test suite across parallel CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # The cap exists to kill a genuinely hung suite, not to bound a healthy one.
-    # The full run has measured 30-38 min across the matrix, so 40 left under 10%
-    # headroom and ordinary runner variance was tipping jobs into a timeout that
-    # reads as 'cancelled' rather than a clear failure. 55 keeps the hang guard
-    # while leaving room for a slow runner.
-    timeout-minutes: 55
+    # It was raised 40 -> 55 once and was reached again: the suite grows, a slow
+    # runner lands within a few minutes of the cap, and a healthy run is killed
+    # at 99%, which GitHub reports as 'cancelled' -- neither a pass nor a
+    # failure, and a full re-run to tell them apart. Sharding is the fix; each
+    # shard now runs a quarter of the modules, so 30 is generous and the guard
+    # bites long before a whole afternoon is spent on a hang.
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -103,24 +109,33 @@ jobs:
           fi
           echo "Test target: $TARGET"
 
+          # --num-shards/--shard splits the suite by test module across the
+          # matrix; -n auto still spreads this shard's tests over the runner's
+          # cores, so a slow file does not serialise its own shard.
+          SHARD="--num-shards 4 --shard ${{ matrix.shard }}"
+
           if [ "$TARGET" = "smoke" ]; then
-            pytest -n auto -k "smoke" --tb=short
+            pytest -n auto $SHARD -k "smoke" --tb=short
           elif [ "$TARGET" = "all" ]; then
-            pytest -n auto --tb=short
+            pytest -n auto $SHARD --tb=short
           else
             MATCH=$(find . -name "$TARGET" | head -n 1)
             if [ -z "$MATCH" ]; then
               echo "ERROR: Could not find test file: $TARGET"; find . -name "test_*.py"; exit 1
             fi
-            pytest -n auto "$MATCH" --tb=short
+            pytest -n auto $SHARD "$MATCH" --tb=short
           fi
 
+      # Once, not once per shard: the dist does not depend on which tests ran,
+      # and four shards uploading the same artifact name is an error.
       - name: Build distribution
+        if: matrix.shard == 0
         run: |
           python -m pip install build
           python -m build
 
       - name: Upload artifact
+        if: matrix.shard == 0
         uses: actions/upload-artifact@v4
         with:
           name: mlsynth-dist
@@ -133,11 +148,15 @@ jobs:
   # avoid duplicating `build`.
   pyversions:
     runs-on: ubuntu-latest
-    timeout-minutes: 55
+    # Same reasoning as `build` above. These are the jobs that reached the old
+    # cap first: 3.12 and 3.13 run slower than the 3.11 `build` job on identical
+    # work, so they were the ones killed at 99%.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.12", "3.13"]
+        shard: [0, 1, 2, 3]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -182,4 +201,6 @@ jobs:
 
       - name: Run tests
         if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
-        run: pytest -n auto --tb=short
+        run: |
+          pytest -n auto --tb=short \
+            --num-shards 4 --shard ${{ matrix.shard }}

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,28 @@
+"""Root conftest: registers the suite's shard options.
+
+``pytest_addoption`` is only honoured from a plugin or from a conftest at the
+rootdir. ``mlsynth/tests/conftest.py`` is a subdirectory conftest, so it
+registers the options only when the command line names a path inside that
+directory -- ``pytest mlsynth/tests`` works and a bare ``pytest`` from the repo
+root fails with ``unrecognized arguments: --num-shards``. CI runs the bare form,
+so the registration has to live here.
+
+Everything else about the suite stays in ``mlsynth/tests/conftest.py``; this file
+exists for the one hook that has to be at the root.
+"""
+
+import pathlib
+import sys
+
+# ``_shard`` sits with the tests it selects, and the tests directory is not a
+# package, so it is not importable until its directory is on the path. pytest
+# adds that directory itself during collection, which is too late for an option
+# that has to exist before the command line is parsed.
+_TESTS = pathlib.Path(__file__).resolve().parent / "mlsynth" / "tests"
+if str(_TESTS) not in sys.path:
+    sys.path.insert(0, str(_TESTS))
+
+from _shard import (  # noqa: E402,F401  (re-export: pytest reads these by name)
+    pytest_addoption,
+    pytest_collection_modifyitems,
+)

--- a/mlsynth/tests/_shard.py
+++ b/mlsynth/tests/_shard.py
@@ -1,0 +1,128 @@
+"""Round-robin sharding for the test suite, so CI can run it in parallel jobs.
+
+The suite is 7592 tests over 335 files and already runs under ``pytest -n auto``,
+so the four cores of a hosted runner are spent before a job starts. The only
+remaining axis is more jobs, which is what ``--num-shards N --shard i`` gives:
+each job collects everything and runs its own disjoint slice.
+
+Whole modules move together. Splitting at test granularity would balance the
+shards more finely, but a module-scoped fixture is built once per shard holding
+any of that module's tests, so a module split three ways builds its fixtures
+three times. On this suite those fixtures are estimator fits measured in
+seconds, so finer splitting buys balance and pays for it in repeated work.
+Within a shard ``-n auto`` still distributes individual tests across workers, so
+one slow file does not serialise its shard.
+
+The split is the round-robin ``sorted(modules)[shard::num_shards]``, the same
+idiom ``benchmarks/run_benchmarks.py`` uses for benchmark cases. Sorting first
+makes it independent of collection order, so the same flags select the same
+tests on any machine. Round-robin over the sorted list also spreads a family of
+related files -- ``test_geox*.py``, which sort adjacently and are slow together
+-- across different shards instead of stacking them in one.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence, Tuple
+
+
+def _validate(shard: int, num_shards: int) -> None:
+    if num_shards < 1:
+        raise ValueError(f"num_shards must be >= 1; got {num_shards}.")
+    if not 0 <= shard < num_shards:
+        raise ValueError(
+            f"shard must be in [0, {num_shards}); got {shard}.")
+
+
+def select_shard_modules(module_paths: Iterable[str], shard: int,
+                         num_shards: int) -> List[str]:
+    """The module paths this shard owns.
+
+    Parameters
+    ----------
+    module_paths : iterable of str
+        Every collected module, in any order and with repeats (one per test is
+        fine -- they collapse).
+    shard : int
+        0-based index of this shard.
+    num_shards : int
+        How many shards the suite is split into.
+
+    Returns
+    -------
+    list of str
+        The sorted slice ``sorted(set(module_paths))[shard::num_shards]``. Empty
+        when this shard has nothing, which happens when there are more shards
+        than modules and is a pass, not an error.
+
+    Raises
+    ------
+    ValueError
+        If ``num_shards < 1`` or ``shard`` is outside ``[0, num_shards)``.
+    """
+    _validate(shard, num_shards)
+    return sorted(set(module_paths))[shard::num_shards]
+
+
+def split_items(items: Sequence, shard: int, num_shards: int) -> Tuple[List, List]:
+    """Partition collected pytest items into ``(selected, deselected)``.
+
+    Collection order is preserved within each part, so a shard runs its tests in
+    the order pytest collected them. With ``num_shards == 1`` everything is
+    selected and nothing is deselected, which is the unsharded run.
+    """
+    _validate(shard, num_shards)
+    if num_shards == 1:
+        return list(items), []
+    keep = set(select_shard_modules(
+        (item.nodeid.split("::")[0] for item in items), shard, num_shards))
+    selected, deselected = [], []
+    for item in items:
+        target = selected if item.nodeid.split("::")[0] in keep else deselected
+        target.append(item)
+    return selected, deselected
+
+
+__all__ = ["select_shard_modules", "split_items"]
+
+
+# --- pytest plugin ---------------------------------------------------------
+#
+# These hooks live here, next to the arithmetic they call, and are re-exported
+# from ``conftest.py``. Keeping them in an importable module means the CI flags
+# can be exercised by running pytest with ``-p _shard`` against a throwaway
+# tree, which is how ``test_shard_selection.py`` checks the wiring: an option
+# registered but never read would pass every unit test and shard nothing.
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("sharding")
+    group.addoption(
+        "--num-shards", type=int, default=1, dest="num_shards",
+        help="split the suite into this many shards (round-robin over test "
+             "modules), for parallel CI jobs")
+    group.addoption(
+        "--shard", type=int, default=0, dest="shard",
+        help="0-based index of the shard to run (with --num-shards)")
+
+
+def pytest_collection_modifyitems(config, items):
+    """Keep this shard's modules and deselect the rest."""
+    num_shards = config.getoption("num_shards")
+    shard = config.getoption("shard")
+    if num_shards == 1 and shard == 0:
+        return
+    try:
+        selected, deselected = split_items(items, shard, num_shards)
+    except ValueError as exc:
+        # A bad --shard/--num-shards pair is a usage error. Reporting it as one
+        # stops a typo from running an empty slice and reporting it as a pass.
+        import pytest
+
+        raise pytest.UsageError(str(exc)) from exc
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected
+
+
+__all__ += ["pytest_addoption", "pytest_collection_modifyitems"]

--- a/mlsynth/tests/conftest.py
+++ b/mlsynth/tests/conftest.py
@@ -146,13 +146,10 @@ def pytest_runtest_makereport(item, call):
                                f"Skipped: {reason}")
 
 
-# Shard selection
-# ---------------
-# ``--num-shards N --shard i`` splits the suite across parallel CI jobs. The
-# hooks and their arithmetic live in ``_shard.py`` so they can be loaded as a
-# plugin and tested directly; re-exporting them here is what makes the flags
-# exist for the real suite.
-from _shard import (  # noqa: E402,F401  (re-export: pytest reads these by name)
-    pytest_addoption,
-    pytest_collection_modifyitems,
-)
+# Shard selection lives in the ROOT conftest, not here. ``pytest_addoption`` is
+# only honoured from a plugin or a rootdir conftest, so registering it in this
+# subdirectory conftest works for ``pytest mlsynth/tests`` and fails for the
+# bare ``pytest`` that CI runs. Registering it in both places is worse than
+# either: pytest loads this file too when the command line names a path inside
+# it, and the second registration raises
+# ``ValueError: option names {'--num-shards'} already added``.

--- a/mlsynth/tests/conftest.py
+++ b/mlsynth/tests/conftest.py
@@ -144,3 +144,15 @@ def pytest_runtest_makereport(item, call):
             report.outcome = "skipped"
             report.longrepr = (str(item.fspath), item.location[1] + 1,
                                f"Skipped: {reason}")
+
+
+# Shard selection
+# ---------------
+# ``--num-shards N --shard i`` splits the suite across parallel CI jobs. The
+# hooks and their arithmetic live in ``_shard.py`` so they can be loaded as a
+# plugin and tested directly; re-exporting them here is what makes the flags
+# exist for the real suite.
+from _shard import (  # noqa: E402,F401  (re-export: pytest reads these by name)
+    pytest_addoption,
+    pytest_collection_modifyitems,
+)

--- a/mlsynth/tests/test_shard_selection.py
+++ b/mlsynth/tests/test_shard_selection.py
@@ -213,3 +213,72 @@ def test_the_repo_conftest_wires_the_plugin_in():
     assert conftest.pytest_addoption is _shard.pytest_addoption
     assert (conftest.pytest_collection_modifyitems
             is _shard.pytest_collection_modifyitems)
+
+
+# --- the workflow cannot drift from the flag ------------------------------
+
+
+class TestTheWorkflowShardCountMatches:
+    """``--num-shards`` must equal the length of the job's shard matrix.
+
+    This is the failure this whole mechanism is exposed to. Raise the matrix to
+    six shards and leave ``--num-shards 4`` behind, and shards 4 and 5 collect
+    nothing while 0-3 run the same quarters as before: a third of the suite
+    never runs and every job reports success. A skipped success is
+    indistinguishable from a real one, which is the same reasoning
+    ``TestCIRunsWhenTheSuiteCanBreak`` records for the paths filter.
+    """
+
+    @staticmethod
+    def _workflow():
+        import pathlib
+
+        root = pathlib.Path(__file__).resolve().parents[2]
+        return (root / ".github" / "workflows" / "build.yml").read_text()
+
+    @staticmethod
+    def _jobs():
+        import pathlib
+
+        import yaml
+
+        root = pathlib.Path(__file__).resolve().parents[2]
+        wf = yaml.safe_load(
+            (root / ".github" / "workflows" / "build.yml").read_text())
+        return wf["jobs"]
+
+    def test_both_test_jobs_are_sharded(self):
+        jobs = self._jobs()
+        for name in ("build", "pyversions"):
+            matrix = jobs[name]["strategy"]["matrix"]
+            assert "shard" in matrix, f"{name} is not sharded"
+
+    def test_the_shard_matrix_is_a_contiguous_range_from_zero(self):
+        """``--shard i`` is a 0-based index, so the matrix must be 0..n-1."""
+        for name, job in self._jobs().items():
+            matrix = job.get("strategy", {}).get("matrix", {})
+            if "shard" not in matrix:
+                continue
+            shards = matrix["shard"]
+            assert shards == list(range(len(shards))), (
+                f"{name}: shard matrix {shards} is not 0..{len(shards) - 1}")
+
+    def test_every_num_shards_matches_a_shard_matrix_length(self):
+        import re
+
+        counts = {len(job["strategy"]["matrix"]["shard"])
+                  for job in self._jobs().values()
+                  if "shard" in job.get("strategy", {}).get("matrix", {})}
+        declared = {int(n) for n in
+                    re.findall(r"--num-shards\s+(\d+)", self._workflow())}
+        assert declared, "no --num-shards found in the workflow"
+        assert declared == counts, (
+            f"--num-shards {sorted(declared)} does not match the shard "
+            f"matrix lengths {sorted(counts)}; some tests would never run")
+
+    def test_every_sharded_job_passes_its_matrix_index(self):
+        """A job that shards but hardcodes ``--shard 0`` runs one quarter, 4x."""
+        wf = self._workflow()
+        assert wf.count("--shard ${{ matrix.shard }}") == len(
+            [j for j in self._jobs().values()
+             if "shard" in j.get("strategy", {}).get("matrix", {})])

--- a/mlsynth/tests/test_shard_selection.py
+++ b/mlsynth/tests/test_shard_selection.py
@@ -1,0 +1,215 @@
+"""Unit tests for the test suite's own shard selection.
+
+The suite runs across parallel CI jobs via ``pytest --num-shards N --shard i``.
+These pin that the split is a genuine partition -- disjoint and exhaustive -- so
+no test is dropped or double-run, and that it splits whole modules, which is
+what keeps module-scoped fixtures from being rebuilt in every shard.
+
+Mirrors ``benchmarks/tests/test_shard_selection.py``, which pins the same
+round-robin idiom for the benchmark runner.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from _shard import select_shard_modules, split_items
+
+MODULES = [f"mlsynth/tests/test_{c}.py" for c in "abcdefghij"]
+
+
+class _FakeItem:
+    """Enough of a pytest item for the split: a nodeid."""
+
+    def __init__(self, module: str, name: str) -> None:
+        self.nodeid = f"{module}::{name}"
+
+
+def _items(modules, per_module=3):
+    return [_FakeItem(m, f"test_{i}") for m in modules for i in range(per_module)]
+
+
+# --- the module selection ------------------------------------------------
+
+
+def test_one_shard_keeps_everything():
+    assert select_shard_modules(MODULES, shard=0, num_shards=1) == sorted(MODULES)
+
+
+def test_shard_is_a_round_robin_slice():
+    got = select_shard_modules(MODULES, shard=1, num_shards=3)
+    assert got == sorted(MODULES)[1::3]
+
+
+def test_shards_partition_exactly():
+    n = 4
+    shards = [select_shard_modules(MODULES, shard=i, num_shards=n)
+              for i in range(n)]
+    flat = [m for s in shards for m in s]
+    assert sorted(flat) == sorted(MODULES)
+    assert len(flat) == len(set(flat)) == len(MODULES)
+
+
+def test_selection_does_not_depend_on_input_order():
+    """Sorted internally, so a different collection order gives the same split.
+
+    Collection order varies with the filesystem and with ``-p no:randomly``
+    style plugins; a shard that depended on it would run different tests on
+    different machines under the same flags.
+    """
+    forward = select_shard_modules(MODULES, shard=2, num_shards=3)
+    reverse = select_shard_modules(list(reversed(MODULES)), shard=2, num_shards=3)
+    assert forward == reverse
+
+
+def test_duplicates_collapse():
+    """A module appears once however many of its tests were collected."""
+    got = select_shard_modules(MODULES + MODULES, shard=0, num_shards=2)
+    assert got == sorted(MODULES)[0::2]
+
+
+def test_shard_sizes_differ_by_at_most_one():
+    n = 3
+    sizes = [len(select_shard_modules(MODULES, shard=i, num_shards=n))
+             for i in range(n)]
+    assert max(sizes) - min(sizes) <= 1
+
+
+def test_more_shards_than_modules_leaves_some_empty_not_broken():
+    """A shard with nothing to do is a pass, not an error.
+
+    Over-sharding is a configuration mistake that should waste a runner, not
+    fail the gate on a suite where every test passed.
+    """
+    n = len(MODULES) + 3
+    shards = [select_shard_modules(MODULES, shard=i, num_shards=n)
+              for i in range(n)]
+    assert sum(len(s) for s in shards) == len(MODULES)
+    assert [] in shards
+
+
+def test_empty_input_is_empty_output():
+    assert select_shard_modules([], shard=0, num_shards=4) == []
+
+
+@pytest.mark.parametrize("shard, num_shards", [
+    (0, 0), (0, -1), (-1, 2), (2, 2), (5, 2),
+])
+def test_invalid_shard_arguments_raise(shard, num_shards):
+    with pytest.raises(ValueError):
+        select_shard_modules(MODULES, shard=shard, num_shards=num_shards)
+
+
+# --- splitting collected items -------------------------------------------
+
+
+def test_split_keeps_whole_modules_together():
+    """Every test in a file lands in the same shard.
+
+    This is the point of splitting by module and not by test. A module-scoped
+    fixture is built once per shard that holds any of its tests, so splitting a
+    module across shards rebuilds its fixtures in each -- which is the cost this
+    is meant to remove, not multiply.
+    """
+    items = _items(MODULES)
+    n = 3
+    for i in range(n):
+        kept, _ = split_items(items, shard=i, num_shards=n)
+        modules = {it.nodeid.split("::")[0] for it in kept}
+        for module in modules:
+            in_module = [it for it in items if it.nodeid.startswith(f"{module}::")]
+            assert all(it in kept for it in in_module)
+
+
+def test_split_partitions_the_items():
+    items = _items(MODULES)
+    n = 4
+    kept = [split_items(items, shard=i, num_shards=n)[0] for i in range(n)]
+    flat = [it for k in kept for it in k]
+    assert len(flat) == len(items)
+    assert {id(it) for it in flat} == {id(it) for it in items}
+
+
+def test_split_reports_the_complement_as_deselected():
+    items = _items(MODULES)
+    kept, dropped = split_items(items, shard=0, num_shards=2)
+    assert len(kept) + len(dropped) == len(items)
+    assert not ({id(i) for i in kept} & {id(i) for i in dropped})
+
+
+def test_one_shard_deselects_nothing():
+    items = _items(MODULES)
+    kept, dropped = split_items(items, shard=0, num_shards=1)
+    assert kept == items
+    assert dropped == []
+
+
+def test_split_preserves_collection_order_within_a_shard():
+    """Ordering is untouched, so a shard runs its tests in collection order."""
+    items = _items(MODULES)
+    kept, _ = split_items(items, shard=1, num_shards=3)
+    assert kept == [it for it in items if it in kept]
+
+
+# --- the pytest options, end to end --------------------------------------
+#
+# The unit tests above pin the arithmetic. These run pytest itself, because the
+# failure mode that matters is the wiring: an option registered but never read
+# would pass every test above and shard nothing, and CI would report four green
+# jobs that each ran the whole suite.
+
+
+def _collect(tmp_path, *args):
+    """Collect a fixed two-module tree under the given flags."""
+    import os
+    import pathlib
+    import subprocess
+    import sys
+
+    for name, count in (("test_alpha.py", 3), ("test_beta.py", 2)):
+        (tmp_path / name).write_text(
+            "".join(f"def test_{i}():\n    pass\n\n" for i in range(count)))
+    env = dict(os.environ, PYTHONPATH=str(pathlib.Path(__file__).resolve().parent))
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", str(tmp_path), "--collect-only", "-q",
+         "-p", "no:cacheprovider", "-p", "_shard", *args],
+        capture_output=True, text=True, cwd=str(tmp_path), env=env)
+    return [line for line in proc.stdout.splitlines() if "::" in line]
+
+
+def test_the_options_are_registered(tmp_path):
+    """`--num-shards`/`--shard` are accepted, and the default collects all."""
+    assert len(_collect(tmp_path)) == 5
+    assert len(_collect(tmp_path, "--num-shards", "1", "--shard", "0")) == 5
+
+
+def test_sharding_actually_partitions_a_real_collection(tmp_path):
+    first = _collect(tmp_path, "--num-shards", "2", "--shard", "0")
+    second = _collect(tmp_path, "--num-shards", "2", "--shard", "1")
+    assert sorted(first + second) == sorted(_collect(tmp_path))
+    assert not (set(first) & set(second))
+    assert first and second        # neither shard is empty on two modules
+
+
+def test_a_shard_holds_whole_files(tmp_path):
+    first = _collect(tmp_path, "--num-shards", "2", "--shard", "0")
+    files = {line.split("::")[0] for line in first}
+    assert len(files) == 1         # one of the two modules, all of it
+    assert len(first) in (2, 3)
+
+
+def test_the_repo_conftest_wires_the_plugin_in():
+    """`_shard`'s hooks are reachable from the suite's own conftest.
+
+    The tests above load `_shard` explicitly with `-p`, which proves the hooks
+    work but not that the real suite has them. A CI job passing `--num-shards`
+    against a conftest that never imported them fails on an unrecognized
+    argument, so this pins the import that makes the flags exist.
+    """
+    import conftest
+
+    import _shard
+
+    assert conftest.pytest_addoption is _shard.pytest_addoption
+    assert (conftest.pytest_collection_modifyitems
+            is _shard.pytest_collection_modifyitems)

--- a/mlsynth/tests/test_suite_sharding.py
+++ b/mlsynth/tests/test_suite_sharding.py
@@ -11,6 +11,8 @@ round-robin idiom for the benchmark runner.
 
 from __future__ import annotations
 
+import pathlib
+
 import pytest
 
 from _shard import select_shard_modules, split_items
@@ -198,21 +200,66 @@ def test_a_shard_holds_whole_files(tmp_path):
     assert len(first) in (2, 3)
 
 
-def test_the_repo_conftest_wires_the_plugin_in():
-    """`_shard`'s hooks are reachable from the suite's own conftest.
+class TestTheHooksAreRegisteredWherePytestReadsThem:
+    """The registration has to be at the rootdir, and in exactly one place.
 
-    The tests above load `_shard` explicitly with `-p`, which proves the hooks
-    work but not that the real suite has them. A CI job passing `--num-shards`
-    against a conftest that never imported them fails on an unrecognized
-    argument, so this pins the import that makes the flags exist.
+    ``pytest_addoption`` is only honoured from a plugin or a conftest at the
+    rootdir. Registering it in ``mlsynth/tests/conftest.py`` works for
+    ``pytest mlsynth/tests`` and fails for the bare ``pytest`` CI runs, with
+    ``unrecognized arguments: --num-shards``. Registering it in both places
+    fails differently: pytest loads the subdirectory conftest as well whenever
+    the command line names a path inside it, and the second registration raises
+    ``ValueError: option names {'--num-shards'} already added``.
+
+    Both of those happened. These pin the shape that avoids each.
     """
-    import conftest
 
-    import _shard
+    @staticmethod
+    def _root():
+        import pathlib
+        return pathlib.Path(__file__).resolve().parents[2]
 
-    assert conftest.pytest_addoption is _shard.pytest_addoption
-    assert (conftest.pytest_collection_modifyitems
-            is _shard.pytest_collection_modifyitems)
+    def test_the_root_conftest_registers_the_hooks(self):
+        import importlib.util
+
+        import _shard
+
+        spec = importlib.util.spec_from_file_location(
+            "_root_conftest", self._root() / "conftest.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        assert module.pytest_addoption is _shard.pytest_addoption
+        assert (module.pytest_collection_modifyitems
+                is _shard.pytest_collection_modifyitems)
+
+    def test_the_tests_conftest_does_not_register_them_again(self):
+        source = (self._root() / "mlsynth" / "tests" / "conftest.py").read_text()
+        assert "from _shard import" not in source, (
+            "the tests conftest registers the shard options a second time; "
+            "pytest raises 'option names already added' when both load")
+
+
+def test_the_flags_work_in_the_bare_invocation(tmp_path):
+    """The form CI runs: no path argument, from the repository root.
+
+    This is the test that was missing. Every other test here passes a path or
+    loads the plugin with ``-p``, and both of those make a subdirectory conftest
+    an initial conftest -- which is exactly what hid the bug. ``--ignore`` keeps
+    it quick without changing what is being tested, since the options are parsed
+    before anything is collected.
+    """
+    import os
+    import subprocess
+    import sys
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q",
+         "-p", "no:cacheprovider", "--ignore=mlsynth/tests",
+         "--num-shards", "2", "--shard", "0"],
+        capture_output=True, text=True, cwd=str(root), env=dict(os.environ))
+    assert "unrecognized arguments" not in proc.stderr + proc.stdout
+    assert proc.returncode == 0, proc.stdout[-2000:]
 
 
 # --- the workflow cannot drift from the flag ------------------------------


### PR DESCRIPTION
## Related Links

- `mlsynth/tests/_shard.py`, `mlsynth/tests/test_shard_selection.py`
- `.github/workflows/build.yml`
- Mirrors `benchmarks/run_benchmarks.py::select_cases` and its tests in
  `benchmarks/tests/test_shard_selection.py`
- Supersedes #401, which raised the cap 55 → 75 as the cheap unblock

## What

- Added `--num-shards N --shard i` to the suite, via hooks in `_shard.py`
  re-exported from `conftest.py`
- `build` is now a 4-shard matrix; `pyversions` a 3-version × 4-shard matrix
- Job cap 55 → 30, since a shard is a quarter of the work
- 26 tests, including two that guard the workflow configuration itself

## Why

The suite is 7592 tests over 335 files and already ran under `pytest -n auto`,
so the four cores of a hosted runner were spent before a job started. The only
axis left was more jobs.

Under the old cap `pyversions (3.12)` and `(3.13)` were killed at 55 minutes on
three consecutive runs — once at 57% and twice at 99%, with no test having
failed. A `timeout-minutes` kill reports as `cancelled`, so it reads as neither
a pass nor a failure and costs a full re-run to diagnose.

## How

Each job collects everything and runs its own disjoint slice,
`sorted(modules)[shard::num_shards]` — the idiom the benchmark runner already
uses. Sorting first makes the split independent of collection order, so the same
flags select the same tests on any machine. Round-robin over sorted names also
spreads a family of related files (`test_geox*.py`, which sort adjacently and
are slow together) across different shards instead of stacking them in one.

Whole modules move together. Splitting at test granularity balances better, but
a module-scoped fixture is built once per shard holding any of that module's
tests, so a module split three ways builds its fixtures three times — the exact
cost removed from `test_geox_realize.py` in #399. Within a shard `-n auto` still
spreads tests across workers, so one slow file does not serialise its shard.

The hooks live in `_shard.py` rather than inline in `conftest.py` so they can be
loaded with `-p _shard` against a throwaway tree. That is how the end-to-end
tests check the wiring, and it earns its keep: an option registered but never
read passes every unit test and shards nothing, and CI would report green jobs
that each ran the whole suite.

## Verification

- Path: not applicable. CI configuration and test-selection plumbing; no
  numerical code, no estimator, no result contract.
- The split is a partition on the real collection:
  1957 + 2232 + 1620 + 1805 = 7614, the unsharded total.
- `mlsynth/tests/test_benchmark_reference.py` still passes — the workflow keeps
  exactly two paths-filter blocks, which that test asserts.
- This PR's own run executes the sharded workflow, so its checks are the test of
  the change.

Two guards on the configuration, because the dangerous failure here is silent
rather than red:

- `--num-shards` must equal each job's shard-matrix length. Raise the matrix to
  six and leave `--num-shards 4` behind, and shards 4 and 5 collect nothing
  while 0–3 repeat their old quarters: a third of the suite never runs and every
  job reports success. Verified by temporarily setting the matrix to six shards
  and watching the test fail with
  `--num-shards [4] does not match the shard matrix lengths [6]`.
- Every sharded job must pass `--shard ${{ matrix.shard }}`; a job that hardcodes
  `--shard 0` runs one quarter four times.

A bad `--shard` value now raises `UsageError` instead of running an empty slice
and reporting it as a pass.

## Scope checks

None of the four blocks fits — CI configuration plus the test-selection plumbing
it needs. On its own branch per CLAUDE.md, separate from the estimator and
benchmark work it unblocks.

## Test Steps

- [x] `pytest mlsynth/tests/test_shard_selection.py -q` — 26 passed
- [x] `pytest mlsynth/tests/test_benchmark_reference.py -q` — 21 passed
- [x] Collection counts across four shards sum to the unsharded total
- [x] Drift guard fails when the matrix and flag disagree
- [ ] This PR's own checks — the actual test of the change

## Other Notes

Branch protection needs a manual update, and this is the one thing I cannot do
from here. Sharding changes the check names: `build` becomes `build (0)` …
`build (3)`, and `pyversions (3.10)` becomes `pyversions (3.10, 0)` … If `build`
or the old `pyversions (…)` names are currently required status checks, they
will never report again and pull requests will block on checks that no longer
exist. The new names need to be required in their place.

Job count goes from 4 to 16. Each is short, so wall-clock falls substantially,
but they may queue against the concurrent-runner limit.

I could not measure per-shard balance locally: two attempts at a full timed run
were lost, the second at 99% when the container restarted, and `--durations`
prints only at the end. The four shards are balanced by module count, not by
time, so the first CI run here is also the measurement. If one shard runs long,
the fix is to order modules by measured duration before the round-robin, which
is a change to `_shard.py` alone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_