### PR TITLE
Give each treated unit's cumulative effect a calibrated band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ now returns and the back-compat guarantee.
 ## [Unreleased]
 
 ### Added
+- `conformal_horizon` on `PPSCMConfig`: a conformal band on each treated unit's
+  CUMULATIVE effect, reported on `PPSCMUnitFit` as `cumulative_effect`,
+  `cumulative_lower`, `cumulative_upper` and `cumulative_windows`. PPSCM reported the
+  cumulative effect as a point estimate with no interval calibrated for it; its
+  per-unit bands carry only the CFPT out-of-sample term, and the in-sample bound
+  mlsynth ships assumes unconstrained weights where PPSCM's live on a simplex.
+  Calibration slides an origin across the pre-period and treats every unit as adopting
+  there: the partially-pooled fit produces all of them in one solve, so a pass costs
+  one solve per origin rather than one per unit per origin, and each unit's summed
+  out-of-sample error is one conformity score for it. The half-width is the shared
+  `conformal.cumulative_conformal_interval`, so the order statistic keeps a single
+  definition across estimators. The band is additional rather than a mode
+  (`inference_method` still selects the bootstrap or jackknife behind the ATT) and is
+  off unless the field is set. Too few non-overlapping windows for the requested level
+  gives an infinite band rather than one that does not cover.
+
+### Added
 - `inference="conformal_cumulative"` on `VanillaSC`: a prediction interval for the
   cumulative (total) treatment effect over `conformal_horizon` post-periods,
   defaulting to the whole post-period. mlsynth already reported the cumulative

--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -217,6 +217,46 @@ estimates are the deliverable.
    for label, uf in res.per_unit.items():  # per-unit estimates + in-sample error
        print(label, uf.att, uf.prefit_rmspe)
 
