### PR TITLE
Write each warm-start bit to the variable the caller named

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ now returns and the back-compat guarantee.
   objective cut only ever applied to the two-way branch-and-bound, which is no
   longer the default route, and the certificate that consumed the same lift now
   uses the closed-form Rayleigh bound. `_sdp_moment_bound_two_way` goes with
-  them. `utils/miqp_accel.py` stays -- MAREX and the other exact designs use it.
+  them. `utils/miqp_accel.py` stays: `solve_synthetic_design` still routes to it
+  when a caller supplies `warm_start_D` or `objective_lower_bound`, though
+  nothing in the library reaches it by default any more.
 - Donor-side restrictions under `mode="two_way_global"`: `donor_exclusion`,
   `donor_region_col` and `exclude_bordering_donors` now raise for that mode, and
   `donor_constraints` refuses `global_2way` directly. A donor rule reads
@@ -99,6 +101,26 @@ now returns and the back-compat guarantee.
   `tests/test_syndes_backend.py`, `tests/test_syndes_exact_properties.py`, and
   nine semantic mutants in `tools/mutation/targets.toml`.
 
+
+### Fixed
+- `utils/miqp_accel.solve_warm_cut` wrote each warm-start bit to the wrong SCIP
+  variable on problems above roughly eleven units. cvxpy returns the boolean
+  columns as a `set`, and the accelerator iterated it directly, so `warm_bits[j]`
+  was paired with whichever column the hash table happened to yield, not with
+  entry `j` of the boolean variable. The two orders agree for short index
+  runs, which is why small problems behaved correctly and larger ones did not:
+  SCIP was started from a design the caller never named. At N=200, K=6 under a
+  60 s limit the start left the solver worse off than no start at all
+  (objective 0.2151 against 0.2070); it now returns the started design, 0.1812.
+  The positions are read in the variable's own order, which for one contiguous
+  boolean block is ascending column. No shipped estimator was affected: nothing
+  in the library passes `warm_start_D` or `objective_lower_bound` since the
+  SYNDES accelerator was removed, so this was a latent defect on a reachable but
+  unused path.
+- `AccelInfo.warm_applied` is set from what `addSol` returned instead of from
+  having called it, and its documentation no longer says the start was
+  "accepted". A stored partial start is one SCIP will try to complete over the
+  continuous variables, not one it has already adopted.
 
 ### Changed
 - `SYNDESConfig.backend` defaults to `"exact"`, so `mode="two_way_global"` is

--- a/mlsynth/tests/test_miqp_accel.py
+++ b/mlsynth/tests/test_miqp_accel.py
@@ -13,14 +13,14 @@ The contract these tests pin:
 * neither injection changes the proven optimum (both are valid);
 * the cut actually raises the reported dual bound to ``L``;
 * a too-high (invalid) ``L`` is caught -- the solve falls back to the un-cut
