### PR TITLE
Enumerate SYNDES treated sets inside the restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,22 @@ now returns and the back-compat guarantee.
 
 
 ### Added
+- `utils/syndes_helpers/enumeration.py`: the exact two-way backend now builds
+  candidate treated sets inside the structural restrictions instead of generating
+  every `C(N, K)` subset and testing each one. Forced units, forbidden units
+  (including size-ineligible ones) and stratum quotas decide which candidates
+  exist, and `design_restrictions` keys each unit to one stratum, so the
+  admissible designs are a product of per-group choices that `SearchSpace.size`
+  counts exactly without walking. `candidate_limit` is compared against that
+  count, so an instance whose unrestricted `C(N, K)` is past the limit is now
+  solved exactly whenever the restrictions leave few enough designs -- where
+  before it raised `MlsynthConfigError`. Conflict pairs, `costs` with a `budget`
+  and the pool's no-good sets do not decompose over a stratum, so they remain
+  tests on finished candidates and do not lower the count; an instance carrying
+  only those is still refused past the limit. With no restrictions the walk
+  reproduces `combinations(range(N), K)` term for term, including order, so no
+  existing result moves.
+
 - `mlsynth.save_spec` / `mlsynth.load_spec`: serialize an analysis specification
   to a portable JSON or YAML file and load it back into a ready-to-fit estimator.
   Because a configuration is plain, validated data, everything but the

--- a/docs/syndes.rst
+++ b/docs/syndes.rst
@@ -740,8 +740,9 @@ Solving it that way
 ~~~~~~~~~~~~~~~~~~~~~
 
 ``backend`` chooses how ``mode="two_way_global"`` is solved. The default,
-``"mip"``, hands the mixed-integer program to ``solver`` exactly as before.
-``"exact"`` searches treated sets instead, using the reduction above.
+``"exact"``, searches treated sets using the reduction above. ``"mip"`` hands the
+mixed-integer program to ``solver`` instead. The other two modes resolve to
+``"mip"`` on their own, and asking them for ``"exact"`` is an error.
 
 The search scores every candidate design with one matrix product, since
 :math:`\mathrm{lb}` depends on the design only through
@@ -754,8 +755,8 @@ the answer certifies itself. On the panels used to develop it, nought or one
 design out of thousands reached that last step.
 
 What changes is the price of a candidate, not the complexity class. Choosing the
-treated set is still a cardinality-constrained max-cut, and above a candidate
-count the search stops enumerating, falls back to a swap search on
+treated set is still a cardinality-constrained max-cut, and above a count of
+admissible designs the search stops enumerating, falls back to a swap search on
 :math:`\boldsymbol{\sigma}^\top \mathbf{R}\, \boldsymbol{\sigma}`, and reports
 the design against the Rayleigh bound instead of claiming a certificate. What it
 buys is that a candidate costs one row of a matrix product instead of a
@@ -775,11 +776,22 @@ search's design is the one that is at least as good.
 reduces to a search over treated sets. Donor-side restrictions
 (``donor_exclusion``, ``donor_region_col``) are refused as well: they tie the
 control weights to which units are treated, so a design stops being scoreable
-from its treated set alone. Every other restriction -- ``to_be_treated``,
-``not_to_be_treated``, cluster and adjacency conflicts, stratum quotas, size
-eligibility, ``costs`` with a ``budget`` -- is a predicate on the treated set and
-is applied while candidates are generated. ``gap_limit``, ``time_limit``,
-``solver`` describe branch-and-bound and are ignored by this path.
+from its treated set alone.
+
+Every other restriction is a predicate on the treated set, and the two kinds are
+handled differently. ``to_be_treated``, ``not_to_be_treated``, size eligibility
+and stratum quotas are structural: they decide which candidates exist, so the
+search builds candidates inside them and counts the admissible designs exactly.
+That count is what the candidate limit reads, so an instance with most of its
+units ineligible is enumerated on the designs it has, not on the
+:math:`\binom{N}{K}` it would have had without the rules. Cluster and adjacency
+conflicts and ``costs`` with a ``budget`` do not decompose over a stratum, so
+they are tested on finished candidates and leave the count alone; an instance
+carrying only those is refused past the limit, since the fallback searches the
+unrestricted space.
+
+``gap_limit``, ``time_limit``, ``solver`` describe branch-and-bound and are
+ignored by this path.
 
 Multiple Treatment Arms
 -----------------------

--- a/mlsynth/tests/test_syndes_enumeration.py
+++ b/mlsynth/tests/test_syndes_enumeration.py
@@ -215,6 +215,28 @@ class TestEdges:
         assert set(_walk(space)) == _brute(6, 3, forced=(0,), strata=strata)
         assert all(len(set(s) & {0, 1, 2}) == 1 for s in _walk(space))
 
+    def test_one_stratum_covering_every_unit(self):
+        """A single group with no leftover, so a quota is the only thing bounding it.
+
+        The unrestricted space is also a single group, and it is the space the
+        walk is specialised for. A specialisation that read ``k_free`` without
+        checking the quota would still be correct there and wrong here.
+        """
+        strata = (((0, 1, 2, 3, 4, 5), 2, 3),)
+        space = SearchSpace.build(6, 3, strata=strata)
+        assert set(_walk(space)) == _brute(6, 3, strata=strata)
+        assert space.size == len(_walk(space)) == comb(6, 3)
+
+    def test_one_stratum_whose_ceiling_excludes_k(self):
+        strata = (((0, 1, 2, 3, 4, 5), None, 2),)
+        space = SearchSpace.build(6, 3, strata=strata)
+        assert space.size == 0 and _walk(space) == []
+
+    def test_one_stratum_whose_floor_excludes_k(self):
+        strata = (((0, 1, 2, 3, 4, 5), 4, None),)
+        space = SearchSpace.build(6, 3, strata=strata)
+        assert space.size == 0 and _walk(space) == []
+
     def test_overlapping_strata_still_enumerate_correctly(self):
         """Disjointness is exploited when present and not assumed when absent.
 

--- a/mlsynth/tests/test_syndes_enumeration.py
+++ b/mlsynth/tests/test_syndes_enumeration.py
@@ -106,6 +106,8 @@ class TestSizeIsExact:
         dict(N=8, K=4, strata=(((0, 1, 2), 1, 2), ((3, 4, 5), None, 1))),
         dict(N=8, K=4, forced=(0,), strata=(((0, 1, 2), 1, 2),)),
         dict(N=8, K=3, forbidden=(0,), strata=(((0, 1, 2), None, 1),)),
+        dict(N=7, K=3, strata=(((4, 5, 6), None, 2),)),
+        dict(N=9, K=4, strata=(((5, 6), None, 1), ((0, 1), 1, None))),
     ]
 
     @pytest.mark.parametrize("case", CASES)
@@ -214,6 +216,19 @@ class TestEdges:
         space = SearchSpace.build(6, 3, forced=(0,), strata=strata)
         assert set(_walk(space)) == _brute(6, 3, forced=(0,), strata=strata)
         assert all(len(set(s) & {0, 1, 2}) == 1 for s in _walk(space))
+
+    def test_groups_out_of_order_still_emit_sorted_sets(self):
+        """The leftover group lands last whatever it holds.
+
+        A stratum over the high units leaves the low ones to the leftover group,
+        so concatenating one pick per group runs downhill. Treating that
+        concatenation as sorted would emit tuples the search reads as a treated
+        set and the design would name the wrong units.
+        """
+        strata = (((4, 5, 6), None, 2),)
+        walked = _walk(SearchSpace.build(7, 3, strata=strata))
+        assert all(list(s) == sorted(s) for s in walked)
+        assert set(walked) == _brute(7, 3, strata=strata)
 
     def test_one_stratum_covering_every_unit(self):
         """A single group with no leftover, so a quota is the only thing bounding it.

