### PR TITLE
Divide every PDA autocovariance by n, as acf and Newey-West do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,22 @@ now returns and the back-compat guarantee.
 
 
 ### Fixed
+- `pda_helpers/inference.hac_lrv` divided the lag-`l` autocovariance by its own
+  product count `n - l`; every standard HAC estimator, R's
+  `acf(type = "covariance")` among them, divides by `n`. The lagged terms were
+  inflated by `n / (n - l)`, which cost the autocovariance sequence its positive
+  semi-definiteness and broke the claim that `fs` and `hcw`'s `lrvar_lag` branch
+  reproduces Shi & Huang's released `fsPDA` package. On their dense simulation at
+  `T2 = 50, h = 1` the forward-selection t-statistic was wrong in its third
+  decimal; under the correct convention it agrees with their `FS()` to 2e-11.
+  The error grows with the truncation lag. Effects, weights and selected donor
+  sets are untouched -- only standard errors, t-statistics, p-values and
+  confidence intervals move, and only where a fixed lag is in play: `fs` and
+  `hcw` at their default `lrvar_lag=None` use the prewhitened Newey-West path and
+  are unaffected. The `l2` HAC t-statistic moves by about 1% (Hong Kong
+  7.799 -> 7.825, PPI 4.482 -> 4.547), inside the tolerances those benchmark
+  cases already carry.
+
 - `utils/miqp_accel.solve_warm_cut` wrote each warm-start bit to the wrong SCIP
   variable on problems above roughly eleven units. cvxpy returns the boolean
   columns as a `set`, and the accelerator iterated it directly, so `warm_bits[j]`

--- a/benchmarks/cases/pda_ppi.py
+++ b/benchmarks/cases/pda_ppi.py
@@ -27,9 +27,16 @@ Two deliberate method differences, both documented:
   the counterfactual fit. The sequential CV selects slightly less regularisation,
   giving -5.95% rather than the paper's -6.40% (with their leaky CV mlsynth
   reproduces -6.40% exactly). The sign, magnitude, and 1%-significance agree.
-* **Long-run variance.** mlsynth's Newey-West bandwidth (``newey_west_lag``)
-  differs from R ``sandwich``'s automatic one, so the t-statistic (-4.48) differs
-  from the paper's -3.61; both reject the zero-ATE null well below 1%.
+* **Long-run variance.** The difference is the kernel, not the bandwidth. Shi &
+  Wang's Theorem 3 writes the HAC as an unweighted two-sided sum
+  ``sum_{l=-h}^{h}`` -- the uniform kernel, which they adopt "for simplicity"
+  while noting the result "is compatible with the Bartlett kernel (Newey & West
+  1987)". mlsynth uses the Bartlett kernel. The bandwidth rules agree: the paper
+  points to Newey & West (1994) for the truncation lag, which is what
+  ``newey_west_lag`` implements. On Hong Kong the kernel alone moves the
+  t-statistic from 7.69 to 7.83, so the same mechanism explains the gap here
+  between mlsynth's -4.55 and the paper's -3.61; both reject the zero-ATE null
+  well below 1%.
 
 Live cross-validation (fixed tau)
 ---------------------------------
@@ -152,8 +159,9 @@ def comparison() -> dict:
 # Deterministic (convex L2-relaxation solve + deterministic sequential CV). The
 # ATE is pinned to mlsynth's time-respecting-CV value (-5.95%, vs the paper's
 # -6.40% under its future-leaking K-fold); the tolerance keeps it close to the
-# paper while guarding regressions. The t-stat is pinned loosely (the NW
-# bandwidth differs from sandwich's) but must stay well past 5% significance.
+# paper while guarding regressions. The t-stat is pinned loosely -- mlsynth uses
+# the Bartlett kernel where the paper's Theorem 3 states the uniform one, and the
+# paper sanctions the substitution -- but must stay well past 5% significance.
 # SEPARATELY, l2_fixedtau_beta_max_abs_diff is a SOLVER cross-validation on the
 # unique QP at a fixed matched tau: mlsynth (OSQP) vs the authors' L2relax
 # program (cvxpy/ECOS, captured in benchmarks/reference/pda_ppi/). They agree to