-  problem and still returns the true optimum rather than a wrong/infeasible one;
+  problem and still returns the true optimum, not a wrong or infeasible one;
 * the warm-start shape guard fires on a mismatch.
 """
 import numpy as np
 import cvxpy as cp
 import pytest
 
-from mlsynth.utils.miqp_accel import solve_warm_cut, AccelInfo
+from mlsynth.utils.miqp_accel import solve_warm_cut, AccelInfo, _bool_positions
 from mlsynth.utils.syndes_helpers.formulation import build_syndes_problem_components
 from mlsynth.utils.syndes_helpers.optimization import estimate_lambda
 from mlsynth.utils.syndes_helpers.certificate import _rayleigh_bound_two_way
@@ -115,3 +115,146 @@ class TestSolveWarmCut:
         prob, D = build()
         with pytest.raises(ValueError):
             solve_warm_cut(prob, D, warm_bits=np.zeros(5))
+
+
+# ----------------------------------------------------------------------
+# Which canonical variable each warm bit is written to
+# ----------------------------------------------------------------------
+
+
+def _pinned_through(data, positions, bits):
+    """Objective with the boolean variables pinned at ``positions`` to ``bits``.
+
+    Builds the model the accelerator builds, fixes the booleans by bound, and
+    solves. What comes back is the objective of whichever design those positions
+    actually name.
+    """
+    from pyscipopt.scip import Model
+    from cvxpy.reductions.solvers.conic_solvers.scip_conif import SCIP as _Base
+
+    base = _Base()
+    model = Model()
+    A, b, c, dims = base._define_data(data)
+    variables = base._create_variables(model, data, c)
+    base._add_constraints(model, variables, A, b, dims)
+    base._set_params(model, False, {}, data, dims)
+    for pos, vpos in enumerate(positions):
+        model.chgVarLb(variables[vpos], float(bits[pos]))
+        model.chgVarUb(variables[vpos], float(bits[pos]))
+    model.hideOutput()
+    model.optimize()
+    return model.getObjVal() if model.getNSols() else None
+
+
+def _instance(N, K, T, seed=1):
+    """A two-way instance plus a fixed design to warm-start from."""
+    rng = np.random.default_rng(seed)
+    Y = rng.standard_normal((T, N))
+    lam = float(estimate_lambda(Y))
+    bits = np.zeros(N)
+    bits[:K] = 1.0
+
+    def build():
+        D = cp.Variable(N, boolean=True)
+        comp = build_syndes_problem_components(Y=Y, D=D, K=K, lam=lam,
+                                               mode="global_2way")
+        return cp.Problem(cp.Minimize(comp.objective), list(comp.constraints)), D
+
+    return Y, lam, bits, build
+
+
+class TestWarmBitAlignment:
+    """A warm bit has to reach the unit the caller named.
+
+    cvxpy hands back ``data[BOOL_IDX]`` as a set, so iterating it yields the hash
+    table's order, which agrees with the variable's own order at some sizes and
+    not at others. Writing ``warm_bits[j]`` to the j-th element of that iteration
+    describes a different design from the one requested, and SCIP is then warm
+    started onto a set the caller never asked for. Below N=11 the two orders
+    happen to agree, which is why small cases pass while real ones do not.
+    """
+
+    SIZES = [(12, 4, 18), (14, 4, 20), (24, 6, 34)]
+
+    def test_cvxpy_hands_back_an_unordered_set(self):
+        """The dependency this guards against, pinned so a change is noticed."""
+        import cvxpy.settings as s
+
+        _, _, _, build = _instance(14, 4, 20)
+        prob, _ = build()
+        data, _, _ = prob.get_problem_data(cp.SCIP)
+        assert isinstance(data[s.BOOL_IDX], set)
+
+    @pytest.mark.parametrize("N,K,T", SIZES)
+    def test_positions_are_the_ascending_block(self, N, K, T):
+        """One boolean variable occupies a contiguous ascending run of columns."""
+        _, _, _, build = _instance(N, K, T)
+        prob, _ = build()
+        data, _, _ = prob.get_problem_data(cp.SCIP)
+        pos = _bool_positions(data)
+        assert pos == sorted(pos)
+        assert pos == list(range(min(pos), min(pos) + len(pos)))
+
+    @pytest.mark.parametrize("N,K,T", SIZES)
+    def test_warm_bits_name_the_design_the_caller_meant(self, N, K, T):
+        """Pinning through the accelerator's positions must equal pinning in cvxpy.
+
+        ``D == bits`` is the caller's intent stated to cvxpy. Fixing the same
+        units through the accelerator's own mapping has to reach the same
+        objective, whatever order the set iterates in.
+        """
+        Y, lam, bits, build = _instance(N, K, T)
+        prob, D = build()
+        intent = cp.Problem(prob.objective, list(prob.constraints) + [D == bits])
+        intent.solve(solver=cp.SCIP)
+
+        data, _, _ = build()[0].get_problem_data(cp.SCIP)
+        through_mapping = _pinned_through(data, _bool_positions(data), bits)
+        assert through_mapping == pytest.approx(intent.value, abs=1e-5)
+
+
+class TestWarmStartHelps:
+    def test_a_warm_start_never_returns_a_worse_design(self):
+        """Incumbents only improve, so a start SCIP keeps bounds what it returns.
+
+        Sized so SCIP cannot finish in the budget: that is the regime where the
+        start is the only thing standing between the caller and a worse design,
+        and where a misaligned one does active harm.
+        """
+        N, K, T = 60, 6, 40
+        Y, lam, _, build = _instance(N, K, T)
+        prob, D = build()
+        prob, _ = solve_warm_cut(prob, D, time_limit=8.0)
+        cold = float(prob.value)
+        cold_bits = np.asarray(D.value).round()
+
+        warm_prob, warm_D = build()
+        warm_prob, info = solve_warm_cut(warm_prob, warm_D, warm_bits=cold_bits,
+                                         time_limit=8.0)
+        assert info.warm_applied
+        assert float(warm_prob.value) <= cold + 1e-6
+
+    def test_warm_applied_reports_what_scip_stored(self):
+        _, _, build = _make(N=7, K=2)
+        warm = np.zeros(7); warm[[0, 1]] = 1.0
+        prob, D = build()
+        _, info = solve_warm_cut(prob, D, warm_bits=warm, time_limit=30.0)
+        assert info.warm_applied is True
+
+    def test_warm_applied_is_false_when_scip_declines_the_start(self, monkeypatch):
+        """The flag reports SCIP's answer, not that the call was made."""
+        import pyscipopt.scip as _scip
+
+        real = _scip.Model
+
+        class Declines(real):
+            def addSol(self, sol, free=True):
+                real.addSol(self, sol, free=free)
+                return False
+
+        monkeypatch.setattr(_scip, "Model", Declines)
+        _, _, build = _make(N=7, K=2)
+        warm = np.zeros(7); warm[[0, 1]] = 1.0
+        prob, D = build()
+        _, info = solve_warm_cut(prob, D, warm_bits=warm, time_limit=30.0)
+        assert info.warm_applied is False

