### PR TITLE
Say what the fsPDA search changed, and refresh a stale l2 timing

### DIFF
--- a/docs/pda.rst
+++ b/docs/pda.rst
@@ -561,31 +561,115 @@ chosen set :math:`\widehat{U}_{\widehat{R}}`. Forward selection evaluates
 Computing the greedy step
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Those :math:`N-r+1` regressions per step are the whole cost of the method, and
-none of them has to be solved. Write :math:`\mathbf{r}` for the pre-period
-residual on the donors already chosen, :math:`P` for the projection onto their
-span (the constant included when one is fitted), and
-:math:`\mathbf{z}_j = \mathbf{x}_j - P\mathbf{x}_j` for a candidate donor
-orthogonalised against that span. Because :math:`\mathbf{r}` is already
-orthogonal to the span, admitting donor :math:`j` lowers the residual sum of
-squares by exactly
+The step as the paper states it. At step :math:`r`, with
+:math:`\widehat{U}_r` the donors already chosen, forward selection scores every
+remaining donor by the pre-period fit its admission would produce, and keeps the
+best:
 
 .. math::
 
-   \Delta_j = \frac{(\mathbf{x}_j^\top\mathbf{r})^2}
-                   {\lVert\mathbf{z}_j\rVert^2},
+   j^\star = \operatorname*{argmin}_{j \notin \widehat{U}_r}
+             \widehat{\sigma}^2\bigl(\widehat{U}_r \cup \{j\}\bigr),
+   \qquad
+   \widehat{\sigma}^2(S) = \frac{1}{T_0}\,
+       \min_{\boldsymbol{\beta}}
+       \bigl\lVert \mathbf{y}_1 - \mathbf{X}_S\,\boldsymbol{\beta}
+       \bigr\rVert_2^2 .
 
-so the donor minimising :math:`\widehat\sigma^2` is the donor maximising
-:math:`\Delta_j`. One matrix-vector product :math:`\mathbf{Z}^\top\mathbf{r}`
-scores the entire pool, and a rank-one downdate of :math:`\mathbf{Z}` carries
-the orthogonalisation into the next step: the step costs :math:`O(T_0 N)`
-arithmetic and a single least-squares solve, for the donor it selects, whose
-:math:`\widehat\sigma^2` is the number the criterion reads. The pool no longer
-multiplies the solves, and a fit that took a quarter of a second at
-:math:`N = 1000` takes ten milliseconds. Donors whose scores agree to within
-rounding -- an exact duplicate of a selected donor, a pool spanning fewer
-directions than it has members -- are settled by the OLS comparison itself, so
-the search selects what the definition selects.
+Read literally that is :math:`N - r` separate least-squares problems per step,
+each on a :math:`T_0 \times (r+1)` design, and the recursion repeats them from
+scratch at every step.
+
+The step as ``mlsynth`` computes it. Let :math:`P_r` be the orthogonal
+projection onto the span of the chosen donors (the constant adjoined when one is
+fitted), and write
+
+.. math::
+
+   \mathbf{e}_r = (\mathbf{I} - P_r)\,\mathbf{y}_1,
+   \qquad
+   \mathbf{z}_j = (\mathbf{I} - P_r)\,\mathbf{x}_j
+
+for the current pre-period residual and for a candidate donor orthogonalised
+against that span. The fit after admitting :math:`j` is then available in
+closed form,
+
+.. math::
+
+   T_0\,\widehat{\sigma}^2\bigl(\widehat{U}_r \cup \{j\}\bigr)
+     = \bigl\lVert\mathbf{e}_r\bigr\rVert_2^2 - \Delta_j,
+   \qquad
+   \Delta_j = \frac{\bigl(\mathbf{x}_j^\top\mathbf{e}_r\bigr)^2}
+                   {\bigl\lVert\mathbf{z}_j\bigr\rVert_2^2},
+
+with :math:`\mathbf{x}_j^\top\mathbf{e}_r =
+\mathbf{z}_j^\top\mathbf{e}_r` because :math:`\mathbf{e}_r` is orthogonal to the
+span by construction. The subtracted term is the only part that depends on
+:math:`j`, so the two selection rules coincide:
+
+.. math::
+
+   \operatorname*{argmin}_{j \notin \widehat{U}_r}
+     \widehat{\sigma}^2\bigl(\widehat{U}_r \cup \{j\}\bigr)
+   \;=\;
+   \operatorname*{argmax}_{j \notin \widehat{U}_r} \Delta_j .
+
+All :math:`N - r` numerators are one matrix-vector product
+:math:`\mathbf{Z}^\top\mathbf{e}_r`, and the denominators reach the next step
+through a rank-one downdate of :math:`\mathbf{Z}`. A donor lying inside the span
+has :math:`\lVert\mathbf{z}_j\rVert_2 = 0` and contributes
+:math:`\Delta_j = 0`, which is the closed form saying it cannot lower the
+residual.
+
+What differs, and what does not. The displayed equality is an identity in exact
+arithmetic, not an approximation, so the two rules select the same donor. The
+criterion :math:`\mathrm{IC}(r)` still reads a :math:`\widehat{\sigma}^2`
+returned by an ordinary least-squares solve on the design the step selects, so
+the stopping rule is evaluated on the same quantity in both forms. What changes
+is the arithmetic spent getting there:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 30 30
+
+   * - Form of the step
+     - Arithmetic per step
+     - Least-squares solves per step
+   * - Scoring by refitting
+     - :math:`O(N T_0 r^2)`
+     - :math:`N - r`
+   * - Scoring by projection
+     - :math:`O(T_0 N)`
+     - :math:`1`
+
+Where the difference is felt. A single fit on :math:`N = 1000` donors over
+:math:`T_0 = 300` pre-periods goes from 189 ms to 7.7 ms. The effect compounds
+wherever the selection is re-run: setting ``prediction_intervals=True`` refits
+the estimator on every bootstrap sample (999 by default -- see
+:ref:`the prediction-interval section <pda-prediction-intervals>`), so a
+forward-selected fit with intervals on 120 donors goes from 22.3 s to 1.3 s.
+
+The estimate is unchanged, and the benchmarks check it --
+``fspda_dense_mc`` reproduces the released R package's selected set on 8 of 8
+Monte Carlo cells, with coefficients, ATE and z-statistic agreeing to
+:math:`10^{-13}`; ``fspda_sparse_mc`` agrees with the authors' ``nonsparse/FS.R``
+rule on 30 of 30 panels; ``pda_table1`` and ``pda_luxurywatch`` return the values
+they returned before.
+
+Where the two forms can name different donors. Donors that fit the pre-period
+identically -- an exact duplicate of a selected donor, or a pool spanning fewer
+directions than it has members -- carry equal :math:`\Delta_j` up to rounding.
+The search settles such a tie by the least-squares comparison itself, across a
+bounded number of the tied candidates, and on the pools an applied panel
+presents it selects what the definition selects. Two regimes sit outside that
+bound: a tied group larger than the shortlist, and a pre-period that has
+interpolated. In the second, once :math:`\mathbf{y}_1` lies exactly in the donor
+span the residual falls to the level of rounding noise, and each further step
+compares one :math:`\widehat{\sigma}^2` of order :math:`10^{-31}` against
+another; both forms admit a few extra donors, and which ones follows the
+floating-point library. In either regime the donors named can differ within a
+set that fits the pre-period equally well, the extras carry coefficients at the
+:math:`10^{-16}` level, and the counterfactual agrees to machine precision.
 
 Assumptions (Shi & Huang). Asymptotics are *multi-index*: :math:`N\to\infty`
 with :math:`T_0 = T_0(N)` deterministic, :math:`\log N / T_0 \to 0`, and
