### PR TITLE
Report a confidence interval from the realized readout

### DIFF
--- a/mlsynth/tests/test_geox_readout_interval.py
+++ b/mlsynth/tests/test_geox_readout_interval.py
@@ -1,0 +1,361 @@
+"""The realized readout reports an interval, not only a p-value.
+
+``InferenceResults`` has carried ``ci_lower`` / ``ci_upper`` all along and the
+GEOX readout never filled them, so ``report.att_ci`` was ``None`` and coverage
+-- the headline metric of any inference comparison -- was not a property of what
+GEOX ships. Both nulls can produce one: the placebo procedure reports a scale,
+and a conformal test can be inverted over a grid of constant effects.
+
+The two intervals are not the same object and the tests keep them apart. The
+placebo interval is ``att +/- z sigma``, symmetric by construction. The
+conformal interval is the set of constant effects the test does not reject, so
+it need not be symmetric and its agreement with the p-value is what makes it an
+interval at all.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+from mlsynth.utils.geox_helpers.engines import resolve_engine
+
+T, PRE, J = 60, 45, 10
+
+
+@pytest.fixture(scope="module")
+def series():
+    rng = np.random.default_rng(3)
+    f = np.zeros(T)
+    e = rng.normal(size=T)
+    f[0] = e[0]
+    for t in range(1, T):
+        f[t] = 0.5 * f[t - 1] + e[t]
+    load = rng.uniform(0.8, 1.2, size=J)
+    Y0 = 500.0 + 40.0 * np.outer(f, load) + rng.normal(scale=8.0, size=(T, J))
+    y = 500.0 + 40.0 * f * load.mean() + rng.normal(scale=8.0, size=T)
+    return y, Y0
+
+
+def _readout(series, engine, inference, alpha=0.1, **kw):
+    y, Y0 = series
+    eng = resolve_engine(engine)
+    fit = eng.fit_once(y, Y0, PRE, PRE, T - 1, 1, augment="ridge",
+                       fixed_effects=True)
+    p, details = eng.point_inference(fit, y, Y0, PRE, PRE, T - 1,
+                                     inference=inference, alpha=alpha,
+                                     n_draws=80, seed=0, **kw)
+    return eng.att(fit, y, PRE, T - 1), p, details
+
+
+# --- the placebo interval -------------------------------------------------
+
+
+@pytest.mark.parametrize("engine", ["sdid", "augsynth"])
+def test_placebo_reports_the_normal_interval(series, engine):
+    att, _, d = _readout(series, engine, "placebo")
+    z = norm.ppf(0.95)
+    assert d["ci_lower"] == pytest.approx(att - z * d["sigma"])
+    assert d["ci_upper"] == pytest.approx(att + z * d["sigma"])
+
+
+@pytest.mark.parametrize("engine", ["sdid", "augsynth"])
+def test_the_interval_brackets_the_estimate(series, engine):
+    att, _, d = _readout(series, engine, "placebo")
+    assert d["ci_lower"] < att < d["ci_upper"]
+
+
+@pytest.mark.parametrize("engine", ["sdid", "augsynth"])
+def test_a_smaller_alpha_widens_it(series, engine):
+    _, _, wide = _readout(series, engine, "placebo", alpha=0.01)
+    _, _, narrow = _readout(series, engine, "placebo", alpha=0.20)
+    assert (wide["ci_upper"] - wide["ci_lower"]
+            > narrow["ci_upper"] - narrow["ci_lower"])
+
+
+@pytest.mark.parametrize("engine", ["sdid", "augsynth"])
+def test_the_interval_agrees_with_the_p_value(series, engine):
+    """Excluding zero and rejecting at ``alpha`` are the same statement.
+
+    Both come from ``|att| / sigma`` against the same critical value, so an
+    interval that excluded zero while the p-value did not reject would mean the
+    readout reports two different tests.
+    """
+    att, p, d = _readout(series, engine, "placebo", alpha=0.1)
+    excludes_zero = not (d["ci_lower"] <= 0.0 <= d["ci_upper"])
+    assert excludes_zero == (p <= 0.1)
+
+
+# --- the conformal interval, by bracketing --------------------------------
+
+
+def _additive(true_effect, seed=5):
+    """A panel with a genuinely CONSTANT effect, which is what is inverted for."""
+    rng = np.random.default_rng(seed)
+    f = np.zeros(T)
+    e = rng.normal(size=T)
+    f[0] = e[0]
+    for t in range(1, T):
+        f[t] = 0.5 * f[t - 1] + e[t]
+    load = rng.uniform(0.9, 1.1, size=J)
+    Y0 = 5000.0 + 300.0 * np.outer(f, load) + rng.normal(scale=60.0, size=(T, J))
+    y = 5000.0 + 300.0 * f * load.mean() + rng.normal(scale=60.0, size=T)
+    y[PRE:] += true_effect
+    return y, Y0
+
+
+def _interval(y, Y0, alpha=0.1):
+    from mlsynth.utils.bilevel.ridge_inference import conformal_att_interval
+
+    eng = resolve_engine("augsynth")
+    fit = eng.fit_once(y, Y0, PRE, PRE, T - 1, 1, augment="ridge",
+                       fixed_effects=True)
+    return conformal_att_interval(
+        y, Y0, PRE, alpha=alpha, ns=200, fixed_effects=True,
+        lambda_=fit.extras["lambda_"]), eng.att(fit, y, PRE, T - 1)
+
+
+@pytest.mark.parametrize("true_effect", [0.0, 400.0, 1200.0])
+def test_the_conformal_interval_covers_a_constant_effect(true_effect):
+    """It brackets the truth, and tracks it instead of sitting still."""
+    (lo, hi), att = _interval(*_additive(true_effect))
+    assert lo <= true_effect <= hi
+    assert lo <= att <= hi
+
+
+def test_it_excludes_zero_exactly_when_the_effect_is_real():
+    (lo0, hi0), _ = _interval(*_additive(0.0))
+    (lo1, hi1), _ = _interval(*_additive(1200.0))
+    assert lo0 <= 0.0 <= hi0                 # no effect: zero is not excluded
+    assert not (lo1 <= 0.0 <= hi1)           # a large one: it is
+
+
+def test_the_endpoints_are_where_the_test_changes_answer():
+    """Bracketing means the bounds are crossings, not grid points."""
+    from mlsynth.utils.bilevel.ridge_inference import conformal_pvalue
+
+    y, Y0 = _additive(400.0)
+    (lo, hi), _ = _interval(y, Y0)
+    eng = resolve_engine("augsynth")
+    lam = eng.fit_once(y, Y0, PRE, PRE, T - 1, 1, augment="ridge",
+                       fixed_effects=True).extras["lambda_"]
+
+    def p_at(tau0):
+        shifted = np.array(y, dtype=float)
+        shifted[PRE:] -= tau0
+        return conformal_pvalue(shifted, Y0, PRE, ns=200, seed=0,
+                                conformal_type="block", fixed_effects=True,
+                                lambda_=lam)
+
+    width = hi - lo
+    assert p_at(lo + 0.05 * width) > 0.1     # inside is accepted
+    assert p_at(hi - 0.05 * width) > 0.1
+    assert p_at(lo - 0.30 * width) <= 0.1    # outside is rejected
+    assert p_at(hi + 0.30 * width) <= 0.1
+
+
+def _recast(scenario, seed):
+    """A Recast panel with its fitted penalty, and the post counterfactual mean."""
+    from mlsynth.utils.geox_helpers.simulate import simulate_recast_panel
+
+    wide, treated, cf, pre = simulate_recast_panel(scenario, 0.0, seed)
+    y = wide[treated].to_numpy()
+    Y0 = wide.drop(columns=[treated]).to_numpy()
+    eng = resolve_engine("augsynth")
+    fit = eng.fit_once(y, Y0, pre, pre, wide.shape[0] - 1, 1, augment="ridge",
+                       fixed_effects=True)
+    return (y, Y0, pre, dict(ns=300, seed=0, conformal_type="block",
+                             fixed_effects=True,
+                             lambda_=fit.extras["lambda_"]),
+            float(np.mean(cf[pre:])))
+
+
+def _a4(seed):
+    """An A4 panel -- 30 pre-days, so the test is weak."""
+    y, Y0, pre, kw, _ = _recast("A4", seed)
+    return y, Y0, pre, kw
+
+
+# --- an empty set is a claim about every candidate, not about one ---------
+
+
+def test_a_rejected_point_estimate_does_not_make_the_set_empty():
+    """The confidence set is ``{tau : p(tau) > alpha}``, and ``p`` does not peak
+    at the pre-period estimate.
+
+    ``conformal_pvalue`` refits on every period, so shifting the post block by a
+    candidate changes the fit as well as the residual, and the most conforming
+    candidate can sit well away from the estimate. On Recast A1 seed 23 the
+    estimate is -4.7% and is rejected at ``p = 0.010``, while the test accepts
+    the whole band around -30%. Concluding empty from the estimate alone throws
+    that band away, and the interval misses the truth for a reason that has
+    nothing to do with the truth.
+    """
+    from mlsynth.utils.bilevel.ridge_inference import (
+        conformal_att_interval, conformal_pvalue,
+    )
+
+    y, Y0, pre, kw, cfm = _recast("A1", 23)
+    inside = -0.30 * cfm
+
+    shifted = np.array(y, dtype=float)
+    shifted[pre:] -= inside
+    assert conformal_pvalue(shifted, Y0, pre, **kw) > 0.05   # it is accepted
+
+    lo, hi = conformal_att_interval(y, Y0, pre, alpha=0.05, **kw)
+    assert not (np.isnan(lo) or np.isnan(hi))
+    assert lo <= inside <= hi
+
+
+def test_a_set_the_test_rejects_everywhere_is_still_empty():
+    """Relocating the centre must not manufacture an interval.
+
+    On Recast A1 seed 45 the statistic is minimised at the point estimate and
+    the test rejects even there, so no constant effect conforms.
+    """
+    from mlsynth.utils.bilevel.ridge_inference import conformal_att_interval
+
+    y, Y0, pre, kw, _ = _recast("A1", 45)
+    lo, hi = conformal_att_interval(y, Y0, pre, alpha=0.05, **kw)
+    assert np.isnan(lo) and np.isnan(hi)
+
+
+@pytest.mark.parametrize("seed", [0, 2, 6])
+def test_a_finite_bound_is_always_a_crossing(seed):
+    """The search span starts the doubling; it does not cap the answer.
+
+    Recast's A4 panels are where this bites: 30 pre-days leave the test so
+    little power that a crossing can sit tens of pre-period sigmas out, or not
+    exist at all. A search that stops doubling and returns its own stopping
+    point reports a bound narrower than the truth, which under-covers. Seed 6 is
+    such a panel; seeds 0 and 2 have genuine crossings.
+    """
+    from mlsynth.utils.bilevel.ridge_inference import (
+        conformal_att_interval, conformal_pvalue,
+    )
+
+    y, Y0, pre, kw = _a4(seed)
+    lo, hi = conformal_att_interval(y, Y0, pre, alpha=0.05, **kw)
+    assert not (np.isnan(lo) or np.isnan(hi))       # the centre is accepted
+
+    def p_at(tau0):
+        shifted = np.array(y, dtype=float)
+        shifted[pre:] -= tau0
+        return conformal_pvalue(shifted, Y0, pre, **kw)
+
+    step = 0.01 * (hi - lo)
+    for bound, out in ((lo, -1), (hi, +1)):
+        if not np.isfinite(bound):
+            continue                                # unbounded: nothing to check
+        assert p_at(bound - out * step) > 0.05      # inside is accepted ...
+        assert p_at(bound + out * step) <= 0.05     # ... outside is rejected
+
+
+def test_a_panel_the_test_never_rejects_on_reports_no_bound():
+    """A4 seed 6 is the case, and it used to come back as two numbers.
+
+    The block reference set is the ``T`` cyclic shifts of the residual path.
+    With 15 of 45 periods in the post block, a third of those shifts overlap it,
+    so a candidate driven arbitrarily far still leaves five of them at least as
+    extreme and the p-value plateaus at ``5 / 45``, never reaching ``0.05``.
+    Nothing is excluded in either direction and the set is the whole line.
+    """
+    from mlsynth.utils.bilevel.ridge_inference import (
+        conformal_att_interval, conformal_pvalue,
+    )
+
+    y, Y0, pre, kw = _a4(6)
+    far = 1e4 * float(np.mean(np.abs(y[pre:])))
+    for tau0 in (-far, far):
+        shifted = np.array(y, dtype=float)
+        shifted[pre:] -= tau0
+        assert conformal_pvalue(shifted, Y0, pre, **kw) > 0.05
+    assert conformal_att_interval(y, Y0, pre, alpha=0.05, **kw) == (-np.inf,
+                                                                   np.inf)
+
+
+def test_a_level_the_test_cannot_reach_gives_an_unbounded_interval():
+    """Block conformal compares against ``T`` cyclic shifts, one of which is the
+    observed path itself, so its p-value cannot fall below ``1 / T``. Below that
+    level no candidate is ever rejected and the confidence set is the whole
+    line. Reporting a finite bound there would invent a rejection.
+    """
+    from mlsynth.utils.bilevel.ridge_inference import conformal_att_interval
+
+    y, Y0 = _additive(0.0)
+    assert 1.0 / T > 0.01                     # the level is below the floor
+    lo, hi = conformal_att_interval(
+        y, Y0, PRE, alpha=0.01, ns=200, fixed_effects=True,
+        conformal_type="block")
+    assert lo == -np.inf and hi == np.inf
+
+
+def test_the_readout_reports_an_unbounded_side_as_infinite():
+    """``None`` would make an unbounded set indistinguishable from an empty one."""
+    eng = resolve_engine("augsynth")
+    y, Y0 = _additive(0.0)
+    fit = eng.fit_once(y, Y0, PRE, PRE, T - 1, 1, augment="ridge",
+                       fixed_effects=True)
+    _, d = eng.point_inference(fit, y, Y0, PRE, PRE, T - 1,
+                               inference="conformal", conformal_type="block",
+                               ns=200, seed=0, alpha=0.01,
+                               augment="ridge", fixed_effects=True)
+    assert d["ci_lower"] == -np.inf and d["ci_upper"] == np.inf
+
+
+def test_a_multiplicative_lift_has_no_constant_effect_interval():
+    """An empty set is the right answer, not a search failure.
+
+    The null inverted is a *constant* effect. A multiplicative lift on a
+    trending panel is not constant in levels, so once the noise is small enough
+    to resolve the difference no candidate conforms and the set is empty. That
+    is the test being right, and it is why the readout can report absent.
+    """
+    y, Y0 = _additive(0.0)
+    y[PRE:] *= 1.25                          # proportional, not additive
+    (lo, hi), _ = _interval(y, Y0)
+    assert np.isnan(lo) and np.isnan(hi)
+
+
+# --- the readout populates the result model -------------------------------
+
+
+@pytest.mark.parametrize("engine, inference", [
+    ("sdid", "placebo"), ("augsynth", "placebo"),
+])
+def test_the_report_exposes_att_ci(engine, inference):
+    """Through the estimator, on the standardized accessor."""
+    import pandas as pd
+
+    from mlsynth import GEOX
+    from mlsynth.config_models import GEOXConfig
+
+    rng = np.random.default_rng(11)
+    n_geo, n_t, pre = 12, 60, 45
+    f = np.zeros(n_t)
+    e = rng.normal(size=n_t)
+    f[0] = e[0]
+    for t in range(1, n_t):
+        f[t] = 0.5 * f[t - 1] + e[t]
+    load = rng.uniform(0.8, 1.2, size=n_geo)
+    Y = 3000.0 + 200.0 * np.outer(f, load) + rng.normal(scale=60.0,
+                                                        size=(n_t, n_geo))
+    Y[pre:, 0] *= 1.10                       # a real lift on the treated geo
+    long = (pd.DataFrame(Y, columns=[f"g{i:02d}" for i in range(n_geo)])
+            .rename_axis("t").reset_index()
+            .melt(id_vars="t", var_name="geo", value_name="Y"))
+    long["post"] = (long["t"] >= pre).astype(int)
+
+    res = GEOX(GEOXConfig(
+        df=long, unitid="geo", time="t", outcome="Y", post_col="post",
+        treatment_size=1, to_be_treated=["g00"], durations=[10],
+        effect_sizes=[0.0, 0.1], n_backtests=2, n_draws=40, seed=0, n_jobs=1,
+        n_validation_backtests=0, alpha=0.05, power_threshold=0.1,
+        engine=engine, inference=inference,
+    )).fit()
+
+    ci = res.report.att_ci
+    assert ci is not None, "att_ci is None; the readout did not fill the interval"
+    assert ci[0] < ci[1]
+    assert res.report.inference.confidence_level == pytest.approx(0.95)

--- a/mlsynth/utils/bilevel/ridge_inference.py
+++ b/mlsynth/utils/bilevel/ridge_inference.py
@@ -174,6 +174,145 @@ def conformal_pvalue(
     return float(np.mean(obs <= perm))
 
 
+
+
+def conformal_att_interval(
+    y: np.ndarray,
+    Y0: np.ndarray,
+    pre: int,
+    *,
+    alpha: float = 0.05,
+    max_span: float = 512.0,
+    rtol: float = 0.02,
+    max_iter: int = 32,
+    **kwargs: Any,
+) -> Tuple[float, float]:
+    """Interval for a constant ATT, by inverting the joint test.
+
+    ``conformal_intervals`` inverts period by period, which gives a band around
+    the path; coverage of the *average* effect needs the set of constant effects
+    the joint test does not reject, which is what this returns.
+
+    The search brackets and bisects instead of scanning a grid. A fixed grid
+    fails here: the non-rejected set is narrow relative to the post-window gap
+    dispersion it would have to be scaled by, so a grid wide enough to be safe
+    steps over the set and reports it empty. Bracketing finds each crossing to a
+    relative tolerance whatever its width.
+
+    From the point estimate, the effect is doubled outward until the test
+    rejects, which brackets a crossing; that bracket is then bisected. Both
+    crossings are found separately, so the interval need not be symmetric --
+    the test's own asymmetry is preserved.
+
+    The point estimate is where the search starts, not where it gives up. The
+    refit reads every period, so shifting the post block by a candidate changes
+    the fit as well as the residual and the most conforming candidate can sit
+    well away from the estimate -- on Recast A1 seed 23 the estimate is rejected
+    at ``p = 0.010`` while the test accepts a band 30% below it. When the
+    estimate is rejected the search therefore relocates to the candidate that
+    minimises the test statistic, found by ternary search (the statistic is
+    unimodal in the candidate), and only calls the set empty if that is rejected
+    too.
+
+    Two answers are not numbers, and both are real.
+
+    ``(nan, nan)`` is an empty confidence set: no constant effect conforms, the
+    most conforming one included. A multiplicative lift on a trending panel
+    produces it, because the null being inverted is a *constant* effect.
+
+    ``-inf`` or ``+inf`` on a side is an unbounded one: the test still accepts
+    ``max_span`` pre-period sigmas out, so nothing in that direction is
+    excluded. Block conformal makes this reachable by construction -- its
+    reference set is the ``T`` cyclic shifts, one of which is the observed path,
+    so the p-value cannot fall below ``1 / T`` and at ``alpha < 1 / T`` no
+    candidate is ever rejected. Returning ``max_span`` sigmas as if it were a
+    bound would invent a rejection and report an interval narrower than the
+    truth.
+    """
+    y = np.asarray(y, dtype=float)
+    Y0 = np.asarray(Y0, dtype=float)
+    kwargs.setdefault("conformal_type", "block")
+    ridge_kwargs = {k: v for k, v in (("lambda_", kwargs.get("lambda_")),)
+                    if v is not None}
+
+    # Centre on the pre-period fit, as `conformal_intervals` does: an
+    # all-period refit treats the post block as matching periods and pulls its
+    # gaps toward zero, which would centre the search away from the effect.
+    if kwargs.get("fixed_effects"):
+        y_m, Y0_m = y[:pre].mean(), Y0[:pre].mean(axis=0)
+        ra = ridge_augment_weights(y[:pre] - y_m, Y0[:pre] - Y0_m, **ridge_kwargs)
+        fitted = (y - y_m) - (Y0 - Y0_m) @ ra.W
+    else:
+        ra = ridge_augment_weights(y[:pre], Y0[:pre], **ridge_kwargs)
+        fitted = y - Y0 @ ra.W
+    centre = float(np.mean(fitted[pre:]))
+    scale = float(np.std(fitted[:pre])) or abs(centre) or 1.0
+
+    def accepts(tau0: float) -> bool:
+        shifted = y.copy()
+        shifted[pre:] -= tau0
+        return conformal_pvalue(shifted, Y0, pre, **kwargs) > alpha
+
+    def statistic(tau0: float) -> float:
+        """The observed post-block statistic under ``H0: tau = tau0``.
+
+        The same quantity ``conformal_pvalue`` compares against its reference
+        set, without the reference set. It is continuous in the candidate where
+        the p-value is a step function of granularity ``1 / T``, so it is what
+        the relocation search can descend.
+        """
+        shifted = y.copy()
+        shifted[pre:] -= tau0
+        Z = Y0
+        if kwargs.get("fixed_effects"):
+            shifted = shifted - shifted.mean()
+            Z = Z - Z.mean(axis=0)
+        gaps = _augmented_gaps(shifted, Z, kwargs.get("Z0"), kwargs.get("z1"),
+                               ridge_kwargs)
+        return _stat(gaps[pre:], kwargs.get("q", 1.0))
+
+    def most_conforming() -> float:
+        """The candidate minimising the statistic, by ternary search."""
+        left, right = centre - max_span * scale, centre + max_span * scale
+        for _ in range(max_iter * 2):
+            if right - left <= rtol * scale:
+                break
+            a, b = left + (right - left) / 3.0, right - (right - left) / 3.0
+            if statistic(a) <= statistic(b):
+                right = b
+            else:
+                left = a
+        return 0.5 * (left + right)
+
+    if not accepts(centre):
+        centre = most_conforming()
+        if not accepts(centre):
+            return float("nan"), float("nan")
+
+    def crossing(sign: int) -> float:
+        """First rejection outward from the centre, located by bisection."""
+        step, far = scale, None
+        while step <= max_span * scale:
+            if not accepts(centre + sign * step):
+                far = centre + sign * step
+                break
+            step *= 2.0
+        if far is None:                     # nothing excluded in this direction
+            return sign * float("inf")
+        near = centre + sign * (step / 2.0) if step > scale else centre
+        for _ in range(max_iter):
+            mid = 0.5 * (near + far)
+            if abs(far - near) <= rtol * scale:
+                break
+            if accepts(mid):
+                near = mid
+            else:
+                far = mid
+        return float(near)
+
+    return crossing(-1), crossing(+1)
+
+
 @dataclass
 class ConformalIntervals:
     """Per-period conformal intervals from :func:`conformal_intervals`.

