### PR TITLE
Keep PPSCM's replicate paths, and build a cumulative band from them

### DIFF
--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -280,6 +280,49 @@ leaving eight windows, which no longer supports a 90% band. Read
   120          0.5    8          below the 90% threshold
   ===========  =====  =========  ===============================================
 
+The cumulative effect overall
+-----------------------------
+
+The band above is per unit. The corresponding question about the pool is what the
+treated units gained in total over the first :math:`L` periods, and
+``cumulative_band=True`` answers it::
+
+   res = PPSCM({..., "cumulative_band": True}).fit()
+   band = res.inference_detail.cumulative
+   for L, point, lo, hi in zip(band.horizons, band.point, band.lower, band.upper):
+       print(L, point, (lo, hi))
+
+Both the jackknife and the wild bootstrap already fit the estimator many times and
+get a whole per-horizon path back from each fit. Those paths are kept on
+``res.inference_detail.replicate_paths``, and the band is built from them, so it
+costs no refits beyond the inference that was going to run anyway.
+
+Keeping them is what makes the band possible. Collapsing each replicate to one
+standard error per horizon -- which is all a per-period band needs -- discards how
+the horizons move together, and that covariance is the entire content of a
+cumulative interval. A caller with only the collapsed standard errors has to
+choose an assumption instead: adding period interval endpoints treats the errors
+as moving in lockstep and grows the width like :math:`L`, while rescaling a
+single period's interval assumes they are independent and grows it like
+:math:`\sqrt{L}`. Accumulating the replicates before taking the standard error
+measures which is true.
+
+The band is *simultaneous*. A cumulative path is read as a path -- "the total is
+positive by week six and stays there" is a claim about every horizon at once --
+and a pointwise band read that way covers at well below its nominal level, by
+more as the number of horizons grows. One shared critical value
+(:func:`mlsynth.utils.supt.supt_critical_value`, the sup-t construction of
+Montiel Olea and Plagborg-Moller) restores the level for the whole path.
+
+Which ensemble produced the band is recorded on ``band.method``, because the two
+are not interchangeable. The wild bootstrap reweights each unit's residual by an
+independent multiplier, which does not cancel the common factors the synthetic
+weights cancel in the point estimate, so its replicate variance is inflated where
+factor structure is strong. The delete-one jackknife refits the weights on each
+leave-one-out, so the factors re-cancel per replicate. The jackknife replicates
+also carry the delete-one inflation and the bootstrap draws do not, since the
+latter are already on the estimator's scale; the band applies whichever matches.
+
 Empirical Illustration: mandatory collective bargaining
 -------------------------------------------------------
 

