### PR TITLE
Return an absent SYNDES bound instead of crashing the fit

### DIFF
--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -509,7 +509,13 @@ class SYNDES:
         warm_D, L_safe = two_way_accel_inputs(
             inputs.Y_pre, self.K, self.lam, margin=self.accel_safety_margin,
         )
-        return {"warm_start_D": warm_D, "objective_lower_bound": L_safe}
+        kwargs = {"warm_start_D": warm_D}
+        if L_safe is not None:
+            # A bound that did not converge leaves the warm start usable on its
+            # own; the solve keeps SCIP's own dual bound (two_way_accel_inputs
+            # warns) instead of failing.
+            kwargs["objective_lower_bound"] = L_safe
+        return kwargs
 
     def _fit_mip(self, inputs, restrictions=None) -> SYNDESResults:
         mode_internal = _MODE_TO_INTERNAL[self.mode_public]

--- a/mlsynth/tests/test_syndes_bound_failure.py
+++ b/mlsynth/tests/test_syndes_bound_failure.py
@@ -1,0 +1,169 @@
+"""What SYNDES does when a relaxation bound solve returns no value.
+
+Both lower bounds behind the SYNDES certificate are convex solves that can fail
+to converge: the two-way bound lifts ``x = [w; q; D]`` to a ``(3N+1)`` moment
+matrix and hands it to SCS under a fixed iteration cap, and the continuous
+relaxation is a QP. When a solve returns without an objective value, CVXPY
+leaves ``.value`` at ``None``.
+
+The bound is a diagnostic and a solver speed-up, never a correctness
+requirement: ``solve_synthetic_design`` takes ``objective_lower_bound`` as
+optional, so a missing bound costs solve time and nothing else. These tests pin
+that a failed bound degrades to "no bound" -- reported through a warning and
+through the certificate's own ``None`` contract -- instead of ending the fit.
+"""
+from __future__ import annotations
+
+import cvxpy as cp
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SYNDES
+from mlsynth.config_models import SYNDESConfig
+from mlsynth.utils.syndes_helpers import accelerate as accel_mod
+from mlsynth.utils.syndes_helpers import certificate as cert_mod
+from mlsynth.utils.syndes_helpers.accelerate import two_way_accel_inputs
+from mlsynth.utils.syndes_helpers.certificate import (
+    SYNDESCertificate,
+    _continuous_relaxation_bound,
+    _sdp_moment_bound_two_way,
+    syndes_certificate,
+)
+from mlsynth.utils.syndes_helpers.optimization import (
+    estimate_lambda,
+    solve_synthetic_design,
+)
+
+TWO_WAY = "global_2way"
+
+
+def _Y(N=12, T=8, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.standard_normal((T, 3))
+    Lam = rng.standard_normal((N, 3))
+    return (Lam @ F.T).T + 0.3 * rng.standard_normal((T, N))
+
+
+def _panel(n_units=12, T=14, n_post=4, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.standard_normal((T, 3))
+    L = rng.standard_normal((3, n_units))
+    Y = F @ L + 0.3 * rng.standard_normal((T, n_units))
+    return pd.DataFrame([
+        {"unit": f"u{j}", "time": t, "y": Y[t, j], "post": int(t >= T - n_post)}
+        for j in range(n_units) for t in range(T)
+    ])
+
+
+@pytest.fixture
+def unsolved(monkeypatch):
+    """Make every CVXPY solve a no-op, so objectives keep ``value is None``."""
+    monkeypatch.setattr(cp.Problem, "solve", lambda self, *a, **k: None)
+
+
+@pytest.fixture
+def bound_fails(monkeypatch):
+    """Make only the two-way SDP bound report failure."""
+    monkeypatch.setattr(accel_mod, "_sdp_moment_bound_two_way",
+                        lambda *a, **k: None)
+    monkeypatch.setattr(cert_mod, "_sdp_moment_bound_two_way",
+                        lambda *a, **k: None)
+
+
+class TestBoundHelpersReturnNone:
+    """A bound that does not solve is ``None``, not a raised TypeError."""
+
+    def test_sdp_moment_bound(self, unsolved):
+        assert _sdp_moment_bound_two_way(_Y(), 3, 1.0) is None
+
+    def test_continuous_relaxation_bound(self, unsolved):
+        assert _continuous_relaxation_bound(_Y(), 3, TWO_WAY, 1.0) is None
+
+    @pytest.mark.parametrize("mode", ["global_equal_weights", TWO_WAY, "per_unit"])
+    def test_no_mode_raises(self, unsolved, mode):
+        assert _continuous_relaxation_bound(_Y(), 3, mode, 1.0) is None
+
+    def test_solved_bound_is_still_a_float(self):
+        lb = _sdp_moment_bound_two_way(_Y(), 3, 1.0)
+        assert isinstance(lb, float) and np.isfinite(lb)
+
+
+class TestCertificateReportsMissingBound:
+    """``SYNDESCertificate`` already documents ``lower_bound`` as optional."""
+
+    def test_fields_are_none_and_uncertified(self, unsolved):
+        c = syndes_certificate(_Y(), 3, TWO_WAY, 1.0)
+        assert isinstance(c, SYNDESCertificate)
+        assert c.lower_bound is None
+        assert c.optimality_gap is None
+        assert c.certified is False
+
+    def test_note_says_the_bound_failed(self, unsolved):
+        c = syndes_certificate(_Y(), 3, TWO_WAY, 1.0)
+        assert c.note, "a missing bound must be explained in the note"
+        assert "converge" in c.note.lower() or "fail" in c.note.lower()
+
+    @pytest.mark.parametrize("mode", ["global_equal_weights", TWO_WAY, "per_unit"])
+    def test_every_mode_degrades(self, unsolved, mode):
+        c = syndes_certificate(_Y(), 3, mode, 1.0)
+        assert c.lower_bound is None and c.optimality_gap is None
+
+    def test_successful_certificate_unchanged(self):
+        Y = _Y()
+        inc = float(solve_synthetic_design(Y, K=3, mode=TWO_WAY).objective_value)
+        c = syndes_certificate(Y, 3, TWO_WAY, inc)
+        assert c.lower_bound is not None
+        assert c.optimality_gap is not None
+        assert c.certified is True
+
+
+class TestAcceleratorDropsTheCut:
+    """The warm start survives a failed bound; only the cut is dropped."""
+
+    def test_returns_none_for_the_cut(self, bound_fails):
+        Y = _Y(N=20)
+        with pytest.warns(UserWarning, match="lower bound"):
+            warm_D, cut = two_way_accel_inputs(Y, 4, float(estimate_lambda(Y)))
+        assert cut is None
+        assert warm_D.shape == (20,)
+        assert int(warm_D.sum()) == 4
+
+    def test_cut_present_when_the_bound_solves(self):
+        Y = _Y(N=14)
+        warm_D, cut = two_way_accel_inputs(Y, 4, float(estimate_lambda(Y)))
+        assert isinstance(cut, float) and np.isfinite(cut)
+        assert int(warm_D.sum()) == 4
+
+    def test_solver_accepts_a_missing_cut(self):
+        """``objective_lower_bound=None`` is already a supported call."""
+        Y = _Y(N=10)
+        d = solve_synthetic_design(Y, K=3, mode=TWO_WAY,
+                                   warm_start_D=None, objective_lower_bound=None)
+        assert d.objective_value is not None
+
+
+class TestFitSurvivesBoundFailure:
+    """End to end: the design still comes back."""
+
+    def test_fit_returns_a_design(self, bound_fails):
+        df = _panel(n_units=12)
+        cfg = SYNDESConfig(df=df, outcome="y", unitid="unit", time="time",
+                           K=3, post_col="post", mode="two_way_global",
+                           accelerate=True, accel_min_tuples=1,
+                           display_graph=False)
+        with pytest.warns(UserWarning, match="lower bound"):
+            res = SYNDES(cfg).fit()
+        assert len(np.asarray(res.design.selected_unit_labels)) == 3
+
+    def test_accelerated_design_matches_the_unaccelerated_one(self, bound_fails):
+        """Dropping the cut changes runtime, not the optimum."""
+        df = _panel(n_units=10)
+        common = dict(df=df, outcome="y", unitid="unit", time="time", K=3,
+                      post_col="post", mode="two_way_global", display_graph=False)
+        with pytest.warns(UserWarning, match="lower bound"):
+            fast = SYNDES(SYNDESConfig(**common, accelerate=True,
+                                       accel_min_tuples=1)).fit()
+        plain = SYNDES(SYNDESConfig(**common, accelerate=False)).fit()
+        assert sorted(map(str, np.asarray(fast.design.selected_unit_labels))) == \
+            sorted(map(str, np.asarray(plain.design.selected_unit_labels)))

--- a/mlsynth/utils/syndes_helpers/accelerate.py
+++ b/mlsynth/utils/syndes_helpers/accelerate.py
@@ -18,6 +18,7 @@ this is an mlsynth addition, not part of Doudchenko et al. (2021).
 """
 from __future__ import annotations
 
+import warnings
 from typing import Optional, Tuple
 
 import numpy as np
@@ -53,14 +54,29 @@ def two_way_accel_inputs(
     *,
     margin: float = 0.01,
     random_state: int = 0,
-) -> Tuple[np.ndarray, float]:
+) -> Tuple[np.ndarray, Optional[float]]:
     """``(warm_D, L_safe)`` for an accelerated two-way solve.
 
     ``L_safe = L * (1 - margin)`` where ``L`` is the SDP/moment lower bound; the
     margin keeps the cut strictly below the bound so it stays valid under the SDP
     solver's (first-order) tolerance. ``warm_D`` is the LEXSCM warm start.
+
+    The cut is ``None`` when the SDP does not converge -- a large lift under a
+    fixed iteration cap. Both levers are speed-ups, so a missing bound costs the
+    dual-bound lift and leaves the warm start, the design, and its optimum
+    untouched; the solve falls back to SCIP's own McCormick bound. The caller is
+    warned because the solve can then take much longer.
     """
     lam_value = float(estimate_lambda(Y)) if lam is None else float(lam)
     warm_D = warm_treated_vector(Y, K, random_state=random_state)
     L = _sdp_moment_bound_two_way(np.asarray(Y, dtype=float), int(K), lam_value)
+    if L is None:
+        warnings.warn(
+            f"SYNDES: the SDP/moment lower bound did not converge at N="
+            f"{int(np.asarray(Y).shape[1])}, K={int(K)}, so the two-way solve "
+            "proceeds without the objective cut and may be slow. Set "
+            "accelerate=False to skip this step, or lower certify_sdp_n_max.",
+            UserWarning, stacklevel=2,
+        )
+        return warm_D, None
     return warm_D, float(L) * (1.0 - float(margin))

--- a/mlsynth/utils/syndes_helpers/certificate.py
+++ b/mlsynth/utils/syndes_helpers/certificate.py
@@ -87,21 +87,42 @@ class SYNDESCertificate:
     note: str = ""
 
 
-def _continuous_relaxation_bound(Y: np.ndarray, K: int, mode: str, lam: float) -> float:
-    """Continuous relaxation optimum (``D`` in ``[0, 1]``): a valid lower bound."""
+def _bound_value(objective: cp.Expression) -> Optional[float]:
+    """The solved objective, or ``None`` when the solve produced no value.
+
+    Both bounds here are convex solves that can end without an optimum -- the
+    moment lift is a large PSD program under a fixed iteration cap. CVXPY leaves
+    ``.value`` at ``None`` in that case, so every caller reads the bound through
+    this helper and gets an absent bound instead of a ``TypeError``.
+    """
+    value = objective.value
+    return None if value is None else float(value)
+
+
+def _continuous_relaxation_bound(
+    Y: np.ndarray, K: int, mode: str, lam: float
+) -> Optional[float]:
+    """Continuous relaxation optimum (``D`` in ``[0, 1]``): a valid lower bound.
+
+    ``None`` when the relaxation does not solve.
+    """
     _, N = Y.shape
     D = cp.Variable(N, nonneg=True)
     comp = build_syndes_problem_components(Y=Y, D=D, K=K, lam=lam, mode=mode)
     prob = cp.Problem(cp.Minimize(comp.objective), list(comp.constraints) + [D <= 1])
     prob.solve(solver=cp.CLARABEL)
-    return float(comp.objective.value)
+    return _bound_value(comp.objective)
 
 
-def _sdp_moment_bound_two_way(Y: np.ndarray, K: int, lam: float) -> float:
+def _sdp_moment_bound_two_way(Y: np.ndarray, K: int, lam: float) -> Optional[float]:
     """SDP / moment (Shor level-1) lower bound for the two-way objective.
 
     Lifts ``x = [w; q; D]`` to a moment matrix and adds the constraints the
     McCormick relaxation drops: ``D_i^2 = D_i`` and ``w_i D_i = q_i = q_i D_i``.
+
+    The lift is ``(3N+1)`` square and SCS runs under a fixed iteration cap, so a
+    large ``N`` can exhaust the budget without an optimum; the bound is ``None``
+    when that happens.
     """
     T, N = Y.shape
     G = Y.T @ Y
@@ -127,12 +148,32 @@ def _sdp_moment_bound_two_way(Y: np.ndarray, K: int, lam: float) -> float:
                        - 4 * cp.sum(cp.multiply(G, Xqw))
                        + cp.sum(cp.multiply(G, Xww))) + lam * cp.trace(Xww)
     cp.Problem(cp.Minimize(obj), cons).solve(solver=cp.SCS, max_iters=8000, eps=1e-5)
-    return float(obj.value)
+    return _bound_value(obj)
 
 
 def _gap(incumbent: float, lb: float) -> float:
     denom = abs(incumbent) if abs(incumbent) > 1e-12 else 1.0
     return max(0.0, (incumbent - lb) / denom)
+
+
+def _certificate(
+    lb: Optional[float],
+    incumbent_obj: float,
+    certified: bool,
+    method: str,
+    note: str = "",
+) -> SYNDESCertificate:
+    """Assemble a certificate, degrading to "no bound" when the solve failed.
+
+    An absent bound is the documented ``lower_bound is None`` case: there is no
+    gap to report and nothing is certified.
+    """
+    if lb is None:
+        return SYNDESCertificate(
+            None, None, False, method,
+            note=(f"the {method} bound solve did not converge, so no lower "
+                  "bound is available and this design carries no certified gap."))
+    return SYNDESCertificate(lb, _gap(incumbent_obj, lb), certified, method, note=note)
 
 
 def syndes_certificate(
@@ -175,24 +216,23 @@ def syndes_certificate(
     lam_value = float(estimate_lambda(Y)) if lam is None else float(lam)
 
     if mode == _ONE_WAY:
-        lb = _continuous_relaxation_bound(Y, K, mode, lam_value)
-        return SYNDESCertificate(lb, _gap(incumbent_obj, lb), True,
-                                 "continuous_relaxation")
+        return _certificate(_continuous_relaxation_bound(Y, K, mode, lam_value),
+                            incumbent_obj, True, "continuous_relaxation")
 
     if mode == _TWO_WAY:
         if N <= sdp_n_max:
-            lb = _sdp_moment_bound_two_way(Y, K, lam_value)
-            return SYNDESCertificate(lb, _gap(incumbent_obj, lb), True, "sdp_moment")
-        lb = _continuous_relaxation_bound(Y, K, mode, lam_value)
-        return SYNDESCertificate(
-            lb, _gap(incumbent_obj, lb), False, "continuous_relaxation",
+            return _certificate(_sdp_moment_bound_two_way(Y, K, lam_value),
+                                incumbent_obj, True, "sdp_moment")
+        return _certificate(
+            _continuous_relaxation_bound(Y, K, mode, lam_value),
+            incumbent_obj, False, "continuous_relaxation",
             note=(f"N={N} exceeds sdp_n_max={sdp_n_max}; the two-way SDP bound was "
                   "skipped and the continuous bound is loose (not a tight certificate)."))
 
     # per_unit: no cheap tight bound (SDP is O(N^4); continuous relaxation ~70% loose)
-    lb = _continuous_relaxation_bound(Y, K, mode, lam_value)
-    return SYNDESCertificate(
-        lb, _gap(incumbent_obj, lb), False, "continuous_relaxation",
+    return _certificate(
+        _continuous_relaxation_bound(Y, K, mode, lam_value),
+        incumbent_obj, False, "continuous_relaxation",
         note=("per-unit has an (N,N) weight matrix, so the SDP lift is intractable "
               "and the continuous relaxation is loose; the gap is not a tight "
               "certificate."))


### PR DESCRIPTION
## Related Links

- Resolves #404
- Touched: `mlsynth/utils/syndes_helpers/certificate.py`, `mlsynth/utils/syndes_helpers/accelerate.py`, `mlsynth/estimators/syndes.py`
- Source paper for the estimator: Doudchenko, Khosravi, Pouget-Abadie, Lahaie, Lubin, Mirrokni, Spiess and Imbens (2021), [arXiv:2112.00278](https://arxiv.org/abs/2112.00278). The SDP/moment bound this PR guards is an mlsynth addition, not part of the paper.
- Found while running a paper-review spike against the design estimators; unrelated to that paper.

## What

- Both lower bounds behind the SYNDES certificate now return `Optional[float]` through one `_bound_value` reader, instead of calling `float()` on a possibly-`None` objective.
- `syndes_certificate` degrades to `lower_bound=None`, `optimality_gap=None`, `certified=False` and a note naming the method that failed.
- `two_way_accel_inputs` returns the warm start with no cut and warns; `SYNDES._accel_kwargs` omits `objective_lower_bound` when there is no bound.
- Added `mlsynth/tests/test_syndes_bound_failure.py` (17 tests).

## Why

`SYNDES(mode="two_way_global")` died on a 40-unit panel before returning a design:

```
File "mlsynth/utils/syndes_helpers/certificate.py", line 130, in _sdp_moment_bound_two_way
    return float(obj.value)
TypeError: float() argument must be a string or a real number, not 'NoneType'
```

The two-way bound lifts `x = [w; q; D]` to a `(3N+1)`-square moment matrix and hands it to SCS under a fixed 8000-iteration cap. At `N = 40` that is a 121x121 PSD program which does not converge, so `obj.value` is `None`. Because `accelerate` defaults to `True` and reaches the bound whenever the mode is two-way with an explicit `K`, `C(N, K) > accel_min_tuples` and `N <= certify_sdp_n_max`, this hit the default configuration.

The bound is a diagnostic and a dual-bound lift for the solver, never a correctness requirement — `solve_synthetic_design` has always declared `objective_lower_bound: Optional[float] = None`. A failed bound should cost solve time and nothing else.

`SYNDESCertificate` already documented the intended contract: `lower_bound : float or None` — "`None` only if the bound solve failed". No code path could produce that `None`; the dataclass anticipated a failure mode the implementation turned into a crash.

## How

`_continuous_relaxation_bound` had the same shape as the function that crashed — `prob.solve(solver=cp.CLARABEL)` then `float(comp.objective.value)`, no status check — so the same failure was reachable through the one-way and per-unit certificate paths. Both bounds read their objective through `_bound_value`, and a new `_certificate` assembler turns an absent bound into the documented no-bound certificate for every mode.

On the accelerator side the warm start is unaffected by a failed bound, so only the cut is dropped. The solve falls back to SCIP's own McCormick dual bound, which is slower, so the caller is warned with `N`, `K`, and how to skip the step.

## Verification

- Path: not applicable. No numerical code changed. The bounds compute the same values when they solve; the change is what happens when they do not.
- Pinned durably by `TestAcceleratorDropsTheCut::test_cut_present_when_the_bound_solves` and `TestCertificateReportsMissingBound::test_successful_certificate_unchanged`, which assert the solved path still returns a finite float and a certified certificate.
- `test_accelerated_design_matches_the_unaccelerated_one` pins the property that matters: with the bound failed, the accelerated design selects the same units as an `accelerate=False` solve. Losing the cut changes runtime, not the optimum.
- No benchmark values move.
- The original reproduction now returns a design in 120.8s (hitting `time_limit` and returning its incumbent) with the warning explaining the missing cut.

## Scope checks

<!-- BUG FIX -->
- [x] A test reproduces the defect and fails without the fix — 13 of the 17 new tests were red against `main`, at `certificate.py:130` with the reported `TypeError`; the other 4 are happy-path regressions that passed from the start.
- [x] It asserts the correct behaviour, not merely the absence of a crash — the tests pin `lower_bound is None`, `optimality_gap is None`, `certified is False`, a note naming the failed method, the warning, and that the returned design is unchanged.
- [x] No docs page, docstring, or comment still states the old behaviour — both bound docstrings now state the `None` case, and `SYNDESCertificate`'s existing docstring becomes accurate for the first time.
- [x] No pinned value moved.

## Designs

No visual output changed; this PR touches an internal bound and the estimator's error path.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_syndes_bound_failure.py -q` — 17 passed
- [x] `pytest mlsynth/tests/test_syndes*.py mlsynth/tests/test_simplex_*.py mlsynth/tests/test_miqp_accel.py mlsynth/tests/test_result_contract.py -q` — 576 passed
- [x] `coverage run --timid -m pytest mlsynth/tests/test_syndes_bound_failure.py mlsynth/tests/test_syndes_certificate.py mlsynth/tests/test_syndes_accelerate.py && coverage report` — `certificate.py` and `accelerate.py` both at 100%; the `syndes.py` diff is covered on both branches. No `# pragma: no cover` added.
- [x] Reproduced the original failure on a 40-market panel and confirmed it now returns a design.

## Other Notes

The underlying reason the bound fails at `N = 40` is the fixed `max_iters=8000` / `eps=1e-5` on the SCS solve, which is not tunable from `SYNDESConfig`. Making the bound's solver budget configurable, or scaling it with `N`, would let the acceleration engage where it currently gives up. Left out of this PR, which is about the crash.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cie5hE19cbHuBrs4EeS2my)_