### PR TITLE
Ask the proximal GMM sandwich for the parameter it is reporting

### DIFF
--- a/benchmarks/cases/dr_proximal_mc.py
+++ b/benchmarks/cases/dr_proximal_mc.py
@@ -33,8 +33,12 @@ In the **just-identified** case the DR and PIPW *point* estimates coincide
 exactly: the treatment bridge solves the balancing moment
 :math:`\\mathbb{E}_{\\text{pre}}[q\\,(1,W)] = \\mathbb{E}_{\\text{post}}[(1,W)]`,
 which makes the DR outcome-bridge correction cancel, so ``dr_bias`` equals
-``pipw_bias`` here. The two still differ in **inference** -- the sandwich SEs,
-and hence the Wald coverage, are not identical.
+``pipw_bias`` here. Their **inference** coincides for the same reason: the same
+estimator against the same moments has the same sandwich, so the SEs and the
+Wald coverage match too. This page previously recorded them as differing, and
+reported PIPW coverage of 0.99 as conservative; both were the off-by-one in
+``estimate_pipw``'s sandwich index, which handed back the standard error of a
+nuisance mean. Corrected, both estimators cover at 0.917.
 
 Path B (scenario 3, the authors' own DGP): the case asserts the geometry --
 both estimators unbiased with reasonable coverage, and DR robust to outcome-
@@ -129,7 +133,7 @@ EXPECTED = {
     "dr_bias": (0.0, 0.06),                 # DR recovers ATE=2
     "pipw_bias": (0.0, 0.06),               # PIPW recovers ATE=2
     "dr_coverage": (0.91, 0.12),            # near nominal 0.95
-    "pipw_coverage": (0.99, 0.08),          # conservative (high) coverage
+    "pipw_coverage": (0.92, 0.12),          # identical to dr_coverage; same estimator
     "pi_att_misspecified": (4.30, 0.6),     # PI collapses under nonlinear confounding
     "dr_att_misspecified": (2.0, 0.25),     # DR holds (correct treatment bridge)
     "dr_beats_pi_under_misspec": (1.0, 0.0),

--- a/mlsynth/tests/test_proximal_helpers.py
+++ b/mlsynth/tests/test_proximal_helpers.py
@@ -202,6 +202,10 @@ def test_estimate_pipw_recovers_effect():
     assert beta.shape == (Z.shape[1] + 1,)
     assert abs(att - 3.0) < 0.6
     assert np.isfinite(se) and se > 0
+    # `se > 0` holds for every parameter's standard error, including the ones
+    # this estimator is not reporting; the Wald interval is what ties it to the
+    # ATT. See test_proximal_sandwich_index.py.
+    assert abs(att - 3.0) <= 1.96 * se
 
 
 def test_dr_pipw_deterministic():

--- a/mlsynth/tests/test_proximal_sandwich_index.py
+++ b/mlsynth/tests/test_proximal_sandwich_index.py
@@ -1,0 +1,143 @@
+"""The GMM sandwich reports the standard error of the parameter it was asked for.
+
+Rung 3 of the ladder in ``agents/agents_tests.md``, for the proximal estimators
+that stack their estimand into a just-identified GMM and read one entry out of
+the sandwich.
+
+The invariant. ``gmm_sandwich_se(theta, moments, phi_index, ...)`` returns the
+square root of one diagonal entry of a covariance matrix over ``theta``. Which
+entry is chosen by an integer, and the moment function unpacks ``theta`` by its
+own hard-coded offsets. Nothing ties the two together: they are two independent
+statements about the same layout, and if they disagree the function returns a
+perfectly well-formed standard error belonging to a different parameter.
+
+So the property asserted here is structural, not numerical -- ``theta`` at the
+index handed to the sandwich must *be* the estimate the routine returns. It needs
+no reference implementation and no known truth, which is what makes it the right
+instrument: the failure it catches produces a finite, positive, plausibly-sized
+number, and every assertion of the form ``se > 0`` passes straight through it.
+
+The second class below is the same invariant reached from the estimator side.
+In the just-identified design the treatment bridge solves
+``E_pre[q (1, W)] = E_post[(1, W)]`` exactly, so the DR correction term vanishes
+and DR and PIPW are the same estimator applied to the same moments. Their point
+estimates coincide, and so must their standard errors. Any drift between the two
+is a disagreement about the layout, not about the econometrics.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthEstimationError
+
+from mlsynth.utils.proximal_helpers.dr.estimation import estimate_dr
+from mlsynth.utils.proximal_helpers.pipw.estimation import estimate_pipw
+
+
+def _panel(seed=0, T=600, nU=2, effect=2.0):
+    """AR(1) latent confounders with independent W and Z proxy blocks."""
+    rng = np.random.default_rng(seed)
+    T0 = T // 2
+    U = np.zeros((T, nU))
+    U[0] = rng.standard_normal(nU)
+    for t in range(1, T):
+        U[t] = 0.1 * U[t - 1] + 0.9 * rng.standard_normal(nU)
+    post = np.arange(T) >= T0
+    Y = effect * post + 2 * U.sum(1) + rng.standard_normal(T)
+    W = 2 * U + rng.standard_normal((T, nU))
+    Z = 2 * U + rng.standard_normal((T, nU))
+    return Y, W, Z, T0
+
+
+class TestTheIndexPointsAtTheEstimand:
+    """The contract ``gmm_sandwich_se`` now enforces, exercised directly.
+
+    A caller that hands the helper an index not holding the estimate gets an
+    error instead of another parameter's standard error.
+    """
+
+    def test_a_mismatched_index_raises(self):
+        from mlsynth.utils.proximal_helpers.bridges import gmm_sandwich_se
+        theta = np.array([1.0, 2.0, 3.0])
+        moments = lambda th: np.column_stack([
+            np.full(50, th[0]), np.full(50, th[1]), np.full(50, th[2])])
+        with pytest.raises(MlsynthEstimationError, match="index 2"):
+            gmm_sandwich_se(theta, moments, 2, 50, 2, expected_value=2.0)
+
+    def test_a_matching_index_is_accepted(self):
+        from mlsynth.utils.proximal_helpers.bridges import gmm_sandwich_se
+        rng = np.random.default_rng(0)
+        theta = np.array([1.0, 2.0])
+        U = rng.standard_normal((80, 2))
+        moments = lambda th: U + th[None, :]
+        assert np.isfinite(gmm_sandwich_se(theta, moments, 1, 80, 2,
+                                           expected_value=2.0))
+
+    def test_the_check_is_opt_in(self):
+        """Omitting the estimate keeps the old signature working."""
+        from mlsynth.utils.proximal_helpers.bridges import gmm_sandwich_se
+        rng = np.random.default_rng(1)
+        U = rng.standard_normal((60, 2))
+        assert np.isfinite(gmm_sandwich_se(np.array([1.0, 2.0]),
+                                           lambda th: U + th[None, :], 0, 60, 2))
+
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_pipw_asks_for_its_own_att(self, seed):
+        """End to end: the estimator wires its own estimate into the check, so a
+        layout drift fails at the call instead of returning a wrong number."""
+        Y, W, Z, T0 = _panel(seed=seed)
+        _, att, se = estimate_pipw(Y, W, Z, T0, hac_bandwidth=4)
+        assert np.isfinite(se) and se > 0 and np.isfinite(att)
+
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_dr_asks_for_its_own_att(self, seed):
+        Y, W, Z, T0 = _panel(seed=seed)
+        *_, att, se = estimate_dr(Y, W, Z, T0, hac_bandwidth=4)
+        assert np.isfinite(se) and se > 0 and np.isfinite(att)
+
+
+class TestDrAndPipwAgreeWhenJustIdentified:
+    """The estimator-side reading of the same invariant."""
+
+    @pytest.mark.parametrize("seed", [0, 1, 2, 3])
+    def test_the_point_estimates_coincide(self, seed):
+        Y, W, Z, T0 = _panel(seed=seed)
+        _, _, _, dr_att, _ = estimate_dr(Y, W, Z, T0, hac_bandwidth=4)
+        _, pipw_att, _ = estimate_pipw(Y, W, Z, T0, hac_bandwidth=4)
+        assert dr_att == pytest.approx(pipw_att, rel=1e-8)
+
+    @pytest.mark.parametrize("seed", [0, 1, 2, 3])
+    def test_the_standard_errors_coincide(self, seed):
+        """Same estimator, same moments, same sandwich: the standard errors
+        cannot differ. A gap here means the two are reading different entries
+        out of it."""
+        Y, W, Z, T0 = _panel(seed=seed)
+        _, _, _, _, dr_se = estimate_dr(Y, W, Z, T0, hac_bandwidth=4)
+        _, _, pipw_se = estimate_pipw(Y, W, Z, T0, hac_bandwidth=4)
+        assert dr_se == pytest.approx(pipw_se, rel=1e-6), (
+            f"DR reports {dr_se:.6f} and PIPW {pipw_se:.6f} for the same estimate")
+
+
+class TestTheStandardErrorIsSized:
+    """What ``se > 0`` cannot see.
+
+    A standard error belonging to the wrong parameter is finite and positive.
+    What separates it from the right one is its size relative to the estimate's
+    own sampling variability, so that is what gets checked.
+    """
+
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_the_wald_interval_covers_the_truth(self, seed):
+        Y, W, Z, T0 = _panel(seed=seed, T=2000, effect=2.0)
+        _, att, se = estimate_pipw(Y, W, Z, T0, hac_bandwidth=4)
+        assert abs(att - 2.0) <= 1.96 * se
+
+    def test_the_standard_error_shrinks_with_the_sample(self):
+        """Root-n: quadrupling T should roughly halve it. A standard error
+        attached to a different parameter need not scale this way."""
+        ses = []
+        for T in (500, 2000):
+            Y, W, Z, T0 = _panel(seed=7, T=T)
+            ses.append(estimate_pipw(Y, W, Z, T0, hac_bandwidth=4)[2])
+        assert 0.3 < ses[1] / ses[0] < 0.8, f"se ratio {ses[1] / ses[0]:.3f}"

--- a/mlsynth/utils/proximal_helpers/bridges.py
+++ b/mlsynth/utils/proximal_helpers/bridges.py
@@ -28,6 +28,8 @@ from typing import Callable, Optional, Tuple
 import numpy as np
 from scipy.optimize import root
 
+from ...exceptions import MlsynthEstimationError
+
 
 def augment(matrix: np.ndarray) -> np.ndarray:
     """Prepend an intercept column of ones."""
@@ -87,6 +89,7 @@ def gmm_sandwich_se(
     total_periods: int,
     bandwidth: int,
     eps: float = 1e-6,
+    expected_value: float | None = None,
 ) -> float:
     """Sandwich SE for one parameter of a just-identified GMM.
 
@@ -102,13 +105,39 @@ def gmm_sandwich_se(
         ``T`` (sandwich normalization).
     bandwidth : int
         Bartlett-HAC bandwidth.
+    expected_value : float, optional
+        The estimate this standard error is meant to belong to. When supplied it
+        is checked against ``theta[param_index]``, which is the only thing tying
+        the index to the estimand.
+
+        The caller states the layout twice -- once in the offsets its moment
+        function unpacks ``theta`` with, once in this index -- and nothing else
+        makes the two agree. When they disagree the sandwich still returns a
+        finite, positive, plausibly-sized number, because every entry on that
+        diagonal is some parameter's standard error. Passing the estimate turns a
+        silent mislabel into a raised error.
 
     Returns
     -------
     float
         ``sqrt(Cov[param_index, param_index])``; ``np.nan`` if the Jacobian
         is singular or the variance is negative.
+
+    Raises
+    ------
+    MlsynthEstimationError
+        If ``expected_value`` is given and does not match ``theta[param_index]``.
     """
+    if expected_value is not None:
+        got = float(theta[param_index])
+        if not np.isclose(got, float(expected_value), rtol=1e-8, atol=1e-10):
+            raise MlsynthEstimationError(
+                f"the GMM sandwich was asked for index {param_index}, which holds "
+                f"{got:.10g}, but the estimate it is meant to describe is "
+                f"{float(expected_value):.10g}. The moment function's parameter "
+                f"layout and the index disagree, so this standard error would "
+                f"belong to a different parameter."
+            )
     base = moments(theta).mean(0)
     p = len(theta)
     G = np.zeros((len(base), p))

--- a/mlsynth/utils/proximal_helpers/dr/estimation.py
+++ b/mlsynth/utils/proximal_helpers/dr/estimation.py
@@ -105,6 +105,7 @@ def estimate_dr(
         g5 = pre.astype(float) * (pm - qq * (Y - hh))          # psi- = E_pre[q(Y-h)]
         return np.column_stack([g1, g2, g3, g4, g5])
 
-    se = gmm_sandwich_se(theta, moments, phi_index, T, hac_bandwidth)
+    se = gmm_sandwich_se(theta, moments, phi_index, T, hac_bandwidth,
+                         expected_value=phi)
     counterfactual = h
     return counterfactual, alpha, beta, phi, se

--- a/mlsynth/utils/proximal_helpers/pipw/estimation.py
+++ b/mlsynth/utils/proximal_helpers/pipw/estimation.py
@@ -75,7 +75,7 @@ def estimate_pipw(
 
     # Parameter order [beta, psi, phi, psi-].
     theta = np.concatenate([beta, psi, [phi], [psi_minus]])
-    phi_index = 2 * nU + 3
+    phi_index = 2 * nU + 2
 
     def moments(th: np.ndarray) -> np.ndarray:
         b = th[: nU + 1]
@@ -89,5 +89,6 @@ def estimate_pipw(
         g4 = pre.astype(float) * (pm - qq * Y)
         return np.column_stack([g1, g2, g3, g4])
 
-    se = gmm_sandwich_se(theta, moments, phi_index, T, hac_bandwidth)
+    se = gmm_sandwich_se(theta, moments, phi_index, T, hac_bandwidth,
+                         expected_value=phi)
     return beta, phi, se

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -364,3 +364,22 @@ timeout = 300.0
   find = "    zc = z - z.mean()"
   replace = "    zc = z"
   models = "autocovariances taken about zero instead of the sample mean. The post-period effect series is centred by the caller in most paths, so this is invisible wherever the mean is already near zero and wrong wherever a real effect shifts it -- the case the estimator exists to test"
+
+[[target]]
+name = "proximal-sandwich-index"
+module-path = "mlsynth/utils/proximal_helpers/pipw/estimation.py"
+test-command = "python -m pytest mlsynth/tests/test_proximal_sandwich_index.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "phi-index-off-by-one"
+  find = "    phi_index = 2 * nU + 2"
+  replace = "    phi_index = 2 * nU + 3"
+  models = "the defect this module was fixed for: the sandwich asked for the index one past the ATT, which holds psi_minus, a nuisance mean. It returns that parameter's standard error instead -- finite, positive, and 44 percent larger on the authors' own normal simulation, where it inflated Wald coverage to 0.99 against a nominal 0.95 and was recorded in the benchmark as conservative inference. The guard added with the fix turns this into a raised error; without the guard only the DR-versus-PIPW agreement catches it"
+
+  [[target.mutant]]
+  id = "sandwich-index-unchecked-and-off-by-one"
+  find = """    se = gmm_sandwich_se(theta, moments, phi_index, T, hac_bandwidth,
+                         expected_value=phi)"""
+  replace = "    se = gmm_sandwich_se(theta, moments, 2 * nU + 3, T, hac_bandwidth)"
+  models = "the pre-fix state exactly: the wrong index and no check tying it to the estimand. This is the mutant that matters, because it is what the code looked like while every test passed. Nothing about the returned value is malformed, so it survives every assertion of the form `isfinite(se) and se > 0`; what kills it is the invariant that DR and PIPW, being the same estimator in the just-identified design, must report the same standard error"


### PR DESCRIPTION
## Related Links

- Affected helper: `mlsynth/utils/proximal_helpers/bridges.py` (`gmm_sandwich_se`) and `pipw/estimation.py`
- Reference: Qiu, Shi, Miao, Dobriban & Tchetgen Tchetgen (2024), "Doubly robust proximal synthetic controls", Biometrics 80(2) ujae055; [`QIU-Hongxiang-David/DR_Proximal_SC`](https://github.com/QIU-Hongxiang-David/DR_Proximal_SC) `simulation/normal`
- Procedure: the five-why ladder in `agents/agents_tests.md`, added in `1edbf25`
- Blocks: the DR-proximal benchmark, which can now pin the corrected SE instead of documenting a discrepancy

## What

- `estimate_pipw`'s `phi_index` corrected from `2*nU + 3` to `2*nU + 2`
- `gmm_sandwich_se` takes an optional `expected_value` and raises `MlsynthEstimationError` when `theta[param_index]` disagrees; both callers pass it
- Added `mlsynth/tests/test_proximal_sandwich_index.py` (21 tests)
- Strengthened the PIPW assertion in `test_proximal_helpers.py`
- Corrected `dr_proximal_mc`'s stated reason and its `pipw_coverage` expectation
- Added a `proximal-sandwich-index` mutation target with two mutants

## Why

`estimate_pipw` builds `theta = [beta, psi, phi, psi_minus]` and unpacks it in
the moment function at `ph = th[2*nU + 2]`, but handed the sandwich
`phi_index = 2*nU + 3`. That index holds `psi_minus`, a nuisance mean, so the
reported standard error belonged to a different parameter.

On the authors' `normal` simulation at `T = 500`:

| | mlsynth before | mlsynth after | their R | gap after |
|---|---|---|---|---|
| PIPW ATT | 2.1833550046 | 2.1833550046 | 2.1833564000 (`correct.q`) | 1.4e-06 |
| PIPW SE | 0.2578412269 | 0.1749891868 | 0.1787469426 | 2.1% |
| DR SE | 0.1749891868 | 0.1749891868 | 0.1793672518 (`correct.DR`) | 2.4% |

The point estimate was never affected. The residual 2.1–2.4% is their
`sandwich::vcovHAC` with an Andrews bandwidth against the fixed Bartlett one
here — a convention difference on current evidence, not chased in this PR.

## How

Diagnosed with the five-why ladder. Rung 0 — the headline ATT — passes, which is
why this survived.

| Rung | Question | Verdict |
|---|---|---|
| 0 | Which reported quantity looks wrong? | passed: ATT agrees to 1.4e-06 |
| 1 | Which other outputs moved? | failed: only PIPW's SE; DR's was within 2.4% |
| 2 | Which term produced it? | failed: `phi_index` off by one; returned `psi_minus`'s SE |
| 3 | Which invariant is violated? | failed: `theta[phi_index]` is not the ATT; DR and PIPW disagree |
| 4 | What contract was unenforced? | failed: the layout is stated twice with nothing tying the two |
| 5 | Would the suite have caught it? | no: the only assertion was `isfinite(se) and se > 0` |

The asymmetry at rung 1 is what ruled out the obvious story. Both estimators
share `_hac_bandwidth`, so a bandwidth cause would have moved both; DR was fine.

The integer is not the interesting part. The parameter layout was stated twice —
once in the offsets the moment function unpacks, once in the index — and nothing
made them agree. When they disagreed the sandwich returned a finite, positive,
plausibly sized number, because every entry on that diagonal is *some*
parameter's standard error. So the fix is the contract: `gmm_sandwich_se` now
takes the estimate it is meant to describe and raises when the index does not
hold it.

## Verification

- Path: cross-validation against the authors' `correct.q` on their own DGP (table above)
- The invariant that needs no reference: in the just-identified design the treatment bridge solves `E_pre[q (1,W)] = E_post[(1,W)]` exactly, so the DR correction cancels and DR and PIPW are the same estimator against the same moments. Their SEs must coincide, and after the fix they do to 1e-6 across four seeds. Before, they were 0.135 against 0.201.
- Pinned in `test_proximal_sandwich_index.py`: the index holds the estimate, the two estimators agree, the Wald interval covers the truth, and the SE falls at the root-n rate (0.3 < ratio < 0.8 for a fourfold increase in T)
- Mutation: `phi-index-off-by-one` and `sandwich-index-unchecked-and-off-by-one` (the pre-fix state entire), both killed

## Scope checks

BUG FIX

- [x] A test reproduces the defect and fails without the fix — `test_the_standard_errors_coincide` reports 0.135 against 0.201 on `main`
- [x] It asserts the correct behaviour, not merely the absence of a crash
- [x] No docs page, docstring, or comment still states the old behaviour
- [x] Any pinned value that moved is justified as the right number, not re-fitted

On that last point, `dr_proximal_mc` had recorded the symptom as behaviour. Its
page said the two estimators "differ in inference — the sandwich SEs, and hence
the Wald coverage, are not identical", which is a reason that was never the
cause, and it pinned `pipw_coverage` at **0.99** commented "conservative (high)
coverage". That 0.99 was the inflated standard error widening the Wald interval.
The cell now reads 0.9167, identical to `dr_coverage` as it must be, and against
a nominal 0.95. It had been passing on a 0.08 tolerance against a 0.073 miss.

## Designs

No visual output; this changes a scalar standard error.

## Test Steps

- [x] `pytest mlsynth/tests/test_proximal_sandwich_index.py -q` — 21 passed
- [x] `pytest mlsynth/tests/test_proximal*.py mlsynth/tests/test_mutation_harness.py -q` — 168 passed
- [x] `pytest mlsynth/tests/ -q -k "proximal or spsc or pioid or dr_"` — 194 passed
- [x] `pytest mlsynth/tests/ -q` — full suite
- [x] `python benchmarks/run_benchmarks.py --case dr_proximal_mc` — passes with the corrected coverage cell
- [x] Mutation: two semantic mutants, both killed

## Other Notes

- `expected_value` is optional, so the helper's existing signature keeps working; only the two proximal callers pass it today.
- The 2.1–2.4% residual against their SEs is a bandwidth and kernel convention difference. Establishing that properly is its own scope, in the same shape as the `l2` kernel finding in #417.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLNEvmPN3YUFUEahAwWAoz)_