--- a/mlsynth/utils/geox_helpers/engines/__init__.py
+++ b/mlsynth/utils/geox_helpers/engines/__init__.py
@@ -96,6 +96,25 @@ def placebo_detection_boundary(att_0: float, baseline: float, sigma, alpha: floa
     return ((z * sigma - att_0) / baseline, (-z * sigma - att_0) / baseline)
 
 
+def placebo_interval(att_value: float, sigma, alpha: float):
+    """``att +/- z sigma``, the interval the placebo test inverts.
+
+    Detection is ``2(1 - Phi(|att| / sigma)) < alpha``, so the set of nulls the
+    test does not reject is exactly this interval -- excluding zero and
+    rejecting are the same statement, which is what keeps the reported interval
+    and the reported p-value from being two different tests.
+
+    ``(nan, nan)`` when sigma is unusable, so an interval is absent instead of
+    degenerate.
+    """
+    from scipy.stats import norm
+
+    if sigma is None or not np.isfinite(sigma) or sigma <= 0:
+        return float("nan"), float("nan")
+    z = float(norm.ppf(1.0 - alpha / 2.0))
+    return float(att_value - z * sigma), float(att_value + z * sigma)
+
+
 def resolve_engine(name: str) -> Engine:
     """The engine registered under ``name``.
 
@@ -116,4 +135,5 @@ def resolve_engine(name: str) -> Engine:
 
 ENGINE_NAMES = frozenset({"sdid", "augsynth"})
 
-__all__ = ["Engine", "EngineFit", "ENGINE_NAMES", "resolve_engine"]
+__all__ = ["Engine", "EngineFit", "ENGINE_NAMES", "resolve_engine",
+           "placebo_interval", "placebo_detection_boundary"]

--- a/mlsynth/utils/geox_helpers/engines/augsynth/__init__.py
+++ b/mlsynth/utils/geox_helpers/engines/augsynth/__init__.py
@@ -37,8 +37,11 @@ import numpy as np
 
 from .....exceptions import MlsynthConfigError
 from .....utils.bilevel.engine import BilevelSCM
-from .....utils.bilevel.ridge_inference import conformal_pvalue
-from .. import Engine, EngineFit, placebo_detection_boundary
+from .....utils.bilevel.ridge_inference import (
+    conformal_att_interval,
+    conformal_pvalue,
+)
+from .. import Engine, EngineFit, placebo_detection_boundary, placebo_interval
 from ...engine import normal_p_value, placebo_sigma
 
 
@@ -173,7 +176,7 @@ def point_inference(
     fit: EngineFit, y, Y0, n_pre: int, start: int, end: int, *,
     inference: str = "conformal", ns: int = 1000, n_draws: int = 200,
     n_tr: int = 1, seed: int = 0, conformal_type: str = "block",
-    finite_sample: bool = False, **_ignored: Any,
+    alpha: float = 0.1, finite_sample: bool = False, **_ignored: Any,
 ) -> Tuple[float, Dict[str, Any]]:
     """One window's test, for the realized readout."""
     y = np.asarray(y, dtype=float).ravel()
@@ -182,20 +185,39 @@ def point_inference(
     if inference == "placebo":
         sigma = placebo_sigma(y, Y0, n_pre, start, end, n_draws=n_draws,
                               n_tr=n_tr, seed=seed)
+        lo, hi = placebo_interval(tau, sigma, alpha)
         return normal_p_value(tau, sigma), {
             "method": "placebo", "sigma": sigma, "att": tau,
-            "n_draws": int(n_draws)}
+            "n_draws": int(n_draws), "ci_lower": lo, "ci_upper": hi}
     if inference != "conformal":
         raise MlsynthConfigError(
             f"inference must be 'conformal' or 'placebo'; got {inference!r}.")
     y_w, Y0_w = _window(y, Y0, end)
+    fe = bool(fit.extras.get("fixed_effects", True))
+    lam = fit.extras.get("lambda_")
     p = float(conformal_pvalue(
-        y_w, Y0_w, n_pre, lambda_=fit.extras.get("lambda_"), ns=ns, seed=seed,
-        conformal_type=conformal_type,
-        fixed_effects=bool(fit.extras.get("fixed_effects", True)),
+        y_w, Y0_w, n_pre, lambda_=lam, ns=ns, seed=seed,
+        conformal_type=conformal_type, fixed_effects=fe,
         finite_sample=finite_sample))
+    # The interval is the set of constant effects this same test does not
+    # reject, located by bracketing and bisection. A fixed grid does not work:
+    # the set is narrow relative to any span wide enough to be safe, so a grid
+    # steps over it and reports it empty.
+    #
+    # Both non-numeric answers are passed through as they come. An infinity is
+    # an unbounded side: nothing in that direction is excluded, which is where
+    # block conformal lands whenever `alpha` is below its 1/T floor. A NaN pair
+    # is an empty set, which is what a multiplicative lift gives once the noise
+    # is small enough to resolve it against a constant null. Collapsing either
+    # to `None` would make the two indistinguishable.
+    lo, hi = conformal_att_interval(
+        y_w, Y0_w, n_pre, alpha=alpha, lambda_=lam, ns=ns, seed=seed,
+        conformal_type=conformal_type, fixed_effects=fe,
+        finite_sample=finite_sample)
     return p, {"method": "conformal", "att": tau, "ns": int(ns),
-               "conformal_type": conformal_type}
+               "conformal_type": conformal_type,
+               "ci_lower": (None if np.isnan(lo) else lo),
+               "ci_upper": (None if np.isnan(hi) else hi)}
 
 
 def detection_boundary(

--- a/mlsynth/utils/geox_helpers/engines/sdid/__init__.py
+++ b/mlsynth/utils/geox_helpers/engines/sdid/__init__.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Iterable, Optional, Tuple
 
 import numpy as np
 
-from .. import Engine, EngineFit, placebo_detection_boundary
+from .. import Engine, EngineFit, placebo_detection_boundary, placebo_interval
 from .....exceptions import MlsynthConfigError
 from ...engine import (
     normal_p_value,
@@ -116,20 +116,23 @@ def sweep_p_values(
 
 def point_inference(
     fit: EngineFit, y, Y0, n_pre: int, start: int, end: int, *,
-    n_draws: int = 200, n_tr: int = 1, seed: int = 0,
+    n_draws: int = 200, n_tr: int = 1, seed: int = 0, alpha: float = 0.1,
     inference: str = "placebo", **_ignored: Any,
 ) -> Tuple[float, Dict[str, Any]]:
-    """One window's test, for the realized readout."""
+    """One window's test and interval, for the realized readout."""
     y = np.asarray(y, dtype=float).ravel()
     Y0 = np.asarray(Y0, dtype=float)
     tau = att(fit, y, start, end)
     sigma = placebo_sigma(y, Y0, n_pre, start, end, n_draws=n_draws,
                           n_tr=n_tr, seed=seed)
+    lo, hi = placebo_interval(tau, sigma, alpha)
     return normal_p_value(tau, sigma), {
         "method": "placebo",
         "sigma": sigma,
         "att": tau,
         "n_draws": int(n_draws),
+        "ci_lower": lo,
+        "ci_upper": hi,
     }
 
 

--- a/mlsynth/utils/geox_helpers/realize.py
+++ b/mlsynth/utils/geox_helpers/realize.py
@@ -37,6 +37,19 @@ from .engines import resolve_engine
 from .shaping import aggregate_treated, donor_matrix
 
 
+def _scaled(value, k: float):
+    """A reported bound on the reported effect's scale, or ``None`` if absent.
+
+    An infinite bound is a bound: it says the procedure excludes nothing in that
+    direction, and multiplying it by the reporting scale leaves it infinite. A
+    NaN is the absence of one, and becomes ``None``.
+    """
+    if value is None:
+        return None
+    value = float(value)
+    return None if np.isnan(value) else value * k
+
+
 def _report_extras(extras: dict) -> dict:
     """An engine's ``extras`` in a form the report can carry.
 
@@ -140,7 +153,7 @@ def realize_design(
     tau = eng.att(fit, treated, start, end)
     p_value, inf_details = eng.point_inference(
         fit, treated, donors, pre_periods, start, end,
-        n_draws=n_draws, n_tr=len(members), seed=seed, **ekw)
+        n_draws=n_draws, n_tr=len(members), seed=seed, alpha=alpha, **ekw)
 
     # Reporting scale. The statistic is a ratio, so it is scale-free and the
     # p-value is unmoved; only the reported paths change units.
@@ -168,6 +181,10 @@ def realize_design(
             p_value=float(p_value),
             method=str(inf_details.get("method", engine)),
             confidence_level=1.0 - alpha,
+            # On the same scale as the reported effect, so `how="sum"` scales
+            # the interval with the ATT it brackets.
+            ci_lower=_scaled(inf_details.get("ci_lower"), k),
+            ci_upper=_scaled(inf_details.get("ci_upper"), k),
             details={**inf_details, "att_mean_scale": float(tau)},
         ),
         weights=WeightsResults(

--- a/mlsynth/utils/geox_helpers/simulate.py
+++ b/mlsynth/utils/geox_helpers/simulate.py
@@ -137,3 +137,113 @@ def simulate_backtest(
                            if cpic is not None else float("nan")),
         })
     return rows
+
+
+# --- the Recast geo-experiment simulation study ---------------------------
+#
+# The data-generating process of getrecast/geolift-simulation-study, ported
+# from ``src/R/generate_panels.R``. That study runs 1000 Monte Carlo iterations
+# per cell across four stress scenarios and publishes per-tool bias, coverage
+# and false-positive rates, with GeoLift among the tools and configured as
+# augmented SC (ridge) with block conformal inference -- which is GEOX's
+# augsynth engine. Their published GeoLift row is therefore an external
+# referent for this engine's inference, which is why it is ported here instead
+# of a DGP being invented.
+#
+# Scenario overrides, from their `scenarios` list:
+#     A1 textbook          defaults
+#     A2 outlier           treated geo's baseline inflated 5x after selection
+#     A3 small pool        9 controls instead of 20
+#     A4 short pre-period  45 total days, 30 pre
+
+_DOW_PROFILE = (-1.0, -0.5, 0.0, 0.2, 0.8, 1.0, 0.5)   # Mon..Sun, day 1 = Mon
+
+RECAST_SCENARIOS = {
+    "A1": {},
+    "A2": {"outlier": True},
+    "A3": {"n_control": 9},
+    "A4": {"total_days": 45, "pre_days": 30},
+}
+
+
+def simulate_recast_panel(scenario: str, effect_pct: float, seed: int, *,
+                          n_control: int = 20, total_days: int = 105,
+                          pre_days: int = 90, baseline_mean: float = 4000.0,
+                          baseline_spread: float = 0.6,
+                          trend_slope: float = 0.001,
+                          seasonality_amplitude: float = 0.10,
+                          autocorrelation: float = 0.30,
+                          noise_level: float = 0.20,
+                          outlier_multiplier: float = 5.0):
+    """One panel from the Recast study's DGP.
+
+    ``Y_cf[i,t] = baseline_i * trend_t * season_t *
+    exp(noise_level * scale_i * ar_noise[i,t])`` with
+    ``scale_i = sqrt(noise_baseline_i / mean(noise_baselines))``, and the
+    treated geo's post window multiplied by ``1 + effect_pct``. Every geo shares
+    the trend and the weekly profile; only the baseline level and the noise draw
+    differ, which is the study's stated cross-geo structure (and its stated
+    caveat -- donors move in lockstep up to noise).
+
+    ``exp`` keeps the panel strictly positive whatever the noise draw, so a
+    multiplicative lift is always well defined.
+
+    The treated geo is the one closest to the median baseline, chosen before any
+    scenario modification; A2's inflation is applied to that geo afterwards and
+    deliberately does not feed the noise scaling, matching their
+    ``noise_baselines`` argument.
+
+    Returns
+    -------
+    (wide, treated, cf)
+        ``wide`` -- ``(total_days, n_geos)`` observed outcomes, columns
+        ``City 1 ...``; ``treated`` -- the treated column's name; ``cf`` -- the
+        treated geo's untreated counterfactual, so the true ATT is exact and
+        not approximated.
+    """
+    import pandas as pd
+
+    over = dict(RECAST_SCENARIOS.get(scenario, {}))
+    n_control = over.get("n_control", n_control)
+    total_days = over.get("total_days", total_days)
+    pre_days = over.get("pre_days", pre_days)
+    outlier = over.get("outlier", False)
+
+    n_geos = 1 + n_control
+    rng = np.random.default_rng(seed)
+
+    # Log-normal baselines with the mean pinned to `baseline_mean`, sorted.
+    meanlog = np.log(baseline_mean) - baseline_spread ** 2 / 2.0
+    baselines = np.sort(rng.lognormal(meanlog, baseline_spread, size=n_geos))
+    names = [f"City {i + 1}" for i in range(n_geos)]
+
+    # Treated = closest to the median baseline, before any inflation.
+    t_idx = int(np.argmin(np.abs(baselines - np.median(baselines))))
+    noise_baselines = baselines.copy()          # A2 must not amplify the noise
+    if outlier:
+        baselines = baselines.copy()
+        baselines[t_idx] *= outlier_multiplier
+
+    t_seq = np.arange(1, total_days + 1)
+    trend = 1.0 + trend_slope * t_seq
+    season = 1.0 + seasonality_amplitude * np.asarray(
+        [_DOW_PROFILE[(t - 1) % 7] for t in t_seq])
+
+    mean_baseline = float(noise_baselines.mean())
+    Y_cf = np.empty((total_days, n_geos))
+    for i in range(n_geos):
+        innov = rng.normal(size=total_days)
+        noise = np.empty(total_days)
+        noise[0] = innov[0]
+        for t in range(1, total_days):
+            noise[t] = autocorrelation * noise[t - 1] + innov[t]
+        scale_i = np.sqrt(noise_baselines[i] / mean_baseline)
+        Y_cf[:, i] = (baselines[i] * trend * season
+                      * np.exp(noise_level * scale_i * noise))
+
+    Y = Y_cf.copy()
+    Y[pre_days:, t_idx] = Y_cf[pre_days:, t_idx] * (1.0 + effect_pct)
+
+    wide = pd.DataFrame(Y, columns=names,
+                        index=pd.RangeIndex(1, total_days + 1, name="date"))
+    return wide, names[t_idx], Y_cf[:, t_idx], pre_days


### PR DESCRIPTION
## Related Links

- `mlsynth/utils/bilevel/ridge_inference.py` — `conformal_att_interval`
- `mlsynth/utils/geox_helpers/engines/__init__.py` — `placebo_interval`
- `mlsynth/tests/test_geox_readout_interval.py` — 24 tests
- Follows #403 (corrected the conformal test in the design path)
- Fast-follow branch `claude/geox-engine-coverage-mc` pins these numbers durably
- Chernozhukov, Wüthrich & Zhu (2021), *An Exact and Robust Conformal Inference
  Method for Counterfactual and Synthetic Controls*, JASA 116(536) —
  [doi:10.1080/01621459.2021.1920957](https://doi.org/10.1080/01621459.2021.1920957)

## What

- Added `att_ci` to the realized readout on both inference paths. It was `None`
  everywhere, so coverage was not a property of what GEOX ships.
- Added `conformal_att_interval` — the set of constant effects the joint test
  does not reject, by bracketing and bisection.
- Added `placebo_interval` — `att ± z σ` from the same σ the p-value uses.
- Added `simulate_recast_panel`, the Recast study's data-generating process.

## Why

Coverage is the headline metric of any inference comparison, and GEOX could not
report it. `InferenceResults` has carried `ci_lower` / `ci_upper` all along; the
readout never filled them, so `report.att_ci` was `None` on every path.

Both nulls produce an interval by their own logic. The placebo one comes from
the σ that already backs the p-value, so excluding zero and rejecting at α are
one statement — pinned by a test. The conformal one is the inverted test.

## How

Three details decide whether the search returns the set or something that only
looks like it. Each was found by measurement, and two of them were wrong in the
first cut of this branch.

**It brackets, it does not scan.** The set is narrow relative to any span wide
enough to be safe on an arbitrary panel, so a grid steps over it and reports it
empty. That is not hypothetical — a 500-unit scan is what led me to conclude the
p-value was invariant to the candidate and withdraw the interval entirely. It is
not invariant: `p` moves 0.017 / 0.617 / 0.017 across −200 / 0 / +200 on the
panel I scanned. The candidate is now doubled outward from the point estimate
until the test rejects, which brackets a crossing, and the bracket is bisected.
Each side separately, so the interval keeps the test's own asymmetry.

Centring is on the pre-period fit, not the all-period refit: the refit treats
the post block as matching periods and pulls its gaps toward zero, which would
centre the search away from the effect.

**The span starts the doubling; it does not cap the answer.** Block conformal
compares against the `T` cyclic shifts of the residual path, and the shifts whose
window overlaps the post block stay large however far the candidate is driven,
so the p-value plateaus above zero. On Recast A4 seed 6 — 45 periods, 15 of them
post — it plateaus at 5/45 in both tails:

```
tau0 =  -10^6 pp → p = 0.1111        0 pp → p = 0.4667      +10^6 pp → p = 0.1111
```

The first cut stopped doubling at 24 pre-period sigmas and returned that as a
bound, so a panel the test never rejects on came back as `(−9853, +8640)` —
two numbers that look like bounds and are not, and an interval narrower than the
truth under-covers. An unexcluded direction now reports `±inf`, and the readout
passes it through. Collapsing it to `None` would make an unbounded interval
indistinguishable from an empty one, which are opposite statements.

**Emptiness is a claim about every candidate, not about one.** The refit reads
all periods, so shifting the post block moves the fit as well as the residual and
the most conforming candidate can sit far from the point estimate. On Recast A1
seed 23 the estimate is −4.7% and rejected at `p = 0.010`, while the test accepts
the entire band from −38.8% to −21.8%. Scanning four such panels:

| panel | point estimate | statistic minimiser | accepted set |
|---|---|---|---|
| A1 s23 | −4.69% | −21.76% | [−38.8, −21.8] |
| A1 s36 | +2.80% | −12.30% | [−42.5, −12.3] |
| A1 s40 | +6.34% | +6.34% | empty |
| A1 s45 | +13.54% | +13.54% | empty |

The minimiser lands inside the set wherever one exists, and coincides with the
estimate wherever the set is genuinely empty. So when the estimate is rejected
the search relocates to the statistic minimiser and re-tests there. The statistic
is what `conformal_pvalue` compares against its reference set, it is continuous
where the p-value is a step function of granularity `1/T`, and it was unimodal on
every panel checked — a ternary search finds it in about 27 steps, paid only on
the panels that need it.

This third fix is the entire coverage deficit. Conditional on reporting an
interval at all, the conformal readout already covered at 0.95 to 1.00.

## Verification

Path: cross-validation, against `getrecast/geolift-simulation-study`, whose
GeoLift arm is augmented SC (ridge) with block conformal at α = 0.05 — the
configuration GEOX runs under `engine="augsynth", inference="conformal"`. 120
panels per cell against their 1000.

| scenario | coverage null | theirs | coverage 7.5% | theirs | width | theirs |
|---|---|---|---|---|---|---|
| A1 textbook | 0.933 | 0.954 | 0.892 | 0.922 | 2062 | 2020 |
| A2 outlier (5×) | 0.950 | 0.958 | 0.917 | 0.936 | 10182 | 9955 |
| A3 small pool | 0.967 | 0.951 | 0.925 | 0.925 | 1968 | 1926 |
| A4 short pre-period | 0.950 | 0.967 | 0.925 | 0.951 | 6339 | 5575 |

Coverage agrees within 0.031. Width agrees to 2% on three of the four, and it is
the sharper comparison: coverage is a rate, and two procedures can both cover at
0.93 with intervals of very different length, whereas agreeing on width says they
reject in the same places.

A4 is the exception at 1.14×, and structurally so. Thirty pre-days against
fifteen post ones puts a third of the block reference set inside the post window,
so some panels are unbounded in a direction; those are excluded from the average
and the remainder is the wider tail.

Pinned durably in `benchmarks/cases/geox_augsynth_recast.py` on the fast-follow
branch, which adds `{sc}_coverage`, `{sc}_coverage_null`, `{sc}_ci_width`,
`{sc}_empty_rate`, `max_coverage_gap_vs_recast` and
`max_ci_width_ratio_vs_recast` — 37 pinned values, all passing.

Not fixed, recorded: the interval reports the connected component of the
accepted set containing the most conforming candidate. A step-function p-value
can in principle produce a disconnected set, and the search would return only the
component it starts in. I did not test for that, and nothing here would have
detected it.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR
- [x] The default preserves existing behaviour exactly — `att_ci` was `None`, so
      every filled value is new information and no reported number moves
- [x] Existing pinned benchmark values unchanged: `geox_augsynth_recast`'s 21
      original rows reproduce to 5e-4, and `alpha` reaching `point_inference`
      does not touch the p-value
- [x] A test pins that placebo's interval and its p-value are the same test
- [x] No new config field; the interval follows the `alpha` already on the config

## Designs

No figures. The change reports numbers the readout already had the slots for; the
tables above are the visual context.

## Test Steps

- [x] `pytest mlsynth/tests/test_geox_readout_interval.py -q` — 24 passed
- [x] `pytest` over the neighbouring GEOX and result-contract suites — 314
      passed, 6 skipped; `inf` bounds pass the result contract unchanged
- [x] `pytest mlsynth/tests/test_geox_conformal_correctness.py -q` — 46 passed,
      2 skipped together with the interval file
- [x] `python benchmarks/run_benchmarks.py --case geox_augsynth_recast` — 37/37
      in 95s
- [x] `python -m sphinx -b dummy docs` — no new warnings

## Other Notes

`placebo_sigma` reassigns donors as pseudo-treated and never reads the treated
series, so it assumes the treated unit is exchangeable with the donors in scale.
Recast A2 breaks that by construction — the treated geo is inflated fivefold and
the donors are not — and the placebo interval comes back bit-identical between A1
and A2 on all 120 seeds, while the conformal interval scales by 5.12×. The
resulting false-positive rate is 0.450 for `augsynth/placebo` and 0.433 for
`sdid/placebo` against a nominal 0.05, and the apparent power of 0.74 is that
false-positive rate in disguise. Both engines call the same routine, so they
differ only in the point estimate. On A4 the same procedure errs the other way,
at 0.008 and 0.025.

That is a defect in placebo inference, not in this PR, and fixing it is its own
scope — the natural direction is to scale the placebo draws by the treated unit's
own level. Nothing here changes placebo behaviour.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_