--- a/mlsynth/tests/test_syndes_removals.py
+++ b/mlsynth/tests/test_syndes_removals.py
@@ -144,9 +144,21 @@ class TestAcceleratorRemoved:
         assert not hasattr(certificate, "_sdp_moment_bound_two_way")
 
     def test_the_shared_warm_cut_helper_survives(self):
-        """Other estimators use it, so only the SYNDES-specific wrapper went."""
+        """Only the SYNDES-specific wrapper went.
+
+        ``solve_synthetic_design`` still routes to it when a caller supplies a
+        warm start or an objective bound, so the entry point stays even though
+        nothing in the library reaches it by default any more.
+        """
         from mlsynth.utils import miqp_accel
         assert hasattr(miqp_accel, "solve_warm_cut")
+
+    def test_the_warm_start_route_is_still_reachable(self):
+        """The parameters that select it are still on the public solver."""
+        import inspect
+        from mlsynth.utils.syndes_helpers.optimization import solve_synthetic_design
+        params = inspect.signature(solve_synthetic_design).parameters
+        assert "warm_start_D" in params and "objective_lower_bound" in params
 
     def test_certify_still_works_on_the_new_default(self):
         res = SYNDES(_cfg(certify=True)).fit()

--- a/mlsynth/utils/miqp_accel.py
+++ b/mlsynth/utils/miqp_accel.py
@@ -22,7 +22,7 @@ Safety. A cut with an ``L`` above the true optimum would remove the optimum (a
 correctness bug, not a slowdown). Callers must margin ``L`` below the bound. As a
 backstop, if the cut renders the model infeasible (``L`` above *every* feasible
 objective), the solve falls back to the un-cut problem and reports ``fell_back``,