@@ -1059,6 +1143,8 @@ signed coefficients (pre-RMSE 0.012); ``lasso`` keeps 11; ``fs`` grows to 9. The
 four estimates bracket the Forward-DiD result on the same data (0.025), a useful
 cross-method check.
 
+.. _pda-prediction-intervals:
+
 Prediction intervals
 --------------------
 
@@ -1306,9 +1392,13 @@ selection rule, not to L1 selection. Both rules are fully powered at ``D5``
 L2-relaxation (Shi & Wang). The ``l2`` method's out-of-sample MPSE falls
 with :math:`T` and its test approaches the nominal 5% size as :math:`T_0 \to
 \infty`, matching Shi & Wang's Table 2 (size :math:`0.142` at :math:`T_0=50`
-→ :math:`0.072` at :math:`200`). Its per-fit cross-validation over the
-:math:`\varepsilon` grid makes large Monte Carlos expensive (~5 s/fit), so the full
-table is summarized, not swept here.
+→ :math:`0.072` at :math:`200`). Each fit cross-validates :math:`\varepsilon`
+over its own grid, which is what makes a large Monte Carlo costly here: at the
+100 donors this study uses, one fit on the default grid takes about a second at
+:math:`T_0 = 50`, against 5 s before the ranking sweep was separated from the
+reported fit (see the note on solving the grid above). The case runs a coarse
+twelve-point grid and summarizes the table, so the full sweep stays out of the
+test suite.
 
 Multiple treated units
 ----------------------


### PR DESCRIPTION
## Related Links

- Page: `docs/pda.rst`, the "Computing the greedy step" subsection under Forward selection, and the L2-relaxation paragraph in Simulation evidence
- Follows #425 (the fsPDA search) and #427 (the L2-relaxation grid), whose behaviour this page now describes
- Source papers: Shi & Huang (2023) for forward selection; Shi & Wang for L2-relaxation

## What

