### PR TITLE
Correct the conformal test in the design path

### DIFF
--- a/docs/geox.rst
+++ b/docs/geox.rst
@@ -231,7 +231,15 @@ window, which is what synthetic DiD's time weights exist to deny --
 :math:`\lambda` says pre-periods are not interchangeable. So conformal
 is available on ``augsynth`` and refused on ``sdid``, with the reason
 stated in the error. ``ns`` sets the number of permutations and
-``conformal_type`` the scheme, ``"iid"`` or ``"block"``.
+``conformal_type`` the scheme. ``"block"`` is the default and takes the
+panel's cyclic shifts, which preserve serial dependence; ``"iid"`` permutes
+residuals freely and assumes an exchangeability a trending or seasonal
+panel denies. ``"iid"`` is also the scheme whose p-value can reach exactly
+zero, since a free permutation can be beaten by the observed statistic
+every time; ``finite_sample_p=True`` reports
+``(1 + #{stat >= observed}) / (1 + ns)`` instead, which cannot. That
+correction is off by default so the GeoLift reproduction keeps augsynth's
+convention; turn it on for inference you intend to report.
 
 Holding one of the two fixed and varying the other separates the two
 sources of a difference between designs. Scoring one panel with both

--- a/mlsynth/tests/test_geox_conformal_correctness.py
+++ b/mlsynth/tests/test_geox_conformal_correctness.py
@@ -1,0 +1,196 @@
+"""The conformal test on GEOX's backtests: which block, and a valid p-value.
+
+Three defects, found by Monte-Carloing the design against a known truth and by
+reading the result against GeoCausality's independent implementation of the same
+GeoLift idea.
+
+Scope. ``conformal_pvalue`` itself was never wrong -- on a true null its
+p-values come back near uniform. What was wrong is how the design calls it, and
+what the p-value is allowed to return at the extreme.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.ridge_inference import conformal_pvalue
+from mlsynth.utils.geox_helpers.engines import resolve_engine
+from mlsynth.utils.geox_helpers.windows import (
+    backtest_pre_periods,
+    backtest_treatment_window,
+)
+
+T, D, J = 80, 10, 12
+
+
+@pytest.fixture(scope="module")
+def series():
+    """A donor pool and a treated series that tracks it, with AR(1) structure."""
+    rng = np.random.default_rng(0)
+    f = np.zeros((T, 2))
+    for k in range(2):
+        e = rng.normal(size=T)
+        f[0, k] = e[0]
+        for t in range(1, T):
+            f[t, k] = 0.6 * f[t - 1, k] + e[t]
+    load = rng.normal(size=(J, 2)) + 2.0
+    Y0 = 100.0 + f @ load.T + rng.normal(scale=0.3, size=(T, J))
+    y = 100.0 + f @ load.mean(axis=0) + rng.normal(scale=0.3, size=T)
+    return y, Y0
+
+
+def _fit(y, Y0, n_pre, a, b):
+    eng = resolve_engine("augsynth")
+    return eng, eng.fit_once(y, Y0, n_pre, a, b, 1,
+                             augment="ridge", fixed_effects=True)
+
+
+# --- the tested block is the backtest window ------------------------------
+
+
+@pytest.mark.parametrize("s", range(1, 9))
+def test_periods_after_the_window_cannot_move_the_p_value(series, s):
+    """A shock outside the pseudo-experiment must not change its p-value.
+
+    The design tested ``resids[n_pre:]`` -- everything to the end of the panel
+    -- so for backtest ``s`` it evaluated ``D + s - 1`` periods instead of the
+    window's ``D``. Only ``s = 1`` coincided. The extra periods were never part
+    of the pseudo-experiment and carry none of its injected effect.
+
+    Corrupting them is the sharpest statement of the bug: if they enter the
+    statistic, the p-value moves; if the tested block is the window, it cannot.
+    """
+    y, Y0 = series
+    n_pre = backtest_pre_periods(T, D, s)
+    a, b = backtest_treatment_window(T, D, s)
+    eng, fit = _fit(y, Y0, n_pre, a, b)
+
+    y_shock = np.array(y, dtype=float)
+    y_shock[b + 1:] += 500.0                      # far outside the window
+    if b + 1 >= T:                                # s = 1 has nothing after it
+        pytest.skip("backtest 1 ends flush with the panel")
+
+    base, _ = eng.point_inference(fit, y, Y0, n_pre, a, b,
+                                  inference="conformal", ns=200, seed=0)
+    shocked, _ = eng.point_inference(fit, y_shock, Y0, n_pre, a, b,
+                                     inference="conformal", ns=200, seed=0)
+    assert base == shocked
+
+
+@pytest.mark.parametrize("s", range(1, 9))
+def test_the_sweep_tests_the_window_too(series, s):
+    """Same property through ``sweep_p_values``, which is what the design uses."""
+    y, Y0 = series
+    n_pre = backtest_pre_periods(T, D, s)
+    a, b = backtest_treatment_window(T, D, s)
+    eng, fit = _fit(y, Y0, n_pre, a, b)
+    if b + 1 >= T:
+        pytest.skip("backtest 1 ends flush with the panel")
+
+    y_shock = np.array(y, dtype=float)
+    y_shock[b + 1:] += 500.0
+    kw = dict(inference="conformal", ns=200, seed=0, analytic=True,
+              augment="ridge", fixed_effects=True)
+    base = eng.sweep_p_values(fit, y, Y0, n_pre, a, b, [0.0, 0.1], **kw)
+    shocked = eng.sweep_p_values(fit, y_shock, Y0, n_pre, a, b, [0.0, 0.1], **kw)
+    assert base["p_value"] == shocked["p_value"]
+
+
+def test_the_realized_readout_is_unaffected(series):
+    """The readout's window already ends at the panel, so nothing changes there.
+
+    Truncation is a no-op when ``end`` is the last period, which is the case for
+    every realized readout. Pinning it keeps the fix from being read as a change
+    to the numbers a finished experiment reports.
+    """
+    y, Y0 = series
+    n_pre = T - D
+    eng, fit = _fit(y, Y0, n_pre, n_pre, T - 1)
+    p, details = eng.point_inference(fit, y, Y0, n_pre, n_pre, T - 1,
+                                     inference="conformal", ns=200, seed=0)
+    assert 0.0 < p <= 1.0
+    assert details["method"] == "conformal"
+
+
+# --- a p-value is never zero ----------------------------------------------
+
+
+def test_the_p_value_is_bounded_away_from_zero(series):
+    """``(1 + #{perm >= obs}) / (1 + ns)``, so never exactly zero.
+
+    ``mean(obs <= perm)`` returns 0 when the observed statistic exceeds every
+    permutation, and zero is not a valid p-value: with ``ns`` draws the evidence
+    cannot exceed ``1 / (ns + 1)``. Under a large injected effect the old form
+    returned exactly 0 in half of all backtests.
+    """
+    y, Y0 = series
+    n_pre = T - D
+    huge = np.array(y, dtype=float)
+    huge[n_pre:] *= 5.0                            # far beyond any permutation
+    p = conformal_pvalue(huge, Y0, n_pre, ns=200, seed=0,
+                         fixed_effects=True, finite_sample=True)
+    assert p > 0.0
+    assert p == pytest.approx(1.0 / 201.0)
+
+
+def test_the_uncorrected_form_is_still_reachable(series):
+    """augsynth's convention stays available, since a benchmark reproduces it.
+
+    ``geox_augsynth_geolift`` matches GeoLift's published values, and GeoLift
+    inherits augsynth's ``mean(obs <= perm)``. The correction is therefore an
+    option and not a silent replacement.
+    """
+    y, Y0 = series
+    n_pre = T - D
+    huge = np.array(y, dtype=float)
+    huge[n_pre:] *= 5.0
+    assert conformal_pvalue(huge, Y0, n_pre, ns=200, seed=0,
+                            fixed_effects=True, finite_sample=False) == 0.0
+
+
+@pytest.mark.parametrize("finite_sample", [True, False])
+def test_the_p_value_stays_a_probability(series, finite_sample):
+    y, Y0 = series
+    n_pre = T - D
+    p = conformal_pvalue(y, Y0, n_pre, ns=200, seed=0, fixed_effects=True,
+                         finite_sample=finite_sample)
+    assert 0.0 <= p <= 1.0
+
+
+def test_the_correction_never_lowers_the_p_value(series):
+    """It shifts upward by construction, so it cannot manufacture significance."""
+    y, Y0 = series
+    for s in range(1, 6):
+        n_pre = backtest_pre_periods(T, D, s)
+        a, b = backtest_treatment_window(T, D, s)
+        inj = np.array(y, dtype=float)
+        inj[a:b + 1] *= 1.15
+        kw = dict(ns=200, seed=0, fixed_effects=True)
+        assert (conformal_pvalue(inj[:b + 1], Y0[:b + 1], n_pre,
+                                 finite_sample=True, **kw)
+                >= conformal_pvalue(inj[:b + 1], Y0[:b + 1], n_pre,
+                                    finite_sample=False, **kw))
+
+
+# --- block is the default for a serially dependent panel ------------------
+
+
+def test_block_is_the_default_conformal_scheme():
+    """Geo panels are serially dependent, which iid permutation denies.
+
+    Cyclic shifts preserve the dependence and have the panel's own length as
+    their reference set, so they cannot return a degenerate zero.
+    """
+    from mlsynth.utils.geox_helpers.config import GEOXConfig
+
+    assert GEOXConfig.model_fields["conformal_type"].default == "block"
+
+
+def test_iid_remains_selectable(series):
+    y, Y0 = series
+    n_pre = T - D
+    for scheme in ("iid", "block"):
+        p = conformal_pvalue(y, Y0, n_pre, ns=200, seed=0, fixed_effects=True,
+                             conformal_type=scheme)
+        assert 0.0 <= p <= 1.0

--- a/mlsynth/utils/bilevel/ridge_inference.py
+++ b/mlsynth/utils/bilevel/ridge_inference.py
@@ -106,6 +106,7 @@ def conformal_pvalue(
     seed: Optional[int] = 0,
     conformal_type: str = "iid",
     fixed_effects: bool = False,
+    finite_sample: bool = False,
     ridge_kwargs: Optional[Dict[str, Any]] = None,
 ) -> float:
     """Conformal p-value for the joint null of no post-treatment effect.
@@ -131,6 +132,13 @@ def conformal_pvalue(
         Number of i.i.d. residual permutations (augsynth default ``1000``).
     seed : int, optional
         RNG seed for the permutations.
+    finite_sample : bool, default False
+        Return ``(1 + #{stat >= obs}) / (1 + ns)`` instead of
+        ``mean(obs <= perm)``. The plain mean is augsynth's convention and is
+        kept as the default because ``geox_augsynth_geolift`` reproduces
+        GeoLift, which inherits it -- but it returns exactly ``0`` when the
+        observed statistic beats every permutation, and zero is not a p-value:
+        ``ns`` draws cannot evidence more than ``1 / (ns + 1)``.
     fixed_effects : bool, default False
         Unit fixed effects (augsynth ``fixed_effects=TRUE``): demean every unit
         by its mean over the full matching window before the refit, so the donor
@@ -142,7 +150,8 @@ def conformal_pvalue(
     Returns
     -------
     float
-        The conformal p-value ``mean(stat(observed_post) <= stat(permuted_post))``.
+        The conformal p-value ``mean(stat(observed_post) <= stat(permuted_post))``,
+        or its finite-sample correction when ``finite_sample`` is set.
     """
     ridge_kwargs = dict(ridge_kwargs or {})
     if lambda_ is not None:
@@ -160,6 +169,8 @@ def conformal_pvalue(
     perm = _reference_stats(
         resids, slice(pre, None), q, conformal_type=conformal_type, ns=ns, seed=seed
     )
+    if finite_sample:
+        return float((1.0 + np.sum(obs <= perm)) / (1.0 + perm.size))
     return float(np.mean(obs <= perm))
 
 

--- a/mlsynth/utils/geox_helpers/config.py
+++ b/mlsynth/utils/geox_helpers/config.py
@@ -136,9 +136,23 @@ class GEOXConfig(BaseMAREXConfig):
         "moves with the injected effect and cannot be hoisted out of it.",
     )
     conformal_type: str = Field(
-        default="iid",
-        description="Conformal permutation scheme (augsynth only): 'iid' or "
-        "'block'.",
+        default="block",
+        description="Conformal permutation scheme (augsynth only): 'block' or "
+        "'iid'. 'block' takes the panel's cyclic shifts, which preserve serial "
+        "dependence and are the default because geo panels have it; 'iid' "
+        "permutes residuals freely, which assumes an exchangeability a "
+        "trending or seasonal panel denies. 'iid' is also the scheme that can "
+        "return a degenerate p-value, since a free permutation can be beaten by "
+        "the observed statistic every time.",
+    )
+    finite_sample_p: bool = Field(
+        default=False,
+        description="Correct the conformal p-value to "
+        "(1 + #{stat >= observed}) / (1 + ns) (augsynth only). augsynth's "
+        "plain mean returns exactly 0 when the observed statistic beats every "
+        "permutation, which is not a p-value. Off by default so the GeoLift "
+        "reproduction keeps augsynth's convention; turn it on for inference "
+        "you intend to report.",
     )
     fixed_effects: Optional[bool] = Field(
         default=None,

--- a/mlsynth/utils/geox_helpers/engines/augsynth/__init__.py
+++ b/mlsynth/utils/geox_helpers/engines/augsynth/__init__.py
@@ -42,6 +42,22 @@ from .. import Engine, EngineFit, placebo_detection_boundary
 from ...engine import normal_p_value, placebo_sigma
 
 
+def _window(y, Y0, end: int):
+    """The panel truncated at the end of the tested window.
+
+    ``conformal_pvalue`` tests ``resids[pre:]`` -- everything from the split to
+    the end of what it is handed. A backtest window ends before the panel does,
+    so passing the whole panel tested ``end - pre + 1`` periods plus every
+    period after the window: for backtest ``s`` that is ``D + s - 1`` instead of
+    ``D``, and only ``s = 1`` coincided. Those trailing periods are no part of
+    the pseudo-experiment and carry none of its injected effect.
+
+    Truncating is a no-op for a realized readout, whose window already ends at
+    the last period.
+    """
+    return y[:end + 1], Y0[:end + 1]
+
+
 def _scaled_l2(A: np.ndarray, B: np.ndarray, w: np.ndarray) -> float:
     """Augsynth scaled L2 imbalance ``||Bw - A|| / ||B w_unif - A||``.
 
@@ -105,8 +121,8 @@ def sweep_p_values(
     fit: EngineFit, y, Y0, n_pre: int, start: int, end: int,
     effect_sizes: Iterable[float], *, inference: str = "conformal",
     ns: int = 1000, n_draws: int = 200, n_tr: int = 1, seed: int = 0,
-    conformal_type: str = "iid", analytic: bool = True, alpha: float = 0.1,
-    **_ignored: Any,
+    conformal_type: str = "block", analytic: bool = True, alpha: float = 0.1,
+    finite_sample: bool = False, **_ignored: Any,
 ) -> Dict[str, Any]:
     """Test every effect size on one backtest.
 
@@ -142,9 +158,11 @@ def sweep_p_values(
         if inference == "placebo":
             ps.append(normal_p_value(tau, sigma))
         else:
+            y_w, Y0_w = _window(injected, Y0, end)
             ps.append(float(conformal_pvalue(
-                injected, Y0, n_pre, lambda_=lam, ns=ns, seed=seed,
-                conformal_type=conformal_type, fixed_effects=fixed_effects)))
+                y_w, Y0_w, n_pre, lambda_=lam, ns=ns, seed=seed,
+                conformal_type=conformal_type, fixed_effects=fixed_effects,
+                finite_sample=finite_sample)))
     up, down = (placebo_detection_boundary(tau0, baseline, sigma, alpha)
                 if inference == "placebo" else (float("nan"), float("nan")))
     return {"tau": taus, "p_value": ps, "sigma": sigma,
@@ -154,8 +172,8 @@ def sweep_p_values(
 def point_inference(
     fit: EngineFit, y, Y0, n_pre: int, start: int, end: int, *,
     inference: str = "conformal", ns: int = 1000, n_draws: int = 200,
-    n_tr: int = 1, seed: int = 0, conformal_type: str = "iid",
-    **_ignored: Any,
+    n_tr: int = 1, seed: int = 0, conformal_type: str = "block",
+    finite_sample: bool = False, **_ignored: Any,
 ) -> Tuple[float, Dict[str, Any]]:
     """One window's test, for the realized readout."""
     y = np.asarray(y, dtype=float).ravel()
@@ -170,10 +188,12 @@ def point_inference(
     if inference != "conformal":
         raise MlsynthConfigError(
             f"inference must be 'conformal' or 'placebo'; got {inference!r}.")
+    y_w, Y0_w = _window(y, Y0, end)
     p = float(conformal_pvalue(
-        y, Y0, n_pre, lambda_=fit.extras.get("lambda_"), ns=ns, seed=seed,
+        y_w, Y0_w, n_pre, lambda_=fit.extras.get("lambda_"), ns=ns, seed=seed,
         conformal_type=conformal_type,
-        fixed_effects=bool(fit.extras.get("fixed_effects", True))))
+        fixed_effects=bool(fit.extras.get("fixed_effects", True)),
+        finite_sample=finite_sample))
     return p, {"method": "conformal", "att": tau, "ns": int(ns),
                "conformal_type": conformal_type}
 

--- a/mlsynth/utils/geox_helpers/orchestration.py
+++ b/mlsynth/utils/geox_helpers/orchestration.py
@@ -142,7 +142,8 @@ def engine_settings(config: GEOXConfig) -> dict:
     if config.engine == "augsynth":
         kw.update(ns=config.ns, conformal_type=config.conformal_type,
                   fixed_effects=bool(config.fixed_effects),
-                  augment=config.augment)
+                  augment=config.augment,
+                  finite_sample=config.finite_sample_p)
     return kw
 
 


### PR DESCRIPTION
## Related Links

- `mlsynth/utils/geox_helpers/engines/augsynth/__init__.py`, `mlsynth/utils/bilevel/ridge_inference.py`
- `mlsynth/tests/test_geox_conformal_correctness.py` — 22 new tests
- Must not disturb: `geox_augsynth_geolift` (reproduces GeoLift's fourteen published values)

## What

- The conformal test now evaluates the backtest window, not everything after it
- `finite_sample_p` reports `(1 + #{stat >= obs}) / (1 + ns)`, so `p == 0` is unreachable
- `conformal_type` defaults to `block` instead of `iid`

## Why

Found by Monte-Carloing the design against a known truth and by reading it
against GeoCausality's independent implementation of the same GeoLift idea.

`conformal_pvalue` itself was never wrong — on a true null its p-values come
back near uniform (median 0.458, mean 0.481, 15% below 0.10 at n=40). What was
wrong is how the design calls it, and what it may return at the extreme.

**The tested block was not the window.** `point_inference` and `sweep_p_values`
passed the whole panel with `n_pre` set to the backtest's pre-period, and
`conformal_pvalue` tests `resids[pre:]`. So backtest `s` evaluated `D + s - 1`
periods instead of `D`:

```
s=1: window [70,79] → tests 10 periods ✓
s=8: window [63,72] → tests 17 periods ✗   7 of them after the window
```

Only `s = 1` coincided. Those trailing periods are no part of the
pseudo-experiment and carry none of its injected effect. GeoCausality avoids it
by truncating (`data.filter(date <= last_post)`); we now do the same.

**`p == 0` was reachable.** `mean(obs <= perm)` returns zero when the observed
statistic beats every permutation, and zero is not a p-value — `ns` draws cannot
evidence more than `1 / (ns + 1)`. Under iid permutation the old form returned
exactly 0 in **26% of backtests at a 0.20 lift and 51% at 0.30**. That is
anti-conservative, the opposite direction from the conservatism I was chasing
when I found it.

**`iid` is misspecified for geo panels.** They are serially dependent; free
permutation assumes an exchangeability they deny.

## How

Truncation is a no-op for a realized readout, whose window already ends at the
panel, and a test pins that.

`finite_sample_p` is **off by default**. `geox_augsynth_geolift` reproduces
GeoLift, and GeoLift inherits augsynth's plain-mean convention; the correction
is an option, not a silent replacement. Turn it on for inference you intend to
report.

Block versus iid on an AR(1) factor DGP, 10 panels × 8 backtests:

| lift | iid power | iid `p==0` | block power | block `p==0` |
|---|---|---|---|---|
| 0.00 | 0.075 | 0.000 | 0.075 | 0.000 |
| 0.10 | 0.338 | 0.000 | 0.325 | 0.000 |
| 0.20 | 0.613 | **0.263** | 0.600 | **0.000** |
| 0.30 | 1.000 | **0.512** | 0.938 | **0.000** |

Block costs 1–6 points of power and eliminates the degenerate zeros outright —
its reference set is the panel's own length, so it cannot be exhausted.

## Verification

- Path: not applicable to the estimand. This corrects a test statistic's
  evaluation window and its extreme value; no estimator changes.
- `geox_augsynth_geolift` — **14/14 exact, unchanged**. It pins
  `conformal_type="iid"` explicitly so the default change does not reach it, but
  the truncation does apply and the published values do not move.
- 295 tests pass across the eight GEOX suites.

Honest about what the truncation buys: pooled over 10 panels, size is unchanged
at 0.075, power at a 0.10 lift moves 0.300 → 0.338, and at 0.20 it *falls*
0.675 → 0.613. It is here because the old block was wrong, not because it buys
power.

The sharpest test is `test_periods_after_the_window_cannot_move_the_p_value`: it
adds a +500 shock to the periods after the window and asserts the p-value is
unchanged. It fails on the old code for every `s > 1` and passes for `s = 1`,
which is the control.

## Scope checks

BUG FIX
- [x] Tests reproduce the defect and fail without the fix — 20 red, the two
      passing being `s = 1`, where the block already coincided
- [x] They assert the correct behaviour, not the absence of a crash
- [x] No docs page still states the old behaviour — `docs/geox.rst` updated for
      the new default and the correction flag
- [x] No pinned value moved

## Test Steps

- [x] `pytest mlsynth/tests/test_geox_conformal_correctness.py -q` — 22 passed, 2 skipped
- [x] `pytest` over the eight GEOX suites — 295 passed, 2 skipped
- [x] `python benchmarks/run_benchmarks.py --case geox_augsynth_geolift` — 14/14
- [x] `python -m sphinx -b dummy docs <out>` — builds, no geox warning

## Other Notes

The default change is behaviour-changing for anyone relying on
`conformal_type="iid"` implicitly: p-values move slightly and the degenerate
zeros disappear. Set `conformal_type="iid"` to keep the old scheme.

A follow-up branch adds the durable Monte Carlo this came out of — size,
power, MDE honesty and coverage for both engines — so this class of defect
fails a check instead of being found by hand.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_