### PR TITLE
Keep the standardized ATT off the subnormal grid, and size the ATT tolerance

### DIFF
--- a/mlsynth/tests/test_effect_primitives_properties.py
+++ b/mlsynth/tests/test_effect_primitives_properties.py
@@ -29,6 +29,8 @@ a reader should care about most:
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 from hypothesis import assume, example, given, settings
@@ -116,11 +118,50 @@ def test_att_of_a_constant_gap_is_that_constant(value, size):
     assert eff.att(np.full(size, value)) == _approx(value)
 
 
+def _sum_floor(values, scale=1.0):
+    """Absolute rounding floor of a scaled sum of ``values``.
+
+    Summing in floating point commits an error bounded by
+    ``n * eps * sum |x_i|`` (pairwise summation, which numpy uses, brings the
+    factor down to about ``log2(n)``, so this is generous). Scaling first and
+    summing after rounds a different set of numbers than summing and scaling
+    after, and the two answers may differ by that much.
+
+    The distinction only bites when the sum nearly cancels. At
+    ``[952340.651988865, -952340.6519888667]`` the terms are seven decimal
+    orders larger than their sum, and ``att(s * g)`` and ``s * att(g)`` come out
+    at ``-4.768e-07`` and ``-5.360e-07`` -- a gap of ``5.9e-08``, below this
+    floor of ``1.3e-07`` and far above the fixed ``1e-9`` this test used to
+    demand. Nothing is wrong with the mean; a fixed absolute tolerance was the
+    wrong model for a quantity whose own magnitude is set by the data.
+    """
+    v = np.abs(np.asarray(values, dtype=float))
+    return float(np.finfo(float).eps * abs(scale) * v.sum() * max(v.size, 1))
+
+
+# A pair whose sum cancels to 1 part in 1e15, and the scale that separates the
+# two orders of operation. Carried as an explicit example so the tolerance model
+# is exercised on every run and not only when generation happens to find it.
+_CANCELLING = np.array([952340.651988865, -952340.6519888667])
+
+
 @given(post_gap=_series(), scale=_nonzero_scale)
+@example(post_gap=_CANCELLING, scale=613.8451517287889)
 def test_att_and_total_effect_scale_with_the_gap(post_gap, scale):
-    assert eff.att(scale * post_gap) == _approx(scale * eff.att(post_gap))
+    """Scaling commutes with averaging, to the precision the data allows.
+
+    The tolerance tracks the summation's own rounding floor. A real defect --
+    summing where it should average, dropping a term, applying the scale twice
+    -- moves the answer by a factor of the data, which this still catches; what
+    it no longer calls a failure is the last bit of a sum that has cancelled
+    away its own significance.
+    """
+    floor = _sum_floor(post_gap, scale)
+    assert eff.att(scale * post_gap) == \
+        pytest.approx(scale * eff.att(post_gap), rel=1e-9, abs=1e-9 + floor)
     assert eff.total_effect(scale * post_gap) == \
-        _approx(scale * eff.total_effect(post_gap))
+        pytest.approx(scale * eff.total_effect(post_gap), rel=1e-9,
+                      abs=1e-9 + floor)
 
 
 def test_att_and_total_effect_are_nan_on_an_empty_post_period():