-so a bad bound degrades to a correct-but-unaccelerated solve rather than a wrong
+so a bad bound degrades to a correct-but-unaccelerated solve instead of a wrong
 or infeasible answer.
 
 Offset. The cut is written on the canonical objective vector ``c`` assuming the
@@ -39,6 +39,22 @@ import cvxpy as cp
 import cvxpy.settings as s
 import numpy as np
 from cvxpy.reductions.solvers.conic_solvers.scip_conif import SCIP as _CvxSCIP
+
+
+def _bool_positions(data) -> list:
+    """Canonical columns holding the boolean variable's entries, in its own order.
+
+    cvxpy returns ``data[BOOL_IDX]`` as a ``set``, so iterating it yields the hash
+    table's order. For a contiguous run of small integers that order is ascending
+    at some lengths and rotated at others, and it agreed with the variable's own
+    order often enough for small problems to look correct.
+
+    A single boolean variable occupies one contiguous ascending block of the
+    canonical vector, stacked column-major, which is the order
+    :func:`solve_warm_cut` flattens ``warm_bits`` into. Ascending column is
+    therefore that variable's own order, and sorting recovers it.
+    """
+    return sorted(data[s.BOOL_IDX])
 
 
 @dataclass(frozen=True)
@@ -60,8 +76,11 @@ class AccelInfo:
     cut_applied : bool
         Whether the objective lower-bound cut was added.
     warm_applied : bool
-        Whether the binary warm start was accepted (length matched the model's
-        boolean variables).
+        Whether SCIP stored the binary warm start: the length matched the model's
+        boolean variables and ``addSol`` reported it kept. The start is a partial
+        solution, so SCIP still has to complete it over the continuous variables
+        before it can become an incumbent; a stored start is one SCIP will try,
+        not one it has already adopted.
     fell_back : bool
         Whether the cut was dropped and the solve retried un-cut because the cut
         made the model infeasible (a too-high ``L``).
@@ -93,7 +112,7 @@ class _WarmCutSCIP(_CvxSCIP):
         self.warm_applied = False
         self.cut_applied = False
         # The built SCIP model, kept so the caller can read the dual bound / gap /
-        # status directly rather than through cvxpy's solution dict, whose keys
+        # status directly instead of through cvxpy's solution dict, whose keys
         # ("model", "scip_status") are internal and vary across cvxpy versions.
         self.model = None
 
@@ -118,15 +137,16 @@ class _WarmCutSCIP(_CvxSCIP):
                           >= float(self._L))
             self.cut_applied = True
 
-        # Binary warm start (partial MIP start on the boolean variables).
+        # Binary warm start (partial MIP start on the boolean variables). The
+        # positions must be read in the variable's own order, not the order the
+        # index set iterates in -- see _bool_positions.
         if self._warm is not None:
-            bidx = list(data[s.BOOL_IDX])
+            bidx = _bool_positions(data)
             if len(bidx) == len(self._warm):
                 sol = model.createPartialSol()
                 for pos, vpos in enumerate(bidx):
                     model.setSolVal(sol, variables[vpos], float(self._warm[pos]))
-                model.addSol(sol)
-                self.warm_applied = True
+                self.warm_applied = bool(model.addSol(sol))
 
         self.model = model
         return self._solve(model, variables, constraints, data, dims)

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -229,3 +229,33 @@ timeout = 180.0
   find = "_presorted=not forced_set and _ascending(groups))"
   replace = "_presorted=not forced_set)"
   models = "the sort skipped whenever no unit is forced, on the assumption that the groups run uphill -- a stratum over the high units leaves the low ones to the leftover group, which lands last, so the emitted tuple runs downhill and names a treated set whose units are read in the wrong positions"
