### PR TITLE
Add an exact two-way SYNDES backend that searches treated sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,36 @@ now returns and the back-compat guarantee.
   Covered by `tests/test_spec.py`, including a parametrized check that `load_spec`
   resolves and behaves gracefully for every estimator the package ships.
 
+### Added
+- `SYNDESConfig.backend` selects how `mode="two_way_global"` is solved, and
+  defaults to `"mip"` so every existing fit is unchanged. `"exact"` searches
+  treated sets directly: naming the set removes the `q = w * D` coupling, so the
+  outer problem is a choice of treated set and the inner problem is convex. The
+  search scores every candidate with the closed form in
+  `utils/syndes_helpers/gram`, settles the candidates whose sign conditions are
+  slack, prunes the rest against the incumbent, and reaches the projected-
+  gradient solver in `utils/syndes_helpers/partition` only for the survivors --
+  nought or one design out of thousands on the panels used to develop it. A
+  candidate costs one row of a matrix product instead of a branch-and-bound
+  node, and `T` leaves the per-candidate cost once the Gram matrix is formed.
+  Above a candidate count the search falls back to a swap search reported
+  against the Rayleigh bound, and says so instead of claiming a certificate.
+
+  Comparing the two backends needs one caveat: `gap_limit` defaults to `0.05`,
+  so the MIP path may return a design 5 percent above the optimum, and does on
+  some panels. The two agree on the treated set once the MIP is asked to prove
+  optimality (`gap_limit=0.0`); otherwise the exact backend's design is the one
+  that is at least as good.
+
+  `backend="exact"` is rejected for `one_way_global` and `per_unit`, where the
+  reformulation does not apply, and with donor-side restrictions, which tie the
+  control weights to the assignment. Every other restriction is a predicate on
+  the treated set and is applied during the search. `select_by_holdout` takes a
+  `pool_fn` so holdout and IC selection reach the new backend. Covered by
+  `tests/test_syndes_exact.py`, `tests/test_syndes_partition.py`,
+  `tests/test_syndes_backend.py`, `tests/test_syndes_exact_properties.py`, and
+  nine semantic mutants in `tools/mutation/targets.toml`.
+
 ### Changed
 - The SYNDES two-way optimality certificate (`certify=True` with
   `mode="two_way_global"`) now reports a closed-form bound on the Gram matrix

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -748,6 +748,52 @@ amounts to maximizing :math:`\boldsymbol{\sigma}^\top \mathbf{R}\,
 cardinality-constrained max-cut. That is where the design problem's hardness
 lives once the weights are optimized away.
 
+Solving it that way
+~~~~~~~~~~~~~~~~~~~~~
+
+``backend`` chooses how ``mode="two_way_global"`` is solved. The default,
+``"mip"``, hands the mixed-integer program to ``solver`` exactly as before.
+``"exact"`` searches treated sets instead, using the reduction above.
+
+The search scores every candidate design with one matrix product, since
+:math:`\mathrm{lb}` depends on the design only through
+:math:`\boldsymbol{\sigma}`. Candidates whose sign conditions turn out slack are
+solved outright by that same formula, and the best of them becomes the
+incumbent; any candidate whose bound already exceeds the incumbent is discarded,
+because its true value can only be higher. Whatever survives goes to a projected-
+gradient solve over the two simplices, which reports a Frank-Wolfe duality gap so
+the answer certifies itself. On the panels used to develop it, nought or one
+design out of thousands reached that last step.
+
+What changes is the price of a candidate, not the complexity class. Choosing the
+treated set is still a cardinality-constrained max-cut, and above a candidate
+count the search stops enumerating, falls back to a swap search on
+:math:`\boldsymbol{\sigma}^\top \mathbf{R}\, \boldsymbol{\sigma}`, and reports
+the design against the Rayleigh bound instead of claiming a certificate. What it
+buys is that a candidate costs one row of a matrix product instead of a
+branch-and-bound node, and that :math:`T` leaves the per-candidate cost entirely
+once :math:`\mathbf{G}` is formed, so a 300-period panel costs what a 20-period
+one does.
+
+One consequence matters when comparing the two backends. ``gap_limit``
+defaults to ``0.05``, so the MIP path may stop at a design 5 percent above the
+optimum, and ``time_limit`` can stop it sooner. The exact backend has no such
+early exit below its candidate limit, so the two agree on the treated set only
+once the MIP is asked to prove optimality (``gap_limit=0.0``); otherwise the
+search's design is the one that is at least as good.
+
+``backend="exact"`` applies to two-way only. One-way pins the treated weights at
+:math:`1/K` and per-unit carries an :math:`(N, N)` weight matrix, so neither
+reduces to a search over treated sets. Donor-side restrictions
+(``donor_exclusion``, ``donor_region_col``) are refused as well: they tie the
+control weights to which units are treated, so a design stops being scoreable
+from its treated set alone. Every other restriction -- ``to_be_treated``,
+``not_to_be_treated``, cluster and adjacency conflicts, stratum quotas, size
+eligibility, ``costs`` with a ``budget`` -- is a predicate on the treated set and
+is applied while candidates are generated. ``gap_limit``, ``time_limit``,
+``solver`` and the ``accel_*`` fields describe branch-and-bound and are ignored
+by this path.
+
 Accelerating the solve
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -65,6 +65,10 @@ from ..utils.syndes_helpers.inference import (
 )
 from ..utils.syndes_helpers.holdout import select_by_holdout
 from ..utils.syndes_helpers.infocriterion import select_by_ic
+from ..utils.syndes_helpers.exact import (
+    solve_synthetic_design_exact,
+    solve_synthetic_design_exact_pool,
+)
 from ..utils.syndes_helpers.optimization import (
     solve_synthetic_design,
     solve_synthetic_design_pool,
@@ -326,6 +330,7 @@ class SYNDES:
         self.post_col: Optional[str] = config.post_col
         self.alpha: float = config.alpha
         self.run_inference: bool = config.run_inference
+        self.backend: str = config.backend
         self.solver: Any = config.solver
         self.gap_limit: Optional[float] = config.gap_limit
         self.time_limit: Optional[float] = config.time_limit
@@ -519,14 +524,30 @@ class SYNDES:
 
     def _fit_mip(self, inputs, restrictions=None) -> SYNDESResults:
         mode_internal = _MODE_TO_INTERNAL[self.mode_public]
+        use_exact = self.backend == "exact"
 
-        solve_kw = dict(
-            Y=inputs.Y_pre, K=self.K, mode=mode_internal, lam=self.lam,
-            solver=self.solver, verbose=self.verbose,
-            unit_index=inputs.unit_index, costs=self.costs, budget=self.budget,
-            gap_limit=self.gap_limit, time_limit=self.time_limit,
-            restrictions=restrictions,
-        )
+        if use_exact:
+            # The exact backend reformulates rather than relaxes, so it takes no
+            # solver knobs: `solver`, `verbose`, `gap_limit` and `time_limit`
+            # describe branch-and-bound, which it does not do.
+            solve_kw = dict(
+                Y=inputs.Y_pre, K=self.K, lam=self.lam,
+                unit_index=inputs.unit_index, costs=self.costs,
+                budget=self.budget, restrictions=restrictions,
+            )
+            solve_one, solve_pool = (solve_synthetic_design_exact,
+                                     solve_synthetic_design_exact_pool)
+        else:
+            solve_kw = dict(
+                Y=inputs.Y_pre, K=self.K, mode=mode_internal, lam=self.lam,
+                solver=self.solver, verbose=self.verbose,
+                unit_index=inputs.unit_index, costs=self.costs, budget=self.budget,
+                gap_limit=self.gap_limit, time_limit=self.time_limit,
+                restrictions=restrictions,
+            )
+            solve_one, solve_pool = (solve_synthetic_design,
+                                     solve_synthetic_design_pool)
+
         pool = None
         if self.selection == "holdout":
             # Holdout selection: learn the candidate pool on the leading
@@ -536,7 +557,7 @@ class SYNDES:
             base_kw = {k: v for k, v in solve_kw.items() if k != "Y"}
             ranked, oos_errors = select_by_holdout(
                 inputs.Y_pre, holdout_frac=self.holdout_frac,
-                top_K=self.top_K, **base_kw,
+                top_K=self.top_K, pool_fn=solve_pool, **base_kw,
             )
             self._require_feasible_pool(ranked)
             design = ranked[0]
@@ -546,7 +567,7 @@ class SYNDES:
             # Information-criterion selection: solve the pool on the whole
             # pre-period, then re-rank by IC = SSR_pre + 2 sigma^2 df (no data
             # split). The returned pool is ranked by IC (rank-1 is the winner).
-            pool_designs = solve_synthetic_design_pool(top_K=self.top_K, **solve_kw)
+            pool_designs = solve_pool(top_K=self.top_K, **solve_kw)
             self._require_feasible_pool(pool_designs)
             ranked, ic_values, df_values, _sigma2 = select_by_ic(
                 pool_designs, inputs.Y_pre,
@@ -557,12 +578,14 @@ class SYNDES:
         elif self.top_K and self.top_K > 1:
             # Solution pool: top-K distinct designs by no-good cuts. The rank-1
             # design IS the single-solve optimum, so reuse it (no double solve).
-            pool_designs = solve_synthetic_design_pool(top_K=self.top_K, **solve_kw)
+            pool_designs = solve_pool(top_K=self.top_K, **solve_kw)
             self._require_feasible_pool(pool_designs)
             design = pool_designs[0]
             pool = _syndes_pool_menu(pool_designs, inputs, self.costs, self.alpha)
+        elif use_exact:
+            design = solve_one(**solve_kw)
         else:
-            design = solve_synthetic_design(
+            design = solve_one(
                 **solve_kw, **self._accel_kwargs(inputs, mode_internal))
 
         # Re-tag with the paper-aligned mode label so the design surface

--- a/mlsynth/tests/test_syndes_backend.py
+++ b/mlsynth/tests/test_syndes_backend.py
@@ -1,0 +1,156 @@
+"""Tests for the ``backend`` switch on the SYNDES estimator.
+
+Contract. ``backend`` selects how ``mode="two_way_global"`` is solved and
+nothing else. It defaults to ``"mip"``, so every existing fit is byte-for-byte
+what it was; ``"exact"`` routes to the treated-set search, which minimises the
+same objective and must therefore reach the same design.
+
+The switch is refused where the reformulation does not apply: one-way pins the
+treated weights and per-unit carries an ``(N, N)`` weight matrix, so neither
+reduces to a search over treated sets, and donor-side restrictions tie the
+control weights to the assignment.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SYNDES
+from mlsynth.exceptions import MlsynthConfigError
+
+
+def _panel(n_units=9, T=16, n_post=4, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.standard_normal((T, 3))
+    L = rng.standard_normal((3, n_units))
+    Y = F @ L + 0.3 * rng.standard_normal((T, n_units))
+    return pd.DataFrame([
+        {"unit": f"u{j}", "time": t, "y": float(Y[t, j]),
+         "post": int(t >= T - n_post)}
+        for j in range(n_units) for t in range(T)
+    ])
+
+
+def _fit(**over):
+    cfg = {"df": _panel(), "outcome": "y", "unitid": "unit", "time": "time",
+           "K": 3, "mode": "two_way_global", "post_col": "post",
+           "run_inference": False}
+    cfg.update(over)
+    return SYNDES(cfg).fit()
+
+
+class TestDefault:
+    def test_backend_defaults_to_the_mip(self):
+        assert _fit().design.raw_results["solver"] != "exact"
+
+    def test_default_fit_is_unchanged(self):
+        """The switch must not perturb the existing path."""
+        explicit = _fit(backend="mip")
+        implicit = _fit()
+        assert (tuple(explicit.design.selected_unit_indices)
+                == tuple(implicit.design.selected_unit_indices))
+        assert explicit.design.objective_value == pytest.approx(
+            implicit.design.objective_value, rel=1e-12)
+
+
+class TestAgreement:
+    """The MIP path stops early by default, so parity is one-sided.
+
+    ``gap_limit`` defaults to 0.05, which lets SCIP return a design up to 5
+    percent above the optimum, and ``time_limit`` can cut it shorter still. The
+    exact backend does not stop early, so the claim that holds at every ``K`` is
+    that it is never worse. Strict set equality is asserted separately, with the
+    MIP told to prove optimality.
+    """
+
+    @pytest.mark.parametrize("K", [2, 3, 4])
+    def test_exact_is_never_worse(self, K):
+        mip, exact = _fit(backend="mip", K=K), _fit(backend="exact", K=K)
+        assert (float(exact.design.objective_value)
+                <= float(mip.design.objective_value) + 1e-8)
+
+    @pytest.mark.parametrize("K", [2, 3, 4])
+    def test_same_design_once_the_mip_must_prove_optimality(self, K):
+        mip = _fit(backend="mip", K=K, gap_limit=0.0, time_limit=600.0)
+        exact = _fit(backend="exact", K=K)
+        assert (tuple(mip.design.selected_unit_indices)
+                == tuple(exact.design.selected_unit_indices))
+        assert exact.design.objective_value == pytest.approx(
+            float(mip.design.objective_value), rel=1e-6)
+
+    def test_exact_reports_its_provenance(self):
+        design = _fit(backend="exact").design
+        assert design.raw_results["solver"] == "exact"
+        assert design.raw_results["certified"] is True
+
+    def test_mode_label_is_the_paper_vocabulary(self):
+        assert _fit(backend="exact").design.mode == "two_way_global"
+
+    def test_exact_beats_the_early_stopping_default_somewhere(self):
+        """Pin the reason parity is one-sided, so the gap_limit default is visible."""
+        beaten = []
+        for K in (2, 3, 4, 5):
+            mip, exact = _fit(backend="mip", K=K), _fit(backend="exact", K=K)
+            if float(exact.design.objective_value) < float(
+                    mip.design.objective_value) - 1e-9:
+                beaten.append(K)
+        assert beaten, (
+            "the MIP's 5 percent gap_limit never bound on this panel; if that "
+            "becomes true generally, the one-sided parity above can tighten")
+
+    def test_results_object_is_the_same_shape(self):
+        mip, exact = _fit(backend="mip"), _fit(backend="exact")
+        assert type(exact) is type(mip)
+        assert exact.design.treated_weights.shape == mip.design.treated_weights.shape
+
+
+class TestPoolAndSelection:
+    def test_pool_agrees_with_the_mip(self):
+        mip = _fit(backend="mip", top_K=3, selection="in_sample")
+        exact = _fit(backend="exact", top_K=3, selection="in_sample")
+        assert (tuple(mip.design.selected_unit_indices)
+                == tuple(exact.design.selected_unit_indices))
+
+    def test_holdout_selection_runs_on_the_exact_backend(self):
+        res = _fit(backend="exact", top_K=3, selection="holdout", holdout_frac=0.3)
+        assert int(res.design.assignment.sum()) == 3
+
+    def test_ic_selection_runs_on_the_exact_backend(self):
+        res = _fit(backend="exact", top_K=3, selection="ic")
+        assert int(res.design.assignment.sum()) == 3
+
+
+class TestRefusals:
+    @pytest.mark.parametrize("mode", ["one_way_global", "per_unit"])
+    def test_rejected_for_other_modes(self, mode):
+        with pytest.raises(MlsynthConfigError):
+            _fit(backend="exact", mode=mode)
+
+    def test_rejected_with_donor_exclusions(self):
+        adjacency = pd.DataFrame(
+            np.eye(9), index=[f"u{i}" for i in range(9)],
+            columns=[f"u{i}" for i in range(9)])
+        with pytest.raises(MlsynthConfigError):
+            _fit(backend="exact", donor_exclusion=adjacency)
+
+    def test_rejects_an_unknown_backend(self):
+        with pytest.raises((MlsynthConfigError, ValueError)):
+            _fit(backend="quantum")
+
+
+class TestRestrictionsThroughTheEstimator:
+    def test_forced_units_reach_the_search(self):
+        res = _fit(backend="exact", to_be_treated=["u0", "u4"])
+        chosen = set(res.design.selected_unit_labels)
+        assert {"u0", "u4"} <= chosen
+
+    def test_forbidden_units_are_excluded(self):
+        res = _fit(backend="exact", not_to_be_treated=["u1", "u2"])
+        assert not ({"u1", "u2"} & set(res.design.selected_unit_labels))
+
+    def test_budget_is_enforced(self):
+        costs = list(np.arange(1.0, 10.0))
+        res = _fit(backend="exact", costs=costs, budget=9.0)
+        spent = sum(costs[i] for i in res.design.selected_unit_indices)
+        assert spent <= 9.0 + 1e-9

--- a/mlsynth/tests/test_syndes_exact.py
+++ b/mlsynth/tests/test_syndes_exact.py
@@ -1,0 +1,417 @@
+"""Tests for the SYNDES exact two-way backend.
+
+Contract. ``solve_synthetic_design_exact`` returns the same ``SYNDESDesign`` the
+SCIP path returns, for ``mode="global_2way"``, by searching treated sets directly
+instead of branch-and-bound. It scores every candidate with the closed form from
+``gram``, settles the rows whose sign conditions are slack, prunes the rest
+against the incumbent, and calls the inner solver only on survivors.
+
+The load-bearing test in this module is parity: for every instance SCIP can
+finish, both backends must select the same treated set and agree on the
+objective. Everything else pins how the search behaves -- that pruning is sound,
+that restrictions are honoured as subset filters, that ``K=None`` ranges over
+cardinalities, and that the pool comes out ranked.
+
+Restrictions on the assignment (forced, forbidden, conflicting, stratum quotas,
+costs and a budget) are pure predicates on the treated set, so the search applies
+them while generating candidates. ``donor_exclusion`` is not: it ties the control
+weights to which units are treated, so the exact backend refuses it.
+"""
+from __future__ import annotations
+
+from itertools import combinations
+
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthEstimationError
+from mlsynth.utils.fast_scm_helpers.structure import IndexSet
+from mlsynth.utils.syndes_helpers.exact import (
+    SubsetFilter,
+    _stream_subsets,
+    solve_synthetic_design_exact,
+    solve_synthetic_design_exact_pool,
+)
+from mlsynth.utils.syndes_helpers.gram import TwoWayProblem
+from mlsynth.utils.syndes_helpers.optimization import solve_synthetic_design
+from mlsynth.utils.syndes_helpers.partition import (
+    solve_partition_batch,
+    split_indices,
+)
+from mlsynth.utils.syndes_helpers.restrictions import DesignRestrictions
+
+
+def _panel(N=9, T=14, rank=3, noise=0.35, seed=0):
+    rng = np.random.default_rng(seed)
+    return (rng.standard_normal((T, rank)) @ rng.standard_normal((rank, N))
+            + noise * rng.standard_normal((T, N)))
+
+
+def _brute_force(Y, K, lam=None):
+    """The optimum by evaluating every subset with the inner solver."""
+    problem = TwoWayProblem.from_panel(Y, lam=lam)
+    subsets = np.array(list(combinations(range(problem.N), K)), dtype=np.int64)
+    t, c = split_indices(problem.N, subsets)
+    values = solve_partition_batch(problem, t, c, max_iter=8000, tol=1e-14).value
+    best = int(np.argmin(values))
+    return tuple(subsets[best]), float(values[best])
+
+
+# ----------------------------------------------------------------------
+# parity with the MIP
+# ----------------------------------------------------------------------
+
+
+class TestParityWithScip:
+    @pytest.mark.parametrize("K", [2, 3, 4, 6])
+    def test_same_treated_set_and_objective(self, K):
+        Y = _panel()
+        mip = solve_synthetic_design(Y=Y, K=K, mode="global_2way", solver="SCIP")
+        exact = solve_synthetic_design_exact(Y=Y, K=K)
+        assert tuple(exact.selected_unit_indices) == tuple(
+            sorted(int(i) for i in np.flatnonzero(mip.assignment)))
+        assert exact.objective_value == pytest.approx(
+            float(mip.objective_value), rel=1e-6)
+
+    def test_exact_is_never_worse_than_the_mip(self):
+        """Both minimise the same objective, so the search cannot lose."""
+        for seed in (1, 2, 3):
+            Y = _panel(seed=seed)
+            mip = solve_synthetic_design(Y=Y, K=3, mode="global_2way", solver="SCIP")
+            exact = solve_synthetic_design_exact(Y=Y, K=3)
+            assert exact.objective_value <= float(mip.objective_value) + 1e-8
+
+    @pytest.mark.parametrize("lam", [0.01, 1.0, 7.5])
+    def test_parity_across_penalties(self, lam):
+        Y = _panel()
+        mip = solve_synthetic_design(Y=Y, K=3, mode="global_2way",
+                                     lam=lam, solver="SCIP")
+        exact = solve_synthetic_design_exact(Y=Y, K=3, lam=lam)
+        assert tuple(exact.selected_unit_indices) == tuple(
+            sorted(int(i) for i in np.flatnonzero(mip.assignment)))
+
+
+class TestAgreesWithBruteForce:
+    @pytest.mark.parametrize("K", [1, 2, 5, 8])
+    def test_finds_the_brute_force_optimum(self, K):
+        Y = _panel()
+        expected_set, expected_value = _brute_force(Y, K)
+        got = solve_synthetic_design_exact(Y=Y, K=K)
+        assert tuple(got.selected_unit_indices) == expected_set
+        assert got.objective_value == pytest.approx(expected_value, rel=1e-7)
+
+    def test_pruning_does_not_discard_the_optimum(self):
+        """A deliberately bad seed must not survive as the answer."""
+        Y = _panel()
+        expected_set, _ = _brute_force(Y, 3)
+        got = solve_synthetic_design_exact(Y=Y, K=3, incumbent_sets=np.array([[0, 1, 2]]))
+        assert tuple(got.selected_unit_indices) == expected_set
+
+
+# ----------------------------------------------------------------------
+# the design object it returns
+# ----------------------------------------------------------------------
+
+
+class TestDesignContract:
+    def test_populates_the_same_fields_as_the_mip(self):
+        Y = _panel()
+        mip = solve_synthetic_design(Y=Y, K=3, mode="global_2way", solver="SCIP")
+        exact = solve_synthetic_design_exact(Y=Y, K=3)
+        for field in ("mode", "objective_value", "lambda_value", "assignment",
+                      "selected_unit_indices", "selected_unit_labels",
+                      "assignment_by_unit", "w", "q", "treated_weights",
+                      "control_weights", "contrast_weights", "contrast_series",
+                      "pre_fit_rmse"):
+            assert getattr(exact, field) is not None, field
+            assert getattr(mip, field) is not None, field
+
+    def test_weight_conventions_match_the_mip(self):
+        """``q`` is the treated block, ``w - q`` the control block."""
+        Y = _panel()
+        exact = solve_synthetic_design_exact(Y=Y, K=3)
+        np.testing.assert_allclose(exact.q, exact.treated_weights, atol=1e-12)
+        np.testing.assert_allclose(exact.w - exact.q, exact.control_weights, atol=1e-12)
+        np.testing.assert_allclose(exact.contrast_weights,
+                                   exact.treated_weights - exact.control_weights,
+                                   atol=1e-12)
+        assert exact.treated_weights.sum() == pytest.approx(1.0)
+        assert exact.control_weights.sum() == pytest.approx(1.0)
+
+    def test_supports_are_disjoint_and_match_the_assignment(self):
+        Y = _panel()
+        exact = solve_synthetic_design_exact(Y=Y, K=3)
+        treated = exact.assignment.astype(bool)
+        assert np.all(exact.treated_weights[~treated] == 0.0)
+        assert np.all(exact.control_weights[treated] == 0.0)
+        assert int(exact.assignment.sum()) == 3
+
+    def test_contrast_series_and_rmse(self):
+        Y = _panel()
+        exact = solve_synthetic_design_exact(Y=Y, K=3)
+        np.testing.assert_allclose(exact.contrast_series,
+                                   Y @ exact.contrast_weights, atol=1e-10)
+        assert exact.pre_fit_rmse == pytest.approx(
+            float(np.sqrt(np.mean(exact.contrast_series ** 2))))
+
+    def test_unit_labels_are_carried_through(self):
+        Y = _panel()
+        labels = [f"u{i}" for i in range(Y.shape[1])]
+        exact = solve_synthetic_design_exact(
+            Y=Y, K=3, unit_index=IndexSet.from_labels(labels))
+        assert set(exact.selected_unit_labels) <= set(labels)
+        assert len(exact.selected_unit_labels) == 3
+        assert set(exact.assignment_by_unit) == set(labels)
+
+    def test_raw_results_record_how_the_search_went(self):
+        Y = _panel()
+        raw = solve_synthetic_design_exact(Y=Y, K=3).raw_results
+        assert raw["solver"] == "exact"
+        assert raw["n_designs"] == 84                      # C(9, 3)
+        assert raw["n_closed_form"] + raw["n_solved"] <= raw["n_designs"]
+        assert raw["certified"] is True
+        assert raw["duality_gap"] >= 0.0
+
+
+# ----------------------------------------------------------------------
+# restrictions, costs, and the pool
+# ----------------------------------------------------------------------
+
+
+class TestSubsetStream:
+    """A slice the filter empties is not the end of the stream."""
+
+    def test_yields_every_admissible_subset_across_chunks(self):
+        filt = SubsetFilter.build(DesignRestrictions(forced_in=[4]), N=6)
+        blocks = list(_stream_subsets(6, 2, filt, chunk=3))
+        seen = {tuple(row) for block in blocks for row in block}
+        expected = {s for s in combinations(range(6), 2) if 4 in s}
+        assert seen == expected
+
+    def test_survives_a_fully_filtered_leading_chunk(self):
+        """The first chunk is entirely rejected; later admissible sets still arrive."""
+        filt = SubsetFilter.build(DesignRestrictions(forced_in=[5]), N=6)
+        assert not filt.accepts((0, 1))                     # the first candidate
+        blocks = list(_stream_subsets(6, 2, filt, chunk=2))
+        seen = {tuple(row) for block in blocks for row in block}
+        assert seen == {s for s in combinations(range(6), 2) if 5 in s}
+
+    def test_empty_when_nothing_is_admissible(self):
+        filt = SubsetFilter.build(DesignRestrictions(forbidden=list(range(6))), N=6)
+        assert list(_stream_subsets(6, 2, filt, chunk=4)) == []
+
+    def test_respects_the_chunk_size(self):
+        filt = SubsetFilter.build(None, N=6)
+        for block in _stream_subsets(6, 2, filt, chunk=4):
+            assert block.shape[0] <= 4
+
+
+class TestRestrictions:
+    def test_forced_units_are_treated(self):
+        Y = _panel()
+        got = solve_synthetic_design_exact(
+            Y=Y, K=3, restrictions=DesignRestrictions(forced_in=[0, 5]))
+        assert {0, 5} <= set(int(i) for i in got.selected_unit_indices)
+
+    def test_forbidden_units_are_not_treated(self):
+        Y = _panel()
+        got = solve_synthetic_design_exact(
+            Y=Y, K=3, restrictions=DesignRestrictions(forbidden=[1, 2, 3]))
+        assert not ({1, 2, 3} & set(int(i) for i in got.selected_unit_indices))
+
+    def test_conflicting_pairs_are_never_both_treated(self):
+        Y = _panel()
+        got = solve_synthetic_design_exact(
+            Y=Y, K=4, restrictions=DesignRestrictions(conflict_pairs=[(0, 1), (2, 3)]))
+        chosen = set(int(i) for i in got.selected_unit_indices)
+        assert not {0, 1} <= chosen
+        assert not {2, 3} <= chosen
+
+    def test_stratum_quotas_are_respected(self):
+        Y = _panel()
+        got = solve_synthetic_design_exact(
+            Y=Y, K=4,
+            restrictions=DesignRestrictions(strata=[((0, 1, 2, 3), 2, 3)]))
+        inside = len({0, 1, 2, 3} & set(int(i) for i in got.selected_unit_indices))
+        assert 2 <= inside <= 3
+
+    def test_restricted_optimum_matches_a_filtered_brute_force(self):
+        Y = _panel()
+        restrictions = DesignRestrictions(forced_in=[0], forbidden=[8])
+        got = solve_synthetic_design_exact(Y=Y, K=3, restrictions=restrictions)
+        problem = TwoWayProblem.from_panel(Y)
+        allowed = [s for s in combinations(range(problem.N), 3)
+                   if 0 in s and 8 not in s]
+        subsets = np.array(allowed, dtype=np.int64)
+        t, c = split_indices(problem.N, subsets)
+        values = solve_partition_batch(problem, t, c, max_iter=8000, tol=1e-14).value
+        assert tuple(got.selected_unit_indices) == tuple(subsets[int(np.argmin(values))])
+
+    def test_budget_caps_total_cost(self):
+        Y = _panel()
+        costs = np.arange(1.0, Y.shape[1] + 1.0)
+        got = solve_synthetic_design_exact(Y=Y, K=3, costs=costs, budget=10.0)
+        assert costs[got.selected_unit_indices].sum() <= 10.0 + 1e-9
+
+    def test_infeasible_restrictions_raise(self):
+        Y = _panel()
+        with pytest.raises(MlsynthEstimationError):
+            solve_synthetic_design_exact(
+                Y=Y, K=2, restrictions=DesignRestrictions(conflict_pairs=[(0, 1)]),
+                forbidden_sets=[np.array([i, j]) for i, j in
+                                combinations(range(Y.shape[1]), 2)])
+
+    def test_donor_exclusions_are_refused(self):
+        """They couple the control weights to the assignment; the search cannot."""
+        Y = _panel()
+        with pytest.raises(MlsynthConfigError):
+            solve_synthetic_design_exact(
+                Y=Y, K=3,
+                restrictions=DesignRestrictions(donor_exclusion=[(0, 4)]))
+
+
+class TestPool:
+    def test_returns_distinct_designs_ranked_by_objective(self):
+        Y = _panel()
+        pool = solve_synthetic_design_exact_pool(Y=Y, K=3, top_K=5)
+        assert len(pool) == 5
+        values = [d.objective_value for d in pool]
+        assert values == sorted(values)
+        chosen = [tuple(d.selected_unit_indices) for d in pool]
+        assert len(set(chosen)) == 5
+
+    def test_first_entry_is_the_single_optimum(self):
+        Y = _panel()
+        pool = solve_synthetic_design_exact_pool(Y=Y, K=3, top_K=4)
+        single = solve_synthetic_design_exact(Y=Y, K=3)
+        assert tuple(pool[0].selected_unit_indices) == tuple(single.selected_unit_indices)
+        assert pool[0].objective_value == pytest.approx(single.objective_value, rel=1e-9)
+
+    def test_stops_early_when_the_region_is_exhausted(self):
+        Y = _panel(N=4, T=10)
+        pool = solve_synthetic_design_exact_pool(Y=Y, K=3, top_K=99)
+        assert len(pool) == 4                              # C(4, 3)
+
+    def test_rejects_a_nonpositive_top_k(self):
+        with pytest.raises(MlsynthConfigError):
+            solve_synthetic_design_exact_pool(Y=_panel(), K=3, top_K=0)
+
+
+# ----------------------------------------------------------------------
+# cardinality
+# ----------------------------------------------------------------------
+
+
+class TestCardinality:
+    def test_k_none_searches_every_size(self):
+        """The paper allows an unpinned K for the global modes."""
+        Y = _panel(N=7, T=12)
+        got = solve_synthetic_design_exact(Y=Y, K=None)
+        assert 1 <= int(got.assignment.sum()) <= 6
+        best = min(_brute_force(Y, k)[1] for k in range(1, 7))
+        assert got.objective_value == pytest.approx(best, rel=1e-7)
+
+    @pytest.mark.parametrize("K", [1, 8])
+    def test_extreme_cardinalities(self, K):
+        Y = _panel()
+        got = solve_synthetic_design_exact(Y=Y, K=K)
+        assert int(got.assignment.sum()) == K
+
+    def test_rejects_out_of_range_k(self):
+        Y = _panel()
+        with pytest.raises(MlsynthConfigError):
+            solve_synthetic_design_exact(Y=Y, K=0)
+        with pytest.raises(MlsynthConfigError):
+            solve_synthetic_design_exact(Y=Y, K=Y.shape[1])
+
+
+class TestSurvivorPath:
+    """When the sign conditions bind, the closed form only bounds and the QP runs.
+
+    A small penalty is what makes them bind: the ridge pulls both weight vectors
+    toward uniform, and as it shrinks the unconstrained minimiser starts putting
+    negative mass on treated units. The panel is full rank so the Gram matrix
+    stays invertible at that penalty.
+    """
+
+    # A full-rank panel at a small penalty where the incumbent from the exact
+    # rows does not prune everything: only 1 of 120 designs settles in closed
+    # form, and 19 survive the screen to reach the inner solver.
+    LAM = 0.05
+    K = 3
+
+    def _full_rank_panel(self, N=10, T=12, seed=0):
+        rng = np.random.default_rng(seed)
+        return rng.standard_normal((T, N))
+
+    def test_some_designs_reach_the_inner_solver(self):
+        Y = self._full_rank_panel()
+        got = solve_synthetic_design_exact(Y=Y, K=self.K, lam=self.LAM)
+        assert got.raw_results["n_solved"] > 0, "the survivor path never ran"
+        assert got.raw_results["n_closed_form"] < got.raw_results["n_designs"]
+
+    def test_still_finds_the_brute_force_optimum(self):
+        Y = self._full_rank_panel()
+        expected_set, expected_value = _brute_force(Y, self.K, lam=self.LAM)
+        got = solve_synthetic_design_exact(Y=Y, K=self.K, lam=self.LAM)
+        assert tuple(got.selected_unit_indices) == expected_set
+        assert got.objective_value == pytest.approx(expected_value, rel=1e-6)
+
+    def test_matches_scip_on_the_binding_instance(self):
+        Y = self._full_rank_panel()
+        mip = solve_synthetic_design(Y=Y, K=self.K, mode="global_2way",
+                                     lam=self.LAM, solver="SCIP")
+        got = solve_synthetic_design_exact(Y=Y, K=self.K, lam=self.LAM)
+        assert got.objective_value <= float(mip.objective_value) + 1e-8
+
+
+class TestCostValidation:
+    def test_costs_without_budget_raises(self):
+        with pytest.raises(MlsynthConfigError):
+            solve_synthetic_design_exact(Y=_panel(), K=3, costs=np.ones(9))
+
+    def test_budget_without_costs_raises(self):
+        with pytest.raises(MlsynthConfigError):
+            solve_synthetic_design_exact(Y=_panel(), K=3, budget=5.0)
+
+    def test_wrong_length_costs_raises(self):
+        with pytest.raises(MlsynthConfigError):
+            solve_synthetic_design_exact(Y=_panel(), K=3, costs=np.ones(3), budget=5.0)
+
+    def test_negative_costs_raise(self):
+        costs = np.ones(9); costs[2] = -1.0
+        with pytest.raises(MlsynthConfigError):
+            solve_synthetic_design_exact(Y=_panel(), K=3, costs=costs, budget=5.0)
+
+    def test_nonpositive_budget_raises(self):
+        with pytest.raises(MlsynthConfigError):
+            solve_synthetic_design_exact(Y=_panel(), K=3, costs=np.ones(9), budget=0.0)
+
+
+class TestLargeInstanceFallback:
+    def test_falls_back_to_search_when_enumeration_is_too_large(self):
+        """Above the candidate limit the answer is a design plus a bound."""
+        Y = _panel(N=24, T=30, seed=5)
+        got = solve_synthetic_design_exact(Y=Y, K=8, candidate_limit=1000)
+        assert int(got.assignment.sum()) == 8
+        assert got.raw_results["certified"] is False
+        assert got.raw_results["lower_bound"] <= got.objective_value + 1e-9
+
+    def test_enumerates_below_the_limit(self):
+        Y = _panel()
+        got = solve_synthetic_design_exact(Y=Y, K=3, candidate_limit=10_000)
+        assert got.raw_results["certified"] is True
+
+    def test_restrictions_past_the_limit_are_refused(self):
+        """The fallback searches the unrestricted space, so it must not pretend."""
+        Y = _panel(N=24, T=30, seed=5)
+        with pytest.raises(MlsynthConfigError):
+            solve_synthetic_design_exact(
+                Y=Y, K=8, candidate_limit=1000,
+                restrictions=DesignRestrictions(forced_in=[0]))
+
+    def test_ill_conditioned_and_too_large_is_reported(self):
+        rng = np.random.default_rng(9)
+        Y = rng.standard_normal((6, 3)) @ rng.standard_normal((3, 24))
+        with pytest.raises(MlsynthEstimationError):
+            solve_synthetic_design_exact(Y=Y, K=8, lam=1e-14, candidate_limit=1000)

--- a/mlsynth/tests/test_syndes_exact.py
+++ b/mlsynth/tests/test_syndes_exact.py
@@ -6,9 +6,8 @@ instead of branch-and-bound. It scores every candidate with the closed form from
 ``gram``, settles the rows whose sign conditions are slack, prunes the rest
 against the incumbent, and calls the inner solver only on survivors.
 
-The load-bearing test in this module is parity: for every instance SCIP can
-finish, both backends must select the same treated set and agree on the
-objective. Everything else pins how the search behaves -- that pruning is sound,
+Parity is the test this module rests on: for every instance SCIP can finish,
+both backends must select the same treated set and agree on the objective. Everything else pins how the search behaves -- that pruning is sound,
 that restrictions are honoured as subset filters, that ``K=None`` ranges over
 cardinalities, and that the pool comes out ranked.
 

--- a/mlsynth/tests/test_syndes_exact_properties.py
+++ b/mlsynth/tests/test_syndes_exact_properties.py
@@ -1,0 +1,228 @@
+"""Generative property tests for the SYNDES inner solver and exact backend.
+
+Reference: Doudchenko, Khosravi, Imbens et al. (2021), the two-way global
+program. Once the treated set is named the program is convex, so the claims here
+hold for every panel, penalty and treated set and are asserted over the domain
+instead of at a fixture.
+
+Why this layer. :mod:`mlsynth.utils.syndes_helpers.partition` is a Layer 1
+helper -- pure linear algebra over a fixed Gram matrix -- which
+``agents/agents_tests.md`` makes the first-choice target for property testing.
+The exact backend sits a layer up, and only its differential claim is generated
+here: on any instance small enough to enumerate, its answer must be the
+brute-force optimum. That is a property with a known truth, which is what makes
+it generable at all.
+
+Two properties carry the weight.
+
+The Frank-Wolfe gap is what lets every other consumer trust an answer without a
+reference solver. ``value - gap`` must lower-bound the converged optimum, or the
+exact backend's pruning is unsound and can discard the true optimum.
+
+The differential claim -- exact backend equals brute force -- is the one that
+would catch a search bug. Pruning, incumbent seeding and the closed-form
+shortcut are all optimisations over "evaluate everything", so any of them going
+wrong shows up exactly here.
+
+Conditioning, not solver tolerance, is the limit: the closed form inverts
+``G + lam I``, so the generators keep ``T >= N`` and ``lam`` away from zero, and
+``assume`` discards any draw the module declines as ill-conditioned.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+import numpy as np
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils.syndes_helpers.exact import solve_synthetic_design_exact
+from mlsynth.utils.syndes_helpers.gram import (
+    BoundEngine,
+    TwoWayProblem,
+    signs_from_subsets,
+)
+from mlsynth.utils.syndes_helpers.partition import (
+    project_simplex,
+    solve_partition_batch,
+    split_indices,
+)
+
+_entry = st.floats(min_value=-5.0, max_value=5.0,
+                   allow_nan=False, allow_infinity=False)
+_penalty = st.floats(min_value=1e-3, max_value=10.0,
+                     allow_nan=False, allow_infinity=False)
+
+
+@st.composite
+def panels(draw, min_units: int = 2, max_units: int = 6) -> np.ndarray:
+    """A ``(T, N)`` pre-period matrix with ``T >= N``."""
+    N = draw(st.integers(min_value=min_units, max_value=max_units))
+    T = draw(st.integers(min_value=N, max_value=N + 4))
+    flat = draw(st.lists(_entry, min_size=T * N, max_size=T * N))
+    Y = np.asarray(flat, dtype=float).reshape(T, N)
+    assume(np.abs(Y).max() > 1e-6)
+    return Y
+
+
+@st.composite
+def instances(draw):
+    """A panel, a penalty, the reduced problem, and a treated-set size."""
+    Y = draw(panels())
+    lam = draw(_penalty)
+    problem = TwoWayProblem.from_panel(Y, lam=lam)
+    assume(BoundEngine.from_problem(problem).reliable)
+    K = draw(st.integers(min_value=1, max_value=problem.N - 1))
+    return Y, problem, K
+
+
+def _all_subsets(N, K):
+    return np.array(list(combinations(range(N), K)), dtype=np.int64)
+
+
+# ----------------------------------------------------------------------
+# the projection
+# ----------------------------------------------------------------------
+
+
+@settings(max_examples=200)
+@given(st.lists(st.lists(_entry, min_size=1, max_size=8), min_size=1, max_size=12))
+def test_projection_lands_on_the_simplex(rows):
+    width = min(len(r) for r in rows)
+    V = np.array([r[:width] for r in rows], dtype=float)
+    P = project_simplex(V)
+    assert np.abs(P.sum(axis=1) - 1.0).max() <= 1e-9
+    assert P.min() >= -1e-15
+
+
+@settings(max_examples=150)
+@given(st.lists(st.lists(_entry, min_size=1, max_size=8), min_size=1, max_size=12))
+def test_projection_is_idempotent(rows):
+    width = min(len(r) for r in rows)
+    P = project_simplex(np.array([r[:width] for r in rows], dtype=float))
+    np.testing.assert_allclose(project_simplex(P), P, atol=1e-10)
+
+
+# ----------------------------------------------------------------------
+# the inner solve
+# ----------------------------------------------------------------------
+
+
+@settings(max_examples=120, deadline=None)
+@given(instances())
+def test_weights_are_feasible(inst):
+    _, problem, K = inst
+    t, c = split_indices(problem.N, _all_subsets(problem.N, K))
+    out = solve_partition_batch(problem, t, c, max_iter=1500, tol=1e-13)
+    assert np.abs(out.treated_weights.sum(axis=1) - 1.0).max() <= 1e-8
+    assert np.abs(out.control_weights.sum(axis=1) - 1.0).max() <= 1e-8
+    assert out.treated_weights.min() >= -1e-12
+    assert out.control_weights.min() >= -1e-12
+
+
+@settings(max_examples=120, deadline=None)
+@given(instances())
+def test_value_is_the_objective_at_the_returned_weights(inst):
+    _, problem, K = inst
+    subsets = _all_subsets(problem.N, K)
+    t, c = split_indices(problem.N, subsets)
+    out = solve_partition_batch(problem, t, c, max_iter=1500, tol=1e-13)
+    for row in range(subsets.shape[0]):
+        a = np.zeros(problem.N); a[t[row]] = out.treated_weights[row]
+        b = np.zeros(problem.N); b[c[row]] = out.control_weights[row]
+        assert abs(problem.evaluate(a, b) - out.value[row]) <= 1e-8 * max(
+            1.0, abs(out.value[row]))
+
+
+@settings(max_examples=120, deadline=None)
+@given(instances())
+def test_gap_lower_bounds_the_converged_optimum(inst):
+    """``value - gap`` must bound below, or the backend's pruning is unsound."""
+    _, problem, K = inst
+    t, c = split_indices(problem.N, _all_subsets(problem.N, K))
+    loose = solve_partition_batch(problem, t, c, max_iter=15, tol=0.0)
+    tight = solve_partition_batch(problem, t, c, max_iter=4000, tol=1e-14)
+    assert np.all(loose.gap >= 0.0)
+    scale = max(float(np.abs(tight.value).max()), 1e-300)
+    assert np.all(loose.value - loose.gap <= tight.value + 1e-7 * scale)
+
+
+@settings(max_examples=120, deadline=None)
+@given(instances())
+def test_agrees_with_the_closed_form_where_it_is_exact(inst):
+    """The seam between ``partition`` and ``gram``, with no reference solver."""
+    _, problem, K = inst
+    engine = BoundEngine.from_problem(problem)
+    subsets = _all_subsets(problem.N, K)
+    closed = engine.bound(signs_from_subsets(problem.N, subsets))
+    assume(closed.exact.any())
+    t, c = split_indices(problem.N, subsets)
+    iterative = solve_partition_batch(problem, t, c, max_iter=4000, tol=1e-14)
+    scale = max(float(np.abs(iterative.value).max()), 1e-300)
+    rows = np.flatnonzero(closed.exact)
+    assert np.max(np.abs(iterative.value[rows] - closed.lower[rows])) <= 1e-7 * scale
+
+
+@settings(max_examples=120, deadline=None)
+@given(instances())
+def test_closed_form_never_exceeds_the_solved_value(inst):
+    """``lb(S) <= f(S)``, with the two sides computed by different modules."""
+    _, problem, K = inst
+    engine = BoundEngine.from_problem(problem)
+    subsets = _all_subsets(problem.N, K)
+    closed = engine.bound(signs_from_subsets(problem.N, subsets))
+    t, c = split_indices(problem.N, subsets)
+    iterative = solve_partition_batch(problem, t, c, max_iter=4000, tol=1e-14)
+    scale = max(float(np.abs(iterative.value).max()), 1e-300)
+    assert np.all(closed.lower <= iterative.value + 1e-7 * scale)
+
+
+@settings(max_examples=80, deadline=None)
+@given(instances(), st.floats(min_value=0.25, max_value=4.0,
+                              allow_nan=False, allow_infinity=False))
+def test_scaling_the_panel_scales_the_value_quadratically(inst, c):
+    """``Y -> cY`` with ``lam -> c^2 lam`` scales the objective by ``c^2``."""
+    Y, problem, K = inst
+    scaled = TwoWayProblem.from_panel(Y * c, lam=problem.lam * c * c)
+    assume(BoundEngine.from_problem(scaled).reliable)
+    ti, ci = split_indices(problem.N, _all_subsets(problem.N, K))
+    base = solve_partition_batch(problem, ti, ci, max_iter=3000, tol=1e-14).value
+    after = solve_partition_batch(scaled, ti, ci, max_iter=3000, tol=1e-14).value
+    np.testing.assert_allclose(after, base * c * c, rtol=1e-5, atol=1e-12)
+
+
+# ----------------------------------------------------------------------
+# the exact backend, against brute force
+# ----------------------------------------------------------------------
+
+
+@settings(max_examples=60, deadline=None)
+@given(instances())
+def test_exact_backend_matches_brute_force(inst):
+    """Pruning, seeding and the closed-form shortcut all fold into this claim."""
+    Y, problem, K = inst
+    subsets = _all_subsets(problem.N, K)
+    t, c = split_indices(problem.N, subsets)
+    values = solve_partition_batch(problem, t, c, max_iter=4000, tol=1e-14).value
+    best = float(values.min())
+
+    got = solve_synthetic_design_exact(Y=Y, K=K, lam=problem.lam)
+    scale = max(abs(best), 1e-300)
+    assert got.objective_value <= best + 1e-7 * scale
+
+
+@settings(max_examples=60, deadline=None)
+@given(instances())
+def test_exact_backend_returns_a_consistent_design(inst):
+    Y, problem, K = inst
+    got = solve_synthetic_design_exact(Y=Y, K=K, lam=problem.lam)
+    treated = got.assignment.astype(bool)
+    assert int(treated.sum()) == K
+    assert abs(got.treated_weights.sum() - 1.0) <= 1e-7
+    assert abs(got.control_weights.sum() - 1.0) <= 1e-7
+    assert np.abs(got.treated_weights[~treated]).max() <= 1e-12
+    assert np.abs(got.control_weights[treated]).max() <= 1e-12
+    assert got.objective_value == np.float64(got.objective_value)
+    np.testing.assert_allclose(got.contrast_series, Y @ got.contrast_weights,
+                               atol=1e-9)

--- a/mlsynth/tests/test_syndes_partition.py
+++ b/mlsynth/tests/test_syndes_partition.py
@@ -1,0 +1,309 @@
+"""Tests for the SYNDES inner solver: the QP that remains once ``S`` is named.
+
+Contract. With the treated set fixed, the two-way global problem is a strictly
+convex quadratic program over a product of two simplices,
+
+    f(S) = min { u'(G + lam I)u : u_S >= 0, sum_S u = 1;
+                                  u_Sc <= 0, sum_Sc u = -1 },
+
+which :mod:`mlsynth.utils.syndes_helpers.partition` solves for a whole batch of
+treated sets at once. Every solve reports a Frank-Wolfe duality gap, so
+``value - gap`` is a valid lower bound and the caller can tell a converged answer
+from an unconverged one without consulting a reference solver.
+
+What the tests pin:
+
+* the projection is the Euclidean projection onto the simplex;
+* the returned weights are feasible for the program (supports and sums);
+* the reported value is the objective at those weights;
+* the value agrees with cvxpy where cvxpy is accurate;
+* the value agrees with the closed form on rows where the closed form is exact,
+  which is the seam between this module and ``gram``;
+* batching changes nothing -- a design solved alone and in company agree.
+"""
+from __future__ import annotations
+
+from itertools import combinations
+
+import cvxpy as cp
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.syndes_helpers.gram import (
+    BoundEngine,
+    TwoWayProblem,
+    signs_from_subsets,
+)
+from mlsynth.utils.syndes_helpers.partition import (
+    project_simplex,
+    solve_partition_batch,
+    split_indices,
+)
+
+
+def _panel(N=8, T=13, rank=3, noise=0.35, seed=0):
+    rng = np.random.default_rng(seed)
+    return (rng.standard_normal((T, rank)) @ rng.standard_normal((rank, N))
+            + noise * rng.standard_normal((T, N)))
+
+
+def _reference_f(problem, treated):
+    """``f(S)`` via cvxpy, independent of the module under test."""
+    N = problem.N
+    mask = np.zeros(N, dtype=bool)
+    mask[list(treated)] = True
+    a, b = cp.Variable(N, nonneg=True), cp.Variable(N, nonneg=True)
+    u = a - b
+    cp.Problem(
+        cp.Minimize(cp.quad_form(u, problem.G, assume_PSD=True)
+                    + problem.lam * (cp.sum_squares(a) + cp.sum_squares(b))),
+        [cp.sum(a) == 1, cp.sum(b) == 1, a[~mask] == 0, b[mask] == 0],
+    ).solve(solver=cp.CLARABEL)
+    av, bv = a.value, b.value
+    uu = av - bv
+    return float(uu @ problem.G @ uu + problem.lam * (av @ av + bv @ bv))
+
+
+def _subsets(N, K):
+    return np.array(list(combinations(range(N), K)), dtype=np.int64)
+
+
+# ----------------------------------------------------------------------
+# simplex projection
+# ----------------------------------------------------------------------
+
+
+class TestProjection:
+    def test_lands_on_the_simplex(self):
+        rng = np.random.default_rng(0)
+        P = project_simplex(rng.normal(size=(200, 7)))
+        np.testing.assert_allclose(P.sum(axis=1), 1.0, atol=1e-12)
+        assert P.min() >= -1e-15
+
+    def test_matches_cvxpy_objective(self):
+        """CLARABEL settles short, so compare objectives: ours must not be worse."""
+        rng = np.random.default_rng(1)
+        V = rng.normal(size=(40, 6))
+        P = project_simplex(V)
+        for i in range(V.shape[0]):
+            x = cp.Variable(6, nonneg=True)
+            cp.Problem(cp.Minimize(cp.sum_squares(x - V[i])),
+                       [cp.sum(x) == 1]).solve(solver=cp.CLARABEL)
+            assert ((P[i] - V[i]) ** 2).sum() <= ((x.value - V[i]) ** 2).sum() + 1e-9
+
+    def test_is_idempotent_on_the_simplex(self):
+        rng = np.random.default_rng(2)
+        P = project_simplex(rng.normal(size=(50, 5)))
+        np.testing.assert_allclose(project_simplex(P), P, atol=1e-12)
+
+    def test_single_column_is_the_only_vertex(self):
+        np.testing.assert_allclose(
+            project_simplex(np.array([[-4.0], [7.0]])), np.ones((2, 1)))
+
+    def test_rejects_a_non_two_dimensional_input(self):
+        with pytest.raises(MlsynthConfigError):
+            project_simplex(np.ones(5))
+
+    def test_rejects_a_zero_width_input(self):
+        with pytest.raises(MlsynthConfigError):
+            project_simplex(np.zeros((3, 0)))
+
+
+# ----------------------------------------------------------------------
+# index bookkeeping
+# ----------------------------------------------------------------------
+
+
+class TestStepSize:
+    def test_step_is_the_reciprocal_of_twice_the_top_eigenvalue(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        top = float(np.linalg.eigvalsh(problem.M)[-1])
+        assert problem.step == pytest.approx(1.0 / (2.0 * top), rel=1e-12)
+
+    def test_step_is_valid_for_every_restricted_subproblem(self):
+        """No treated set may see a curvature above the one the step assumes."""
+        problem = TwoWayProblem.from_panel(_panel())
+        ceiling = 1.0 / (2.0 * problem.step)
+        for subset in _subsets(problem.N, 3):
+            signs = -np.ones(problem.N)
+            signs[subset] = 1.0
+            flipped = problem.M * np.outer(signs, signs)
+            assert float(np.linalg.eigvalsh(flipped)[-1]) <= ceiling + 1e-9
+
+
+class TestSplitIndices:
+    def test_control_is_the_complement(self):
+        treated = np.array([[0, 3], [1, 2]], dtype=np.int64)
+        t, c = split_indices(5, treated)
+        np.testing.assert_array_equal(t, treated)
+        np.testing.assert_array_equal(c, np.array([[1, 2, 4], [0, 3, 4]]))
+
+    def test_rejects_duplicate_units(self):
+        with pytest.raises(MlsynthConfigError):
+            split_indices(5, np.array([[1, 1]], dtype=np.int64))
+
+    def test_rejects_out_of_range(self):
+        with pytest.raises(MlsynthConfigError):
+            split_indices(4, np.array([[0, 9]], dtype=np.int64))
+
+
+# ----------------------------------------------------------------------
+# the inner solve
+# ----------------------------------------------------------------------
+
+
+class TestInnerSolve:
+    def test_weights_are_feasible(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        subsets = _subsets(problem.N, 3)
+        t, c = split_indices(problem.N, subsets)
+        out = solve_partition_batch(problem, t, c)
+        np.testing.assert_allclose(out.treated_weights.sum(axis=1), 1.0, atol=1e-9)
+        np.testing.assert_allclose(out.control_weights.sum(axis=1), 1.0, atol=1e-9)
+        assert out.treated_weights.min() >= -1e-12
+        assert out.control_weights.min() >= -1e-12
+
+    def test_value_is_the_objective_at_the_returned_weights(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        subsets = _subsets(problem.N, 3)
+        t, c = split_indices(problem.N, subsets)
+        out = solve_partition_batch(problem, t, c)
+        for row in range(subsets.shape[0]):
+            a = np.zeros(problem.N); a[t[row]] = out.treated_weights[row]
+            b = np.zeros(problem.N); b[c[row]] = out.control_weights[row]
+            assert problem.evaluate(a, b) == pytest.approx(out.value[row], rel=1e-9)
+
+    @pytest.mark.parametrize("K", [1, 2, 4, 7])
+    def test_agrees_with_cvxpy(self, K):
+        problem = TwoWayProblem.from_panel(_panel())
+        subsets = _subsets(problem.N, K)
+        t, c = split_indices(problem.N, subsets)
+        out = solve_partition_batch(problem, t, c, max_iter=6000, tol=1e-14)
+        reference = np.array([_reference_f(problem, s) for s in subsets])
+        scale = max(reference.max(), 1e-12)
+        assert np.max(np.abs(out.value - reference)) <= 1e-7 * scale
+
+    def test_gap_is_nonnegative_and_bounds_below(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        subsets = _subsets(problem.N, 3)
+        t, c = split_indices(problem.N, subsets)
+        out = solve_partition_batch(problem, t, c, max_iter=40, tol=0.0)
+        assert np.all(out.gap >= 0.0)
+        tight = solve_partition_batch(problem, t, c, max_iter=8000, tol=1e-14)
+        scale = max(tight.value.max(), 1e-12)
+        assert np.all(out.value - out.gap <= tight.value + 1e-9 * scale)
+
+    def test_more_iterations_never_worsen_the_value(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        subsets = _subsets(problem.N, 3)
+        t, c = split_indices(problem.N, subsets)
+        short = solve_partition_batch(problem, t, c, max_iter=25, tol=0.0)
+        long = solve_partition_batch(problem, t, c, max_iter=4000, tol=1e-14)
+        scale = max(long.value.max(), 1e-12)
+        assert np.all(long.value <= short.value + 1e-9 * scale)
+
+    def test_batching_changes_nothing(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        subsets = _subsets(problem.N, 3)
+        t, c = split_indices(problem.N, subsets)
+        together = solve_partition_batch(problem, t, c, max_iter=3000, tol=1e-14)
+        for row in (0, 5, len(subsets) - 1):
+            alone = solve_partition_batch(
+                problem, t[row][None, :], c[row][None, :],
+                max_iter=3000, tol=1e-14)
+            assert alone.value[0] == pytest.approx(together.value[row], rel=1e-8)
+
+
+class TestAgreementWithTheClosedForm:
+    """The seam between ``partition`` and ``gram``, checked without a reference."""
+
+    def test_matches_the_closed_form_where_it_is_exact(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        engine = BoundEngine.from_problem(problem)
+        subsets = _subsets(problem.N, 3)
+        closed = engine.bound(signs_from_subsets(problem.N, subsets))
+        t, c = split_indices(problem.N, subsets)
+        iterative = solve_partition_batch(problem, t, c, max_iter=8000, tol=1e-14)
+
+        assert closed.exact.any(), "no subset was settled in closed form"
+        scale = max(iterative.value.max(), 1e-12)
+        exact_rows = np.flatnonzero(closed.exact)
+        assert np.max(np.abs(
+            iterative.value[exact_rows] - closed.lower[exact_rows])) <= 1e-7 * scale
+
+    def test_never_falls_below_the_closed_form_bound(self):
+        """``lb(S) <= f(S)``, with ``f`` computed here and ``lb`` computed there."""
+        problem = TwoWayProblem.from_panel(_panel())
+        engine = BoundEngine.from_problem(problem)
+        subsets = _subsets(problem.N, 4)
+        closed = engine.bound(signs_from_subsets(problem.N, subsets))
+        t, c = split_indices(problem.N, subsets)
+        iterative = solve_partition_batch(problem, t, c, max_iter=8000, tol=1e-14)
+        scale = max(iterative.value.max(), 1e-12)
+        assert np.all(closed.lower <= iterative.value + 1e-8 * scale)
+
+
+# ----------------------------------------------------------------------
+# edges and failures
+# ----------------------------------------------------------------------
+
+
+class TestEdges:
+    def test_single_treated_unit(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        t, c = split_indices(problem.N, np.array([[2]], dtype=np.int64))
+        out = solve_partition_batch(problem, t, c, max_iter=4000, tol=1e-14)
+        assert out.treated_weights.shape == (1, 1)
+        assert out.treated_weights[0, 0] == pytest.approx(1.0)
+        assert out.value[0] == pytest.approx(_reference_f(problem, [2]), rel=1e-6)
+
+    def test_single_control_unit(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        treated = np.array([[i for i in range(problem.N) if i != 3]], dtype=np.int64)
+        t, c = split_indices(problem.N, treated)
+        out = solve_partition_batch(problem, t, c, max_iter=4000, tol=1e-14)
+        assert out.control_weights[0, 0] == pytest.approx(1.0)
+
+    def test_two_units(self):
+        problem = TwoWayProblem.from_panel(_panel(N=2, T=6))
+        t, c = split_indices(2, np.array([[0]], dtype=np.int64))
+        out = solve_partition_batch(problem, t, c, max_iter=4000, tol=1e-14)
+        assert out.value[0] == pytest.approx(_reference_f(problem, [0]), rel=1e-6)
+
+    def test_duplicate_donors_do_not_break_the_solve(self):
+        Y = _panel(N=6, T=12, rank=2, noise=0.0)
+        Y[:, 1] = Y[:, 0]
+        problem = TwoWayProblem.from_panel(Y)
+        t, c = split_indices(6, _subsets(6, 2))
+        out = solve_partition_batch(problem, t, c, max_iter=4000, tol=1e-13)
+        assert np.all(np.isfinite(out.value))
+        assert np.all(out.gap >= 0.0)
+
+
+class TestFailures:
+    def test_rejects_mismatched_batch_sizes(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        t = np.array([[0, 1], [2, 3]], dtype=np.int64)
+        c = np.array([[2, 3, 4, 5, 6, 7]], dtype=np.int64)
+        with pytest.raises(MlsynthConfigError):
+            solve_partition_batch(problem, t, c)
+
+    def test_rejects_an_empty_side(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        with pytest.raises(MlsynthConfigError):
+            solve_partition_batch(problem, np.zeros((1, 0), dtype=np.int64),
+                                  np.arange(problem.N)[None, :])
+
+    def test_rejects_indices_out_of_range(self):
+        problem = TwoWayProblem.from_panel(_panel())
+        with pytest.raises(MlsynthConfigError):
+            solve_partition_batch(problem, np.array([[99]], dtype=np.int64),
+                                  np.array([[0, 1]], dtype=np.int64))
+
+    def test_rejects_overlapping_sides(self):
+        """A unit cannot be treated and control at once."""
+        problem = TwoWayProblem.from_panel(_panel())
+        with pytest.raises(MlsynthConfigError):
+            solve_partition_batch(problem, np.array([[0, 1]], dtype=np.int64),
+                                  np.array([[1, 2]], dtype=np.int64))

--- a/mlsynth/utils/syndes_helpers/config.py
+++ b/mlsynth/utils/syndes_helpers/config.py
@@ -115,6 +115,21 @@ class SYNDESConfig(BaseMAREXConfig):
                           description="Permutation test significance level.")
     run_inference: bool = Field(default=True,
                                  description="Run post-period inference when post data are present.")
+    backend: Literal["mip", "exact"] = Field(
+        default="mip",
+        description=(
+            "How ``mode='two_way_global'`` is solved. ``'mip'`` hands the "
+            "mixed-integer program to ``solver`` (the default, unchanged). "
+            "``'exact'`` searches treated sets directly: naming the set removes "
+            "every binary and leaves a convex program in the Gram matrix, so a "
+            "candidate design costs one row of a matrix product instead of a "
+            "branch-and-bound node, and the panel length drops out after the "
+            "Gram step. Only valid for ``mode='two_way_global'``, and not with "
+            "donor-side restrictions, which tie the control weights to the "
+            "assignment. ``gap_limit``, ``time_limit``, ``solver`` and the "
+            "``accel_*`` fields apply to the MIP path only."
+        ),
+    )
     solver: Any = Field(default="SCIP",
                          description="CVXPY-compatible mixed-integer solver "
                          "(ignored for the annealed mode).")
@@ -398,6 +413,21 @@ class SYNDESConfig(BaseMAREXConfig):
         df = values.df
         n_units = df[values.unitid].nunique()
         n_periods = df[values.time].nunique()
+
+        # The exact backend is a reformulation of the two-way objective only:
+        # one-way pins the treated weights and per-unit carries an (N, N) weight
+        # matrix, so neither reduces to a search over treated sets.
+        if values.backend == "exact":
+            if values.mode != "two_way_global":
+                raise MlsynthConfigError(
+                    f"backend='exact' is only available for "
+                    f"mode='two_way_global'; got mode={values.mode!r}.")
+            if values.donor_exclusion is not None or values.donor_region_col:
+                raise MlsynthConfigError(
+                    "backend='exact' cannot apply donor-side restrictions: they "
+                    "tie the control weights to which units are treated, so a "
+                    "design is not scoreable from its treated set alone. Drop "
+                    "donor_exclusion / donor_region_col, or use backend='mip'.")
 
         # Resolve the design-selection rule (None infers from holdout_frac).
         # A solution pool (top_K >= 2) is holdout-validated by default: rank the

--- a/mlsynth/utils/syndes_helpers/exact.py
+++ b/mlsynth/utils/syndes_helpers/exact.py
@@ -1,0 +1,524 @@
+"""The exact two-way SYNDES backend: search treated sets, not branch-and-bound.
+
+:mod:`mlsynth.utils.syndes_helpers.gram` shows that naming the treated set
+removes every binary from the two-way global MIP, leaving a convex program in
+``G = Y'Y / T``, and gives a closed form for a relaxation of it,
+
+    lb(S) = 4 alpha / (sigma' R sigma),
+
+which lower-bounds ``f(S)`` always and equals it whenever the dropped sign
+conditions turn out to be slack. :mod:`mlsynth.utils.syndes_helpers.partition`
+solves ``f(S)`` for a batch of treated sets when they do bind.
+
+This module is the outer search those two make cheap. One matrix product scores
+every candidate design; the rows the closed form settles are solved outright and
+supply an incumbent; every design whose bound clears that incumbent is discarded
+soundly; only the survivors reach the iterative solver. On the panels used to
+develop it, that leaves nought or one design out of thousands.
+
+What the search buys over branch-and-bound is a change in the price of a
+candidate, not in the complexity class. Choosing ``S`` is still hard -- ranking
+designs by the bound is a cardinality-constrained max-cut. But a candidate costs
+one row of a matrix product instead of a node with an LP relaxation, and the
+panel length drops out entirely after the Gram step, so a long panel costs no
+more per design than a short one. Above ``candidate_limit`` designs, enumeration
+stops being affordable and the search falls back to max-cut candidates polished
+on the objective, reported against the Rayleigh bound.
+
+Restrictions on the assignment are predicates on the treated set -- forced,
+forbidden, conflicting, stratum quotas, a cost budget, and the pool's no-good
+sets -- so they are applied while candidates are generated. ``donor_exclusion``
+is the exception: it ties the control weights to which units are treated, so the
+closed form's matrix would differ per candidate and the batch product would not
+hold. The backend refuses it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import combinations, islice
+from math import comb
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError, MlsynthEstimationError
+from ..fast_scm_helpers.structure import IndexSet
+from .gram import (
+    BoundEngine,
+    TwoWayProblem,
+    maxcut_candidates,
+    signs_from_subsets,
+)
+from .partition import solve_partition_batch, split_indices
+from .structures import SYNDESDesign
+
+#: Above this many candidate designs, enumeration stops being affordable and the
+#: search falls back to max-cut candidates reported against the Rayleigh bound.
+CANDIDATE_LIMIT = 20_000_000
+
+#: Designs generated per chunk while streaming. Bounds peak memory without
+#: changing any result.
+CHUNK = 200_000
+
+
+# ----------------------------------------------------------------------
+# candidate generation
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SubsetFilter:
+    """Predicates on the treated set, applied while candidates are generated.
+
+    Every restriction the two-way design supports is a statement about which
+    units are treated, so each is a test on a candidate rather than a constraint
+    handed to a solver.
+    """
+
+    forced_in: frozenset = frozenset()
+    forbidden: frozenset = frozenset()
+    conflict_pairs: Tuple[Tuple[int, int], ...] = ()
+    strata: Tuple[Tuple[Tuple[int, ...], Optional[int], Optional[int]], ...] = ()
+    costs: Optional[np.ndarray] = None
+    budget: Optional[float] = None
+    forbidden_sets: Tuple[frozenset, ...] = ()
+
+    @classmethod
+    def build(
+        cls,
+        restrictions: Optional[Any] = None,
+        costs: Optional[np.ndarray] = None,
+        budget: Optional[float] = None,
+        forbidden_sets: Optional[Sequence[np.ndarray]] = None,
+        N: Optional[int] = None,
+    ) -> "SubsetFilter":
+        """Assemble the predicate set, validating cost inputs.
+
+        Raises
+        ------
+        MlsynthConfigError
+            If ``costs`` and ``budget`` are not supplied together, if ``costs``
+            has the wrong length or a negative entry, if ``budget`` is not
+            positive, or if ``restrictions`` carries a donor exclusion.
+        """
+        if restrictions is not None and getattr(restrictions, "donor_exclusion", None):
+            raise MlsynthConfigError(
+                "donor exclusions are not supported by the exact two-way backend: "
+                "they tie the control weights to which units are treated, so the "
+                "design cannot be scored as a function of the treated set alone. "
+                "Drop the donor rules, or use mode='one_way_global' / 'per_unit'."
+            )
+        if (costs is None) != (budget is None):
+            raise MlsynthConfigError(
+                "costs and budget must be supplied together (or both None).")
+
+        cost_vec = None
+        if costs is not None:
+            cost_vec = np.asarray(costs, dtype=float).reshape(-1)
+            if N is not None and cost_vec.shape[0] != N:
+                raise MlsynthConfigError(
+                    f"costs must have length N={N}; got {cost_vec.shape[0]}.")
+            if np.any(cost_vec < 0):
+                raise MlsynthConfigError("costs must be non-negative.")
+            if float(budget) <= 0:
+                raise MlsynthConfigError("budget must be strictly positive.")
+
+        return cls(
+            forced_in=frozenset(int(i) for i in getattr(restrictions, "forced_in", ())),
+            forbidden=frozenset(int(i) for i in getattr(restrictions, "forbidden", ())),
+            conflict_pairs=tuple(
+                (int(i), int(j)) for i, j in getattr(restrictions, "conflict_pairs", ())),
+            strata=tuple(
+                (tuple(int(m) for m in members), lo, hi)
+                for members, lo, hi in getattr(restrictions, "strata", ())),
+            costs=cost_vec,
+            budget=None if budget is None else float(budget),
+            forbidden_sets=tuple(
+                frozenset(int(i) for i in np.asarray(fs).reshape(-1))
+                for fs in (forbidden_sets or []) if np.asarray(fs).size),
+        )
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.forced_in or self.forbidden or self.conflict_pairs
+                    or self.strata or self.costs is not None or self.forbidden_sets)
+
+    def accepts(self, subset: Tuple[int, ...]) -> bool:
+        """Whether a candidate treated set satisfies every predicate."""
+        chosen = frozenset(subset)
+        if not self.forced_in <= chosen:
+            return False
+        if chosen & self.forbidden:
+            return False
+        for i, j in self.conflict_pairs:
+            if i in chosen and j in chosen:
+                return False
+        for members, lower, upper in self.strata:
+            inside = len(chosen.intersection(members))
+            if lower is not None and inside < lower:
+                return False
+            if upper is not None and inside > upper:
+                return False
+        if self.costs is not None:
+            if float(self.costs[list(subset)].sum()) > self.budget + 1e-9:
+                return False
+        if chosen in self.forbidden_sets:
+            return False
+        return True
+
+
+def _stream_subsets(N: int, K: int, filt: SubsetFilter, chunk: int):
+    """Yield ``(B, K)`` arrays of admissible treated sets, ``B <= chunk``.
+
+    An exhausted source and a slice the filter emptied are different things: the
+    first ends the stream, the second only skips a yield.
+    """
+    source = combinations(range(N), K)
+    while True:
+        raw = list(islice(source, chunk))
+        if not raw:
+            return
+        block = [s for s in raw if filt.accepts(s)]
+        if block:
+            yield np.array(block, dtype=np.int64)
+
+
+# ----------------------------------------------------------------------
+# the search
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class SearchOutcome:
+    """One design plus how the search arrived at it."""
+
+    treated: np.ndarray
+    value: float
+    treated_weights: np.ndarray
+    control_weights: np.ndarray
+    duality_gap: float
+    lower_bound: Optional[float]
+    certified: bool
+    n_designs: int = 0
+    n_closed_form: int = 0
+    n_solved: int = 0
+
+
+def _settle(problem: TwoWayProblem, engine: BoundEngine, treated: np.ndarray):
+    """Best available value and weights for one treated set.
+
+    Prefers the closed form when its minimiser respects the sign conditions --
+    there it is the optimum at machine precision. The iterative solver loses
+    relative accuracy as ``lam`` approaches zero, and the closed form does not.
+    """
+    treated = np.sort(np.asarray(treated, dtype=np.int64))
+    t_idx, c_idx = split_indices(problem.N, treated[None, :])
+
+    if engine.reliable:
+        closed = engine.bound(signs_from_subsets(problem.N, treated[None, :]))
+        if bool(closed.exact[0]):
+            u = closed.contrast[0]
+            return (float(closed.lower[0]), np.maximum(u, 0.0),
+                    np.maximum(-u, 0.0), 0.0)
+
+    solved = solve_partition_batch(problem, t_idx, c_idx,
+                                   max_iter=20_000, tol=1e-15)
+    a = np.zeros(problem.N); a[t_idx[0]] = solved.treated_weights[0]
+    b = np.zeros(problem.N); b[c_idx[0]] = solved.control_weights[0]
+    return float(solved.value[0]), a, b, float(solved.gap[0])
+
+
+def _search(
+    problem: TwoWayProblem,
+    K: int,
+    filt: SubsetFilter,
+    *,
+    candidate_limit: int,
+    incumbent_sets: Optional[np.ndarray],
+    seed: int,
+) -> SearchOutcome:
+    """Enumerate and prune, or fall back to max-cut candidates when too large."""
+    engine = BoundEngine.from_problem(problem)
+    N = problem.N
+    total = comb(N, K)
+
+    if total > candidate_limit or not engine.reliable:
+        return _search_by_candidates(problem, engine, K, filt, seed=seed,
+                                     n_designs=total)
+
+    best_value, best_set = np.inf, None
+    if incumbent_sets is not None and len(np.atleast_2d(incumbent_sets)):
+        for seed_set in np.atleast_2d(np.asarray(incumbent_sets, dtype=np.int64)):
+            if filt.accepts(tuple(int(i) for i in np.sort(seed_set))):
+                value, _, _, _ = _settle(problem, engine, seed_set)
+                if value < best_value:
+                    best_value, best_set = value, np.sort(seed_set)
+
+    kept: List[np.ndarray] = []
+    kept_bounds: List[np.ndarray] = []
+    n_designs = 0
+    n_closed_form = 0
+
+    for block in _stream_subsets(N, K, filt, CHUNK):
+        n_designs += block.shape[0]
+        scored = engine.bound(signs_from_subsets(N, block))
+        if scored.exact.any():
+            n_closed_form += int(scored.exact.sum())
+            local = int(np.argmin(np.where(scored.exact, scored.lower, np.inf)))
+            if scored.lower[local] < best_value:
+                best_value, best_set = float(scored.lower[local]), block[local]
+        alive = np.flatnonzero((~scored.exact) & (scored.lower < best_value))
+        if alive.size:
+            kept.append(block[alive])
+            kept_bounds.append(scored.lower[alive])
+
+    if n_designs == 0:
+        raise MlsynthEstimationError(
+            "SYNDES found no feasible design: the active restrictions "
+            "(forced/forbidden units, spillover/adjacency conflict, stratum "
+            "quotas, cost budget) are jointly unsatisfiable for the requested K. "
+            "Relax the restrictions or reduce K.")
+
+    n_solved = 0
+    if kept:
+        candidates = np.concatenate(kept)
+        bounds = np.concatenate(kept_bounds)
+        alive = bounds < best_value
+        candidates = candidates[alive]
+        n_solved = int(candidates.shape[0])
+        if n_solved:
+            t_idx, c_idx = split_indices(N, candidates)
+            solved = solve_partition_batch(problem, t_idx, c_idx,
+                                           max_iter=4000, tol=1e-14)
+            j = int(np.argmin(solved.value))
+            if float(solved.value[j]) < best_value:
+                best_value, best_set = float(solved.value[j]), candidates[j]
+
+    value, a, b, gap = _settle(problem, engine, best_set)
+    scale = max(abs(value), 1e-300)
+    return SearchOutcome(
+        treated=np.sort(np.asarray(best_set, dtype=np.int64)),
+        value=value, treated_weights=a, control_weights=b,
+        duality_gap=gap, lower_bound=engine.global_lower_bound(K),
+        certified=bool(gap / scale <= 1e-8),
+        n_designs=n_designs, n_closed_form=n_closed_form, n_solved=n_solved,
+    )
+
+
+def _search_by_candidates(
+    problem: TwoWayProblem,
+    engine: BoundEngine,
+    K: int,
+    filt: SubsetFilter,
+    *,
+    seed: int,
+    n_designs: int,
+) -> SearchOutcome:
+    """Max-cut candidates polished on the objective, for instances too large to enumerate."""
+    if not engine.reliable:
+        raise MlsynthEstimationError(
+            "the two-way Gram matrix is too ill-conditioned for the exact backend "
+            f"(cond(M) = {engine.condition:.3e}), and the instance is too large to "
+            "enumerate. Raise lam, add pre-treatment periods, or use the MIP backend.")
+    if not filt.is_empty:
+        raise MlsynthConfigError(
+            f"the exact backend cannot apply design restrictions to an instance "
+            f"with {n_designs} candidate designs, which is past the enumeration "
+            "limit. Reduce K, drop the restrictions, or raise candidate_limit.")
+
+    candidates = maxcut_candidates(engine, K, seed=seed)
+    t_idx, c_idx = split_indices(problem.N, candidates)
+    ranked = solve_partition_batch(problem, t_idx, c_idx, max_iter=2000, tol=1e-13)
+    j = int(np.argmin(ranked.value))
+
+    value, a, b, gap = _settle(problem, engine, candidates[j])
+    return SearchOutcome(
+        treated=np.sort(candidates[j]), value=value,
+        treated_weights=a, control_weights=b, duality_gap=gap,
+        lower_bound=engine.global_lower_bound(K), certified=False,
+        n_designs=n_designs, n_closed_form=0, n_solved=int(candidates.shape[0]),
+    )
+
+
+# ----------------------------------------------------------------------
+# public entry points
+# ----------------------------------------------------------------------
+
+
+def solve_synthetic_design_exact(
+    Y: np.ndarray,
+    K: Optional[int],
+    *,
+    lam: Optional[float] = None,
+    unit_index: Optional[IndexSet] = None,
+    costs: Optional[np.ndarray] = None,
+    budget: Optional[float] = None,
+    restrictions: Optional[Any] = None,
+    forbidden_sets: Optional[Sequence[np.ndarray]] = None,
+    incumbent_sets: Optional[np.ndarray] = None,
+    candidate_limit: int = CANDIDATE_LIMIT,
+    seed: int = 0,
+) -> SYNDESDesign:
+    """Solve the two-way global design by searching treated sets.
+
+    Returns the same :class:`SYNDESDesign` as
+    :func:`mlsynth.utils.syndes_helpers.optimization.solve_synthetic_design` with
+    ``mode="global_2way"``, so the two backends are interchangeable downstream.
+
+    Parameters
+    ----------
+    Y : np.ndarray
+        Pre-treatment outcome matrix of shape ``(T, N)``.
+    K : int or None
+        Number of treated units. ``None`` searches every size from ``1`` to
+        ``N - 1``, which the paper allows for the global modes.
+    lam : float, optional
+        Penalty on the weights; estimated from ``Y`` when ``None``, matching the
+        MIP path so both minimise the same objective.
+    unit_index : IndexSet, optional
+        Label mapping, used to populate the design's label fields.
+    costs, budget : optional
+        Per-unit treatment cost and a cap on their total over the treated set.
+    restrictions : DesignRestrictions, optional
+        Assignment restrictions. Donor exclusions are refused.
+    forbidden_sets : sequence of arrays, optional
+        Treated sets to exclude, which is how the pool asks for the next-best
+        distinct design.
+    incumbent_sets : np.ndarray, optional
+        Treated sets to seed the incumbent with, so more designs prune on their
+        bound alone. A poor seed costs time and nothing else.
+    candidate_limit : int, optional
+        Above this many candidate designs the search stops enumerating and falls
+        back to max-cut candidates reported against the Rayleigh bound.
+    seed : int, optional
+        Seed for the fallback's restarts.
+
+    Raises
+    ------
+    MlsynthConfigError
+        For an out-of-range ``K``, malformed cost inputs, or donor exclusions.
+    MlsynthEstimationError
+        When no admissible design exists under the restrictions.
+    """
+    problem = TwoWayProblem.from_panel(Y, lam=lam)
+    N = problem.N
+    filt = SubsetFilter.build(restrictions, costs, budget, forbidden_sets, N=N)
+
+    if K is None:
+        sizes = range(1, N)
+    else:
+        if not 1 <= int(K) <= N - 1:
+            raise MlsynthConfigError(
+                f"K must lie in 1..{N - 1} for a two-way design; got {K}.")
+        sizes = [int(K)]
+
+    best: Optional[SearchOutcome] = None
+    failures: List[str] = []
+    for size in sizes:
+        try:
+            outcome = _search(problem, size, filt,
+                              candidate_limit=candidate_limit,
+                              incumbent_sets=incumbent_sets, seed=seed)
+        except MlsynthEstimationError as exc:
+            failures.append(str(exc))
+            continue
+        if best is None or outcome.value < best.value:
+            best = outcome
+
+    if best is None:
+        raise MlsynthEstimationError(
+            failures[0] if failures else
+            "SYNDES found no feasible design under the active restrictions.")
+
+    return _to_design(problem, Y, best, unit_index)
+
+
+def solve_synthetic_design_exact_pool(
+    Y: np.ndarray,
+    K: int,
+    top_K: int = 1,
+    **kwargs: Any,
+) -> List[SYNDESDesign]:
+    """The ``top_K`` best distinct designs, ranked by objective.
+
+    Re-searches with each chosen treated set added to ``forbidden_sets``, so the
+    next call returns the next-best distinct design. Stops early, returning fewer
+    than ``top_K``, once the admissible region is exhausted.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``top_K`` is not a positive integer.
+    """
+    if not isinstance(top_K, (int, np.integer)) or top_K < 1:
+        raise MlsynthConfigError(f"top_K must be a positive integer; got {top_K!r}.")
+
+    excluded = list(kwargs.pop("forbidden_sets", None) or [])
+    designs: List[SYNDESDesign] = []
+    for _ in range(int(top_K)):
+        try:
+            design = solve_synthetic_design_exact(
+                Y, K, forbidden_sets=excluded, **kwargs)
+        except MlsynthEstimationError:
+            break
+        designs.append(design)
+        excluded.append(np.asarray(design.selected_unit_indices, dtype=np.int64))
+    return designs
+
+
+def _to_design(
+    problem: TwoWayProblem,
+    Y: np.ndarray,
+    outcome: SearchOutcome,
+    unit_index: Optional[IndexSet],
+) -> SYNDESDesign:
+    """Package a search outcome in the shared design container.
+
+    Mirrors ``optimization._extract_weights``' two-way convention so the two
+    backends are interchangeable downstream: ``q`` is the treated block, ``w - q``
+    the control block, and the contrast is their difference.
+    """
+    N = problem.N
+    assignment = np.zeros(N, dtype=int)
+    assignment[outcome.treated] = 1
+
+    if unit_index is not None:
+        selected_labels = unit_index.get_labels(outcome.treated)
+        all_labels = unit_index.labels
+    else:
+        selected_labels = outcome.treated
+        all_labels = np.arange(N)
+
+    a, b = outcome.treated_weights, outcome.control_weights
+    contrast_weights = a - b
+    contrast_series = np.asarray(Y, dtype=float) @ contrast_weights
+    pre_fit_rmse = float(np.sqrt(np.mean(contrast_series ** 2)))
+    return SYNDESDesign(
+        mode="global_2way",
+        objective_value=outcome.value,
+        lambda_value=problem.lam,
+        assignment=assignment,
+        selected_unit_indices=outcome.treated,
+        selected_unit_labels=np.asarray(selected_labels),
+        assignment_by_unit={
+            label: int(val) for label, val in zip(all_labels, assignment)},
+        w=a + b,
+        q=a,
+        z=None,
+        treated_weights=a,
+        control_weights=b,
+        contrast_weights=contrast_weights,
+        contrast_series=contrast_series,
+        pre_fit_rmse=pre_fit_rmse,
+        raw_results={
+            "status": "optimal" if outcome.certified else "feasible",
+            "solver": "exact",
+            "n_designs": outcome.n_designs,
+            "n_closed_form": outcome.n_closed_form,
+            "n_solved": outcome.n_solved,
+            "duality_gap": outcome.duality_gap,
+            "lower_bound": outcome.lower_bound,
+            "certified": outcome.certified,
+        },
+    )

--- a/mlsynth/utils/syndes_helpers/exact.py
+++ b/mlsynth/utils/syndes_helpers/exact.py
@@ -72,8 +72,8 @@ class SubsetFilter:
     """Predicates on the treated set, applied while candidates are generated.
 
     Every restriction the two-way design supports is a statement about which
-    units are treated, so each is a test on a candidate rather than a constraint
-    handed to a solver.
+    units are treated, so each is a test on a candidate, not a constraint handed
+    to a solver.
     """
 
     forced_in: frozenset = frozenset()

--- a/mlsynth/utils/syndes_helpers/gram.py
+++ b/mlsynth/utils/syndes_helpers/gram.py
@@ -144,6 +144,17 @@ class TwoWayProblem:
         G = 0.5 * (G + G.T)
         return cls(G=G, M=G + lam_value * np.eye(N), lam=lam_value, N=N)
 
+    @property
+    def step(self) -> float:
+        """Projected-gradient step ``1 / (2 lam_max(M))``.
+
+        Valid simultaneously for every treated set: restricting the quadratic
+        form to a coordinate subset and flipping signs on part of it is a
+        principal submatrix of an orthogonal similarity, so neither operation
+        raises the top eigenvalue.
+        """
+        return 1.0 / (2.0 * float(np.linalg.eigvalsh(self.M)[-1]))
+
     def evaluate(self, a: np.ndarray, b: np.ndarray) -> float:
         """The objective at explicit treated and control weight vectors."""
         u = np.asarray(a, dtype=float) - np.asarray(b, dtype=float)

--- a/mlsynth/utils/syndes_helpers/holdout.py
+++ b/mlsynth/utils/syndes_helpers/holdout.py
@@ -23,7 +23,7 @@ to balance out of sample, which is the quantity overfitting inflates.
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Tuple
+from typing import Any, Callable, List, Optional, Tuple
 
 import numpy as np
 
@@ -94,6 +94,7 @@ def select_by_holdout(
     *,
     holdout_frac: float,
     top_K: int,
+    pool_fn: Optional[Callable[..., List[Any]]] = None,
     **solve_kw: Any,
 ) -> Tuple[List[Any], List[float]]:
     """Rank the SYNDES candidate pool by out-of-sample (holdout) contrast error.
@@ -109,8 +110,11 @@ def select_by_holdout(
     holdout_frac : float
         Validation-tail fraction in ``(0, 1)`` (see :func:`split_pre`).
     top_K : int
-        Candidate-pool size handed to
-        :func:`~mlsynth.utils.syndes_helpers.optimization.solve_synthetic_design_pool`.
+        Candidate-pool size handed to the pool solver.
+    pool_fn : callable, optional
+        The pool solver. Defaults to
+        :func:`~mlsynth.utils.syndes_helpers.optimization.solve_synthetic_design_pool`;
+        the exact two-way backend passes its own here.
     **solve_kw
         Remaining solver arguments (``K``, ``mode``, ``lam``, ``solver``,
         ``verbose``, ``unit_index``, ``costs``, ``budget``, ``gap_limit``,
@@ -124,7 +128,8 @@ def select_by_holdout(
         (same order). Ties keep the solver's in-sample order (stable sort).
     """
     Y_train, Y_val, _ = split_pre(Y_pre, holdout_frac)
-    designs = solve_synthetic_design_pool(Y=Y_train, top_K=top_K, **solve_kw)
+    solve_pool = pool_fn or solve_synthetic_design_pool
+    designs = solve_pool(Y=Y_train, top_K=top_K, **solve_kw)
     oos = [oos_contrast_rmse(d, Y_val) for d in designs]
     order = sorted(range(len(designs)), key=lambda i: (oos[i], i))   # stable
     ranked = [designs[i] for i in order]

--- a/mlsynth/utils/syndes_helpers/partition.py
+++ b/mlsynth/utils/syndes_helpers/partition.py
@@ -1,0 +1,229 @@
+"""The SYNDES inner solver: the quadratic program left once ``S`` is named.
+
+:mod:`mlsynth.utils.syndes_helpers.gram` shows that naming the treated set
+removes every binary from the two-way global MIP. What remains, for a given
+``S``, is a strictly convex quadratic program over a product of two simplices:
+
+.. math::
+
+   f(S) = \\min \\{ u'(G + \\lambda I) u : u_S \\ge 0, \\textstyle\\sum_S u = 1;
+   \\; u_{S^c} \\le 0, \\textstyle\\sum_{S^c} u = -1 \\}.
+
+Geometrically that is the ridge-penalised distance between the convex hull of the
+treated units' pre-treatment columns and the hull of the control units'. Its
+minimiser is the pair of weight vectors the design uses.
+
+Two facts shape the implementation. The feasible set is a product of two
+simplices, so the Euclidean projection onto it is separable and exact -- a sort
+per block. And the objective depends on the panel only through ``G``, so a batch
+of designs shares one matrix and evaluates in one product per iteration. Together
+they make projected gradient the right method: thousands of designs advance
+together, each block projected in a single vectorised sort.
+
+The iteration is FISTA at the fixed step ``1 / (2 lam_max(M))``. That step is
+valid for every row at once because restricting the quadratic form to a
+coordinate subset and flipping signs on part of it cannot raise the top
+eigenvalue.
+
+Every solve returns a Frank-Wolfe duality gap alongside the value. For a convex
+objective over a compact convex set the gap bounds the distance to the optimum,
+so ``value - gap`` is a valid lower bound and a caller can tell a converged
+answer from an unconverged one without a reference solver. That matters here
+because the conic solvers one would otherwise check against lose relative
+accuracy as ``lam`` approaches zero, exactly where this program becomes hard.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError
+from .gram import TwoWayProblem
+
+
+def project_simplex(V: np.ndarray) -> np.ndarray:
+    """Row-wise Euclidean projection of a ``(B, n)`` array onto the unit simplex.
+
+    The standard sort-and-threshold construction: sort each row descending, find
+    the largest prefix whose implied threshold keeps its own entries positive,
+    and shift by that threshold.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``V`` is not two-dimensional or has no columns.
+    """
+    V = np.asarray(V, dtype=float)
+    if V.ndim != 2:
+        raise MlsynthConfigError(
+            f"project_simplex expects a (B, n) array; got shape {V.shape}.")
+    B, n = V.shape
+    if n == 0:
+        raise MlsynthConfigError("cannot project onto a simplex with no coordinates.")
+
+    ordered = -np.sort(-V, axis=1)
+    cumulative = np.cumsum(ordered, axis=1)
+    cumulative -= 1.0
+    position = np.arange(1, n + 1, dtype=float)
+    condition = ordered * position > cumulative
+    rho = n - 1 - np.argmax(condition[:, ::-1], axis=1)
+    theta = cumulative[np.arange(B), rho] / (rho + 1.0)
+    return np.maximum(V - theta[:, None], 0.0)
+
+
+def split_indices(N: int, treated: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Split ``(B, K)`` treated indices into treated and control index arrays.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If any row repeats a unit or names one outside ``0 .. N-1``.
+    """
+    treated = np.atleast_2d(np.asarray(treated, dtype=np.int64))
+    B, K = treated.shape
+    if K and (treated.min() < 0 or treated.max() >= N):
+        raise MlsynthConfigError(
+            f"treated indices must lie in 0..{N - 1}; got "
+            f"[{treated.min()}, {treated.max()}].")
+
+    mask = np.zeros((B, N), dtype=bool)
+    np.put_along_axis(mask, treated, True, axis=1)
+    if int(mask.sum()) != B * K:
+        raise MlsynthConfigError("a treated set repeats a unit.")
+
+    control = np.tile(np.arange(N), (B, 1))[~mask].reshape(B, N - K)
+    return treated, control
+
+
+@dataclass(frozen=True)
+class PartitionSolution:
+    """Batched inner-QP output.
+
+    Attributes
+    ----------
+    value : np.ndarray
+        ``(B,)`` objective at the returned weights.
+    gap : np.ndarray
+        ``(B,)`` Frank-Wolfe duality gap. ``value - gap`` lower-bounds ``f(S)``,
+        so a small gap certifies the value.
+    treated_weights : np.ndarray
+        ``(B, K)`` weights on the treated units, in the order given.
+    control_weights : np.ndarray
+        ``(B, N - K)`` weights on the control units, in the order given.
+    """
+
+    value: np.ndarray
+    gap: np.ndarray
+    treated_weights: np.ndarray
+    control_weights: np.ndarray
+
+
+def solve_partition_batch(
+    problem: TwoWayProblem,
+    treated_idx: np.ndarray,
+    control_idx: np.ndarray,
+    *,
+    max_iter: int = 400,
+    tol: float = 1e-11,
+    check_every: int = 10,
+) -> PartitionSolution:
+    """Solve ``f(S)`` for a batch of treated sets given as dense index arrays.
+
+    ``treated_idx`` is ``(B, K)`` and ``control_idx`` is ``(B, N - K)``; row ``b``
+    lists the units on each side of design ``b``. Keeping both blocks dense means
+    the projection sorts ``K`` and ``N - K`` columns instead of masking ``N``,
+    which is where the time goes.
+
+    Iterates until every row's Frank-Wolfe gap falls under ``tol``, or for
+    ``max_iter`` steps. Pass ``tol=0.0`` to run a fixed number of steps, which is
+    what a cheap screening pass wants: the gaps are then loose but still valid,
+    so pruning on ``value - gap`` stays sound.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If the two index arrays disagree on batch size, if either side is empty,
+        if an index is out of range, or if a unit appears on both sides.
+    """
+    M = problem.M
+    N = problem.N
+    treated_idx = np.atleast_2d(np.asarray(treated_idx, dtype=np.int64))
+    control_idx = np.atleast_2d(np.asarray(control_idx, dtype=np.int64))
+
+    if treated_idx.shape[0] != control_idx.shape[0]:
+        raise MlsynthConfigError(
+            f"treated and control index arrays disagree on batch size: "
+            f"{treated_idx.shape[0]} vs {control_idx.shape[0]}.")
+    B, K = treated_idx.shape
+    n_control = control_idx.shape[1]
+    if K == 0 or n_control == 0:
+        raise MlsynthConfigError(
+            "a two-way design needs at least one unit on each side; got "
+            f"{K} treated and {n_control} control.")
+    for name, block in (("treated", treated_idx), ("control", control_idx)):
+        if block.min() < 0 or block.max() >= N:
+            raise MlsynthConfigError(
+                f"{name} indices must lie in 0..{N - 1}; got "
+                f"[{block.min()}, {block.max()}].")
+
+    rows = np.arange(B)[:, None]
+    occupancy = np.zeros((B, N), dtype=np.int64)
+    np.add.at(occupancy, (rows, treated_idx), 1)
+    np.add.at(occupancy, (rows, control_idx), 1)
+    if occupancy.max() > 1:
+        raise MlsynthConfigError(
+            "a unit appears on both sides of a design, or twice on one side; "
+            "the treated and control blocks must partition distinct units.")
+
+    step = problem.step
+    A = np.full((B, K), 1.0 / K)
+    Bw = np.full((B, n_control), 1.0 / n_control)
+    A_prev, B_prev = A, Bw
+    Ay, By = A, Bw
+    momentum = 1.0
+    contrast = np.zeros((B, N))
+
+    def _gradients(a: np.ndarray, b: np.ndarray):
+        contrast.fill(0.0)
+        contrast[rows, treated_idx] = a
+        contrast[rows, control_idx] = -b
+        product = contrast @ M
+        return product, 2.0 * product[rows, treated_idx], -2.0 * product[rows, control_idx]
+
+    for iteration in range(max_iter):
+        _, grad_a, grad_b = _gradients(Ay, By)
+        A_new = project_simplex(Ay - step * grad_a)
+        B_new = project_simplex(By - step * grad_b)
+
+        next_momentum = 0.5 * (1.0 + np.sqrt(1.0 + 4.0 * momentum * momentum))
+        weight = (momentum - 1.0) / next_momentum
+        Ay = A_new + weight * (A_new - A_prev)
+        By = B_new + weight * (B_new - B_prev)
+        A_prev, B_prev, momentum = A_new, B_new, next_momentum
+
+        if tol > 0.0 and (iteration + 1) % check_every == 0:
+            if _duality_gap(*_gradients(A_prev, B_prev)[1:],
+                            A_prev, B_prev).max() < tol:
+                break
+
+    product, grad_a, grad_b = _gradients(A_prev, B_prev)
+    value = np.einsum("bi,bi->b", contrast, product)
+    gap = _duality_gap(grad_a, grad_b, A_prev, B_prev)
+    return PartitionSolution(value=value, gap=gap,
+                             treated_weights=A_prev, control_weights=B_prev)
+
+
+def _duality_gap(grad_a, grad_b, a, b) -> np.ndarray:
+    """Frank-Wolfe gap: the linear model's drop over the feasible set.
+
+    A linear form is minimised over a simplex at one of its vertices, so the
+    minimum is the smallest gradient entry within each block.
+    """
+    linear_drop = (
+        np.einsum("bi,bi->b", grad_a, a) + np.einsum("bi,bi->b", grad_b, b)
+        - grad_a.min(axis=1) - grad_b.min(axis=1)
+    )
+    return np.maximum(linear_drop, 0.0)

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -139,3 +139,45 @@ timeout = 180.0
   find = "g += 2.0 * (R[:, j] - R[:, i])"
   replace = "g += 2.0 * R[:, j]"
   models = "an incremental update that adds the entering unit without removing the leaving one, so every later sweep scores its neighbourhood against a gradient for a design that was never visited and the returned set is not a local optimum"
+
+[[target]]
+name = "syndes-partition"
+module-path = "mlsynth/utils/syndes_helpers/partition.py"
+test-command = "python -m pytest mlsynth/tests/test_syndes_exact_properties.py mlsynth/tests/test_syndes_partition.py -q -p no:cacheprovider"
+timeout = 180.0
+
+  [[target.mutant]]
+  id = "contrast-sums-the-two-synthetic-paths"
+  find = "contrast[rows, control_idx] = -b"
+  replace = "contrast[rows, control_idx] = b"
+  models = "a residual built from the sum of the treated and control synthetic paths instead of their difference, which optimises a program the paper never wrote while still returning feasible-looking weights"
+
+  [[target.mutant]]
+  id = "duality-gap-taken-against-the-worst-vertex"
+  find = "- grad_a.min(axis=1) - grad_b.min(axis=1)"
+  replace = "- grad_a.max(axis=1) - grad_b.max(axis=1)"
+  models = "a Frank-Wolfe gap linearised toward the worst vertex of each simplex rather than the best, so 'value - gap' stops bounding the optimum from below and the exact backend can prune the design it was looking for"
+
+[[target]]
+name = "syndes-exact"
+module-path = "mlsynth/utils/syndes_helpers/exact.py"
+test-command = "python -m pytest mlsynth/tests/test_syndes_exact.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "screen-never-escalates-to-the-inner-solver"
+  find = "alive = np.flatnonzero((~scored.exact) & (scored.lower < best_value))"
+  replace = "alive = np.flatnonzero(np.zeros(scored.lower.shape, dtype=bool))"
+  models = "a search that trusts the closed form for every design and never solves a survivor, so on any instance where the sign conditions bind it returns whichever design happened to settle in closed form and calls it optimal"
+
+  [[target.mutant]]
+  id = "budget-is-validated-then-ignored"
+  find = "if float(self.costs[list(subset)].sum()) > self.budget + 1e-9:"
+  replace = "if float(self.costs[list(subset)].sum()) < 0.0:"
+  models = "a cost budget checked for well-formedness at configuration time and then never enforced during the search, so the returned design can cost more than the experiment can pay"
+
+  [[target.mutant]]
+  id = "forcing-satisfied-by-any-one-named-unit"
+  find = "if not self.forced_in <= chosen:"
+  replace = "if self.forced_in and not (self.forced_in & chosen):"
+  models = "a to_be_treated rule read as 'at least one of these' instead of 'all of these', which silently drops units the experimenter committed to treating"

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -156,7 +156,7 @@ timeout = 180.0
   id = "duality-gap-taken-against-the-worst-vertex"
   find = "- grad_a.min(axis=1) - grad_b.min(axis=1)"
   replace = "- grad_a.max(axis=1) - grad_b.max(axis=1)"
-  models = "a Frank-Wolfe gap linearised toward the worst vertex of each simplex rather than the best, so 'value - gap' stops bounding the optimum from below and the exact backend can prune the design it was looking for"
+  models = "a Frank-Wolfe gap linearised toward the worst vertex of each simplex instead of the best, so 'value - gap' stops bounding the optimum from below and the exact backend can prune the design it was looking for"
 
 [[target]]
 name = "syndes-exact"


### PR DESCRIPTION
## Related Links

- Stacked on #408 — base is `claude/syndes-gram`, not `main`. Merge #408 first; this rebases onto `main` after
- Source paper: Doudchenko, Khosravi, Imbens et al. (2021), the `(two-way global)` objective
- Docs: `docs/syndes.rst`, new section "Solving it that way"
- Stage 2 of 3. Stage 3 (`claude/syndes-default`) flips the default and removes the annealed mode

## What

- Added `utils/syndes_helpers/partition.py` — the inner QP, batched
- Added `utils/syndes_helpers/exact.py` — the outer search over treated sets
- Added `SYNDESConfig.backend` (`"mip"` | `"exact"`), defaulting to `"mip"`
- Updated `estimators/syndes.py` to dispatch, and `select_by_holdout` to take a `pool_fn`
- Added `tests/test_syndes_partition.py`, `test_syndes_exact.py`, `test_syndes_backend.py`, `test_syndes_exact_properties.py`, and nine semantic mutants in `tools/mutation/targets.toml`

## Why

#408 established that naming the treated set removes every binary. This is the solver that follows from it: the outer problem is a choice of treated set, the inner problem is convex, and the closed-form bound makes most candidates free to score.

## How

`partition.py` runs FISTA over the product of two simplices at the fixed step `1 / (2 lam_max(M))` — valid for every row at once, because restricting the form to a coordinate subset and flipping signs on part of it cannot raise the top eigenvalue. Every solve reports a Frank-Wolfe gap, so `value - gap` bounds the optimum below and an answer certifies itself without a reference solver. That matters because CLARABEL loses relative accuracy as `lam → 0`, exactly where this program gets hard.

`exact.py` scores every candidate with one matrix product, settles the rows whose sign conditions are slack, prunes the rest against the incumbent, and calls the inner solver only on survivors — nought or one design out of thousands on the panels I measured. Assignment restrictions are predicates on the treated set, so they filter during generation. Above `candidate_limit` designs it falls back to a swap search on `sigma' R sigma` reported against the Rayleigh bound, and says `certified=False` instead of claiming otherwise.