--- a/mlsynth/tests/test_syndes_enumeration.py
+++ b/mlsynth/tests/test_syndes_enumeration.py
@@ -1,0 +1,327 @@
+"""Enumerating treated sets inside the restrictions, not around them.
+
+The exact two-way backend used to generate every ``C(N, K)`` subset and test each
+one against the restrictions. That made the enumeration limit a statement about
+the unrestricted problem: an instance with a handful of admissible designs was
+refused whenever ``C(N, K)`` was large, because the cost of reaching those designs
+was the cost of walking past all the others.
+
+Three of the restrictions are structural and can be honoured while candidates are
+built. Forced units are in every design, forbidden units are in none, and a
+stratum quota bounds how many members of a disjoint group a design may hold. What
+survives is a product of per-group choices, which this module both counts and
+walks.
+
+The remaining restrictions -- conflict pairs, a cost budget, and the pool's
+no-good sets -- stay predicates on a finished candidate. They only ever remove
+designs, so the count here is an upper bound on the admissible designs and an
+exact count of what the walk emits.
+
+The contract these tests pin:
+
+* the walk emits exactly ``size`` subsets, and ``size`` is computed without
+  walking;
+* the walk emits exactly the subsets a brute-force filter would keep;
+* an unrestricted space reproduces ``combinations(range(N), K)`` verbatim,
+  including order, so removing the old path changes no existing result;
+* an unsatisfiable restriction set gives ``size == 0`` and an empty walk, which
+  is how the search reports that no design exists.
+"""
+from __future__ import annotations
+
+from itertools import combinations
+from math import comb
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from mlsynth.utils.syndes_helpers.enumeration import SearchSpace
+
+
+# ----------------------------------------------------------------------
+# brute-force reference: what the old generate-then-filter path kept
+# ----------------------------------------------------------------------
+
+
+def _structural(subset, forced, forbidden, strata):
+    """Whether ``subset`` satisfies the three structural restrictions."""
+    chosen = set(subset)
+    if not set(forced) <= chosen:
+        return False
+    if chosen & set(forbidden):
+        return False
+    for members, lo, hi in strata:
+        inside = len(chosen.intersection(members))
+        if lo is not None and inside < lo:
+            return False
+        if hi is not None and inside > hi:
+            return False
+    return True
+
+
+def _brute(N, K, forced=(), forbidden=(), strata=()):
+    """Every admissible size-``K`` subset, by exhaustive test."""
+    return {s for s in combinations(range(N), K)
+            if _structural(s, forced, forbidden, strata)}
+
+
+def _walk(space):
+    return [tuple(s) for s in space.iter_subsets()]
+
+
+# ----------------------------------------------------------------------
+# smoke
+# ----------------------------------------------------------------------
+
+
+class TestSmoke:
+    def test_builds_and_walks(self):
+        space = SearchSpace.build(5, 2)
+        walked = _walk(space)
+        assert space.size == comb(5, 2)
+        assert len(walked) == comb(5, 2)
+        assert all(len(s) == 2 for s in walked)
+
+    def test_forced_unit_appears_in_every_design(self):
+        space = SearchSpace.build(6, 3, forced=(1,))
+        assert all(1 in s for s in _walk(space))
+
+    def test_forbidden_unit_appears_in_none(self):
+        space = SearchSpace.build(6, 3, forbidden=(4,))
+        assert all(4 not in s for s in _walk(space))
+
+
+# ----------------------------------------------------------------------
+# the count is exact, and computed without walking
+# ----------------------------------------------------------------------
+
+
+class TestSizeIsExact:
+    CASES = [
+        dict(N=6, K=3),
+        dict(N=6, K=3, forced=(0,)),
+        dict(N=6, K=3, forced=(0, 5)),
+        dict(N=7, K=3, forbidden=(1, 2)),
+        dict(N=7, K=3, forced=(0,), forbidden=(6,)),
+        dict(N=8, K=4, strata=(((0, 1, 2), 1, 2), ((3, 4, 5), None, 1))),
+        dict(N=8, K=4, forced=(0,), strata=(((0, 1, 2), 1, 2),)),
+        dict(N=8, K=3, forbidden=(0,), strata=(((0, 1, 2), None, 1),)),
+    ]
+
+    @pytest.mark.parametrize("case", CASES)
+    def test_size_equals_walk_length(self, case):
+        space = SearchSpace.build(**case)
+        assert space.size == len(_walk(space))
+
+    @pytest.mark.parametrize("case", CASES)
+    def test_walk_equals_brute_force(self, case):
+        space = SearchSpace.build(**case)
+        assert set(_walk(space)) == _brute(**case)
+
+    @pytest.mark.parametrize("case", CASES)
+    def test_walk_has_no_duplicates(self, case):
+        walked = _walk(space := SearchSpace.build(**case))
+        assert len(walked) == len(set(walked)) == space.size
+
+    @pytest.mark.parametrize("case", CASES)
+    def test_every_subset_is_sorted_and_sized(self, case):
+        K = case["K"]
+        for s in _walk(SearchSpace.build(**case)):
+            assert list(s) == sorted(s)
+            assert len(s) == K
+            assert len(set(s)) == K
+
+    def test_size_never_exceeds_the_unrestricted_count(self):
+        for case in self.CASES:
+            assert SearchSpace.build(**case).size <= comb(case["N"], case["K"])
+
+
+# ----------------------------------------------------------------------
+# the unrestricted space is the old path, verbatim
+# ----------------------------------------------------------------------
+
+
+class TestUnrestrictedIsUnchanged:
+    @pytest.mark.parametrize("N,K", [(5, 2), (6, 3), (7, 1), (7, 6)])
+    def test_matches_combinations_including_order(self, N, K):
+        """No restrictions must reproduce the previous generator exactly.
+
+        Order is part of this: the search breaks ties by which design it meets
+        first, so a reordering would be free to move a reported design.
+        """
+        assert _walk(SearchSpace.build(N, K)) == list(combinations(range(N), K))
+
+    def test_size_is_the_binomial(self):
+        assert SearchSpace.build(9, 4).size == comb(9, 4)
+
+
+# ----------------------------------------------------------------------
+# restrictions shrink the space, which is the point
+# ----------------------------------------------------------------------
+
+
+class TestRestrictionsShrinkTheSpace:
+    def test_forced_units_collapse_the_ground_set(self):
+        """``C(200, 6)`` is past any enumeration limit; forcing five is not."""
+        space = SearchSpace.build(200, 6, forced=(0, 1, 2, 3, 4))
+        assert space.size == 195
+        assert comb(200, 6) > 8e10
+
+    def test_forbidding_most_units_collapses_the_ground_set(self):
+        space = SearchSpace.build(200, 6, forbidden=tuple(range(10, 200)))
+        assert space.size == comb(10, 6)
+
+    def test_a_full_quota_of_forced_units_leaves_one_design(self):
+        space = SearchSpace.build(50, 3, forced=(7, 11, 13))
+        assert space.size == 1
+        assert _walk(space) == [(7, 11, 13)]
+
+    def test_stratum_ceiling_removes_designs(self):
+        capped = SearchSpace.build(8, 4, strata=(((0, 1, 2, 3), None, 1),))
+        assert capped.size < comb(8, 4)
+        assert set(_walk(capped)) == _brute(8, 4, strata=(((0, 1, 2, 3), None, 1),))
+
+
+# ----------------------------------------------------------------------
+# edge cases
+# ----------------------------------------------------------------------
+
+
+class TestEdges:
+    @pytest.mark.parametrize("K", [1, 7])
+    def test_extreme_k(self, K):
+        space = SearchSpace.build(8, K)
+        assert space.size == comb(8, K) == len(_walk(space))
+
+    def test_k_equal_to_the_forced_count(self):
+        space = SearchSpace.build(6, 2, forced=(1, 4))
+        assert _walk(space) == [(1, 4)]
+
+    def test_stratum_with_no_selectable_member(self):
+        """Every member forbidden: admissible only when the floor is zero."""
+        strata = (((0, 1), None, 2),)
+        space = SearchSpace.build(6, 2, forbidden=(0, 1), strata=strata)
+        assert set(_walk(space)) == _brute(6, 2, forbidden=(0, 1), strata=strata)
+
+    def test_open_ended_quotas(self):
+        """``None`` bounds are no bound, not a bound of zero."""
+        strata = (((0, 1, 2), None, None),)
+        space = SearchSpace.build(6, 3, strata=strata)
+        assert space.size == comb(6, 3)
+
+    def test_forced_unit_inside_a_capped_stratum_consumes_quota(self):
+        strata = (((0, 1, 2), None, 1),)
+        space = SearchSpace.build(6, 3, forced=(0,), strata=strata)
+        assert set(_walk(space)) == _brute(6, 3, forced=(0,), strata=strata)
+        assert all(len(set(s) & {0, 1, 2}) == 1 for s in _walk(space))
+
+    def test_overlapping_strata_still_enumerate_correctly(self):
+        """Disjointness is exploited when present and not assumed when absent.
+
+        Restrictions built by ``design_restrictions`` key each unit to one
+        stratum, so the groups partition the units. A caller may hand over
+        overlapping sets, and the walk must stay correct there -- covering a
+        superset and leaving the rest to the candidate test.
+        """
+        strata = (((0, 1, 2), None, 1), ((2, 3, 4), 1, None))
+        space = SearchSpace.build(7, 3, strata=strata)
+        walked = _walk(space)
+        assert set(walked) >= _brute(7, 3, strata=strata)
+        assert space.size == len(walked)
+        # Treating overlapping sets as a partition would let unit 2 be drawn by
+        # both groups, emitting a repeated unit and the same design twice.
+        assert len(walked) == len(set(walked))
+        assert all(len(set(s)) == 3 for s in walked)
+
+
+# ----------------------------------------------------------------------
+# unsatisfiable restrictions: an empty space, not an exception
+# ----------------------------------------------------------------------
+
+
+class TestUnsatisfiable:
+    """The search reports "no admissible design" from a count of zero.
+
+    Raising here would move that message, so an impossible space is a space of
+    size zero.
+    """
+
+    def test_forced_and_forbidden_collide(self):
+        space = SearchSpace.build(6, 2, forced=(1,), forbidden=(1,))
+        assert space.size == 0 and _walk(space) == []
+
+    def test_more_forced_than_k(self):
+        space = SearchSpace.build(6, 2, forced=(0, 1, 2))
+        assert space.size == 0 and _walk(space) == []
+
+    def test_too_few_units_left(self):
+        space = SearchSpace.build(6, 4, forbidden=(0, 1, 2, 3))
+        assert space.size == 0 and _walk(space) == []
+
+    def test_stratum_floor_exceeds_k(self):
+        space = SearchSpace.build(6, 2, strata=(((0, 1, 2, 3), 3, None),))
+        assert space.size == 0 and _walk(space) == []
+
+    def test_stratum_ceilings_cannot_reach_k(self):
+        """Two groups capped at one apiece cover every unit, so K=3 is impossible."""
+        strata = (((0, 1, 2), None, 1), ((3, 4, 5), None, 1))
+        space = SearchSpace.build(6, 3, strata=strata)
+        assert space.size == 0 and _walk(space) == []
+
+    def test_forced_unit_breaks_a_stratum_ceiling(self):
+        space = SearchSpace.build(6, 3, forced=(0, 1), strata=(((0, 1, 2), None, 1),))
+        assert space.size == 0 and _walk(space) == []
+
+
+# ----------------------------------------------------------------------
+# properties
+# ----------------------------------------------------------------------
+
+
+_UNITS = st.integers(min_value=0, max_value=7)
+
+
+@st.composite
+def _instance(draw):
+    N = draw(st.integers(min_value=3, max_value=8))
+    K = draw(st.integers(min_value=1, max_value=N - 1))
+    forced = draw(st.frozensets(st.integers(0, N - 1), max_size=2))
+    forbidden = draw(st.frozensets(st.integers(0, N - 1), max_size=2))
+    members = draw(st.frozensets(st.integers(0, N - 1), min_size=1, max_size=4))
+    lo = draw(st.one_of(st.none(), st.integers(0, 2)))
+    hi = draw(st.one_of(st.none(), st.integers(0, 3)))
+    use_stratum = draw(st.booleans())
+    strata = ((tuple(sorted(members)), lo, hi),) if use_stratum else ()
+    return dict(N=N, K=K, forced=tuple(sorted(forced)),
+                forbidden=tuple(sorted(forbidden)), strata=strata)
+
+
+class TestProperties:
+    @settings(max_examples=250, deadline=None)
+    @given(case=_instance())
+    def test_walk_equals_brute_force(self, case):
+        """The only property that matters: the same designs, however reached."""
+        assert set(_walk(SearchSpace.build(**case))) == _brute(**case)
+
+    @settings(max_examples=250, deadline=None)
+    @given(case=_instance())
+    def test_size_counts_the_walk(self, case):
+        space = SearchSpace.build(**case)
+        assert space.size == len(_walk(space))
+
+    @settings(max_examples=250, deadline=None)
+    @given(case=_instance())
+    def test_size_bounds_the_admissible_count(self, case):
+        """A safe gate needs the count to bound what the restrictions allow."""
+        space = SearchSpace.build(**case)
+        assert space.size >= len(_brute(**case))
+        assert space.size <= comb(case["N"], case["K"])
+
+    @settings(max_examples=200, deadline=None)
+    @given(case=_instance())
+    def test_every_emitted_subset_is_a_valid_design(self, case):
+        for s in _walk(SearchSpace.build(**case)):
+            assert len(s) == case["K"]
+            assert list(s) == sorted(set(s))
+            assert set(case["forced"]) <= set(s)
+            assert not set(s) & set(case["forbidden"])

