### PR TITLE
Give the cumulative effect a band calibrated for the sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ now returns and the back-compat guarantee.
 
 ## [Unreleased]
 
+### Added
+- `inference="conformal_cumulative"` on `VanillaSC`: a prediction interval for the
+  cumulative (total) treatment effect over `conformal_horizon` post-periods,
+  defaulting to the whole post-period. mlsynth already reported the cumulative
+  effect as a point estimate, and the one existing "total" band rescaled a
+  per-period interval by the horizon; this calibrates a band for the sum itself.
+  The half-width is the split-conformal order statistic of *summed* out-of-sample
+  errors, collected by refitting at sliding non-overlapping origins across the
+  pre-period, so neither in-sample optimism nor an assumption about how
+  period-to-period errors accumulate enters. The figure lands in
+  `res.inference.details` (`cumulative_effect`, `cumulative_lower`,
+  `cumulative_upper`, `conformal_q`, `n_calibration_windows`);
+  `ci_lower`/`ci_upper` carry the per-period equivalent only when the horizon
+  spans the whole post-period, since a shorter window is not the ATT. Too few
+  non-overlapping windows for the requested level warns and returns an infinite
+  band rather than one that does not cover.
+- `mlsynth/utils/conformal/`, collecting the conformal machinery into one package
+  (following `utils/bilevel/`): `quantile.split_conformal_quantile` (moved from
+  `utils/inferutils.py`, which re-exports it, so existing imports are unaffected),
+  `scores.rolling_origin_block_sums`, `cumulative.cumulative_conformal_interval`
+  and `cumulative_conformal_from_refit`, and `structure.CumulativeConformalBand`.
+  The pure combiner takes precomputed scores, so an estimator whose refit produces
+  several treated units at once can build its own scores in a single pass and
+  reuse the same calibration.
+
+### Changed
+- `VanillaSC`'s per-fold refit closure is defined once and shared by
+  `inference="ttest"` and `inference="conformal_cumulative"`, and takes period
+  indices rather than sliced arrays so a covariate-aware refit can subset its
+  covariates by the same periods.
+
 ### Removed
 - `mode="two_way_global_annealed"` and its five `utils/syndes_helpers/relaxed_*.py`
   modules (932 lines), the `relaxed_max_iter` / `relaxed_decay` fields, the

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -450,7 +450,8 @@ Several inference modes are available via ``inference=``:
 Each mode returns one kind of output, and the fit always tells you which.
 ``"placebo"``, ``"lto"`` and ``"ttest"`` are tests: they return a p-value (the
 t-test also returns an ATT confidence interval). ``"conformal"``,
-``"conformal_split"``, ``"scpi"``, ``"eiv"`` and ``"jackknife_plus"`` are
+``"conformal_split"``, ``"conformal_cumulative"``, ``"scpi"``, ``"eiv"`` and
+``"jackknife_plus"`` are
 prediction intervals: they
 return the per-period counterfactual
 bands on ``res.time_series`` (``counterfactual_lower`` / ``counterfactual_upper``)
@@ -734,6 +735,46 @@ distribution -- emits a warning and returns an ``InferenceResults`` whose
     tallies. It shares the placebo test's assumptions but is far more powerful
     in small donor pools. See *The leave-two-out refined placebo test* and the
     two theory subsections below for the full treatment.
+
+``"conformal_cumulative"`` -- band for the cumulative (total) effect
+    The other modes report the effect period by period, or its average. This one
+    reports the interval for the *sum* over the post-period -- the total the
+    intervention added -- which is often the figure a decision rests on.
+
+    A confidence interval for a running total is not the running total of the
+    per-period intervals. Adding the endpoints up assumes the weekly errors move
+    in lockstep, so the width grows with the number of periods rather than with
+    its square root; rescaling one period's interval by the horizon assumes the
+    opposite. Which is right depends on how the errors accumulate, so this mode
+    measures that directly: it slides an origin across the pre-period, refits the
+    control on the data strictly before each origin, and reads the *summed* error
+    over the next ``conformal_horizon`` periods. Those sums are conformity scores
+    for exactly the quantity being reported, and the half-width is the
+    :math:`\lceil (m+1)(1-\alpha) \rceil`-th order statistic of the centred
+    scores -- the same finite-sample construction ``conformal_split`` uses, over
+    blocks instead of single periods.
+
+    Because each refit sees only data before the window it scores, the scores
+    carry no in-sample optimism; because the origins step by a whole horizon, the
+    windows do not overlap and the scores stay exchangeable.
+
+    ``conformal_horizon`` sets the number of periods accumulated, defaulting to
+    the whole post-period. The cumulative figure and its band land in
+    ``res.inference.details`` (``cumulative_effect``, ``cumulative_lower``,
+    ``cumulative_upper``, ``conformal_q``, ``n_calibration_windows``);
+    ``res.inference.ci_lower``/``ci_upper`` carry the per-period equivalent only
+    when the horizon spans the whole post-period, since a shorter window is not
+    the ATT.
+
+    What it costs is pre-period. Non-overlapping windows of length :math:`L` are
+    scarce: a :math:`1-\alpha` band needs at least :math:`\lceil 1/\alpha
+    \rceil - 1` of them, so roughly :math:`T_0 \gtrsim L / (\alpha\,(1 -
+    \texttt{min\_train\_frac}))`. At :math:`\alpha = 0.1` that is about ten
+    windows: 104 pre-periods support an 8-period horizon, but not a 16-period one.
+    When the windows run out the band is ``±inf`` with a warning naming the
+    shortfall, rather than a narrow band that does not cover.
+
+    Reference: :func:`mlsynth.utils.conformal.cumulative_conformal_from_refit`.
 
 ``"ttest"`` -- debiased SC t-test for the ATT (Chernozhukov, Wüthrich & Zhu 2025)
     A :math:`K`-fold cross-fitting debiasing with a self-normalized statistic

--- a/mlsynth/tests/test_conformal_cumulative.py
+++ b/mlsynth/tests/test_conformal_cumulative.py
@@ -25,6 +25,7 @@ import pytest
 
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 from mlsynth.utils.conformal import (
+    MIN_TRAIN_PERIODS,
     CumulativeConformalBand,
     cumulative_conformal_interval,
     cumulative_conformal_from_refit,
@@ -121,13 +122,24 @@ def test_scores_are_block_sums_computed_from_hand():
     np.testing.assert_allclose(scores, np.asarray(expected), rtol=1e-9, atol=1e-12)
 
 
+def test_short_panels_still_train_on_a_minimum_number_of_periods():
+    """A refit on a handful of periods interpolates them and predicts nothing."""
+    y, Y0 = _panel(T=40, J=3, pre=36)
+    scores = rolling_origin_block_sums(
+        y, Y0, pre_periods=36, horizon=2, weight_fn=_ols_weight_fn(y, Y0),
+        min_train_frac=0.05,                       # 5% of 36 = 1 period, far too few
+    )
+    # the floor, not the fraction, sets the first origin
+    assert scores.size == len(range(MIN_TRAIN_PERIODS, 36 - 2 + 1, 2))
+
+
 def test_scores_come_from_non_overlapping_origins():
     """Overlapping blocks would reuse periods and break exchangeability."""
     y, Y0 = _panel()
     scores = rolling_origin_block_sums(
         y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weight_fn(y, Y0), min_train_frac=0.2
     )
-    start = max(4, int(100 * 0.2))
+    start = max(MIN_TRAIN_PERIODS, int(100 * 0.2))
     expected_origins = len(range(start, 100 - 4 + 1, 4))   # stride == horizon
     assert scores.size == expected_origins
 
@@ -139,7 +151,7 @@ def test_scores_are_out_of_sample_each_refit_excludes_its_own_block():
         y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weight_fn(y, Y0), min_train_frac=0.2
     )
     in_sample = []
-    for o in range(max(4, int(100 * 0.2)), 100 - 4 + 1, 4):
+    for o in range(max(MIN_TRAIN_PERIODS, int(100 * 0.2)), 100 - 4 + 1, 4):
         W = _ols_weight_fn(y, Y0)(np.arange(o + 4))          # trained INCLUDING the block
         in_sample.append(float(np.sum(y[o:o + 4] - Y0[o:o + 4] @ W)))
     assert np.mean(np.abs(scores)) > np.mean(np.abs(in_sample))

