### PR TITLE
Fix the two broken references the docs build reports

### DIFF
--- a/benchmarks/reference/build_validation.py
+++ b/benchmarks/reference/build_validation.py
@@ -110,12 +110,30 @@ _ESTIMATOR_REMAP = {
 }
 
 
+def _exported_names() -> dict:
+    """``{lowercased export name: export name}`` for everything mlsynth exposes.
+
+    Case authors write the estimator field by hand, so the same estimator arrives
+    spelled two ways -- ``CLUSTERSC`` from one bundle and ``ClusterSC/PCR
+    (run_pcr ...)`` from another. Both name the class ``mlsynth.CLUSTERSC``, and
+    resolving against the package's own exports is what folds them together
+    without a hand-maintained list of spellings.
+    """
+    try:
+        import mlsynth
+    except ImportError:                       # pragma: no cover - packaging guard
+        return {}
+    return {name.lower(): name for name in getattr(mlsynth, "__all__", [])}
+
+
 def _canon(est: str) -> str:
     """Canonical estimator label: strip the descriptive backend/config suffix the
-    case authors append (``ClusterSC/PCR (run_pcr ...)`` -> ``ClusterSC``) and map
-    the handful of function-name fields to the estimator a reader recognises."""
+    case authors append (``ClusterSC/PCR (run_pcr ...)`` -> ``ClusterSC``), map
+    the handful of function-name fields to the estimator a reader recognises, and
+    settle on the spelling mlsynth exports so case variants land in one section."""
     base = (est or "?").split("(")[0].split("/")[0].strip() or "?"
-    return _ESTIMATOR_REMAP.get(base, base)
+    base = _ESTIMATOR_REMAP.get(base, base)
+    return _exported_names().get(base.lower(), base)
 
 
 def collect() -> dict:
@@ -187,6 +205,28 @@ def _slug(est: str) -> str:
     return "val-" + "".join(c.lower() if c.isalnum() else "-" for c in est)
 
 
+def _check_slugs(ests) -> None:
+    """Refuse to emit two sections that would claim the same anchor.
+
+    The slug lowercases, so two estimator spellings differing only in case
+    produce one label defined twice. Sphinx reports that as a duplicate label and
+    every ``:ref:`` to it as undefined, which is how ``CLUSTERSC`` and
+    ``ClusterSC`` broke the summary table's links: both rows pointed at
+    ``val-clustersc`` and neither resolved.
+    """
+    seen: dict = {}
+    for est in ests:
+        seen.setdefault(_slug(est), []).append(est)
+    clashes = {slug: names for slug, names in seen.items() if len(names) > 1}
+    if clashes:
+        detail = "; ".join(f"{slug} <- {names}" for slug, names in sorted(clashes.items()))
+        raise SystemExit(
+            "build_validation: estimator names collide on their anchor: "
+            f"{detail}. Add the canonical spelling to _ESTIMATOR_REMAP, or export "
+            "it from mlsynth so _canon can resolve it."
+        )
+
+
 def _verdict_mix(recs: list) -> str:
     """A compact honest summary like ``4 exact · 3 tight``."""
     counts = {}
@@ -199,6 +239,7 @@ def _verdict_mix(recs: list) -> str:
 def to_rst(by_est: dict, only: str | None = None, pend: list | None = None) -> str:
     ests = [only] if only else sorted(by_est)
     ests = [e for e in ests if by_est.get(e)]
+    _check_slugs(ests)
     pend = pend or []
     n_checks = sum(len(by_est[e]) for e in ests)
     n_exact = sum(1 for e in ests for r in by_est[e] if r["verdict"] == "exact")

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -62,7 +62,8 @@ below moves between vanilla Robust SCM, its convex variant from Dennis
 Shen's MIT master's thesis (`MIT DSpace
 <https://dspace.mit.edu/bitstream/handle/1721.1/115743/1036986794-MIT.pdf?sequence=1&isAllowed=y>`_),
 the clustered variant of `Rho et al. (2025)
-<https://arxiv.org/pdf/2503.21629>`_, and `the Bayesian variant<https://jmlr.csail.mit.edu/papers/volume19/17-777/17-777.pdf>`_ -- all
+<https://arxiv.org/pdf/2503.21629>`_, and `the Bayesian variant
+<https://jmlr.csail.mit.edu/papers/volume19/17-777/17-777.pdf>`_ -- all
 via the same :class:`~mlsynth.CLUSTERSC` class:
 
 .. code-block:: python

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -10,7 +10,7 @@ enforces. Each row links to the reference implementation, the dataset (with
 checksum), and the mlsynth case that runs the check.
 
 Coverage: **77 cross-validation checks** against original
-implementations across **44 estimators** -- 29 reproduce the reference to display precision, 28 to
+implementations across **43 estimators** -- 29 reproduce the reference to display precision, 28 to
 within two percent. A further 3 are captured on the next daily run (see `Pending capture`_). Per-estimator paper replications (Path A / Path B) are catalogued in :doc:`replications`.
 
 Legend: **exact** (agreement to display precision), **tight** (worst
@@ -46,9 +46,9 @@ Summary
      - 1 tight
      - 0.00041
    * - :ref:`CLUSTERSC <val-clustersc>`
-     - 2
-     - 2 exact
-     - 0
+     - 4
+     - 3 exact · 1 tight
+     - 0.036
    * - :ref:`COMPSC <val-compsc>`
      - 1
      - 1 tight
@@ -57,10 +57,6 @@ Summary
      - 1
      - 1 tight
      - 0.014
-   * - :ref:`ClusterSC <val-clustersc>`
-     - 2
-     - 1 exact · 1 tight
-     - 0.036
    * - :ref:`DPSC <val-dpsc>`
      - 1
      - 1 exact
@@ -321,6 +317,18 @@ CLUSTERSC
      - 0
      - exact — matches to display precision
      - `clustersc_rpca_germany <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/clustersc_rpca_germany.py>`__
+   * - jehangiramjad/tslib RobustSyntheticControl (live run, captured), modelType='svd', kSingularValuesToKeep=3
+     - ``smoking_data.csv`` (a13dd4d5d6e4…)
+     - 8
+     - 0.036
+     - tight
+     - `pcr_rsc_ref <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/pcr_rsc_ref.py>`__
+   * - deshen24/panel-data-regressions var.var_est (homoskedastic + jackknife)
+     - —
+     - 6
+     - 0
+     - exact — matches to display precision
+     - `rsc_shen_coverage <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/rsc_shen_coverage.py>`__
    * - scpi_pkg scest(w_constr={'name':'ridge'}) + df_EST
      - ``scpi_germany.csv`` (10b150fbcc2c…)
      - 3
@@ -371,34 +379,6 @@ CSCM
      - 0.014
      - tight
      - `cscm_viszero <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/cscm_viszero.py>`__
-
-.. _val-clustersc:
-
-ClusterSC
----------
-
-.. list-table::
-   :header-rows: 1
-   :widths: 22 28 8 12 14 16
-
-   * - Reference
-     - Dataset
-     - #
-     - max \|Δ\|
-     - Verdict
-     - Case
-   * - jehangiramjad/tslib RobustSyntheticControl (live run, captured), modelType='svd', kSingularValuesToKeep=3
-     - ``smoking_data.csv`` (a13dd4d5d6e4…)
-     - 8
-     - 0.036
-     - tight
-     - `pcr_rsc_ref <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/pcr_rsc_ref.py>`__
-   * - deshen24/panel-data-regressions var.var_est (homoskedastic + jackknife)
-     - —
-     - 6
-     - 0
-     - exact — matches to display precision
-     - `rsc_shen_coverage <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/rsc_shen_coverage.py>`__
 
 .. _val-dpsc:
 

--- a/mlsynth/tests/test_export_comparison.py
+++ b/mlsynth/tests/test_export_comparison.py
@@ -2,9 +2,9 @@
 
 The daily benchmark action creates a per-case ``comparison.csv`` for any
 cross-validation case that lacks one (``--missing``), then rebuilds the public
-web-native dashboard ``docs/validation.rst`` from the committed CSVs -- rather
-than re-running every (stochastic) case daily. These pin that behaviour without
-a live reference run.
+web-native dashboard ``docs/validation.rst`` from the committed CSVs, instead of
+re-running every (stochastic) case daily. These pin that behaviour without a
+live reference run.
 """
 from __future__ import annotations
 