--- a/mlsynth/tests/test_syndes_exact.py
+++ b/mlsynth/tests/test_syndes_exact.py
@@ -19,6 +19,7 @@ weights to which units are treated, so the exact backend refuses it.
 from __future__ import annotations
 
 from itertools import combinations
+from math import comb
 
 import numpy as np
 import pytest
@@ -414,3 +415,88 @@ class TestLargeInstanceFallback:
         Y = rng.standard_normal((6, 3)) @ rng.standard_normal((3, 24))
         with pytest.raises(MlsynthEstimationError):
             solve_synthetic_design_exact(Y=Y, K=8, lam=1e-14, candidate_limit=1000)
+
+
+def _brute_force_admissible(Y, K, filt, lam=None):
+    """The optimum over the sets a filter admits, by generating all and testing.
+
+    This is the semantics the backend had before the enumeration was taught to
+    build candidates inside the restrictions, so it is the reference the new walk
+    has to reproduce.
+    """
+    problem = TwoWayProblem.from_panel(Y, lam=lam)
+    admissible = [s for s in combinations(range(problem.N), K) if filt.accepts(s)]
+    subsets = np.array(admissible, dtype=np.int64)
+    t, c = split_indices(problem.N, subsets)
+    values = solve_partition_batch(problem, t, c, max_iter=8000, tol=1e-14).value
+    best = int(np.argmin(values))
+    return tuple(subsets[best]), float(values[best])
+
+
+class TestRestrictedEnumeration:
+    """Structural restrictions shrink the space the enumeration limit reads.
+
+    Forced units, forbidden units and stratum quotas are honoured while
+    candidates are built, so the count that decides whether the search may
+    enumerate is the count of admissible designs, not ``C(N, K)``. An instance
+    whose unrestricted count is past the limit is now solved exactly whenever the
+    restrictions leave few enough designs, where before it was refused.
+
+    Conflict pairs, a cost budget and the pool's no-good sets do not decompose
+    over a group, so they stay candidate tests and cannot move the gate. The last
+    test here pins that, so the improvement is not overstated.
+    """
+
+    N, K, LIMIT = 14, 5, 500
+
+    def _Y(self):
+        return _panel(N=self.N, T=20, seed=3)
+
+    def _solve(self, restrictions):
+        return solve_synthetic_design_exact(
+            Y=self._Y(), K=self.K, candidate_limit=self.LIMIT,
+            restrictions=restrictions)
+
+    def test_the_unrestricted_instance_is_past_the_limit(self):
+        """Without this the rest of the class would prove nothing."""
+        assert comb(self.N, self.K) > self.LIMIT
+        with pytest.raises(MlsynthConfigError):
+            self._solve(DesignRestrictions(conflict_pairs=[(0, 1)]))
+
+    @pytest.mark.parametrize("restrictions", [
+        DesignRestrictions(forbidden=[10, 11, 12, 13]),
+        DesignRestrictions(forced_in=[0, 1, 2]),
+        DesignRestrictions(strata=[(tuple(range(10)), None, 1)]),
+        DesignRestrictions(forced_in=[0], forbidden=[11, 12, 13]),
+    ])
+    def test_restricted_instances_now_enumerate_exactly(self, restrictions):
+        got = self._solve(restrictions)
+        assert int(got.assignment.sum()) == self.K
+        assert got.raw_results["certified"] is True
+
+    @pytest.mark.parametrize("restrictions", [
+        DesignRestrictions(forbidden=[10, 11, 12, 13]),
+        DesignRestrictions(forced_in=[0, 1, 2]),
+        DesignRestrictions(strata=[(tuple(range(10)), None, 1)]),
+    ])
+    def test_it_reaches_the_same_design_as_generate_then_filter(self, restrictions):
+        Y = self._Y()
+        filt = SubsetFilter.build(restrictions, N=self.N)
+        expected_set, expected_value = _brute_force_admissible(Y, self.K, filt)
+        got = self._solve(restrictions)
+        assert tuple(got.selected_unit_indices) == expected_set
+        assert got.objective_value == pytest.approx(expected_value, rel=1e-6)
+
+    def test_the_reported_design_count_is_the_admissible_count(self):
+        restrictions = DesignRestrictions(forbidden=[10, 11, 12, 13])
+        got = self._solve(restrictions)
+        assert got.raw_results["n_designs"] == comb(10, self.K)
+
+    def test_a_budget_still_applies_inside_a_shrunken_space(self):
+        """A non-structural rule keeps working once the gate has been cleared."""
+        costs = np.ones(self.N); costs[:3] = 10.0
+        got = solve_synthetic_design_exact(
+            Y=self._Y(), K=self.K, candidate_limit=self.LIMIT,
+            restrictions=DesignRestrictions(forbidden=[10, 11, 12, 13]),
+            costs=costs, budget=7.0)
+        assert not set(got.selected_unit_indices) & {0, 1, 2}