+
+[[target]]
+name = "miqp-accel"
+module-path = "mlsynth/utils/miqp_accel.py"
+test-command = "python -m pytest mlsynth/tests/test_miqp_accel.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "warm-bits-follow-the-index-set-iteration-order"
+  find = "return sorted(data[s.BOOL_IDX])"
+  replace = "return list(data[s.BOOL_IDX])"
+  models = "the defect this helper exists to prevent: cvxpy returns the boolean columns as a set, so iterating it pairs each warm bit with whichever variable the hash table happens to yield, and SCIP is started from a design the caller never named -- correct below the size where the two orders diverge, and silently wrong above it"
+
+  [[target.mutant]]
+  id = "warm-start-reported-applied-without-being-stored"
+  find = "self.warm_applied = bool(model.addSol(sol))"
+  replace = "model.addSol(sol); self.warm_applied = True"
+  models = "the flag set from having called addSol instead of from what it returned, so a start SCIP declined is reported to the caller as applied and a solve that was never accelerated looks as though it was"
+
+  # Recorded, not carried: replacing the objective's support with every column
+  # ("nz = np.arange(c.shape[0])") is an equivalent mutant. The extra terms all
+  # carry coefficient zero, so quicksum builds the same constraint and only the
+  # time spent building it changes. It survived, correctly, and is retired here
+  # so nobody re-adds it expecting a kill.
+
+  [[target.mutant]]
+  id = "invalid-bound-backstop-only-catches-a-failed-solve"
+  find = "if val is None or val < L - 1e-6 * max(1.0, abs(L)):"
+  replace = "if val is None:"
+  models = "the backstop reduced to a check that the solve produced a value. The objective is an epigraph variable, so a cut above the true optimum does not make the model infeasible -- it inflates that variable and returns a design whose real objective sits below the cut floor. Without the comparison the caller keeps that design and the too-high bound is never detected"


### PR DESCRIPTION
## Related Links

- The defect was recorded as an open item in the #411 body, found while investigating whether a warm start speeds up SCIP at N=200
- Touches `utils/miqp_accel.py`, the shared accelerator kept when #410 removed the SYNDES-specific wrapper
- No issue; found by measurement

## What

- `solve_warm_cut` reads the boolean columns through a new `_bool_positions(data)` helper, which sorts them, instead of iterating `data[BOOL_IDX]` directly
- `AccelInfo.warm_applied` is set from what `addSol` returned instead of from having called it, and its documentation no longer says the start was "accepted"
- Added `TestWarmBitAlignment` and `TestWarmStartHelps` to `tests/test_miqp_accel.py`, and a `miqp-accel` mutation target with 3 mutants
- Corrected two statements that said MAREX and the other exact designs use this path. They do not

## Why

cvxpy returns `data[BOOL_IDX]` as a `set`, so iterating it yields the hash table's order. For a contiguous run of small integers that order is ascending at some lengths and rotated at others, and `enumerate()` then paired `warm_bits[j]` with whichever column came out j-th. SCIP was started from a design nobody asked for.

The two orders agree below roughly eleven units, which is why the existing tests passed: they run at N=7.

A scrambled start is worse than no start, because SCIP spends its budget improving on a design that was never good. At N=200, K=6 under a 60 s limit:

| | returned objective |
|---|---|
| no warm start | 0.2070 |
| warm start, before | 0.2151 |
| warm start, after | 0.1812 |

## How

A single boolean variable occupies one contiguous ascending block of the canonical vector, stacked column-major, which is the order `solve_warm_cut` already flattens `warm_bits` into. Ascending column is that variable's own order, so sorting recovers it.

Three hypotheses were tested and discarded before this one:

The `completesol` heuristic's `maxunknownrate` (default 0.85) looked like the obvious suspect, since a partial start over the booleans alone leaves most variables unknown. Measured, the unknown rate is 0.6897 at N=9 and 0.6678 at N=200 — under the threshold at every size, so the heuristic was never declining on that ground.

