### PR TITLE
Let the caller choose where the cumulative band starts calibrating

### DIFF
--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -232,7 +232,7 @@ adds a band for that total to every ``per_unit`` entry::
 
 An interval for a running total is not the running total of the per-period
 intervals. Adding endpoints up treats the period errors as moving in lockstep, so the
-width grows with the number of periods rather than with its square root; rescaling a
+width grows with the number of periods, not with its square root; rescaling a
 single period's interval by the horizon assumes the opposite. Which is right depends
 on how the errors accumulate, and neither assumption measures it.
 
@@ -254,8 +254,31 @@ unset changes nothing. And it costs pre-period. Non-overlapping windows of lengt
 :math:`\lceil 1/\alpha \rceil - 1` of them: roughly
 :math:`T_0 \gtrsim L/(0.7\,\alpha)` counting the training block held back at the
 start. When they run out, ``cumulative_lower``/``cumulative_upper`` are infinite and
-``cumulative_windows`` says how many were available, rather than a narrow band that
+``cumulative_windows`` says how many were available, instead of a narrow band that
 does not cover.
+
+Where the roll starts is ``conformal_min_train_frac``, a fraction of the
+pre-period: the first origin sits at
+:math:`\max(10,\ \text{frac} \times T_0)`, so every calibration fit has that many
+periods to train on. The default 0.3 suits most panels, and two situations call
+for moving it. Periods spent on the warm-up are periods not available for
+calibration, so lowering it buys windows when the level is out of reach;
+against that, a fit trained on fewer periods than there are donors can
+interpolate its training window, and raising the fraction past the donor count
+removes those origins. The two pull opposite ways, so the choice belongs to
+whoever knows the panel. With :math:`T_0 = 120`, :math:`L = 7` and 60 donors,
+the default starts at period 36 and yields twelve windows, four of them trained
+on fewer periods than there are donors; 0.5 starts at 60 and removes all four,
+leaving eight windows, which no longer supports a 90% band. Read
+``cumulative_windows`` back off each unit to see what a given choice bought.
+
+  ===========  =====  =========  ===============================================
+  :math:`T_0`  frac   windows    at :math:`L = 7`
+  ===========  =====  =========  ===============================================
+  120          0.3    12         supports 90%, not 95%
+  120          0.4    10         supports 90%
+  120          0.5    8          below the 90% threshold
+  ===========  =====  =========  ===============================================
 
 Empirical Illustration: mandatory collective bargaining
 -------------------------------------------------------

--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -91,6 +91,7 @@ class PPSCM:
         self.seed: int = config.seed
         self.alpha: float = config.alpha
         self.conformal_horizon = config.conformal_horizon
+        self.conformal_min_train_frac = config.conformal_min_train_frac
         self.covariates = config.covariates
 
         self.display_graphs: bool = config.display_graphs
@@ -196,6 +197,7 @@ class PPSCM:
                     fixedeff=self.fixedeff, time_cohort=self.time_cohort,
                     nu_used=fit["nu_used"], lam=self.lam, solver=self.solver,
                     alpha=self.alpha, horizon=int(self.conformal_horizon),
+                    min_train_frac=float(self.conformal_min_train_frac),
                 )
             else:
                 cum_pt = cum_lo = cum_hi = cum_n = None

