### PR TITLE
Report a treatment bridge that did not solve its moment

### DIFF
--- a/mlsynth/tests/test_proximal.py
+++ b/mlsynth/tests/test_proximal.py
@@ -411,8 +411,53 @@ def test_proximal_spsc_basis_degree_must_be_positive(
 
 # --- DR + PIPW (doubly robust proximal) ---
 
-def test_proximal_dr_pipw_path(sample_proximal_data: pd.DataFrame) -> None:
+def _solvable_proximal_panel(T: int = 200, T0: int = 100) -> pd.DataFrame:
+    """A panel long enough for the treatment bridge to have a solution.
+
+    ``sample_proximal_data`` gives six pre-periods against four post ones, and
+    the bridge moment ``E_pre[q (1,W)] = E_post[(1,W)]`` has no root there --
+    ``fit_treatment_bridge`` raises on it, which is asserted separately below.
+    The DR/PIPW plumbing still needs exercising, so it gets a panel where the
+    fit exists.
+    """
+    rng = np.random.default_rng(11)
+    U = np.zeros((T, 2))
+    U[0] = rng.standard_normal(2)
+    for t in range(1, T):
+        U[t] = 0.1 * U[t - 1] + 0.9 * rng.standard_normal(2)
+    post = np.arange(T) >= T0
+    rows = []
+    y = 2.0 * post + 2 * U.sum(1) + rng.standard_normal(T)
+    for t in range(T):
+        rows.append({"UnitIdentifier": 1, "TimeIdx": t + 1, "OutcomeValue": y[t],
+                     "DonorProxyVar1": 0.0, "IsTreated": int(post[t])})
+    for j in range(2):
+        w = 2 * U[:, j] + rng.standard_normal(T)
+        z = 2 * U[:, j] + rng.standard_normal(T)
+        for t in range(T):
+            rows.append({"UnitIdentifier": j + 2, "TimeIdx": t + 1,
+                         "OutcomeValue": w[t], "DonorProxyVar1": z[t],
+                         "IsTreated": 0})
+    return pd.DataFrame(rows)
+
+
+def test_proximal_dr_pipw_raises_when_the_bridge_has_no_solution(
+        sample_proximal_data: pd.DataFrame) -> None:
+    """Six pre-periods against four post ones does not admit a bridge.
+
+    Before ``fit_treatment_bridge`` checked its own solve, this returned an
+    ordinary-looking ATT built from a moment residual of 0.219.
+    """
+    from mlsynth.exceptions import MlsynthEstimationError
+    with pytest.raises(MlsynthEstimationError, match="treatment bridge"):
+        PROXIMAL(PROXIMALConfig(**_base(
+            sample_proximal_data, methods=["DR", "PIPW"],
+            vars={"donorproxies": ["DonorProxyVar1"]}))).fit()
+
+
+def test_proximal_dr_pipw_path() -> None:
     """Methods=['DR','PIPW'] run off donors + donorproxies (W, Z)."""
+    sample_proximal_data = _solvable_proximal_panel()
     results = PROXIMAL(PROXIMALConfig(**_base(
         sample_proximal_data, methods=["DR", "PIPW"],
         vars={"donorproxies": ["DonorProxyVar1"]}))).fit()

--- a/mlsynth/tests/test_proximal_bridge_convergence.py
+++ b/mlsynth/tests/test_proximal_bridge_convergence.py
@@ -1,0 +1,134 @@
+"""The treatment bridge solves the moment it says it solves, or says it did not.
+
+Rung 3 of the ladder in ``agents/agents_tests.md``, for the root solve that both
+proximal estimators depend on.
+
+``fit_treatment_bridge`` returns the ``beta`` satisfying
+
+    E_pre[exp((1,Z) beta) (1,W)] = E_post[(1,W)]
+
+which is a square system, and it finds it with a Newton/hybr solve. A root
+finder can fail, and when it does there is a returned vector either way. The
+failure is not visible in the shape or the finiteness of that vector, and the
+downstream estimate built from it is an ordinary-looking number: on the authors'
+``short_post`` and ``small_T`` designs a non-converged bridge produced ATTs
+within 1e-2 of theirs and standard errors of 8.5 to 12.4, which are not
+estimates of anything.
+
+So the invariant is the defining property of the answer, checked on the answer:
+the moment residual at the returned ``beta`` is zero. It needs no reference
+implementation and no known truth, and it is exactly what the solver's own
+``success`` flag was reporting before that flag was discarded.
+
+The short post-period is what makes the system hard. ``psi = E_post[(1, W)]`` is
+a mean over the post-treatment periods, so with twenty of them it is noisy, and
+the exponential tilt that has to reproduce it may sit far out in ``beta`` or not
+exist at all in finite sample. That is a real property of the design rather than
+a numerical accident, which is why it is reported instead of retried away.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthEstimationError
+from mlsynth.utils.proximal_helpers.bridges import augment, fit_treatment_bridge
+
+
+def _panel(seed=0, T=600, T_post=None, nU=2):
+    """AR(1) confounders; ``T_post`` short enough to strain the bridge if given."""
+    rng = np.random.default_rng(seed)
+    T0 = T - (T_post if T_post is not None else T // 2)
+    U = np.zeros((T, nU))
+    U[0] = rng.standard_normal(nU)
+    for t in range(1, T):
+        U[t] = 0.1 * U[t - 1] + 0.9 * rng.standard_normal(nU)
+    post = np.arange(T) >= T0
+    Y = 2.0 * post + 2 * U.sum(1) + rng.standard_normal(T)
+    W = 2 * U + rng.standard_normal((T, nU))
+    Z = 2 * U + rng.standard_normal((T, nU))
+    return Y, W, Z, T0
+
+
+def _residual(beta, Zc_pre, Wc_pre, psi):
+    q = np.exp(Zc_pre @ beta)
+    return float(np.max(np.abs((q[:, None] * Wc_pre).mean(0) - psi)))
+
+
+class TestTheReturnedBridgeSolvesItsMoment:
+    @pytest.mark.parametrize("seed", [0, 1, 2, 3])
+    def test_the_moment_residual_is_zero(self, seed):
+        Y, W, Z, T0 = _panel(seed=seed)
+        pre = np.arange(len(Y)) < T0
+        Wc, Zc = augment(W), augment(Z)
+        psi = Wc[~pre].mean(0)
+        beta = fit_treatment_bridge(Zc[pre], Wc[pre], psi)
+        assert _residual(beta, Zc[pre], Wc[pre], psi) < 1e-6
+
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_a_supplied_start_reaches_the_same_root(self, seed):
+        """The root is a property of the moment, not of where the search began."""
+        Y, W, Z, T0 = _panel(seed=seed)
+        pre = np.arange(len(Y)) < T0
+        Wc, Zc = augment(W), augment(Z)
+        psi = Wc[~pre].mean(0)
+        a = fit_treatment_bridge(Zc[pre], Wc[pre], psi)
+        b = fit_treatment_bridge(Zc[pre], Wc[pre], psi, beta_init=a + 0.05)
+        assert np.allclose(a, b, atol=1e-6)
+
+
+class TestAFailedSolveIsReported:
+    """What the discarded ``success`` flag was for."""
+
+    def test_an_unreachable_moment_raises(self):
+        """``psi`` outside the range of the exponential tilt has no solution.
+
+        A negative target for a moment that is a positive-weight average of
+        positive quantities cannot be met, so no ``beta`` exists.
+        """
+        rng = np.random.default_rng(0)
+        Zc = augment(rng.standard_normal((200, 2)))
+        Wc = augment(np.abs(rng.standard_normal((200, 2))) + 1.0)
+        psi = np.array([-5.0, -5.0, -5.0])
+        with pytest.raises(MlsynthEstimationError, match="treatment bridge"):
+            fit_treatment_bridge(Zc, Wc, psi)
+
+    def test_the_error_reports_the_residual(self):
+        rng = np.random.default_rng(1)
+        Zc = augment(rng.standard_normal((150, 2)))
+        Wc = augment(np.abs(rng.standard_normal((150, 2))) + 1.0)
+        with pytest.raises(MlsynthEstimationError, match=r"residual"):
+            fit_treatment_bridge(Zc, Wc, np.array([-3.0, -3.0, -3.0]))
+
+    def test_a_reachable_moment_does_not_raise(self):
+        Y, W, Z, T0 = _panel(seed=5)
+        pre = np.arange(len(Y)) < T0
+        Wc, Zc = augment(W), augment(Z)
+        beta = fit_treatment_bridge(Zc[pre], Wc[pre], Wc[~pre].mean(0))
+        assert np.all(np.isfinite(beta))
+
+
+class TestTheEstimatorsSurfaceIt:
+    """The translated error reaches the caller instead of a wrong number."""
+
+    def test_pipw_raises_on_an_unsolvable_bridge(self):
+        from mlsynth.utils.proximal_helpers.pipw.estimation import estimate_pipw
+        rng = np.random.default_rng(3)
+        T, T0 = 120, 100
+        Y = rng.standard_normal(T)
+        W = np.abs(rng.standard_normal((T, 2))) + 1.0
+        W[T0:] *= -1.0                      # post-period mean outside the tilt's range
+        Z = rng.standard_normal((T, 2))
+        with pytest.raises(MlsynthEstimationError):
+            estimate_pipw(Y, W, Z, T0, hac_bandwidth=2)
+
+    def test_dr_raises_on_an_unsolvable_bridge(self):
+        from mlsynth.utils.proximal_helpers.dr.estimation import estimate_dr
+        rng = np.random.default_rng(4)
+        T, T0 = 120, 100
+        Y = rng.standard_normal(T)
+        W = np.abs(rng.standard_normal((T, 2))) + 1.0
+        W[T0:] *= -1.0
+        Z = rng.standard_normal((T, 2))
+        with pytest.raises(MlsynthEstimationError):
+            estimate_dr(Y, W, Z, T0, hac_bandwidth=2)

--- a/mlsynth/utils/proximal_helpers/bridges.py
+++ b/mlsynth/utils/proximal_helpers/bridges.py
@@ -30,6 +30,11 @@ from scipy.optimize import root
 
 from ...exceptions import MlsynthEstimationError
 
+#: Largest absolute moment residual accepted as a solved treatment bridge. The
+#: system is square and solves to machine precision when a root exists, so this
+#: separates a root from a search that stalled, not a good fit from a poor one.
+_BRIDGE_TOL = 1e-6
+
 
 def augment(matrix: np.ndarray) -> np.ndarray:
     """Prepend an intercept column of ones."""
@@ -49,9 +54,20 @@ def fit_treatment_bridge(
 ) -> np.ndarray:
     """Solve ``E_pre[exp((1,Z) beta) (1,W)] = psi`` for ``beta``.
 
-    ``psi = E_post[(1, W)]`` is the post-period donor mean. The system is
-    square (``dim(beta) = dim(W)+1``); a Newton/hybr solve from ``beta=0``
-    (with a logistic-regression fallback init) recovers it.
+    ``psi = E_post[(1, W)]`` is the post-period donor mean. The system is square
+    (``dim(beta) = dim(W)+1``) and is solved by a Newton/hybr search from
+    ``beta = 0``, or from ``beta_init`` when the caller supplies one.
+
+    Raises
+    ------
+    MlsynthEstimationError
+        If no start reaches a root. The returned vector is otherwise
+        indistinguishable from a solution -- finite, right-shaped, and it yields
+        an ordinary-looking ATT -- so a failed search is reported instead of
+        returned. A short post-period is the usual reason: ``psi`` is a mean over
+        the post-treatment periods, and with a few dozen of them the exponential
+        tilt that reproduces it may sit far out in ``beta`` or not exist in
+        finite sample.
     """
     p = Zc_pre.shape[1]
 
@@ -60,13 +76,29 @@ def fit_treatment_bridge(
         return (q[:, None] * Wc_pre).mean(0) - psi
 
     inits = [np.zeros(p)] if beta_init is None else [beta_init, np.zeros(p)]
-    last = None
+    best, best_residual = None, np.inf
     for b0 in inits:
-        sol = root(moment, b0, method="hybr")
-        last = sol.x
-        if sol.success:
+        with np.errstate(over="ignore", invalid="ignore"):
+            sol = root(moment, b0, method="hybr")
+            residual = float(np.max(np.abs(moment(sol.x))))
+        if np.isfinite(residual) and residual < best_residual:
+            best, best_residual = sol.x, residual
+        # The residual decides, not the solver's own flag. hybr reports success
+        # from the size of its last step, which can be small at a point that
+        # does not solve the system; the moment being zero is the property that
+        # makes the vector an answer.
+        if residual <= _BRIDGE_TOL:
             return sol.x
-    return last  # best effort; downstream SE will reflect any residual error
+
+    raise MlsynthEstimationError(
+        f"the treatment bridge did not solve its moment condition: the largest "
+        f"absolute residual of E_pre[q (1,W)] - E_post[(1,W)] is "
+        f"{best_residual:.3g} against a tolerance of {_BRIDGE_TOL:g}. The "
+        f"weighting estimate built from this vector would look ordinary and mean "
+        f"nothing. With {Wc_pre.shape[1] - 1} proxies this usually means the "
+        f"post-period is too short for its mean to be reproducible by an "
+        f"exponential tilt of the pre-period."
+    )
 
 
 def _bartlett_hac(U: np.ndarray, bandwidth: int) -> np.ndarray:

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -383,3 +383,21 @@ timeout = 300.0
                          expected_value=phi)"""
   replace = "    se = gmm_sandwich_se(theta, moments, 2 * nU + 3, T, hac_bandwidth)"
   models = "the pre-fix state exactly: the wrong index and no check tying it to the estimand. This is the mutant that matters, because it is what the code looked like while every test passed. Nothing about the returned value is malformed, so it survives every assertion of the form `isfinite(se) and se > 0`; what kills it is the invariant that DR and PIPW, being the same estimator in the just-identified design, must report the same standard error"
+
+[[target]]
+name = "proximal-bridge-convergence"
+module-path = "mlsynth/utils/proximal_helpers/bridges.py"
+test-command = "python -m pytest mlsynth/tests/test_proximal_bridge_convergence.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "non-converged-bridge-returned-as-a-solution"
+  find = "        if residual <= _BRIDGE_TOL:\n            return sol.x"
+  replace = "        return sol.x"
+  models = "the defect this module was fixed for: the root finder's own success flag discarded and the last iterate returned. The vector is finite and right-shaped, and the estimate built from it looks ordinary -- on the authors' short_post and small_T designs it landed within 1e-2 of theirs with standard errors of 8.5 to 12.4 -- so nothing downstream can tell a solution from a stalled search. Only checking the moment residual at the returned beta separates them"
+
+  [[target.mutant]]
+  id = "bridge-tolerance-loose-enough-to-admit-anything"
+  find = "_BRIDGE_TOL = 1e-6"
+  replace = "_BRIDGE_TOL = 1e6"
+  models = "the convergence check kept but its threshold widened past every attainable residual, which is the shape a tolerance takes when it is relaxed to make a red test green. The square system solves to machine precision when a root exists, so any tolerance loose enough to admit a stalled search is loose enough to admit all of them"


### PR DESCRIPTION
## Related Links

- Affected helper: `mlsynth/utils/proximal_helpers/bridges.py` (`fit_treatment_bridge`)
- Reference: Qiu, Shi, Miao, Dobriban & Tchetgen Tchetgen (2024), Biometrics 80(2) ujae055; [`QIU-Hongxiang-David/DR_Proximal_SC`](https://github.com/QIU-Hongxiang-David/DR_Proximal_SC) `simulation/{short_post,small_T}`
- Follows: #419, the sandwich index in the same module
- Procedure: the five-why ladder in `agents/agents_tests.md`
- Blocks: the DR-proximal benchmark, whose `short_post` and `small_T` cells can now assert the raise instead of being excluded

## What

- `fit_treatment_bridge` raises `MlsynthEstimationError` when no start reaches a root, instead of returning the last iterate
- The accept condition is the moment residual against `_BRIDGE_TOL = 1e-6`, not the solver's own `success` flag
- Added `mlsynth/tests/test_proximal_bridge_convergence.py` (12 tests)
- `test_proximal_dr_pipw_path` moved onto a panel where the fit exists; the old fixture gets a test asserting the raise
- Added a `proximal-bridge-convergence` mutation target with two mutants

## Why

The bridge solves `E_pre[exp((1,Z) beta)(1,W)] = E_post[(1,W)]`, a square
system, by Newton/hybr search. When the search failed the function returned
`sol.x` anyway, with the comment that "downstream SE will reflect any residual
error". It does not. The returned vector is finite and the right shape, and the
estimate built from it is an ordinary-looking number, so nothing between that
line and the caller can tell a solution from a stalled search.

Found while cross-validating against their simulation directory. Five of their
scenarios agree with mlsynth to 1e-6. The disagreement sat entirely in the two
short-post-period designs:

| scenario | `T_post` | max abs Δφ vs theirs | mlsynth SE |
|---|---|---|---|
| `normal`, `detrend`, `nonstationary`, `just_identified`, `select_donor` | 250 | ~1e-6 | 0.10 – 0.20 |
| `short_post` | 22 | 1.3e-01 | up to 9.34 |
| `small_T` | 20 | 1.2e-01 | up to 12.39 |

On those cells the solve reports failure from a zero start and a logistic one
alike, and the repo's own `sample_proximal_data` fixture — six pre-periods
against four post — carries a moment residual of **0.219**.

The short post-period is a property of the design, not a numerical accident:
`psi` is a mean over the post-treatment periods, so with twenty of them the
exponential tilt that reproduces it may sit far out in `beta` or not exist in
finite sample. That is a fact about what can be estimated there, and it is now
reported instead of returned.

## How

Diagnosed with the ladder.

| Rung | Question | Verdict |
|---|---|---|
| 0 | Which reported quantity looks wrong? | the ATT, by 1e-2 — small enough to read as noise |
| 1 | Which other outputs moved? | the SE too (8.5–12.4), so not inference-only |
| 2 | Which term produced it? | `fit_treatment_bridge` returns `sol.x` when `sol.success` is `False` |
| 3 | Which invariant is violated? | the returned `beta` does not satisfy the moment it claims to solve |
| 4 | What contract was unenforced? | convergence; the solver's own flag was discarded |
| 5 | Would the suite have caught it? | no — there were no tests on this function at all |

The decision moved onto the residual because of rung 5, not by design. The
tolerance mutant **survived** a first attempt that gated on `sol.success and
residual <= tol`: every test written for it hit the no-solution path, where
`success` is already `False`, so the threshold was doing no work. Gating on the
residual alone is also the better criterion — `hybr` sets `success` from the size
of its last step, which can be small at a point that does not solve the system.

## Verification

- Path: cross-validation against the authors' `correct.DR` / `correct.q` on their own scenarios (table above)
- The invariant needs no reference: the moment residual at the returned `beta` is zero, asserted across four seeds
- Failure tests: an unreachable `psi` (a negative target for a positive-weight average of positive quantities) raises with the residual in the message, and both `estimate_dr` and `estimate_pipw` surface the translated error
- Mutation: `non-converged-bridge-returned-as-a-solution` (the pre-fix state) and `bridge-tolerance-loose-enough-to-admit-anything`, both killed

## Scope checks

BUG FIX

- [x] A test reproduces the defect and fails without the fix — four "DID NOT RAISE" on `main`
- [x] It asserts the correct behaviour: the moment residual, not the absence of a crash
- [x] No docstring or comment still states the old behaviour; the "downstream SE will reflect any residual error" comment is gone
- [x] Any pinned value that moved is justified, not re-fitted

On that last point, one existing test moved. `test_proximal_dr_pipw_path` ran on
the 6-pre/4-post fixture where the residual is 0.219 and asserted
`isinstance(att, float)` on the result — a smoke test passing on a number built
from an unsolved moment. The plumbing it covers is real, so it now runs on a
panel where the fit exists, and the small fixture gets its own test asserting the
raise. Both benchmarks that reach the bridge (`dr_proximal_mc`,
`dr_proximal_brazil`) pass unchanged.

## Designs

No visual output.

## Test Steps

- [x] `pytest mlsynth/tests/test_proximal_bridge_convergence.py -q` — 12 passed
- [x] `pytest mlsynth/tests/test_proximal*.py -q` — 92 passed
- [x] `pytest mlsynth/tests/ -q` — full suite
- [x] `python benchmarks/run_benchmarks.py --case dr_proximal_mc --case dr_proximal_brazil` — both pass
- [x] Mutation: two semantic mutants, both killed

## Other Notes

- This is the second defect of the same class in this module in as many days: a fault of omission behind a comment stating something the code did not do. The first was #419's sandwich index.
- The DR-proximal benchmark currently excludes `short_post` and `small_T`. With this merged it can cover them by asserting the raise, which is the honest cell for a design where the estimator cannot fit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLNEvmPN3YUFUEahAwWAoz)_