--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -31,7 +31,7 @@ from ..exceptions import (
 from ..utils.ppscm_helpers.engine import run_multisynth
 from ..utils.ppscm_helpers.inference import (
     jackknife_inference, bootstrap_inference, per_unit_intervals,
-    cumulative_conformal_per_unit)
+    cumulative_conformal_per_unit, cumulative_supt_band)
 from ..utils.ppscm_helpers.plotter import plot_ppscm
 from ..utils.ppscm_helpers.setup import prepare_ppscm_inputs
 from ..utils.ppscm_helpers.structures import (
@@ -92,6 +92,7 @@ class PPSCM:
         self.alpha: float = config.alpha
         self.conformal_horizon = config.conformal_horizon
         self.conformal_min_train_frac = config.conformal_min_train_frac
+        self.cumulative_band: bool = config.cumulative_band
         self.covariates = config.covariates
 
         self.display_graphs: bool = config.display_graphs
@@ -136,18 +137,20 @@ class PPSCM:
 
             per_time = fit["per_time"]
             att = fit["att"]
+            replicate_paths = None
             if self.run_inference and self.inference_method == "bootstrap":
-                att, se, ci, pt_se, pt_ci = bootstrap_inference(
+                att, se, ci, pt_se, pt_ci, replicate_paths = bootstrap_inference(
                     fit, alpha=self.alpha, n_boot=self.n_boot, seed=self.seed,
-                    per_time_full=per_time, att_full=att,
+                    per_time_full=per_time, att_full=att, return_paths=True,
                 )
                 method = "bootstrap"
             elif self.run_inference:
-                att, se, ci, pt_se, pt_ci = jackknife_inference(
+                att, se, ci, pt_se, pt_ci, replicate_paths = jackknife_inference(
                     Xy, trt, d, n_leads, n_lags,
                     fixedeff=self.fixedeff, time_cohort=self.time_cohort,
                     nu_used=fit["nu_used"], lam=self.lam, solver=self.solver,
                     alpha=self.alpha, per_time_full=per_time, att_full=att,
+                    return_paths=True,
                 )
                 method = "jackknife"
             else:
@@ -160,8 +163,21 @@ class PPSCM:
             event_study = PPSCMEventStudy(
                 horizons=np.arange(n_leads), tau=per_time, se=pt_se, ci=pt_ci,
             )
+            # The cumulative band, when asked for. Built from the replicate paths
+            # the pass above already produced -- the jackknife needs the
+            # delete-one inflation, the bootstrap draws are already on the
+            # estimator's scale.
+            cumulative = None
+            if self.cumulative_band and replicate_paths is not None:
+                cumulative = cumulative_supt_band(
+                    per_time, replicate_paths, alpha=self.alpha,
+                    jackknife=(method == "jackknife"), seed=self.seed,
+                    method=method,
+                )
             inference = PPSCMInference(att=float(att), se=float(se),
-                                      ci=tuple(ci), method=method)
+                                      ci=tuple(ci), method=method,
+                                      replicate_paths=replicate_paths,
+                                      cumulative=cumulative)
 
             # donor weights per treated cohort (label -> {donor: weight})
             donor_weights: Dict[Any, Dict[Any, float]] = {}

--- a/mlsynth/tests/test_ppscm_cumulative_supt.py
+++ b/mlsynth/tests/test_ppscm_cumulative_supt.py
@@ -1,0 +1,242 @@
+"""PPSCM's cumulative band, and the replicate paths it is built from.
+
+Both the jackknife and the wild bootstrap fit the estimator many times and get a
+whole per-horizon path back from each fit. Until now PPSCM collapsed those paths
+to one standard error per horizon and dropped the rest, which throws away the
+only thing a cumulative band needs: how the horizons move together. A caller
+wanting a band for the running total then has to rebuild the replicates from the
+primitives, refitting everything a second time to recover what the first pass
+already computed.
+
+So the paths are kept, and the band is built from them here.
+
+Two claims are pinned. The band is simultaneous, so reading the whole cumulative
+path -- "the total is positive by week six and stays there" -- is covered at
+``1 - alpha``, not at whatever a pointwise band degrades to across horizons. And
+its width follows the correlation the replicates actually show, growing like
+``sqrt(L)`` when the period errors are independent and like ``L`` when they move
+as one, instead of assuming either.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PPSCM
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.ppscm_helpers.inference import cumulative_supt_band
+
+
+def _panel(seed=0, n_donors=10, n_treated=3, pre=18, post=6, effect=0.0, noise=0.4):
+    rng = np.random.default_rng(seed)
+    T = pre + post
+    factors = rng.standard_normal((T, 2))
+    load_d = rng.standard_normal((n_donors, 2)) * 0.5
+    load_t = load_d.mean(axis=0)
+    rec = []
+    for j in range(n_treated):
+        s = factors @ (load_t + 0.1 * rng.standard_normal(2))
+        s = s + rng.standard_normal(T) * noise
+        s[pre:] += effect
+        rec += [{"unit": f"t_{j}", "year": 2000 + t, "y": float(s[t]),
+                 "tr": int(t >= pre)} for t in range(T)]
+    for d in range(n_donors):
+        s = factors @ load_d[d] + rng.standard_normal(T) * noise
+        rec += [{"unit": f"d_{d}", "year": 2000 + t, "y": float(s[t]), "tr": 0}
+                for t in range(T)]
+    return pd.DataFrame(rec)
+
+
+def _fit(**kw):
+    cfg = dict(df=_panel(), outcome="y", treat="tr", unitid="unit", time="year",
+               display_graphs=False, run_inference=True, alpha=0.10)
+    cfg.update(kw)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return PPSCM(cfg).fit()
+
+
+def _paths(n=40, H=6, rho=0.0, seed=0):
+    rng = np.random.default_rng(seed)
+    common = rng.normal(size=(n, 1))
+    idio = rng.normal(size=(n, H))
+    return np.sqrt(rho) * common + np.sqrt(1.0 - rho) * idio
+
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+def test_the_band_has_one_entry_per_horizon():
+    pt = np.array([1.0, 0.5, -0.2, 0.8, 0.1, 0.3])
+    band = cumulative_supt_band(pt, _paths(), alpha=0.10)
+    for arr in (band.horizons, band.point, band.lower, band.upper, band.se):
+        assert arr.shape == pt.shape
+    assert band.horizons[0] == 1 and band.horizons[-1] == pt.size
+
+
+def test_the_point_path_is_the_running_total_of_the_effects():
+    pt = np.array([1.0, 2.0, -0.5])
+    band = cumulative_supt_band(pt, _paths(H=3), alpha=0.10)
+    assert band.point == pytest.approx(np.array([1.0, 3.0, 2.5]))
+
+
+# ---------------------------------------------------------------------------
+# Unit
+# ---------------------------------------------------------------------------
+
+def test_the_band_is_symmetric_about_the_point_path():
+    pt = np.array([0.4, -0.2, 0.9, 0.1])
+    band = cumulative_supt_band(pt, _paths(H=4), alpha=0.10)
+    assert (band.upper - band.point) == pytest.approx(band.point - band.lower)
+
+
+def test_the_band_is_wider_than_the_pointwise_one_it_replaces():
+    """The correction is the whole point; without it the path is under-covered."""
+    from scipy.stats import norm
+
+    pt = np.zeros(8)
+    band = cumulative_supt_band(pt, _paths(H=8, rho=0.0, seed=3), alpha=0.10)
+    pointwise = norm.ppf(0.95) * band.se
+    assert np.all(band.upper - band.point > pointwise)
+    assert band.critical_value > norm.ppf(0.95)
+
+
+def test_independent_period_errors_widen_the_band_like_sqrt_L():
+    """The reason the band is built from paths instead of assembled from endpoints."""
+    pt = np.zeros(9)
+    band = cumulative_supt_band(pt, _paths(n=4000, H=9, rho=0.0, seed=2), alpha=0.10)
+    assert band.se / band.se[0] == pytest.approx(np.sqrt(np.arange(1, 10)), rel=0.15)
+
+
+def test_perfectly_correlated_period_errors_widen_it_like_L():
+    rng = np.random.default_rng(11)
+    paths = np.repeat(rng.normal(size=(4000, 1)), 9, axis=1)
+    band = cumulative_supt_band(np.zeros(9), paths, alpha=0.10)
+    assert band.se / band.se[0] == pytest.approx(np.arange(1, 10), rel=0.02)
+
+
+def test_a_smaller_alpha_never_narrows_the_band():
+    pt = np.zeros(6)
+    wide = cumulative_supt_band(pt, _paths(rho=0.3), alpha=0.01)
+    narrow = cumulative_supt_band(pt, _paths(rho=0.3), alpha=0.10)
+    assert np.all(wide.upper >= narrow.upper - 1e-12)
+
+
+def test_the_jackknife_inflation_is_applied_by_default():
+    """Delete-one replicates differ by O(1/m), so they need the inflation.
+
+    Without it the band would be narrower by roughly ``(m-1)/sqrt(m)``, which at
+    a few dozen units is a factor of several -- an interval that looks precise
+    and covers nothing.
+    """
+    paths = _paths(n=30, H=4, seed=1)
+    jack = cumulative_supt_band(np.zeros(4), paths, alpha=0.10, jackknife=True)
+    boot = cumulative_supt_band(np.zeros(4), paths, alpha=0.10, jackknife=False)
+    assert np.all(jack.se > boot.se)
+
+
+def test_missing_replicates_are_dropped_not_counted():
+    """A leave-one-out refit that failed is absent, and must not read as zero."""
+    paths = _paths(n=30, H=5, seed=4)
+    holed = paths.copy()
+    holed[3] = np.nan
+    a = cumulative_supt_band(np.zeros(5), paths[np.arange(30) != 3], alpha=0.10)
+    b = cumulative_supt_band(np.zeros(5), holed, alpha=0.10)
+    assert b.se == pytest.approx(a.se)
+    assert b.n_replicates == a.n_replicates == 29
+
+
+# ---------------------------------------------------------------------------
+# Wiring on the estimator
+# ---------------------------------------------------------------------------
+
+def test_the_replicate_paths_are_kept_rather_than_discarded():
+    """The cross-horizon structure survives the fit, so no second pass is needed."""
+    res = _fit(inference_method="jackknife")
+    paths = res.inference_detail.replicate_paths
+    assert paths is not None
+    assert paths.ndim == 2
+    assert paths.shape[1] == res.event_study.tau.size
+
+
+def test_the_cumulative_band_is_off_unless_asked_for():
+    res = _fit()
+    assert res.inference_detail.cumulative is None
+
+
+def test_asking_for_it_attaches_a_band_covering_every_horizon():
+    res = _fit(cumulative_band=True, inference_method="jackknife")
+    band = res.inference_detail.cumulative
+    assert band is not None
+    assert band.point.size == res.event_study.tau.size
+    assert band.point == pytest.approx(np.cumsum(res.event_study.tau))
+    assert np.all(band.lower <= band.point) and np.all(band.point <= band.upper)
+
+
+def test_the_band_covers_a_true_zero_at_about_its_nominal_rate():
+    """Coverage over draws, not on one draw.
+
+    A 90% band misses one panel in ten by construction, so asserting coverage on
+    a single fit is asserting that a fair coin lands heads. Over 20 null panels
+    the measured rate is 0.90 at the total and 0.875 simultaneously across all
+    horizons (0.925 and 0.875 at M=40). The floor below sits about four binomial
+    standard errors under nominal -- ``sqrt(.9*.1/20) = 0.067`` -- so it cannot
+    flake, and it still catches the failure that matters: dropping the
+    delete-one inflation shrinks the band by a factor of several and coverage
+    collapses toward zero.
+    """
+    M = 20
+    hits = 0
+    for seed in range(M):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = PPSCM(dict(
+                df=_panel(seed=seed), outcome="y", treat="tr", unitid="unit",
+                time="year", display_graphs=False, run_inference=True,
+                alpha=0.10, cumulative_band=True, inference_method="jackknife",
+            )).fit()
+        band = res.inference_detail.cumulative
+        hits += int(band.lower[-1] <= 0.0 <= band.upper[-1])
+    assert hits / M >= 0.65
+
+
+def test_the_bootstrap_path_also_yields_a_band():
+    """Both ensembles produce paths, so both can carry a cumulative band."""
+    res = _fit(cumulative_band=True, inference_method="bootstrap", n_boot=60)
+    assert res.inference_detail.cumulative is not None
+    assert res.inference_detail.cumulative.method == "bootstrap"
+
+
+def test_the_band_records_which_ensemble_it_came_from():
+    """A jackknife band and a bootstrap band are not interchangeable numbers."""
+    res = _fit(cumulative_band=True, inference_method="jackknife")
+    assert res.inference_detail.cumulative.method == "jackknife"
+
+
+# ---------------------------------------------------------------------------
+# Edge / failure
+# ---------------------------------------------------------------------------
+
+def test_requesting_the_band_without_inference_is_reported():
+    with pytest.raises(MlsynthConfigError, match="run_inference"):
+        _fit(cumulative_band=True, run_inference=False)
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1, 1.5, "0.1", None])
+def test_an_invalid_alpha_is_rejected(bad):
+    with pytest.raises(MlsynthConfigError, match="alpha"):
+        cumulative_supt_band(np.zeros(4), _paths(H=4), alpha=bad)
+
+
+def test_a_path_matrix_of_the_wrong_width_is_reported():
+    with pytest.raises(Exception):
+        cumulative_supt_band(np.zeros(5), _paths(H=4), alpha=0.10)
+
+
+def test_fewer_than_two_replicates_is_reported():
+    with pytest.raises(Exception):
+        cumulative_supt_band(np.zeros(4), _paths(n=1, H=4), alpha=0.10)

--- a/mlsynth/tests/test_supt.py
+++ b/mlsynth/tests/test_supt.py
@@ -206,6 +206,60 @@ def test_jackknife_se_skips_missing_replicates():
 
 
 # ---------------------------------------------------------------------------
+# Unit: the correlation route equals the covariance route
+# ---------------------------------------------------------------------------
+
+def _covariance_route(draws, *, alpha, n_sim=200_000, seed=0):
+    """The same critical value, computed the other way, written independently.
+
+    Montiel Olea and Plagborg-Moller can be implemented either by simulating
+    ``N(0, Sigma)`` and dividing each coordinate by its own standard deviation,
+    or by simulating ``N(0, R)`` from the correlation directly. The two are the
+    same distribution, since dividing a mean-zero Gaussian coordinate-wise by
+    its standard deviations is exactly the change of variables from ``Sigma`` to
+    ``R``. :func:`supt_critical_value` takes the second route because it needs no
+    scale from the draws; this takes the first, so a defect in the change of
+    variables shows up as disagreement.
+    """
+    R = np.asarray(draws, float)
+    R = R[np.isfinite(R).all(axis=1)]
+    m, H = R.shape
+    dev = R - R.mean(axis=0)
+    Sigma = (m - 1) / m * (dev.T @ dev)
+    sd = np.sqrt(np.clip(np.diag(Sigma), 0.0, None))
+    sd_safe = np.where(sd > 0, sd, np.inf)
+    rng = np.random.default_rng(seed)
+    G = rng.multivariate_normal(np.zeros(H), Sigma, size=n_sim)
+    return float(np.quantile(np.max(np.abs(G) / sd_safe, axis=1), 1.0 - alpha))
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 3])
+def test_the_correlation_route_matches_the_covariance_route(seed):
+    """Agreement to the simulation error of the two independent tabulations."""
+    rng = np.random.default_rng(seed)
+    n, H = int(rng.integers(12, 70)), int(rng.integers(3, 12))
+    draws = (rng.normal(size=(n, 2)) @ rng.normal(size=(2, H))
+             + 0.4 * rng.normal(size=(n, H)))
+    mine = supt_critical_value(draws, alpha=0.10, n_sims=200_000, seed=0)
+    other = _covariance_route(draws, alpha=0.10, seed=0)
+    assert mine == pytest.approx(other, rel=0.02)
+
+
+def test_the_jackknife_se_matches_the_covariance_diagonal():
+    """``jackknife_se`` is the square root of the jackknife covariance diagonal.
+
+    Pinned to machine precision, because the two are the same arithmetic and any
+    gap would mean one of them has picked up a stray degrees-of-freedom factor.
+    """
+    rng = np.random.default_rng(5)
+    draws = rng.normal(size=(41, 7))
+    dev = draws - draws.mean(axis=0)
+    m = draws.shape[0]
+    diag = np.sqrt(np.diag((m - 1) / m * (dev.T @ dev)))
+    assert jackknife_se(draws) == pytest.approx(diag, rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
 # Edge
 # ---------------------------------------------------------------------------
 

--- a/mlsynth/tests/test_supt.py
+++ b/mlsynth/tests/test_supt.py
@@ -1,0 +1,250 @@
+"""Simultaneous (sup-t) bands from resampling draws.
+
+A pointwise band covers each horizon with probability ``1 - alpha`` one at a
+time. Read across a whole event-study path -- which is how anyone reads one --
+it covers the entire path with much less, and the gap widens with the number of
+horizons. A simultaneous band fixes the level for the path as a whole by
+inflating every interval by one shared critical value, chosen so the *largest*
+standardized deviation across horizons stays inside with probability
+``1 - alpha``.
+
+The construction is Montiel Olea and Plagborg-Moller (2019): standardize the
+draws, estimate the correlation across horizons, and take the ``1 - alpha``
+quantile of ``max_h |z_h|`` for ``z`` drawn from that correlation. Simulating
+rather than reading the quantile off the draws themselves matters when the draws
+are a delete-one jackknife: there are only as many of them as units, so an
+empirical quantile at 0.95 is coarse, and jackknife deviations are on a
+different scale from the estimator's sampling distribution.
+
+What the tests pin:
+
+* the critical value is at least the pointwise one, and equals it for a single
+  horizon (there is nothing to correct for);
+* perfectly correlated horizons return the pointwise value, since the path moves
+  as one number;
+* independent horizons cost the most, and the cost grows with their number;
+* the cumulative path's standard error grows like ``sqrt(L)`` under independent
+  per-period errors and like ``L`` under perfectly correlated ones -- which is
+  the whole reason a cumulative band cannot be assembled by adding endpoints.
+"""
+import numpy as np
+import pytest
+from scipy.stats import norm
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.supt import (
+    cumulative_from_paths,
+    jackknife_se,
+    supt_critical_value,
+)
+
+
+def _draws(n, H, rho=0.0, seed=0):
+    """``n`` draws over ``H`` horizons with equicorrelation ``rho``."""
+    rng = np.random.default_rng(seed)
+    common = rng.normal(size=(n, 1))
+    idio = rng.normal(size=(n, H))
+    return np.sqrt(rho) * common + np.sqrt(1.0 - rho) * idio
+
+
+# ---------------------------------------------------------------------------
+# Smoke
+# ---------------------------------------------------------------------------
+
+def test_returns_a_finite_positive_scalar():
+    c = supt_critical_value(_draws(40, 5), alpha=0.05, seed=0)
+    assert np.isfinite(c) and c > 0.0
+
+
+def test_is_deterministic_under_a_seed():
+    kw = dict(alpha=0.05, seed=7)
+    d = _draws(40, 5)
+    assert supt_critical_value(d, **kw) == supt_critical_value(d, **kw)
+
+
+# ---------------------------------------------------------------------------
+# Unit: the invariants that make it a simultaneous band
+# ---------------------------------------------------------------------------
+
+def test_one_horizon_is_the_pointwise_critical_value():
+    """With nothing to be simultaneous over, the correction must vanish."""
+    c = supt_critical_value(_draws(200, 1), alpha=0.05, n_sims=200_000, seed=0)
+    assert c == pytest.approx(norm.ppf(0.975), rel=0.02)
+
+
+#: Simulation error of the tabulated quantile, as a tolerance. The critical value
+#: is the ``1 - alpha`` sample quantile of ``max_h |z_h|`` over ``n_sims`` draws,
+#: so it carries a Monte Carlo standard error of
+#: ``sqrt(a (1-a) / n_sims) / f(q)``; at ``alpha = 0.05`` and the default
+#: ``n_sims`` that is about 0.004. Asserting an exact inequality against the
+#: analytic pointwise value would be asserting below the computation's own floor.
+_MC_TOL = 0.02
+
+
+def test_never_narrower_than_pointwise():
+    """A simultaneous band that undercut the pointwise one would be a bug.
+
+    The maximum of several standardized deviations is at least any one of them,
+    so its quantile cannot be smaller -- up to the simulation error of the
+    quantile itself, which is what ``_MC_TOL`` allows and nothing more.
+    """
+    z = norm.ppf(0.975)
+    for H in (1, 2, 5, 12):
+        c = supt_critical_value(_draws(200, H, rho=0.3), alpha=0.05, seed=1)
+        assert c >= z - _MC_TOL
+
+
+def test_the_simulation_error_is_smaller_than_the_correction_it_measures():
+    """The tolerance above must not be wide enough to hide a missing correction.
+
+    Eight independent horizons need a correction of roughly 0.7 over pointwise.
+    If the simulation error were the same size, the test above would pass on an
+    implementation that returned the pointwise value and did nothing else.
+    """
+    z = norm.ppf(0.975)
+    c = supt_critical_value(_draws(400, 8, rho=0.0, seed=5), alpha=0.05,
+                            n_sims=100_000, seed=0)
+    assert c - z > 10.0 * _MC_TOL
+
+
+def test_perfectly_correlated_horizons_cost_nothing():
+    """If every horizon is the same number, there is only one thing to cover."""
+    n = 300
+    rng = np.random.default_rng(3)
+    one = rng.normal(size=(n, 1))
+    d = np.repeat(one, 6, axis=1)
+    c = supt_critical_value(d, alpha=0.05, n_sims=200_000, seed=0)
+    assert c == pytest.approx(norm.ppf(0.975), rel=0.05)
+
+
+def test_more_independent_horizons_cost_more():
+    """The correction grows with the number of things being covered at once."""
+    cs = [supt_critical_value(_draws(400, H, rho=0.0, seed=H), alpha=0.05,
+                              n_sims=100_000, seed=0)
+          for H in (2, 4, 8, 16)]
+    assert all(a < b for a, b in zip(cs, cs[1:]))
+
+
+def test_correlation_reduces_the_correction():
+    """Correlated horizons are closer to one horizon, so they cost less."""
+    low = supt_critical_value(_draws(400, 8, rho=0.0, seed=5), alpha=0.05,
+                              n_sims=100_000, seed=0)
+    high = supt_critical_value(_draws(400, 8, rho=0.9, seed=5), alpha=0.05,
+                               n_sims=100_000, seed=0)
+    assert high < low
+
+
+def test_a_smaller_alpha_never_gives_a_smaller_critical_value():
+    d = _draws(200, 6, rho=0.4)
+    wide = supt_critical_value(d, alpha=0.01, n_sims=100_000, seed=0)
+    narrow = supt_critical_value(d, alpha=0.10, n_sims=100_000, seed=0)
+    assert wide > narrow
+
+
+def test_the_critical_value_ignores_the_scale_of_the_draws():
+    """It is computed from the correlation, so rescaling a horizon changes nothing."""
+    d = _draws(300, 6, rho=0.3)
+    scaled = d * np.array([1.0, 10.0, 0.1, 5.0, 2.0, 100.0])
+    a = supt_critical_value(d, alpha=0.05, n_sims=100_000, seed=0)
+    b = supt_critical_value(scaled, alpha=0.05, n_sims=100_000, seed=0)
+    assert a == pytest.approx(b, rel=0.02)
+
+
+# ---------------------------------------------------------------------------
+# Unit: the cumulative path, and why it is not a running sum of endpoints
+# ---------------------------------------------------------------------------
+
+def test_cumulative_is_the_running_sum_of_the_path():
+    paths = np.array([[1.0, 2.0, 3.0], [0.0, -1.0, 4.0]])
+    assert cumulative_from_paths(paths) == pytest.approx(
+        np.array([[1.0, 3.0, 6.0], [0.0, -1.0, 3.0]])
+    )
+
+
+def test_independent_period_errors_grow_the_cumulative_se_like_sqrt_L():
+    """The reason a cumulative band is not the running total of period bands.
+
+    Adding period interval endpoints assumes the errors move together, which
+    grows the width like ``L``. When they are independent it grows like
+    ``sqrt(L)``, and the difference is a factor of ``sqrt(L)`` of width that a
+    reader is either given or denied for no reason.
+    """
+    draws = _draws(4000, 9, rho=0.0, seed=2)
+    se = jackknife_se(cumulative_from_paths(draws), jackknife=False)
+    ratio = se / se[0]
+    assert ratio == pytest.approx(np.sqrt(np.arange(1, 10)), rel=0.12)
+
+
+def test_perfectly_correlated_period_errors_grow_it_like_L():
+    rng = np.random.default_rng(11)
+    one = rng.normal(size=(4000, 1))
+    draws = np.repeat(one, 9, axis=1)
+    se = jackknife_se(cumulative_from_paths(draws), jackknife=False)
+    ratio = se / se[0]
+    assert ratio == pytest.approx(np.arange(1, 10), rel=0.02)
+
+
+def test_jackknife_se_uses_the_delete_one_inflation():
+    """``(m-1)/m * sum (x - xbar)^2``, the delete-one jackknife variance.
+
+    Not the sample variance: jackknife replicates differ from the estimate by
+    O(1/m), so they need the inflation to estimate a sampling standard error.
+    """
+    x = np.array([[1.0], [2.0], [3.0], [6.0]])
+    m = 4
+    expected = np.sqrt((m - 1) / m * np.sum((x[:, 0] - x[:, 0].mean()) ** 2))
+    assert jackknife_se(x)[0] == pytest.approx(expected)
+
+
+def test_jackknife_se_skips_missing_replicates():
+    """A leave-one-out fit that failed is absent, not zero."""
+    x = np.array([[1.0], [np.nan], [3.0], [5.0]])
+    got = jackknife_se(x)[0]
+    kept = np.array([1.0, 3.0, 5.0])
+    m = 3
+    assert got == pytest.approx(np.sqrt((m - 1) / m * np.sum((kept - kept.mean()) ** 2)))
+
+
+# ---------------------------------------------------------------------------
+# Edge
+# ---------------------------------------------------------------------------
+
+def test_a_constant_horizon_does_not_produce_a_nan_critical_value():
+    """A horizon with no variation has no correlation; it must not poison the rest."""
+    d = _draws(200, 4, rho=0.2)
+    d[:, 2] = 5.0
+    c = supt_critical_value(d, alpha=0.05, n_sims=50_000, seed=0)
+    assert np.isfinite(c) and c >= norm.ppf(0.975) - 1e-6
+
+
+def test_fewer_than_two_replicates_gives_nan_se_rather_than_zero():
+    assert np.isnan(jackknife_se(np.array([[1.0]]))[0])
+
+
+def test_all_missing_replicates_gives_nan_se():
+    assert np.isnan(jackknife_se(np.full((4, 1), np.nan))[0])
+
+
+# ---------------------------------------------------------------------------
+# Failure
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1, 1.5, "0.05", None])
+def test_an_alpha_outside_the_open_unit_interval_is_rejected(bad):
+    with pytest.raises(MlsynthConfigError, match="alpha"):
+        supt_critical_value(_draws(20, 3), alpha=bad)
+
+
+def test_a_one_dimensional_draw_matrix_is_rejected():
+    with pytest.raises(MlsynthDataError, match="2-D"):
+        supt_critical_value(np.zeros(10), alpha=0.05)
+
+
+def test_too_few_draws_to_estimate_a_correlation_is_reported():
+    with pytest.raises(MlsynthDataError, match="draws"):
+        supt_critical_value(np.zeros((1, 4)), alpha=0.05)
+
+
+def test_a_nonpositive_simulation_count_is_rejected():
+    with pytest.raises(MlsynthConfigError, match="n_sims"):
+        supt_critical_value(_draws(20, 3), alpha=0.05, n_sims=0)

--- a/mlsynth/utils/ppscm_helpers/config.py
+++ b/mlsynth/utils/ppscm_helpers/config.py
@@ -178,10 +178,32 @@ class PPSCMConfig(BaseEstimatorConfig):
         ),
     )
 
+    cumulative_band: bool = Field(
+        default=False,
+        description=(
+            "Attach a simultaneous (sup-t) band for the CUMULATIVE effect path "
+            "to the aggregate inference -- the running total over horizons, with "
+            "one shared critical value so the whole path is covered at "
+            "``1 - alpha`` at once, which is how a cumulative path is read. "
+            "Built from the replicate paths ``inference_method`` already "
+            "produces, so it costs no extra refits. Its growth is measured "
+            "instead of assumed: the replicates are accumulated before the "
+            "standard error is taken, so independent period errors widen it "
+            "like ``sqrt(L)`` and perfectly correlated ones like ``L``, where "
+            "adding up per-period interval endpoints would always give the "
+            "latter. Needs ``run_inference``. Off by default."
+        ),
+    )
+
     @model_validator(mode="after")
     def _check_inference_method(self):
         if self.inference_method not in ("jackknife", "bootstrap"):
             raise MlsynthConfigError(
                 "inference_method must be 'jackknife' or 'bootstrap'; got "
                 f"{self.inference_method!r}.")
+        if self.cumulative_band and not self.run_inference:
+            raise MlsynthConfigError(
+                "cumulative_band needs run_inference=True: the band is built "
+                "from the replicate paths the jackknife or bootstrap produces, "
+                "and with inference off there are none.")
         return self

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -12,7 +12,7 @@ are built from these SEs around the full-sample point estimates.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 from scipy.stats import norm
@@ -126,7 +126,7 @@ _WILD_PROBS = np.array([(_PHI + 1.0) / (2.0 * _PHI), (_PHI - 1.0) / (2.0 * _PHI)
 
 def bootstrap_inference(
     fit: dict, *, alpha: float, n_boot: int, seed: int,
-    per_time_full: np.ndarray, att_full: float,
+    per_time_full: np.ndarray, att_full: float, return_paths: bool = False,
 ):
     """augsynth's default Mammen wild/multiplier bootstrap (``weighted_bootstrap_multi``).
 
@@ -158,15 +158,101 @@ def bootstrap_inference(
     ci = (att_full - z * se, att_full + z * se)
     per_time_ci = np.column_stack([per_time_full - z * per_time_se,
                                    per_time_full + z * per_time_se])
+    if return_paths:
+        return float(att_full), se, ci, per_time_se, per_time_ci, pt_b
     return float(att_full), se, ci, per_time_se, per_time_ci
+
+
+def cumulative_supt_band(
+    per_time_full: np.ndarray,
+    replicate_paths: np.ndarray,
+    *,
+    alpha: float,
+    jackknife: bool = True,
+    n_sims: int = 200_000,
+    seed: Optional[int] = 0,
+    method: str = "jackknife",
+):
+    """Simultaneous band for the running total, from the replicate paths.
+
+    An interval for a cumulative effect is not the running total of the
+    per-period intervals. Adding endpoints treats the period errors as moving in
+    lockstep, so the width grows with the number of periods; rescaling one
+    period's interval assumes the opposite. Here the replicate paths are
+    accumulated first and the standard error taken after, so whatever
+    correlation the errors have is the correlation the band inherits.
+
+    The band is simultaneous over horizons
+    (:func:`mlsynth.utils.supt.supt_critical_value`), because a cumulative path
+    is read as a path.
+
+    Parameters
+    ----------
+    per_time_full : np.ndarray, shape (H,)
+        The per-horizon effect path from the full fit.
+    replicate_paths : np.ndarray, shape (n_replicates, H)
+        One per-horizon path per replicate. Rows containing ``NaN`` are dropped,
+        so a leave-one-out refit that failed is absent instead of counted as zero.
+    alpha : float
+        The band is simultaneous at ``1 - alpha``.
+    jackknife : bool, default True
+        Apply the delete-one inflation to the standard error. True for
+        leave-one-out replicates, which differ from the full estimate by
+        ``O(1/m)``; False for bootstrap draws, already on the estimator's scale.
+    n_sims, seed
+        Tabulation of the sup-t critical value.
+    method : str
+        Which ensemble produced the paths, recorded on the result -- a jackknife
+        band and a bootstrap band are not interchangeable numbers.
+
+    Returns
+    -------
+    PPSCMCumulativeBand
+    """
+    from ..supt import cumulative_from_paths, jackknife_se, supt_critical_value
+    from .structures import PPSCMCumulativeBand
+
+    if (isinstance(alpha, bool) or not isinstance(alpha, (int, float, np.floating))
+            or not 0.0 < float(alpha) < 1.0):
+        raise MlsynthConfigError(
+            f"alpha must be a number in the open interval (0, 1); got {alpha!r}."
+        )
+    pt = np.asarray(per_time_full, dtype=float).ravel()
+    R = np.asarray(replicate_paths, dtype=float)
+    if R.ndim != 2 or R.shape[1] != pt.size:
+        raise MlsynthDataError(
+            f"replicate_paths must be (n_replicates, {pt.size}); got shape {R.shape}."
+        )
+    R = R[np.isfinite(R).all(axis=1)]
+    if R.shape[0] < 2:
+        raise MlsynthDataError(
+            f"need at least 2 complete replicate paths to form a band; got {R.shape[0]}."
+        )
+
+    cum = cumulative_from_paths(R)
+    se = jackknife_se(cum, jackknife=jackknife)
+    q = supt_critical_value(cum, alpha=float(alpha), n_sims=n_sims, seed=seed)
+    point = np.cumsum(pt)
+    return PPSCMCumulativeBand(
+        horizons=np.arange(1, pt.size + 1),
+        point=point, lower=point - q * se, upper=point + q * se, se=se,
+        critical_value=float(q), alpha=float(alpha),
+        n_replicates=int(R.shape[0]), method=str(method),
+    )
 
 
 def jackknife_inference(
     Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
     *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
     solver: Any, alpha: float, per_time_full: np.ndarray, att_full: float,
+    return_paths: bool = False,
 ) -> Tuple[float, float, Tuple[float, float], np.ndarray, np.ndarray]:
-    """Return ``(att, se, ci, per_time_se, per_time_ci)``."""
+    """Return ``(att, se, ci, per_time_se, per_time_ci)``.
+
+    With ``return_paths`` the leave-one-out per-horizon paths are appended. They
+    are computed either way; keeping them lets a caller build a cumulative band
+    without refitting the whole jackknife a second time.
+    """
     n = Xy.shape[0]
     H = n_leads
     att_loo = np.full(n, np.nan)
@@ -202,6 +288,8 @@ def jackknife_inference(
     ci = (att_full - z * se, att_full + z * se)
     per_time_ci = np.column_stack([per_time_full - z * per_time_se,
                                    per_time_full + z * per_time_se])
+    if return_paths:
+        return float(att_full), se, ci, per_time_se, per_time_ci, pt_loo
     return float(att_full), se, ci, per_time_se, per_time_ci
 
 

--- a/mlsynth/utils/ppscm_helpers/structures.py
+++ b/mlsynth/utils/ppscm_helpers/structures.py
@@ -116,6 +116,33 @@ class PPSCMEventStudy:
 
 
 @dataclass(frozen=True)
+class PPSCMCumulativeBand:
+    """Simultaneous band for the cumulative (running-total) effect path.
+
+    ``lower[L]`` and ``upper[L]`` bound the total effect over horizons ``0..L``,
+    and the band covers *every* ``L`` at once with probability ``1 - alpha`` --
+    so a statement about the path ("positive by week six and never back") is
+    covered at the stated level, which a pointwise band read the same way is not.
+
+    ``se`` is the standard error of the running total at each horizon, taken
+    from the replicate paths themselves. That is what makes the band's growth
+    an observation instead of an assumption: independent period errors grow it
+    like ``sqrt(L)``, perfectly correlated ones like ``L``, and the replicates
+    carry whichever is true.
+    """
+
+    horizons: np.ndarray          # 1, 2, ..., H
+    point: np.ndarray             # cumulative effect at each horizon
+    lower: np.ndarray
+    upper: np.ndarray
+    se: np.ndarray
+    critical_value: float         # the shared sup-t multiplier
+    alpha: float
+    n_replicates: int
+    method: str                   # "jackknife" or "bootstrap"
+
+
+@dataclass(frozen=True)
 class PPSCMInference:
     """Overall (post-period average) ATT and its inference."""
 
@@ -123,6 +150,15 @@ class PPSCMInference:
     se: float
     ci: Tuple[float, float]
     method: str
+    # The per-horizon replicate paths behind ``se`` -- ``(n_replicates, H)``,
+    # one row per leave-one-out refit or bootstrap draw. Kept because collapsing
+    # them to a per-horizon standard error discards how the horizons move
+    # together, which is the only thing a cumulative band needs; a caller who
+    # wants one would otherwise have to refit everything a second time to
+    # recover what this pass already computed. ``None`` when inference is off.
+    replicate_paths: Optional[np.ndarray] = None
+    # Simultaneous band for the running total; ``None`` unless asked for.
+    cumulative: Optional["PPSCMCumulativeBand"] = None
 
 
 @dataclass(frozen=True)

--- a/mlsynth/utils/supt.py
+++ b/mlsynth/utils/supt.py
@@ -1,0 +1,209 @@
+"""Simultaneous (sup-t) confidence bands from resampling draws.
+
+A pointwise band covers each horizon with probability ``1 - alpha`` one horizon
+at a time. Nobody reads an event study one horizon at a time. Read across the
+path -- "the effect is positive from week three onward", "it never leaves the
+band" -- the pointwise band covers the whole path with much less than
+``1 - alpha``, and the shortfall grows with the number of horizons. With nine
+independent horizons a nominal 95% pointwise band covers the path about 63% of
+the time.
+
+A simultaneous band restores the level for the path as a whole. Every interval
+is inflated by one shared critical value ``c``, chosen so that the *largest*
+standardized deviation across horizons stays inside with probability
+``1 - alpha``:
+
+    P( max_h |theta_h - theta_h| / se_h  <=  c )  =  1 - alpha
+
+Following Montiel Olea and Plagborg-Moller (2019), ``c`` comes from the
+correlation across horizons: standardize the draws, estimate their correlation
+matrix, draw ``z ~ N(0, R)``, and take the ``1 - alpha`` quantile of
+``max_h |z_h|``. Simulating instead of reading the quantile off the draws
+themselves is what makes this usable with a delete-one jackknife -- there are
+only as many replicates as units, so an empirical quantile at 0.95 is coarse,
+and jackknife deviations sit on a different scale from the estimator's own
+sampling distribution. Only the correlation is taken from the draws; the scale
+comes from ``se_h`` separately.
+
+The cumulative case is why this module exists at all. An interval for a running
+total is not the running total of the period intervals: adding endpoints treats
+the period errors as moving in lockstep, so the width grows like ``L``, while
+independent errors grow it like ``sqrt(L)``. Neither assumption measures
+anything. :func:`cumulative_from_paths` accumulates the draws themselves, so
+whatever correlation the errors actually have is carried into the standard
+error, and the band inherits it.
+
+References
+----------
+Montiel Olea, J. L., & Plagborg-Moller, M. (2019). Simultaneous confidence bands:
+Theory, implementation, and an application to SVARs. Journal of Applied
+Econometrics, 34(1), 1-17.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from ..exceptions import MlsynthConfigError, MlsynthDataError
+
+#: Draws used to tabulate the ``max_h |z_h|`` quantile. Large enough that the
+#: critical value is stable to about three decimals, which is far finer than the
+#: correlation matrix it is conditioned on is known.
+DEFAULT_N_SIMS = 200_000
+
+
+def _check_alpha(alpha) -> float:
+    if (isinstance(alpha, bool) or not isinstance(alpha, (int, float, np.floating))
+            or not 0.0 < float(alpha) < 1.0):
+        raise MlsynthConfigError(
+            f"alpha must be a number in the open interval (0, 1); got {alpha!r}."
+        )
+    return float(alpha)
+
+
+def cumulative_from_paths(paths: np.ndarray) -> np.ndarray:
+    """Accumulate each draw's period path into its running total.
+
+    Parameters
+    ----------
+    paths : np.ndarray, shape (n_draws, H)
+        One per-period path per draw.
+
+    Returns
+    -------
+    np.ndarray, shape (n_draws, H)
+        ``out[i, L]`` is the total over horizons ``0 .. L`` of draw ``i``, so a
+        standard error taken down its columns carries whatever correlation the
+        period errors have.
+    """
+    paths = np.asarray(paths, dtype=float)
+    if paths.ndim != 2:
+        raise MlsynthDataError(
+            f"paths must be 2-D (n_draws, H); got shape {paths.shape}."
+        )
+    return np.cumsum(paths, axis=1)
+
+
+def jackknife_se(draws: np.ndarray, *, jackknife: bool = True) -> np.ndarray:
+    """Column-wise standard error of a set of replicates.
+
+    Parameters
+    ----------
+    draws : np.ndarray, shape (n_draws, H)
+        Replicates, one row each. ``NaN`` marks a replicate that could not be
+        computed -- a leave-one-out fit that failed to converge, say -- and is
+        omitted from that column rather than counted as zero.
+    jackknife : bool, default True
+        Apply the delete-one inflation ``(m-1)/m * sum (x - xbar)^2``. Jackknife
+        replicates differ from the full-sample estimate by ``O(1/m)``, so they
+        need it to estimate a sampling standard error. Set ``False`` for draws
+        that are already on the estimator's own scale (a bootstrap, or a direct
+        simulation), where the ordinary sample standard deviation is wanted.
+
+    Returns
+    -------
+    np.ndarray, shape (H,)
+        The standard error per column; ``NaN`` where fewer than two replicates
+        survived, since one point has no spread.
+    """
+    draws = np.asarray(draws, dtype=float)
+    if draws.ndim != 2:
+        raise MlsynthDataError(
+            f"draws must be 2-D (n_draws, H); got shape {draws.shape}."
+        )
+    out = np.full(draws.shape[1], np.nan)
+    for h in range(draws.shape[1]):
+        x = draws[:, h]
+        x = x[~np.isnan(x)]
+        m = x.size
+        if m < 2:
+            continue
+        ss = float(np.sum((x - x.mean()) ** 2))
+        out[h] = np.sqrt((m - 1) / m * ss) if jackknife else np.sqrt(ss / (m - 1))
+    return out
+
+
+def supt_critical_value(
+    draws: np.ndarray,
+    *,
+    alpha: float,
+    n_sims: int = DEFAULT_N_SIMS,
+    seed: Optional[int] = 0,
+) -> float:
+    """The shared multiplier that makes a band cover the whole path at once.
+
+    Parameters
+    ----------
+    draws : np.ndarray, shape (n_draws, H)
+        Replicates of the quantity being banded, one row each. Only their
+        *correlation* across horizons is used, so the draws need not be on the
+        estimator's scale and rescaling any horizon leaves the answer unchanged.
+        ``NaN`` entries are dropped pairwise.
+    alpha : float
+        Level; the band is simultaneous at ``1 - alpha``.
+    n_sims : int
+        Draws used to tabulate the quantile of ``max_h |z_h|``.
+    seed : int, optional
+        RNG seed, so a reported band is reproducible.
+
+    Returns
+    -------
+    float
+        ``c``, to be applied as ``theta_h +/- c * se_h``. Always at least the
+        pointwise ``z_{1 - alpha/2}``, and equal to it when there is one horizon
+        or when the horizons are perfectly correlated.
+
+    Raises
+    ------
+    MlsynthConfigError
+        ``alpha`` outside ``(0, 1)``, or a non-positive ``n_sims``.
+    MlsynthDataError
+        ``draws`` not 2-D, or fewer than two replicates.
+    """
+    alpha = _check_alpha(alpha)
+    if isinstance(n_sims, bool) or not isinstance(n_sims, (int, np.integer)) or n_sims < 1:
+        raise MlsynthConfigError(f"n_sims must be a positive integer; got {n_sims!r}.")
+    draws = np.asarray(draws, dtype=float)
+    if draws.ndim != 2:
+        raise MlsynthDataError(
+            f"draws must be 2-D (n_draws, H); got shape {draws.shape}."
+        )
+    n, H = draws.shape
+    if n < 2:
+        raise MlsynthDataError(
+            f"need at least 2 draws to estimate a correlation; got {n}."
+        )
+
+    # Correlation across horizons, pairwise-complete so one failed replicate does
+    # not discard a whole horizon. A horizon with no variation carries no
+    # information about co-movement; it is given a unit diagonal and zero
+    # off-diagonals, which is the neutral choice and keeps the matrix usable.
+    with np.errstate(invalid="ignore", divide="ignore"):
+        R = np.eye(H)
+        sd = np.nanstd(draws, axis=0)
+        good = np.isfinite(sd) & (sd > 0.0)
+        idx = np.flatnonzero(good)
+        if idx.size > 1:
+            sub = draws[:, idx]
+            keep = ~np.isnan(sub).any(axis=1)
+            if keep.sum() > 1:
+                C = np.corrcoef(sub[keep], rowvar=False)
+                C = np.nan_to_num(C, nan=0.0)
+                R[np.ix_(idx, idx)] = C
+    np.fill_diagonal(R, 1.0)
+
+    # Nearest usable covariance: the estimated correlation can be indefinite when
+    # there are fewer replicates than horizons, which a jackknife over a modest
+    # panel reaches easily. Clipping the eigenvalues at zero is the standard
+    # projection and leaves a matrix that is still a correlation on the diagonal.
+    w, V = np.linalg.eigh(R)
+    w = np.clip(w, 0.0, None)
+    L = V * np.sqrt(w)
+
+    rng = np.random.default_rng(seed)
+    z = rng.standard_normal(size=(int(n_sims), H)) @ L.T
+    scale = np.sqrt(np.clip(np.einsum("ij,ij->i", L, L), 1e-300, None))
+    m = np.max(np.abs(z / scale), axis=1)
+    return float(np.quantile(m, 1.0 - alpha))

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -621,6 +621,30 @@ timeout = 600.0
   models = "forgetting to move adoption to the calibration origin, so every fit is the real one and each 'calibration score' is the actual treatment effect rather than a placebo window -- the scores stop measuring prediction error entirely and the band is calibrated on the thing it is supposed to be testing"
 
 [[target]]
+name = "simultaneous-band"
+module-path = "mlsynth/utils/supt.py"
+test-command = "python -m pytest mlsynth/tests/test_supt.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "supt-collapses-to-the-pointwise-critical-value"
+  find = "    m = np.max(np.abs(z / scale), axis=1)"
+  replace = "    m = np.abs(z / scale)[:, 0]"
+  models = "taking one horizon's deviation instead of the largest across horizons, which is the pointwise critical value wearing a simultaneous band's name. Every shape, sign and monotonicity assertion still passes; what fails is the coverage the band claims, and only a test that compares the correction against its own simulation error can see it"
+
+  [[target.mutant]]
+  id = "jackknife-inflation-dropped"
+  find = "        out[h] = np.sqrt((m - 1) / m * ss) if jackknife else np.sqrt(ss / (m - 1))"
+  replace = "        out[h] = np.sqrt(ss / (m - 1))"
+  models = "treating delete-one replicates as if they were bootstrap draws. Jackknife replicates differ from the full estimate by O(1/m), so without the inflation the standard error is smaller by roughly (m-1)/sqrt(m) -- a factor of eight at 66 units -- and the band looks precise while covering almost nothing"
+
+  [[target.mutant]]
+  id = "cumulative-averages-instead-of-accumulating"
+  find = "    return np.cumsum(paths, axis=1)"
+  replace = "    return np.cumsum(paths, axis=1) / np.arange(1, paths.shape[1] + 1)"
+  models = "reporting the running mean where the running total was asked for, so the band is for a different estimand and its growth law inverts -- shrinking with the horizon instead of growing"
+
+[[target]]
 name = "conformal-refit-rule"
 module-path = "mlsynth/utils/conformal/refit.py"
 test-command = "python -m pytest mlsynth/tests/test_conformal_refit.py mlsynth/tests/test_conformal_refit_properties.py -q -p no:cacheprovider"


### PR DESCRIPTION
## Related Links

- Completes the cumulative story started in #431 (the shared conformal package), #432
  (the per-unit band) and #435 (its Path B validation): those cover a *unit's* total,
  this covers the *pool's*.
- Follows #437, which is in the same area of `PPSCMConfig`.
- Docs page: `docs/ppscm.rst`, new section "The cumulative effect overall".
- Method: Montiel Olea, J. L., & Plagborg-Møller, M. (2019). Simultaneous confidence
  bands. *Journal of Applied Econometrics* 34(1), 1–17.
  [doi:10.1002/jae.2656](https://doi.org/10.1002/jae.2656)

## What

- Adds `mlsynth/utils/supt.py` — `supt_critical_value`, `jackknife_se`,
  `cumulative_from_paths`. The shared simultaneous-band construction; nothing in the
  library had one that a caller with draws could reach.
- `jackknife_inference` and `bootstrap_inference` gain `return_paths` (default
  `False`, so every existing call is unchanged) and PPSCM keeps the paths on
  `PPSCMInference.replicate_paths`.
- `cumulative_band=True` attaches `PPSCMCumulativeBand` — the simultaneous band for
  the running total — built from those paths at no extra refits.

## Why

Both inference methods fit the estimator many times and get a whole per-horizon path
back from each fit. PPSCM collapsed those paths to one standard error per horizon and
dropped the rest. That discards the only thing a cumulative band needs — how the
horizons move together — so a caller wanting one had to rebuild the replicates from
`run_multisynth` and `predict_tau`, refitting everything a second time to recover what
the first pass had computed and thrown away.

Two properties the band has to have, and neither survives the collapse:

**Simultaneous.** A cumulative path is read as a path — "the total is positive by week
six and stays there" is a claim about every horizon at once. A pointwise band read
that way covers at well under its nominal level, by more as horizons multiply. One
shared sup-t multiplier restores it.

**Growth measured, not assumed.** Adding per-period interval endpoints treats the
errors as moving in lockstep and grows the width like `L`; rescaling one period's
interval assumes independence and grows it like `sqrt(L)`. Accumulating the replicates
*before* taking the standard error measures which is true. Both laws are pinned.

## How

The jackknife gets the delete-one inflation `(m-1)/m * sum(x - xbar)^2` and the
bootstrap does not, since its draws are already on the estimator's scale. Getting that
backwards shrinks the jackknife band by roughly `(m-1)/sqrt(m)` — a factor of eight at
66 units — so the band records which ensemble produced it on `band.method`.

`supt_critical_value` simulates from the *correlation* estimated from the draws, not
their covariance, so it needs no scale from them and rescaling any horizon leaves the
answer unchanged. That is what lets delete-one replicates feed it; reading the quantile
off the replicates directly would not work, since there are only as many as there are
units. A test implements the covariance route independently and asserts the two agree,
so the change of variables cannot drift.

Indefinite correlation matrices are projected by clipping eigenvalues at zero — with
more horizons than replicates the estimate is rank-deficient, which a jackknife over a
modest panel reaches easily.

## Verification

- Path: **cross-validation** against an independent implementation of the same
  construction, plus a coverage check under a known null.
- Coverage over 40 null panels where every true effect is exactly zero: **0.925** at
  the total and **0.875** simultaneously across all horizons, against a nominal 0.90
  with a binomial standard error of 0.047.
- The suite asserts coverage over draws with a floor four standard errors below
  nominal, never on a single fit — a 90% band misses one panel in ten by construction.
- `jackknife_se` is pinned to the jackknife covariance diagonal at `rel=1e-12`.
- Mutation: `python tools/mutation/run_mutants.py --target simultaneous-band` — **3/3
  killed** (critical value collapsing to pointwise, inflation dropped, running total
  becoming a running mean).

## Scope checks

<!-- FEATURE ON AN EXISTING ESTIMATOR -->
- [x] The default preserves existing behaviour exactly — `cumulative_band=False`, and
      `return_paths=False` keeps both inference functions returning their existing
      five-tuple.
- [x] Existing pinned benchmark values unchanged; `ppscm_bfr_mc.py` does not set the
      field.
- [x] Tests pin that the default attaches nothing and leaves the per-unit fields alone.
- [x] New config field has a `Field(...)` description saying when to reach for it.

## Test Steps

- [x] `pytest mlsynth/tests/test_supt.py mlsynth/tests/test_ppscm_cumulative_supt.py -q` — 56 passed.
- [x] `pytest mlsynth/tests/test_ppscm.py test_ppscm_conformal_cumulative.py test_ppscm_conformal_cumulative_properties.py test_result_contract.py -q` — 225 passed.
- [x] `pytest test_supt.py test_ppscm_cumulative_supt.py test_ppscm_min_train_frac.py -q` after rebasing onto #437 — 77 passed.
- [x] `python tools/mutation/run_mutants.py --target simultaneous-band` — 3/3 killed.
- [x] Docs sweep: no banned words, no RST bold, underlines at least title length, new
      section parses.

## Other Notes

- A durable benchmark arm for the aggregate band is a follow-up, kept separate per the
  repo's rule that benchmark authoring does not ride along with a feature. The 40-draw
  coverage above is the evidence for now and is stated in the commit rather than left
  implied.
- `jackknife_se` absorbs a private nested `_se` that `jackknife_inference` carried, so
  the delete-one inflation has one definition instead of two.
- SCPI already has a simultaneous band, but it is Cattaneo–Feng–Titiunik's own
  construction over its in-sample simulation, not something a caller holding draws can
  reach. The two stay separate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKrMz8fQvjDNM1eur5kQ2V)_