@@ -82,9 +82,38 @@ def test_validation_verdict_bands():
 
 def test_validation_canonicalises_estimator_labels():
     bv = _bv()
-    assert bv._canon("ClusterSC/PCR (run_pcr OLS, fixed rank)") == "ClusterSC"
     assert bv._canon("ridge_augment_weights") == "VanillaSC"   # remapped
     assert bv._canon("VanillaSC") == "VanillaSC"
+
+
+def test_validation_folds_case_variants_onto_the_exported_name():
+    """Two spellings of one estimator have to reach one section.
+
+    Case authors write the estimator field by hand, so ``CLUSTERSC`` arrived
+    from one bundle and ``ClusterSC/PCR (run_pcr ...)`` from another. The anchor
+    is lowercased, so the two produced one label defined twice: Sphinx reported
+    a duplicate label and both ``:ref:`` links to it as undefined, which left the
+    dashboard's summary row pointing nowhere.
+    """
+    bv = _bv()
+    assert bv._canon("CLUSTERSC") == "CLUSTERSC"
+    assert bv._canon("ClusterSC/PCR (run_pcr OLS, fixed rank)") == "CLUSTERSC"
+    assert bv._canon("clustersc") == "CLUSTERSC"
+    assert bv._slug(bv._canon("CLUSTERSC")) == bv._slug(bv._canon("ClusterSC"))
+
+
+def test_validation_refuses_two_sections_claiming_one_anchor():
+    """A slug collision is a broken page, so the build stops instead of writing it."""
+    bv = _bv()
+    bv._check_slugs(["VanillaSC", "CLUSTERSC"])          # distinct anchors: fine
+    with pytest.raises(SystemExit, match="collide on their anchor"):
+        bv._check_slugs(["CLUSTERSC", "ClusterSC"])
+
+
+def test_validation_corpus_has_no_colliding_anchors():
+    """The committed corpus itself must not reintroduce the collision."""
+    bv = _bv()
+    bv._check_slugs(sorted(bv.collect()))
 
 
 def test_validation_page_builds_from_real_corpus():