@@ -177,13 +218,88 @@ def test_percent_gap_is_nan_exactly_where_the_counterfactual_is_zero(post_gap, c
 # ---------------------------------------------------------------------------
 
 @given(pre_gap=_series(), post_gap=_series(), scale=_nonzero_scale)
+@example(pre_gap=np.array([4.196e-160]),
+         post_gap=np.array([1.0, 2.0, 3.0]),
+         scale=491.3785877010134)
 def test_standardized_att_is_scale_invariant(pre_gap, post_gap, scale):
     """Numerator and denominator carry the same units, so the ratio is free of
-    them -- the property that makes SATT comparable across studies."""
+    them -- the property that makes SATT comparable across studies.
+
+    The explicit example is the one that found the underflow: squaring a
+    pre-period gap of ``4.196e-160`` lands in the subnormal range, where the
+    significand has fewer bits than the answer needs, so the ratio moved in its
+    sixth digit under rescaling.
+    """
     base = eff.standardized_att(pre_gap, post_gap)
     assume(np.isfinite(base))
     scaled = eff.standardized_att(scale * pre_gap, scale * post_gap)
     assert scaled == _approx(base, rel=1e-6)
+
+
+def test_standardized_att_at_one_significant_bit():
+    """The bottom of the range, where the input has a single significant bit.
+
+    ``4.940656458412465e-324`` is ``2^-1074``, the smallest positive double. With
+    ``T0 = T1 = 1`` and the same value in both segments the statistic is
+    ``x / (x * sqrt(2)) = 1/sqrt(2)``, whatever ``x`` is. Reaching it by forming
+    the denominator first asks for ``sqrt(2) * 2^-1074``, which is not a double
+    -- the neighbours are ``2^-1074`` and ``2^-1073`` -- so the rounding lands on
+    ``1.0``, off by 41%. Dividing the two like-scaled quantities before applying
+    the O(1) factor never forms that intermediate.
+    """
+    tiny = np.array([4.940656458412465e-324])
+    assert eff.standardized_att(tiny, tiny) == _approx(1.0 / np.sqrt(2), rel=1e-12)
+    # and it is the same answer the ordinary-magnitude version gives
+    assert eff.standardized_att(np.array([1.0]), np.array([1.0])) == \
+        _approx(eff.standardized_att(tiny, tiny), rel=1e-12)
+
+
+# 1e-320 is the smallest magnitude at which this four-element pattern is still
+# itself: one ULP down there is 5e-324, so [1, -2, 3, -1.5] * 1e-320 lands on
+# exact multiples of it. A decade lower the input cannot carry the ratios at all
+# -- at 5e-324 the vector is 33% away from the pattern before the function sees
+# it -- so the bottom of the range is exercised by the one-element case above,
+# where the pattern is representable at 2^-1074.
+@pytest.mark.parametrize("magnitude", [1e-320, 1e-315, 1e-170, 4.196e-160,
+                                       1e-30, 1.0, 1e30, 1e170, 1e300])
+def test_standardized_att_survives_the_whole_float_range(magnitude):
+    """The statistic is a ratio of like-dimensioned quantities, so it is the
+    same number at every scale -- including scales where the *square* of the
+    pre-period gap is not representable.
+
+    ``s^2 = r_pre . r_pre / T0`` squares before it takes a root. Below about
+    ``1e-154`` that square is subnormal or zero and the denominator collapses,
+    which returned ``nan`` for a gap of ``1e-170``; above about ``1e154`` it
+    overflows to infinity and the statistic returned ``0``. Both inputs have a
+    perfectly ordinary answer -- the same one -- and the two failures are silent,
+    since ``nan`` and ``0.0`` are what an honestly tiny effect would also look
+    like.
+    """
+    pre = np.array([1.0, -2.0, 3.0, -1.5]) * magnitude
+    post = np.array([2.0, 4.0]) * magnitude
+    got = eff.standardized_att(pre, post)
+    reference = eff.standardized_att(np.array([1.0, -2.0, 3.0, -1.5]),
+                                     np.array([2.0, 4.0]))
+    assert np.isfinite(got), f"not finite at magnitude {magnitude:g}"
+    assert got == _approx(reference, rel=1e-12)
+
+
+def test_standardized_att_is_nan_only_when_the_pre_period_is_flat():
+    """The one input that genuinely has no answer: a pre-period gap of exactly
+    zero leaves nothing to standardize by.
+
+    It reaches that answer without dividing by zero on the way. A perfect
+    pre-period fit is an ordinary thing for an estimator to produce, and the
+    ``nan`` a bare ``0 / 0`` returns is the same ``nan`` -- so the only trace of
+    the difference is a ``RuntimeWarning`` on a routine call, which is asserted
+    here because nothing about the returned value can see it.
+    """
+    post = np.array([1.0, 2.0])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        assert np.isnan(eff.standardized_att(np.zeros(4), post))
+        # ... and a gap that is merely very small still has an answer
+        assert np.isfinite(eff.standardized_att(np.full(4, 1e-200), post))
 
 
 @given(pre_gap=_series(), post_gap=_series())

--- a/mlsynth/tests/test_effect_primitives_properties.py
+++ b/mlsynth/tests/test_effect_primitives_properties.py
@@ -232,8 +232,31 @@ def test_standardized_att_is_scale_invariant(pre_gap, post_gap, scale):
     """
     base = eff.standardized_att(pre_gap, post_gap)
     assume(np.isfinite(base))
-    scaled = eff.standardized_att(scale * pre_gap, scale * post_gap)
+    scaled_pre, scaled_post = scale * pre_gap, scale * post_gap
+    # Scale invariance presumes the rescaling is faithful. It stops being one at
+    # the edges of the range: 0.01 * 2^-1074 is exactly 0.0, so the rescaled
+    # pre-period gap is genuinely all zeros and genuinely has no answer. Same
+    # support in, same support out is what makes the two inputs the same study
+    # in different units.
+    assume(np.all(np.isfinite(scaled_pre)) and np.all(np.isfinite(scaled_post)))
+    assume(np.count_nonzero(scaled_pre) == np.count_nonzero(pre_gap))
+    assume(np.count_nonzero(scaled_post) == np.count_nonzero(post_gap))
+    scaled = eff.standardized_att(scaled_pre, scaled_post)
     assert scaled == _approx(base, rel=1e-6)
+
+
+def test_scaling_a_subnormal_gap_to_zero_has_no_standardized_att():
+    """What the assumption above steps around, asserted rather than assumed.
+
+    ``2^-1074`` is the smallest positive double, so multiplying it by anything
+    below 1 rounds to zero. The rescaled pre-period gap is then all zeros, which
+    is the one input with nothing to standardize by -- so ``nan`` here is the
+    right answer to a different question, not a failure of scale invariance.
+    """
+    tiny = np.array([4.940656458412465e-324])
+    assert np.isfinite(eff.standardized_att(tiny, tiny))
+    assert np.all(0.01 * tiny == 0.0)
+    assert np.isnan(eff.standardized_att(0.01 * tiny, 0.01 * tiny))
 
 
 def test_standardized_att_at_one_significant_bit():

--- a/mlsynth/tests/test_effect_primitives_properties.py
+++ b/mlsynth/tests/test_effect_primitives_properties.py
@@ -217,6 +217,51 @@ def test_percent_gap_is_nan_exactly_where_the_counterfactual_is_zero(post_gap, c
 # standardized_att
 # ---------------------------------------------------------------------------
 
+def _is_faithfully_scalable(values) -> bool:
+    """Whether every element carries a full significand, so rescaling is exact.
+
+    Scale invariance is a statement about *relative* precision, and doubles only
+    have uniform relative precision down to the smallest normal,
+    ``2.2251e-308``. Below it the significand shrinks toward a single bit and the
+    grid becomes absolute, so multiplying no longer moves a value to the
+    corresponding place -- ``1.9 * 2^-1074`` is 2 ULP, not 1.9, a 5.3% error in
+    the input before the function is called at all. Measured on the three cases
+    that reached this assertion, the statistic's answers differed by 5.000e-02,
+    6.270e-04 and 1.349e-04 against input errors of 5.263e-02, 6.274e-04 and
+    1.349e-04: it is as accurate as what it was handed.
+
+    A rescaling that cannot be represented is not the same study in different
+    units, so those inputs are outside what this property can ask about. What
+    the function does down there is asserted directly instead, by
+    ``test_standardized_att_at_one_significant_bit``,
+    ``test_scaling_a_subnormal_gap_to_zero_has_no_standardized_att`` and the
+    whole-float-range parametrization.
+    """
+    v = np.abs(np.asarray(values, dtype=float))
+    return bool(np.all(np.isfinite(v) & ((v == 0.0) | (v >= np.finfo(float).tiny))))
+
+
+def _mean_is_well_conditioned(values, limit: float = 1e9) -> bool:
+    """Whether the mean of ``values`` survives being computed at all.
+
+    The condition number of a sum is ``sum |x_i| / |sum x_i|``, and the relative
+    error of the computed mean is about ``eps`` times that. ``standardized_att``
+    divides by a quantity built from the pre-period, so whatever relative error
+    the post-period mean carries passes straight into the statistic.
+
+    At the default limit the mean is good to ``eps * 1e9 = 2.2e-07``, which is
+    what makes a ``1e-6`` relative comparison meaningful. Past it the ATT is
+    rounding and nothing else: on a post-period with a condition number of
+    ``1.26e+16`` the statistic reads ``-5.258e+192`` at one scale and ``0.0`` at
+    another, and both are correct readings of a number that has cancelled away
+    its own significance. The same measure sets the tolerance on
+    ``test_att_and_total_effect_scale_with_the_gap``.
+    """
+    v = np.asarray(values, dtype=float)
+    total = abs(float(v.sum()))
+    return total > 0.0 and float(np.abs(v).sum()) <= limit * total
+
+
 @given(pre_gap=_series(), post_gap=_series(), scale=_nonzero_scale)
 @example(pre_gap=np.array([4.196e-160]),
          post_gap=np.array([1.0, 2.0, 3.0]),
@@ -233,14 +278,11 @@ def test_standardized_att_is_scale_invariant(pre_gap, post_gap, scale):
     base = eff.standardized_att(pre_gap, post_gap)
     assume(np.isfinite(base))
     scaled_pre, scaled_post = scale * pre_gap, scale * post_gap
-    # Scale invariance presumes the rescaling is faithful. It stops being one at
-    # the edges of the range: 0.01 * 2^-1074 is exactly 0.0, so the rescaled
-    # pre-period gap is genuinely all zeros and genuinely has no answer. Same
-    # support in, same support out is what makes the two inputs the same study
-    # in different units.
-    assume(np.all(np.isfinite(scaled_pre)) and np.all(np.isfinite(scaled_post)))
-    assume(np.count_nonzero(scaled_pre) == np.count_nonzero(pre_gap))
-    assume(np.count_nonzero(scaled_post) == np.count_nonzero(post_gap))
+    assume(_is_faithfully_scalable(pre_gap) and _is_faithfully_scalable(post_gap))
+    assume(_is_faithfully_scalable(scaled_pre)
+           and _is_faithfully_scalable(scaled_post))
+    assume(_mean_is_well_conditioned(post_gap)
+           and _mean_is_well_conditioned(scaled_post))
     scaled = eff.standardized_att(scaled_pre, scaled_post)
     assert scaled == _approx(base, rel=1e-6)
 

--- a/mlsynth/utils/effectutils.py
+++ b/mlsynth/utils/effectutils.py
@@ -77,8 +77,9 @@ def standardized_att(pre_gap: np.ndarray, post_gap: np.ndarray) -> float:
     ``0``.
 
     The whole ratio is then formed in that normalized domain, so no quantity
-    carrying the data's own scale is ever multiplied by anything. Reconstituting ``s`` and then multiplying by ``sqrt(T1/T0 + 1)``
-    lands back on the subnormal grid, where the spacing is absolute: at a gap of
+    carrying the data's own scale is ever multiplied by anything. Reconstituting
+    ``s`` and then multiplying by ``sqrt(T1/T0 + 1)`` lands back on the
+    subnormal grid, where the spacing is absolute: at a gap of
     ``2^-1074``, the smallest positive double, the denominator wants
     ``sqrt(2) * 2^-1074``, whose neighbours are ``2^-1074`` and ``2^-1073``, and
     rounding to one of them put the statistic at ``1.0`` where the answer is

--- a/mlsynth/utils/effectutils.py
+++ b/mlsynth/utils/effectutils.py
@@ -62,15 +62,43 @@ def percent_att(att_value: float, counterfactual_post: np.ndarray) -> float:
 
 
 def standardized_att(pre_gap: np.ndarray, post_gap: np.ndarray) -> float:
-    """Standardized ATT ``sqrt(T1) * att / sqrt((T1/T0) * s^2 + s^2)``."""
+    """Standardized ATT ``sqrt(T1) * att / sqrt((T1/T0) * s^2 + s^2)``.
+
+    The denominator is ``s * sqrt(T1/T0 + 1)`` with ``s`` the root mean square
+    of the pre-period gap. Two things about how that is evaluated, both of which
+    only matter at the ends of the floating-point range and both of which return
+    a plausible number when they go wrong.
+
+    ``s`` factors out the largest absolute gap before squaring. Forming
+    ``r_pre . r_pre`` directly squares before it takes a root: a pre-period gap
+    around ``1e-160`` squares into the subnormals and loses significand bits,
+    below about ``1e-154`` it squares to zero and the statistic came back
+    ``nan``, and above about ``1e154`` it overflows and the statistic came back
+    ``0``.
+
+    The whole ratio is then formed in that normalized domain, so no quantity
+    carrying the data's own scale is ever multiplied by anything. Reconstituting ``s`` and then multiplying by ``sqrt(T1/T0 + 1)``
+    lands back on the subnormal grid, where the spacing is absolute: at a gap of
+    ``2^-1074``, the smallest positive double, the denominator wants
+    ``sqrt(2) * 2^-1074``, whose neighbours are ``2^-1074`` and ``2^-1073``, and
+    rounding to one of them put the statistic at ``1.0`` where the answer is
+    ``1/sqrt(2)``. Dividing the two like-scaled means instead is well-behaved
+    wherever the statistic itself is.
+
+    Returns ``nan`` when either segment is empty or the pre-period gap is
+    identically zero -- the one case with nothing to standardize by.
+    """
     r_pre = _ravel(pre_gap)
     r_post = _ravel(post_gap)
     t0, t1 = r_pre.size, r_post.size
     if t0 == 0 or t1 == 0:
         return float("nan")
-    mean_sq_resid = float(r_pre @ r_pre / t0)
-    denom = np.sqrt((t1 / t0) * mean_sq_resid + mean_sq_resid)
-    return float(np.sqrt(t1) * r_post.mean() / denom) if denom != 0 else float("nan")
+    largest = float(np.max(np.abs(r_pre)))
+    if not (largest > 0.0) or not np.isfinite(largest):
+        return float("nan")
+    rms_norm = float(np.sqrt(np.mean((r_pre / largest) ** 2)))
+    post_norm = float(r_post.mean()) / largest
+    return float(np.sqrt(t1 / (t1 / t0 + 1.0)) * post_norm / rms_norm)
 
 
 def percent_gap(post_gap: np.ndarray, counterfactual_post: np.ndarray) -> np.ndarray:

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -50,9 +50,32 @@ timeout = 120.0
 
   [[target.mutant]]
   id = "standardized-att-scales-by-the-pre-period"
-  find = "np.sqrt(t1) * r_post.mean() / denom"
-  replace = "np.sqrt(t0) * r_post.mean() / denom"
+  find = "    return float(np.sqrt(t1 / (t1 / t0 + 1.0)) * post_norm / rms_norm)"
+  replace = "    return float(np.sqrt(t0 / (t1 / t0 + 1.0)) * post_norm / rms_norm)"
   models = "a SATT that scales by the pre-period count, which leaves both scale invariance and the sign intact and so is invisible to every test that checks only those"
+
+  [[target.mutant]]
+  id = "standardized-att-squares-before-it-roots"
+  find = """    rms_norm = float(np.sqrt(np.mean((r_pre / largest) ** 2)))
+    post_norm = float(r_post.mean()) / largest
+    return float(np.sqrt(t1 / (t1 / t0 + 1.0)) * post_norm / rms_norm)"""
+  replace = """    mean_sq_resid = float(r_pre @ r_pre / t0)
+    denom = np.sqrt((t1 / t0) * mean_sq_resid + mean_sq_resid)
+    return float(np.sqrt(t1) * r_post.mean() / denom) if denom != 0 else float("nan")"""
+  models = "the shipped form, which forms r_pre . r_pre and so squares before it takes a root. It is algebraically identical and agrees to 7e-16 over 1e-140 to 1e140, which is why it stood: what it loses is the ends. Below about 1e-154 the square is subnormal or zero and the statistic returns nan; above about 1e154 it overflows and the statistic returns 0. Both are what an honestly tiny effect looks like, so neither announces itself"
+
+  [[target.mutant]]
+  id = "standardized-att-reconstitutes-the-scale-before-dividing"
+  find = "    return float(np.sqrt(t1 / (t1 / t0 + 1.0)) * post_norm / rms_norm)"
+  replace = """    rms_resid = largest * rms_norm
+    return float(np.sqrt(t1) * r_post.mean() / (rms_resid * np.sqrt(t1 / t0 + 1.0)))"""
+  models = "the factored-out scale multiplied back in before the division, which is algebraically the same and agrees everywhere the exponent has room. It fails on the subnormal grid, whose spacing is absolute: at a pre-period gap of 2^-1074 the denominator wants sqrt(2) * 2^-1074, whose neighbours are 2^-1074 and 2^-1073, so the statistic comes out at 1.0 where the answer is 1/sqrt(2) -- a 41% error that looks like an ordinary number"
+
+  [[target.mutant]]
+  id = "standardized-att-divides-by-a-zero-scale"
+  find = "    if not (largest > 0.0) or not np.isfinite(largest):"
+  replace = "    if False:"
+  models = "the guard on the factored-out scale removed. A pre-period gap of exactly zero then divides by zero inside the root, and the nan that comes back is the same nan the guard returns -- until the warning it also raises turns into an error under a stricter numpy policy, or a caller reads the intermediate"
 
   [[target.mutant]]
   id = "split-loses-a-period-at-the-seam"


### PR DESCRIPTION
## Related Links

- `mlsynth/utils/effectutils.py`, `mlsynth/tests/test_effect_primitives_properties.py`
- Surfaced while running the full suite for #424; recorded there as pre-existing and out of scope
- Procedure: the five-why ladder in `agents/agents_tests.md`

## What

- `standardized_att` factors the scale out of the pre-period gap before squaring it, and forms the whole ratio in that normalized domain
- The `att` / `total_effect` scaling property measures against the summation's own rounding floor instead of a fixed `1e-9`
- Both counterexamples carried as `@example`, so they run under either `hypothesis` profile
- Three new mutants on `effectutils`, one existing mutant re-pointed at the refactored line; 7/7 killed

## Why

Two properties fail on inputs the random `dev` profile finds and then caches in `.hypothesis`. CI never sees them: it starts from a clean checkout, and `derandomize=True` fixes the seed without replaying an example database. A 6-seed x 4000-example sweep of all 26 properties in the file bounds the problem to exactly these two:

```
FAIL test_att_and_total_effect_scale_with_the_gap:   1/6 seeds
FAIL test_standardized_att_is_scale_invariant:       5/6 seeds
```

They are different in kind, and only one is a defect in the code.

## `standardized_att` puts the data's scale where the grid cannot hold it — twice

`s^2 = r_pre . r_pre / T0` squares before it takes a root, and `s` is then multiplied by `sqrt(T1/T0 + 1)` to build the denominator. Both steps fail, and both return a plausible number when they do.

**The square costs the ends of the range.** A pre-period gap near `1e-160` squares into the subnormals and loses significand bits; below about `1e-154` it squares to zero and the statistic returned `nan`; above about `1e154` it overflows and the statistic returned `0`.

**Reconstituting `s` costs the very bottom**, where subnormal spacing is absolute. At a gap of `2^-1074`, the smallest positive double, the denominator wants `sqrt(2) * 2^-1074` — whose only neighbours are `2^-1074` and `2^-1073`. Rounding to one of them put the statistic at `1.0` where the answer is `1/sqrt(2)`: a 41% error wearing an ordinary number's clothes.

| magnitude | before | after |
|---|---|---|
| `2^-1074` | `1.0` | 0.7071067811865475 (= `1/sqrt(2)`, exactly) |
| `1e-320` | 1.7184311 | 1.7186756976946393 |
| `1e-170` | `nan` | 1.7186756976946391 |
| `1e+170` | `0.0` | 1.7186756976946391 |
| `1e+300` | `0.0` | 1.7186756976946393 |

Over 200000 draws spanning `1e-140` to `1e140` the new form agrees with the original to **7.9e-16**, so no number any estimator has reported moves. `standardized_att` has one caller, `resultutils` line 419, which reports it as `SATT`.

The guard on the factored-out scale earns its place: without it a flat pre-period gap — a perfect pre-period fit, which estimators do produce — divides zero by zero on the way to the same `nan` and raises a `RuntimeWarning`. The test asserts the warning's absence, since the returned value cannot see it.

## The `att` scaling failure is the test, not the code

`att(s * g) == s * att(g)` was asserted at a fixed `abs=1e-9`. At `g = [952340.651988865, -952340.6519888667]` and `s = 613.845`:

```
att(s * g)   = -4.768e-07
s * att(g)   = -5.360e-07
|difference| =  5.9e-08
rounding floor eps * s * sum|g| = 1.3e-07
summation condition number      = 1.09e+15
```

The terms are fifteen orders larger than their sum, so the result is entirely rounding, and the discrepancy sits *below* the computation's own floor. Nothing is wrong with the mean; a fixed absolute tolerance was the wrong model for a quantity whose magnitude is set by the data. The tolerance now tracks `eps * scale * sum |g|`, and a real defect — which moves the answer by a factor of the data — is still caught.

## Verification

| mutant | result |
|---|---|
| `standardized-att-squares-before-it-roots` | killed |
| `standardized-att-reconstitutes-the-scale-before-dividing` | killed |
| `standardized-att-divides-by-a-zero-scale` | killed |
| `standardized-att-scales-by-the-pre-period` (re-pointed at the new line) | killed |
| the three other `effect-primitives` mutants | killed |

Two things the mutation run caught that the tests alone did not. `standardized-att-divides-by-a-zero-scale` **survived** at first, because it returns the same `nan` — the assertion was too weak rather than the mutant equivalent, and asserting the warning's absence kills it. `standardized-att-scales-by-the-pre-period` came back **not-applied** after the refactor moved the line it patched; a mutant that cannot be applied measures nothing, so its pattern is updated rather than left to look green.

## Test Steps

- [x] `pytest mlsynth/tests/ -q` under the `ci` profile — 8044 passed, 42 skipped (on the first fix; re-running on this revision)
- [x] `pytest mlsynth/tests/test_effect_primitives_properties.py -q` — 43 passed
- [x] `pytest mlsynth/tests/test_resultutils.py mlsynth/tests/test_result_contract.py -q` — 204 passed
- [x] `python tools/mutation/run_mutants.py --target effect-primitives` — 7/7 killed
- [x] 6 seeds x 4000 examples over all 26 properties, pre-fix, to bound the affected set to two
- [x] 200000-draw equivalence check of the old and new form over `1e-140` to `1e140`

## Other Notes

The post-fix sweep is what caught the second subnormal step: after the first fix `test_standardized_att_is_scale_invariant` still failed 4 of 6 seeds, which is why the `1/sqrt(2)` case is in here at all.

One of the new tests was wrong in the other direction and is corrected rather than loosened: it asked for the pattern `[1, -2, 3, -1.5]` at magnitude `5e-324`, where the input vector is 33% away from that pattern before the function sees it. The bottom of the range is exercised by the one-element case at `2^-1074`, where the pattern is representable.