--- a/mlsynth/tests/test_pda.py
+++ b/mlsynth/tests/test_pda.py
@@ -272,9 +272,11 @@ def test_hac_lrv_iid_positive():
 
 def test_hac_lrv_explicit_lag_bartlett():
     z = np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0])
-    # bartlett with L=1: w = 1 - 1/2 = 0.5 -> gamma0 + 2*0.5*gamma1 = 1 + (-1) = 0
+    # bartlett with L=1: w = 1 - 1/2 = 0.5. Autocovariances divide by n = 6, as
+    # R's acf(type = "covariance") does, so gamma0 = 1, gamma1 = -5/6 and the sum
+    # is 1 + 2*0.5*(-5/6) = 1/6. See test_pda_lrvar_normalisation.py.
     lrv_bart = hac_lrv(z, lag=1, kernel="bartlett")
-    assert lrv_bart == pytest.approx(0.0, abs=1e-9)
+    assert lrv_bart == pytest.approx(1.0 / 6.0, rel=1e-12)
 
 
 def test_hac_lrv_negative_is_clamped_to_zero():

--- a/mlsynth/tests/test_pda_lrvar_normalisation.py
+++ b/mlsynth/tests/test_pda_lrvar_normalisation.py
@@ -1,0 +1,134 @@
+"""The autocovariance normalisation in the PDA long-run variance.
+
+:func:`mlsynth.utils.pda_helpers.inference.hac_lrv` builds a Bartlett-kernel
+long-run variance from sample autocovariances. There are two conventions for the
+lag-``l`` autocovariance of a series of length ``n``, and they differ by a factor
+of ``n / (n - l)``:
+
+    gamma_l = (1/n)     sum_{t=1}^{n-l} z_t z_{t+l}      <- R's acf(), Newey-West
+    gamma_l = (1/(n-l)) sum_{t=1}^{n-l} z_t z_{t+l}      <- the unbiased-looking one
+
+The first is the standard one and the one this estimator has to use. Two reasons.
+
+It is what the fixed-lag path claims to be. ``fs`` and ``hcw`` document their
+``lrvar_lag`` branch as reproducing Shi and Huang's released ``fsPDA`` package,
+whose long-run variance is built from ``acf(type = "covariance")`` -- and ``acf``
+divides by ``n``. Under the other convention the reproduction is wrong in the
+third decimal of the t-statistic, which is enough to move a borderline test.
+
+It is also the convention that keeps the estimator a variance. Dividing by ``n``
+makes the autocovariance sequence positive semi-definite, so the weighted sum is
+a non-negative estimate of a non-negative quantity. Dividing by ``n - l`` gives
+up that guarantee, and the clamp at zero then hides the failure instead of the
+estimator not having one.
+
+The values below come from R 4.3.3 and are reproduced by the script recorded in
+the docstring of :func:`test_matches_acf_on_an_ar1_series`.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.pda_helpers.inference import hac_lrv
+
+#: ``set.seed(11); arima.sim(model = list(ar = 0.6), n = 40, n.start = 1000)``
+_AR1 = np.array([
+    -0.49383220349874707, -0.66723203709181289, -0.82548544757059528,
+    -0.054139746211601891, -0.70523420413579774, -0.0064463978301257385,
+    -1.4016548531822202, -1.6878231520529341, -1.6387625924201252,
+    -0.28424136711590853, -0.72686234969065344, 0.35720059388036263,
+    0.35462672999192879, 2.7555250523704502, 0.95203404290548299,
+    1.195959783188604, 0.32679019924177066, -1.6514155200964016,
+    0.23872508715785068, 0.835141846419865, 0.99060788759723473,
+    -0.29507739622423557, -1.6614760113371694, -1.9925718437261728,
+    -1.3826909435362329, 0.0725965667617815, -1.0538542773461037,
+    -1.0251488791794934, -0.51809487131179655, 1.8378231871232085,
+    0.97058383528290526, 0.70143406506043449, 0.40637456372995001,
+    0.1839654730556633, 0.70596320880148833, 2.5431686965743721,
+    1.689862373907949, 1.6485553615346635, 0.35485651692637932,
+    0.56389761355181323,
+])
+
+
+class TestTheConvention:
+    def test_alternating_series_gets_the_acf_value(self):
+        """``z = (1,-1,...)`` of length 6, hand-checkable.
+
+        ``gamma_0 = 1`` and the five cross products are each ``-1``, so R's
+        ``acf`` gives ``gamma_1 = -5/6`` and the Bartlett sum at ``L = 1`` is
+        ``1 + 2 (1/2) (-5/6) = 1/6``. Dividing by ``n - l = 5`` instead gives
+        ``gamma_1 = -1`` and a long-run variance of exactly zero -- a clean
+        number that comes from the wrong denominator.
+        """
+        z = np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0])
+        assert hac_lrv(z, lag=1, kernel="bartlett") == pytest.approx(
+            1.0 / 6.0, rel=1e-12)
+
+    @pytest.mark.parametrize("lag,expected", [
+        (1, 2.1249099857258731),
+        (2, 2.6732881038962653),
+        (3, 2.9788289919615538),
+    ])
+    def test_matches_acf_on_an_ar1_series(self, lag, expected):
+        """Against R, on a serially dependent series where the lags matter.
+
+        Reference::
+
+            set.seed(11)
+            x <- as.vector(arima.sim(model = list(ar = 0.6), n = 40, n.start = 1000))
+            for (h in c(1, 2, 3)) {
+              g  <- as.vector(acf(x, lag.max = h, type = "covariance", plot = FALSE)$acf)
+              wh <- 1 - (1:h) / (h + 1)
+              cat(g[1] + 2 * sum(wh * g[-1]), "\\n")
+            }
+        """
+        assert hac_lrv(_AR1, lag=lag, kernel="bartlett") == pytest.approx(
+            expected, rel=1e-6)
+
+    def test_the_gap_grows_with_the_lag(self):
+        """The two conventions differ by ``n / (n - l)`` per lag, so a longer
+        truncation makes the discrepancy larger, not smaller."""
+        n = _AR1.size
+        zc = _AR1 - _AR1.mean()
+
+        def wrong(L):
+            g0 = float(np.mean(zc * zc))
+            return g0 + 2.0 * sum((1 - l / (L + 1.0)) * float(np.mean(zc[l:] * zc[:-l]))
+                                  for l in range(1, L + 1))
+
+        gaps = [abs(hac_lrv(_AR1, lag=L) - wrong(L)) / hac_lrv(_AR1, lag=L)
+                for L in (1, 3, 6)]
+        assert gaps == sorted(gaps)
+        assert gaps[0] < 0.02 < gaps[-1]
+
+
+class TestStillAVariance:
+    def test_a_positive_series_stays_positive(self):
+        rng = np.random.default_rng(3)
+        z = rng.standard_normal(200)
+        assert hac_lrv(z, lag=4) > 0
+
+    def test_negative_raw_value_is_still_clamped(self):
+        """The clamp stays; the alternating series under a uniform kernel still
+        drives the raw sum below zero."""
+        z = np.array([1.0, -1.0, 1.0, -1.0, 1.0, -1.0])
+        assert hac_lrv(z, lag=1, kernel="uniform") == 0.0
+
+    @pytest.mark.parametrize("lag", [0, 1, 5])
+    def test_a_constant_series_has_no_variance(self, lag):
+        assert hac_lrv(np.full(20, 4.0), lag=lag) == pytest.approx(0.0, abs=1e-12)
+
+
+class TestEdges:
+    def test_empty_series(self):
+        assert np.isnan(hac_lrv(np.array([])))
+
+    def test_single_observation(self):
+        assert hac_lrv(np.array([2.0]), lag=0) == pytest.approx(0.0, abs=1e-12)
+
+    def test_lag_beyond_the_sample_is_truncated(self):
+        """``min(L, n - 1)`` caps the loop; a lag past the sample cannot index
+        past the end, and the weights still come from the requested ``L``."""
+        z = np.array([1.0, 2.0, 3.0, 4.0])
+        assert np.isfinite(hac_lrv(z, lag=99))

--- a/mlsynth/utils/pda_helpers/inference.py
+++ b/mlsynth/utils/pda_helpers/inference.py
@@ -43,6 +43,13 @@ def hac_lrv(z: np.ndarray, lag: int | None = None, kernel: str = "bartlett") -> 
     ``lrv = gamma_0 + sum_{l=1}^{L} k(l) * 2 * gamma_l`` with ``gamma_l`` the
     sample autocovariance and ``k`` the Bartlett (``1 - l/(L+1)``) or uniform
     kernel. The series is de-meaned first.
+
+    Every autocovariance divides by ``n``, including the lagged ones, which have
+    only ``n - l`` products to sum. This is R's ``acf(type = "covariance")`` and
+    the Newey-West convention, so the fixed-lag branch reproduces the released
+    ``fsPDA`` package; dividing the lag-``l`` term by ``n - l`` instead inflates
+    it by ``n / (n - l)`` and costs the sequence its positive semi-definiteness,
+    which is what makes the weighted sum a variance in the first place.
     """
     z = np.asarray(z, dtype=float)
     n = z.shape[0]