--- a/mlsynth/utils/syndes_helpers/enumeration.py
+++ b/mlsynth/utils/syndes_helpers/enumeration.py
@@ -79,6 +79,7 @@ class SearchSpace:
     k_free: int
     size: int
     _ways: Tuple[Tuple[int, ...], ...] = ()
+    _presorted: bool = False
 
     # ------------------------------------------------------------------
     # construction
@@ -116,7 +117,8 @@ class SearchSpace:
         ways = _count_ways(groups, k_free)
         return cls(forced=tuple(sorted(forced_set)), groups=groups,
                    k_free=k_free, size=ways[0][k_free],
-                   _ways=tuple(tuple(row) for row in ways))
+                   _ways=tuple(tuple(row) for row in ways),
+                   _presorted=not forced_set and _ascending(groups))
 
     @classmethod
     def _empty(cls, forced: frozenset, k_free: int) -> "SearchSpace":
@@ -189,7 +191,12 @@ class SearchSpace:
     def _walk(self, g: int, remaining: int,
               picked: List[int]) -> Iterator[Tuple[int, ...]]:
         if g == len(self.groups):
-            yield tuple(sorted(self.forced + tuple(picked)))
+            # Picks arrive group by group, ascending inside each. When the groups
+            # are themselves ascending and nothing has to be merged in, that is
+            # already the sorted treated set, and a restriction trimming the
+            # space by a third does not earn a sort per design.
+            yield (tuple(picked) if self._presorted
+                   else tuple(sorted(self.forced + tuple(picked))))
             return
         group = self.groups[g]
         for take in range(group.lo, min(group.hi, remaining) + 1):