### PR DESCRIPTION
## Related Links

- Pages: `docs/about.rst`, `docs/validation.rst` (generated)
- Generator: `benchmarks/reference/build_validation.py`
- Follows #428, whose local Sphinx build surfaced these; both predate that branch

## What

- `docs/about.rst`: added the missing space in a hyperlink so the target parses
- `benchmarks/reference/build_validation.py`: `_canon` now resolves an estimator name against mlsynth's own exports, so case variants fold onto one section; `_check_slugs` refuses to write a page whose sections would claim the same anchor
- `docs/validation.rst`: regenerated from that
- `mlsynth/tests/test_export_comparison.py`: updated the test that pinned the old spelling, added three

## Why

Building the docs reports one error and two warnings that have nothing to do with the pages they sit on.

`docs/about.rst:59` reads ``` `the Bayesian variant<https://...>`_ ```. RST needs a space before the angle bracket; without one, docutils treats the whole string as a target name and reports `ERROR: Unknown target name: "the bayesian variant<https://...>"`. The link did not render.

`docs/validation.rst:48,60` both do `:ref:`...<val-clustersc>`` and Sphinx resolved neither. The page is generated, so the fault is upstream: `_slug` lowercases its input, and the committed corpus spells one estimator two ways — `CLUSTERSC` in `clustersc_rpca_germany` and `scpi_ridge_germany`, `ClusterSC/PCR (run_pcr OLS, fixed rank)` in `pcr_rsc_ref` and `rsc_shen_coverage`. `_canon` stripped the backend suffix but kept the case, so `by_est` carried two keys for one estimator and the generator emitted two sections claiming `val-clustersc`. Sphinx reported a duplicate label and both references as undefined.

## How

`_canon` resolves the stripped, remapped name against `mlsynth.__all__`, case-insensitively:

```python
return _exported_names().get(base.lower(), base)
```

Resolving against the package's exports means no hand-maintained list of spellings, and it settles on the name a reader can import. The four references now sit in one `CLUSTERSC` section (3 exact, 1 tight), and the coverage line drops from 44 estimators to 43 — the old count double-counted one estimator.

`_check_slugs` runs before the page is assembled and exits with the colliding slug, the names that produced it, and the two ways to resolve it. A new spelling in a future bundle cannot reintroduce the broken anchors without stopping the build.

## Verification

- Path: not applicable. The corpus is untouched; this changes how estimator names are canonicalised for display, and one hyperlink's punctuation. No estimator, no numerical code.
- The regenerated dashboard carries the same 77 cross-validation rows as before, with the two ClusterSC sections merged: `CLUSTERSC` now reports 4 checks, 3 exact and 1 tight, worst 0.036.
- Docs build after the change: succeeded on Sphinx 8.2.3, 749 warnings against 753 before. Grepping the log for `Unknown target name`, `undefined label: 'val-clustersc'` and `duplicate label: val-clustersc` returns nothing.
- The fold test was checked against the pre-fix behaviour (`_exported_names` stubbed to `{}`): `_canon("ClusterSC/PCR (...)")` returns `ClusterSC`, the two slugs compare equal, and the test fails. It catches the regression it describes.

## Scope checks

None of the four blocks fits. This is a docs-and-tooling fix: a generator bug and an RST typo, with tests. No estimator, no config, no result contract, no benchmark case, and no committed reference bundle changed.

## Designs

No figures. The visible change is that the dashboard's `CLUSTERSC` summary row now links to a section instead of nowhere, and the two near-duplicate sections are one.

## Test Steps

- [x] `pytest mlsynth/tests/test_export_comparison.py -q` — 9 passed
- [x] `python benchmarks/reference/build_validation.py` — wrote `docs/validation.rst`, 77 rows across 43 estimators
- [x] `python -m sphinx -b html docs <out>` — build succeeded; the error and both warnings are gone
- [x] Banned-word sweep over the changed files
- [ ] `pytest mlsynth/tests/` — full suite not run locally; the only Python touched is the dashboard generator and its own test file. CI covers it

## Other Notes

- `docs/validation.rst` still has a section titled `?` (anchor `val--`), from two bundles whose `comparison.csv` records an empty estimator field: `brabander_brexit_table1`, which runs seven estimators and so has no single name to record, and `lamba_tigers`. Sphinx does not complain, so it is outside what this branch was for, and naming them is a call about what the dashboard should show for a multi-estimator case. Left alone deliberately.
- The banned-word sweep found one pre-existing `rather` in the docstring of the test file this branch edits; fixed in passing. The same word appears about 420 more times across `docs/`, `mlsynth/` and `benchmarks/`, which is its own sweep and not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163wFMcmTbLfKK3Q1hF5crJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0163wFMcmTbLfKK3Q1hF5crJ)_