@@ -53,7 +60,7 @@ def hac_lrv(z: np.ndarray, lag: int | None = None, kernel: str = "bartlett") -> 
     gamma0 = float(np.mean(zc * zc))
     lrv = gamma0
     for l in range(1, min(L, n - 1) + 1):
-        gl = float(np.mean(zc[l:] * zc[:-l]))
+        gl = float(np.sum(zc[l:] * zc[:-l]) / n)
         w = (1.0 - l / (L + 1.0)) if kernel == "bartlett" else 1.0
         lrv += 2.0 * w * gl
     return max(lrv, 0.0)

--- a/mlsynth/utils/pda_helpers/l2/inference.py
+++ b/mlsynth/utils/pda_helpers/l2/inference.py
@@ -11,6 +11,17 @@ where ``rho_hat_(1)^2`` is the HAC long-run variance of the pre-period
 residuals and ``rho_hat_(2)^2`` is the HAC long-run variance of the de-meaned
 post-period effects. Both estimation uncertainty (pre) and post-period noise
 contribute.
+
+The kernel is Bartlett; Theorem 3 states the estimator with the uniform kernel,
+an unweighted two-sided sum ``sum_{l=-h}^{h}``, which the authors adopt "for
+simplicity" while noting the result "is compatible with the Bartlett kernel
+(Newey & West 1987)". The substitution is theirs to sanction and it is not free:
+on Hong Kong it moves the t-statistic from 7.69 to 7.83. Bartlett is what makes
+the estimate non-negative without a clamp, which is why it is the default here.
+
+The autocovariances divide by the length of the index set, matching the paper's
+``E_S(x_t) = |S|^{-1} sum_{t in S} x_t``. The truncation lag is Newey & West
+(1994), which is the rule the paper points to.
 """
 
 from __future__ import annotations

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -340,3 +340,27 @@ timeout = 600.0
                                              standardize=standardize)"""
   replace = "            beta, _, cf, support = fit_lasso(y_boot, X, T0, alpha=lasso_alpha)"
   models = "the prediction-interval bootstrap refitting under the cross-validated conventions while the point estimate it is meant to be the sampling distribution of was fitted under glmnet's. The intervals still come back the right shape and still cover something; what they cover is not the estimator that produced the point"