Donor exclusions are refused. They tie the control weights to which units are treated, so the closed form's matrix would differ per candidate and the batch product would not hold. Refusing is the decision recorded in the plan; stage 3 drops them for two-way outright.

## Verification

- Path: cross-validation against the SCIP backend, plus brute force over all subsets
- Compared: treated set and objective, across `K in {1,2,3,4,5,6,8}`, `lam in {0.01, 1.0, 7.5}` and the default, with and without restrictions, for the single solve, the pool, `K=None`, holdout and IC selection
- Pinned in `tests/test_syndes_exact.py` (parity + brute force) and `tests/test_syndes_backend.py` (through the estimator)
- Tolerance: `rel=1e-6` on objectives against SCIP, `rel=1e-7` against brute force

**One result does not match, and it is the MIP that is wrong.** `gap_limit` defaults to `0.05`, so SCIP may stop 5 percent above the optimum. On this panel at `K=4` it does: SCIP returns `optimal_inaccurate` at `1.092891` against the search's `1.088821`. So parity is asserted one-sided at every `K` (the search is never worse), with strict set equality asserted separately under `gap_limit=0.0`. `test_exact_beats_the_early_stopping_default_somewhere` pins the discrepancy so it stays visible; if the default ever stops binding, that test fails and tells you the one-sided assertion can tighten.