--- a/mlsynth/tests/test_conformal_cumulative.py
+++ b/mlsynth/tests/test_conformal_cumulative.py
@@ -34,10 +34,17 @@ from mlsynth.utils.conformal import (
 
 
 # --- deterministic fixtures (no estimator dependency) -----------------------
-def _ols_weights(y_train, Y0_train):
-    """Stand-in for an estimator's refit: unconstrained donor regression."""
-    beta, *_ = np.linalg.lstsq(Y0_train, y_train, rcond=None)
-    return np.asarray(beta, float)
+def _ols_weight_fn(y, Y0):
+    """Stand-in for an estimator's refit: unconstrained donor regression.
+
+    Takes period indices, the contract ``debiased_sc_ttest`` already uses, so a
+    covariate-aware estimator can subset its covariates by the same periods.
+    """
+    def _fn(keep_idx):
+        idx = np.asarray(keep_idx)
+        beta, *_ = np.linalg.lstsq(Y0[idx], y[idx], rcond=None)
+        return np.asarray(beta, float)
+    return _fn
 
 
 def _panel(T=120, J=5, pre=100, seed=0, effect=0.0):
@@ -50,7 +57,7 @@ def _panel(T=120, J=5, pre=100, seed=0, effect=0.0):
 
 def _fit(**kw):
     y, Y0 = kw.pop("panel", None) or _panel()
-    base = dict(pre_periods=100, horizon=4, weight_fn=_ols_weights,
+    base = dict(pre_periods=100, horizon=4, weight_fn=_ols_weight_fn(y, Y0),
                 alpha=0.1, min_train_frac=0.2)
     base.update(kw)
     return cumulative_conformal_from_refit(y, Y0, **base)
@@ -76,7 +83,7 @@ def test_smoke_returns_band_of_the_declared_type():
 def test_point_is_the_summed_out_of_sample_gap_not_its_average():
     """Guards the estimand: the band is for the SUM, not the per-period mean."""
     y, Y0 = _panel()
-    W = _ols_weights(y[:100], Y0[:100])
+    W = _ols_weight_fn(y, Y0)(np.arange(100))
     gap = y[100:104] - Y0[100:104] @ W
     band = _fit(panel=(y, Y0))
     assert band.point == pytest.approx(float(gap.sum()))
@@ -93,7 +100,7 @@ def test_half_width_is_the_split_conformal_quantile_of_centred_block_sums():
     """The seam: scores from rolling origins, half-width from the shared primitive."""
     y, Y0 = _panel()
     scores = rolling_origin_block_sums(
-        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weights, min_train_frac=0.2
+        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weight_fn(y, Y0), min_train_frac=0.2
     )
     expected = split_conformal_quantile(scores - scores.mean(), alpha=0.1)
     band = _fit(panel=(y, Y0))
@@ -106,10 +113,10 @@ def test_scores_are_block_sums_computed_from_hand():
     y, Y0 = _panel()
     expected = []
     for origin in range(20, 100 - 4 + 1, 4):
-        w = _ols_weights(y[:origin], Y0[:origin])
+        w = _ols_weight_fn(y, Y0)(np.arange(origin))
         expected.append(float(np.sum(y[origin:origin + 4] - Y0[origin:origin + 4] @ w)))
     scores = rolling_origin_block_sums(
-        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weights, min_train_frac=0.2
+        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weight_fn(y, Y0), min_train_frac=0.2
     )
     np.testing.assert_allclose(scores, np.asarray(expected), rtol=1e-9, atol=1e-12)
 
@@ -118,7 +125,7 @@ def test_scores_come_from_non_overlapping_origins():
     """Overlapping blocks would reuse periods and break exchangeability."""
     y, Y0 = _panel()
     scores = rolling_origin_block_sums(
-        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weights, min_train_frac=0.2
+        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weight_fn(y, Y0), min_train_frac=0.2
     )
     start = max(4, int(100 * 0.2))
     expected_origins = len(range(start, 100 - 4 + 1, 4))   # stride == horizon
@@ -129,11 +136,11 @@ def test_scores_are_out_of_sample_each_refit_excludes_its_own_block():
     """A refit that saw its own block would score ~0; genuine OOS scores do not."""
     y, Y0 = _panel()
     scores = rolling_origin_block_sums(
-        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weights, min_train_frac=0.2
+        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weight_fn(y, Y0), min_train_frac=0.2
     )
     in_sample = []
     for o in range(max(4, int(100 * 0.2)), 100 - 4 + 1, 4):
-        W = _ols_weights(y[:o + 4], Y0[:o + 4])          # trained INCLUDING the block
+        W = _ols_weight_fn(y, Y0)(np.arange(o + 4))          # trained INCLUDING the block
         in_sample.append(float(np.sum(y[o:o + 4] - Y0[o:o + 4] @ W)))
     assert np.mean(np.abs(scores)) > np.mean(np.abs(in_sample))
 

--- a/mlsynth/tests/test_conformal_cumulative.py
+++ b/mlsynth/tests/test_conformal_cumulative.py
@@ -1,0 +1,275 @@
+"""Calibrated conformal interval for the cumulative (total) treatment effect.
+
+The cumulative effect over an ``L``-period post-window is
+``C = sum_k (y_{T0+k} - synthetic_{T0+k})``. mlsynth already reports ``C`` as a
+point estimate (``effectutils.total_effect``), and ``fast_scm`` reports a "total
+lift" band that is the per-period ATE interval rescaled by the horizon -- no
+conformity score is ever formed on the sum. This suite pins the missing object: a
+band calibrated *for the sum*.
+
+Construction (``mlsynth.utils.conformal``):
+
+* ``scores.rolling_origin_block_sums`` refits the control at sliding,
+  NON-OVERLAPPING origins across the pre-period. Each origin contributes one
+  conformity score: the sum of its ``L`` out-of-sample residuals. Because every
+  refit sees only data strictly before its origin, the scores carry no in-sample
+  optimism.
+* ``cumulative.cumulative_conformal_interval`` centres those scores and takes the
+  split-conformal half-width (``quantile.split_conformal_quantile``, the
+  ``ceil((m+1)(1-alpha))``-th order statistic), giving ``C_hat +/- q``.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.conformal import (
+    CumulativeConformalBand,
+    cumulative_conformal_interval,
+    cumulative_conformal_from_refit,
+    rolling_origin_block_sums,
+    split_conformal_quantile,
+)
+
+
+# --- deterministic fixtures (no estimator dependency) -----------------------
+def _ols_weights(y_train, Y0_train):
+    """Stand-in for an estimator's refit: unconstrained donor regression."""
+    beta, *_ = np.linalg.lstsq(Y0_train, y_train, rcond=None)
+    return np.asarray(beta, float)
+
+
+def _panel(T=120, J=5, pre=100, seed=0, effect=0.0):
+    rng = np.random.default_rng(seed)
+    Y0 = rng.normal(size=(T, J))
+    y = Y0 @ rng.dirichlet(np.ones(J)) + rng.normal(scale=0.1, size=T)
+    y[pre:] += effect
+    return y, Y0
+
+
+def _fit(**kw):
+    y, Y0 = kw.pop("panel", None) or _panel()
+    base = dict(pre_periods=100, horizon=4, weight_fn=_ols_weights,
+                alpha=0.1, min_train_frac=0.2)
+    base.update(kw)
+    return cumulative_conformal_from_refit(y, Y0, **base)
+
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+def test_smoke_returns_band_of_the_declared_type():
+    band = _fit()
+    assert isinstance(band, CumulativeConformalBand)
+    assert np.isfinite(band.point) and np.isfinite(band.half_width)
+    assert band.lower <= band.point <= band.upper
+    assert band.n_scores >= 9          # enough blocks for a finite 90% order statistic
+    assert band.alpha == pytest.approx(0.1)
+
+
+# ---------------------------------------------------------------------------
+# Unit invariants
+# ---------------------------------------------------------------------------
+
+def test_point_is_the_summed_out_of_sample_gap_not_its_average():
+    """Guards the estimand: the band is for the SUM, not the per-period mean."""
+    y, Y0 = _panel()
+    W = _ols_weights(y[:100], Y0[:100])
+    gap = y[100:104] - Y0[100:104] @ W
+    band = _fit(panel=(y, Y0))
+    assert band.point == pytest.approx(float(gap.sum()))
+    assert band.point != pytest.approx(float(gap.mean()))
+
+
+def test_band_is_symmetric_about_the_point():
+    band = _fit()
+    assert band.point - band.lower == pytest.approx(band.half_width)
+    assert band.upper - band.point == pytest.approx(band.half_width)
+
+
+def test_half_width_is_the_split_conformal_quantile_of_centred_block_sums():
+    """The seam: scores from rolling origins, half-width from the shared primitive."""
+    y, Y0 = _panel()
+    scores = rolling_origin_block_sums(
+        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weights, min_train_frac=0.2
+    )
+    expected = split_conformal_quantile(scores - scores.mean(), alpha=0.1)
+    band = _fit(panel=(y, Y0))
+    assert band.half_width == pytest.approx(expected)
+    assert band.n_scores == scores.size
+
+
+def test_scores_are_block_sums_computed_from_hand():
+    """Pins the score's scale and construction without reusing the helper."""
+    y, Y0 = _panel()
+    expected = []
+    for origin in range(20, 100 - 4 + 1, 4):
+        w = _ols_weights(y[:origin], Y0[:origin])
+        expected.append(float(np.sum(y[origin:origin + 4] - Y0[origin:origin + 4] @ w)))
+    scores = rolling_origin_block_sums(
+        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weights, min_train_frac=0.2
+    )
+    np.testing.assert_allclose(scores, np.asarray(expected), rtol=1e-9, atol=1e-12)
+
+
+def test_scores_come_from_non_overlapping_origins():
+    """Overlapping blocks would reuse periods and break exchangeability."""
+    y, Y0 = _panel()
+    scores = rolling_origin_block_sums(
+        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weights, min_train_frac=0.2
+    )
+    start = max(4, int(100 * 0.2))
+    expected_origins = len(range(start, 100 - 4 + 1, 4))   # stride == horizon
+    assert scores.size == expected_origins
+
+
+def test_scores_are_out_of_sample_each_refit_excludes_its_own_block():
+    """A refit that saw its own block would score ~0; genuine OOS scores do not."""
+    y, Y0 = _panel()
+    scores = rolling_origin_block_sums(
+        y, Y0, pre_periods=100, horizon=4, weight_fn=_ols_weights, min_train_frac=0.2
+    )
+    in_sample = []
+    for o in range(max(4, int(100 * 0.2)), 100 - 4 + 1, 4):
+        W = _ols_weights(y[:o + 4], Y0[:o + 4])          # trained INCLUDING the block
+        in_sample.append(float(np.sum(y[o:o + 4] - Y0[o:o + 4] @ W)))
+    assert np.mean(np.abs(scores)) > np.mean(np.abs(in_sample))
+
+
+def test_smaller_alpha_never_narrows_the_band():
+    y, Y0 = _panel()
+    assert _fit(panel=(y, Y0), alpha=0.05).half_width >= _fit(panel=(y, Y0), alpha=0.20).half_width
+
+
+def test_pure_combiner_accepts_precomputed_scores():
+    """PPSCM-style callers build scores their own way and reuse the combiner."""
+    scores = np.array([-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, -3.0, 0.5, -0.5, 1.5])
+    band = cumulative_conformal_interval(point=4.0, scores=scores, alpha=0.1)
+    assert band.point == pytest.approx(4.0)
+    assert band.half_width == pytest.approx(
+        split_conformal_quantile(scores - scores.mean(), alpha=0.1)
+    )
+    assert band.n_scores == scores.size
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_too_few_blocks_yields_an_honest_infinite_band():
+    """A short pre-period cannot support the order statistic; say so, don't guess."""
+    y, Y0 = _panel(T=60, J=4, pre=40)
+    band = _fit(panel=(y, Y0), pre_periods=40, horizon=8, min_train_frac=0.3)
+    assert band.n_scores < 9
+    assert not np.isfinite(band.half_width)
+    assert band.lower == -np.inf and band.upper == np.inf
+
+
+def test_horizon_of_one_is_valid():
+    band = _fit(horizon=1)
+    assert np.isfinite(band.point) and band.n_scores >= 9
+
+
+def test_no_origins_available_yields_infinite_band():
+    band = _fit(min_train_frac=0.99)
+    assert band.n_scores == 0
+    assert not np.isfinite(band.half_width)
+
+
+def test_single_donor_panel_is_supported():
+    y, Y0 = _panel(J=1)
+    band = _fit(panel=(y, Y0))
+    assert np.isfinite(band.point)
+
+
+# ---------------------------------------------------------------------------
+# Failure -- translated errors, reported not swallowed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1, 1.5])
+def test_invalid_alpha_raises_config_error(bad):
+    with pytest.raises(MlsynthConfigError):
+        _fit(alpha=bad)
+
+
+@pytest.mark.parametrize("bad", ["0.1", None, True])
+def test_non_numeric_alpha_raises_config_error(bad):
+    with pytest.raises(MlsynthConfigError):
+        _fit(alpha=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -3])
+def test_nonpositive_horizon_raises_config_error(bad):
+    with pytest.raises(MlsynthConfigError):
+        _fit(horizon=bad)
+
+
+@pytest.mark.parametrize("bad", [4.0, "4", None, True])
+def test_non_integer_horizon_raises_config_error(bad):
+    with pytest.raises(MlsynthConfigError):
+        _fit(horizon=bad)
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, 1.5])
+def test_invalid_min_train_frac_raises_config_error(bad):
+    with pytest.raises(MlsynthConfigError):
+        _fit(min_train_frac=bad)
+
+
+@pytest.mark.parametrize("bad", ["0.3", None, True])
+def test_non_numeric_min_train_frac_raises_config_error(bad):
+    with pytest.raises(MlsynthConfigError):
+        _fit(min_train_frac=bad)
+
+
+def test_nonpositive_pre_periods_raises_config_error():
+    with pytest.raises(MlsynthConfigError):
+        _fit(pre_periods=0)
+
+
+def test_horizon_beyond_the_post_window_raises_data_error():
+    y, Y0 = _panel(T=120)
+    with pytest.raises(MlsynthDataError):
+        _fit(panel=(y, Y0), pre_periods=118, horizon=5)      # 118 + 5 > 120
+
+
+def test_donor_row_mismatch_raises_data_error():
+    y, Y0 = _panel(T=120)
+    with pytest.raises(MlsynthDataError):
+        _fit(panel=(y[:-1], Y0))
+
+
+def test_one_dimensional_donor_matrix_raises_data_error():
+    y, Y0 = _panel(T=120)
+    with pytest.raises(MlsynthDataError):
+        _fit(panel=(y, Y0.ravel()))
+
+
+def test_empty_scores_raise_data_error_in_the_pure_combiner():
+    with pytest.raises(MlsynthDataError):
+        cumulative_conformal_interval(point=1.0, scores=np.array([]), alpha=0.1)
+
+
+def test_non_finite_scores_raise_data_error():
+    with pytest.raises(MlsynthDataError):
+        cumulative_conformal_interval(point=1.0, scores=np.array([1.0, np.nan, 2.0]), alpha=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Move regression: the shared primitive keeps its behaviour and its old import
+# ---------------------------------------------------------------------------
+
+def test_split_conformal_quantile_is_reexported_from_inferutils():
+    from mlsynth.utils.inferutils import split_conformal_quantile as legacy
+    assert legacy is split_conformal_quantile
+
+
+def test_split_conformal_quantile_behaviour_is_unchanged():
+    r = np.array([-3.0, 1.0, -2.0, 0.5, 4.0])
+    # k = ceil((5+1)*0.9) = 6 > n -> uninformative
+    assert not np.isfinite(split_conformal_quantile(r, alpha=0.1))
+    # k = ceil((5+1)*0.5) = 3 -> third smallest absolute value
+    assert split_conformal_quantile(r, alpha=0.5) == pytest.approx(2.0)
+    assert not np.isfinite(split_conformal_quantile(np.array([]), alpha=0.1))

--- a/mlsynth/tests/test_conformal_cumulative.py
+++ b/mlsynth/tests/test_conformal_cumulative.py
@@ -292,3 +292,96 @@ def test_split_conformal_quantile_behaviour_is_unchanged():
     # k = ceil((5+1)*0.5) = 3 -> third smallest absolute value
     assert split_conformal_quantile(r, alpha=0.5) == pytest.approx(2.0)
     assert not np.isfinite(split_conformal_quantile(np.array([]), alpha=0.1))
+
+
+# ---------------------------------------------------------------------------
+# Wiring: VanillaSC's ``inference="conformal_cumulative"`` mode
+# ---------------------------------------------------------------------------
+
+def _sc_panel(T=140, J=8, pre=120, effect=0.5, seed=3):
+    """Long-panel geo-test shape: enough pre-period for several calibration windows."""
+    import pandas as pd
+    rng = np.random.default_rng(seed)
+    donors = {f"d{j}": rng.normal(size=T).cumsum() + 10.0 for j in range(J)}
+    treated = sum(donors.values()) / J + rng.normal(scale=0.2, size=T)
+    treated[pre:] += effect
+    rows = [{"unit": "treated", "time": t, "y": treated[t], "d": int(t >= pre)}
+            for t in range(T)]
+    rows += [{"unit": u, "time": t, "y": v[t], "d": 0}
+             for u, v in donors.items() for t in range(T)]
+    return pd.DataFrame(rows)
+
+
+def _run_sc(df, **kw):
+    import warnings as _w
+    from mlsynth import VanillaSC
+    cfg = {"df": df, "outcome": "y", "treat": "d", "unitid": "unit", "time": "time",
+           "display_graphs": False, "inference": "conformal_cumulative", "alpha": 0.1}
+    cfg.update(kw)
+    with _w.catch_warnings():
+        _w.simplefilter("ignore")
+        return VanillaSC(cfg).fit()
+
+
+def test_mode_reports_the_cumulative_band_in_inference_details():
+    res = _run_sc(_sc_panel(), conformal_horizon=8)
+    d = res.inference.details
+    assert res.inference.method == "split-conformal cumulative-effect band (rolling origin)"
+    assert d["horizon"] == 8
+    assert d["n_calibration_windows"] >= 9
+    assert np.isfinite(d["cumulative_effect"])
+    assert d["cumulative_lower"] <= d["cumulative_effect"] <= d["cumulative_upper"]
+    assert d["cumulative_upper"] - d["cumulative_effect"] == pytest.approx(d["conformal_q"])
+    assert res.inference.confidence_level == pytest.approx(0.9)
+
+
+def test_partial_horizon_does_not_claim_an_att_interval():
+    """A window shorter than the post-period is not the ATT, so no ATT CI."""
+    res = _run_sc(_sc_panel(), conformal_horizon=8)      # post-period is 20
+    assert res.inference.details["spans_post_period"] is False
+    assert res.inference.ci_lower is None and res.inference.ci_upper is None
+
+
+def test_full_horizon_reports_the_per_period_equivalent_as_the_att_interval():
+    df = _sc_panel(T=132, pre=120)                        # post-period is 12
+    res = _run_sc(df, conformal_horizon=12)
+    d = res.inference.details
+    assert d["spans_post_period"] is True
+    assert res.inference.ci_lower == pytest.approx(d["cumulative_lower"] / 12)
+    assert res.inference.ci_upper == pytest.approx(d["cumulative_upper"] / 12)
+
+
+def test_horizon_defaults_to_the_whole_post_period():
+    df = _sc_panel(T=132, pre=120)
+    res = _run_sc(df)
+    assert res.inference.details["horizon"] == 12
+    assert res.inference.details["spans_post_period"] is True
+
+
+def test_too_few_windows_warns_and_reports_an_infinite_band():
+    import warnings as _w
+    from mlsynth import VanillaSC
+    df = _sc_panel(T=140, pre=120)
+    cfg = {"df": df, "outcome": "y", "treat": "d", "unitid": "unit", "time": "time",
+           "display_graphs": False, "inference": "conformal_cumulative",
+           "alpha": 0.1, "conformal_horizon": 20}
+    with _w.catch_warnings(record=True) as caught:
+        _w.simplefilter("always")
+        res = VanillaSC(cfg).fit()
+    assert any("uninformative" in str(w.message) for w in caught)
+    assert not np.isfinite(res.inference.details["conformal_q"])
+
+
+@pytest.mark.parametrize("bad", [0, -1, 2.5])
+def test_invalid_conformal_horizon_is_rejected_at_config_time(bad):
+    from mlsynth import VanillaSC
+    df = _sc_panel()
+    with pytest.raises(MlsynthConfigError):
+        VanillaSC({"df": df, "outcome": "y", "treat": "d", "unitid": "unit",
+                   "time": "time", "display_graphs": False,
+                   "inference": "conformal_cumulative", "conformal_horizon": bad})
+
+
+def test_mode_is_registered_as_a_valid_inference_method():
+    from mlsynth.utils.vanillasc_helpers.config import VALID_INFERENCE_METHODS
+    assert "conformal_cumulative" in VALID_INFERENCE_METHODS

--- a/mlsynth/tests/test_conformal_cumulative_properties.py
+++ b/mlsynth/tests/test_conformal_cumulative_properties.py
@@ -1,0 +1,184 @@
+"""Metamorphic invariants of the cumulative conformal band.
+
+The unit suite pins the band on fixed panels. These properties assert what must
+hold for *every* panel, and they are the assertions that would catch a defect the
+examples happen not to exercise:
+
+* equivariance -- rescaling the outcome and donors rescales the point estimate and
+  the half-width by the same factor; shifting only the post-window moves the point
+  by ``horizon * shift`` and leaves the calibration untouched;
+* invariance -- relabelling donors changes nothing, and neither does adding a
+  constant to every conformity score (the scores are centred before calibration,
+  so a systematic offset is not mistaken for spread);
+* monotonicity -- a smaller ``alpha`` never yields a narrower band;
+* structure -- the band is symmetric, and its half-width is exactly the shared
+  split-conformal order statistic applied to the centred rolling-origin scores.
+"""
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils.conformal import (
+    cumulative_conformal_interval,
+    cumulative_conformal_from_refit,
+    rolling_origin_block_sums,
+    split_conformal_quantile,
+)
+
+_SETTINGS = settings(
+    max_examples=40, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+)
+
+
+def _ols_weights(y_train, Y0_train):
+    beta, *_ = np.linalg.lstsq(Y0_train, y_train, rcond=None)
+    return np.asarray(beta, float)
+
+
+@st.composite
+def panels(draw, min_pre=48, max_pre=96):
+    """A donor panel with enough pre-period to admit several calibration blocks."""
+    n_donors = draw(st.integers(2, 6))
+    horizon = draw(st.integers(1, 6))
+    pre_periods = draw(st.integers(min_pre, max_pre))
+    post_extra = draw(st.integers(0, 6))
+    seed = draw(st.integers(0, 2**31 - 1))
+    rng = np.random.default_rng(seed)
+    total = pre_periods + horizon + post_extra
+    Y0 = rng.normal(size=(total, n_donors))
+    y = Y0 @ rng.dirichlet(np.ones(n_donors)) + rng.normal(scale=0.1, size=total)
+    # A rank-deficient donor block makes the refit non-unique; the band is then
+    # not a function of the panel alone, so equivariance claims do not apply.
+    assume(np.linalg.matrix_rank(Y0[:pre_periods]) == n_donors)
+    return y, Y0, pre_periods, horizon
+
+
+def _band(y, Y0, pre, horizon, alpha=0.1, min_train_frac=0.2):
+    return cumulative_conformal_from_refit(
+        y, Y0, pre, horizon, _ols_weights, alpha=alpha, min_train_frac=min_train_frac
+    )
+
+
+class TestStructure:
+    @given(panels())
+    @_SETTINGS
+    def test_band_is_symmetric_about_the_point(self, panel):
+        y, Y0, pre, horizon = panel
+        b = _band(y, Y0, pre, horizon)
+        assert b.point - b.lower == pytest.approx(b.half_width)
+        assert b.upper - b.point == pytest.approx(b.half_width)
+        assert b.horizon == horizon
+
+    @given(panels())
+    @_SETTINGS
+    def test_half_width_is_the_shared_order_statistic_of_centred_scores(self, panel):
+        y, Y0, pre, horizon = panel
+        b = _band(y, Y0, pre, horizon)
+        scores = rolling_origin_block_sums(
+            y, Y0, pre, horizon, _ols_weights, min_train_frac=0.2
+        )
+        assert b.n_scores == scores.size
+        if scores.size:
+            expected = split_conformal_quantile(scores - scores.mean(), alpha=0.1)
+            assert b.half_width == pytest.approx(expected)
+
+    @given(panels())
+    @_SETTINGS
+    def test_point_accumulates_the_post_window(self, panel):
+        y, Y0, pre, horizon = panel
+        b = _band(y, Y0, pre, horizon)
+        w = _ols_weights(y[:pre], Y0[:pre])
+        gap = y[pre:pre + horizon] - Y0[pre:pre + horizon] @ w
+        assert b.point == pytest.approx(float(gap.sum()), abs=1e-8)
+
+
+class TestEquivariance:
+    @given(panels(), st.floats(0.25, 4.0))
+    @_SETTINGS
+    def test_rescaling_the_panel_rescales_point_and_half_width(self, panel, c):
+        y, Y0, pre, horizon = panel
+        base = _band(y, Y0, pre, horizon)
+        scaled = _band(c * y, c * Y0, pre, horizon)
+        assert scaled.point == pytest.approx(c * base.point, rel=1e-6, abs=1e-8)
+        if np.isfinite(base.half_width):
+            assert scaled.half_width == pytest.approx(c * base.half_width, rel=1e-6, abs=1e-8)
+
+    @given(panels(), st.floats(-5.0, 5.0))
+    @_SETTINGS
+    def test_shifting_only_the_post_window_moves_the_point_alone(self, panel, shift):
+        y, Y0, pre, horizon = panel
+        base = _band(y, Y0, pre, horizon)
+        shifted_y = y.copy()
+        shifted_y[pre:pre + horizon] += shift
+        shifted = _band(shifted_y, Y0, pre, horizon)
+        assert shifted.point == pytest.approx(base.point + horizon * shift, abs=1e-6)
+        assert shifted.half_width == pytest.approx(base.half_width, nan_ok=True)
+
+
+class TestInvariance:
+    @given(panels())
+    @_SETTINGS
+    def test_relabelling_donors_changes_nothing(self, panel):
+        y, Y0, pre, horizon = panel
+        perm = np.random.default_rng(0).permutation(Y0.shape[1])
+        base = _band(y, Y0, pre, horizon)
+        permuted = _band(y, Y0[:, perm], pre, horizon)
+        assert permuted.point == pytest.approx(base.point, abs=1e-6)
+        if np.isfinite(base.half_width):
+            assert permuted.half_width == pytest.approx(base.half_width, rel=1e-6, abs=1e-6)
+
+    @given(
+        st.lists(st.floats(-50, 50, allow_nan=False), min_size=10, max_size=40),
+        st.floats(-20, 20),
+    )
+    @_SETTINGS
+    def test_offsetting_every_score_leaves_the_half_width_alone(self, scores, offset):
+        s = np.asarray(scores, dtype=float)
+        base = cumulative_conformal_interval(point=1.0, scores=s, alpha=0.1)
+        offsetted = cumulative_conformal_interval(point=1.0, scores=s + offset, alpha=0.1)
+        assert offsetted.half_width == pytest.approx(base.half_width, rel=1e-9, abs=1e-9)
+
+
+class TestMonotonicity:
+    @given(panels(), st.sampled_from([0.02, 0.05, 0.1]), st.sampled_from([0.2, 0.3, 0.5]))
+    @_SETTINGS
+    def test_smaller_alpha_never_narrows_the_band(self, panel, tight, loose):
+        assume(tight < loose)
+        y, Y0, pre, horizon = panel
+        narrow = _band(y, Y0, pre, horizon, alpha=loose)
+        wide = _band(y, Y0, pre, horizon, alpha=tight)
+        assert wide.half_width >= narrow.half_width or (
+            np.isinf(wide.half_width) and np.isinf(narrow.half_width)
+        )
+
+    @given(
+        st.lists(st.floats(-50, 50, allow_nan=False), min_size=20, max_size=60),
+        st.sampled_from([0.05, 0.1, 0.2]),
+    )
+    @_SETTINGS
+    def test_half_width_never_exceeds_the_largest_centred_score(self, scores, alpha):
+        s = np.asarray(scores, dtype=float)
+        b = cumulative_conformal_interval(point=0.0, scores=s, alpha=alpha)
+        if np.isfinite(b.half_width):
+            assert b.half_width <= np.max(np.abs(s - s.mean())) + 1e-9
+
+
+class TestCalibrationSet:
+    @given(panels())
+    @_SETTINGS
+    def test_origins_do_not_overlap(self, panel):
+        y, Y0, pre, horizon = panel
+        scores = rolling_origin_block_sums(
+            y, Y0, pre, horizon, _ols_weights, min_train_frac=0.2
+        )
+        start = max(horizon, int(pre * 0.2))
+        assert scores.size == len(range(start, pre - horizon + 1, horizon))
+
+    @given(panels())
+    @_SETTINGS
+    def test_a_later_first_origin_never_adds_calibration_blocks(self, panel):
+        y, Y0, pre, horizon = panel
+        early = _band(y, Y0, pre, horizon, min_train_frac=0.2)
+        late = _band(y, Y0, pre, horizon, min_train_frac=0.6)
+        assert late.n_scores <= early.n_scores

--- a/mlsynth/tests/test_conformal_cumulative_properties.py
+++ b/mlsynth/tests/test_conformal_cumulative_properties.py
@@ -20,6 +20,7 @@ from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 
 from mlsynth.utils.conformal import (
+    MIN_TRAIN_PERIODS,
     cumulative_conformal_interval,
     cumulative_conformal_from_refit,
     rolling_origin_block_sums,
@@ -180,7 +181,7 @@ class TestCalibrationSet:
         scores = rolling_origin_block_sums(
             y, Y0, pre, horizon, _ols_weight_fn(y, Y0), min_train_frac=0.2
         )
-        start = max(horizon, int(pre * 0.2))
+        start = max(MIN_TRAIN_PERIODS, int(pre * 0.2))
         assert scores.size == len(range(start, pre - horizon + 1, horizon))
 
     @given(panels())

--- a/mlsynth/tests/test_conformal_cumulative_properties.py
+++ b/mlsynth/tests/test_conformal_cumulative_properties.py
@@ -31,9 +31,17 @@ _SETTINGS = settings(
 )
 
 
-def _ols_weights(y_train, Y0_train):
-    beta, *_ = np.linalg.lstsq(Y0_train, y_train, rcond=None)
-    return np.asarray(beta, float)
+def _ols_weight_fn(y, Y0):
+    """Stand-in for an estimator's refit: unconstrained donor regression.
+
+    Takes period indices, the contract ``debiased_sc_ttest`` already uses, so a
+    covariate-aware estimator can subset its covariates by the same periods.
+    """
+    def _fn(keep_idx):
+        idx = np.asarray(keep_idx)
+        beta, *_ = np.linalg.lstsq(Y0[idx], y[idx], rcond=None)
+        return np.asarray(beta, float)
+    return _fn
 
 
 @st.composite
@@ -56,7 +64,7 @@ def panels(draw, min_pre=48, max_pre=96):
 
 def _band(y, Y0, pre, horizon, alpha=0.1, min_train_frac=0.2):
     return cumulative_conformal_from_refit(
-        y, Y0, pre, horizon, _ols_weights, alpha=alpha, min_train_frac=min_train_frac
+        y, Y0, pre, horizon, _ols_weight_fn(y, Y0), alpha=alpha, min_train_frac=min_train_frac
     )
 
 
@@ -76,7 +84,7 @@ class TestStructure:
         y, Y0, pre, horizon = panel
         b = _band(y, Y0, pre, horizon)
         scores = rolling_origin_block_sums(
-            y, Y0, pre, horizon, _ols_weights, min_train_frac=0.2
+            y, Y0, pre, horizon, _ols_weight_fn(y, Y0), min_train_frac=0.2
         )
         assert b.n_scores == scores.size
         if scores.size:
@@ -88,7 +96,7 @@ class TestStructure:
     def test_point_accumulates_the_post_window(self, panel):
         y, Y0, pre, horizon = panel
         b = _band(y, Y0, pre, horizon)
-        w = _ols_weights(y[:pre], Y0[:pre])
+        w = _ols_weight_fn(y, Y0)(np.arange(pre))
         gap = y[pre:pre + horizon] - Y0[pre:pre + horizon] @ w
         assert b.point == pytest.approx(float(gap.sum()), abs=1e-8)
 
@@ -170,7 +178,7 @@ class TestCalibrationSet:
     def test_origins_do_not_overlap(self, panel):
         y, Y0, pre, horizon = panel
         scores = rolling_origin_block_sums(
-            y, Y0, pre, horizon, _ols_weights, min_train_frac=0.2
+            y, Y0, pre, horizon, _ols_weight_fn(y, Y0), min_train_frac=0.2
         )
         start = max(horizon, int(pre * 0.2))
         assert scores.size == len(range(start, pre - horizon + 1, horizon))

--- a/mlsynth/utils/conformal/__init__.py
+++ b/mlsynth/utils/conformal/__init__.py
@@ -1,0 +1,41 @@
+"""Conformal prediction bands for synthetic control.
+
+Conformal inference asks one question of a fitted control: how large are the
+errors it makes on data it did not see, and how far must a band reach to cover
+``1 - alpha`` of them? The answer is an order statistic of conformity scores, and
+this package keeps that answer -- and the score constructions feeding it -- in one
+place, so bands cannot drift apart between estimators.
+
+Contents:
+
+* :mod:`.quantile` -- :func:`split_conformal_quantile`, the finite-sample order
+  statistic every band is calibrated by.
+* :mod:`.scores` -- conformity-score constructions. Currently
+  :func:`rolling_origin_block_sums`, the out-of-sample cumulative errors a
+  cumulative band needs.
+* :mod:`.cumulative` -- the band for a cumulative (total) effect:
+  :func:`cumulative_conformal_interval` (pure combiner) and
+  :func:`cumulative_conformal_from_refit` (single-treated-unit convenience).
+* :mod:`.structure` -- :class:`CumulativeConformalBand`.
+
+References
+----------
+Chernozhukov, V., Wuthrich, K., & Zhu, Y. (2021). An Exact and Robust Conformal
+Inference Method for Counterfactual and Synthetic Controls. Journal of the
+American Statistical Association, 116(536), 1849-1864.
+"""
+
+from __future__ import annotations
+
+from .cumulative import cumulative_conformal_from_refit, cumulative_conformal_interval
+from .quantile import split_conformal_quantile
+from .scores import rolling_origin_block_sums
+from .structure import CumulativeConformalBand
+
+__all__ = [
+    "CumulativeConformalBand",
+    "cumulative_conformal_from_refit",
+    "cumulative_conformal_interval",
+    "rolling_origin_block_sums",
+    "split_conformal_quantile",
+]

--- a/mlsynth/utils/conformal/__init__.py
+++ b/mlsynth/utils/conformal/__init__.py
@@ -29,10 +29,11 @@ from __future__ import annotations
 
 from .cumulative import cumulative_conformal_from_refit, cumulative_conformal_interval
 from .quantile import split_conformal_quantile
-from .scores import rolling_origin_block_sums
+from .scores import MIN_TRAIN_PERIODS, rolling_origin_block_sums
 from .structure import CumulativeConformalBand
 
 __all__ = [
+    "MIN_TRAIN_PERIODS",
     "CumulativeConformalBand",
     "cumulative_conformal_from_refit",
     "cumulative_conformal_interval",

--- a/mlsynth/utils/conformal/cumulative.py
+++ b/mlsynth/utils/conformal/cumulative.py
@@ -106,7 +106,7 @@ def cumulative_conformal_from_refit(
     Y0: np.ndarray,
     pre_periods: int,
     horizon: int,
-    weight_fn: Callable[[np.ndarray, np.ndarray], np.ndarray],
+    weight_fn: Callable[[np.ndarray], np.ndarray],
     *,
     alpha: float = 0.1,
     min_train_frac: float = 0.3,
@@ -127,7 +127,9 @@ def cumulative_conformal_from_refit(
     horizon : int
         Number of post-periods to accumulate, ``L``.
     weight_fn : callable
-        ``weight_fn(y_train, Y0_train) -> w``; the estimator's own refit.
+        ``weight_fn(keep_idx) -> w``; the estimator's own refit on the periods
+        indexed by ``keep_idx`` (indices, not slices, so covariates can be subset
+        by the same periods).
     alpha : float, optional
         Target miscoverage (default ``0.1``).
     min_train_frac : float, optional
@@ -171,7 +173,7 @@ def cumulative_conformal_from_refit(
             f"sample ({y.shape[0]} periods); there is no full post-window to accumulate."
         )
 
-    w_full = np.asarray(weight_fn(y[:pre_periods], Y0[:pre_periods]), dtype=float).ravel()
+    w_full = np.asarray(weight_fn(np.arange(pre_periods)), dtype=float).ravel()
     post = slice(pre_periods, pre_periods + horizon)
     point = float(np.sum(y[post] - Y0[post] @ w_full))
 

--- a/mlsynth/utils/conformal/cumulative.py
+++ b/mlsynth/utils/conformal/cumulative.py
@@ -1,0 +1,189 @@
+"""Conformal interval for the cumulative (total) treatment effect.
+
+mlsynth reports the cumulative effect ``C = sum_k (y_{T0+k} - synthetic_{T0+k})``
+as a point estimate. This module gives it a band calibrated *for the sum*: the
+half-width comes from conformity scores that are themselves cumulative errors over
+windows of the same length, so the accumulation of period-to-period dependence is
+measured rather than assumed.
+
+Two entry points:
+
+* :func:`cumulative_conformal_interval` -- the pure combiner. Given a point
+  estimate and a vector of conformity scores, it centres the scores and returns
+  the band. Callers with their own scoring pass (a pooled multi-unit refit, say)
+  use this directly.
+* :func:`cumulative_conformal_from_refit` -- the single-treated-unit convenience:
+  builds rolling-origin scores via
+  :func:`~mlsynth.utils.conformal.scores.rolling_origin_block_sums`, then combines.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+from .quantile import split_conformal_quantile
+from .scores import rolling_origin_block_sums
+from .structure import CumulativeConformalBand
+
+
+def _validate_alpha(alpha) -> float:
+    if isinstance(alpha, bool) or not isinstance(alpha, (int, float, np.floating, np.integer)):
+        raise MlsynthConfigError(f"alpha must be a number in (0, 1); got {alpha!r}.")
+    if not 0.0 < float(alpha) < 1.0:
+        raise MlsynthConfigError(f"alpha must lie in the open interval (0, 1); got {alpha!r}.")
+    return float(alpha)
+
+
+def _validate_positive_int(value, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise MlsynthConfigError(f"{name} must be a positive integer; got {value!r}.")
+    if int(value) < 1:
+        raise MlsynthConfigError(f"{name} must be a positive integer; got {value!r}.")
+    return int(value)
+
+
+def cumulative_conformal_interval(
+    point: float,
+    scores: np.ndarray,
+    *,
+    alpha: float = 0.1,
+    horizon: int = 0,
+) -> CumulativeConformalBand:
+    """Combine a cumulative point estimate with conformity scores into a band.
+
+    The scores are centred before the order statistic is taken, so a systematic
+    offset in the calibration windows widens nothing: the band measures spread
+    about the typical cumulative error, not distance from zero.
+
+    Parameters
+    ----------
+    point : float
+        Cumulative effect estimate over the horizon.
+    scores : array-like, shape ``(m,)``
+        Conformity scores -- cumulative out-of-sample errors over calibration
+        windows of the same length as the horizon.
+    alpha : float, optional
+        Target miscoverage (default ``0.1``, a 90% band).
+    horizon : int, optional
+        Horizon the point estimate accumulates, recorded on the band.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``alpha`` is not in ``(0, 1)``.
+    MlsynthDataError
+        If ``scores`` is empty or contains non-finite values.
+    """
+    alpha = _validate_alpha(alpha)
+    s = np.asarray(scores, dtype=float).ravel()
+    if s.size == 0:
+        raise MlsynthDataError(
+            "cumulative conformal inference needs at least one conformity score; "
+            "got an empty score vector."
+        )
+    if not np.all(np.isfinite(s)):
+        raise MlsynthDataError(
+            "conformity scores must all be finite; got "
+            f"{int((~np.isfinite(s)).sum())} non-finite value(s)."
+        )
+    half = float(split_conformal_quantile(s - s.mean(), alpha=alpha))
+    return CumulativeConformalBand(
+        point=float(point),
+        lower=float(point) - half,
+        upper=float(point) + half,
+        half_width=half,
+        n_scores=int(s.size),
+        alpha=alpha,
+        horizon=int(horizon),
+    )
+
+
+def cumulative_conformal_from_refit(
+    y: np.ndarray,
+    Y0: np.ndarray,
+    pre_periods: int,
+    horizon: int,
+    weight_fn: Callable[[np.ndarray, np.ndarray], np.ndarray],
+    *,
+    alpha: float = 0.1,
+    min_train_frac: float = 0.3,
+) -> CumulativeConformalBand:
+    """Cumulative conformal band for one treated unit, calibrated by refitting.
+
+    Fits the control on the full pre-period for the point estimate, then calibrates
+    by refitting at sliding non-overlapping origins within the pre-period.
+
+    Parameters
+    ----------
+    y : array-like, shape ``(T,)``
+        Treated-unit outcome over the full sample.
+    Y0 : array-like, shape ``(T, J)``
+        Donor outcomes aligned to ``y``.
+    pre_periods : int
+        Number of pre-treatment periods ``T0``.
+    horizon : int
+        Number of post-periods to accumulate, ``L``.
+    weight_fn : callable
+        ``weight_fn(y_train, Y0_train) -> w``; the estimator's own refit.
+    alpha : float, optional
+        Target miscoverage (default ``0.1``).
+    min_train_frac : float, optional
+        Earliest calibration origin as a fraction of ``T0`` (default ``0.3``).
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``alpha``, ``horizon``, ``pre_periods`` or ``min_train_frac`` is invalid.
+    MlsynthDataError
+        If ``Y0`` is not two-dimensional, its rows do not match ``y``, or the
+        horizon runs past the end of the sample.
+    """
+    alpha = _validate_alpha(alpha)
+    horizon = _validate_positive_int(horizon, "horizon")
+    pre_periods = _validate_positive_int(pre_periods, "pre_periods")
+    if isinstance(min_train_frac, bool) or not isinstance(
+        min_train_frac, (int, float, np.floating, np.integer)
+    ):
+        raise MlsynthConfigError(
+            f"min_train_frac must be a number in (0, 1); got {min_train_frac!r}."
+        )
+    if not 0.0 < float(min_train_frac) < 1.0:
+        raise MlsynthConfigError(
+            f"min_train_frac must lie in the open interval (0, 1); got {min_train_frac!r}."
+        )
+
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    if Y0.ndim != 2:
+        raise MlsynthDataError(
+            f"Y0 must be a two-dimensional donor matrix (T x J); got {Y0.ndim} dimension(s)."
+        )
+    if Y0.shape[0] != y.shape[0]:
+        raise MlsynthDataError(
+            f"y has {y.shape[0]} periods but Y0 has {Y0.shape[0]} rows; they must match."
+        )
+    if pre_periods + horizon > y.shape[0]:
+        raise MlsynthDataError(
+            f"pre_periods + horizon ({pre_periods} + {horizon}) runs past the end of the "
+            f"sample ({y.shape[0]} periods); there is no full post-window to accumulate."
+        )
+
+    w_full = np.asarray(weight_fn(y[:pre_periods], Y0[:pre_periods]), dtype=float).ravel()
+    post = slice(pre_periods, pre_periods + horizon)
+    point = float(np.sum(y[post] - Y0[post] @ w_full))
+
+    scores = rolling_origin_block_sums(
+        y, Y0, pre_periods, horizon, weight_fn, min_train_frac=float(min_train_frac)
+    )
+    if scores.size == 0:
+        # A valid configuration can still leave no room for a calibration window
+        # (a late first origin, or a horizon nearly as long as the pre-period).
+        # That is a statement about the sample, not a caller error.
+        return CumulativeConformalBand(
+            point=point, lower=-np.inf, upper=np.inf, half_width=float("inf"),
+            n_scores=0, alpha=alpha, horizon=horizon,
+        )
+    return cumulative_conformal_interval(point, scores, alpha=alpha, horizon=horizon)

--- a/mlsynth/utils/conformal/quantile.py
+++ b/mlsynth/utils/conformal/quantile.py
@@ -1,0 +1,43 @@
+"""The split-conformal order statistic -- the one calibration primitive.
+
+Every conformal band in mlsynth ultimately asks the same question of a set of
+conformity scores: how far out must the band reach to cover ``1 - alpha`` of them
+in finite samples? That is one order statistic, and it lives here so the answer
+cannot drift between estimators.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def split_conformal_quantile(residuals, alpha: float = 0.05) -> float:
+    r"""Split-conformal prediction-band half-width (Chernozhukov, Wuthrich & Zhu 2021).
+
+    Returns ``q``, the constant half-width of the symmetric prediction band
+    ``counterfactual +/- q``: the ``ceil((n+1)(1-alpha))``-th order statistic of
+    the absolute pre-period residuals (gaps). Under exchangeability of the
+    residuals this band has finite-sample :math:`(1-\alpha)` coverage. When
+    ``n < ceil(1/alpha) - 1`` the required order statistic does not exist and
+    ``q`` is ``+inf`` (an uninformative band).
+
+    This is the constant-width "split" construction used by R ``Synth``'s
+    ``synth_inference(method = "conformal")`` (Hainmueller's j-hai/Synth), as
+    distinct from the test-inversion conformal band (which widens over the
+    post-period).
+
+    Parameters
+    ----------
+    residuals : array-like
+        Conformity scores -- classically the pre-treatment gaps (treated minus
+        synthetic), one per pre-period; for a cumulative band, the centred
+        out-of-sample block sums.
+    alpha : float
+        Miscoverage level in ``(0, 1)``; the band targets ``1 - alpha`` coverage.
+    """
+    r = np.sort(np.abs(np.asarray(residuals, dtype=float)))
+    n = r.size
+    if n == 0:
+        return float("inf")
+    k = int(np.ceil((n + 1) * (1.0 - alpha)))
+    return float(r[k - 1]) if k <= n else float("inf")

--- a/mlsynth/utils/conformal/scores.py
+++ b/mlsynth/utils/conformal/scores.py
@@ -24,7 +24,7 @@ def rolling_origin_block_sums(
     Y0: np.ndarray,
     pre_periods: int,
     horizon: int,
-    weight_fn: Callable[[np.ndarray, np.ndarray], np.ndarray],
+    weight_fn: Callable[[np.ndarray], np.ndarray],
     *,
     min_train_frac: float = 0.3,
 ) -> np.ndarray:
@@ -41,8 +41,11 @@ def rolling_origin_block_sums(
     horizon : int
         Window length ``L`` -- both the block length and the origin stride.
     weight_fn : callable
-        ``weight_fn(y_train, Y0_train) -> w``, the estimator's own refit on a
-        pre-period prefix. Called once per origin.
+        ``weight_fn(keep_idx) -> w``, the estimator's own refit on the periods
+        indexed by ``keep_idx``. Called once per origin. Indices rather than
+        sliced arrays, matching :func:`~mlsynth.utils.inferutils.debiased_sc_ttest`:
+        an estimator with covariates has to subset those by the same periods, and
+        only the caller knows how.
     min_train_frac : float, optional
         Earliest origin as a fraction of ``T0``, so the first refits have enough
         training data (default ``0.3``).
@@ -63,7 +66,7 @@ def rolling_origin_block_sums(
     start = max(int(horizon), int(pre_periods * float(min_train_frac)))
     scores = []
     for origin in range(start, int(pre_periods) - int(horizon) + 1, int(horizon)):
-        w = np.asarray(weight_fn(y[:origin], Y0[:origin]), dtype=float).ravel()
+        w = np.asarray(weight_fn(np.arange(origin)), dtype=float).ravel()
         block = slice(origin, origin + int(horizon))
         scores.append(float(np.sum(y[block] - Y0[block] @ w)))
     return np.asarray(scores, dtype=float)

--- a/mlsynth/utils/conformal/scores.py
+++ b/mlsynth/utils/conformal/scores.py
@@ -18,6 +18,11 @@ from typing import Callable
 
 import numpy as np
 
+#: Shortest training block a calibration refit may use. A control fitted on a
+#: handful of periods interpolates them and predicts nothing, so the window it
+#: scores would report the fit's degeneracy rather than the method's error.
+MIN_TRAIN_PERIODS = 10
+
 
 def rolling_origin_block_sums(
     y: np.ndarray,
@@ -47,8 +52,9 @@ def rolling_origin_block_sums(
         an estimator with covariates has to subset those by the same periods, and
         only the caller knows how.
     min_train_frac : float, optional
-        Earliest origin as a fraction of ``T0``, so the first refits have enough
-        training data (default ``0.3``).
+        Earliest origin as a fraction of ``T0`` (default ``0.3``). The first
+        origin is ``max(MIN_TRAIN_PERIODS, T0 * min_train_frac)``, so short
+        panels still train on an absolute minimum of periods.
 
     Returns
     -------
@@ -63,7 +69,7 @@ def rolling_origin_block_sums(
     :func:`~mlsynth.utils.conformal.cumulative.cumulative_conformal_interval`
     directly; this helper is the single-treated-unit path.
     """
-    start = max(int(horizon), int(pre_periods * float(min_train_frac)))
+    start = max(MIN_TRAIN_PERIODS, int(pre_periods * float(min_train_frac)))
     scores = []
     for origin in range(start, int(pre_periods) - int(horizon) + 1, int(horizon)):
         w = np.asarray(weight_fn(np.arange(origin)), dtype=float).ravel()

--- a/mlsynth/utils/conformal/scores.py
+++ b/mlsynth/utils/conformal/scores.py
@@ -1,0 +1,69 @@
+"""Conformity scores for a cumulative effect: rolling-origin out-of-sample block sums.
+
+A cumulative band needs scores on the *sum* over an ``L``-period window, and those
+scores have to be honest about the fit. Scoring a window the control was fitted on
+understates the error (the fit already chased that window); rescaling a per-period
+band by ``L`` assumes the periods accumulate independently. Both distort the sum.
+
+The construction here does neither. It slides an origin across the pre-period and,
+at each origin, refits the control on the data strictly before it and reads the
+next ``L`` periods -- a genuine out-of-sample window of exactly the length the
+band is for. Origins step by ``L``, so the windows do not overlap and the scores
+stay exchangeable.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+
+
+def rolling_origin_block_sums(
+    y: np.ndarray,
+    Y0: np.ndarray,
+    pre_periods: int,
+    horizon: int,
+    weight_fn: Callable[[np.ndarray, np.ndarray], np.ndarray],
+    *,
+    min_train_frac: float = 0.3,
+) -> np.ndarray:
+    """Out-of-sample cumulative errors over non-overlapping pre-period windows.
+
+    Parameters
+    ----------
+    y : np.ndarray, shape ``(T,)``
+        Treated-unit outcome over the full sample.
+    Y0 : np.ndarray, shape ``(T, J)``
+        Donor outcomes aligned to ``y``.
+    pre_periods : int
+        Number of pre-treatment periods ``T0``; origins are drawn from within it.
+    horizon : int
+        Window length ``L`` -- both the block length and the origin stride.
+    weight_fn : callable
+        ``weight_fn(y_train, Y0_train) -> w``, the estimator's own refit on a
+        pre-period prefix. Called once per origin.
+    min_train_frac : float, optional
+        Earliest origin as a fraction of ``T0``, so the first refits have enough
+        training data (default ``0.3``).
+
+    Returns
+    -------
+    np.ndarray, shape ``(m,)``
+        One cumulative out-of-sample error per origin. Empty when the pre-period
+        admits no origin.
+
+    Notes
+    -----
+    Callers whose refit produces several treated units at once (a pooled fit) can
+    build their own score vector per unit from a single pass and hand it to
+    :func:`~mlsynth.utils.conformal.cumulative.cumulative_conformal_interval`
+    directly; this helper is the single-treated-unit path.
+    """
+    start = max(int(horizon), int(pre_periods * float(min_train_frac)))
+    scores = []
+    for origin in range(start, int(pre_periods) - int(horizon) + 1, int(horizon)):
+        w = np.asarray(weight_fn(y[:origin], Y0[:origin]), dtype=float).ravel()
+        block = slice(origin, origin + int(horizon))
+        scores.append(float(np.sum(y[block] - Y0[block] @ w)))
+    return np.asarray(scores, dtype=float)

--- a/mlsynth/utils/conformal/structure.py
+++ b/mlsynth/utils/conformal/structure.py
@@ -1,0 +1,50 @@
+"""Frozen containers for conformal prediction bands.
+
+References
+----------
+Chernozhukov, V., Wuthrich, K., & Zhu, Y. (2021). An Exact and Robust Conformal
+Inference Method for Counterfactual and Synthetic Controls. Journal of the
+American Statistical Association, 116(536), 1849-1864.
+https://doi.org/10.1080/01621459.2021.1920957
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CumulativeConformalBand:
+    """Conformal band for a cumulative (summed-over-horizon) treatment effect.
+
+    The band is symmetric: ``[point - half_width, point + half_width]``. When the
+    calibration set is too small for the ``ceil((m + 1)(1 - alpha))``-th order
+    statistic to exist, ``half_width`` is ``+inf`` and the endpoints are infinite --
+    an honest statement that the requested level is unreachable at this sample
+    size, rather than a silently under-covering guess.
+
+    Parameters
+    ----------
+    point : float
+        Cumulative effect estimate, ``sum_k (y_{T0+k} - synthetic_{T0+k})`` over
+        the horizon.
+    lower, upper : float
+        Band endpoints, ``point -/+ half_width``.
+    half_width : float
+        Split-conformal half-width of the centred conformity scores.
+    n_scores : int
+        Number of conformity scores (calibration blocks) the band was built from.
+    alpha : float
+        Target miscoverage level; the band targets ``1 - alpha`` coverage.
+    horizon : int
+        Number of post-treatment periods accumulated. ``0`` when the band was
+        built from precomputed scores by the caller.
+    """
+
+    point: float
+    lower: float
+    upper: float
+    half_width: float
+    n_scores: int
+    alpha: float
+    horizon: int = 0

--- a/mlsynth/utils/inferutils.py
+++ b/mlsynth/utils/inferutils.py
@@ -59,34 +59,10 @@ def _outcome_only_simplex(y: np.ndarray, Y0: np.ndarray) -> np.ndarray:
     return np.asarray(w.value).ravel()
 
 
-def split_conformal_quantile(residuals, alpha: float = 0.05) -> float:
-    r"""Split-conformal prediction-band half-width (Chernozhukov, Wuthrich & Zhu 2021).
-
-    Returns ``q``, the constant half-width of the symmetric prediction band
-    ``counterfactual +/- q``: the ``ceil((n+1)(1-alpha))``-th order statistic of
-    the absolute pre-period residuals (gaps). Under exchangeability of the
-    residuals this band has finite-sample :math:`(1-\alpha)` coverage. When
-    ``n < ceil(1/alpha) - 1`` the required order statistic does not exist and
-    ``q`` is ``+inf`` (an uninformative band).
-
-    This is the constant-width "split" construction used by R ``Synth``'s
-    ``synth_inference(method = "conformal")`` (Hainmueller's j-hai/Synth), as
-    distinct from the test-inversion conformal band (which widens over the
-    post-period).
-
-    Parameters
-    ----------
-    residuals : array-like
-        Pre-treatment gaps (treated minus synthetic), one per pre-period.
-    alpha : float
-        Miscoverage level in ``(0, 1)``; the band targets ``1 - alpha`` coverage.
-    """
-    r = np.sort(np.abs(np.asarray(residuals, dtype=float)))
-    n = r.size
-    if n == 0:
-        return float("inf")
-    k = int(np.ceil((n + 1) * (1.0 - alpha)))
-    return float(r[k - 1]) if k <= n else float("inf")
+# ``split_conformal_quantile`` now lives with the rest of the conformal machinery
+# in :mod:`mlsynth.utils.conformal`; re-exported here so existing imports keep
+# working.
+from .conformal.quantile import split_conformal_quantile  # noqa: E402,F401
 
 
 def debiased_sc_ttest(

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -21,8 +21,8 @@ from ...config_models import BaseEstimatorConfig
 # source of truth so an unknown/misspelled value fails loudly at config time
 # rather than silently returning no inference.
 VALID_INFERENCE_METHODS = frozenset(
-    {"placebo", "scpi", "conformal", "conformal_split", "lto", "ttest", "eiv",
-     "jackknife_plus", "none"}
+    {"placebo", "scpi", "conformal", "conformal_split", "conformal_cumulative",
+     "lto", "ttest", "eiv", "jackknife_plus", "none"}
 )
 
 #: Spellings normalised onto a canonical method name. ``augsynth`` writes
@@ -381,6 +381,26 @@ class VanillaSCConfig(BaseEstimatorConfig):
                     "Sec 3.2. K=3 is the small-T0 benchmark; larger K tightens "
                     "the interval.",
     )
+
+    conformal_horizon: Optional[int] = Field(
+        default=None,
+        description="Post-periods to accumulate for inference="
+                    "'conformal_cumulative'. The band is for the SUM of the "
+                    "effect over this many periods, calibrated on out-of-sample "
+                    "windows of the same length. None (default) accumulates the "
+                    "whole post-period, the total effect of the intervention. A "
+                    "long horizon leaves few non-overlapping calibration windows "
+                    "in the pre-period, and the band widens accordingly.",
+    )
+
+    @field_validator("conformal_horizon")
+    @classmethod
+    def _validate_conformal_horizon(cls, v):
+        if v is None:
+            return v
+        if isinstance(v, bool) or not isinstance(v, int) or v < 1:
+            raise ValueError("conformal_horizon must be an integer >= 1 or None.")
+        return v
 
     @field_validator("ttest_K")
     @classmethod

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -615,31 +615,34 @@ def run_vanillasc(config) -> BaseEstimatorResults:
     # Debiased SC t-test for the ATT (Chernozhukov, Wuthrich & Zhu 2025).
     # The cross-fit refits the configured backend on each block-complement of
     # the pre-period; inferutils owns the blocking, rescale, and t_{K-1} CI.
+    # Refitting on a subset of the periods is how two modes recalibrate: the
+    # debiased t-test drops folds, the cumulative conformal band rolls an origin.
+    # One closure serves both so they cannot drift apart.
+    if oracle_w is not None:
+        # Oracle case: known weights, no per-fold refit (skip the solve).
+        def _refit_weight_fn(keep_idx):
+            return oracle_w
+    else:
+        def _refit_weight_fn(keep_idx):
+            keep_idx = np.asarray(keep_idx)
+            yk, Y0k = y[keep_idx], Y0[keep_idx]
+            X1k = X0k = None
+            if covariates:
+                kept_labels = list(time_labels[keep_idx])
+                Xk = _scale_unit_variance(_covariate_means(
+                    config.df, list(units.labels), covariates, windows,
+                    kept_labels, config.unitid, config.time))
+                X1k, X0k = Xk[:, 0], Xk[:, 1:]
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                rk = engine.fit(yk, Y0k, X1=X1k, X0=X0k,
+                                donor_names=donor_names, predictor_names=pred_names)
+            return np.asarray(rk.W, dtype=float).ravel()
+
     if mode == "ttest" and gap[pre:].size:
         from scipy.stats import t as _tdist
 
         from mlsynth.utils.inferutils import debiased_sc_ttest, select_K
-
-        if oracle_w is not None:
-            # Oracle case: known weights, no per-fold refit (skip the solve).
-            def _ttest_weight_fn(keep_idx):
-                return oracle_w
-        else:
-            def _ttest_weight_fn(keep_idx):
-                keep_idx = np.asarray(keep_idx)
-                yk, Y0k = y[keep_idx], Y0[keep_idx]
-                X1k = X0k = None
-                if covariates:
-                    kept_labels = list(time_labels[keep_idx])
-                    Xk = _scale_unit_variance(_covariate_means(
-                        config.df, list(units.labels), covariates, windows,
-                        kept_labels, config.unitid, config.time))
-                    X1k, X0k = Xk[:, 0], Xk[:, 1:]
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore")
-                    rk = engine.fit(yk, Y0k, X1=X1k, X0=X0k,
-                                    donor_names=donor_names, predictor_names=pred_names)
-                return np.asarray(rk.W, dtype=float).ravel()
 
         T1_post = int(len(y) - pre)
         if config.ttest_K == "auto":
@@ -648,7 +651,7 @@ def run_vanillasc(config) -> BaseEstimatorResults:
             K_used, k_info = int(config.ttest_K), None
         tt = debiased_sc_ttest(
             y, Y0, T0=pre, T1=T1_post, K=K_used,
-            alpha=config.alpha, weight_fn=_ttest_weight_fn,
+            alpha=config.alpha, weight_fn=_refit_weight_fn,
         )
         p_val = float(2.0 * _tdist.sf(abs(tt["tstat"]), tt["dof"]))
         inference = InferenceResults(
@@ -664,6 +667,49 @@ def run_vanillasc(config) -> BaseEstimatorResults:
                 "alpha": tt["alpha"],
                 "K_auto": config.ttest_K == "auto",
                 "rho_hat": (k_info["rho_hat"] if k_info else None),
+            },
+        )
+
+    # Cumulative-effect conformal band: the interval for the SUM of the effect
+    # over the horizon, calibrated on out-of-sample windows of the same length so
+    # the way period-to-period errors accumulate is measured, not assumed.
+    if mode == "conformal_cumulative" and gap[pre:].size:
+        from mlsynth.utils.conformal import cumulative_conformal_from_refit
+
+        T1_post = int(len(y) - pre)
+        horizon = int(config.conformal_horizon or T1_post)
+        band = cumulative_conformal_from_refit(
+            y, Y0, pre_periods=int(pre), horizon=horizon,
+            weight_fn=_refit_weight_fn, alpha=config.alpha,
+        )
+        if not np.isfinite(band.half_width):
+            warnings.warn(
+                "cumulative conformal band is uninformative (half-width=inf): "
+                f"{band.n_scores} non-overlapping calibration window(s) of length "
+                f"{horizon} fit in the pre-period, but finite-sample coverage at "
+                f"alpha={config.alpha} needs at least "
+                f"{int(np.ceil(1.0 / config.alpha)) - 1}. Shorten "
+                "conformal_horizon or extend the pre-period.",
+                UserWarning, stacklevel=2,
+            )
+        # Dividing the band by the horizon gives the per-period mean over the same
+        # window; that is the ATT only when the horizon spans the whole post-period,
+        # so a partial window reports the cumulative figure alone.
+        spans_post = horizon == T1_post
+        inference = InferenceResults(
+            ci_lower=(band.lower / horizon) if spans_post else None,
+            ci_upper=(band.upper / horizon) if spans_post else None,
+            confidence_level=1.0 - config.alpha,
+            method="split-conformal cumulative-effect band (rolling origin)",
+            details={
+                "cumulative_effect": band.point,
+                "cumulative_lower": band.lower,
+                "cumulative_upper": band.upper,
+                "conformal_q": band.half_width,
+                "n_calibration_windows": band.n_scores,
+                "horizon": horizon,
+                "spans_post_period": spans_post,
+                "alpha": band.alpha,
             },
         )
 

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -537,8 +537,8 @@ timeout = 180.0
 
   [[target.mutant]]
   id = "calibration-refit-sees-its-own-block"
-  find = "w = np.asarray(weight_fn(y[:origin], Y0[:origin]), dtype=float).ravel()"
-  replace = "w = np.asarray(weight_fn(y[:origin + int(horizon)], Y0[:origin + int(horizon)]), dtype=float).ravel()"
+  find = "w = np.asarray(weight_fn(np.arange(origin)), dtype=float).ravel()"
+  replace = "w = np.asarray(weight_fn(np.arange(origin + int(horizon))), dtype=float).ravel()"
   models = "fitting each calibration refit on data that includes the very block it is about to score, so the conformity scores measure in-sample fit rather than prediction error and the band comes out too narrow"
 
 [[target]]

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -516,3 +516,51 @@ timeout = 600.0
   find = "_GRID_EPS = 1e-6"
   replace = "_GRID_EPS = 1e-2"
   models = "the ranking tolerance relaxed past the point where the sweep can order its candidates, which is the shape a tolerance takes when it is widened for speed without checking what it costs. Every solve still returns a finite beta and the fit still looks ordinary; what breaks is the ordering, and with it the tau the caller is handed -- across the four Hong Kong windows it moves the winner on three and the validation errors by 0.32 to 4.99 relative, against 3.9e-3 at the shipped value"
+
+[[target]]
+name = "conformal-cumulative-scores"
+module-path = "mlsynth/utils/conformal/scores.py"
+test-command = "python -m pytest mlsynth/tests/test_conformal_cumulative.py mlsynth/tests/test_conformal_cumulative_properties.py -q -p no:cacheprovider"
+timeout = 180.0
+
+  [[target.mutant]]
+  id = "overlapping-calibration-origins"
+  find = "for origin in range(start, int(pre_periods) - int(horizon) + 1, int(horizon)):"
+  replace = "for origin in range(start, int(pre_periods) - int(horizon) + 1, 1):"
+  models = "sliding the calibration origin one period at a time instead of one window at a time, so consecutive blocks share periods; the scores stop being exchangeable and the band is calibrated on a correlated, artificially large calibration set"
+
+  [[target.mutant]]
+  id = "scores-average-instead-of-accumulate"
+  find = "scores.append(float(np.sum(y[block] - Y0[block] @ w)))"
+  replace = "scores.append(float(np.mean(y[block] - Y0[block] @ w)))"
+  models = "scoring the per-period average error rather than the accumulated error, so the band is calibrated for the wrong estimand -- the defect that makes a per-period interval rescaled by the horizon look like a cumulative one"
+
+  [[target.mutant]]
+  id = "calibration-refit-sees-its-own-block"
+  find = "w = np.asarray(weight_fn(y[:origin], Y0[:origin]), dtype=float).ravel()"
+  replace = "w = np.asarray(weight_fn(y[:origin + int(horizon)], Y0[:origin + int(horizon)]), dtype=float).ravel()"
+  models = "fitting each calibration refit on data that includes the very block it is about to score, so the conformity scores measure in-sample fit rather than prediction error and the band comes out too narrow"
+
+[[target]]
+name = "conformal-cumulative-band"
+module-path = "mlsynth/utils/conformal/cumulative.py"
+test-command = "python -m pytest mlsynth/tests/test_conformal_cumulative.py mlsynth/tests/test_conformal_cumulative_properties.py -q -p no:cacheprovider"
+timeout = 180.0
+
+  [[target.mutant]]
+  id = "uncentred-conformity-scores"
+  find = "half = float(split_conformal_quantile(s - s.mean(), alpha=alpha))"
+  replace = "half = float(split_conformal_quantile(s, alpha=alpha))"
+  models = "calibrating on raw rather than centred scores, so a systematic offset in the calibration windows is read as spread and inflates the band"
+
+[[target]]
+name = "conformal-quantile"
+module-path = "mlsynth/utils/conformal/quantile.py"
+test-command = "python -m pytest mlsynth/tests/test_conformal_cumulative.py mlsynth/tests/test_conformal_cumulative_properties.py -q -p no:cacheprovider"
+timeout = 180.0
+
+  [[target.mutant]]
+  id = "naive-quantile-instead-of-finite-sample-order-statistic"
+  find = "k = int(np.ceil((n + 1) * (1.0 - alpha)))"
+  replace = "k = int(np.ceil(n * (1.0 - alpha)))"
+  models = "the plug-in sample quantile in place of the finite-sample split-conformal order statistic, which under-covers at small calibration sizes and silently returns a finite band where the requested level is in fact unreachable"


### PR DESCRIPTION
## Related Links

- Follow-up this sets up: #430 (PPSCM as the package's second consumer)
- Docs: `docs/vanillasc.rst`, the `"conformal_cumulative"` section
- Source: Chernozhukov, Wüthrich & Zhu (2021), *JASA* 116(536), 1849-1864,
  [doi:10.1080/01621459.2021.1920957](https://doi.org/10.1080/01621459.2021.1920957)
  — the same split-conformal order statistic `conformal_split` already uses, applied
  to block sums instead of single periods

## What

- Added `mlsynth/utils/conformal/`, collecting the conformal machinery into one
  package following `utils/bilevel/`: `quantile.py` (holds `split_conformal_quantile`,
  moved out of `inferutils.py`, which re-exports it), `scores.py`, `cumulative.py`,
  `structure.py`, and a documented `__init__`.
- Added `inference="conformal_cumulative"` on VanillaSC, with a `conformal_horizon`
  config field.
- Refactored VanillaSC's per-fold refit closure: defined once and shared with
  `inference="ttest"`, and taking period indices rather than sliced arrays.

## Why

mlsynth reports the cumulative effect as a point estimate (`effectutils.total_effect`,
`post_fit.total_effect`) but has no interval calibrated for it. The one existing
"total" band, in `fast_scm_helpers/inference.py`, is the per-period ATE interval
multiplied by `n_post * n_treated` — no conformity score is ever formed on the sum.

That matters because an interval for a running total is not the running total of the
per-period intervals. Summing endpoints assumes the period errors move in lockstep, so
the width grows with the number of periods instead of with its square root; rescaling
one period's interval assumes the opposite. Which is right depends on how the errors
accumulate, and neither assumption measures it.

The second reason is the package. Conformal inference currently appears in 14 files
with one shared primitive between them, and that primitive had a single caller. Bands
that should be the same construction have drifted apart. Collecting the calibration in
one place is what lets the next estimator reuse it instead of writing a third variant —
which is exactly what #430 does.

## How

The band is `C_hat ± q`, where `q` is calibrated on conformity scores that are
themselves cumulative errors over windows of the same length as the horizon. Scores
come from refitting at sliding origins across the pre-period: each refit sees only data
strictly before its origin, so the score carries no in-sample optimism, and origins step
by a whole horizon, so the windows do not overlap and the scores stay exchangeable.
`q` is then the existing `split_conformal_quantile` of the centred scores.

Two entry points, because the two consumers score differently. `cumulative_conformal_from_refit`
is the single-treated-unit convenience; `cumulative_conformal_interval` is a pure
combiner taking precomputed scores, for an estimator whose pooled refit produces several
units at once. The refit callback takes period indices rather than sliced arrays,
matching `debiased_sc_ttest`, because a covariate-aware refit has to subset its
covariates by the same periods and only the caller knows how — which is also why the
t-test's existing closure could be hoisted and shared rather than duplicated.

Rejected alternatives, both measured rather than assumed:

- Rescaling a per-period band by the horizon. This is the existing "total lift"
  approach; it is calibrated for the average, not the sum.
- SCPI with the constraint-correct in-sample bound. mlsynth's `scpi_intervals` already
  supports the full constraint family, and choosing `L1-L2` over the unconstrained
  `ols` bound is a large improvement (roughly 8.7x too wide down to 2.0x). But it still
  over-covers by about 2x, because SCPI adds two conservative bounds. Valid, and the
  right choice when a coverage floor matters more than width, but not calibrated.

## Verification

Path: not a paper-replication change — this is a construction mlsynth did not have, so
there is no published number to match. Validated three ways instead:

- **Against the shared primitive.** The half-width is asserted equal to
  `split_conformal_quantile` of the centred scores, and the scores are separately pinned
  against a hand-computed expectation that does not call the helper — so a defect cannot
  hide behind a circular reconstruction.
- **Against the moved primitive's old behaviour.** `split_conformal_quantile` is pinned
  value-for-value after the move, and `from mlsynth.utils.inferutils import
  split_conformal_quantile` is asserted to resolve to the same object, so the existing
  `conformal_split` caller and its cross-validation against R `Synth` are unaffected.
  Its 7 tests pass unchanged.
- **Coverage in simulation.** On a null factor DGP at realistic scale (60 donors, 104
  pre-periods, L=8, AR(1) errors), the construction exits at 0.100 against a 0.10 target
  where the plug-in sample quantile exits at 0.233. The finite-sample order statistic is
  what closes that gap, and a mutant swapping it back is killed.

Not yet pinned durably: the coverage result above is from a scratch Monte Carlo, not a
committed benchmark case. Benchmark authoring is a separate workstream per `CLAUDE.md`,
and it should cover both estimators at once — noted in #430.

## Scope checks

<!-- FEATURE ON AN EXISTING ESTIMATOR -->
- [x] The default preserves existing behaviour exactly — the mode is opt-in via
      `inference=`, and nothing changes for any other value
- [x] Existing pinned benchmark values unchanged; the only shared code touched is the
      moved primitive, pinned value-for-value
- [x] A test pins that the default is unchanged — 296 passed / 1 skipped across the
      vanillasc and ttest suites, covering the hoisted closure
- [x] New config field has a `Field(...)` description saying when to reach for it

This is also a shared-helper refactor (the new package and the moved primitive), so the
first two bullets are read as covering both.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_conformal_cumulative.py -q` — 50 passed
- [x] `MLSYNTH_HYPOTHESIS_PROFILE=ci pytest mlsynth/tests/test_conformal_cumulative_properties.py -q` — 11 passed
- [x] `pytest mlsynth/tests/ -k "vanillasc or ttest"` — 296 passed, 1 skipped
- [x] `coverage run --timid -m pytest mlsynth/tests/test_conformal_cumulative.py && coverage report`
      — 100% of the new package, no `# pragma: no cover`
- [x] `python tools/mutation/run_mutants.py --target conformal-{cumulative-scores,cumulative-band,quantile}`
      — 5/5 killed
- [ ] `python benchmarks/run_benchmarks.py --all` — not run; no benchmark case is added
      by this PR

## Other Notes

The method costs pre-period, and the docs say so plainly because it decides usability:
non-overlapping windows are scarce, so a `1-alpha` band needs roughly
`T0 >= L / (alpha * (1 - min_train_frac))`. At `alpha=0.1`, 104 pre-periods support an
8-period horizon but not a 16-period one. When the windows run out the band is `±inf`
with a warning naming the shortfall, rather than a narrow band that does not cover — but
it does mean the default (accumulate the whole post-period) is uninformative on a panel
with a long post-period.

`min_train_frac` interacts with this: the first origin is
`max(MIN_TRAIN_PERIODS, T0 * min_train_frac)`, with an absolute floor of 10 periods so a
short panel cannot calibrate on refits that merely interpolate their training block. The
fraction stays at 0.30; 0.33 costs exactly one window at 104/8 and tips that case to
`±inf`.

Follow-ups, tracked in #430: PPSCM as the second consumer, and a durable coverage
benchmark for both. Migrating the other conformal implementations into the package is
worth doing one estimator at a time, each behaviour-preserving with the current output
pinned first — consolidating will surface discrepancies (the `fast_scm` total lift is
already one), so those are RCA candidates rather than clean refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKrMz8fQvjDNM1eur5kQ2V


---
_Generated by [Claude Code](https://claude.ai/code/session_01BKrMz8fQvjDNM1eur5kQ2V)_