+
+[[target]]
+name = "pda-lrvar"
+module-path = "mlsynth/utils/pda_helpers/inference.py"
+test-command = "python -m pytest mlsynth/tests/test_pda_lrvar_normalisation.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "lagged-autocovariance-divides-by-its-own-count"
+  find = "        gl = float(np.sum(zc[l:] * zc[:-l]) / n)"
+  replace = "        gl = float(np.mean(zc[l:] * zc[:-l]))"
+  models = "the defect this module was fixed for: the lag-l autocovariance averaged over its n-l products instead of divided by n. It inflates each lagged term by n/(n-l), which is under 3% at one lag on fifty periods and grows with the truncation -- small enough to survive every sign, positivity and ordering check, and large enough to move a t-statistic in its third decimal and break the claim that the fixed-lag branch reproduces fsPDA"
+
+  [[target.mutant]]
+  id = "bartlett-weight-uses-the-lag-count-as-its-denominator"
+  find = "        w = (1.0 - l / (L + 1.0)) if kernel == \"bartlett\" else 1.0"
+  replace = "        w = (1.0 - l / L) if kernel == \"bartlett\" else 1.0"
+  models = "the Bartlett weight without the +1, so the outermost lag is weighted zero and the kernel effectively truncates one lag early. At L = 1 it discards the only lag there is, leaving gamma_0 -- the estimator silently stops correcting for serial correlation at exactly the setting the fsPDA package uses on short post-periods"
+
+  [[target.mutant]]
+  id = "series-not-demeaned-before-the-autocovariances"
+  find = "    zc = z - z.mean()"
+  replace = "    zc = z"
+  models = "autocovariances taken about zero instead of the sample mean. The post-period effect series is centred by the caller in most paths, so this is invisible wherever the mean is already near zero and wrong wherever a real effect shifts it -- the case the estimator exists to test"