@@ -198,6 +205,24 @@ class SearchSpace:
             for pick in combinations(group.members, take):
                 yield from self._walk(g + 1, remaining - take,
                                       picked + list(pick))
+
+
+def _ascending(groups: Tuple[Group, ...]) -> bool:
+    """Whether concatenating one pick per group, in order, comes out sorted.
+
+    Members inside a group are ascending because the ground set is. This asks the
+    same of the groups: every member of one below every member of the next. A
+    caller is free to list strata in any order, and the leftover group lands last
+    whatever it holds, so this is checked and not assumed.
+    """
+    highest = -1
+    for group in groups:
+        if not group.members:
+            continue
+        if group.members[0] <= highest:
+            return False
+        highest = group.members[-1]
+    return True
 
 
 def _disjoint(strata: Sequence[Stratum]) -> bool:

--- a/mlsynth/utils/syndes_helpers/enumeration.py
+++ b/mlsynth/utils/syndes_helpers/enumeration.py
@@ -1,0 +1,219 @@
+"""The restricted space of treated sets: how many there are, and how to walk it.
+
+The exact two-way backend searches treated sets, and how many it must visit
+decides whether it can finish. Generating every ``C(N, K)`` subset and testing
+each against the restrictions makes that count a property of the unrestricted
+problem, so an instance with two hundred units and all but ten of them forbidden
+costs what two hundred free units cost, though only ``C(10, K)`` designs exist.
+
+Three restrictions are structural, meaning they can be honoured while a candidate
+is built:
+
+``forced``
+    units in every design, so they leave the choice entirely;
+``forbidden``
+    units in no design, so they leave the ground set;
+``strata``
+    a lower and upper quota on how many members of a group a design may hold.
+
+:func:`design_restrictions` keys each unit to one stratum, so the groups are
+disjoint and the admissible designs are a product of independent per-group
+choices. That product is countable by a short dynamic program and walkable in the
+same order, which is what this module provides: :attr:`SearchSpace.size` is the
+exact number of subsets :meth:`SearchSpace.iter_subsets` will emit, computed
+without emitting any of them.
+
+The count is what the enumeration limit should be measured against. Conflict
+pairs, a cost budget and the pool's no-good sets stay predicates on a finished
+candidate, since none of them decomposes over a group. They only remove designs,
+so :attr:`SearchSpace.size` bounds the admissible count from above and the gate
+stays safe.
+
+With no restrictions the walk is ``combinations(range(N), K)`` term for term,
+including order, so the search meets designs in the order it always did.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import combinations
+from math import comb
+from typing import Iterable, Iterator, List, Optional, Sequence, Tuple
+
+#: A stratum as :mod:`restrictions` states it: members, then optional bounds.
+Stratum = Tuple[Sequence[int], Optional[int], Optional[int]]
+
+
+@dataclass(frozen=True)
+class Group:
+    """Selectable units sharing a quota, with the quota resolved to integers.
+
+    ``lo`` and ``hi`` are the bounds after the forced units inside the group have
+    been credited against them and after the forbidden ones have left
+    ``members``, so a walk reads them directly.
+    """
+
+    members: Tuple[int, ...]
+    lo: int
+    hi: int
+
+
+@dataclass(frozen=True)
+class SearchSpace:
+    """The treated sets a restricted enumeration will visit.
+
+    Attributes
+    ----------
+    forced : tuple of int
+        Units present in every emitted design.
+    groups : tuple of Group
+        Disjoint blocks of selectable units, each with a resolved quota.
+    k_free : int
+        How many units the walk still chooses, once ``forced`` is accounted for.
+    size : int
+        Exactly how many subsets :meth:`iter_subsets` emits. Zero when the
+        restrictions are jointly unsatisfiable.
+    """
+
+    forced: Tuple[int, ...]
+    groups: Tuple[Group, ...]
+    k_free: int
+    size: int
+    _ways: Tuple[Tuple[int, ...], ...] = ()
+
+    # ------------------------------------------------------------------
+    # construction
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def build(
+        cls,
+        N: int,
+        K: int,
+        *,
+        forced: Iterable[int] = (),
+        forbidden: Iterable[int] = (),
+        strata: Sequence[Stratum] = (),
+    ) -> "SearchSpace":
+        """Resolve the structural restrictions into groups and count the result.
+
+        An unsatisfiable combination gives a space of size zero with an empty
+        walk. The search reads that as "no admissible design" and raises with the
+        message it already had, so an impossible instance keeps one explanation.
+        """
+        forced_set = frozenset(int(i) for i in forced)
+        forbidden_set = frozenset(int(i) for i in forbidden)
+        k_free = int(K) - len(forced_set)
+
+        if forced_set & forbidden_set or k_free < 0:
+            return cls._empty(forced_set, k_free)
+
+        free = [i for i in range(int(N))
+                if i not in forced_set and i not in forbidden_set]
+        groups = cls._groups(free, forced_set, strata, K=int(K))
+        if groups is None:
+            return cls._empty(forced_set, k_free)
+
+        ways = _count_ways(groups, k_free)
+        return cls(forced=tuple(sorted(forced_set)), groups=groups,
+                   k_free=k_free, size=ways[0][k_free],
+                   _ways=tuple(tuple(row) for row in ways))
+
+    @classmethod
+    def _empty(cls, forced: frozenset, k_free: int) -> "SearchSpace":
+        return cls(forced=tuple(sorted(forced)), groups=(),
+                   k_free=max(k_free, 0), size=0, _ways=())
+
+    @staticmethod
+    def _groups(
+        free: List[int],
+        forced: frozenset,
+        strata: Sequence[Stratum],
+        *,
+        K: int,
+    ) -> Optional[Tuple[Group, ...]]:
+        """Partition the free units into quota groups, or ``None`` if impossible.
+
+        Falls back to a single unquotaed group when the strata overlap, which
+        keeps the walk correct for a caller that supplies its own: the emitted
+        designs then cover the admissible ones, and the quota is applied as a
+        candidate test downstream.
+        """
+        if not strata or not _disjoint(strata):
+            return (Group(tuple(free), 0, len(free)),)
+
+        groups: List[Group] = []
+        claimed: set = set()
+        for members, lo, hi in strata:
+            member_set = frozenset(int(m) for m in members)
+            claimed |= member_set
+            selectable = tuple(i for i in free if i in member_set)
+            held = len(forced & member_set)
+            low = max(0, (0 if lo is None else int(lo)) - held)
+            high = min(len(selectable),
+                       (K if hi is None else int(hi)) - held)
+            if high < low:
+                return None
+            groups.append(Group(selectable, low, high))
+
+        leftover = tuple(i for i in free if i not in claimed)
+        if leftover:
+            groups.append(Group(leftover, 0, len(leftover)))
+        return tuple(groups)
+
+    # ------------------------------------------------------------------
+    # the walk
+    # ------------------------------------------------------------------
+
+    def iter_subsets(self) -> Iterator[Tuple[int, ...]]:
+        """Yield every admissible treated set once, as a sorted tuple.
+
+        Emits exactly :attr:`size` subsets. Branches that no completion can
+        finish are skipped on the same table the count was read from, so the walk
+        does no work per design it does not emit.
+        """
+        if not self.size:
+            return
+        yield from self._walk(0, self.k_free, [])
+
+    def _walk(self, g: int, remaining: int,
+              picked: List[int]) -> Iterator[Tuple[int, ...]]:
+        if g == len(self.groups):
+            yield tuple(sorted(self.forced + tuple(picked)))
+            return
+        group = self.groups[g]
+        for take in range(group.lo, min(group.hi, remaining) + 1):
+            if not self._ways[g + 1][remaining - take]:
+                continue
+            for pick in combinations(group.members, take):
+                yield from self._walk(g + 1, remaining - take,
+                                      picked + list(pick))
+
+
+def _disjoint(strata: Sequence[Stratum]) -> bool:
+    """Whether no unit belongs to two strata."""
+    seen: set = set()
+    for members, _, _ in strata:
+        member_set = {int(m) for m in members}
+        if seen & member_set:
+            return False
+        seen |= member_set
+    return True
+
+
+def _count_ways(groups: Tuple[Group, ...], k_free: int) -> List[List[int]]:
+    """``ways[g][j]``: how many ways groups ``g`` onward supply ``j`` units.
+
+    Read backwards so ``ways[0][k_free]`` is the size of the whole space and
+    ``ways[g + 1][.]`` tells the walk whether a branch can still be completed.
+    """
+    n_groups = len(groups)
+    ways = [[0] * (k_free + 1) for _ in range(n_groups + 1)]
+    ways[n_groups][0] = 1
+    for g in range(n_groups - 1, -1, -1):
+        group = groups[g]
+        for j in range(k_free + 1):
+            total = 0
+            for take in range(group.lo, min(group.hi, j) + 1):
+                total += comb(len(group.members), take) * ways[g + 1][j - take]
+            ways[g][j] = total
+    return ways

--- a/mlsynth/utils/syndes_helpers/enumeration.py
+++ b/mlsynth/utils/syndes_helpers/enumeration.py
@@ -170,8 +170,19 @@ class SearchSpace:
         Emits exactly :attr:`size` subsets. Branches that no completion can
         finish are skipped on the same table the count was read from, so the walk
         does no work per design it does not emit.
+
+        One group and no forced units is the unrestricted case, and there the
+        general walk would pay a frame and a sort per design for a merge it does
+        not need: a single group's members are ascending, so its combinations are
+        already sorted treated sets. That case defers to
+        :func:`itertools.combinations`, which is what the search used before
+        candidates were built inside the restrictions. A quota can still make the
+        one group unreachable, so the size check above is what admits this path.
         """
         if not self.size:
