### PR TITLE
Pin the treated-set search against SCIP proving optimality

### DIFF
--- a/benchmarks/cases/syndes_exact_vs_mip.py
+++ b/benchmarks/cases/syndes_exact_vs_mip.py
@@ -1,0 +1,108 @@
+"""The SYNDES treated-set search against SCIP proving optimality.
+
+``mode="two_way_global"`` defaults to ``backend="exact"``: naming the treated set
+removes every binary from the design MIP, leaving a convex program, so the design
+is found by searching treated sets instead of by branch-and-bound. The claim that
+default rests on is that the search reaches the design SCIP would prove optimal.
+
+This pins it on the panel Doudchenko et al. (2021) use themselves --
+``basedata/urate_cps.csv``, the BLS state unemployment series behind
+:mod:`benchmarks.cases.syndes_bls` -- across several sub-panels and treated-set
+sizes. SCIP is asked to prove optimality (``gap_limit=0``), which makes it an
+independent referent: it is a separate, widely used exact solver handed the same
+mixed-integer program.
+
+This is not a replication of a published number. It is a cross-check of two
+solvers on one program, which is why it reports agreement and not a match to a
+table. The estimator's own replication is
+:mod:`benchmarks.cases.syndes_bls` (Path B, Table 1).
+
+What the comparison has to control for
+---------------------------------------
+``gap_limit`` defaults to ``0.05``, so the MIP path may stop at a design five
+percent above the optimum, and on some panels it does. The two backends agree on
+the treated set only once the MIP is asked to prove optimality, which is the
+configuration used here. Where they would otherwise differ, the search returns
+the better design.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+
+_DATA = Path(__file__).resolve().parents[2] / "basedata" / "urate_cps.csv"
+
+#: Sub-panels drawn from the 40-month x 50-state matrix. Sized so SCIP can close
+#: the gap in seconds while the search still ranks thousands of designs.
+_PANELS = ((12, 20), (15, 20))
+_KS = (3, 5)
+_DRAWS = 2
+SEED = 0
+
+
+def _subpanel(Y: np.ndarray, n_units: int, n_periods: int, seed: int) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    cols = np.sort(rng.choice(Y.shape[1], size=n_units, replace=False))
+    return Y[:n_periods][:, cols]
+
+
+def run() -> dict:
+    from mlsynth.utils.syndes_helpers.exact import solve_synthetic_design_exact
+    from mlsynth.utils.syndes_helpers.optimization import solve_synthetic_design
+
+    Y = np.loadtxt(_DATA, delimiter=",")
+    agree, gaps, cells = [], [], 0
+    search_never_worse = []
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for n_units, n_periods in _PANELS:
+            for draw in range(_DRAWS):
+                panel = _subpanel(Y, n_units, n_periods, SEED + draw)
+                for K in _KS:
+                    search = solve_synthetic_design_exact(Y=panel, K=K)
+                    mip = solve_synthetic_design(panel, K=K, mode="global_2way",
+                                                 gap_limit=0.0, time_limit=300.0)
+                    agree.append(float(
+                        tuple(int(i) for i in search.selected_unit_indices)
+                        == tuple(int(i) for i in mip.selected_unit_indices)))
+                    s_obj = float(search.objective_value)
+                    m_obj = float(mip.objective_value)
+                    gaps.append(abs(s_obj - m_obj))
+                    search_never_worse.append(float(s_obj <= m_obj + 1e-6))
+                    cells += 1
+
+    return {
+        "n_cells": float(cells),
+        "treated_set_agreement": float(np.mean(agree)),
+        "max_objective_gap": float(np.max(gaps)),
+        "search_never_worse": float(np.mean(search_never_worse)),
+    }
+
+
+# Tolerances.
+#
+# The two agreement figures are exact. Every cell is a program SCIP has proven
+# optimal, so the search must select the same treated set in all of them and its
+# objective can never exceed SCIP's. A single disagreeing cell means the search
+# missed an optimum, which is the defect this case exists to catch, and no
+# fraction below one is acceptable.
+#
+# The objective gap is bounded by the two solvers' numerical tolerances, not by
+# any modelling difference: both minimise the same quadratic over the same
+# feasible set. Measured 1.2e-09 to 2.2e-09 across these cells, where the
+# outcomes are unemployment rates on [0.01, 0.17] so the objective scale is
+# small. 1e-05 leaves four orders of headroom for a differently-built SCIP while
+# staying far below the spacing between distinct designs, which is where a
+# genuine disagreement would show.
+#
+# n_cells guards the loop itself: a case that silently stopped covering panels
+# would still report perfect agreement over whatever remained.
+EXPECTED = {
+    "n_cells": (8.0, 0.0),
+    "treated_set_agreement": (1.0, 0.0),
+    "max_objective_gap": (0.0, 1e-5),
+    "search_never_worse": (1.0, 0.0),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -7,6 +7,7 @@ import importlib
 CASES = {
     "spcd_prop99": "benchmarks.cases.spcd_prop99",      # Path A: SPCD design vs random/SC on Prop 99 (Lu et al. 2022)
     "syndes_bls": "benchmarks.cases.syndes_bls",        # Path B: Doudchenko et al. 2021 Monte Carlo (BLS unemployment)
+    "syndes_exact_vs_mip": "benchmarks.cases.syndes_exact_vs_mip",  # solver cross-check: the two-way treated-set search vs SCIP proving optimality on the BLS panel
     "si_prop99": "benchmarks.cases.si_prop99",          # cross-val vs Agarwal-Shah-Shen 2026 authors' code (Prop 99)
     "snn_prop99": "benchmarks.cases.snn_prop99",        # cross-val vs deshen24/syntheticNN (Prop 99)
     "ppscm_paglayan": "benchmarks.cases.ppscm_paglayan",  # cross-val vs augsynth::multisynth (jackknife + bootstrap SEs)

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -266,6 +266,8 @@ Path B — Monte Carlo / simulation
      - SPSC IFEM recovery + DT-vs-NoDT coverage (Park-Tchetgen)
    * - ``syndes_bls``
      - Doudchenko et al. 2021 Monte Carlo (BLS unemployment)
+   * - ``syndes_exact_vs_mip``
+     - SYNDES two-way treated-set search vs SCIP proving optimality on the same program (BLS panel)
    * - ``tasc_mc``
      - TASC vs SC state-space ablation (Rho et al.)
    * - ``tssc_figure2``

--- a/docs/replications/syndes.rst
+++ b/docs/replications/syndes.rst
@@ -65,3 +65,32 @@ The durable case is ``benchmarks/cases/syndes_bls.py``; broader Monte-Carlo
 coverage (effects, sizes, power across all three designs vs the randomized
 baseline) lives in the estimator's own simulation harness — see the Verification
 note on :doc:`../syndes`.
+
+The treated-set search against SCIP
+------------------------------------
+
+``mode="two_way_global"`` defaults to ``backend="exact"``. Naming the treated set
+removes every binary from the design MIP, leaving a convex program, so the design
+is found by searching treated sets instead of by branch-and-bound. That default
+rests on the search reaching the design SCIP would prove optimal, which is a
+solver question and not a replication of any published number.
+
+``syndes_exact_vs_mip`` pins it on the same BLS panel used above: eight cells
+across two sub-panel shapes, two draws and two treated-set sizes, with SCIP asked
+to prove optimality (``gap_limit=0``). The two select the same treated set in
+every cell, the search's objective never exceeds SCIP's, and the largest
+disagreement in objective is 2.1e-09 — the solvers' numerical tolerance, on
+outcomes that are unemployment rates in :math:`[0.01, 0.17]`.
+
+One caveat governs how the comparison is set up. ``gap_limit`` defaults to
+``0.05``, so the MIP path may stop at a design five percent above the optimum,
+and on some panels it does. The two agree on the treated set only once the MIP is
+asked to prove optimality; otherwise the search's design is the one that is at
+least as good.
+
+`benchmarks/cases/syndes_exact_vs_mip.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/syndes_exact_vs_mip.py>`_
+
+.. code-block:: bash
+
+   python benchmarks/run_benchmarks.py --case syndes_exact_vs_mip


### PR DESCRIPTION
## Related Links

- The claim comes from #408 (the Gram reduction), #409 (the exact backend) and #410 (making it the default)
- Data: `basedata/urate_cps.csv`, the same BLS panel `benchmarks/cases/syndes_bls.py` uses — Doudchenko et al.'s own file, footnote 4
- Replication page: `docs/replications/syndes.rst`, extended with a section for this

## What

- Added `benchmarks/cases/syndes_exact_vs_mip.py`, registered it, and documented it on the SYNDES replication page and the benchmarks index

## Why

`mode="two_way_global"` defaults to `backend="exact"`. Naming the treated set removes every binary from the design MIP, leaving a convex program, so the design is found by searching treated sets instead of by branch-and-bound. The default rests on the search reaching the design SCIP would prove optimal — and until now that claim lived only in unit tests on tiny synthetic panels.

## How

Eight cells: two sub-panel shapes drawn from the 40-month by 50-state matrix, two draws each, two treated-set sizes. For each, the search and SCIP solve the same mixed-integer program, with SCIP asked to prove optimality.

Asking SCIP to prove optimality is not incidental. `gap_limit` defaults to `0.05`, so the MIP path may stop at a design five percent above the optimum, and on some panels it does. The two agree on the treated set only under `gap_limit=0`; otherwise the search returns the better design, and a comparison at the default would be measuring the early exit, not the solvers.

## Verification

Path: not applicable, and the case docstring says so plainly. This is a cross-check of two solvers on one program, so it reports agreement and not a match to a published table. The estimator's own replication is `syndes_bls` (Path B, Table 1), which is unaffected.

Results: the two select the same treated set in all eight cells, the search's objective never exceeds SCIP's, and the largest objective disagreement is 2.1e-09 — the solvers' numerical tolerance, on outcomes that are unemployment rates in `[0.01, 0.17]`.

## Scope checks

Benchmark / validation.

- [x] Path stated: solver cross-check, not Path A or B, and the case is explicit that it does not replicate a number
- [x] Expected values are structural (agreement is one, the objective gap is solver tolerance), not read off a table
- [x] Tolerances justified in a comment: zero for the agreement figures, since a single disagreeing cell is exactly the defect the case exists to catch; 1e-05 for the gap, four orders above the measured 1.2e-09 to 2.2e-09 and far below the spacing between distinct designs
- [x] Deterministic — seeded draws, and both solvers reproduce their numbers
- [x] `n_cells` is pinned so a loop that silently stopped covering panels cannot still report perfect agreement
- [x] Branch is benchmark authoring only

## Designs

No visual output. The case reports four scalars.

## Test Steps

- [x] `python benchmarks/run_benchmarks.py --case syndes_exact_vs_mip` — 4/4 pass, 26s
- [x] Re-run reproduces the same numbers
- [ ] `--all` not re-run on this branch. The last full sweep was 107 passed, 18 skipped for missing optional dependencies, plus one uncaught `ModuleNotFoundError: No module named 'jax'` in a spotsynth case that raises instead of skipping. That predates this branch and is unrelated, but I have not confirmed it against a clean `main`, so I am not claiming it
- [ ] Docs build not run — sphinx is not installed here. Read the Docs covers it

## Other Notes

- This replaces an earlier attempt that put the same check on Abadie & Zhao's Section 5 simulation panel. That panel belongs to MAREX (see #414), and using it here forced an argument about mismatched estimands that disappears once the check runs on SYNDES's own data
- The sub-panels are sized so SCIP can close the gap in seconds. Larger panels are where the search's advantage actually shows — at N=200, K=6 SCIP does not finish at all — but a case cannot pin agreement against a solver that never proves anything

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLNEvmPN3YUFUEahAwWAoz)_