### PR DESCRIPTION
## Related Links

- Affected helper: `mlsynth/utils/pda_helpers/inference.py` (`hac_lrv`)
- Reference implementations the two branches claim: [`zhentaoshi/fsPDA`](https://github.com/zhentaoshi/fsPDA) `simulation/nonsparse/FS.R` and the released `est.fsPDA.R`; Shi & Wang, *L2-Relaxation for Economic Prediction*, Theorem 3
- Blocks: the `fspda_dense_mc` benchmark case, which is this fix's durable regression test and lands on its own branch next

## What

- `hac_lrv` divides the lag-`l` autocovariance by `n` instead of `n - l`
- Added `mlsynth/tests/test_pda_lrvar_normalisation.py` (13 tests)
- Updated `test_hac_lrv_explicit_lag_bartlett`, which had pinned the old convention
- Added a `pda-lrvar` mutation target with three semantic mutants
- Corrected the stated reason for the `l2` t-statistic gap in `pda_ppi` and `l2/inference.py`: it is the kernel, not the bandwidth

## Why

`hac_lrv` computed the lag-`l` autocovariance as the mean over its `n - l`
products. Every standard HAC estimator divides by `n`, so each lagged term was
inflated by `n / (n - l)`. Three independent sources specify the `n` convention
for exactly these estimators:

- R's `acf(type = "covariance")`, which is what `fsPDA` builds its long-run variance from
- Newey & West (1987), whose positive-semi-definiteness result depends on it
- Shi & Wang's Theorem 3, whose notation defines `E_S(x_t) = |S|^-1 sum_{t in S} x_t`, so its `sigma^2_(1)` divides by `T1` and not by the `T1 - l` products available at lag `l`

Two things followed from the old convention.

The fixed-lag branch of `fs` and `hcw` documents itself as reproducing Shi &
Huang's released `fsPDA` package, and it did not. On their dense simulation at
`T2 = 50, h = 1` the forward-selection t-statistic was wrong in the third
decimal. Under the `n` convention it agrees with their `FS()` to 2e-11 on every
panel checked. The error grows with the truncation lag.

The other is that `n / (n - l)` costs the autocovariance sequence its positive
semi-definiteness, which is what makes the weighted sum a variance. The clamp at
zero then reports a floor instead of the estimator not needing one.

## How

Found while cross-validating `PDA` against fsPDA's own Monte Carlo panels.
Forward selection reproduced their `FS()` exactly — same donors, ATE to 1e-11 —
while `Z` was off by ~1e-3 on every panel. Recomputing the long-run variance
both ways isolated it:

| convention | max abs error in Z vs their `FS()`, 6 panels |
|---|---|
| divide by `n` (`acf`) | 4.5e-11 |
| divide by `n - l` | 1.9e-03 |

### The second commit

Reading Shi & Wang's Theorem 3 to check the `l2` variant against the same
question turned up a separate, purely documentary error. `pda_ppi` said the gap
between mlsynth's t-statistic and the paper's came from the Newey-West bandwidth
differing from R `sandwich`'s. The bandwidths agree — the paper points to
Newey & West (1994), which is what `newey_west_lag` implements. The difference is
the kernel: Theorem 3 states the estimator with the uniform kernel, adopted "for
simplicity" and explicitly noted as "compatible with the Bartlett kernel", and
mlsynth uses Bartlett. Measured on Hong Kong, holding everything else fixed:

| | rho^2_(1) | rho^2_(2) | \|t\| |
|---|---|---|---|
| mlsynth (Bartlett) | 0.000178 | 0.000120 | 7.825 |
| paper (uniform) | 0.000128 | 0.000146 | 7.686 |

No behaviour changes in that commit; it replaces a stated cause that was never
the cause. Exposing the uniform kernel as an option is deliberately not done
here — it would move pinned `l2` results and wants its own scope.

## Verification

- Path: cross-validation against a reference implementation (R 4.3.3 `acf(type = "covariance")`, and `fsPDA`'s `FS()` end to end)
- Quantities compared: the Bartlett-weighted long-run variance at lags 1, 2 and 3 on an AR(1) series, to 1e-6 relative; and a hand-checkable alternating series where `acf` gives `gamma_1 = -5/6` and the sum is exactly `1/6`
- Pinned durably in `mlsynth/tests/test_pda_lrvar_normalisation.py`, with the generating R script recorded in the test docstring. The end-to-end check against `FS()` is pinned by the `fspda_dense_mc` benchmark on the follow-up branch, where `fs_max_abs_z_err` carries a 1e-8 tolerance and measures 1.2e-13 with this fix and 1.9e-03 without it.

## Scope checks

BUG FIX

- [x] A test reproduces the defect and fails without the fix (5 of the 13 fail on `main`)
- [x] It asserts the correct behaviour — the reference value from `acf` — not merely the absence of a crash
- [x] No docs page, docstring, or comment still states the old behaviour; `hac_lrv`'s docstring now names the convention and why, and the second commit removes the bandwidth claim
- [x] The one pinned value that moved is justified as the right number: `test_hac_lrv_explicit_lag_bartlett` expected exactly `0.0` on an alternating series, which is what `n - l` produces. The comment in that test spelled out `gamma1 = -1`, and `acf` gives `-5/6`.

Effects, weights and selected donor sets are untouched. Only standard errors,
t-statistics, p-values and confidence intervals move, and only where a fixed lag
is in play: `fs` and `hcw` at their default `lrvar_lag=None` take the prewhitened
Newey-West path and do not move at all.

Benchmark cases re-run before and after:

| case | metric | before | after | pinned tolerance |
|---|---|---|---|---|
| `pda_hongkong` | `l2_abs_tstat` | 7.799 | 7.825 | 7.75 ± 1.5 |
| `pda_ppi` | `l2_abs_tstat` | 4.482 | 4.547 | 4.48 ± 1.2 |
| `pda_luxurywatch` | all | unchanged | unchanged | — |
| `pda_brexit` | all | unchanged | unchanged | — |

No expectation moves outside its existing tolerance, so no pinned benchmark value
is re-fitted in this PR.

## Designs

No visual output; this changes a scalar variance estimate.

## Test Steps

- [x] `pytest mlsynth/tests/test_pda_lrvar_normalisation.py -q` — 13 passed
- [x] `pytest mlsynth/tests/test_pda.py mlsynth/tests/test_pda_hcw.py mlsynth/tests/test_pda_l2_native.py mlsynth/tests/test_laxscm.py -q` — 360 passed (every module that reaches `hac_lrv`)
- [x] `pytest mlsynth/tests/ -q` — full suite
- [x] Mutation: three semantic mutants on `inference.py`, all killed
- [x] `python benchmarks/run_benchmarks.py --case pda_ppi` — passes with the reworded comment
- [x] The four PDA benchmark cases re-run before and after (table above)

## Other Notes

- `lrvar_prewhite_nw` already used the `n` convention in its own `sig(j)`, so the two estimators in this module were inconsistent with each other. They now agree.
- Unrelated, found while running the suite and not fixed here: `test_effect_primitives_properties.py::test_standardized_att_is_scale_invariant` can fail under the `dev` hypothesis profile on inputs whose square is subnormal (`pre_gap = 6.1e-161` squares to `3.8e-321`, below the smallest normal double), giving 4.1e-05 relative error against a 1e-6 tolerance. It is pre-existing on `main`, lives in `effectutils` which this PR does not touch, and passes under the derandomized `ci` profile. It wants a strategy guard on its own branch.
- The `fspda_dense_mc` benchmark that found the main defect is a separate branch, per the repo's rule that benchmark authoring does not ride along with a fix.