+            return
+        if not self.forced and len(self.groups) == 1:
+            yield from combinations(self.groups[0].members, self.k_free)
             return
         yield from self._walk(0, self.k_free, [])
 

--- a/mlsynth/utils/syndes_helpers/exact.py
+++ b/mlsynth/utils/syndes_helpers/exact.py
@@ -21,29 +21,35 @@ candidate, not in the complexity class. Choosing ``S`` is still hard -- ranking
 designs by the bound is a cardinality-constrained max-cut. But a candidate costs
 one row of a matrix product instead of a node with an LP relaxation, and the
 panel length drops out entirely after the Gram step, so a long panel costs no
-more per design than a short one. Above ``candidate_limit`` designs, enumeration
-stops being affordable and the search falls back to max-cut candidates polished
-on the objective, reported against the Rayleigh bound.
+more per design than a short one. Above ``candidate_limit`` admissible designs,
+enumeration stops being affordable and the search falls back to max-cut candidates
+polished on the objective, reported against the Rayleigh bound.
 
-Restrictions on the assignment are predicates on the treated set -- forced,
-forbidden, conflicting, stratum quotas, a cost budget, and the pool's no-good
-sets -- so they are applied while candidates are generated. ``donor_exclusion``
-is the exception: it ties the control weights to which units are treated, so the
-closed form's matrix would differ per candidate and the batch product would not
-hold. The backend refuses it.
+Restrictions on the assignment are predicates on the treated set, and they split
+in two. Forced units, forbidden units and stratum quotas are structural: they
+decide which candidates exist, so
+:mod:`mlsynth.utils.syndes_helpers.enumeration` builds candidates inside them and
+counts the result exactly. That count is what ``candidate_limit`` is measured
+against, so an instance with most of its units forbidden is enumerated on the
+designs it has instead of the designs it would have had. Conflict pairs, a cost
+budget and the pool's no-good sets do not decompose over a group, so they stay
+tests on a finished candidate and cannot lower the count.
+
+``donor_exclusion`` is refused outright: it ties the control weights to which
+units are treated, so the closed form's matrix would differ per candidate and the
+batch product would not hold.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from itertools import combinations, islice
-from math import comb
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 
 from ...exceptions import MlsynthConfigError, MlsynthEstimationError
 from ..fast_scm_helpers.structure import IndexSet