Handing SCIP a complete solution instead of a partial one appeared to fail too, which would have pointed at the injection mechanism. That probe was invalid: it built the complete solution by pinning the binaries through the same broken mapping. With the mapping fixed the plain partial start works, so no extra machinery is needed.

The mapping itself was then isolated by pinning the binaries two ways and comparing against `D == bits` stated to cvxpy, which is the caller's intent expressed independently of any canonical index:

```
N= 12 scrambled=True   cvxpy D==warm 0.73546020
      pinned via list(BOOL_IDX)   0.51317158   matches: False
      pinned via sorted(BOOL_IDX) 0.73546009   matches: True
```

## Verification

- Path: not applicable. This corrects which SCIP variable a warm bit is written to; it changes no estimator's numerical output
- `test_warm_bits_name_the_design_the_caller_meant` is the check the fix rests on. It pins the binaries through the accelerator's own mapping and requires the objective to equal the one cvxpy reaches from `D == bits`, at three sizes including two where the set order is scrambled. It fails without the fix and is fast, needing one convex solve
- `test_positions_are_the_ascending_block` asserts the positions form a contiguous ascending run, and `test_cvxpy_hands_back_an_unordered_set` pins the dependency's behaviour so a cvxpy change is noticed
- `test_a_warm_start_never_returns_a_worse_design` covers the property that was violated, at a size where SCIP cannot finish in the budget — the only regime where the start decides the answer

No shipped estimator was affected. Nothing in the library passes `warm_start_D` or `objective_lower_bound`: the SYNDES accelerator was the last consumer and went in #410. The route stays reachable through `solve_synthetic_design`, so this was a latent defect on an unused path, not a wrong answer any estimator was returning. `test_the_warm_start_route_is_still_reachable` pins that the parameters selecting it remain.

## Scope checks

Bug fix.

- [x] A test reproduces the defect and fails without the fix (`test_warm_bits_name_the_design_the_caller_meant`, at N=12 and N=14)
- [x] It asserts the correct behaviour — the objective of the design the caller named — not merely the absence of a crash
- [x] No docstring or comment still states the old behaviour. `warm_applied`'s documentation no longer claims the start was "accepted", and the two places claiming MAREX uses this path are corrected
- [x] No pinned value moved; the fix changes no estimator output

## Designs

No visual output. The accelerator sits below the estimators and produces no figures.

## Test Steps

- [x] `pytest mlsynth/tests/test_miqp_accel.py -q` — 16 passed
- [x] `pytest mlsynth/tests/test_syndes*.py mlsynth/tests/test_miqp_accel.py -q` — 626 passed
- [x] `pytest mlsynth/tests/` — 7919 passed, 42 skipped, 0 failed (49 min, all 345 test files)
- [x] `coverage run --timid --source=mlsynth/utils -m pytest mlsynth/tests/test_miqp_accel.py` — `miqp_accel.py` at 100 percent, no `# pragma: no cover`
- [x] `python tools/mutation/run_mutants.py --target miqp-accel` — 3/3 killed
- [ ] Docs build not run — sphinx is not installed here. Read the Docs covers it. No docs page changed

## Other Notes

- Two mutants survived the first run and both were answered. `warm-start-reported-applied-without-being-stored` exposed a weak assertion: the flag was only checked where SCIP stores the start, so a test that makes `addSol` decline was added. `cut-written-over-every-column` is an equivalent mutant — the extra terms all carry coefficient zero, so `quicksum` builds the same constraint — and it is retired in `targets.toml` with the reason, per the convention in `tools/mutation/README.md`, instead of being carried as a permanent survivor
- Three pre-existing uses of a word the style rules ban were cleared in the two files this branch already edits, so the grep stays clean
- The partial start still depends on SCIP's `completesol` heuristic to reach an incumbent, which is why `warm_applied` now documents storage and not adoption. A caller wanting a guaranteed incumbent would need a complete solution, which is more machinery than any current consumer needs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLNEvmPN3YUFUEahAwWAoz)_