+The cumulative effect per unit
+------------------------------
+
+The per-unit bands above cover a unit's effect in a single period, or its average
+across the post-period. A different question is what a unit gained in *total*: the
+sum of its effects over the periods since adoption. Setting ``conformal_horizon``
+adds a band for that total to every ``per_unit`` entry::
+
+   res = PPSCM({..., "conformal_horizon": 8}).fit()
+   for label, uf in res.per_unit.items():
+       print(label, uf.cumulative_effect,
+             (uf.cumulative_lower, uf.cumulative_upper), uf.cumulative_windows)
+
+An interval for a running total is not the running total of the per-period
+intervals. Adding endpoints up treats the period errors as moving in lockstep, so the
+width grows with the number of periods rather than with its square root; rescaling a
+single period's interval by the horizon assumes the opposite. Which is right depends
+on how the errors accumulate, and neither assumption measures it.
+
+So the band measures it. An origin slides across the pre-period, and at each one every
+treated unit is treated as if it had adopted there: partially-pooled SCM fits them all
+in a single solve, so one pass yields each unit's summed error over the following
+window at the cost of one solve per origin, not one per unit per origin. Those sums are
+conformity scores for exactly the quantity being reported, and the half-width is the
+:math:`\lceil (m+1)(1-\alpha) \rceil`-th order statistic of the centred scores
+(:func:`mlsynth.utils.conformal.cumulative_conformal_interval`, shared with
+VanillaSC's ``inference="conformal_cumulative"``). Each fit sees only data before the
+window it scores, so the scores carry no in-sample optimism, and origins step by a
+whole horizon, so the windows do not overlap.
+
+Two things to note. The band is *additional*, not a mode: ``inference_method`` still
+chooses the bootstrap or jackknife behind the ATT, and leaving ``conformal_horizon``
+unset changes nothing. And it costs pre-period. Non-overlapping windows of length
+:math:`L` are scarce, so a :math:`1-\alpha` band needs at least
+:math:`\lceil 1/\alpha \rceil - 1` of them: roughly
+:math:`T_0 \gtrsim L/(0.7\,\alpha)` counting the training block held back at the
+start. When they run out, ``cumulative_lower``/``cumulative_upper`` are infinite and
+``cumulative_windows`` says how many were available, rather than a narrow band that
+does not cover.
+
 Empirical Illustration: mandatory collective bargaining
 -------------------------------------------------------
 

--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -30,7 +30,8 @@ from ..exceptions import (
 )
 from ..utils.ppscm_helpers.engine import run_multisynth
 from ..utils.ppscm_helpers.inference import (
-    jackknife_inference, bootstrap_inference, per_unit_intervals)
+    jackknife_inference, bootstrap_inference, per_unit_intervals,
+    cumulative_conformal_per_unit)
 from ..utils.ppscm_helpers.plotter import plot_ppscm
 from ..utils.ppscm_helpers.setup import prepare_ppscm_inputs
 from ..utils.ppscm_helpers.structures import (
@@ -89,6 +90,7 @@ class PPSCM:
         self.n_boot: int = config.n_boot
         self.seed: int = config.seed
         self.alpha: float = config.alpha
+        self.conformal_horizon = config.conformal_horizon
         self.covariates = config.covariates
 
         self.display_graphs: bool = config.display_graphs
@@ -184,6 +186,19 @@ class PPSCM:
             else:
                 nan = np.full(len(fit["groups"]), np.nan)
                 pu_lo, pu_hi, pu_p, pu_tlo, pu_thi = nan, nan, nan, None, None
+
+            # Per-unit band on the CUMULATIVE effect -- the total each unit gained.
+            # Additional to the pooled inference above, not a replacement for it, so
+            # it is off unless a horizon is asked for.
+            if self.conformal_horizon is not None:
+                cum_pt, cum_lo, cum_hi, cum_n = cumulative_conformal_per_unit(
+                    Xy, trt, d, n_leads, n_lags,
+                    fixedeff=self.fixedeff, time_cohort=self.time_cohort,
+                    nu_used=fit["nu_used"], lam=self.lam, solver=self.solver,
+                    alpha=self.alpha, horizon=int(self.conformal_horizon),
+                )
+            else:
+                cum_pt = cum_lo = cum_hi = cum_n = None
             per_unit: Dict[Any, PPSCMUnitFit] = {}
             for k, g in enumerate(fit["groups"]):
                 key = (str(inputs.time_labels[fit["adopt_of"][g]]) if self.time_cohort
@@ -206,6 +221,10 @@ class PPSCM:
                                if pu_tlo is not None else None),
                     tau_upper=(np.asarray(pu_thi[k], dtype=float)
                                if pu_thi is not None else None),
+                    cumulative_effect=(float(cum_pt[k]) if cum_pt is not None else None),
+                    cumulative_lower=(float(cum_lo[k]) if cum_lo is not None else None),
+                    cumulative_upper=(float(cum_hi[k]) if cum_hi is not None else None),
+                    cumulative_windows=(int(cum_n[k]) if cum_n is not None else None),
                 )
 
             results = PPSCMResults(

--- a/mlsynth/tests/test_ppscm_conformal_cumulative.py
+++ b/mlsynth/tests/test_ppscm_conformal_cumulative.py
@@ -175,3 +175,77 @@ def test_no_treated_units_raises_data_error():
     trt = np.full(trt.shape, np.inf)                 # nobody adopts
     with pytest.raises(MlsynthDataError):
         _call((Xy, trt))
+
+
+# ---------------------------------------------------------------------------
+# Wiring: PPSCM's ``conformal_horizon`` field
+# ---------------------------------------------------------------------------
+
+def _staggered_df(seed=0, adoption=(14, 18), n_donors=8, T=34, effect=-3.0, noise=0.4):
+    """Staggered panel with enough pre-period for several calibration windows."""
+    import pandas as pd
+    rng = np.random.default_rng(seed)
+    factors = rng.standard_normal((T, 2))
+    load_d = rng.standard_normal((n_donors, 2)) * 0.5
+    load_t = load_d.mean(axis=0)
+    rec = []
+    for j, Tj in enumerate(adoption):
+        series = factors @ (load_t + 0.1 * rng.standard_normal(2)) + rng.standard_normal(T) * noise
+        series[Tj:] += effect
+        rec += [{"unit": f"treated_{j}", "year": 2000 + t, "y": float(series[t]),
+                 "tr": int(t >= Tj)} for t in range(T)]
+    for dd in range(n_donors):
+        series = factors @ load_d[dd] + rng.standard_normal(T) * noise
+        rec += [{"unit": f"d_{dd}", "year": 2000 + t, "y": float(series[t]), "tr": 0}
+                for t in range(T)]
+    return pd.DataFrame(rec)
+
+
+def _fit_ppscm(**kw):
+    import warnings as _w
+    from mlsynth import PPSCM
+    cfg = dict(df=_staggered_df(), outcome="y", treat="tr", unitid="unit",
+               time="year", display_graphs=False, run_inference=False)
+    cfg.update(kw)
+    with _w.catch_warnings():
+        _w.simplefilter("ignore")
+        return PPSCM(cfg).fit()
+
+
+def test_default_leaves_every_per_unit_result_untouched():
+    """Nothing changes unless a horizon is asked for."""
+    res = _fit_ppscm()
+    assert res.per_unit
+    for unit in res.per_unit.values():
+        assert unit.cumulative_effect is None
+        assert unit.cumulative_lower is None
+        assert unit.cumulative_upper is None
+        assert unit.cumulative_windows is None
+
+
+def test_setting_the_horizon_populates_a_per_unit_cumulative_band():
+    res = _fit_ppscm(conformal_horizon=3, alpha=0.2)
+    assert res.per_unit
+    for unit in res.per_unit.values():
+        assert unit.cumulative_effect is not None
+        assert unit.cumulative_windows is not None and unit.cumulative_windows >= 1
+        assert unit.cumulative_lower <= unit.cumulative_effect <= unit.cumulative_upper
+
+
+def test_the_cumulative_band_does_not_disturb_the_existing_per_unit_fields():
+    """The band is additional; the ATT machinery must be untouched by it."""
+    base = _fit_ppscm(run_inference=True, alpha=0.2)
+    with_band = _fit_ppscm(run_inference=True, alpha=0.2, conformal_horizon=3)
+    for key, unit in base.per_unit.items():
+        other = with_band.per_unit[key]
+        assert other.att == pytest.approx(unit.att)
+        np.testing.assert_allclose(other.tau, unit.tau, equal_nan=True)
+        assert other.ci_lower == pytest.approx(unit.ci_lower, nan_ok=True)
+
+
+@pytest.mark.parametrize("bad", [0, -1, 2.5])
+def test_invalid_conformal_horizon_is_rejected_at_config_time(bad):
+    from mlsynth import PPSCM
+    with pytest.raises(MlsynthConfigError):
+        PPSCM(dict(df=_staggered_df(), outcome="y", treat="tr", unitid="unit",
+                   time="year", display_graphs=False, conformal_horizon=bad))

--- a/mlsynth/tests/test_ppscm_conformal_cumulative.py
+++ b/mlsynth/tests/test_ppscm_conformal_cumulative.py
@@ -105,6 +105,41 @@ def test_calibration_is_the_shared_combiner_not_a_second_implementation(panel):
         assert n_scores[k] == expected.n_scores
 
 
+def test_scores_match_a_pooled_refit_computed_by_hand(panel):
+    """Pins the score's scale and its training window without reusing the helper.
+
+    Computing the first origin's score directly catches both a score that averages
+    instead of accumulating and a calibration fit that balances on the window it is
+    about to score.
+    """
+    from mlsynth.utils.ppscm_helpers.inference import rolling_pooled_block_sums
+    Xy, trt = panel
+    first_origin = max(10, int(40 * 0.3))
+    trt_o = trt.copy()
+    trt_o[np.isfinite(trt)] = first_origin
+    fo = run_multisynth(Xy, trt_o, first_origin, 4, first_origin, fixedeff=True,
+                        time_cohort=False, nu=0.5, lam=0.0, solver=None)
+    expected = [float(np.sum(np.asarray(fo["tau_rel"][k], float)[:4]))
+                for k in range(len(fo["groups"]))]
+    scores = rolling_pooled_block_sums(
+        Xy, trt, d=40, n_leads=4, n_lags=40, fixedeff=True, time_cohort=False,
+        nu_used=0.5, lam=0.0, solver=None, horizon=4, min_train_frac=0.3)
+    for k, want in enumerate(expected):
+        assert scores[k][0] == pytest.approx(want, rel=1e-6, abs=1e-8)
+
+
+def test_origins_step_by_a_whole_window(panel):
+    """Overlapping windows would reuse periods and break exchangeability."""
+    from mlsynth.utils.ppscm_helpers.inference import rolling_pooled_block_sums
+    Xy, trt = panel
+    scores = rolling_pooled_block_sums(
+        Xy, trt, d=40, n_leads=4, n_lags=40, fixedeff=True, time_cohort=False,
+        nu_used=0.5, lam=0.0, solver=None, horizon=4, min_train_frac=0.3)
+    expected = len(range(max(10, int(40 * 0.3)), 40 - 4 + 1, 4))   # stride == horizon
+    for s in scores:
+        assert s.size == expected
+
+
 def test_one_pooled_solve_per_origin_not_one_per_unit(panel, monkeypatch):
     """The efficiency the pooled fit buys: scores for every unit from one solve."""
     import mlsynth.utils.ppscm_helpers.inference as inf

--- a/mlsynth/tests/test_ppscm_conformal_cumulative.py
+++ b/mlsynth/tests/test_ppscm_conformal_cumulative.py
@@ -1,0 +1,177 @@
+"""PPSCM per-unit cumulative conformal bands.
+
+PPSCM reports each treated unit's cumulative effect as a point estimate and has no
+interval calibrated for it: the existing per-unit bands come from the CFPT
+out-of-sample term alone, which under-covers, and the in-sample bound mlsynth ships
+is derived for unconstrained weights while PPSCM's live on a simplex.
+
+This suite pins the calibrated alternative. The construction is the one added in
+#431, with the scores built the way PPSCM can afford: partially-pooled SCM fits every
+treated unit in a single solve, so one rolling pass over origins yields a score vector
+for *each* unit at the cost of one pooled solve per origin -- not one per unit per
+origin. The calibration itself is not reimplemented; it is
+``conformal.cumulative_conformal_interval``, so a defect in the order statistic has
+one place to be fixed.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.conformal import cumulative_conformal_interval
+from mlsynth.utils.ppscm_helpers.engine import run_multisynth
+
+
+def _panel(n_ctrl=10, n_trt=2, t0=40, horizon=4, rho=0.0, sigma=0.3, effect=0.0,
+           n_factors=2, seed=0):
+    """Small factor panel with simultaneous adoption (fast enough for a QP loop)."""
+    rng = np.random.default_rng(seed)
+    T = t0 + horizon
+    n = n_ctrl + n_trt
+    common = rng.uniform(0.3, 1.3, (n, n_factors)) @ rng.normal(size=(n_factors, T))
+    e = rng.normal(scale=sigma, size=(n, T))
+    if rho:
+        for t in range(1, T):
+            e[:, t] = rho * e[:, t - 1] + np.sqrt(1 - rho ** 2) * e[:, t]
+    Xy = rng.normal(scale=2.0, size=n)[:, None] + common + e
+    Xy[:n_trt, t0:] += effect
+    trt = np.full(n, np.inf)
+    trt[:n_trt] = t0
+    return Xy, trt
+
+
+@pytest.fixture(scope="module")
+def panel():
+    return _panel()
+
+
+def _call(panel, **kw):
+    from mlsynth.utils.ppscm_helpers.inference import cumulative_conformal_per_unit
+    Xy, trt = panel
+    base = dict(d=40, n_leads=4, n_lags=40, fixedeff=True, time_cohort=False,
+                nu_used=0.5, lam=0.0, solver=None, alpha=0.1, horizon=4,
+                min_train_frac=0.3)
+    base.update(kw)
+    return cumulative_conformal_per_unit(Xy, trt, **base)
+
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+def test_smoke_returns_one_band_per_treated_unit(panel):
+    point, lower, upper, n_scores = _call(panel)
+    for arr in (point, lower, upper, n_scores):
+        assert arr.shape == (2,)                     # one row per treated cohort
+    assert np.isfinite(point).all()
+    assert (lower <= point).all() and (point <= upper).all()
+
+
+# ---------------------------------------------------------------------------
+# Unit invariants
+# ---------------------------------------------------------------------------
+
+def test_point_is_each_unit_summed_effect_over_the_horizon(panel):
+    Xy, trt = panel
+    full = run_multisynth(Xy, trt, 40, 4, 40, fixedeff=True, time_cohort=False,
+                          nu=0.5, lam=0.0, solver=None)
+    expected = [float(np.sum(np.asarray(full["tau_rel"][k], float)[:4]))
+                for k in range(len(full["groups"]))]
+    point, *_ = _call(panel)
+    np.testing.assert_allclose(point, expected, rtol=1e-6, atol=1e-8)
+
+
+def test_bands_are_symmetric_about_their_points(panel):
+    point, lower, upper, _ = _call(panel)
+    np.testing.assert_allclose(point - lower, upper - point, rtol=1e-9, atol=1e-9)
+
+
+def test_calibration_is_the_shared_combiner_not_a_second_implementation(panel):
+    """Guards the reuse: a divergence from the package must fail, not drift."""
+    from mlsynth.utils.ppscm_helpers.inference import (
+        cumulative_conformal_per_unit, rolling_pooled_block_sums)
+    Xy, trt = panel
+    scores = rolling_pooled_block_sums(
+        Xy, trt, d=40, n_leads=4, n_lags=40, fixedeff=True, time_cohort=False,
+        nu_used=0.5, lam=0.0, solver=None, horizon=4, min_train_frac=0.3)
+    point, lower, upper, n_scores = cumulative_conformal_per_unit(
+        Xy, trt, d=40, n_leads=4, n_lags=40, fixedeff=True, time_cohort=False,
+        nu_used=0.5, lam=0.0, solver=None, alpha=0.1, horizon=4, min_train_frac=0.3)
+    for k in range(len(point)):
+        expected = cumulative_conformal_interval(point[k], scores[k], alpha=0.1, horizon=4)
+        assert lower[k] == pytest.approx(expected.lower)
+        assert upper[k] == pytest.approx(expected.upper)
+        assert n_scores[k] == expected.n_scores
+
+
+def test_one_pooled_solve_per_origin_not_one_per_unit(panel, monkeypatch):
+    """The efficiency the pooled fit buys: scores for every unit from one solve."""
+    import mlsynth.utils.ppscm_helpers.inference as inf
+    calls = {"n": 0}
+    real = inf.run_multisynth
+
+    def counting(*a, **k):
+        calls["n"] += 1
+        return real(*a, **k)
+
+    monkeypatch.setattr(inf, "run_multisynth", counting)
+    _, _, _, n_scores = _call(panel)
+    n_units = len(n_scores)
+    n_origins = int(n_scores[0])
+    assert n_units == 2 and n_origins >= 2
+    # one solve per origin, plus the full fit -- NOT n_origins * n_units
+    assert calls["n"] == n_origins + 1
+    assert calls["n"] < n_origins * n_units + 1
+
+
+def test_smaller_alpha_never_narrows_the_bands(panel):
+    _, lo_tight, hi_tight, _ = _call(panel, alpha=0.05)
+    _, lo_loose, hi_loose, _ = _call(panel, alpha=0.30)
+    assert ((hi_tight - lo_tight) >= (hi_loose - lo_loose) - 1e-12).all()
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_too_few_windows_gives_honest_infinite_bands(panel):
+    """A horizon that leaves too few windows must say so, not guess."""
+    _, lower, upper, n_scores = _call(panel, horizon=4, min_train_frac=0.9)
+    assert (n_scores < 9).all()
+    assert np.isinf(lower).all() and np.isinf(upper).all()
+
+
+def test_single_treated_unit_is_supported():
+    p = _panel(n_trt=1)
+    point, lower, upper, _ = _call(p)
+    assert point.shape == (1,)
+    assert np.isfinite(point).all()
+
+
+# ---------------------------------------------------------------------------
+# Failure -- translated errors, reported not swallowed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1])
+def test_invalid_alpha_raises_config_error(panel, bad):
+    with pytest.raises(MlsynthConfigError):
+        _call(panel, alpha=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -2])
+def test_nonpositive_horizon_raises_config_error(panel, bad):
+    with pytest.raises(MlsynthConfigError):
+        _call(panel, horizon=bad)
+
+
+def test_horizon_beyond_the_post_window_raises_data_error(panel):
+    with pytest.raises(MlsynthDataError):
+        _call(panel, horizon=99)
+
+
+def test_no_treated_units_raises_data_error():
+    Xy, trt = _panel()
+    trt = np.full(trt.shape, np.inf)                 # nobody adopts
+    with pytest.raises(MlsynthDataError):
+        _call((Xy, trt))

--- a/mlsynth/tests/test_ppscm_conformal_cumulative_properties.py
+++ b/mlsynth/tests/test_ppscm_conformal_cumulative_properties.py
@@ -1,0 +1,129 @@
+"""Metamorphic invariants of PPSCM's per-unit cumulative conformal bands.
+
+The unit suite pins the bands on fixed panels. These assert what must hold for every
+panel the estimator accepts:
+
+* structure -- one band per treated cohort, symmetric about its point, and the point
+  is the unit's own summed effect rather than an average or a pooled quantity;
+* equivariance -- rescaling the panel rescales points and half-widths together;
+* invariance -- relabelling donors leaves the bands alone;
+* monotonicity -- a smaller ``alpha`` never narrows a band, and a later first origin
+  never adds calibration windows.
+
+The panels are deliberately small: every example runs a pooled QP per origin.
+"""
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils.ppscm_helpers.inference import (
+    cumulative_conformal_per_unit, rolling_pooled_block_sums)
+
+_SETTINGS = settings(
+    max_examples=8, deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+
+
+@st.composite
+def panels(draw):
+    """Small staggered-adoption panel with room for a few calibration windows."""
+    n_ctrl = draw(st.integers(6, 9))
+    n_trt = draw(st.integers(1, 2))
+    t0 = draw(st.integers(28, 36))
+    horizon = draw(st.integers(2, 4))
+    seed = draw(st.integers(0, 2**31 - 1))
+    rng = np.random.default_rng(seed)
+    n, T = n_ctrl + n_trt, t0 + horizon
+    common = rng.uniform(0.3, 1.3, (n, 2)) @ rng.normal(size=(2, T))
+    Xy = rng.normal(scale=2.0, size=n)[:, None] + common + rng.normal(scale=0.3, size=(n, T))
+    trt = np.full(n, np.inf)
+    trt[:n_trt] = t0
+    assume(np.isfinite(Xy).all())
+    return Xy, trt, t0, horizon
+
+
+def _bands(Xy, trt, t0, horizon, alpha=0.1, min_train_frac=0.3):
+    return cumulative_conformal_per_unit(
+        Xy, trt, t0, horizon, t0, fixedeff=True, time_cohort=False, nu_used=0.5,
+        lam=0.0, solver=None, alpha=alpha, horizon=horizon,
+        min_train_frac=min_train_frac,
+    )
+
+
+class TestStructure:
+    @given(panels())
+    @_SETTINGS
+    def test_one_symmetric_band_per_treated_cohort(self, panel):
+        Xy, trt, t0, horizon = panel
+        point, lower, upper, n_scores = _bands(Xy, trt, t0, horizon)
+        n_trt = int(np.isfinite(trt).sum())
+        assert point.shape == lower.shape == upper.shape == n_scores.shape
+        assert 1 <= point.size <= n_trt
+        np.testing.assert_allclose(point - lower, upper - point, rtol=1e-9, atol=1e-9)
+
+    @given(panels())
+    @_SETTINGS
+    def test_each_point_is_that_unit_own_summed_effect(self, panel):
+        from mlsynth.utils.ppscm_helpers.engine import run_multisynth
+        Xy, trt, t0, horizon = panel
+        full = run_multisynth(Xy, trt, t0, horizon, t0, fixedeff=True,
+                              time_cohort=False, nu=0.5, lam=0.0, solver=None)
+        expected = [float(np.sum(np.asarray(full["tau_rel"][k], float)[:horizon]))
+                    for k in range(len(full["groups"]))]
+        point, *_ = _bands(Xy, trt, t0, horizon)
+        np.testing.assert_allclose(point, expected, rtol=1e-6, atol=1e-8)
+
+
+class TestEquivariance:
+    @given(panels(), st.sampled_from([0.5, 2.0, 3.0]))
+    @_SETTINGS
+    def test_rescaling_the_panel_rescales_points_and_widths(self, panel, c):
+        Xy, trt, t0, horizon = panel
+        p0, lo0, hi0, _ = _bands(Xy, trt, t0, horizon)
+        p1, lo1, hi1, _ = _bands(c * Xy, trt, t0, horizon)
+        np.testing.assert_allclose(p1, c * p0, rtol=1e-5, atol=1e-7)
+        finite = np.isfinite(hi0 - lo0)
+        if finite.any():
+            np.testing.assert_allclose((hi1 - lo1)[finite], c * (hi0 - lo0)[finite],
+                                       rtol=1e-5, atol=1e-7)
+
+
+class TestInvariance:
+    @given(panels())
+    @_SETTINGS
+    def test_relabelling_donors_leaves_the_bands_alone(self, panel):
+        Xy, trt, t0, horizon = panel
+        donors = np.where(~np.isfinite(trt))[0]
+        treated = np.where(np.isfinite(trt))[0]
+        perm = np.concatenate([treated, np.random.default_rng(0).permutation(donors)])
+        p0, lo0, hi0, _ = _bands(Xy, trt, t0, horizon)
+        p1, lo1, hi1, _ = _bands(Xy[perm], trt[perm], t0, horizon)
+        np.testing.assert_allclose(p1, p0, rtol=1e-5, atol=1e-7)
+        finite = np.isfinite(lo0)
+        if finite.any():
+            np.testing.assert_allclose(lo1[finite], lo0[finite], rtol=1e-5, atol=1e-6)
+
+
+class TestMonotonicity:
+    @given(panels())
+    @_SETTINGS
+    def test_smaller_alpha_never_narrows_a_band(self, panel):
+        Xy, trt, t0, horizon = panel
+        _, lo_t, hi_t, _ = _bands(Xy, trt, t0, horizon, alpha=0.05)
+        _, lo_l, hi_l, _ = _bands(Xy, trt, t0, horizon, alpha=0.30)
+        assert ((hi_t - lo_t) >= (hi_l - lo_l) - 1e-9).all()
+
+    @given(panels())
+    @_SETTINGS
+    def test_a_later_first_origin_never_adds_windows(self, panel):
+        Xy, trt, t0, horizon = panel
+        early = rolling_pooled_block_sums(
+            Xy, trt, t0, horizon, t0, fixedeff=True, time_cohort=False, nu_used=0.5,
+            lam=0.0, solver=None, horizon=horizon, min_train_frac=0.2)
+        late = rolling_pooled_block_sums(
+            Xy, trt, t0, horizon, t0, fixedeff=True, time_cohort=False, nu_used=0.5,
+            lam=0.0, solver=None, horizon=horizon, min_train_frac=0.7)
+        for k in range(min(len(early), len(late))):
+            assert late[k].size <= early[k].size

--- a/mlsynth/utils/ppscm_helpers/config.py
+++ b/mlsynth/utils/ppscm_helpers/config.py
@@ -7,7 +7,7 @@ Co-located with the helper package; re-exported from
 from __future__ import annotations
 
 from typing import Any, List, Literal, Optional, Union
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 from ...config_models import BaseEstimatorConfig
 from ...exceptions import MlsynthConfigError
 
@@ -102,6 +102,31 @@ class PPSCMConfig(BaseEstimatorConfig):
         lt=1.0,
         description="Significance level for the Wald confidence band.",
     )
+    conformal_horizon: Optional[int] = Field(
+        default=None,
+        description=(
+            "Post-periods to accumulate for a per-unit conformal band on the "
+            "CUMULATIVE effect -- the total each treated unit gained, rather than "
+            "its per-period or time-averaged effect. ``None`` (default) leaves it "
+            "off and nothing changes. Unlike VanillaSC, where "
+            "``inference='conformal_cumulative'`` selects one mode, this band is "
+            "an additional object: ``inference_method`` still chooses the bootstrap "
+            "or jackknife used for the ATT. Calibration needs non-overlapping "
+            "windows of this length in the pre-period, so roughly "
+            "``T0 >= horizon / (alpha * 0.7)`` are required before the band is "
+            "finite."
+        ),
+    )
+
+    @field_validator("conformal_horizon")
+    @classmethod
+    def _validate_conformal_horizon(cls, v):
+        if v is None:
+            return v
+        if isinstance(v, bool) or not isinstance(v, int) or v < 1:
+            raise ValueError("conformal_horizon must be an integer >= 1 or None.")
+        return v
+
     covariates: Optional[List[str]] = Field(
         default=None,
         description=(

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -12,10 +12,12 @@ are built from these SEs around the full-sample point estimates.
 
 from __future__ import annotations
 
-from typing import Any, Tuple
+from typing import Any, Dict, List, Tuple
 
 import numpy as np
 from scipy.stats import norm
+
+from ...exceptions import MlsynthConfigError, MlsynthDataError
 
 from .engine import run_multisynth, predict_tau
 
@@ -201,3 +203,131 @@ def jackknife_inference(
     per_time_ci = np.column_stack([per_time_full - z * per_time_se,
                                    per_time_full + z * per_time_se])
     return float(att_full), se, ci, per_time_se, per_time_ci
+
+
+def rolling_pooled_block_sums(
+    Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
+    *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
+    solver: Any, horizon: int, min_train_frac: float = 0.3,
+) -> List[np.ndarray]:
+    """Per-unit cumulative out-of-sample errors, one pooled solve per origin.
+
+    Slides an origin across the pre-period and, at each one, pretends every treated
+    unit adopted there: a single partially-pooled fit on the data before the origin
+    yields *every* unit's weights at once, and each unit's summed effect over the next
+    ``horizon`` periods is one conformity score for it. So a pass costs one solve per
+    origin, not one per unit per origin.
+
+    Origins step by ``horizon``, so the windows do not overlap and the scores stay
+    exchangeable, and each fit sees only data strictly before the window it scores.
+
+    Returns
+    -------
+    list of numpy.ndarray
+        One array of finite scores per treated cohort, in ``groups`` order.
+    """
+    from ..conformal import MIN_TRAIN_PERIODS
+
+    trt = np.asarray(trt, dtype=float)
+    adopted = np.isfinite(trt)
+    if not adopted.any():
+        raise MlsynthDataError(
+            "cumulative conformal inference needs at least one treated unit; "
+            "no unit has a finite adoption time."
+        )
+    horizon = int(horizon)
+    earliest = int(np.min(trt[adopted]))
+    start = max(MIN_TRAIN_PERIODS, int(earliest * float(min_train_frac)))
+
+    scores: Dict[int, List[float]] = {}
+    n_groups = 0
+    for origin in range(start, earliest - horizon + 1, horizon):
+        trt_o = trt.copy()
+        trt_o[adopted] = origin
+        try:
+            fo = run_multisynth(
+                Xy, trt_o, origin, horizon, origin,
+                fixedeff=fixedeff, time_cohort=time_cohort,
+                nu=nu_used, lam=lam, solver=solver,
+            )
+        except Exception:  # pragma: no cover - a degenerate origin is skipped
+            continue
+        n_groups = max(n_groups, len(fo["groups"]))
+        for k in range(len(fo["groups"])):
+            path = np.asarray(fo["tau_rel"][k], dtype=float)[:horizon]
+            if path.size == horizon and np.isfinite(path).all():
+                scores.setdefault(k, []).append(float(path.sum()))
+    return [np.asarray(scores.get(k, []), dtype=float) for k in range(n_groups)]
+
+
+def cumulative_conformal_per_unit(
+    Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
+    *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
+    solver: Any, alpha: float, horizon: int, min_train_frac: float = 0.3,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Per-unit conformal band for each treated unit's cumulative effect.
+
+    The point estimates come from the full fit's ``tau_rel``; the calibration comes
+    from :func:`rolling_pooled_block_sums` and
+    :func:`mlsynth.utils.conformal.cumulative_conformal_interval` -- the same
+    combiner VanillaSC uses, so the order statistic has one definition.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        ``(point, lower, upper, n_scores)``, each of shape ``(J,)`` in ``groups``
+        order. A unit with too few calibration windows for the requested level gets
+        an infinite band rather than a narrow one that does not cover.
+    """
+    from ..conformal import cumulative_conformal_interval
+
+    if isinstance(alpha, bool) or not isinstance(alpha, (int, float, np.floating)):
+        raise MlsynthConfigError(f"alpha must be a number in (0, 1); got {alpha!r}.")
+    if not 0.0 < float(alpha) < 1.0:
+        raise MlsynthConfigError(
+            f"alpha must lie in the open interval (0, 1); got {alpha!r}."
+        )
+    if isinstance(horizon, bool) or not isinstance(horizon, (int, np.integer)) or int(horizon) < 1:
+        raise MlsynthConfigError(f"horizon must be a positive integer; got {horizon!r}.")
+    horizon = int(horizon)
+    if horizon > int(n_leads):
+        raise MlsynthDataError(
+            f"horizon ({horizon}) exceeds the {int(n_leads)} post-period lead(s) "
+            "estimated; there is no full window to accumulate."
+        )
+
+    if not np.isfinite(np.asarray(trt, dtype=float)).any():
+        raise MlsynthDataError(
+            "cumulative conformal inference needs at least one treated unit; "
+            "no unit has a finite adoption time."
+        )
+
+    full = run_multisynth(
+        Xy, trt, d, n_leads, n_lags, fixedeff=fixedeff, time_cohort=time_cohort,
+        nu=nu_used, lam=lam, solver=solver,
+    )
+    n_units = len(full["groups"])
+    point = np.array(
+        [float(np.sum(np.asarray(full["tau_rel"][k], dtype=float)[:horizon]))
+         for k in range(n_units)], dtype=float,
+    )
+
+    per_unit_scores = rolling_pooled_block_sums(
+        Xy, trt, d, n_leads, n_lags, fixedeff=fixedeff, time_cohort=time_cohort,
+        nu_used=nu_used, lam=lam, solver=solver, horizon=horizon,
+        min_train_frac=min_train_frac,
+    )
+
+    lower = np.full(n_units, np.nan)
+    upper = np.full(n_units, np.nan)
+    n_scores = np.zeros(n_units, dtype=int)
+    for k in range(n_units):
+        s = per_unit_scores[k] if k < len(per_unit_scores) else np.asarray([])
+        n_scores[k] = int(s.size)
+        if s.size == 0:
+            lower[k], upper[k] = -np.inf, np.inf
+            continue
+        band = cumulative_conformal_interval(
+            point[k], s, alpha=float(alpha), horizon=horizon)
+        lower[k], upper[k] = band.lower, band.upper
+    return point, lower, upper, n_scores

--- a/mlsynth/utils/ppscm_helpers/structures.py
+++ b/mlsynth/utils/ppscm_helpers/structures.py
@@ -191,6 +191,14 @@ class PPSCMUnitFit:
     # inference is off. See ``per_unit_intervals`` in ``inference.py``.
     tau_lower: Optional[np.ndarray] = None
     tau_upper: Optional[np.ndarray] = None
+    # Conformal band on this unit's CUMULATIVE effect over ``conformal_horizon``
+    # periods -- the total it gained, calibrated on out-of-sample windows of the
+    # same length. None unless ``conformal_horizon`` is set. See
+    # ``cumulative_conformal_per_unit`` in ``inference.py``.
+    cumulative_effect: Optional[float] = None
+    cumulative_lower: Optional[float] = None
+    cumulative_upper: Optional[float] = None
+    cumulative_windows: Optional[int] = None
 
 
 class PPSCMResults(_BaseEstimatorResults):

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -564,3 +564,27 @@ timeout = 180.0
   find = "k = int(np.ceil((n + 1) * (1.0 - alpha)))"
   replace = "k = int(np.ceil(n * (1.0 - alpha)))"
   models = "the plug-in sample quantile in place of the finite-sample split-conformal order statistic, which under-covers at small calibration sizes and silently returns a finite band where the requested level is in fact unreachable"
+
+[[target]]
+name = "ppscm-conformal-cumulative"
+module-path = "mlsynth/utils/ppscm_helpers/inference.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_conformal_cumulative.py mlsynth/tests/test_ppscm_conformal_cumulative_properties.py -q -p no:cacheprovider"
+timeout = 600.0
+
+  [[target.mutant]]
+  id = "cumulative-scores-average-instead-of-accumulate"
+  find = "scores.setdefault(k, []).append(float(path.sum()))"
+  replace = "scores.setdefault(k, []).append(float(path.mean()))"
+  models = "calibrating on each unit's average post-period error rather than its accumulated error, so the band is sized for the wrong estimand and comes out roughly a factor of the horizon too narrow"
+
+  [[target.mutant]]
+  id = "cumulative-calibration-origins-overlap"
+  find = "for origin in range(start, earliest - horizon + 1, horizon):"
+  replace = "for origin in range(start, earliest - horizon + 1, 1):"
+  models = "sliding the calibration origin one period at a time instead of one window at a time, so consecutive windows share periods; the scores stop being exchangeable and the calibration set is inflated with near-duplicates"
+
+  [[target.mutant]]
+  id = "cumulative-calibration-fit-sees-its-own-window"
+  find = """                Xy, trt_o, origin, horizon, origin,"""
+  replace = """                Xy, trt_o, origin + horizon, horizon, origin + horizon,"""
+  models = "letting each calibration fit balance on the very window it is about to score, so the conformity scores measure in-sample fit rather than prediction error and every band comes out too narrow"

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -583,8 +583,16 @@ timeout = 600.0
   replace = "for origin in range(start, earliest - horizon + 1, 1):"
   models = "sliding the calibration origin one period at a time instead of one window at a time, so consecutive windows share periods; the scores stop being exchangeable and the calibration set is inflated with near-duplicates"
 
+  # EQUIVALENT MUTANT, recorded rather than dropped silently. Advancing the `d` and
+  # `n_lags` arguments to `origin + horizon` -- intended to make each calibration fit
+  # balance on the window it scores -- changes nothing: `run_multisynth` takes the
+  # adoption boundary from `trt`, so `adopt_of` stays at the origin and the extra
+  # periods are clipped. Verified directly: both call forms return byte-identical
+  # `tau_rel` sums. The defect it was meant to model is expressed below instead, at
+  # the line that actually controls what each fit is held out from.
+
   [[target.mutant]]
-  id = "cumulative-calibration-fit-sees-its-own-window"
-  find = """                Xy, trt_o, origin, horizon, origin,"""
-  replace = """                Xy, trt_o, origin + horizon, horizon, origin + horizon,"""
-  models = "letting each calibration fit balance on the very window it is about to score, so the conformity scores measure in-sample fit rather than prediction error and every band comes out too narrow"
+  id = "cumulative-calibration-keeps-the-real-adoption-time"
+  find = "        trt_o[adopted] = origin"
+  replace = "        trt_o[adopted] = trt[adopted]"
+  models = "forgetting to move adoption to the calibration origin, so every fit is the real one and each 'calibration score' is the actual treatment effect rather than a placebo window -- the scores stop measuring prediction error entirely and the band is calibrated on the thing it is supposed to be testing"


### PR DESCRIPTION
## Related Links

- Closes #430
- Follows #431, which added `mlsynth/utils/conformal/` and wired VanillaSC as its
  first consumer. This is the second consumer the package was factored for.
- Docs: `docs/ppscm.rst`, "The cumulative effect per unit"
- Source: Chernozhukov, Wüthrich & Zhu (2021), *JASA* 116(536), 1849-1864 — the
  split-conformal order statistic, applied to pooled block sums

## What

- Added `rolling_pooled_block_sums` and `cumulative_conformal_per_unit` to
  `utils/ppscm_helpers/inference.py`.
- Added `conformal_horizon` to `PPSCMConfig`, and `cumulative_effect`,
  `cumulative_lower`, `cumulative_upper`, `cumulative_windows` to `PPSCMUnitFit`.
- Wired both through `estimators/ppscm.py`.

## Why

PPSCM reports each treated unit's cumulative effect as a point estimate with no
interval calibrated for it. Its per-unit bands come from `out_of_sample_intervals`,
which contributes only the out-of-sample term and under-covers; adding the in-sample
bound mlsynth ships over-covers badly, because that bound is derived for unconstrained
weights while PPSCM's live on a simplex. On a null factor DGP at realistic scale
(60 donors, 104 pre-periods, L=8), against a 0.10 target exit rate:

| construction | exit rate |
| --- | --- |
| out-of-sample only (today) | 0.24 |
| plus the unconstrained in-sample bound | 0.02 |
| SCPI with the constraint-correct `L1-L2` bound | 0.00-0.02, ~2x too wide |
| rolling-origin conformal, finite-sample order statistic | 0.100 |

The conformal construction is the one that lands on target, and about 1.5x tighter
than the best SCPI variant at the same nominal level.

## How

An origin slides across the pre-period, and at each one every treated unit is treated
as if it had adopted there. Partially-pooled SCM fits them all in a single solve, so
one pass yields each unit's summed out-of-sample error at the cost of **one solve per
origin, not one per unit per origin** — 9 solves where six units would otherwise have
taken 54. Origins step by a whole horizon, so the windows do not overlap, and each fit
sees only data before the window it scores.

The calibration is not reimplemented: `cumulative_conformal_interval` from #431 does
it, so the order statistic keeps one definition across estimators. A test asserts the
band equals the combiner's output on the same scores, so a divergence fails rather
than drifts.

The band is additional rather than a mode. `inference_method` still selects the
bootstrap or jackknife behind the ATT; `conformal_horizon` adds the cumulative band
alongside it. That asymmetry with VanillaSC (where `inference=` selects one mode) is
stated in the docs rather than left to be discovered.

## Verification

Path: not a paper-replication change. Validated by construction and by reuse:

- **Against an independent computation.** The first origin's score is recomputed from
  a pooled refit by hand, and the origin count is pinned against the stride — neither
  shares the implementation's premise.
- **Against the shared combiner.** Per-unit bands are asserted equal to
  `cumulative_conformal_interval` on the same scores.
- **Solve count.** A monkeypatched counter pins one pooled solve per origin, asserted
  strictly below one-per-unit-per-origin.

The coverage figure above is from a scratch Monte Carlo, not a committed benchmark.
#430 carries the Path B spec: BFR's own simulation (Section 6, calibrated to the
Paglayan panel — two-way FE, a gsynth-fitted factor model, and an lme4-fitted AR(3),
all under a sharp null) reports 95% coverage for the wild bootstrap and jackknife, and
that table independently confirms the motivation here: the bootstrap is near nominal
under two-way FE (93.7) and conservative once factor structure is present (95.9 and
97.2). Exact reproduction is not possible from the paper — no replication archive, no
stated replication count, unreported fitted parameters — so the case must assert
geometry, which is why it is a separate PR.