- Wrote out both selection rules and the identity relating them
- Added a table of the arithmetic and the solve count each form spends
- Pointed the section at the bootstrap refit path, and gave the prediction-interval section an anchor to link to
- Named the benchmarks that hold the estimate fixed
- Corrected the degenerate-pool paragraph, which was imprecise about which pools separate the two forms
- Replaced the stale `~5 s/fit` L2 cross-validation figure with a measured one

Docs only. No code, no tests, no behaviour.

## Why

The section explained the projection score but left two questions a reader of an optimisation section will have. It never stated how the computed rule differs from the rule the paper states, so the equality between them had to be taken on trust. And it never said whether the estimate moved, which for a page that points every estimator at its replication is the question that matters.

Separately, the Simulation evidence section still claimed the L2 per-fit cross-validation "makes large Monte Carlos expensive (~5 s/fit)". #427 cut that path, so the figure described code that no longer exists.

## How

Both rules are displayed. The paper's step:

```
j* = argmin_{j not in U_r}  sigma^2( U_r + {j} ),
sigma^2(S) = (1/T0) min_beta || y1 - X_S beta ||^2
```

which is `N - r` separate least-squares problems per step on a `T0 x (r+1)` design. The computed step, with `e_r = (I - P_r) y1` the current residual and `z_j = (I - P_r) x_j` a candidate orthogonalised against the selected span:

```
T0 * sigma^2( U_r + {j} ) = ||e_r||^2 - Delta_j,
Delta_j = (x_j' e_r)^2 / ||z_j||^2
```

Since `||e_r||^2` carries no `j`, the argmin of the first is the argmax of `Delta_j`, and the page says so as a displayed equality. The identity is exact, so what separates the forms is arithmetic and not the answer:

| Form of the step | Arithmetic per step | Least-squares solves per step |
| --- | --- | --- |
| Scoring by refitting | `O(N T0 r^2)` | `N - r` |
| Scoring by projection | `O(T0 N)` | 1 |

Where it is felt now points at the bootstrap, since the single-fit figure understates the change: `prediction_intervals=True` re-runs the selection on every bootstrap sample, and the section links `pda-prediction-intervals` (a new anchor) alongside the 22.3 s to 1.3 s figure on 120 donors.

The degenerate-pool paragraph opened by claiming two pools separate the two forms and then described a case where they agree. It now distinguishes ties below the shortlist bound, which the least-squares comparison settles, from a larger tied group and an interpolating pre-period, which can name a different member of a set of donors that fit the pre-period equally well.

## Verification

- Path: not applicable. This changes prose describing behaviour verified in #425 and #427; no numerical code is touched.
- The figures quoted in the new text are the ones those PRs measured: 189 ms to 7.7 ms at N = 1000 over T0 = 300, and 22.3 s to 1.3 s for a fit with 999 bootstrap intervals on 120 donors.
- The replaced L2 figure was re-measured for this change at the shape `pda_l2_sim` uses (100 donors, `T0` = 50, default grid, 3 fits averaged): 5.26 s at the tolerance the old claim was written against, 1.03 s now. At `T0` = 200 the same measurement is 1.61 s and 0.87 s.
- The benchmark results the page now names are the ones on record: `fspda_dense_mc` at `fs_selection_match_rate` 1.0 over 8 cells with errors at 1e-13, `fspda_sparse_mc` at `fs_matches_its_own_rule` 1.0 over 30 panels, `pda_table1` and `pda_luxurywatch` unchanged.

## Scope checks

None of the four blocks fits — this is a docs-only change. No config, no estimator, no result contract, no benchmark case.

## Designs

No figures added. The new content is two displayed equations, one displayed equality between the selection rules, and a three-column table.

## Test Steps

- [x] `python -m sphinx -b html docs <out>` — build succeeded on sphinx 8.2.3; `pda.rst` emits no warnings, and the new `:ref:` resolves to a rendered anchor. This closes a gap I had flagged on both previous PRs, where no Sphinx was available in the session container
- [x] Banned-word sweep from `CLAUDE.md` over the whole page: `\brather\b|\bquietly\b|\bloudly\b|load.bearing`, `\bworth\b|\bdeserves?\b|^A note on`, and `\b(crucially|importantly|interestingly)\b|\bnote that\b` all return nothing
- [x] No RST bold in the new prose
- [x] Section underlines at least as long as their titles, checked programmatically
- [ ] `pytest mlsynth/tests/` — not run; no Python changed. CI covers it

## Other Notes

- The build surfaces two pre-existing problems on other pages, left alone as a separate scope: `docs/about.rst:59` has a malformed external link target (`ERROR: Unknown target name`), and `docs/validation.rst:48,60` reference an undefined label `val-clustersc`. Both predate this branch.
- The build also emits ~750 warnings from autodoc duplicate object descriptions and unreachable intersphinx inventories. Neither is caused by this change, and the intersphinx failures are the container's proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163wFMcmTbLfKK3Q1hF5crJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0163wFMcmTbLfKK3Q1hF5crJ)_