I found this because a test I wrote asserted equality and failed. Recording it rather than loosening the assertion silently.

## Scope checks

<!-- FEATURE ON AN EXISTING ESTIMATOR -->
- [x] The default preserves existing behaviour exactly — `backend` defaults to `"mip"`, and `test_default_fit_is_unchanged` pins that an explicit `"mip"` and the default agree to `rel=1e-12`
- [x] Existing pinned benchmark values unchanged; no benchmark case sets `backend`
- [x] A test pins that the default is unchanged
- [x] New config field has a `Field(...)` description saying when to reach for it and which knobs it ignores

## Designs

No visual change — the same `SYNDESDesign` from a different search, so every plotter and post-fit path is untouched. `test_populates_the_same_fields_as_the_mip` pins the contract field by field.

## Test Steps

- [x] `pytest mlsynth/tests/test_syndes_exact.py test_syndes_partition.py test_syndes_backend.py test_syndes_exact_properties.py -q` — 176 passed with the gram suites
- [x] `pytest mlsynth/tests/test_syndes*.py -q` — 543 passed
- [x] `pytest mlsynth/tests/test_result_contract.py mlsynth/tests/test_spec.py -q` — 267 passed
- [x] `coverage run --timid -m pytest ... && coverage report` — `partition.py` and `exact.py` both 100%, no `# pragma: no cover`
- [x] `python tools/mutation/run_mutants.py --target syndes-{gram,partition,exact}` — 9/9 killed, 0 survived
- [ ] `pytest mlsynth/tests/` — full suite not run locally; it did not complete in this environment on #408 either
- [ ] Docs build not run — sphinx is not installed here

## Other Notes

- The mutants are semantic, per `tools/mutation/README.md`: a claim-inverting bound (`eigvalsh[-1]` → `[0]`), a guard that never fires, a stale incremental gradient, a gap taken against the worst vertex, a screen that never escalates, a budget validated then ignored, and a forcing rule read as "any" instead of "all". No generic operator swaps — cosmic-ray's territory
- Stage 3 flips the default, deletes the annealed mode and the five `relaxed_*.py` modules, deletes `accelerate.py` and its config fields once two-way stops using SCIP, and drops donor exclusions for two-way
- A durable benchmark case for the SCDesign DGP remains a separate workstream per CLAUDE.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLNEvmPN3YUFUEahAwWAoz)_