+from .enumeration import SearchSpace
 from .gram import (
     BoundEngine,
     TwoWayProblem,
@@ -168,20 +174,40 @@ class SubsetFilter:
         return True
 
 
-def _stream_subsets(N: int, K: int, filt: SubsetFilter, chunk: int):
+def _search_space(N: int, K: int, filt: SubsetFilter) -> SearchSpace:
+    """The structural half of ``filt``, resolved into a space to walk.
+
+    Forced units, forbidden units and stratum quotas shape which candidates
+    exist, so they are handed to the generator. What remains is applied to
+    finished candidates.
+    """
+    return SearchSpace.build(N, K, forced=filt.forced_in,
+                             forbidden=filt.forbidden, strata=filt.strata)
+
+
+def _stream_from_space(space: SearchSpace, filt: SubsetFilter, chunk: int):
     """Yield ``(B, K)`` arrays of admissible treated sets, ``B <= chunk``.
 
-    An exhausted source and a slice the filter emptied are different things: the
-    first ends the stream, the second only skips a yield.
+    The walk already honours the structural restrictions, so ``filt`` is consulted
+    here for the ones that do not decompose over a group: conflict pairs, the cost
+    budget, and the pool's no-good sets. Blocks fill to ``chunk`` from whatever
+    survives, so a long rejected run delays a yield instead of shrinking one.
     """
-    source = combinations(range(N), K)
-    while True:
-        raw = list(islice(source, chunk))
-        if not raw:
-            return
-        block = [s for s in raw if filt.accepts(s)]
-        if block:
+    block: List[Tuple[int, ...]] = []
+    for subset in space.iter_subsets():
+        if not filt.accepts(subset):
+            continue
+        block.append(subset)
+        if len(block) == chunk:
             yield np.array(block, dtype=np.int64)
+            block = []
+    if block:
+        yield np.array(block, dtype=np.int64)
+
+
+def _stream_subsets(N: int, K: int, filt: SubsetFilter, chunk: int):
+    """Yield ``(B, K)`` arrays of admissible treated sets, ``B <= chunk``."""
+    yield from _stream_from_space(_search_space(N, K, filt), filt, chunk)
 
 
 # ----------------------------------------------------------------------
@@ -241,11 +267,11 @@ def _search(
     """Enumerate and prune, or fall back to max-cut candidates when too large."""
     engine = BoundEngine.from_problem(problem)
     N = problem.N
-    total = comb(N, K)
+    space = _search_space(N, K, filt)
 
-    if total > candidate_limit or not engine.reliable:
+    if space.size > candidate_limit or not engine.reliable:
         return _search_by_candidates(problem, engine, K, filt, seed=seed,
-                                     n_designs=total)
+                                     n_designs=space.size)
 
     best_value, best_set = np.inf, None
     if incumbent_sets is not None and len(np.atleast_2d(incumbent_sets)):
@@ -260,7 +286,7 @@ def _search(
     n_designs = 0
     n_closed_form = 0
 
-    for block in _stream_subsets(N, K, filt, CHUNK):
+    for block in _stream_from_space(space, filt, CHUNK):
         n_designs += block.shape[0]
         scored = engine.bound(signs_from_subsets(N, block))
         if scored.exact.any():

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -181,3 +181,39 @@ timeout = 300.0
   find = "if not self.forced_in <= chosen:"
   replace = "if self.forced_in and not (self.forced_in & chosen):"
   models = "a to_be_treated rule read as 'at least one of these' instead of 'all of these', which silently drops units the experimenter committed to treating"
+
+[[target]]
+name = "syndes-enumeration"
+module-path = "mlsynth/utils/syndes_helpers/enumeration.py"
+test-command = "python -m pytest mlsynth/tests/test_syndes_enumeration.py -q -p no:cacheprovider"
+timeout = 180.0
+
+  [[target.mutant]]
+  id = "gate-reads-the-unrestricted-count"
+  find = "size=ways[0][k_free],"
+  replace = "size=comb(int(N), int(K)),"
+  models = "the count this module exists to compute, reverted to the binomial the search used before -- the walk still visits only admissible designs, but the enumeration limit is measured against designs that do not exist, so a restricted instance is refused for being large in a space it never enters"
+
+  [[target.mutant]]
+  id = "quota-ignores-forced-members"
+  find = "held = len(forced & member_set)"
+  replace = "held = 0"
+  models = "a stratum quota that does not credit the forced units already inside the group, so a ceiling of one admits a design holding a forced member plus another, and the returned design breaks the coverage rule it was given"
+
+  [[target.mutant]]
+  id = "overlapping-strata-treated-as-a-partition"
+  find = "if not strata or not _disjoint(strata):"
+  replace = "if not strata:"
+  models = "disjointness assumed instead of checked, so a unit shared by two strata is drawn once by each -- the walk emits sets with a repeated unit and the same design more than once, and the count inherits both"
+
+  [[target.mutant]]
+  id = "forbidden-units-stay-in-the-ground-set"
+  find = "if i not in forced_set and i not in forbidden_set]"
+  replace = "if i not in forced_set]"
+  models = "a ground set that drops the forced units but keeps the forbidden ones, so units the design is required to leave alone are offered to the walk and can be treated"
+
+  [[target.mutant]]
+  id = "stratum-floor-is-dropped"
+  find = "low = max(0, (0 if lo is None else int(lo)) - held)"
+  replace = "low = 0"
+  models = "only the ceilings of a coverage quota enforced, so a minimum-per-stratum rule is accepted and silently does nothing, and designs that cover too few groups are admitted"

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -217,3 +217,9 @@ timeout = 180.0
   find = "low = max(0, (0 if lo is None else int(lo)) - held)"
   replace = "low = 0"
   models = "only the ceilings of a coverage quota enforced, so a minimum-per-stratum rule is accepted and silently does nothing, and designs that cover too few groups are admitted"
+
+  [[target.mutant]]
+  id = "fast-path-ignores-forced-units"
+  find = "if not self.forced and len(self.groups) == 1:"
+  replace = "if len(self.groups) == 1:"
+  models = "the single-group shortcut taken when forced units exist, so the units the design must contain are never merged in and every emitted set is short by the forced count -- the specialisation for the unrestricted case silently applied to a restricted one"

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -223,3 +223,9 @@ timeout = 180.0
   find = "if not self.forced and len(self.groups) == 1:"
   replace = "if len(self.groups) == 1:"
   models = "the single-group shortcut taken when forced units exist, so the units the design must contain are never merged in and every emitted set is short by the forced count -- the specialisation for the unrestricted case silently applied to a restricted one"
+
+  [[target.mutant]]
+  id = "group-order-assumed-ascending"
+  find = "_presorted=not forced_set and _ascending(groups))"
+  replace = "_presorted=not forced_set)"
+  models = "the sort skipped whenever no unit is forced, on the assumption that the groups run uphill -- a stratum over the high units leaves the low ones to the leftover group, which lands last, so the emitted tuple runs downhill and names a treated set whose units are read in the wrong positions"


### PR DESCRIPTION
## Related Links

- Follows #408 (the Gram reduction and its bounds), #409 (the exact backend) and #410 (making it the default). This closes a limitation left open by those
- Docs: `docs/syndes.rst`, the `backend` section
- Source paper: Doudchenko, Khosravi, Imbens et al. (2021), the `(two-way global)` objective

## What

- Added `utils/syndes_helpers/enumeration.py`: `SearchSpace` resolves the structural restrictions into disjoint quota groups, counts the admissible designs exactly with a dynamic program, and walks them
- `candidate_limit` is now compared against that count instead of `C(N, K)`
- `_stream_subsets` keeps its signature and delegates; `_search` builds the space once and streams from it
- Corrected `docs/syndes.rst`, which still said `backend` defaults to `"mip"` — #410 flipped it to `"exact"` and missed the line
- Added `tests/test_syndes_enumeration.py` (69 tests) and a `TestRestrictedEnumeration` class in `tests/test_syndes_exact.py`
- Added 7 semantic mutants under a new `syndes-enumeration` target

## Why

The backend generated every `C(N, K)` subset and tested each against the restrictions, so the enumeration limit measured the unrestricted problem. An instance with two hundred units and all but ten forbidden cost what two hundred free units cost, though only `C(10, K)` designs existed.

Past the limit with any restriction set, the backend did not fall back to the heuristic — it raised `MlsynthConfigError`, because the fallback searches the unrestricted space and must not pretend otherwise. So this converts refused into solved exactly for a whole class of instances.

## How

Three restrictions decide which candidates exist: forced units are in every design, forbidden units (including size-ineligible ones) are in none, and a stratum quota bounds how many members of a group a design may hold. `design_restrictions` keys each unit to one stratum, so the groups are disjoint and the admissible designs are a product of per-group choices — countable by a backward dynamic program and walkable on the same table, which also lets the walk skip branches no completion can finish.

Conflict pairs, `costs` with a `budget` and the pool's no-good sets do not decompose over a group, so they stay tests on a finished candidate and cannot lower the count. `test_the_unrestricted_instance_is_past_the_limit` pins that an instance carrying only those is still refused, so the improvement is not overstated.

Disjointness is checked, not assumed. A caller may hand over overlapping strata, and those fall back to one unquotaed group with the quota applied downstream.

Two performance regressions were found by benchmarking and fixed, both from the general walk paying a sort per design to merge forced units into picks drawn from several groups:

1. The unrestricted case went 1.6x slower (6.72s to 10.55s at N=30, K=8). One group and no forced units has nothing to merge, and a group's members are ascending, so that case now defers to `itertools.combinations` — the code the search used before.
2. A restriction that shrinks the space only modestly still took the general walk. One stratum capped at four over half the units trims 5,852,925 designs to 3,858,075, a third, and ran 9 percent slower than generate-then-filter. The sort is now skipped whenever no unit is forced and the groups already ascend. Group order is checked: a stratum over the high units leaves the low ones to the leftover group, which lands last.

## Verification

- Path: not applicable. This changes which candidates are generated and how they are counted, not what any design scores. The numerical claims are verified in #408 and #409
- The correctness claim rests on `test_it_reaches_the_same_design_as_generate_then_filter`: for each restriction kind it computes the optimum by generating every subset, filtering with `SubsetFilter.accepts` and scoring with the inner solver — the exact semantics the backend had before — and asserts the new walk reaches the same treated set and objective
- `test_matches_combinations_including_order` pins that an unrestricted space reproduces `combinations(range(N), K)` term for term, including order. The search breaks ties by which design it meets first, so a reordering would be free to move a reported design. No existing result moves
- Four property tests (hypothesis, 250 examples each) assert the walk equals a brute-force filter, that `size` counts the walk, and that `size` bounds the admissible count from above and `C(N, K)` from below — the two inequalities that make the gate safe

Timings are recorded here and not as a test, so CI does not depend on them. Generation only, best of three, alternating so neither path pays the other's warmup:

| case | designs | old | new | |
|---|---|---|---|---|
| N=20, K=6 | 38,760 | 0.037s | 0.042s | 0.89x |
| N=24, K=8 | 735,471 | 0.843s | 0.865s | 0.97x |
| N=30, K=8 | 5,852,925 | 6.74s | 7.09s | 0.95x |
| N=30, K=8, one capped stratum | 3,858,075 | 7.56s | 7.50s | 1.01x |
| N=30, K=8, one forced unit | 1,560,780 | 3.84s | 2.91s | 1.32x |
| N=24, K=8, half forbidden | 495 | 0.558s | 0.001s | 983x |
| N=200, K=6, all but ten forbidden | 210 | 8.2e10 tuples | 0.000s | — |

What remains on the unrestricted path is a few percent of fixed cost — `SearchSpace.build` and its counting table, paid once per solve. At N=20 that is 5 milliseconds, and it shrinks in relative terms as the case grows. Run-to-run noise on the machine used is the same order.

## Scope checks

Feature on an existing estimator.

- [x] The default preserves existing behaviour exactly. With no restrictions the walk is `combinations(range(N), K)` term for term, including order
- [x] No pinned benchmark values moved
- [x] `test_matches_combinations_including_order` and `test_the_unrestricted_instance_is_past_the_limit` pin the unchanged behaviour on both sides of the gate
- [x] No new config field. `candidate_limit` keeps its meaning — a cap on designs the search will enumerate — and now reads a count that reflects the restrictions

## Designs

No visual output changes. This alters which candidates are generated, not what a design is or how it is plotted.

## Test Steps

- [x] `pytest mlsynth/tests/test_syndes_enumeration.py -q` — 69 passed
- [x] `pytest mlsynth/tests/test_syndes.py mlsynth/tests/test_syndes_*.py mlsynth/tests/test_result_contract.py -q` — 775 passed
- [x] `pytest mlsynth/tests/` — 7908 passed, 42 skipped, 0 failed (51 min, all 345 test files)
- [x] `coverage run --timid --source=mlsynth/utils/syndes_helpers -m pytest mlsynth/tests/test_syndes_enumeration.py` — `enumeration.py` at 100 percent, no `# pragma: no cover`
- [x] `python tools/mutation/run_mutants.py --target syndes-enumeration` — 7/7 killed
- [x] `--target syndes-{gram,partition,exact}` — 14/14 killed, re-run because `exact.py` changed
- [ ] Docs build not run — sphinx is not installed here. Read the Docs covers it

## Other Notes

- The gate is measured on the count of designs the walk emits, which is the real cost: the walk generates only admissible candidates, so nothing is paid for designs that do not exist
- A restricted instance can still exceed the limit, and is then refused exactly as before if any restriction is active. The fallback searches the unrestricted space, so it cannot honour restrictions at any size
- Unrelated and still open from the #410 work: `miqp_accel.solve_warm_cut`'s warm start is not honoured by SCIP. `addSol` returns `True` and `AccelInfo.warm_applied` is set, but the partial solution does not become an incumbent, so the docstring's "whether the binary warm start was accepted" overstates what is verified. SYNDES no longer uses that path; MAREX and the other exact designs do. Its own scope and its own branch