### PR TITLE
Refit the control the estimator actually used under the conformal null

### DIFF
--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -521,6 +521,28 @@ distribution -- emits a warning and returns an ``InferenceResults`` whose
     (shaded on the plot) alongside the joint ``["joint_p_value"]`` --
     :func:`mlsynth.utils.bilevel.ridge_inference.conformal_intervals`.
 
+    Which control is refit under the null follows the estimator, and is reported
+    in ``res.inference.details["refit"]``. A plain synthetic control is refit as
+    one (``"sc"``, the rule the procedure was published on and the one the
+    authors' ``scinference`` package uses); with ``augment="ridge"`` the
+    ridge-augmented control is refit instead, matching ``augsynth``. The
+    distinction is not cosmetic. Refitting an unconstrained control under the
+    null lets it absorb the effect by re-levelling the series, and the level it
+    adds lands in the pre-treatment residuals the test calibrates against, so
+    both sides of the comparison grow together and the :math:`p`-value stops
+    responding to the effect size. Convex weights cannot do that, which is what
+    leaves the effect where the test can see it. Against ``scinference`` on the
+    Swedish carbon tax panel, the simplex refit returns the authors' 0.391 under
+    the null and :math:`1/T = 0.0217` for any injected effect from 1 upward.
+
+    ``conformal_type`` picks the permutation scheme: ``"iid"`` (the default)
+    draws random permutations of the residual path and assumes the errors are
+    exchangeable, while ``"block"`` uses the :math:`T` cyclic shifts, preserving
+    serial dependence. ``"block"`` is ``scinference``'s default and the one to
+    prefer on a panel with persistent errors; being a set of :math:`T` shifts,
+    one of which is the observed path, its :math:`p`-value cannot fall below
+    :math:`1/T`, and at :math:`\alpha < 1/T` it never rejects.
+
 ``"jackknife_plus"`` -- jackknife+ over pre-treatment periods (Ben-Michael, Feller & Rothstein 2021)
     ``augsynth``'s ``inf_type = "jackknife+"``, and only defined for the
     ridge-augmented fit (``augment="ridge"``); asking for it without the

--- a/mlsynth/tests/test_conformal_refit.py
+++ b/mlsynth/tests/test_conformal_refit.py
@@ -1,0 +1,245 @@
+"""The conformal refit rule: which control the test-inversion procedure refits.
+
+Chernozhukov, Wuthrich & Zhu's conformal test subtracts a candidate effect from
+the treated post-treatment outcomes, refits the control on the adjusted series,
+and compares the post-block residual against the pre-block ones. The refit is
+the only place the procedure touches the estimator, so the rule it uses is what
+ties the inference to the estimate: a p-value computed from a refit the point
+estimate did not use is a p-value about a different control.
+
+Two rules are supported, and they are not interchangeable:
+
+* ``"sc"`` -- the simplex synthetic control (non-negative weights summing to
+  one). This is ``estimation_method = "sc"`` in the authors' ``scinference`` R
+  package and ``progfunc = "None"`` in ``augsynth``. Convexity bounds the fit,
+  so an injected post-period effect cannot be re-levelled away.
+* ``"ridge"`` -- the ridge-augmented SCM, ``augsynth``'s ``progfunc = "Ridge"``
+  and the refit its conformal mode is defined on. The augmentation leaves the
+  simplex by construction, which is what makes it a bias correction and also
+  what lets it absorb a post-period level shift.
+
+The reference values below are the authors' own package: ``scinference`` at
+``567c688`` on the Swedish carbon tax panel, moving-block scheme, reproduced
+here to six decimals.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.bilevel.ridge_inference import conformal_pvalue
+from mlsynth.utils.conformal import CONFORMAL_REFIT_RULES, conformal_refit_gaps
+
+CARBONTAX = "basedata/carbontax_data.dta"
+
+# scinference @ 567c688, estimation_method="sc", permutation_method="mb",
+# alpha=0.1, lsei_type=1, on the panel built below.
+SCINFERENCE_CARBONTAX_MB = 0.391304
+# Its p-value under any injected post-period effect from +1 upward: the floor of
+# the moving-block reference set, 1 / T with T = 46.
+SCINFERENCE_CARBONTAX_MB_FLOOR = 0.021739
+
+
+@pytest.fixture(scope="module")
+def carbontax():
+    """Sweden vs 14 OECD donors, CO2 transport per capita, treated from 1990."""
+    ct = pd.read_stata(CARBONTAX)
+    wide = ct.pivot(index="year", columns="country", values="CO2_transport_capita")
+    y = wide["Sweden"].to_numpy(dtype=float)
+    Y0 = wide.drop(columns=["Sweden"]).to_numpy(dtype=float)
+    pre = int((wide.index.to_numpy() < 1990).sum())
+    return y, Y0, pre
+
+
+def _panel(seed=0, pre=18, post=6, n_donors=5):
+    rng = np.random.default_rng(seed)
+    total = pre + post
+    Y0 = rng.normal(size=(total, n_donors)) + rng.normal(size=(1, n_donors)) * 3.0
+    y = Y0 @ rng.dirichlet(np.ones(n_donors)) + 0.2 * rng.normal(size=total)
+    return y, Y0, pre
+
+
+# --------------------------------------------------------------------------
+# smoke
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("rule", CONFORMAL_REFIT_RULES)
+def test_refit_returns_one_finite_gap_per_period(rule):
+    y, Y0, _ = _panel()
+    gaps = conformal_refit_gaps(y, Y0, rule=rule)
+    assert gaps.shape == y.shape
+    assert np.all(np.isfinite(gaps))
+
+
+@pytest.mark.parametrize("rule", CONFORMAL_REFIT_RULES)
+def test_refit_can_return_its_base_weights(rule):
+    """``return_base`` hands back the weights the next refit can warm-start from."""
+    y, Y0, _ = _panel()
+    gaps, w_base = conformal_refit_gaps(y, Y0, rule=rule, return_base=True)
+    assert gaps.shape == y.shape
+    assert w_base.shape == (Y0.shape[1],)
+    assert np.all(w_base >= -1e-9)
+    assert float(w_base.sum()) == pytest.approx(1.0, abs=1e-6)
+
+
+# --------------------------------------------------------------------------
+# unit: the rule is what reproduces the authors' package
+# --------------------------------------------------------------------------
+
+def test_sc_rule_reproduces_scinference_under_the_null(carbontax):
+    """The p-value with no injected effect matches ``scinference`` exactly."""
+    y, Y0, pre = carbontax
+    p = conformal_pvalue(y, Y0, pre, conformal_type="block", refit="sc")
+    assert p == pytest.approx(SCINFERENCE_CARBONTAX_MB, abs=5e-6)
+
+
+@pytest.mark.parametrize("effect", [1.0, 5.0, 20.0, 100.0])
+def test_sc_rule_reproduces_scinference_under_an_injected_effect(carbontax, effect):
+    """And matches it at the floor, for every injected effect the authors' run used.
+
+    This is the assertion the suite was missing. Nothing previously checked that
+    the conformal test had any power at all: the existing tests pin the shape of
+    the interval, the range of the p-value and its determinism, all of which a
+    procedure with no power satisfies.
+    """
+    y, Y0, pre = carbontax
+    shifted = y.copy()
+    shifted[pre:] += effect
+    p = conformal_pvalue(shifted, Y0, pre, conformal_type="block", refit="sc")
+    assert p == pytest.approx(SCINFERENCE_CARBONTAX_MB_FLOOR, abs=5e-6)
+
+
+def test_ridge_rule_is_the_augsynth_refit_and_is_kept(carbontax):
+    """The augmented rule stays available and stays the default.
+
+    ``conformal_pvalue`` is augsynth's conformal p-value and the GeoX augsynth
+    engine depends on reproducing it, so changing the default would be a
+    different defect. Pinned here so the default cannot drift silently.
+    """
+    y, Y0, pre = carbontax
+    explicit = conformal_pvalue(y, Y0, pre, conformal_type="block", refit="ridge")
+    default = conformal_pvalue(y, Y0, pre, conformal_type="block")
+    assert explicit == default
+    assert explicit != pytest.approx(SCINFERENCE_CARBONTAX_MB, abs=5e-6)
+
+
+def test_reselecting_the_penalty_on_the_full_window_costs_the_test_its_power(carbontax):
+    """The second fault the same incident had, isolated.
+
+    ``conformal_pvalue`` called without ``lambda_`` cross-validates the ridge
+    penalty on the matching window -- which, for a conformal refit, is the whole
+    path including the post block. That window picks a penalty orders of
+    magnitude below the one the pre-period fit picks, and the augmentation it
+    then permits absorbs the effect: the p-value stops responding to the effect
+    size entirely, reading 0.348 whether the injected effect is 5 or 100.
+
+    Pinning the penalty at the fitted value -- what augsynth does, and what the
+    GeoX engine and VanillaSC both pass -- leaves the test its power. The
+    docstring used to call re-selection "slightly anti-conservative"; the
+    numbers below are why it no longer does.
+    """
+    y, Y0, pre = carbontax
+    from mlsynth.utils.bilevel.ridge_augment import ridge_augment_weights
+
+    fitted_lambda = float(ridge_augment_weights(y[:pre], Y0[:pre]).lambda_)
+    stalled, powered = [], []
+    for effect in (5.0, 100.0):
+        shifted = y.copy()
+        shifted[pre:] += effect
+        stalled.append(conformal_pvalue(shifted, Y0, pre, conformal_type="block",
+                                        refit="ridge"))
+        powered.append(conformal_pvalue(shifted, Y0, pre, conformal_type="block",
+                                        refit="ridge", lambda_=fitted_lambda))
+    # A twentyfold larger effect leaves the re-selected penalty's p-value
+    # unmoved -- that is the ceiling, stated as an assertion.
+    assert stalled[0] == pytest.approx(stalled[1], abs=1e-9)
+    assert stalled[0] > 0.3
+    # The pinned penalty reaches the floor of the reference set for both.
+    assert powered == [pytest.approx(SCINFERENCE_CARBONTAX_MB_FLOOR, abs=5e-6)] * 2
+
+
+def test_the_two_rules_disagree_on_the_same_panel(carbontax):
+    """If they agreed, the argument would be decoration rather than a choice."""
+    y, Y0, pre = carbontax
+    sc = conformal_refit_gaps(y, Y0, rule="sc")
+    ridge = conformal_refit_gaps(y, Y0, rule="ridge")
+    assert not np.allclose(sc, ridge)
+    # The augmented fit is the better in-sample fit -- that is what it is for.
+    assert np.mean(np.abs(ridge)) < np.mean(np.abs(sc))
+
+
+# --------------------------------------------------------------------------
+# edge
+# --------------------------------------------------------------------------
+
+def test_single_donor_leaves_the_only_weight_at_one():
+    """With one donor the simplex is a point, so the fit is that donor."""
+    y, Y0, _ = _panel(n_donors=1)
+    gaps, w = conformal_refit_gaps(y, Y0, rule="sc", return_base=True)
+    assert w == pytest.approx(np.array([1.0]))
+    assert gaps == pytest.approx(y - Y0[:, 0])
+
+
+def test_collinear_donors_still_produce_finite_gaps():
+    """Duplicated donors make the weights non-unique; the fit is still unique."""
+    y, Y0, _ = _panel(n_donors=3)
+    duplicated = np.hstack([Y0, Y0])
+    gaps = conformal_refit_gaps(y, duplicated, rule="sc")
+    assert np.all(np.isfinite(gaps))
+    assert gaps == pytest.approx(conformal_refit_gaps(y, Y0, rule="sc"), abs=1e-6)
+
+
+def test_a_treated_series_outside_the_hull_is_not_forced_inside():
+    """The gaps report the miss rather than the refit pretending to close it."""
+    y, Y0, _ = _panel()
+    y = y + 50.0
+    gaps = conformal_refit_gaps(y, Y0, rule="sc")
+    assert np.all(gaps > 0.0)
+
+
+def test_single_post_period_is_a_valid_block(carbontax):
+    """A one-period post block is the per-period test ``conformal_intervals`` runs."""
+    y, Y0, _ = carbontax
+    p = conformal_pvalue(y, Y0, y.size - 1, conformal_type="block", refit="sc")
+    assert 0.0 < p <= 1.0
+
+
+# --------------------------------------------------------------------------
+# failure: the contracts the rule argument now enforces
+# --------------------------------------------------------------------------
+
+def test_unknown_rule_is_rejected():
+    y, Y0, _ = _panel()
+    with pytest.raises(MlsynthConfigError, match="refit rule"):
+        conformal_refit_gaps(y, Y0, rule="lasso")
+
+
+def test_covariates_are_rejected_by_the_sc_rule():
+    """The simplex rule is outcome-only, so silently dropping covariates is wrong.
+
+    ``scinference``'s ``estimation_method = "sc"`` matches on outcomes alone.
+    Accepting ``Z0`` / ``z1`` and ignoring them would produce a fit that is not
+    the one the caller asked for, and no output would show it.
+    """
+    y, Y0, _ = _panel()
+    Z0 = np.ones((Y0.shape[1], 2))
+    with pytest.raises(MlsynthConfigError, match="covariates"):
+        conformal_refit_gaps(y, Y0, rule="sc", Z0=Z0, z1=np.ones(2))
+
+
+def test_mismatched_donor_length_is_reported():
+    y, Y0, _ = _panel()
+    with pytest.raises((MlsynthDataError, ValueError)):
+        conformal_refit_gaps(y, Y0[:-1], rule="sc")
+
+
+def test_empty_donor_pool_is_reported():
+    y, _, _ = _panel()
+    with pytest.raises((MlsynthConfigError, MlsynthDataError, ValueError)):
+        conformal_refit_gaps(y, np.empty((y.size, 0)), rule="sc")
+
+
+def test_conformal_pvalue_rejects_an_unknown_rule(carbontax):
+    y, Y0, pre = carbontax
+    with pytest.raises(MlsynthConfigError, match="refit rule"):
+        conformal_pvalue(y, Y0, pre, refit="nonesuch")

--- a/mlsynth/tests/test_conformal_refit_properties.py
+++ b/mlsynth/tests/test_conformal_refit_properties.py
@@ -1,0 +1,170 @@
+"""Metamorphic invariants of the conformal refit rule.
+
+A test-inversion conformal procedure works by refitting the control on outcomes
+that have had a candidate effect subtracted, then asking whether the residuals
+on the post block look like the residuals on the pre block. Everything the test
+can see is the residual path, so the refit rule decides how much the test can
+see.
+
+The invariant these properties pin is *saturation*. Inject a constant shift
+``tau`` into the post block of the treated series and refit. The counterfactual
+the refit produces on the *pre* block must stop moving once ``tau`` is large:
+the pre-period outcomes were not touched, so a refit that keeps chasing a larger
+and larger post block is redistributing the treatment effect into the very
+residuals that form the test's reference distribution. Convexity gives
+saturation for free -- a convex combination of donors is bounded by the donor
+pool whatever the treated series does -- so the ``"sc"`` rule satisfies it on
+every panel, exactly. An unconstrained rule does not: its displacement is linear
+in ``tau``, without bound.
+
+The consequence, asserted here on the p-value itself, is power. If the pre-block
+residuals grow with ``tau`` alongside the post-block ones, the observed
+statistic and its reference distribution grow together and the p-value stalls at
+a ceiling no effect size can push it past. Saturation is what stops that.
+
+The properties:
+
+* saturation -- ``d(10 tau) ~ d(tau)`` for large ``tau``, where ``d`` is the
+  largest pre-block displacement of the counterfactual;
+* boundedness -- that displacement never exceeds the donor pool's own range,
+  the bound convexity supplies;
+* power -- a large enough injected effect drives the block-scheme p-value to
+  ``1 / T``, the floor of its reference set;
+* equivariance -- the refit commutes with a common rescaling of the treated and
+  donor series, and with a relabelling of the donors.
+"""
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils.conformal import conformal_refit_gaps
+from mlsynth.utils.bilevel.ridge_inference import conformal_pvalue
+
+_SETTINGS = settings(
+    max_examples=25, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+)
+
+# Large enough that the simplex weights have reached a vertex, so the two scales
+# below differ only in whether the rule keeps responding after that.
+_TAU = 1.0e3
+
+
+@st.composite
+def panels(draw):
+    """A donor panel with a treated unit inside the donor pool's convex hull."""
+    n_donors = draw(st.integers(3, 12))
+    pre = draw(st.integers(14, 32))
+    post = draw(st.integers(3, 14))
+    seed = draw(st.integers(0, 2**31 - 1))
+    rng = np.random.default_rng(seed)
+    total = pre + post
+    # Heterogeneous donor levels and trends: the structure an unconstrained
+    # refit exploits to manufacture a post-only level shift.
+    Y0 = (rng.normal(size=(total, n_donors))
+          + rng.normal(size=(1, n_donors)) * 3.0
+          + np.arange(total)[:, None] * rng.normal(scale=0.1, size=(1, n_donors)))
+    y = Y0 @ rng.dirichlet(np.ones(n_donors)) + 0.2 * rng.normal(size=total)
+    return y, Y0, pre
+
+
+def _counterfactual(y, Y0, pre, tau, rule):
+    """The refit's fitted counterfactual with ``tau`` injected into the post block."""
+    shifted = np.asarray(y, dtype=float).copy()
+    shifted[pre:] += tau
+    return shifted - conformal_refit_gaps(shifted, Y0, rule=rule)
+
+
+def _pre_displacement(y, Y0, pre, tau, rule):
+    """How far the pre-block counterfactual moves when ``tau`` is injected."""
+    base = _counterfactual(y, Y0, pre, 0.0, rule)
+    shifted = _counterfactual(y, Y0, pre, tau, rule)
+    return float(np.max(np.abs(shifted[:pre] - base[:pre])))
+
+
+@given(panels())
+@_SETTINGS
+def test_sc_refit_saturates_in_the_injected_shift(panel):
+    """Ten times the shift must not move the pre block ten times as far.
+
+    The pre-period outcomes are identical in both refits; only the post block
+    differs. A rule whose pre-block fit keeps tracking the post block is
+    contaminating the test's reference distribution with the effect it is meant
+    to detect.
+    """
+    y, Y0, pre = panel
+    near = _pre_displacement(y, Y0, pre, _TAU, "sc")
+    far = _pre_displacement(y, Y0, pre, 10.0 * _TAU, "sc")
+    assert far <= near + 1e-6 * max(near, 1.0)
+
+
+@given(panels())
+@_SETTINGS
+def test_sc_refit_stays_inside_the_donor_pool(panel):
+    """The refit counterfactual is a convex combination, so the pool bounds it.
+
+    This is the reason saturation holds, asserted directly: whatever is done to
+    the treated series, the fitted values cannot leave the per-period range of
+    the donors, so their displacement is bounded by the pool's own spread.
+    """
+    y, Y0, pre = panel
+    lo, hi = Y0.min(axis=1), Y0.max(axis=1)
+    for tau in (0.0, _TAU, 10.0 * _TAU):
+        cf = _counterfactual(y, Y0, pre, tau, "sc")
+        tol = 1e-6 * max(1.0, float(np.max(np.abs(Y0))))
+        assert np.all(cf >= lo - tol) and np.all(cf <= hi + tol)
+
+
+@given(panels())
+@_SETTINGS
+def test_sc_refit_has_power_against_a_large_effect(panel):
+    """A large enough effect must reach the floor of the reference set.
+
+    Under the block scheme the reference set is the ``T`` cyclic shifts of the
+    residual path, one of which is the observed path, so ``1 / T`` is the
+    smallest p-value attainable. Any procedure worth inverting must get there
+    for an effect large enough, and a saturating refit does.
+    """
+    y, Y0, pre = panel
+    T = y.size
+    shifted = y.copy()
+    shifted[pre:] += 1.0e4 * max(1.0, float(np.std(y)))
+    p = conformal_pvalue(shifted, Y0, pre, conformal_type="block", refit="sc")
+    assert p == pytest.approx(1.0 / T)
+
+
+@given(panels(), st.floats(0.25, 4.0))
+@_SETTINGS
+def test_refit_gaps_are_scale_equivariant(panel, scale):
+    """Rescaling treated and donors together rescales the gaps by the same factor."""
+    y, Y0, _ = panel
+    base = conformal_refit_gaps(y, Y0, rule="sc")
+    scaled = conformal_refit_gaps(y * scale, Y0 * scale, rule="sc")
+    assert np.allclose(scaled, base * scale, atol=1e-6 * max(1.0, abs(scale)))
+
+
+@given(panels(), st.integers(0, 2**31 - 1))
+@_SETTINGS
+def test_refit_gaps_ignore_donor_order(panel, seed):
+    """Donors are exchangeable: permuting the columns cannot change the gaps."""
+    y, Y0, _ = panel
+    order = np.random.default_rng(seed).permutation(Y0.shape[1])
+    base = conformal_refit_gaps(y, Y0, rule="sc")
+    permuted = conformal_refit_gaps(y, Y0[:, order], rule="sc")
+    assert np.allclose(permuted, base, atol=1e-6)
+
+
+@given(panels())
+@_SETTINGS
+def test_ridge_refit_does_not_saturate(panel):
+    """The augmented rule keeps responding, which is why it must not be the default.
+
+    Not a defect in the ridge augmentation itself -- relaxing the simplex is the
+    whole point of it, and augsynth's conformal mode is defined on the augmented
+    fit. It is a fact about the rule that the caller has to choose knowingly,
+    and pinning it here is what makes the choice visible.
+    """
+    y, Y0, pre = panel
+    near = _pre_displacement(y, Y0, pre, _TAU, "ridge")
+    far = _pre_displacement(y, Y0, pre, 10.0 * _TAU, "ridge")
+    assert far > 2.0 * near

--- a/mlsynth/tests/test_vanillasc_conformal_refit.py
+++ b/mlsynth/tests/test_vanillasc_conformal_refit.py
@@ -1,0 +1,166 @@
+"""VanillaSC's test-inversion conformal mode, against the authors' own package.
+
+``inference="conformal"`` inverts the sharp null of Chernozhukov, Wuthrich & Zhu
+(2021). Their reference implementation is the ``scinference`` R package; with
+``estimation_method = "sc"`` it refits a simplex synthetic control under each
+candidate null. VanillaSC's point estimate is a simplex synthetic control too
+(unless ``augment="ridge"`` is asked for), so its null refit has to be the same
+control, and these tests pin that it is -- by reproducing ``scinference``'s
+p-values on the Swedish carbon tax panel to six decimals.
+
+The tests that matter most here are the power ones. A refit free to re-level the
+treated series absorbs a post-period effect and spreads it over the pre-period
+residuals the test calibrates against, and the p-value then stops responding to
+the effect size entirely. That failure is invisible to a test that checks only
+that the p-value is a number in ``[0, 1]``, which is why it is checked directly:
+inject an effect, watch the p-value reach the floor of its reference set.
+
+Reference: ``scinference`` @ ``567c688``, ``inference_method = "conformal"``,
+``estimation_method = "sc"``, ``alpha = 0.1``, ``lsei_type = 1``. The run script
+is ``benchmarks/reference/cwz_conformal/reference.R``.
+"""
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import VanillaSC
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.vanillasc_helpers.config import VanillaSCConfig
+
+# scinference, moving-block scheme, on the panel built below.
+SCINFERENCE_MB_NULL = 0.391304
+SCINFERENCE_MB_FLOOR = 0.021739     # 1 / T, T = 46
+
+
+@pytest.fixture(scope="module")
+def carbontax():
+    ct = pd.read_stata("basedata/carbontax_data.dta")
+    ct["treat"] = ((ct.country == "Sweden") & (ct.year >= 1990)).astype(int)
+    return ct
+
+
+def _fit(df, *, effect=0.0, **kw):
+    d = df.copy()
+    if effect:
+        d.loc[d.treat == 1, "CO2_transport_capita"] += effect
+    cfg = dict(df=d, unitid="country", time="year",
+               outcome="CO2_transport_capita", treat="treat",
+               display_graphs=False, inference="conformal", seed=0)
+    cfg.update(kw)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return VanillaSC(VanillaSCConfig(**cfg)).fit()
+
+
+# --------------------------------------------------------------------------
+# the permutation scheme has to be reachable
+# --------------------------------------------------------------------------
+
+def test_conformal_type_is_configurable(carbontax):
+    """The moving-block scheme is the authors' default and must be selectable.
+
+    Without this the config could only reach the i.i.d. scheme, which assumes
+    exchangeable errors -- the assumption panel data usually breaks, and the one
+    Chernozhukov, Wuthrich & Zhu introduce the block scheme to avoid.
+    """
+    res = _fit(carbontax, conformal_type="block")
+    assert res.inference.details["conformal_type"] == "block"
+
+
+def test_conformal_type_rejects_an_unknown_scheme(carbontax):
+    with pytest.raises((MlsynthConfigError, ValueError)):
+        _fit(carbontax, conformal_type="bootstrap")
+
+
+# --------------------------------------------------------------------------
+# the reference values
+# --------------------------------------------------------------------------
+
+def test_block_pvalue_matches_scinference_under_the_null(carbontax):
+    res = _fit(carbontax, conformal_type="block")
+    assert res.inference.p_value == pytest.approx(SCINFERENCE_MB_NULL, abs=5e-6)
+
+
+@pytest.mark.parametrize("effect", [1.0, 5.0, 100.0])
+def test_block_pvalue_reaches_the_floor_under_an_injected_effect(carbontax, effect):
+    """Power, asserted as the authors' package reports it.
+
+    ``scinference`` returns ``1 / T`` for every one of these injected effects --
+    the smallest value the moving-block reference set can produce, since one of
+    the ``T`` cyclic shifts is the observed path.
+    """
+    res = _fit(carbontax, conformal_type="block", effect=effect)
+    assert res.inference.p_value == pytest.approx(SCINFERENCE_MB_FLOOR, abs=5e-6)
+
+
+def test_iid_pvalue_responds_to_an_injected_effect(carbontax):
+    """The other scheme has to move too, or the refit is absorbing the effect."""
+    null = _fit(carbontax).inference.p_value
+    shifted = _fit(carbontax, effect=100.0).inference.p_value
+    assert null > 0.2
+    assert shifted < 1e-9
+
+
+# --------------------------------------------------------------------------
+# the refit follows the estimator
+# --------------------------------------------------------------------------
+
+def test_ridge_augmented_fit_keeps_the_augmented_refit(carbontax):
+    """``augment="ridge"`` is augsynth's ASCM, and its conformal mode goes with it.
+
+    Reported rather than corrected: the refit a caller gets is the one their own
+    estimator uses, and silently substituting a different one would make
+    VanillaSC stop reproducing augsynth.
+    """
+    res = _fit(carbontax, augment="ridge", conformal_type="block")
+    assert res.inference.details["refit"] == "ridge"
+    assert _fit(carbontax, conformal_type="block").inference.details["refit"] == "sc"
+
+
+def test_the_augmented_refit_agrees_here_because_its_penalty_is_large(carbontax):
+    """On this panel the augmentation is inert, so the two rules coincide.
+
+    Worth pinning because it is the reason the rule alone does not explain the
+    disagreement with ``scinference``. Cross-validation on the pre-period picks
+    a penalty near 700 for the carbon tax panel, which leaves the ridge
+    correction negligible and the augmented fit sitting on the simplex. What
+    unleashes the augmentation is re-selecting that penalty on a window that
+    includes the post block -- see ``test_conformal_refit.py`` -- not the
+    augmentation being available.
+    """
+    ridge = _fit(carbontax, augment="ridge", conformal_type="block")
+    assert ridge.inference.details["lambda"] > 100.0
+    assert ridge.inference.p_value == pytest.approx(SCINFERENCE_MB_NULL, abs=5e-6)
+
+
+def test_covariates_without_ridge_are_refused_rather_than_dropped(carbontax):
+    """A refit that quietly ignores the covariates would answer a different question."""
+    df = carbontax.copy()
+    df["gdp"] = df.groupby("country")["CO2_transport_capita"].transform(
+        lambda s: s.rolling(3, min_periods=1).mean()
+    )
+    with pytest.raises(MlsynthConfigError, match="augment='ridge'"):
+        _fit(df, covariates=["gdp"])
+
+
+# --------------------------------------------------------------------------
+# the band the p-value comes with
+# --------------------------------------------------------------------------
+
+def test_interval_brackets_the_point_effect(carbontax):
+    res = _fit(carbontax, conformal_type="block")
+    d = res.inference.details
+    tau, lo, hi = d["tau"], d["pi_lower"], d["pi_upper"]
+    finite = np.isfinite(lo) & np.isfinite(hi)
+    assert finite.any()
+    assert np.all(lo[finite] <= tau[finite] + 1e-9)
+    assert np.all(tau[finite] <= hi[finite] + 1e-9)
+
+
+def test_the_mode_is_deterministic_under_the_block_scheme(carbontax):
+    """The block reference set is the ``T`` cyclic shifts, so no RNG enters it."""
+    a = _fit(carbontax, conformal_type="block").inference.p_value
+    b = _fit(carbontax, conformal_type="block", seed=99).inference.p_value
+    assert a == b

--- a/mlsynth/utils/bilevel/ridge_inference.py
+++ b/mlsynth/utils/bilevel/ridge_inference.py
@@ -1,10 +1,10 @@
-"""Conformal inference for ridge-augmented SCM (Ben-Michael, Feller & Rothstein
-2021, §5.4; augsynth ``inf_type="conformal"``, the package default).
+"""Conformal test inversion for synthetic control (Chernozhukov, Wuthrich & Zhu
+2021; augsynth ``inf_type="conformal"``, the package default, applies it to ASCM
+-- Ben-Michael, Feller & Rothstein 2021, §5.4).
 
-The conformal procedure of Chernozhukov, Wuthrich & Zhu (2019) adapted to ASCM:
-for a sharp null ``H0: tau = tau0`` it subtracts ``tau0`` from the treated
-post-treatment outcomes, **refits** the ridge ASCM treating the (adjusted) post
-periods as additional matching periods, and asks whether the post-treatment
+For a sharp null ``H0: tau = tau0`` the procedure subtracts ``tau0`` from the
+treated post-treatment outcomes, **refits** the control treating the (adjusted)
+post periods as additional matching periods, and asks whether the post-treatment
 residual "conforms" with the pre-treatment residuals -- comparing the post-block
 test statistic ``(sum|x|^q / sqrt(n))^(1/q)`` against permutations of the
 residual path.
@@ -13,10 +13,30 @@ Two products, mirroring augsynth:
 
 * :func:`conformal_pvalue` -- the joint-null p-value (the ``( p )`` printed next
   to the Average ATT). The treated outcomes are unchanged (``tau0 = 0``), the
-  ASCM is refit on **all** periods, and the post-block statistic is compared to
-  ``ns`` i.i.d. permutations of the residuals.
+  control is refit on **all** periods, and the post-block statistic is compared
+  to ``ns`` i.i.d. permutations of the residuals.
 * :func:`conformal_intervals` -- per-period confidence intervals (Eq. 29) by
   inverting the test on a grid of nulls for each post period.
+
+Two things decide whether the test has any power, and both are the caller's:
+
+``refit``
+    Which control the null refit uses -- the simplex synthetic control
+    (``"sc"``, the procedure as published, and ``scinference``'s
+    ``estimation_method = "sc"``) or the ridge-augmented one (``"ridge"``, the
+    default here, which is what augsynth's conformal mode is defined on). It
+    should match the estimator whose effect is being tested; the reasoning is in
+    :mod:`mlsynth.utils.conformal.refit`, which owns the choice.
+
+``lambda_``
+    Whether the ridge penalty is pinned at the fitted value or re-selected. Not
+    a performance knob. Re-selection cross-validates on the conformal matching
+    window, which *includes the post block*, and on the Swedish carbon tax panel
+    that picks a penalty around 0.1 where the pre-period fit picks 688 -- the
+    augmentation is then free to re-level the treated series, absorbing the
+    effect into the pre-period residuals the test calibrates against. The
+    p-value reads 0.348 whether the injected effect is 5 or 100. Pass the fitted
+    penalty, as augsynth does.
 """
 
 from __future__ import annotations
@@ -26,6 +46,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 
+from ...exceptions import MlsynthConfigError
+from ..conformal.refit import CONFORMAL_REFIT_RULES, conformal_refit_gaps
 from .ridge_augment import ridge_augment_weights
 
 
@@ -75,22 +97,53 @@ def _augmented_gaps(
     ridge_kwargs: Dict[str, Any],
     warm_start: Optional[np.ndarray] = None,
     return_base: bool = False,
+    refit: str = "ridge",
 ):
-    """Refit ridge ASCM matching on the full (given) outcome window; return gaps.
+    """Refit the control matching on the full (given) outcome window; return gaps.
 
     Passing the *entire* outcome path as the matching window is exactly augsynth's
-    conformal refit (``X <- cbind(X, y)``): the ASCM balances every period and
+    conformal refit (``X <- cbind(X, y)``): the control balances every period and
     the residuals are the treated-minus-synthetic gaps over the whole window.
     ``warm_start`` seeds the base simplex solve (e.g. the previous tau0 in a grid
     sweep); ``return_base`` also returns the base weights so the caller can chain
     the warm start. The default (no warm start, gaps only) is unchanged.
+
+    ``refit`` picks which control is refit -- ``"ridge"`` for the augmented one
+    augsynth's conformal mode is defined on (the default here, so this module's
+    augsynth-facing behaviour is unchanged), ``"sc"`` for the simplex control the
+    conformal procedure was published on. The rule matters for power, not just
+    for fidelity; see :mod:`mlsynth.utils.conformal.refit`, which owns the
+    choice so the two cannot drift apart between callers.
     """
-    ra = ridge_augment_weights(y, Y0, Z0=Z0, z1=z1, warm_start=warm_start,
-                               **ridge_kwargs)
-    gaps = np.asarray(y, dtype=float) - np.asarray(Y0, dtype=float) @ ra.W
-    if return_base:
-        return gaps, ra.W_base
-    return gaps
+    return conformal_refit_gaps(
+        y, Y0, rule=refit, Z0=Z0, z1=z1, ridge_kwargs=ridge_kwargs,
+        warm_start=warm_start, return_base=return_base,
+    )
+
+
+def _pre_fit_gaps(
+    y: np.ndarray,
+    Y0: np.ndarray,
+    pre: int,
+    refit: str,
+    ridge_kwargs: Dict[str, Any],
+) -> np.ndarray:
+    """Gaps over the full window from weights fit on the pre-block alone.
+
+    Distinct from :func:`_augmented_gaps`, which matches on every period: this
+    is the ordinary point fit, used to centre a search or to report the effect,
+    and it must never see the post block. Dispatches on the same rule so the
+    centre and the refits around it describe the same control.
+    """
+    y = np.asarray(y, dtype=float)
+    Y0 = np.asarray(Y0, dtype=float)
+    if refit == "sc":
+        from .ridge_augment import simplex_qp
+
+        w = simplex_qp(Y0[:pre], y[:pre])
+    else:
+        w = ridge_augment_weights(y[:pre], Y0[:pre], **ridge_kwargs).W
+    return y - Y0 @ w
 
 
 def conformal_pvalue(
@@ -107,6 +160,7 @@ def conformal_pvalue(
     conformal_type: str = "iid",
     fixed_effects: bool = False,
     finite_sample: bool = False,
+    refit: str = "ridge",
     ridge_kwargs: Optional[Dict[str, Any]] = None,
 ) -> float:
     """Conformal p-value for the joint null of no post-treatment effect.
@@ -122,8 +176,17 @@ def conformal_pvalue(
     lambda_ : float, optional
         Ridge penalty to **reuse** in the refit. augsynth fixes the penalty at
         the originally CV-selected value for every conformal refit (it does not
-        re-cross-validate); pass the fitted ``lambda_`` to reproduce it. ``None``
-        re-selects by CV on each refit (slower, and slightly anti-conservative).
+        re-cross-validate); pass the fitted ``lambda_`` to reproduce it.
+
+        ``None`` re-selects by CV on each refit, and that is not merely slower.
+        The conformal matching window is the whole path, post block included, so
+        the CV that picks the penalty is run on data containing the effect. On
+        the Swedish carbon tax panel it returns 0.105 where the pre-period fit
+        returns 688, and the augmentation that penalty permits absorbs the
+        effect: the block-scheme p-value is 0.348 for an injected effect of 5
+        and 0.348 for one of 100, against 1/T = 0.0217 with the penalty pinned.
+        Only leave it ``None`` when no fitted penalty exists, and do not read the
+        resulting p-value as evidence of no effect.
     Z0, z1 : np.ndarray, optional
         Auxiliary covariates (donor ``(J, K)`` / treated ``(K,)``).
     q : float
@@ -141,11 +204,25 @@ def conformal_pvalue(
         ``ns`` draws cannot evidence more than ``1 / (ns + 1)``.
     fixed_effects : bool, default False
         Unit fixed effects (augsynth ``fixed_effects=TRUE``): demean every unit
-        by its mean over the full matching window before the refit, so the donor
-        pool cannot absorb a post-period level shift. Use the same value as the
-        point fit.
+        by its mean over the full matching window before the refit. Use the same
+        value as the point fit. Note that this does *not* stop the refit
+        absorbing a post-period level shift -- a shift of ``tau`` over ``T1`` of
+        ``T`` periods survives demeaning as the same pre-to-post contrast, and
+        on the Swedish carbon tax panel the p-value under the ``"ridge"`` rule
+        is 0.348 at an injected effect of 100 with fixed effects on or off.
+        Absorption is governed by ``refit``, not by this.
+    refit : {"ridge", "sc"}, default "ridge"
+        Which control the null refit uses. ``"ridge"`` is the ridge-augmented
+        ASCM augsynth's conformal mode is defined on, and is the default so this
+        function keeps reproducing that package. ``"sc"`` is the simplex
+        synthetic control of ``scinference``'s ``estimation_method = "sc"``,
+        which is what a plain SCM point estimate should be tested against: the
+        augmented refit can re-level an arbitrarily large post-period effect
+        away, and then the test has no power against it. See
+        :mod:`mlsynth.utils.conformal.refit`.
     ridge_kwargs : dict, optional
         Other hyper-parameters forwarded to :func:`ridge_augment_weights`.
+        Ignored under ``refit="sc"``.
 
     Returns
     -------
@@ -153,6 +230,11 @@ def conformal_pvalue(
         The conformal p-value ``mean(stat(observed_post) <= stat(permuted_post))``,
         or its finite-sample correction when ``finite_sample`` is set.
     """
+    if refit not in CONFORMAL_REFIT_RULES:
+        raise MlsynthConfigError(
+            f"conformal refit rule must be one of {CONFORMAL_REFIT_RULES}; "
+            f"got {refit!r}."
+        )
     ridge_kwargs = dict(ridge_kwargs or {})
     if lambda_ is not None:
         ridge_kwargs["lambda_"] = lambda_
@@ -164,7 +246,7 @@ def conformal_pvalue(
         # full path -- so the donor pool cannot absorb a post-period level shift.
         y = y - y.mean()
         Y0 = Y0 - Y0.mean(axis=0)
-    resids = _augmented_gaps(y, Y0, Z0, z1, ridge_kwargs)
+    resids = _augmented_gaps(y, Y0, Z0, z1, ridge_kwargs, refit=refit)
     obs = _stat(resids[pre:], q)
     perm = _reference_stats(
         resids, slice(pre, None), q, conformal_type=conformal_type, ns=ns, seed=seed
@@ -232,19 +314,20 @@ def conformal_att_interval(
     y = np.asarray(y, dtype=float)
     Y0 = np.asarray(Y0, dtype=float)
     kwargs.setdefault("conformal_type", "block")
+    refit = kwargs.get("refit", "ridge")
     ridge_kwargs = {k: v for k, v in (("lambda_", kwargs.get("lambda_")),)
                     if v is not None}
 
     # Centre on the pre-period fit, as `conformal_intervals` does: an
     # all-period refit treats the post block as matching periods and pulls its
-    # gaps toward zero, which would centre the search away from the effect.
+    # gaps toward zero, which would centre the search away from the effect. The
+    # centring fit uses the same rule as the refits it centres, so the search
+    # starts on the control the test is about.
     if kwargs.get("fixed_effects"):
         y_m, Y0_m = y[:pre].mean(), Y0[:pre].mean(axis=0)
-        ra = ridge_augment_weights(y[:pre] - y_m, Y0[:pre] - Y0_m, **ridge_kwargs)
-        fitted = (y - y_m) - (Y0 - Y0_m) @ ra.W
+        fitted = _pre_fit_gaps(y - y_m, Y0 - Y0_m, pre, refit, ridge_kwargs)
     else:
-        ra = ridge_augment_weights(y[:pre], Y0[:pre], **ridge_kwargs)
-        fitted = y - Y0 @ ra.W
+        fitted = _pre_fit_gaps(y, Y0, pre, refit, ridge_kwargs)
     centre = float(np.mean(fitted[pre:]))
     scale = float(np.std(fitted[:pre])) or abs(centre) or 1.0
 
@@ -268,7 +351,7 @@ def conformal_att_interval(
             shifted = shifted - shifted.mean()
             Z = Z - Z.mean(axis=0)
         gaps = _augmented_gaps(shifted, Z, kwargs.get("Z0"), kwargs.get("z1"),
-                               ridge_kwargs)
+                               ridge_kwargs, refit=kwargs.get("refit", "ridge"))
         return _stat(gaps[pre:], kwargs.get("q", 1.0))
 
     def most_conforming() -> float:
@@ -357,6 +440,7 @@ def _period_pvalue(
     warm_start: Optional[np.ndarray] = None,
     conformal_type: str = "iid",
     fixed_effects: bool = False,
+    refit: str = "ridge",
 ):
     """Conformal p-value for ``H0: tau_j = tau0`` at a single post period ``j``.
 
@@ -377,7 +461,8 @@ def _period_pvalue(
         y_fit = y_fit - y_fit.mean()
         Y0_fit = Y0_fit - Y0_fit.mean(axis=0)
     resids, w_base = _augmented_gaps(y_fit, Y0_fit, Z0, z1, ridge_kwargs,
-                                     warm_start=warm_start, return_base=True)
+                                     warm_start=warm_start, return_base=True,
+                                     refit=refit)
     obs = _stat(resids[-1:], q)
     perm = _reference_stats(
         resids, slice(-1, None), q, conformal_type=conformal_type, ns=ns, seed=seed
@@ -400,6 +485,7 @@ def conformal_intervals(
     seed: Optional[int] = 0,
     conformal_type: str = "iid",
     fixed_effects: bool = False,
+    refit: str = "ridge",
     ridge_kwargs: Optional[Dict[str, Any]] = None,
 ) -> ConformalIntervals:
     """Per-period conformal confidence intervals by test inversion (Eq. 29).
@@ -408,7 +494,19 @@ def conformal_intervals(
     point estimate is tested; the interval is the range of nulls not rejected at
     level ``alpha``. Also returns the joint-null p-value. ``lambda_`` is reused
     across refits (augsynth's behaviour; pass the fitted penalty).
+
+    ``refit`` selects the control the null refits use, and should match the
+    estimator whose effect is being tested -- ``"sc"`` for a plain simplex
+    synthetic control, ``"ridge"`` (the default) for a ridge-augmented one. It
+    is not a tuning knob: an augmented refit can re-level a large post-period
+    effect away, and the test then has no power against it. See
+    :mod:`mlsynth.utils.conformal.refit`.
     """
+    if refit not in CONFORMAL_REFIT_RULES:
+        raise MlsynthConfigError(
+            f"conformal refit rule must be one of {CONFORMAL_REFIT_RULES}; "
+            f"got {refit!r}."
+        )
     ridge_kwargs = dict(ridge_kwargs or {})
     if lambda_ is not None:
         ridge_kwargs["lambda_"] = lambda_
@@ -424,7 +522,16 @@ def conformal_intervals(
     # fixed effects, demean each unit by its pre-period mean and restore the
     # level (the residual gap is invariant to the treated mean), mirroring
     # ``fit_augsynth_once(fixed_effects=True)``.
-    if fixed_effects:
+    if refit == "sc":
+        from .ridge_augment import simplex_qp
+
+        if fixed_effects:
+            y_pre_m, Y0_pre_m = y[:pre].mean(), Y0[:pre].mean(axis=0)
+            w = simplex_qp(Y0[:pre] - Y0_pre_m, y[:pre] - y_pre_m)
+            gap_full = (y - y_pre_m) - (Y0 - Y0_pre_m) @ w
+        else:
+            gap_full = y - Y0 @ simplex_qp(Y0[:pre], y[:pre])
+    elif fixed_effects:
         y_pre_m = y[:pre].mean()
         Y0_pre_m = Y0[:pre].mean(axis=0)
         ra = ridge_augment_weights(y[:pre] - y_pre_m, Y0[:pre] - Y0_pre_m,
@@ -453,7 +560,7 @@ def conformal_intervals(
             ps[gi], w_prev = _period_pvalue(
                 y, Y0, pre, j, tau0, Z0, z1, q, ns, seed, ridge_kwargs,
                 warm_start=w_prev, conformal_type=conformal_type,
-                fixed_effects=fixed_effects,
+                fixed_effects=fixed_effects, refit=refit,
             )
         kept = grid[ps >= alpha]
         if kept.size:
@@ -464,7 +571,7 @@ def conformal_intervals(
     joint_p = conformal_pvalue(
         y, Y0, pre, Z0=Z0, z1=z1, q=q, ns=ns, seed=seed,
         conformal_type=conformal_type, fixed_effects=fixed_effects,
-        ridge_kwargs=ridge_kwargs,
+        refit=refit, ridge_kwargs=ridge_kwargs,
     )
     return ConformalIntervals(
         periods=post, att=att, lower=lower, upper=upper,

--- a/mlsynth/utils/conformal/__init__.py
+++ b/mlsynth/utils/conformal/__init__.py
@@ -16,6 +16,9 @@ Contents:
 * :mod:`.cumulative` -- the band for a cumulative (total) effect:
   :func:`cumulative_conformal_interval` (pure combiner) and
   :func:`cumulative_conformal_from_refit` (single-treated-unit convenience).
+* :mod:`.refit` -- :func:`conformal_refit_gaps`, the refit a test-inversion
+  procedure performs under a candidate null, and the one place the choice
+  between a simplex and a ridge-augmented control is made.
 * :mod:`.structure` -- :class:`CumulativeConformalBand`.
 
 References
@@ -29,12 +32,15 @@ from __future__ import annotations
 
 from .cumulative import cumulative_conformal_from_refit, cumulative_conformal_interval
 from .quantile import split_conformal_quantile
+from .refit import CONFORMAL_REFIT_RULES, conformal_refit_gaps
 from .scores import MIN_TRAIN_PERIODS, rolling_origin_block_sums
 from .structure import CumulativeConformalBand
 
 __all__ = [
+    "CONFORMAL_REFIT_RULES",
     "MIN_TRAIN_PERIODS",
     "CumulativeConformalBand",
+    "conformal_refit_gaps",
     "cumulative_conformal_from_refit",
     "cumulative_conformal_interval",
     "rolling_origin_block_sums",

--- a/mlsynth/utils/conformal/refit.py
+++ b/mlsynth/utils/conformal/refit.py
@@ -1,0 +1,160 @@
+"""The refit rule a test-inversion conformal procedure uses.
+
+Chernozhukov, Wuthrich & Zhu (2021) invert a sharp null: subtract a candidate
+effect from the treated post-treatment outcomes, refit the control on the
+adjusted series, and ask whether the post-block residual conforms with the
+pre-block ones. The refit is the only point at which the procedure touches an
+estimator, so the rule it uses is what ties the inference to the estimate.
+
+Getting that rule wrong does not produce a wrong-looking number. It produces a
+test with no power, which looks like a large p-value and reads like a null
+result. The mechanism is worth stating because it is not obvious: an
+unconstrained refit handed a treated series with a large post-period effect will
+part-absorb the effect by re-levelling, and the level it adds is spread over the
+whole matching window -- including the pre-period, which was never touched. Both
+halves of the test then scale with the effect. The observed statistic grows, the
+reference distribution built from the pre-period residuals grows with it, and
+their ratio -- which is all the p-value sees -- stalls. On the Swedish carbon
+tax panel the p-value is 0.348 whether the injected effect is 5 or 100.
+
+Convexity is what stops it. A synthetic control with non-negative weights
+summing to one is bounded per period by the donor pool, so its fitted values
+cannot follow an arbitrarily large shift, and the pre-period residuals stop
+responding once the weights reach a vertex. The effect then has nowhere to go
+but the post-block residual, which is where the test looks for it.
+
+Hence two rules, chosen by the caller to match the estimator whose effect is
+being tested:
+
+``"sc"``
+    Simplex synthetic control. ``estimation_method = "sc"`` in the authors'
+    ``scinference`` package, ``progfunc = "None"`` in ``augsynth``. Outcome-only.
+
+``"ridge"``
+    Ridge-augmented SCM -- ``augsynth``'s ``progfunc = "Ridge"``, the refit its
+    conformal mode is defined on. The augmentation leaves the simplex on
+    purpose: that is what makes it a bias correction, and it is also what lets
+    it absorb. Correct when the point estimate is itself ridge-augmented, and
+    then the absence of power against a large level shift is a property of the
+    published method rather than of this implementation.
+
+References
+----------
+Chernozhukov, V., Wuthrich, K., & Zhu, Y. (2021). An Exact and Robust Conformal
+Inference Method for Counterfactual and Synthetic Controls. Journal of the
+American Statistical Association, 116(536), 1849-1864.
+
+Ben-Michael, E., Feller, A., & Rothstein, J. (2021). The Augmented Synthetic
+Control Method. Journal of the American Statistical Association, 116(536),
+1789-1803.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+
+#: The refit rules :func:`conformal_refit_gaps` accepts, in the order they are
+#: documented. ``"sc"`` is first because it is the rule the conformal procedure
+#: was published on; ``"ridge"`` remains the default of the augsynth-facing
+#: entry points, which reproduce that package.
+CONFORMAL_REFIT_RULES = ("sc", "ridge")
+
+
+def conformal_refit_gaps(
+    y: np.ndarray,
+    Y0: np.ndarray,
+    *,
+    rule: str,
+    Z0: Optional[np.ndarray] = None,
+    z1: Optional[np.ndarray] = None,
+    ridge_kwargs: Optional[Dict[str, Any]] = None,
+    warm_start: Optional[np.ndarray] = None,
+    return_base: bool = False,
+):
+    """Refit the control on the whole given window and return treated-minus-fit.
+
+    The entire outcome path is passed as the matching window, which is what the
+    conformal refit means: every period is balanced, and the residuals are the
+    gaps over the whole window. Callers slice the post block out afterwards.
+
+    Parameters
+    ----------
+    y : np.ndarray, shape (T,)
+        Treated outcomes over the matching window, already adjusted by the
+        candidate effect if one is being tested.
+    Y0 : np.ndarray, shape (T, J)
+        Donor outcomes over the same window.
+    rule : {"sc", "ridge"}
+        Which control to refit. See the module docstring; there is no default,
+        because a silent one is how the estimate and the inference drift apart.
+    Z0, z1 : np.ndarray, optional
+        Auxiliary covariates, donor ``(J, K)`` and treated ``(K,)``. Only the
+        ``"ridge"`` rule accepts them -- the simplex rule is outcome-only, and
+        accepting covariates it would then ignore would produce a fit the caller
+        did not ask for with no output showing it.
+    ridge_kwargs : dict, optional
+        Hyper-parameters forwarded to
+        :func:`~mlsynth.utils.bilevel.ridge_augment.ridge_augment_weights`.
+        Ignored by the ``"sc"`` rule, which has none.
+    warm_start : np.ndarray, optional
+        Previous simplex weights to seed the solve with; the two rules both
+        solve a simplex QP at their base, so a grid sweep can chain them.
+    return_base : bool, default False
+        Also return the base simplex weights, for that chaining. Under the
+        ``"sc"`` rule the base weights are the weights.
+
+    Returns
+    -------
+    np.ndarray, shape (T,)
+        The gaps, or ``(gaps, base_weights)`` when ``return_base`` is set.
+
+    Raises
+    ------
+    MlsynthConfigError
+        Unknown ``rule``, covariates supplied to the ``"sc"`` rule, or an empty
+        donor pool.
+    MlsynthDataError
+        Treated and donor windows of different lengths.
+    """
+    if rule not in CONFORMAL_REFIT_RULES:
+        raise MlsynthConfigError(
+            f"conformal refit rule must be one of {CONFORMAL_REFIT_RULES}; "
+            f"got {rule!r}."
+        )
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    if Y0.ndim != 2:
+        raise MlsynthDataError(
+            f"donor outcomes must be 2-D (T, J); got shape {Y0.shape}."
+        )
+    if Y0.shape[0] != y.shape[0]:
+        raise MlsynthDataError(
+            f"treated and donor windows must have the same length; got "
+            f"{y.shape[0]} treated periods and {Y0.shape[0]} donor periods."
+        )
+    if Y0.shape[1] == 0:
+        raise MlsynthConfigError("conformal refit needs at least one donor; got 0.")
+
+    if rule == "sc":
+        if Z0 is not None or z1 is not None:
+            raise MlsynthConfigError(
+                "the 'sc' refit rule matches on outcomes only and cannot use "
+                "covariates; pass rule='ridge' to include them, or drop Z0/z1."
+            )
+        from ..bilevel.ridge_augment import simplex_qp
+
+        w = np.asarray(simplex_qp(Y0, y, warm_start=warm_start), dtype=float)
+        gaps = y - Y0 @ w
+        return (gaps, w) if return_base else gaps
+
+    from ..bilevel.ridge_augment import ridge_augment_weights
+
+    ra = ridge_augment_weights(
+        y, Y0, Z0=Z0, z1=z1, warm_start=warm_start, **(ridge_kwargs or {})
+    )
+    gaps = y - Y0 @ ra.W
+    return (gaps, ra.W_base) if return_base else gaps

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -382,6 +382,17 @@ class VanillaSCConfig(BaseEstimatorConfig):
                     "the interval.",
     )
 
+    conformal_type: Literal["iid", "block"] = Field(
+        default="iid",
+        description="Permutation scheme for inference='conformal'. 'iid' draws "
+                    "random permutations of the residual path, which assumes "
+                    "the errors are exchangeable. 'block' uses the T cyclic "
+                    "shifts of the path (the moving-block scheme), preserving "
+                    "serial dependence and matching scinference's default; it "
+                    "is deterministic, and its p-value cannot fall below 1/T "
+                    "because one shift is the observed path.",
+    )
+
     conformal_horizon: Optional[int] = Field(
         default=None,
         description="Post-periods to accumulate for inference="

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -432,15 +432,34 @@ def run_vanillasc(config) -> BaseEstimatorResults:
     # Conformal test-inversion prediction intervals (Chernozhukov, Wuthrich &
     # Zhu 2021; augsynth's default ASCM inference). Reuses the fitted ridge
     # penalty across refits, matching augsynth.
+    #
+    # The refit rule follows the estimator, and must: the refit is the only
+    # place the test touches the fit, and an augmented refit -- unconstrained by
+    # construction -- can re-level a large post-period effect away, spreading it
+    # over the pre-period residuals that form the reference distribution. Both
+    # halves of the test then scale together and the p-value stalls. Against
+    # ``scinference`` on the Swedish carbon tax panel that ceiling is visible
+    # directly: an augmented refit gives 0.348 for an injected effect of 5 or of
+    # 100, where the simplex refit gives the authors' 1 / T = 0.0217 for both.
     if mode == "conformal" and gap[pre:].size:
         from ..bilevel import conformal_intervals
-        Z0 = X0.T if X0 is not None else None
-        z1 = X1 if X1 is not None else None
+        refit = "ridge" if config.augment == "ridge" else "sc"
+        if refit == "sc" and covariates:
+            raise MlsynthConfigError(
+                "inference='conformal' with covariates needs augment='ridge': "
+                "the null refit for a plain simplex SCM matches on outcomes "
+                "alone (as scinference's estimation_method='sc' does), so the "
+                f"covariates {list(covariates)} would not enter it. Set "
+                "augment='ridge' to match on them, or drop them."
+            )
+        Z0 = X0.T if X0 is not None and refit == "ridge" else None
+        z1 = X1 if X1 is not None and refit == "ridge" else None
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             ci = conformal_intervals(
                 y, Y0, pre, lambda_=res.lambda_, Z0=Z0, z1=z1,
                 alpha=config.alpha, ns=config.scpi_sims, seed=config.seed,
+                refit=refit, conformal_type=config.conformal_type,
                 ridge_kwargs={"residualize": config.residualize},
             )
         # per-period counterfactual bands: gap tau in [lower, upper] => cf in
@@ -462,6 +481,8 @@ def run_vanillasc(config) -> BaseEstimatorResults:
                 "counterfactual_upper": cf_upper,
                 "period_p_value": ci.p_value,
                 "joint_p_value": ci.joint_p_value,
+                "conformal_type": config.conformal_type,
+                "refit": refit,
                 "lambda": res.lambda_,
             },
         )

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -619,3 +619,29 @@ timeout = 600.0
   find = "        trt_o[adopted] = origin"
   replace = "        trt_o[adopted] = trt[adopted]"
   models = "forgetting to move adoption to the calibration origin, so every fit is the real one and each 'calibration score' is the actual treatment effect rather than a placebo window -- the scores stop measuring prediction error entirely and the band is calibrated on the thing it is supposed to be testing"
+
+[[target]]
+name = "conformal-refit-rule"
+module-path = "mlsynth/utils/conformal/refit.py"
+test-command = "python -m pytest mlsynth/tests/test_conformal_refit.py mlsynth/tests/test_conformal_refit_properties.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "refit-rule-ignored-and-always-augments"
+  find = '    if rule == "sc":'
+  replace = "    if False:"
+  models = "the defect this module was written to remove: the conformal null refit ignoring which control the caller asked for and always using the ridge-augmented one. Unconstrained weights can re-level an arbitrarily large post-period effect away and spread it over the pre-period residuals the test calibrates against, so the observed statistic and its reference distribution scale together and the p-value stalls -- 0.348 on the Swedish carbon tax panel whether the injected effect is 5 or 100, where the authors' scinference returns 1/T"
+
+  [[target.mutant]]
+  id = "sc-refit-drops-the-simplex-constraint"
+  find = "        w = np.asarray(simplex_qp(Y0, y, warm_start=warm_start), dtype=float)"
+  replace = "        w = np.linalg.lstsq(Y0, y, rcond=None)[0]"
+  models = "solving the 'sc' refit by unconstrained least squares instead of over the simplex. The in-sample fit is better, which is what makes it tempting, and every shape and range assertion still passes -- but convexity is the whole mechanism: without the bound the fitted path follows an injected effect without limit and the test loses its power in exactly the way the augmented refit does"
+
+  [[target.mutant]]
+  id = "covariates-silently-dropped-by-the-sc-rule"
+  find = """        if Z0 is not None or z1 is not None:
+            raise MlsynthConfigError("""
+  replace = """        if False:
+            raise MlsynthConfigError("""
+  models = "accepting covariates on the outcome-only rule and quietly ignoring them, so the refit answers a question the caller did not ask and no output records the substitution"


### PR DESCRIPTION
## Related Links

- Reference implementation: [`kwuthrich/scinference`](https://github.com/kwuthrich/scinference) @ `567c688`, the authors' own package.
- Source paper: Chernozhukov, Wüthrich & Zhu (2021), JASA 116(536), 1849–1864. [doi:10.1080/01621459.2021.1920957](https://doi.org/10.1080/01621459.2021.1920957)
- Docs page: `docs/vanillasc.rst`, the `"conformal"` inference mode.
- Relates to #436 (the CWZ golden benchmark), which is what turned this up.

## What

- Adds `mlsynth/utils/conformal/refit.py` — `conformal_refit_gaps`, the one place the
  test-inversion refit chooses between a simplex control (`"sc"`) and a ridge-augmented
  one (`"ridge"`).
- Threads `refit` through `conformal_pvalue`, `conformal_intervals`,
  `conformal_att_interval` and `_period_pvalue`. Default stays `"ridge"`, so the GeoX
  augsynth engine is unchanged.
- VanillaSC passes the rule its own point fit used and reports it in
  `res.inference.details["refit"]`.
- Adds `conformal_type` to `VanillaSCConfig`. It was already threaded through the
  helpers but unreachable from the config, so the moving-block scheme could not be
  selected at all.
- Refuses covariates on the outcome-only rule instead of dropping them.

## Why

`VanillaSC(inference="conformal")` disagreed with `scinference` on the Swedish carbon
tax panel, and not by a little:

| injected effect | scinference (mb) | mlsynth, before |
| --- | --- | --- |
| 0 | 0.391304 | 0.608696 |
| 1 | 0.021739 | 0.326087 |
| 5 | 0.021739 | 0.347826 |
| 100 | 0.021739 | 0.347826 |

The p-value reads 0.348 for an injected effect of 5 and 0.348 for one of 100. That is
a test with no power, not a test that disagrees.

Two faults, both reachable from that one call.

**The refit rule.** The null refit went through the ridge-augmented ASCM whatever the
point estimate was, so a plain simplex synthetic control was being tested against a
control it never used. Unconstrained weights can re-level the treated series, and the
level lands in the pre-period residuals forming the reference distribution — both
sides of the comparison scale with the effect, and their ratio, which is all the
p-value sees, does not move. Convexity stops it: a convex combination is bounded by
the donor pool, so the pre-period fit stops responding once the weights reach a vertex
and the effect has nowhere to go but the post block.

**The penalty.** Called without `lambda_`, the refit cross-validates the ridge penalty
on the conformal matching window — which includes the post block. That picks 0.105
where the pre-period fit picks 688, and the augmentation it then permits does the
absorbing. augsynth pins the fitted penalty and the GeoX engine already passed it;
VanillaSC did not, because a plain fit has none to pass.

## How

Diagnosed with the five-why ladder in `.claude/commands/rca.md`:

| Rung | Question | Result |
| --- | --- | --- |
| 0 | Which reported quantity looks wrong? | fails — the table above |
| — | Reproduce minimally | does not reproduce on a synthetic T=20, J=3 panel. First finding |
| 1 | Which other outputs moved with it? | geometry (`T1/T` × `J`) all give exactly `1/T`; donor richness on the real panel drives absorption 2.8% (J=1) → 88.9% (J=14) |
| 2 | Which term produced them? | two branches — the refit absorbs ~89% at every magnitude and inflates pre-residuals 0.036 → 7.61; and the re-selected penalty is 0.105 against the fitted 688 |
| 3 | Which invariant is violated? | saturation: `d(10τ) ≈ d(τ)`. Simplex ratio 1.00 on every panel, ridge 9.9 |
| 4 | Which contract was never enforced? | nothing asserted the test had power. Existing tests check shape, range and determinism — all satisfied by a test with none |
| 5 | Would the suite have caught it? | 3/3 mutants killed |

Confirmation, both *no*: absent the augmented refit the failure does not occur;
corrected, it does not recur.

## Verification

- Path: **cross-validation** against `scinference` @ `567c688`, the authors' package.
- Quantities compared: the joint-null conformal p-value under the moving-block scheme,
  on the Swedish carbon tax panel (T=46, T0=30, J=14), at zero effect and at injected
  effects of 1, 5, 20 and 100. Tolerance `abs=5e-6`.
- After the fix mlsynth returns `0.391304` under the null and `1/T = 0.021739` for
  every injected effect from 1 upward — the reference values exactly.
- Pinned durably in `mlsynth/tests/test_conformal_refit.py` and
  `test_vanillasc_conformal_refit.py`, so a regression fails a check.
- The `"ridge"` path is pinned unchanged, since the GeoX augsynth engine reproduces
  augsynth and must keep doing so.

## Scope checks

<!-- BUG FIX -->
- [x] Tests reproduce the defect and fail without the fix — the power tests return the
      stalled 0.348 on the old code.
- [x] They assert the correct behaviour (the reference values), not the absence of a
      crash.
- [x] No docstring or docs page still states the old behaviour. Two claims that turned
      out to be wrong are corrected: that `fixed_effects` stops the donor pool
      absorbing a post-period level shift (it does not — 0.348 with it on or off), and
      that penalty re-selection is "slightly anti-conservative" (it costs the test its
      power, and the docstring now carries the measurement).
- [x] No pinned value re-fitted to new output.

## Test Steps

- [x] `pytest mlsynth/tests/test_conformal_refit.py mlsynth/tests/test_conformal_refit_properties.py mlsynth/tests/test_vanillasc_conformal_refit.py -q` — 39 passed.
- [x] `pytest mlsynth/tests/test_bilevel_ridge.py test_geox_conformal_correctness.py test_geox_augsynth_engine.py test_geox_readout_interval.py test_vanillasc_split_conformal.py test_conformal_cumulative.py test_conformal_cumulative_properties.py -q` — 168 passed, 2 skipped.
- [x] `python tools/mutation/run_mutants.py --target conformal-refit-rule` — 3/3 killed.
- [ ] Full suite — running locally, and CI covers it here.

## Other Notes

- The correction to my own first reading, recorded because the PR description would
  otherwise state a cause that is not the one that fired: on this panel the *fitted*
  penalty is 688, which leaves the augmentation inert, so the two refit rules agree
  there. The rule was the wrong-control fault; penalty re-selection is what produced
  the observed ceiling. Both are fixed and both are pinned.
- `VanillaSC` with covariates and no `augment="ridge"` now raises instead of running an
  outcome-only refit that ignores them. No test or benchmark exercised that
  combination, so nothing regresses, but it is a behaviour change for a caller who had
  been getting a silently different fit.
- Reaching the simplex refit through the bilevel package is the shape that fits today's
  callers. Consolidating every conformal method onto `mlsynth/utils/conformal/` is #434
  and stays there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKrMz8fQvjDNM1eur5kQ2V)_