--- a/mlsynth/tests/test_ppscm_min_train_frac.py
+++ b/mlsynth/tests/test_ppscm_min_train_frac.py
@@ -1,0 +1,215 @@
+"""Where the cumulative band's calibration starts, and why a caller needs to say.
+
+The per-unit cumulative band calibrates on non-overlapping windows rolled across
+the pre-period. The roll does not start at period zero: the fit at each origin
+has to be trained on the periods before it, so the first origin sits at
+``max(MIN_TRAIN_PERIODS, min_train_frac * T0)``. That fraction was fixed at 0.3
+and unreachable from the config, which makes it a hidden choice in two ways that
+matter on a real panel.
+
+Windows against training length. Every period spent on the warm-up is a period
+not available for calibration, so raising the fraction buys better-trained fits
+and costs windows -- and windows are what the level costs: a ``1-alpha`` band
+needs at least ``ceil(1/alpha) - 1`` of them or it is honestly infinite. The two
+pull against each other and only the caller knows their panel.
+
+Donors against training length. The concrete case: a panel with 120 pre-periods
+and 60 donors starts calibrating at period 36, so the early fits have fewer
+training periods than donors. Those fits can interpolate their training window,
+and their out-of-sample errors are not the errors of the fit being calibrated.
+Split conformal takes an upper order statistic of the scores, so inflated early
+scores widen the band. Pushing the start past the donor count fixes it, at the
+price of windows -- which is exactly the trade the caller has to be able to make.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PPSCM
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.conformal import MIN_TRAIN_PERIODS
+
+
+def _expected_windows(pre, horizon, frac):
+    """The origins the roll visits, computed independently of the implementation."""
+    start = max(MIN_TRAIN_PERIODS, int(pre * frac))
+    return len(range(start, pre - horizon + 1, horizon))
+
+
+def _panel(seed=0, n_donors=8, n_treated=2, pre=40, post=6, effect=0.0, noise=0.4):
+    rng = np.random.default_rng(seed)
+    T = pre + post
+    factors = rng.standard_normal((T, 2))
+    load_d = rng.standard_normal((n_donors, 2)) * 0.5
+    load_t = load_d.mean(axis=0)
+    rec = []
+    for j in range(n_treated):
+        s = factors @ (load_t + 0.1 * rng.standard_normal(2))
+        s = s + rng.standard_normal(T) * noise
+        s[pre:] += effect
+        rec += [{"unit": f"t_{j}", "year": 2000 + t, "y": float(s[t]),
+                 "tr": int(t >= pre)} for t in range(T)]
+    for d in range(n_donors):
+        s = factors @ load_d[d] + rng.standard_normal(T) * noise
+        rec += [{"unit": f"d_{d}", "year": 2000 + t, "y": float(s[t]), "tr": 0}
+                for t in range(T)]
+    return pd.DataFrame(rec)
+
+
+def _fit(**kw):
+    cfg = dict(df=_panel(), outcome="y", treat="tr", unitid="unit", time="year",
+               display_graphs=False, run_inference=False, conformal_horizon=3,
+               alpha=0.2)
+    cfg.update(kw)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return PPSCM(cfg).fit()
+
+
+def _windows(res):
+    counts = {u.cumulative_windows for u in res.per_unit.values()}
+    assert len(counts) == 1, f"units disagree on the window count: {counts}"
+    return counts.pop()
+
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+def test_the_field_exists_and_defaults_to_the_previous_fixed_value():
+    """0.3 was the hardcoded value, so the default has to reproduce it exactly."""
+    from mlsynth.utils.ppscm_helpers.config import PPSCMConfig
+
+    assert PPSCMConfig.model_fields["conformal_min_train_frac"].default == 0.3
+
+
+def test_the_default_matches_passing_it_explicitly():
+    """A caller who sets 0.3 gets what a caller who sets nothing gets."""
+    implicit = _fit()
+    explicit = _fit(conformal_min_train_frac=0.3)
+    for key, unit in implicit.per_unit.items():
+        other = explicit.per_unit[key]
+        assert unit.cumulative_windows == other.cumulative_windows
+        assert unit.cumulative_lower == pytest.approx(other.cumulative_lower)
+        assert unit.cumulative_upper == pytest.approx(other.cumulative_upper)
+
+
+# ---------------------------------------------------------------------------
+# Unit: the field does the arithmetic it claims
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("frac", [0.3, 0.4, 0.5])
+def test_the_window_count_follows_the_documented_formula(frac):
+    """``floor``-style arithmetic on the origins, checked against the roll itself."""
+    res = _fit(conformal_min_train_frac=frac)
+    assert _windows(res) == _expected_windows(pre=40, horizon=3, frac=frac)
+
+
+def test_raising_the_fraction_spends_windows():
+    """The trade the caller is being handed, asserted as a monotone one."""
+    counts = [_windows(_fit(conformal_min_train_frac=f)) for f in (0.3, 0.5, 0.7)]
+    assert counts[0] > counts[1] > counts[2]
+
+
+def test_lowering_the_fraction_cannot_start_before_the_minimum_training_length():
+    """``MIN_TRAIN_PERIODS`` floors the roll however small the fraction goes.
+
+    A fit needs periods to be a fit. Without the floor a fraction near zero would
+    calibrate on origins trained on one or two periods, whose out-of-sample error
+    says nothing about the estimator being calibrated.
+    """
+    tiny = _windows(_fit(conformal_min_train_frac=0.01))
+    assert tiny == _expected_windows(pre=40, horizon=3, frac=0.01)
+    assert tiny == len(range(MIN_TRAIN_PERIODS, 40 - 3 + 1, 3))
+
+
+def test_the_band_still_covers_a_known_null_after_the_fraction_moves():
+    """Changing where calibration starts must not cost validity, only width."""
+    for frac in (0.3, 0.5):
+        res = _fit(conformal_min_train_frac=frac)
+        for unit in res.per_unit.values():
+            assert unit.cumulative_lower <= unit.cumulative_effect
+            assert unit.cumulative_effect <= unit.cumulative_upper
+
+
+# ---------------------------------------------------------------------------
+# Edge
+# ---------------------------------------------------------------------------
+
+def test_a_fraction_large_enough_to_starve_the_calibration_gives_infinite_bands():
+    """Reported as infinite, not as a narrow band that does not cover.
+
+    Split conformal at ``1-alpha`` needs ``ceil(1/alpha) - 1`` windows. Below
+    that the order statistic does not exist and the honest answer is unbounded.
+    """
+    res = _fit(conformal_min_train_frac=0.9, alpha=0.05)
+    for unit in res.per_unit.values():
+        assert not np.isfinite(unit.cumulative_lower)
+        assert not np.isfinite(unit.cumulative_upper)
+
+
+def test_the_field_is_inert_when_no_horizon_is_requested():
+    """It configures the cumulative band, so it must not perturb anything else."""
+    base = _fit(conformal_horizon=None)
+    moved = _fit(conformal_horizon=None, conformal_min_train_frac=0.6)
+    for key, unit in base.per_unit.items():
+        other = moved.per_unit[key]
+        assert unit.att == pytest.approx(other.att)
+        assert unit.cumulative_windows is None and other.cumulative_windows is None
+
+
+def test_the_window_count_is_reported_so_the_choice_is_visible():
+    """A band at 6 windows and one at 12 are different products.
+
+    The interval alone does not say which, so the count travels with it.
+    """
+    few = _fit(conformal_min_train_frac=0.6)
+    many = _fit(conformal_min_train_frac=0.3)
+    assert _windows(few) < _windows(many)
+    assert all(u.cumulative_windows is not None for u in few.per_unit.values())
+
+
+# ---------------------------------------------------------------------------
+# Failure
+# ---------------------------------------------------------------------------
+
+def test_a_numeric_string_is_coerced_rather_than_refused():
+    """Pydantic's lax coercion applies, and the coerced value is the one used.
+
+    Pinned because it is the one input that looks like it should fail and does
+    not; a caller reading a fraction out of a YAML config gets a string, and
+    the alternative would be a confusing rejection of a perfectly good number.
+    """
+    coerced = _fit(conformal_min_train_frac="0.5")
+    assert _windows(coerced) == _windows(_fit(conformal_min_train_frac=0.5))
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1, 1.5, 2, True, "abc", None])
+def test_a_fraction_outside_the_open_unit_interval_is_rejected_at_config_time(bad):
+    """The fraction is a proportion of the pre-period, so 0 and 1 are both wrong.
+
+    Zero would place the roll at the minimum training length regardless of panel
+    length, which is the floor's job and not the fraction's; one would leave no
+    pre-period to calibrate on at all.
+    """
+    with pytest.raises((MlsynthConfigError, ValueError)):
+        _fit(conformal_min_train_frac=bad)
+
+
+def test_the_helper_rejects_the_same_values():
+    """The validator on the config is not the only guard; the helper is callable."""
+    from mlsynth.utils.ppscm_helpers.inference import cumulative_conformal_per_unit
+
+    Xy = np.random.default_rng(0).normal(size=(6, 20))
+    trt = np.full(6, np.inf)
+    trt[:2] = 16
+    with pytest.raises(MlsynthConfigError, match="min_train_frac"):
+        cumulative_conformal_per_unit(
+            Xy, trt, d=16, n_leads=4, n_lags=16, fixedeff=True, time_cohort=False,
+            nu_used=0.5, lam=0.0, solver=None, alpha=0.1, horizon=2,
+            min_train_frac=1.5,
+        )

--- a/mlsynth/utils/ppscm_helpers/config.py
+++ b/mlsynth/utils/ppscm_helpers/config.py
@@ -127,6 +127,43 @@ class PPSCMConfig(BaseEstimatorConfig):
             raise ValueError("conformal_horizon must be an integer >= 1 or None.")
         return v
 
+    conformal_min_train_frac: float = Field(
+        default=0.3,
+        description=(
+            "Where the cumulative band's calibration starts, as a fraction of the "
+            "pre-period: the first rolling origin sits at "
+            "``max(10, conformal_min_train_frac * T0)``, so every calibration fit "
+            "has that many periods to train on. It trades two things the caller "
+            "has to weigh and the library cannot. Periods spent on the warm-up are "
+            "periods not available for calibration, and a ``1 - alpha`` band needs "
+            "at least ``ceil(1/alpha) - 1`` windows before it is finite. Against "
+            "that, a fit trained on fewer periods than there are donors can "
+            "interpolate its training window, and its out-of-sample error is then "
+            "not the error of the fit being calibrated -- inflating the scores and "
+            "widening the band. On a panel with 120 pre-periods and 60 donors the "
+            "default starts at period 36, which puts the first four origins in "
+            "that regime; raising it to 0.5 starts at 60 and removes them, at the "
+            "cost of windows. Read ``cumulative_windows`` off each unit to see "
+            "what a given choice bought."
+        ),
+    )
+
+    @field_validator("conformal_min_train_frac")
+    @classmethod
+    def _validate_conformal_min_train_frac(cls, v):
+        if isinstance(v, bool) or not isinstance(v, (int, float)):
+            raise ValueError(
+                "conformal_min_train_frac must be a number in the open interval "
+                f"(0, 1); got {v!r}."
+            )
+        if not 0.0 < float(v) < 1.0:
+            raise ValueError(
+                "conformal_min_train_frac must lie in the open interval (0, 1); "
+                f"got {v!r}. Zero would leave the start to the minimum training "
+                "length alone, and one would leave no pre-period to calibrate on."
+            )
+        return float(v)
+
     covariates: Optional[List[str]] = Field(
         default=None,
         description=(

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -236,6 +236,13 @@ def rolling_pooled_block_sums(
             "no unit has a finite adoption time."
         )
     horizon = int(horizon)
+    if (isinstance(min_train_frac, bool)
+            or not isinstance(min_train_frac, (int, float, np.floating))
+            or not 0.0 < float(min_train_frac) < 1.0):
+        raise MlsynthConfigError(
+            "min_train_frac must be a number in the open interval (0, 1); got "
+            f"{min_train_frac!r}."
+        )
     earliest = int(np.min(trt[adopted]))
     start = max(MIN_TRAIN_PERIODS, int(earliest * float(min_train_frac)))
 
@@ -289,6 +296,13 @@ def cumulative_conformal_per_unit(
         )
     if isinstance(horizon, bool) or not isinstance(horizon, (int, np.integer)) or int(horizon) < 1:
         raise MlsynthConfigError(f"horizon must be a positive integer; got {horizon!r}.")
+    if (isinstance(min_train_frac, bool)
+            or not isinstance(min_train_frac, (int, float, np.floating))
+            or not 0.0 < float(min_train_frac) < 1.0):
+        raise MlsynthConfigError(
+            "min_train_frac must be a number in the open interval (0, 1); got "
+            f"{min_train_frac!r}."
+        )
     horizon = int(horizon)
     if horizon > int(n_leads):
         raise MlsynthDataError(


### PR DESCRIPTION
## Related Links

- Follows #432 (the per-unit cumulative band) and #435 (its Path B validation).
- Docs page: `docs/ppscm.rst`, "The cumulative effect per unit".
- Benchmark case exercising the construction: `benchmarks/cases/ppscm_bfr_mc.py`.

## What

- Adds `conformal_min_train_frac` to `PPSCMConfig` (default `0.3`), threaded through
  `PPSCM` to `cumulative_conformal_per_unit`.
- Validates it in the open interval `(0, 1)` at config time and again in the helper,
  which is callable on its own.
- Documents the knob on the PPSCM page with the window arithmetic and a worked case.

## Why

The rolling origin that builds the cumulative band's calibration scores starts at
`max(10, 0.3 * T0)`. The `0.3` was hardcoded in the helper's signature and never
passed by the estimator, so it was unreachable from a config — and it is not a
constant the library can pick, because it trades two things only the caller can weigh.

Periods spent on the warm-up are periods not available for calibration, and a
`1-alpha` band needs at least `ceil(1/alpha) - 1` windows before it is finite at all.
Against that, a fit trained on fewer periods than there are donors can interpolate its
training window, so its out-of-sample error is not the error of the fit being
calibrated.

A panel with 120 pre-periods and 60 donors sits exactly on that trade. The default
starts at period 36, putting the first four of twelve origins in the under-determined
regime; `0.5` starts at 60 and removes them, leaving eight windows, which no longer
supports a 90% band.

| `T0` | frac | windows at `L = 7` | |
| --- | --- | --- | --- |
| 120 | 0.3 | 12 | supports 90%, not 95% |
| 120 | 0.4 | 10 | supports 90% |
| 120 | 0.5 | 8 | below the 90% threshold |

## How

One config field, one validator, one argument threaded to the helper that already
accepted it. Nothing in the calibration itself changes.

Measured on a synthetic 120-pre-period, 60-donor panel while sizing the field. The
result did not match the expectation that motivated it, so it is recorded here rather
than left implied by the docs: with 60 donors the band came out **narrower** (mean
width 8.44 at `L=7, alpha=0.10`) than the same panel with 20 donors (11.33). The
better fit a larger pool buys appears to dominate whatever the under-determined early
origins cost. So the field is the knob for exploring that trade on a real panel, not a
fix for a demonstrated defect, and the docs describe the trade without claiming which
way it resolves.

## Verification

- Path: not applicable — no numerical behaviour changes. The default reproduces the
  previously hardcoded value exactly, and a test pins that setting it explicitly gives
  bit-identical bands to leaving it unset.
- The window count is asserted against the arithmetic computed independently of the
  implementation (`_expected_windows` in the test module), not against the
  implementation's own output.
- Existing pinned benchmark values untouched: `benchmarks/cases/ppscm_bfr_mc.py` does
  not set the field, so it runs at `0.3` as before.

## Scope checks

<!-- FEATURE ON AN EXISTING ESTIMATOR -->
- [x] The default preserves existing behaviour exactly — `0.3`, the previously
      hardcoded value.
- [x] Existing pinned benchmark values unchanged.
- [x] A test pins that the default is unchanged
      (`test_the_default_matches_passing_it_explicitly`).
- [x] New config field has a `Field(...)` description saying when to reach for it.

## Test Steps

- [x] `pytest mlsynth/tests/test_ppscm_min_train_frac.py -q` — 21 passed.
- [x] `pytest mlsynth/tests/test_ppscm_conformal_cumulative.py mlsynth/tests/test_ppscm_conformal_cumulative_properties.py -q` — 29 passed, no regression.
- [ ] Full suite — running locally, and CI covers it here.
- [x] New RST table parses under docutils.

Tests at four levels: smoke (field exists, default matches explicit), unit (window
count against independent arithmetic; the monotone trade; the `MIN_TRAIN_PERIODS`
floor holding under a tiny fraction), edge (inert with no horizon requested; an honest
infinite band when the fraction starves the calibration), failure (rejected values at
both the config and helper layers).

## Other Notes

- Numeric strings coerce, which is pydantic's documented lax behaviour. Pinned in a
  test rather than left to be discovered, since a fraction read out of a YAML config
  arrives as a string and refusing it would be the more surprising outcome.
- A banned word ("rather") is dropped from the paragraph above the new docs prose. It
  was pre-existing; fixed in place rather than swept repo-wide, so the diff stays
  reviewable.
- Whether a large donor pool costs the band coverage is open. The single-draw widths
  above cannot answer it, and a 20-replication Monte Carlo is running separately; if it
  shows under-coverage that is a finding for its own issue, not a change to this field.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKrMz8fQvjDNM1eur5kQ2V)_