## Scope checks

<!-- FEATURE ON AN EXISTING ESTIMATOR -->
- [x] The default preserves existing behaviour exactly — `conformal_horizon=None`
      leaves every per-unit field untouched, pinned by comparing a fit with and
      without the band
- [x] Existing pinned benchmark values unchanged; no existing code path is modified
- [x] A test pins that the default is unchanged; PPSCM suite: 80 passed
- [x] New config field has a `Field(...)` description saying when to reach for it

## Test Steps

- [x] `pytest mlsynth/tests/test_ppscm_conformal_cumulative.py -q` — 23 passed
- [x] `MLSYNTH_HYPOTHESIS_PROFILE=ci pytest mlsynth/tests/test_ppscm_conformal_cumulative_properties.py -q` — 6 passed
- [x] `pytest mlsynth/tests/ -k ppscm` — 80 passed
- [x] `python tools/mutation/run_mutants.py --target ppscm-conformal-cumulative` — 3/3 killed
- [ ] `python benchmarks/run_benchmarks.py --all` — not run; no benchmark case is added
      by this PR

## Other Notes

The mutation run is worth reading rather than just counting. The first pass killed
0 of 3: every mutant survived because the tests compared the helper against itself, so
both sides moved together under the mutation — the same circularity #431 avoided with
a hand-computed pin, which I had not ported here. Adding the by-hand first-origin score
and the stride pin killed two.

The third survived a second pass and turned out to be an **equivalent mutant**:
advancing `d` and `n_lags` past the origin does not make the fit balance on the window
it scores, because `run_multisynth` takes the adoption boundary from `trt` and clips
the rest — both call forms return byte-identical `tau_rel` sums. That is recorded in
`targets.toml` with the verification, and replaced by a mutant on the line that does
control the holdout (keeping the real adoption time instead of moving it to the
origin), which is killed.

The pre-period cost carries over from #431 and is documented: non-overlapping windows
of length `L` are scarce, so a `1-alpha` band needs roughly `T0 >= L/(0.7*alpha)`.
When they run out, the band is infinite and `cumulative_windows` reports how many were
available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKrMz8fQvjDNM1eur5kQ2V


---
_Generated by [Claude Code](https://claude.ai/code/session_01BKrMz8fQvjDNM1eur5kQ2V)_