### PR TITLE
Credit SYNDES to Doudchenko et al.

### DIFF
--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -763,13 +763,13 @@ Identification under endogeneity
 Experimental design
 -------------------
 
-* :doc:`syndes` -- Abadie & Zhao (2025) synthetic design.
+* :doc:`syndes` -- Doudchenko et al. (2021) synthetic design.
   Path B: Section 5 ablation across the three design types
   (``per_unit`` / ``two_way_global`` / ``one_way_global``) at 40
   reps under AR(1) factors; ``per_unit`` design RMSE = 0.098
   against a random-DiM baseline of 0.982, power = 0.50 at
   MDE = 0.157.
-* :doc:`marex` -- Abadie & Zhao (2025) market-exclusion design.
+* :doc:`marex` -- Abadie & Zhao (2024) market-exclusion design.
   Path A: Walmart 45-store weekly-sales placebo design --
   pre-fit RMSE 2.2%, placebo ATT :math:`-1.0%`, p-value 0.937
   against the paper's 0.933. Path B: Lin-factor DGP recovers


### PR DESCRIPTION
## Related Links

- `docs/replications.rst`, the estimator index
- `docs/references.rst` carries both entries: `[SYNDES]` (Doudchenko et al. 2021, arXiv:2112.00278) and `[ABADIE2024]` (Abadie & Zhao, arXiv:2108.02196, dated 2024)

## What

- The replication index entry for SYNDES credited Abadie & Zhao; it now credits Doudchenko et al. (2021)
- The MAREX entry's year follows the reference list (2024, was 2025)

## Why

SYNDES implements Doudchenko, Khosravi, Pouget-Abadie, Lahaie, Lubin, Mirrokni, Spiess and Imbens (2021), whose three forms are per-unit, two-way global and one-way global — the three the index entry itself goes on to name.

Abadie & Zhao is MAREX. Their formulations are a different decomposition of a related problem: a baseline design matching both synthetic units to the population predictor vector, a weakly targeted design that matches the treated synthetic to that vector and ties the control synthetic to it through a weight `beta`, and a unit-level design. `MAREXConfig.design` exposes them as `standard` / `weakly_targeted` / `penalized` / `unit_penalized`.

Both papers are cited correctly elsewhere — `docs/syndes.rst` credits Doudchenko for the three forms, `docs/marex.rst` credits Abadie & Zhao — so this was one stale line in the index, not a confusion in the estimator pages.

## How

Two string edits. No code, no numbers.

## Verification

Path: not applicable. This is a docs attribution correction and changes no numerical output.

## Scope checks

Docs only — none of the four scope blocks fits. No estimator, feature, bug fix or benchmark case is involved.

## Designs

No visual output.

## Test Steps

- [x] `grep` confirms the two entries now read as intended
- [ ] Docs build not run — sphinx is not installed here. Read the Docs covers it. Two inline string edits, no directives touched

## Other Notes

- The year for Abadie & Zhao is inconsistent across the docs: `docs/marex.rst` and `docs/pangeo.rst` say 2026, `docs/spcd.rst` says 2021, `docs/references.rst` says 2024. This PR makes the index agree with the reference list and leaves the rest; a year sweep is its own change and would touch pages this one has no reason to open

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLNEvmPN3YUFUEahAwWAoz)_