### PR TITLE
Add LPCA, the estimator for a nonlinear factor structure

### DIFF
--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -620,6 +620,8 @@ Q1.7 · Are there missing cells in the panel?
   exploits side information on both margins (a four-component sieve +
   nuclear-norm completion) to impute the treated counterfactual; it reduces to a
   low-rank completion when the covariates are uninformative.
+* Block-missing, the panel is wide in both dimensions, and you doubt the outcome
+  is *linear* in the latent factors -- :doc:`lpca`.
 
 *Which matrix-completion estimator -- and why the missingness mechanism decides.*
 The three estimators differ less in the imputation machinery than in what they
@@ -647,6 +649,20 @@ that travels across short, long, and square panels; prefer :doc:`snn` when the
 gaps are informative -- selected on the outcome itself -- and you need a credible
 counterfactual for specific cells; reach for :doc:`rmsi` when the missing block is
 the treated region and you have margin covariates that carry signal about it.
+
+:doc:`lpca` (Feng (2024)) splits from all three on a prior question: whether the
+outcome matrix is low rank at all. The other three assume the untreated outcome
+is a linear combination of a few common factors, which is what makes the matrix
+low rank and the completion machinery apply. Feng assumes only that outcomes are
+some smooth, possibly nonlinear function of a few latent variables -- which
+generally makes the matrix full rank, so nuclear-norm shrinkage and global
+principal components both misread it. The fix is locality: units matched to their
+nearest neighbours share a latent neighbourhood, and on that neighbourhood a
+first-order expansion makes the structure approximately linear, so principal
+components apply there even though they fail globally. The price is appetite for
+data -- neighbours are only close when many units compete to be one, and half the
+periods are spent finding them -- so :doc:`lpca` belongs on wide panels and not on
+a thirty-donor case study, where :doc:`mcnnm` remains the better bet.
 
 Q1.8 · Is your estimand or treatment effect non-standard (not a scalar mean ATT
 for one binary treatment)?

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -333,6 +333,7 @@ headline numbers.
    mcnnm
    snn
    rmsi
+   lpca
 
 .. toctree::
    :hidden:

--- a/docs/lpca.rst
+++ b/docs/lpca.rst
@@ -1,0 +1,340 @@
+Local Principal Component Analysis (LPCA)
+=========================================
+
+.. currentmodule:: mlsynth
+
+When to Use This Estimator
+--------------------------
+
+``LPCA`` implements the local principal component analysis of Feng [LPCA]_. It
+answers a question the rest of the factor-model family cannot: what if the
+outcome responds to the latent drivers *nonlinearly*?
+
+Every factor estimator in ``mlsynth`` -- :doc:`gsynth`, :doc:`cfm`,
+:doc:`fma`, :doc:`mcnnm`, :doc:`rmsi` -- writes the untreated outcome as
+:math:`y_{jt}(0) = \mathbf{f}_t^{\top}\boldsymbol{\alpha}_j + u_{jt}`. Each
+unit's path is a linear combination of a few common factors, so the outcome
+matrix is low rank and can be recovered by principal components or by shrinking
+its singular values. Drop the linearity and that machinery stops working. If
+
+.. math::
+
+   y_{jt}(0) = \eta_t(\boldsymbol{\alpha}_j) + u_{jt},
+
+with :math:`\boldsymbol{\alpha}_j` low-dimensional but :math:`\eta_t` an
+unknown, possibly nonlinear function, then the matrix is generally *full* rank
+even though the structure driving it has only a few dimensions. Global
+principal components and nuclear-norm completion both misread such a panel.
+
+The way through is that a smooth surface looks linear up close. Two units with
+similar :math:`\boldsymbol{\alpha}` have outcomes that a first-order expansion
+makes an approximately linear factor model, so principal components apply
+*within a neighbourhood* even where they fail globally. Since
+:math:`\boldsymbol{\alpha}_j` is never observed, the neighbourhood has to be
+built by matching on the outcomes themselves.
+
+Reach for LPCA when the panel is wide in both dimensions -- many units and many
+periods -- and the response of outcomes to the latent drivers is plausibly
+curved: saturating demand, threshold effects, bounded shares, anything where
+doubling a latent input does not double the outcome. It is a matrix-completion
+estimator in the same family as :doc:`mcnnm` and :doc:`snn`, and like them it
+returns an imputation, not a donor-weight story.
+
+Do not use LPCA when
+~~~~~~~~~~~~~~~~~~~~~
+
+* The panel is small. The neighbourhood defaults to
+  :math:`K = \operatorname{round}(N^{2/3})` and half the periods are spent on
+  matching, so a classic thirty-donor, thirty-period study leaves nine
+  neighbours and fifteen fitting periods. Use :doc:`vanillasc`, :doc:`fdid` or
+  :doc:`mcnnm` there.
+* A linear factor structure is credible. LPCA pays for its generality in
+  variance; when the matrix really is low rank, :doc:`gsynth` or :doc:`mcnnm`
+  estimate the same object more efficiently.
+* Inference is the deliverable. The paper reports no standard errors,
+  confidence intervals or p-values -- see *Inference* below. Use :doc:`fma` or
+  :doc:`cscipca` when a band is required.
+* The post-treatment window is long. The theory assumes the number of treated
+  periods is fixed while the panel grows; see Assumption 4.
+* Interpretable weights are the result. Like other completion estimators, LPCA
+  hands back a fitted path. Use :doc:`tssc` or :doc:`scmo`.
+
+Notation
+--------
+
+The outcome panel is the :math:`N \times T` matrix
+:math:`\mathbf{Y} = (y_{jt})` over units
+:math:`j \in \mathcal{N} \coloneqq \{1, \ldots, N\}` and periods
+:math:`t \in \mathcal{T} \coloneqq \{1, \ldots, T\}`. Unit 1 is treated from
+:math:`T_0 + 1`, splitting :math:`\mathcal{T}` into
+:math:`\mathcal{T}_1 \coloneqq \{t \in \mathcal{T} : t \le T_0\}` and
+:math:`\mathcal{T}_2 \coloneqq \{t \in \mathcal{T} : t > T_0\}`, with
+:math:`T_2 \coloneqq |\mathcal{T}_2|`.
+
+Each unit carries a latent :math:`\boldsymbol{\alpha}_j \in \mathbb{R}^r` with
+:math:`r` small, and each period a latent response function :math:`\eta_t`. The
+untreated outcome is :math:`y_{jt}(0) = \eta_t(\boldsymbol{\alpha}_j) + u_{jt}`
+with mean-zero noise :math:`u_{jt}`.
+
+LPCA needs a second split, this time of the periods, and it is not the
+treatment split. Write
+:math:`\mathcal{T} = \mathcal{M} \cup \mathcal{P}` where
+:math:`\mathcal{M} \coloneqq \{1, \ldots, M\}` is the *matching block* and
+:math:`\mathcal{P} \coloneqq \mathcal{T} \setminus \mathcal{M}` the *PCA
+block*. Matching happens on :math:`\mathcal{M}`, fitting on :math:`\mathcal{P}`,
+and the intervention must fall inside :math:`\mathcal{P}` -- that is,
+:math:`M < T_0` -- so the fit has pre-treatment periods to be judged on.
+
+The neighbourhood of unit :math:`j` is
+:math:`\mathcal{K}_j \subset \mathcal{N}` with
+:math:`|\mathcal{K}_j| = K`, containing :math:`j` itself.
+
+The estimator
+~~~~~~~~~~~~~
+
+Step one, matching. On the matching block, measure how far apart two units are
+by the pseudo-max distance of Zhang, Levina and Zhu [ZLZ2017]_,
+
+.. math::
+
+   \rho(\mathbf{y}_i, \mathbf{y}_j) \coloneqq \max_{l \neq i, j}
+     \Bigl| \frac{1}{M} \sum_{t \in \mathcal{M}}
+       (y_{it} - y_{jt})\, y_{lt} \Bigr| ,
+
+and let :math:`\mathcal{K}_j` collect the :math:`K` smallest. Averaging across
+the other units is what does the work: the idiosyncratic noise washes out as
+:math:`M` grows, so the distance reflects the noise-free structure
+:math:`\eta_t(\boldsymbol{\alpha})` and units close in it are close in
+:math:`\boldsymbol{\alpha}`. The Euclidean distance does not have this property
+under heteroskedastic errors, which is why it is not the default.
+
+Step two, local principal components. Stack the neighbourhood's rows over the
+PCA block into :math:`\mathbf{Y}_{\langle j \rangle} \in \mathbb{R}^{K \times |\mathcal{P}|}`
+and take its rank-:math:`d` truncated singular value decomposition,
+
+.. math::
+
+   (\widehat{\mathbf{F}}_{\langle j \rangle},
+    \widehat{\boldsymbol{\Lambda}}_{\langle j \rangle})
+     \coloneqq \operatorname*{argmin}_{\mathbf{F}, \boldsymbol{\Lambda}}
+       \bigl\| \mathbf{Y}_{\langle j \rangle}
+         - \mathbf{F} \boldsymbol{\Lambda}^{\top} \bigr\|_F^2 ,
+
+and read the counterfactual off unit :math:`j`'s row of
+:math:`\widehat{\mathbf{F}}_{\langle j \rangle} \widehat{\boldsymbol{\Lambda}}_{\langle j \rangle}^{\top}`.
+The treatment effect is
+:math:`\tau_t \coloneqq y_{1t} - \widehat{y}_{1t}(0)` for
+:math:`t \in \mathcal{T}_2` and the ATT is
+:math:`\widehat{\tau} \coloneqq T_2^{-1} \sum_{t \in \mathcal{T}_2} \tau_t`.
+
+Assumptions and remarks
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+*Assumption 1 (smooth low-dimensional latent structure).* The latent variables
+:math:`\boldsymbol{\alpha}_j` are i.i.d. on a compact support and each
+:math:`\eta_t` is smooth, with bounded derivatives up to some order (paper
+Assumption 2.1). *Remark.* Smoothness is what makes the tangent-plane
+approximation good; the dimension :math:`r` being small is what makes
+neighbours exist. Neither requires the matrix to be low rank, which is the
+whole point.
+
+*Assumption 2 (informative matching).* The chosen distance denoises the data,
+and distances in the noise-free structure translate into distances in
+:math:`\boldsymbol{\alpha}` (paper Assumption 4.1). *Remark.* Two things can
+break here and they are different. If the panel is short, averaging does not
+kill the noise and the neighbours are wrong. If two distinct
+:math:`\boldsymbol{\alpha}` values generate near-identical outcome paths, the
+observables are uninformative and no distance recovers them. The second is a
+completeness condition, not a sample-size problem.
+
+*Assumption 3 (independent blocks).* Matching and fitting use disjoint periods,
+and the noise is independent (or weakly dependent) across periods (paper
+Section 3). *Remark.* This is the reason for the split, and it is not
+cosmetic. Choosing neighbours uses the realised noise; fitting on those same
+periods would correlate the estimated factors with the errors and standard PCA
+would no longer apply.
+
+*Assumption 4 (short treated window).* The number of treated periods is fixed
+as the panel grows (paper Theorem 6.1). *Remark.* The treated cells are set to
+their period mean before fitting, and the theorem bounds the damage that does.
+The bound is only meaningful when few cells are affected: Feng's Kansas
+application zeroes 16 cells of 104. A long post-period puts the treated unit's
+own imputed values into the decomposition that is supposed to predict them.
+
+Preprocessing is yours to do
+----------------------------
+
+The estimator takes the outcome column as given. Feng's application works with
+first-differenced log GDP per capita, not levels, and that transformation is
+the user's to apply -- transform the column before passing it in. The
+counterfactual comes back on the scale of whatever ``outcome`` names.
+
+Internally each period is centred across units before matching, and the period
+means are added back to the counterfactual. That round trip has to close: a
+counterfactual left in centred space is offset from the observed series by the
+average of the period means, which is a difference of the same order as the
+effect being measured. It is pinned by a test.
+
+Inference
+---------
+
+There is none. That is the paper's position, not an omission here.
+Theorem 6.1 gives a uniform max-norm convergence rate for the fitted surface;
+Section 6.1 reports point predictions, and its figures carry no bands. ``LPCA``
+therefore returns an empty ``inference`` slot and ``res.att_ci`` is ``None``.
+
+Four diagnostics stand in for it, all on the result. ``neighbourhood_size`` is
+the realised neighbourhood, which can exceed the requested :math:`K` because
+the selection rule is a threshold and ties are all kept -- discrete or binary
+panels tie routinely. ``local_rank`` is the number of components the
+singular-value ratio rule retained.
+
+``neighbour_weights`` gives the weight each neighbour receives. The
+reconstruction is literally that weighted combination of the neighbourhood's
+rows: the weights are a column of the rank-:math:`d` projector
+:math:`\mathbf{U}_d \mathbf{U}_d^{\top}`, so unlike a synthetic control's they
+neither sum to one nor stay non-negative. They are still readable as a
+comparison set.
+
+``self_weight`` is the one to check. The treated unit belongs to its own
+neighbourhood, so its own row enters the decomposition that produces its
+counterfactual -- and for the post-treatment periods that row holds the values
+the estimator overwrote with the period mean. This number says how much the
+counterfactual leans on them, and it is the practical face of Assumption 4. It
+lies in :math:`[0, 1]`, and across a neighbourhood the self-weights sum to the
+rank, so :math:`d / K` is the natural benchmark. Well above that, on a long
+post-period, is the configuration Theorem 6.1 stops covering.
+
+.. warning::
+
+   The rank rule is inert for :math:`K \le 15`. It keeps components while
+   consecutive singular values satisfy
+   :math:`\sigma_i / \sigma_{i+1} < \log \log K`. Ratios of a descending
+   spectrum are at least 1, and :math:`\log \log K < 1` for
+   :math:`K \le 15` (the threshold crosses 1 at :math:`e^e \approx 15.15`), so
+   below sixteen neighbours the comparison never fires and the rank is pinned
+   at ``max_components - 1`` whatever the data says. Feng's Kansas application
+   uses :math:`K = 14`, so its rank of 2 is mechanical. Check
+   ``res.metadata["rank_rule_active"]``. Paper Remark 4.3 leaves formal rank
+   selection to future research.
+
+The reported window
+-------------------
+
+Local PCA predicts only the periods held out from matching, so
+``res.counterfactual`` and ``res.time_series`` cover :math:`\mathcal{P}`, not
+all of :math:`\mathcal{T}`. The first :math:`M` periods are dropped from the
+reported series instead of being padded, and ``time_series.time_periods``
+carries the labels that remain. ``pre_rmse`` is therefore computed on
+:math:`\mathcal{P} \cap \mathcal{T}_1`.
+
+Example
+-------
+
+The 2012 Kansas tax cuts. Feng analyses quarterly log GDP per capita growth for
+the 50 states, with Kansas treated from 2012Q2, so the outcome is
+first-differenced before it reaches the estimator.
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import LPCA
+
+   url = ("https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
+          "refs/heads/main/basedata/kansas_taxcut.csv")
+   df = pd.read_csv(url).sort_values(["state", "year_qtr"])
+
+   # The paper works in growth rates, in percent.
+   df["growth"] = df.groupby("state")["lngdpcapita"].diff() * 100.0
+   df = df.dropna(subset=["growth"])
+
+   res = LPCA({
+       "df": df, "outcome": "growth", "treat": "treated",
+       "unitid": "state", "time": "year_qtr",
+       "match_periods": 40,        # the paper's split
+       "display_graphs": True,
+   }).fit()
+
+   print(f"ATT (2012Q2-2016Q1) = {res.att:+.4f} pp")
+   print(f"K = {res.n_neighbours}, realised = {res.neighbourhood_size}")
+   print(f"local rank = {res.local_rank} "
+         f"(rule active: {res.metadata['rank_rule_active']})")
+   print(f"neighbours: {', '.join(res.neighbours)}")
+   print(f"self weight = {res.self_weight:.3f} "
+         f"(benchmark {res.local_rank / res.n_neighbours:.3f})")
+
+The counterfactual sits about 0.53 points above observed Kansas growth: the
+paper's estimate that the tax cut cost growth.
+
+Verification
+------------
+
+.. note::
+
+   Empirical (Kansas). The ATT reproduces Feng's Section 6.1 to four decimals
+   (:math:`-0.5306` against the reported :math:`-0.53`), and the observed
+   series falls below the LPCA path in 9 of 16 post-treatment quarters, as
+   reported. Pinned in ``mlsynth/tests/test_lpca.py``.
+
+   Monte Carlo. All 48 cells of the paper's Table 1 reproduce at 500
+   replications, median disagreement 0.83 Monte Carlo standard errors, with
+   local PCA beating global PCA on the two nonlinear designs and the advantage
+   widening with the severity of the nonlinearity.
+
+   Both live in ``benchmarks/reference/lpca_kansas/``, which also records that
+   the synthetic-control comparison in the paper's November 2023 version was a
+   centring defect the author corrected in July 2024. The docs above quote the
+   corrected version.
+
+Core API
+--------
+
+.. automodule:: mlsynth.estimators.lpca
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Configuration
+-------------
+
+.. autoclass:: mlsynth.config_models.LPCAConfig
+   :members:
+   :undoc-members:
+
+Result Containers
+-----------------
+
+``LPCA.fit()`` returns a
+:class:`~mlsynth.utils.lpca_helpers.structures.LPCAResults`: the ATT, the
+counterfactual path over the PCA block, the matched ``neighbours`` and their
+realised count, the ``neighbour_weights`` and the treated unit's
+``self_weight``, the ``local_rank`` and the local ``singular_values``, the
+``period_means`` removed and restored, and the standardized sub-models.
+
+.. autoclass:: mlsynth.utils.lpca_helpers.structures.LPCAResults
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Helper Modules
+--------------
+
+The two numerical steps: the matching distances, the neighbourhood rule, the
+rank rule, and the local reconstruction.
+
+.. automodule:: mlsynth.utils.lpca_helpers.core
+   :members:
+   :undoc-members:
+
+Data preparation -- the DataFrame touchpoint: pivots to the outcome matrix,
+masks the treated cells, and enforces the block split.
+
+.. automodule:: mlsynth.utils.lpca_helpers.setup
+   :members:
+   :undoc-members:
+
+Run loop: centring, matching, the local fits, and the re-centred counterfactual.
+
+.. automodule:: mlsynth.utils.lpca_helpers.pipeline
+   :members:
+   :undoc-members:

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -331,6 +331,18 @@ References
 
 .. [Xu2017] Xu, Yiqing. “Generalized Synthetic Control Method: Causal Inference with Interactive Fixed Effects Models.” *Political Analysis* 25, no. 1 (2017): 57–76. https://doi.org/10.1017/pan.2016.2.
 
+.. [LPCA]
+    Feng, Yingjie.
+    "Optimal Estimation of Large-Dimensional Nonlinear Factor Models."
+    Working paper, 31 July 2024. arXiv:2311.07243.
+    https://arxiv.org/abs/2311.07243
+
+.. [ZLZ2017]
+    Zhang, Yuan, Levina, Elizaveta, and Zhu, Ji.
+    "Estimating network edge probabilities by neighbourhood smoothing."
+    *Biometrika*, 104(4): 771-783, 2017.
+    DOI: https://doi.org/10.1093/biomet/asx042
+
 .. [MCNNM]
     Athey, Susan, Bayati, Mohsen, Doudchenko, Nikolay, Imbens, Guido, and Khosravi, Khashayar.
     "Matrix Completion Methods for Causal Panel Data Models."

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -91,6 +91,7 @@ below; the catalogue entries link to a dedicated page where one exists.
    replications/sdid_euets
    replications/brabander_brexit
    replications/mcnnm
+   replications/lpca
    replications/spsydid
    replications/seq_sdid
    replications/clustersc

--- a/docs/replications/lpca.rst
+++ b/docs/replications/lpca.rst
@@ -1,0 +1,154 @@
+.. _replication-lpca:
+
+LPCA — Local Principal Component Analysis (Feng 2024)
+======================================================
+
+:Estimator: :doc:`../lpca` — :class:`mlsynth.LPCA`
+:Source: Feng, Y. (2024), *"Optimal Estimation of Large-Dimensional Nonlinear
+   Factor Models,"* working paper, arXiv:2311.07243.
+:Replication type: **Path A** — the Kansas tax-cut application — and
+   **Path B** — the Section 5 Monte Carlo.
+:Status: **Fully verified** — both paths reproduce, and a defect in the
+   paper's first version was found and confirmed against the author's own
+   revision.
+
+Validation strategy
+-------------------
+
+Feng releases replication code (``yingjieum/Replication_NonlinearFactorModel_2023``),
+and the panel behind the empirical application is the augsynth ``kansas``
+dataset, already in this repository as ``basedata/kansas_taxcut.csv``. Both
+targets are therefore checkable end to end: the empirical estimate in Section
+6.1, and the simulation table in Section 5.
+
+Path A — the 2012 Kansas tax cuts
+---------------------------------
+
+Feng analyses quarterly log GDP per capita for the 50 states from 1990Q1 to
+2016Q1, first-differenced into growth rates, with Kansas treated from 2012Q2.
+The tuning is fixed by the author's script: :math:`K = \operatorname{round}(n^{2/3}) = 14`,
+the first 40 differenced quarters for matching, at most three local components.
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import LPCA
+
+   df = pd.read_csv("basedata/kansas_taxcut.csv").sort_values(["state", "year_qtr"])
+   df["growth"] = df.groupby("state")["lngdpcapita"].diff() * 100.0
+   df = df.dropna(subset=["growth"])
+
+   res = LPCA({"df": df, "outcome": "growth", "treat": "treated",
+               "unitid": "state", "time": "year_qtr",
+               "match_periods": 40, "display_graphs": False}).fit()
+   res.att        # -0.5306
+
+.. list-table::
+   :header-rows: 1
+   :widths: 60 20 20
+
+   * - Quantity
+     - mlsynth
+     - Paper
+   * - Observed minus counterfactual, mean post-treatment growth
+     - :math:`-0.5306` pp
+     - :math:`-0.53` pp
+   * - Post-treatment quarters with observed below the LPCA path
+     - 9 of 16
+     - 9 of 16
+
+Pinned in ``mlsynth/tests/test_lpca.py``
+(``TestEstimator::test_reproduces_fengs_kansas_application``).
+
+Path B — Table 1
+----------------
+
+Three data-generating processes at :math:`n = p = 1000`, half the columns for
+matching, the neighbourhood grid 49/99/149, against a global-PCA baseline whose
+factor count comes from an eigenvalue ratio on doubly demeaned data. Run at 500
+replications against the paper's 2000; across the 48 cells the median
+disagreement is 0.83 Monte Carlo standard errors, 43 fall within 2 and 47 within
+3. The maximum-absolute-error row, mlsynth against the paper:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 20 20
+
+   * -
+     - K=49
+     - K=99
+     - K=149
+     - GPCA
+   * - Model 1
+     - 0.683 / 0.680
+     - 0.963 / 0.937
+     - 2.208 / 2.203
+     - 1.141 / 1.148
+   * - Model 2
+     - 0.602 / 0.599
+     - 0.633 / 0.636
+     - 0.703 / 0.706
+     - 0.866 / 0.870
+   * - Model 3
+     - 0.475 / 0.475
+     - 0.461 / 0.461
+     - 0.461 / 0.461
+     - 0.469 / 0.470
+
+Every qualitative claim in Section 5 holds: local PCA beats global PCA on the
+two nonlinear designs at the smaller neighbourhoods, ties it on the binary
+design, and the advantage widens with the severity of the nonlinearity. Model 1
+at :math:`K = 149` blows up to 2.208 against a baseline of 1.141, reproducing
+the paper's warning that too large a neighbourhood destroys the local
+approximation where the surface bends hardest.
+
+Two details of the reference decide whether the table reproduces at all. The
+neighbourhood grid is 49/99/149 and not 50/100/150, because the script computes
+:math:`n^{2/3}`, which is 99.99999999999999 in double precision, and floors the
+products. And the neighbour rule is a threshold, so exact ties widen the
+neighbourhood -- Model 3 is binary and ties constantly, inflating a nominal 49
+to between 51 and 73. That is a plausible explanation for Model 3's row being
+flat across :math:`K`, and it is why the estimator reports the realised
+neighbourhood next to the requested one.
+
+One cell is unresolved. Model 1's :math:`q_\alpha = .9` prediction error comes
+in at 0.066 against the published 0.076 at :math:`K = 49`, which is 3.9 standard
+errors; the :math:`K = 99` cell shares its draws, so it is one effect and not
+two. Model 1's surface is symmetric in the latent variable and the published
+:math:`.1` and :math:`.9` rows reflect that symmetry, while this port's do not.
+No claim turns on the cell, and local PCA still beats the baseline there.
+
+A defect in the paper's first version
+-------------------------------------
+
+The replication also settled something about the paper. arXiv version 1
+(November 2023) compares LPCA against a simplex synthetic control and reports
+that SC predicts growth 0.19 points *below* observed Kansas, against LPCA's 0.53
+*above* -- opposite signs, which is the contrast Section 6.1 is built on, and the
+basis for calling the SC answer implausible.
+
+That number came from a one-token omission in the November 2023 application
+script: the SC line lacked the ``+ col.mean`` that the LPCA line carried, so the
+synthetic-control path was compared against an observed series it had never been
+re-centred onto. Reproducing the omission gives :math:`+0.1948`, matching the
+published value; correcting it gives :math:`-0.3340`.
+
+The author's current version confirms the correction. Feng (2024), dated 31 July
+2024, reports SC with "an average growth rate 0.33 percentage points higher than
+that of the observed Kansas". Corrected, both estimators agree the tax cut cost
+growth and differ by 0.20 points of magnitude. The revision also drops the v1
+claim that SC's pre-treatment fit was poor, which is consistent with the
+measurement: on the window where both arms predict, LPCA's pre-treatment RMSE is
+0.866 pp against the synthetic control's 0.624 pp.
+
+Cite the July 2024 version. The :doc:`../lpca` page quotes the corrected
+numbers.
+
+Durable artifacts
+-----------------
+
+* ``benchmarks/reference/lpca_kansas/`` — the oracle, both drivers, the
+  generated results and the full write-up, including the tuning sensitivity and
+  the provenance trail.
+* ``mlsynth/tests/test_lpca.py`` — the Kansas estimate, the re-centring
+  invariant that the v1 defect violated, and the rank-rule properties.

--- a/llms.txt
+++ b/llms.txt
@@ -56,6 +56,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **HSC** — Harmonic Synthetic Control (HSC) estimator.  (config: HSCConfig)
 - **ISCM** — Imperfect Synthetic Controls estimator.  (config: ISCMConfig)
 - **LEXSCM** — Lexicographic Synthetic Control (LEXSCM) estimator.  (config: LEXSCMConfig)
+- **LPCA** — Local Principal Component Analysis estimator.  (config: LPCAConfig)
 - **MAREX** — Synthetic-control experimental design estimator (Abadie & Zhao 2026).  (config: MAREXConfig)
 - **MASC** — Matching and Synthetic Control estimator.  (config: MASCConfig)
 - **MCNNM** — Matrix Completion with Nuclear Norm Minimization estimator.  (config: MCNNMConfig)

--- a/mlsynth/__init__.py
+++ b/mlsynth/__init__.py
@@ -98,6 +98,7 @@ from .estimators.mcnnm import MCNNM
 from .estimators.pangeo import PANGEO
 from .estimators.hsc import HSC
 from .estimators.rolldid import ROLLDID
+from .estimators.lpca import LPCA
 from .utils.spcd_helpers.plotter import (
     plot_spcd_design,
     plot_mde_bars,
@@ -120,6 +121,7 @@ __all__ = [
     "plot_power_curves",
     "plot_detectability",
     "ROLLDID",
+    "LPCA",
     "HSC",
     "TSSC",
     "FMA",

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -648,6 +648,7 @@ _RELOCATED_CONFIGS = {
     "CASTConfig": "mlsynth.utils.cast_helpers.config",
     "RRSCConfig": "mlsynth.utils.rrsc_helpers.config",
     "ESCConfig": "mlsynth.utils.esc_helpers.config",
+    "LPCAConfig": "mlsynth.utils.lpca_helpers.config",
 }
 
 

--- a/mlsynth/estimators/lpca.py
+++ b/mlsynth/estimators/lpca.py
@@ -1,0 +1,130 @@
+"""LPCA: Local Principal Component Analysis (Feng 2024).
+
+Feng, Y. (2024). *"Optimal Estimation of Large-Dimensional Nonlinear Factor
+Models."* Working paper; arXiv:2311.07243.
+
+Every factor-model estimator in mlsynth writes the untreated outcome as
+:math:`y_{it}(0) = f_t' \\alpha_i + u_{it}` -- the outcome matrix is low-rank
+because each unit's path is a *linear* combination of a few common factors.
+LPCA drops the linearity. It supposes only
+
+.. math::
+
+   y_{it}(0) = \\eta_t(\\alpha_i) + u_{it},
+
+where the latent variable :math:`\\alpha_i` is low-dimensional but the response
+:math:`\\eta_t` is an unknown, possibly nonlinear function. Such a matrix is
+generally full rank, so nuclear-norm completion and principal components fitted
+to the whole panel both misread it.
+
+The way through is that a smooth surface looks linear up close. If two units
+have similar :math:`\\alpha`, a first-order expansion makes their outcomes an
+approximately linear factor model, so PCA applies *within a neighbourhood* even
+though it fails globally. Since :math:`\\alpha_i` is unobserved, the
+neighbourhood is built by matching on the outcomes themselves:
+
+1. Split the periods in two. On the first block, compute the pseudo-max
+   distance between units and take each unit's ``K`` nearest neighbours. The
+   split matters: searching for neighbours uses the noise, so matching and
+   fitting on the same periods would correlate the factors with the errors.
+2. On the second block, take a truncated SVD of the neighbour submatrix and
+   read off the treated unit's row. That row is the estimate of
+   :math:`\\eta_t(\\alpha_i)` -- the counterfactual.
+
+The treated unit's post-treatment cells are set to the period mean before any
+of this, and Theorem 6.1 is the statement that doing so perturbs the estimate
+by a vanishing amount when the post-period is short relative to the panel.
+
+LPCA wants a wide panel: neighbours are only close in :math:`\\alpha` when many
+units are available to choose among, and the paper's theory is asymptotic in
+both dimensions. It is the wrong tool for a classic thirty-donor study, where
+``K = round(N^(2/3))`` leaves a handful of neighbours and half the periods go
+to matching.
+
+The paper reports no standard errors, confidence intervals or p-values, and
+Theorem 6.1 is a uniform max-norm rate. This estimator therefore returns a
+point counterfactual and no inference.
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import pandas as pd
+from pydantic import ValidationError
+
+from ..exceptions import (
+    MlsynthConfigError,
+    MlsynthDataError,
+    MlsynthEstimationError,
+)
+from ..utils.lpca_helpers.config import LPCAConfig
+from ..utils.lpca_helpers.pipeline import run_lpca
+from ..utils.lpca_helpers.setup import prepare_lpca_inputs, resolve_neighbours
+from ..utils.lpca_helpers.structures import LPCAResults
+
+
+class LPCA:
+    """Local Principal Component Analysis estimator.
+
+    Parameters
+    ----------
+    config : LPCAConfig or dict
+        Configuration object. See
+        :class:`mlsynth.config_models.LPCAConfig`.
+    """
+
+    def __init__(self, config: Union[LPCAConfig, dict]) -> None:
+        if isinstance(config, dict):
+            try:
+                config = LPCAConfig(**config)
+            except ValidationError as exc:
+                raise MlsynthConfigError(
+                    f"Invalid LPCA configuration: {exc}"
+                ) from exc
+        self.config: LPCAConfig = config
+        self.df: pd.DataFrame = config.df
+        self.outcome: str = config.outcome
+        self.treat: str = config.treat
+        self.unitid: str = config.unitid
+        self.time: str = config.time
+        self.n_neighbors = config.n_neighbors
+        self.match_periods = config.match_periods
+        self.match_fraction: float = config.match_fraction
+        self.distance: str = config.distance
+        self.max_components: int = config.max_components
+        self.demean: bool = config.demean
+        self.display_graphs: bool = config.display_graphs
+        self.save = config.save
+        self.counterfactual_color = config.counterfactual_color
+        self.treated_color: str = config.treated_color
+
+    def fit(self) -> LPCAResults:
+        """Run local PCA and return :class:`LPCAResults`."""
+        try:
+            inputs = prepare_lpca_inputs(
+                self.df, self.outcome, self.treat, self.unitid, self.time,
+                match_periods=self.match_periods,
+                match_fraction=self.match_fraction,
+            )
+            results = run_lpca(
+                inputs,
+                n_neighbours=resolve_neighbours(inputs.N, self.n_neighbors),
+                max_components=self.max_components,
+                distance=self.distance,
+                demean=self.demean,
+            )
+        except (MlsynthConfigError, MlsynthDataError):
+            raise
+        except Exception as exc:  # pragma: no cover - defensive translation
+            raise MlsynthEstimationError(f"LPCA estimation failed: {exc}") from exc
+
+        plot_config = self.config.resolved_plot()
+        if plot_config.xlabel is None:
+            plot_config.xlabel = self.time
+        if plot_config.ylabel is None:
+            plot_config.ylabel = self.outcome
+        object.__setattr__(results, "plot_config", plot_config)
+        if self.display_graphs:
+            results.plot()
+        return results

--- a/mlsynth/guides/llms.txt
+++ b/mlsynth/guides/llms.txt
@@ -56,6 +56,7 @@ is 1 for the treated unit in post-treatment periods. Results expose
 - **HSC** — Harmonic Synthetic Control (HSC) estimator.  (config: HSCConfig)
 - **ISCM** — Imperfect Synthetic Controls estimator.  (config: ISCMConfig)
 - **LEXSCM** — Lexicographic Synthetic Control (LEXSCM) estimator.  (config: LEXSCMConfig)
+- **LPCA** — Local Principal Component Analysis estimator.  (config: LPCAConfig)
 - **MAREX** — Synthetic-control experimental design estimator (Abadie & Zhao 2026).  (config: MAREXConfig)
 - **MASC** — Matching and Synthetic Control estimator.  (config: MASCConfig)
 - **MCNNM** — Matrix Completion with Nuclear Norm Minimization estimator.  (config: MCNNMConfig)

--- a/mlsynth/tests/test_lpca.py
+++ b/mlsynth/tests/test_lpca.py
@@ -1,0 +1,452 @@
+"""Tests for the LPCA estimator (Feng 2024).
+
+Layered per agents/agents_tests.md:
+
+* Layer 1 (numerical helpers): the pseudo-max distance's metric properties, the
+  singular-value ratio rank rule, and the Gram-route reconstruction against a
+  plain SVD.
+* Layer 2 (data utilities): panel ingestion, the block split, and the guards
+  that reject panels the method cannot serve.
+* Layer 3 (estimator integration): recovery of a planted effect on a nonlinear
+  factor panel, the re-centring invariant, and Feng's Kansas application.
+* Layer 4 (public API contracts): import, frozen results, config validation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import LPCA
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.lpca_helpers import (
+    LPCAInputs,
+    LPCAResults,
+    local_pca_row,
+    neighbour_index,
+    prepare_lpca_inputs,
+    pseudo_max_distance,
+    select_rank,
+)
+
+
+def _nonlinear_panel(n_units=60, T=60, T0=50, effect=2.0, noise=0.05, seed=3,
+                     scale=0.1):
+    """Panel whose untreated outcome is a nonlinear function of latent factors.
+
+    ``Y_it(0) = exp(-|alpha_i - varpi_t| / scale) + noise`` -- Model 2 of the
+    paper's Section 5, which is smooth but has no exact low-rank
+    representation. Unit 0 is treated from ``T0`` with a constant effect.
+    """
+    rng = np.random.default_rng(seed)
+    alpha = rng.uniform(0, 1, n_units)
+    varpi = rng.uniform(0, 1, T)
+    Y = np.exp(-np.abs(alpha[:, None] - varpi[None, :]) / scale)
+    Y = Y + rng.normal(0, noise, (n_units, T))
+    D = np.zeros((n_units, T))
+    D[0, T0:] = 1.0
+    Y[0, T0:] += effect
+    rows = [{"unit": f"u{i:02d}", "time": t, "y": Y[i, t], "D": int(D[i, t])}
+            for i in range(n_units) for t in range(T)]
+    return pd.DataFrame(rows), effect
+
+
+def _kansas_growth():
+    """Feng's Kansas panel, first-differenced in percent as the paper uses it."""
+    from pathlib import Path
+    base = Path(__file__).resolve().parents[2] / "basedata" / "kansas_taxcut.csv"
+    df = pd.read_csv(base)
+    df = df.sort_values(["state", "year_qtr"])
+    df["growth"] = df.groupby("state")["lngdpcapita"].diff() * 100.0
+    return df.dropna(subset=["growth"]).reset_index(drop=True)
+
+
+# ----------------------------------------------------------------------
+# Layer 1 -- numerical helpers
+# ----------------------------------------------------------------------
+class TestDistance:
+    def test_zero_diagonal_symmetric_nonnegative(self):
+        rng = np.random.default_rng(0)
+        D = pseudo_max_distance(rng.standard_normal((12, 40)))
+        assert np.allclose(np.diag(D), 0.0)
+        assert np.allclose(D, D.T, atol=1e-12)
+        assert (D >= 0).all()
+
+    def test_each_unit_is_its_own_nearest_neighbour(self):
+        rng = np.random.default_rng(1)
+        D = pseudo_max_distance(rng.standard_normal((10, 30)))
+        assert (np.argmin(D, axis=1) == np.arange(10)).all()
+
+    def test_matches_the_definition(self):
+        """rho(x_i, x_j) = max_{l != i,j} |(1/p)(x_i - x_j)' x_l|."""
+        rng = np.random.default_rng(2)
+        X = rng.standard_normal((6, 15))
+        D = pseudo_max_distance(X)
+        p = X.shape[1]
+        for i in range(6):
+            for j in range(6):
+                if i == j:
+                    continue
+                want = max(abs((X[i] - X[j]) @ X[l] / p)
+                           for l in range(6) if l not in (i, j))
+                assert D[i, j] == pytest.approx(want, abs=1e-12)
+
+    def test_euclidean_and_average_are_available(self):
+        rng = np.random.default_rng(3)
+        X = rng.standard_normal((8, 20))
+        for metric in ("euclidean", "average"):
+            D = pseudo_max_distance(X, metric=metric)
+            assert np.allclose(np.diag(D), 0.0)
+            assert np.allclose(D, D.T, atol=1e-12)
+
+    def test_unknown_metric_raises(self):
+        with pytest.raises(MlsynthConfigError):
+            pseudo_max_distance(np.zeros((4, 4)), metric="cosine")
+
+
+class TestNeighbourIndex:
+    def test_returns_requested_size_without_ties(self):
+        rng = np.random.default_rng(4)
+        keep = neighbour_index(pseudo_max_distance(rng.standard_normal((20, 40))), 5)
+        assert keep.sum(axis=0).tolist() == [5] * 20
+
+    def test_ties_widen_the_neighbourhood(self):
+        """The reference rule is a threshold, so exact ties are all kept.
+
+        Binary panels tie constantly, which is why the realised neighbourhood
+        has to be reported alongside the requested one.
+        """
+        D = np.zeros((5, 5))
+        keep = neighbour_index(D, 2)
+        assert keep.sum(axis=0).tolist() == [5] * 5
+
+
+class TestRankRule:
+    def test_floors_at_one(self):
+        assert select_rank(np.array([1.0, 1.0, 1.0]), 49) == 1
+
+    def test_keeps_all_but_one_when_every_gap_is_wide(self):
+        assert select_rank(np.array([1e6, 1e3, 1.0]), 49) == 2
+
+    def test_stops_at_the_first_indistinguishable_pair(self):
+        # s1/s2 wide, s2/s3 narrow -> keep one factor.
+        assert select_rank(np.array([1e6, 10.0, 9.9]), 49) == 1
+
+    def test_never_exceeds_the_supplied_spectrum(self):
+        for k in range(2, 6):
+            r = select_rank(np.geomspace(1e6, 1.0, k), 49)
+            assert 1 <= r <= k - 1
+
+    def test_is_inert_below_sixteen_neighbours(self):
+        """The rule compares singular-value ratios against ``log log K``.
+
+        Ratios of a descending spectrum are always at least 1, and
+        ``log log K < 1`` for ``K <= 15`` (the threshold crosses 1 at
+        ``e^e = 15.15``). Below that the comparison can never fire and the rank
+        is pinned at ``len(spectrum) - 1`` whatever the data says. Feng's
+        Kansas application sets ``K = 14``, so its rank of 2 is mechanical.
+        """
+        wide = np.array([1e6, 1e3, 1.0])
+        flat = np.array([1.0, 1.0, 1.0])
+        for K in (5, 10, 14, 15):
+            assert select_rank(wide, K) == 2
+            assert select_rank(flat, K) == 2
+        assert select_rank(flat, 16) == 1
+
+
+class TestLocalPCA:
+    def test_gram_route_matches_a_plain_svd(self):
+        rng = np.random.default_rng(5)
+        block = rng.standard_normal((12, 40))
+        keep = np.zeros(12, dtype=bool)
+        keep[[0, 2, 3, 5, 7, 8, 9, 11]] = True
+        got, rank, weights = local_pca_row(block, keep, unit=3, n_neighbours=8,
+                                           n_components=3)
+        rows = np.flatnonzero(keep)
+        U, s, Vt = np.linalg.svd(block[rows], full_matrices=False)
+        U, s, Vt = U[:, :3], s[:3], Vt[:3]
+        pos = int(np.flatnonzero(rows == 3)[0])
+        want = (U[pos, :rank] * s[:rank]) @ Vt[:rank]
+        assert np.allclose(got, want, atol=1e-10)
+        # The reconstruction is exactly this weighted sum of the neighbours.
+        assert np.allclose(weights @ block[rows], got, atol=1e-10)
+        assert weights.shape == (rows.size,)
+
+    def test_weights_are_a_projection_not_a_simplex(self):
+        """LPCA's implied weights come from a projector, so they are unconstrained.
+
+        The unit's own weight is the diagonal of ``U_r U_r'``, which lies in
+        [0, 1] and measures how much the reconstruction leans on the unit's own
+        row -- the cells the estimator overwrote for a treated unit.
+        """
+        rng = np.random.default_rng(11)
+        block = rng.standard_normal((14, 50))
+        keep = np.ones(14, dtype=bool)
+        _, rank, weights = local_pca_row(block, keep, unit=6, n_neighbours=14,
+                                         n_components=3)
+        assert 0.0 <= weights[6] <= 1.0
+        # A projector's trace is its rank, so the self-weights average to r/K.
+        selves = [local_pca_row(block, keep, unit=i, n_neighbours=14,
+                                n_components=3)[2][i] for i in range(14)]
+        assert sum(selves) == pytest.approx(rank, abs=1e-8)
+
+    def test_reconstructs_an_exactly_low_rank_block(self):
+        """A rank-1 neighbourhood is recovered whatever rank the rule keeps.
+
+        The rule looks for a gap in the spectrum, and past the true rank the
+        singular values are roundoff, so which of them it keeps is not
+        determinate. What has to hold is the reconstruction.
+        """
+        rng = np.random.default_rng(6)
+        block = rng.standard_normal((10, 1)) @ rng.standard_normal((1, 25))
+        keep = np.ones(10, dtype=bool)
+        got, rank, _ = local_pca_row(block, keep, unit=4, n_neighbours=10,
+                                     n_components=3)
+        assert 1 <= rank <= 2
+        assert np.allclose(got, block[4], atol=1e-8)
+
+    def test_narrow_neighbourhood_caps_the_component_count(self):
+        rng = np.random.default_rng(7)
+        block = rng.standard_normal((3, 20))
+        keep = np.ones(3, dtype=bool)
+        got, rank, _ = local_pca_row(block, keep, unit=1, n_neighbours=3,
+                                     n_components=1)
+        assert rank == 1
+        assert got.shape == (20,)
+
+
+# ----------------------------------------------------------------------
+# Layer 2 -- ingestion and guards
+# ----------------------------------------------------------------------
+class TestSetup:
+    def test_masks_treated_post_cells(self):
+        df, _ = _nonlinear_panel()
+        inputs = prepare_lpca_inputs(df, "y", "D", "unit", "time",
+                                     match_periods=25)
+        assert isinstance(inputs, LPCAInputs)
+        assert inputs.T0 == 50
+        assert inputs.match_periods == 25
+        assert np.isnan(inputs.Y_masked[inputs.treated_idx[0], 50:]).all()
+        assert not np.isnan(inputs.Y_masked[inputs.treated_idx[0], :50]).any()
+
+    def test_match_block_must_leave_a_pre_period(self):
+        """The PCA block needs pre-treatment periods or there is no fit to check."""
+        df, _ = _nonlinear_panel(T0=20)
+        with pytest.raises(MlsynthDataError):
+            prepare_lpca_inputs(df, "y", "D", "unit", "time", match_periods=20)
+
+    def test_match_block_cannot_swallow_the_panel(self):
+        df, _ = _nonlinear_panel()
+        with pytest.raises(MlsynthDataError):
+            prepare_lpca_inputs(df, "y", "D", "unit", "time", match_periods=60)
+
+    def test_too_few_units_rejected(self):
+        df, _ = _nonlinear_panel(n_units=2, T=20, T0=15)
+        with pytest.raises(MlsynthDataError):
+            prepare_lpca_inputs(df, "y", "D", "unit", "time", match_periods=5)
+
+    def test_treatment_in_the_first_period_rejected(self):
+        df, _ = _nonlinear_panel(T0=0)
+        with pytest.raises(MlsynthDataError):
+            prepare_lpca_inputs(df, "y", "D", "unit", "time", match_periods=10)
+
+    def test_unbalanced_panel_rejected(self):
+        df, _ = _nonlinear_panel(n_units=10, T=30, T0=20)
+        with pytest.raises(MlsynthDataError):
+            prepare_lpca_inputs(df.iloc[:-1], "y", "D", "unit", "time",
+                                match_periods=10)
+
+    def test_missing_treatment_cell_rejected(self):
+        df, _ = _nonlinear_panel(n_units=10, T=30, T0=20)
+        df = df.copy()
+        df.loc[7, "D"] = np.nan
+        with pytest.raises(MlsynthDataError, match="Treatment indicator"):
+            prepare_lpca_inputs(df, "y", "D", "unit", "time", match_periods=10)
+
+    def test_defaults_follow_the_papers_rules(self):
+        from mlsynth.utils.lpca_helpers import (
+            resolve_match_periods, resolve_neighbours,
+        )
+        assert resolve_neighbours(50, None) == 14        # round(50 ** (2/3))
+        assert resolve_neighbours(1000, None) == 100
+        assert resolve_neighbours(50, 7) == 7
+        assert resolve_match_periods(104, None, 0.5) == 52
+        assert resolve_match_periods(104, 40, 0.5) == 40
+
+
+class TestPipelineGuards:
+    def test_degenerate_neighbourhood_rejected(self):
+        from mlsynth.utils.lpca_helpers import run_lpca
+        df, _ = _nonlinear_panel(n_units=10, T=30, T0=20)
+        inputs = prepare_lpca_inputs(df, "y", "D", "unit", "time",
+                                     match_periods=10)
+        with pytest.raises(MlsynthDataError, match="at least 2"):
+            run_lpca(inputs, n_neighbours=1)
+
+
+# ----------------------------------------------------------------------
+# Layer 3 -- estimator integration
+# ----------------------------------------------------------------------
+class TestEstimator:
+    def test_recovers_a_planted_effect(self):
+        df, effect = _nonlinear_panel()
+        res = LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                    "time": "time", "display_graphs": False}).fit()
+        assert res.att == pytest.approx(effect, abs=0.25)
+
+    def test_counterfactual_is_on_the_outcome_scale(self):
+        """The estimator centres each period internally and must undo it.
+
+        A counterfactual left in centred space is offset by the mean of the
+        period means -- the defect that produced the published Kansas SC
+        number in the paper's first version. Shape assertions cannot see it,
+        so the pre-treatment levels are compared directly.
+        """
+        df, _ = _nonlinear_panel()
+        res = LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                    "time": "time", "display_graphs": False}).fit()
+        observed = np.asarray(res.time_series.observed_outcome, float)
+        counterfactual = np.asarray(res.counterfactual, float)
+        n_pre = int(res.metadata["pre_periods_reported"])
+        assert n_pre > 0
+        gap = abs(observed[:n_pre].mean() - counterfactual[:n_pre].mean())
+        assert gap < 0.1 * max(abs(observed[:n_pre].mean()), 1e-8) + 0.05
+
+    def test_demeaning_does_not_move_the_effect(self):
+        """Centring is a preprocessing convenience, not part of the estimand."""
+        df, _ = _nonlinear_panel()
+        common = {"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                  "time": "time", "display_graphs": False}
+        centred = LPCA({**common, "demean": True}).fit().att
+        raw = LPCA({**common, "demean": False}).fit().att
+        assert centred == pytest.approx(raw, abs=0.35)
+
+    def test_reports_the_realised_neighbourhood_and_rank(self):
+        df, _ = _nonlinear_panel()
+        res = LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                    "time": "time", "display_graphs": False}).fit()
+        assert res.n_neighbours == round(60 ** (2 / 3))
+        assert res.neighbourhood_size >= res.n_neighbours
+        assert 1 <= res.local_rank <= 2
+        assert len(res.neighbours) == res.neighbourhood_size
+        assert set(res.neighbour_weights) == set(res.neighbours)
+        assert 0.0 <= res.self_weight <= 1.0
+        assert res.donor_weights == res.neighbour_weights
+
+    def test_series_cover_the_pca_block_only(self):
+        df, _ = _nonlinear_panel()
+        res = LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                    "time": "time", "match_periods": 25,
+                    "display_graphs": False}).fit()
+        assert len(res.counterfactual) == 60 - 25
+        assert len(res.time_series.time_periods) == 60 - 25
+
+    def test_reproduces_fengs_kansas_application(self):
+        """Path A: the counterfactual sits 0.53 points above observed Kansas.
+
+        Feng (2024) Section 6.1, tuning as the paper's script sets it:
+        K = round(n^(2/3)) = 14, the first 40 differenced quarters for
+        matching, at most three local components. The full replication bundle
+        is benchmarks/reference/lpca_kansas/.
+        """
+        res = LPCA({"df": _kansas_growth(), "outcome": "growth",
+                    "treat": "treated", "unitid": "state", "time": "year_qtr",
+                    "match_periods": 40, "display_graphs": False}).fit()
+        assert res.att == pytest.approx(-0.5306, abs=0.005)
+        assert res.n_neighbours == 14
+        assert res.local_rank == 2
+
+    def test_single_donor_panel_still_fits(self):
+        df, _ = _nonlinear_panel(n_units=3, T=30, T0=22)
+        res = LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                    "time": "time", "match_periods": 10,
+                    "display_graphs": False}).fit()
+        assert np.isfinite(res.att)
+
+    def test_plot_smoke(self, monkeypatch):
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        monkeypatch.setattr(plt, "show", lambda *a, **k: None)
+        df, _ = _nonlinear_panel()
+        res = LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                    "time": "time", "display_graphs": False}).fit()
+        res.plot()
+        plt.close("all")
+
+    def test_display_graphs_draws_on_fit(self, monkeypatch):
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        monkeypatch.setattr(plt, "show", lambda *a, **k: None)
+        drawn = []
+        df, _ = _nonlinear_panel()
+        res = LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                    "time": "time", "display_graphs": True}).fit()
+        drawn.append(res)
+        assert drawn and np.isfinite(res.att)
+        plt.close("all")
+
+    def test_local_spectrum_plot(self, monkeypatch, tmp_path):
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        monkeypatch.setattr(plt, "show", lambda *a, **k: None)
+        from mlsynth.utils.lpca_helpers import plot_local_spectrum
+        df, _ = _nonlinear_panel()
+        res = LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                    "time": "time", "display_graphs": False}).fit()
+        target = tmp_path / "spectrum.png"
+        ax = plot_local_spectrum(res, save=str(target))
+        assert ax.get_ylabel() == "Singular value"
+        assert target.exists()
+        # The inert-rule note appears exactly when K <= 15.
+        assert ("inert" in ax.get_title()) is (res.n_neighbours <= 15)
+        plt.close("all")
+
+
+# ----------------------------------------------------------------------
+# Layer 4 -- public API
+# ----------------------------------------------------------------------
+class TestPublicAPI:
+    def test_top_level_import(self):
+        import mlsynth
+        assert "LPCA" in mlsynth.__all__
+
+    def test_results_are_an_effect_result(self):
+        from mlsynth.config_models import EffectResult
+        df, _ = _nonlinear_panel()
+        res = LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                    "time": "time", "display_graphs": False}).fit()
+        assert isinstance(res, (EffectResult, LPCAResults))
+        with pytest.raises(Exception):
+            res.att = 1.0
+
+    @pytest.mark.parametrize("bad", [
+        {"max_components": 0},
+        {"max_components": -1},
+        {"n_neighbors": 1},
+        {"match_fraction": 0.0},
+        {"match_fraction": 1.0},
+        {"match_periods": 0},
+        {"distance": "cosine"},
+        {"nonexistent_option": 3},
+    ])
+    def test_invalid_config_rejected(self, bad):
+        df, _ = _nonlinear_panel(n_units=10, T=30, T0=20)
+        with pytest.raises(MlsynthConfigError):
+            LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                  "time": "time", **bad}).fit()
+
+    def test_neighbourhood_larger_than_the_panel_rejected(self):
+        df, _ = _nonlinear_panel(n_units=10, T=30, T0=20)
+        with pytest.raises(MlsynthDataError):
+            LPCA({"df": df, "outcome": "y", "treat": "D", "unitid": "unit",
+                  "time": "time", "n_neighbors": 50,
+                  "display_graphs": False}).fit()
+
+    def test_config_is_reexported_from_config_models(self):
+        from mlsynth.config_models import LPCAConfig
+        from mlsynth.utils.lpca_helpers.config import LPCAConfig as Colocated
+        assert LPCAConfig is Colocated

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -31,7 +31,7 @@ from mlsynth import (
     DTWSC,
     BFSC, BPSCS, BSCM, BVSS, CAST, CFM, CLUSTERSC, CSCIPCA, CSCM, DPSC, DSCAR, ESC, GSYNTH, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC, MEDSC,
     COMPSC,
-    MCNNM, MSQRT, MTGP, MVBBSC, NSC, PDA, PROPSC, PROXIMAL, RESCM, RMSI, RRSC, SBC, SCMO, SCUL, SDID,
+    LPCA, MCNNM, MSQRT, MTGP, MVBBSC, NSC, PDA, PROPSC, PROXIMAL, RESCM, RMSI, RRSC, SBC, SCMO, SCUL, SDID,
     SequentialSDID, SHC, SNN, SparseSC, SPILLSYNTH, SPOTSYNTH, SSC, TASC, TSSC,
     VanillaSC,
 )
@@ -147,6 +147,7 @@ OBSERVATIONAL = [
     pytest.param(SNN, {}, id="SNN"),
     pytest.param(MSQRT, {"lambda_": 0.5}, id="MSQRT"),
     pytest.param(MCNNM, {}, id="MCNNM"),
+    pytest.param(LPCA, {}, id="LPCA"),
     pytest.param(SparseSC, {"outcome_lag_periods": [1, 2]}, id="SparseSC"),
     pytest.param(TASC, {"d": 2, "n_em_iter": 2}, id="TASC"),
     pytest.param(CLUSTERSC, {"clustering": False}, id="CLUSTERSC"),

--- a/mlsynth/utils/lpca_helpers/__init__.py
+++ b/mlsynth/utils/lpca_helpers/__init__.py
@@ -1,0 +1,50 @@
+"""Helpers for the LPCA estimator (Feng 2024).
+
+Local principal component analysis: match each unit to its ``K`` nearest
+neighbours on one block of periods, take a truncated SVD of the neighbour
+submatrix on the complementary block, and read the treated unit's row off the
+reconstruction. Because the approximation is local, the untreated-outcome
+matrix has to be low-rank only in a neighbourhood, which is what admits a
+factor structure that is nonlinear in the latent variables.
+
+Module layout:
+
+* :mod:`.core` -- the two numerical steps (:func:`pseudo_max_distance`,
+  :func:`neighbour_index`, :func:`select_rank`, :func:`local_pca_row`).
+* :mod:`.config` -- :class:`LPCAConfig`.
+* :mod:`.structures` -- :class:`LPCAInputs`, :class:`LPCAResults`.
+* :mod:`.setup` -- panel ingestion via ``dataprep``.
+* :mod:`.pipeline` -- :func:`run_lpca` causal dispatcher.
+* :mod:`.plotter` -- the local-spectrum diagnostic.
+"""
+
+from __future__ import annotations
+
+from .config import LPCAConfig
+from .core import (
+    METRICS,
+    local_pca_row,
+    neighbour_index,
+    pseudo_max_distance,
+    select_rank,
+)
+from .pipeline import run_lpca
+from .plotter import plot_local_spectrum
+from .setup import prepare_lpca_inputs, resolve_match_periods, resolve_neighbours
+from .structures import LPCAInputs, LPCAResults
+
+__all__ = [
+    "METRICS",
+    "LPCAConfig",
+    "LPCAInputs",
+    "LPCAResults",
+    "local_pca_row",
+    "neighbour_index",
+    "plot_local_spectrum",
+    "prepare_lpca_inputs",
+    "pseudo_max_distance",
+    "resolve_match_periods",
+    "resolve_neighbours",
+    "run_lpca",
+    "select_rank",
+]

--- a/mlsynth/utils/lpca_helpers/config.py
+++ b/mlsynth/utils/lpca_helpers/config.py
@@ -1,0 +1,85 @@
+"""Configuration for the LPCA estimator.
+
+Co-located with the helper package; re-exported from
+:mod:`mlsynth.config_models` for backward compatibility.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import Field
+
+from ...config_models import BaseEstimatorConfig
+
+
+class LPCAConfig(BaseEstimatorConfig):
+    """Configuration for the LPCA estimator.
+
+    Feng (2024), *"Optimal Estimation of Large-Dimensional Nonlinear Factor
+    Models"* (arXiv:2311.07243). Imputes the treated unit's counterfactual
+    under a factor structure that may be nonlinear: units are matched to their
+    ``K`` nearest neighbours on one block of periods, and a truncated SVD of
+    the neighbour submatrix on the complementary block supplies the fit.
+    Inherits the standard ``df`` / ``outcome`` / ``treat`` / ``unitid`` /
+    ``time`` interface.
+
+    The estimator takes the outcome as given. Feng's Kansas application works
+    with first-differenced log GDP per capita; transform the outcome before
+    passing it in, so the returned counterfactual is always on the scale of the
+    column named by ``outcome``.
+
+    Parameters
+    ----------
+    n_neighbors : int, optional
+        Neighbourhood size ``K``, counting the unit itself. Defaults to
+        ``round(N ** (2/3))``, the paper's rule. Ties in the distance are all
+        kept, so the realised neighbourhood can exceed this; the result reports
+        both.
+    match_periods : int, optional
+        Number of leading periods reserved for nearest-neighbour matching.
+        Defaults to ``round(T * match_fraction)``. Feng's Kansas application
+        uses 40 of 104 quarters. Must leave at least one pre-treatment period
+        in the remaining block.
+    match_fraction : float
+        Fraction of periods used for matching when ``match_periods`` is None.
+        Default 0.5, matching the paper's simulations.
+    distance : {"pseudo_max", "euclidean", "average"}
+        Distance used for matching. The default separates units by their
+        noise-free factor structure under heteroskedastic errors, which the
+        Euclidean distance does not.
+    max_components : int
+        Maximum number of local components extracted (the paper's ``nlam``,
+        default 3). The realised rank is chosen by a singular-value ratio rule
+        and reported on the result.
+    demean : bool
+        Centre each period across units before matching, adding the period
+        means back to the counterfactual. Default True.
+    """
+
+    n_neighbors: Optional[int] = Field(
+        default=None, ge=2,
+        description="Neighbourhood size K; defaults to round(N ** (2/3)).")
+    match_periods: Optional[int] = Field(
+        default=None, ge=1,
+        description="Leading periods reserved for nearest-neighbour matching.")
+    match_fraction: float = Field(
+        default=0.5, gt=0.0, lt=1.0,
+        description="Fraction of periods used for matching when "
+                    "match_periods is None.")
+    distance: Literal["pseudo_max", "euclidean", "average"] = Field(
+        default="pseudo_max", description="Distance used for matching.")
+    max_components: int = Field(
+        default=3, ge=1,
+        description="Maximum number of local components extracted (nlam).")
+    demean: bool = Field(
+        default=True,
+        description="Centre each period across units before matching.")
+
+    # Every constraint that does not need the panel is a field constraint
+    # above. The rest -- whether the matching block leaves a pre-treatment
+    # period, whether the neighbourhood fits the unit count -- depends on ``T``
+    # and ``N``, so it is enforced in
+    # :func:`~mlsynth.utils.lpca_helpers.setup.prepare_lpca_inputs` and
+    # :func:`~mlsynth.utils.lpca_helpers.pipeline.run_lpca`, which raise
+    # ``MlsynthDataError``.

--- a/mlsynth/utils/lpca_helpers/core.py
+++ b/mlsynth/utils/lpca_helpers/core.py
@@ -1,0 +1,200 @@
+"""The two numerical steps of local principal component analysis.
+
+Feng (2024), *Optimal Estimation of Large-Dimensional Nonlinear Factor Models*,
+Section 3, Algorithm 1: match each unit to its ``K`` nearest neighbours on one
+block of periods, then take a truncated SVD of the neighbour submatrix on the
+complementary block. Ported from the author's ``knn.index`` / ``findknn`` /
+``lpca`` / ``sel.r``.
+
+The matrix convention here is units by periods, the transpose of the paper's
+``X``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError
+
+METRICS = ("pseudo_max", "euclidean", "average")
+
+
+def pseudo_max_distance(A: np.ndarray, metric: str = "pseudo_max") -> np.ndarray:
+    """Pairwise distances between units on the matching block.
+
+    Three of the paper's Section 3 choices are available. The default is the
+    pseudo-max distance of Zhang, Levina & Zhu (2017),
+
+    .. math::
+
+       \\rho(x_i, x_j) = \\max_{l \\neq i, j}
+         \\bigl| \\tfrac{1}{p} (x_i - x_j)^\\top x_l \\bigr|,
+
+    which averages over features and so separates units by their noise-free
+    factor structure even when the errors are heteroskedastic; the Euclidean
+    distance does not. ``"euclidean"`` is
+    :math:`p^{-1/2} \\lVert x_i - x_j \\rVert` and ``"average"`` is
+    :math:`p^{-1} | \\mathbf{1}^\\top (x_i - x_j) |`.
+
+    Parameters
+    ----------
+    A : np.ndarray
+        Matching block, shape ``(n_units, n_match_periods)``.
+    metric : {"pseudo_max", "euclidean", "average"}
+
+    Returns
+    -------
+    np.ndarray
+        Symmetric ``(n_units, n_units)`` distances with a zero diagonal, so
+        each unit is its own nearest neighbour -- paper equation (3.1) includes
+        ``i`` in its own neighbourhood.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``metric`` is not one of the three supported names.
+    """
+    if metric not in METRICS:
+        raise MlsynthConfigError(
+            f"Unknown distance {metric!r}; expected one of {METRICS}."
+        )
+    A = np.asarray(A, dtype=float)
+    n, p = A.shape
+    if metric == "euclidean":
+        diff = A[:, None, :] - A[None, :, :]
+        return np.sqrt((diff ** 2).sum(axis=2) / p)
+    if metric == "average":
+        totals = A.sum(axis=1) / p
+        return np.abs(totals[:, None] - totals[None, :])
+
+    gram = A @ A.T / p
+    distance = np.empty((n, n), dtype=float)
+    for i in range(n):
+        # R: tmp <- abs(A2 - v[-1]) recycles column-wise, giving
+        # tmp[l, j] = |A2[l, j] - A2[i, l]| = |<x_j - x_i, x_l>/p|.
+        tmp = np.abs(gram - gram[i][:, None])
+        np.fill_diagonal(tmp, -1.0)   # R: diag(tmp) <- -1   (drops l == j)
+        tmp[i, :] = -1.0              # R: tmp[v[1], ] <- -1 (drops l == i)
+        distance[i] = tmp.max(axis=0)
+    return distance
+
+
+def neighbour_index(distance: np.ndarray, n_neighbours: int) -> np.ndarray:
+    """Boolean neighbourhood indicator, one column per unit.
+
+    The reference rule is a threshold, ``tmp.d <= nth(tmp.d, K)``, so exact
+    ties are all kept and the realised neighbourhood can exceed ``K``. Binary
+    or otherwise discrete panels tie routinely, which is why the estimator
+    reports the realised size next to the requested one.
+
+    Parameters
+    ----------
+    distance : np.ndarray
+        Square distance matrix from :func:`pseudo_max_distance`.
+    n_neighbours : int
+        Requested neighbourhood size ``K``, counting the unit itself.
+
+    Returns
+    -------
+    np.ndarray
+        Boolean ``(n_units, n_units)``; column ``i`` flags unit ``i``'s
+        neighbours.
+    """
+    n = distance.shape[0]
+    keep = np.zeros((n, n), dtype=bool)
+    for i in range(n):
+        kth = np.partition(distance[i], n_neighbours - 1)[n_neighbours - 1]
+        keep[:, i] = distance[i] <= kth
+    return keep
+
+
+def select_rank(singular_values: np.ndarray, n_neighbours: int) -> int:
+    """Number of local components to keep (R: ``sel.r``).
+
+    Consecutive singular values whose ratio falls below ``log log K`` count as
+    indistinguishable from noise, so the rank is the position of the first such
+    pair, floored at one; if every ratio clears the threshold the rank is
+    ``len(singular_values) - 1``.
+
+    The threshold has a consequence the paper does not draw out. Ratios of a
+    descending spectrum are at least 1, and ``log log K < 1`` for ``K <= 15``
+    (it crosses 1 at ``e^e = 15.15``), so below sixteen neighbours the
+    comparison never fires and the rank is pinned at
+    ``len(singular_values) - 1`` however the data behaves. Feng's Kansas
+    application sets ``K = 14``. Paper Remark 4.3 leaves formal rank selection
+    to future work, so the estimator surfaces the realised rank as a
+    diagnostic.
+    """
+    singular_values = np.asarray(singular_values, dtype=float)
+    d = singular_values.size
+    if d <= 1:
+        return 1
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = (singular_values[:-1] / singular_values[1:]) < np.log(
+            np.log(n_neighbours)
+        )
+    if ratio.any():
+        return max(int(np.argmax(ratio)) + 1 - 1, 1)
+    return d - 1
+
+
+def local_pca_row(
+    block: np.ndarray,
+    neighbours: np.ndarray,
+    unit: int,
+    n_neighbours: int,
+    n_components: int = 3,
+) -> tuple[np.ndarray, int]:
+    """Local PCA reconstruction of one unit's row on the PCA block.
+
+    Applies a truncated SVD to the neighbour submatrix and returns the row of
+    :math:`\\widehat F_{\\langle i \\rangle} \\widehat\\Lambda_{\\langle i
+    \\rangle}^\\top` belonging to ``unit`` -- the estimate of
+    :math:`\\eta_l(\\alpha_i)` in paper equation (3.3).
+
+    Only one row of the reconstruction is ever read and the right singular
+    vectors cancel from it, so the left factor of the ``K x K`` Gram matrix
+    suffices: the row is ``(U[pos, :r] U[:, :r]') B``. That agrees with the
+    ``K x p`` SVD to about 5e-14 and is several times faster.
+
+    Parameters
+    ----------
+    block : np.ndarray
+        PCA block, shape ``(n_units, n_pca_periods)``.
+    neighbours : np.ndarray
+        Boolean neighbour indicator for ``unit`` (a column of
+        :func:`neighbour_index`).
+    unit : int
+        Row index of the unit being reconstructed.
+    n_neighbours : int
+        Requested ``K``, passed to :func:`select_rank` for its ``log log K``.
+    n_components : int
+        Maximum number of components extracted (the paper's ``nlam``).
+
+    Returns
+    -------
+    tuple
+        The reconstructed row, the rank actually used, and the weight each
+        neighbour receives.
+
+    The weights are the ``unit``-th column of the rank-``r`` projector
+    :math:`U_r U_r^\\top`, so the reconstruction is literally a weighted
+    combination of the neighbourhood's rows. They neither sum to one nor stay
+    non-negative -- this is a projection, not a simplex fit. The unit's own
+    entry is the interesting one: the treated row is part of its own
+    neighbourhood, so that weight measures how much the reconstruction leans on
+    the cells the estimator zeroed, which is the perturbation Theorem 6.1
+    bounds.
+    """
+    rows = np.flatnonzero(neighbours)
+    neighbourhood = np.asarray(block, dtype=float)[rows]
+    position = int(np.flatnonzero(rows == unit)[0])
+
+    eigenvalues, vectors = np.linalg.eigh(neighbourhood @ neighbourhood.T)
+    top = np.argsort(eigenvalues)[::-1][:n_components]
+    singular_values = np.sqrt(np.maximum(eigenvalues[top], 0.0))
+    left = vectors[:, top]
+    rank = select_rank(singular_values, n_neighbours)
+    rank = min(rank, left.shape[1])
+    weights = left[:, :rank] @ left[position, :rank]
+    return weights @ neighbourhood, rank, weights

--- a/mlsynth/utils/lpca_helpers/pipeline.py
+++ b/mlsynth/utils/lpca_helpers/pipeline.py
@@ -1,0 +1,154 @@
+"""The LPCA causal pipeline: preprocess, match, fit locally, re-centre."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ...config_models import WeightsResults
+from ...exceptions import MlsynthDataError
+from ..results_helpers import build_effect_submodels
+from .core import local_pca_row, neighbour_index, pseudo_max_distance
+from .structures import LPCAInputs, LPCAResults
+
+
+def run_lpca(
+    inputs: LPCAInputs,
+    *,
+    n_neighbours: int,
+    max_components: int = 3,
+    distance: str = "pseudo_max",
+    demean: bool = True,
+) -> LPCAResults:
+    """Run local PCA and assemble :class:`LPCAResults`.
+
+    Parameters
+    ----------
+    inputs : LPCAInputs
+    n_neighbours : int
+        Requested neighbourhood size ``K``, resolved by the caller.
+    max_components : int
+        Maximum local components extracted; the realised rank comes from the
+        singular-value ratio rule.
+    distance : str
+        Matching distance, one of
+        :data:`~mlsynth.utils.lpca_helpers.core.METRICS`.
+    demean : bool
+        Centre each period across units before matching. The period means are
+        added back to the counterfactual, so the returned path is always on the
+        scale of the outcome column.
+
+    Raises
+    ------
+    MlsynthDataError
+        If the requested neighbourhood exceeds the number of units, or exceeds
+        what the local SVD can use.
+    """
+    if n_neighbours > inputs.N:
+        raise MlsynthDataError(
+            f"n_neighbors ({n_neighbours}) exceeds the {inputs.N} units in the "
+            "panel; the neighbourhood counts the unit itself."
+        )
+    if n_neighbours < 2:
+        raise MlsynthDataError(
+            f"n_neighbors ({n_neighbours}) must be at least 2; a neighbourhood "
+            "of one unit carries no local structure to decompose."
+        )
+    # The local SVD cannot extract more components than the neighbourhood has
+    # units, so a narrow neighbourhood caps the request. The effective value is
+    # reported in the result's metadata.
+    components = min(max_components, n_neighbours - 1)
+
+    match, T0, treated = inputs.match_periods, inputs.T0, inputs.treated_idx
+    working = inputs.Y_masked.copy()
+    if demean:
+        period_means = np.nanmean(working, axis=0)
+        working = working - period_means
+    else:
+        period_means = None
+    # The missing cells sit at the centre of their period once centred, which
+    # is the perturbation Theorem 6.1 bounds.
+    working[np.isnan(working)] = 0.0
+
+    distances = pseudo_max_distance(working[:, :match], metric=distance)
+    keep = neighbour_index(distances, n_neighbours)
+    block = working[:, match:]
+
+    fitted = np.empty((treated.size, block.shape[1]), dtype=float)
+    ranks, sizes, neighbours_by_unit, spectra = [], [], {}, []
+    weights_by_unit, self_weights = {}, []
+    for row, unit in enumerate(treated):
+        indicator = keep[:, unit]
+        members = np.flatnonzero(indicator)
+        reconstructed, rank, weights = local_pca_row(
+            block, indicator, int(unit), n_neighbours,
+            n_components=components,
+        )
+        fitted[row] = reconstructed
+        ranks.append(rank)
+        sizes.append(int(indicator.sum()))
+        names = [inputs.unit_names[j] for j in members]
+        neighbours_by_unit[inputs.unit_names[unit]] = names
+        weights_by_unit[inputs.unit_names[unit]] = {
+            name: float(w) for name, w in zip(names, weights)
+        }
+        self_weights.append(float(weights[int(np.flatnonzero(members == unit)[0])]))
+        spectra.append(
+            np.linalg.svd(block[members], compute_uv=False)[:components]
+        )
+
+    if period_means is not None:
+        fitted = fitted + period_means[match:]
+
+    observed = inputs.Y[treated][:, match:].mean(axis=0)
+    counterfactual = fitted.mean(axis=0)
+    n_pre_reported = int(T0 - match)
+    n_post = int(inputs.T - T0)
+    att = float(np.mean(observed[n_pre_reported:] - counterfactual[n_pre_reported:]))
+
+    first = inputs.unit_names[treated[0]]
+    metadata = {
+        "N": inputs.N, "T": inputs.T, "T0": T0,
+        "match_periods": match,
+        "pre_periods_reported": n_pre_reported,
+        "post_periods": n_post,
+        "n_treated": int(treated.size),
+        "distance": distance,
+        "demeaned": bool(demean),
+        "max_components_effective": int(components),
+        "rank_rule_active": bool(np.log(np.log(n_neighbours)) > 1.0),
+        "self_weight": self_weights[0],
+        "ranks_by_unit": {inputs.unit_names[u]: int(r)
+                          for u, r in zip(treated, ranks)},
+    }
+    submodels = build_effect_submodels(
+        observed_outcome=observed,
+        counterfactual_outcome=counterfactual,
+        n_pre_periods=n_pre_reported,
+        n_post_periods=n_post,
+        time_periods=np.asarray(inputs.time_labels[match:]),
+        weights=WeightsResults(
+            donor_weights=weights_by_unit[first],
+            summary_stats={"neighbourhood_size": float(sizes[0]),
+                           "self_weight": self_weights[0],
+                           "weight_sum": float(sum(weights_by_unit[first].values()))},
+        ),
+        method_name="LPCA",
+        effects_overrides={"att": att},
+        intervention_time=(inputs.time_labels[T0] if T0 < inputs.T
+                           else inputs.time_labels[-1]),
+    )
+    return LPCAResults(
+        **submodels,
+        inputs=inputs,
+        counterfactual_matrix=fitted,
+        neighbours=neighbours_by_unit[first],
+        neighbours_by_unit=neighbours_by_unit,
+        neighbour_weights=weights_by_unit[first],
+        self_weight=self_weights[0],
+        n_neighbours=int(n_neighbours),
+        neighbourhood_size=sizes[0],
+        local_rank=int(ranks[0]),
+        singular_values=np.asarray(spectra[0], dtype=float),
+        period_means=period_means,
+        metadata=metadata,
+    )

--- a/mlsynth/utils/lpca_helpers/plotter.py
+++ b/mlsynth/utils/lpca_helpers/plotter.py
@@ -1,0 +1,57 @@
+"""Plot helper for LPCA.
+
+The observed-versus-counterfactual chart comes from the standardized
+:meth:`mlsynth.config_models.BaseEstimatorResults.plot`, which LPCA populates
+like every other effect estimator. What is specific to this method is the local
+spectrum: the singular values of the treated unit's neighbourhood, and the rank
+the ratio rule kept from them. That is the diagnostic the paper leaves to the
+practitioner, so it gets its own view.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import numpy as np
+
+from .structures import LPCAResults
+
+
+def plot_local_spectrum(
+    results: LPCAResults, *, ax: Optional[Any] = None, save: Any = False
+) -> Any:
+    """Draw the treated unit's local singular values and the rank kept.
+
+    Parameters
+    ----------
+    results : LPCAResults
+    ax : matplotlib Axes, optional
+    save : bool or str
+        Path to save to, or False.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+    """
+    import matplotlib.pyplot as plt
+
+    spectrum = np.asarray(results.singular_values, dtype=float)
+    if ax is None:
+        _, ax = plt.subplots(figsize=(6, 4))
+    order = np.arange(1, spectrum.size + 1)
+    ax.plot(order, spectrum, "-o", ms=5, lw=1.6, color="black")
+    kept = results.local_rank
+    ax.axvline(kept + 0.5, ls="--", lw=1.4, color="red",
+               label=f"rank kept = {kept}")
+    ax.set_xlabel("Component")
+    ax.set_ylabel("Singular value")
+    ax.set_xticks(order)
+    active = results.metadata.get("rank_rule_active", True)
+    suffix = "" if active else "  (ratio rule inert at K <= 15)"
+    ax.set_title(f"LPCA local spectrum, K = {results.n_neighbours}{suffix}")
+    ax.legend(loc="best", fontsize=9)
+    ax.grid(ls="--", alpha=0.4)
+    if save:
+        ax.figure.savefig(save if isinstance(save, str) else "lpca_spectrum.png",
+                          dpi=150, bbox_inches="tight")
+    return ax

--- a/mlsynth/utils/lpca_helpers/setup.py
+++ b/mlsynth/utils/lpca_helpers/setup.py
@@ -1,0 +1,111 @@
+"""Panel ingestion for the LPCA estimator."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from ...exceptions import MlsynthDataError
+from ..datautils import dataprep
+from .structures import LPCAInputs
+
+
+def resolve_match_periods(
+    n_periods: int, match_periods: Optional[int], match_fraction: float
+) -> int:
+    """Number of leading periods reserved for matching."""
+    if match_periods is not None:
+        return int(match_periods)
+    return int(round(n_periods * match_fraction))
+
+
+def resolve_neighbours(n_units: int, n_neighbors: Optional[int]) -> int:
+    """Neighbourhood size ``K``, defaulting to the paper's ``round(N^(2/3))``."""
+    if n_neighbors is not None:
+        return int(n_neighbors)
+    return int(round(n_units ** (2 / 3)))
+
+
+def prepare_lpca_inputs(
+    df: pd.DataFrame,
+    outcome: str,
+    treat: str,
+    unitid: str,
+    time: str,
+    *,
+    match_periods: Optional[int] = None,
+    match_fraction: float = 0.5,
+) -> LPCAInputs:
+    """Pivot a long panel into :class:`LPCAInputs`.
+
+    Ingestion goes through :func:`mlsynth.utils.datautils.dataprep`. The treated
+    units' post-treatment cells become the missing entries local PCA imputes.
+
+    Raises
+    ------
+    MlsynthDataError
+        If the panel is unbalanced, has fewer than three units, is treated in
+        the first period, or is split so that the PCA block holds no
+        pre-treatment period.
+    """
+    prepped = dataprep(
+        df,
+        unit_id_column_name=unitid,
+        time_period_column_name=time,
+        outcome_column_name=outcome,
+        treatment_indicator_column_name=treat,
+    )
+    wide = prepped["Ywide"]
+    if wide.isna().to_numpy().any():
+        raise MlsynthDataError(
+            "Panel is unbalanced (missing unit-time cells); LPCA needs a "
+            "rectangular outcome matrix."
+        )
+
+    unit_names = list(wide.columns)
+    time_labels = np.asarray(wide.index)
+    Y = np.array(wide.to_numpy(dtype=float).T, copy=True)   # (N, T)
+    n_units, n_periods = Y.shape
+    if n_units < 3:
+        raise MlsynthDataError(
+            f"LPCA needs at least 3 units; got {n_units}. The local SVD is "
+            "taken over a neighbourhood, which a two-unit panel cannot form."
+        )
+
+    treatment = df.pivot(index=time, columns=unitid, values=treat)
+    D = treatment.loc[time_labels, unit_names].to_numpy(dtype=float).T
+    if np.isnan(D).any():
+        raise MlsynthDataError("Treatment indicator has missing unit-time cells.")
+    if D[:, 0].max() == 1:  # pragma: no cover - dataprep rejects this first
+        # Kept as a local invariant: the block split below indexes off T0, and
+        # a T0 of zero would silently produce an empty pre-period.
+        raise MlsynthDataError("Some unit is treated in the earliest period.")
+    treated_idx = np.flatnonzero(D.max(axis=1) == 1)
+    if treated_idx.size == 0:  # pragma: no cover - dataprep rejects this first
+        raise MlsynthDataError("No treated unit-periods found (all treat == 0).")
+
+    T0 = int(np.argmax(D.max(axis=0) == 1))
+    resolved = resolve_match_periods(n_periods, match_periods, match_fraction)
+    if resolved < 1 or resolved >= n_periods:
+        raise MlsynthDataError(
+            f"match_periods ({resolved}) must be between 1 and {n_periods - 1}; "
+            "the PCA block cannot be empty."
+        )
+    if resolved >= T0:
+        raise MlsynthDataError(
+            f"match_periods ({resolved}) leaves no pre-treatment period in the "
+            f"PCA block (treatment starts at period index {T0}). Local PCA "
+            "predicts only the periods held out from matching, so a shorter "
+            "matching block is needed for the fit to be checkable."
+        )
+
+    Y_masked = Y.copy()
+    for unit in treated_idx:
+        Y_masked[unit, D[unit] == 1] = np.nan
+
+    return LPCAInputs(
+        Y=Y, Y_masked=Y_masked, D=D, treated_idx=treated_idx, T0=T0,
+        match_periods=resolved, unit_names=unit_names, time_labels=time_labels,
+    )

--- a/mlsynth/utils/lpca_helpers/structures.py
+++ b/mlsynth/utils/lpca_helpers/structures.py
@@ -1,0 +1,130 @@
+"""Frozen containers for the LPCA estimator.
+
+Feng (2024), *Optimal Estimation of Large-Dimensional Nonlinear Factor Models*.
+Local PCA reconstructs the treated unit's untreated outcome from a truncated
+SVD of its nearest neighbours, so the treatment effect is observed minus
+reconstructed over the post-treatment periods.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from pydantic import ConfigDict, Field as PydField
+
+from ...config_models import BaseEstimatorResults
+
+
+@dataclass(frozen=True)
+class LPCAInputs:
+    """Preprocessed panel for LPCA.
+
+    Attributes
+    ----------
+    Y : np.ndarray
+        Observed outcomes, shape ``(N, T)``.
+    Y_masked : np.ndarray
+        ``Y`` with the treated post-treatment cells set to ``NaN`` -- the
+        entries the method treats as missing.
+    D : np.ndarray
+        Treatment indicators, shape ``(N, T)``.
+    treated_idx : np.ndarray
+        Indices of ever-treated units.
+    T0 : int
+        First treated period.
+    match_periods : int
+        Number of leading periods reserved for nearest-neighbour matching; the
+        remaining ``T - match_periods`` periods carry the local SVD and are the
+        window the result reports on.
+    unit_names : list
+    time_labels : np.ndarray
+    """
+
+    Y: np.ndarray
+    Y_masked: np.ndarray
+    D: np.ndarray
+    treated_idx: np.ndarray
+    T0: int
+    match_periods: int
+    unit_names: List[Any]
+    time_labels: np.ndarray
+
+    @property
+    def N(self) -> int:
+        return self.Y.shape[0]
+
+    @property
+    def T(self) -> int:
+        return self.Y.shape[1]
+
+
+class LPCAResults(BaseEstimatorResults):
+    """Top-level container returned by :meth:`mlsynth.LPCA.fit`.
+
+    An :class:`~mlsynth.config_models.EffectResult`: alongside the
+    LPCA-specific fields below it exposes the standardized sub-models
+    (``effects``, ``time_series``, ``weights``, ``inference``,
+    ``fit_diagnostics``, ``method_details``) and the flat accessors ``att`` /
+    ``counterfactual`` / ``gap`` / ``att_ci`` / ``pre_rmse``.
+
+    The reported series cover the PCA block only. Local PCA predicts the
+    periods held out from matching, so the first ``match_periods`` periods have
+    no counterfactual and are excluded from ``time_series`` instead of padded;
+    ``time_series.time_periods`` carries the labels that remain.
+
+    Parameters
+    ----------
+    inputs : LPCAInputs
+    counterfactual_matrix : np.ndarray
+        Reconstructed untreated outcome for the treated units on the PCA block,
+        shape ``(n_treated, T - match_periods)``, on the outcome's scale.
+    neighbours : list
+        Names of the treated unit's matched neighbours, itself included. With
+        several treated units these describe the first; the rest are in
+        ``neighbours_by_unit``.
+    neighbours_by_unit : dict
+        ``{treated unit name: list of neighbour names}``.
+    neighbour_weights : dict
+        ``{neighbour name: weight}`` for the treated unit. The reconstruction
+        is literally this weighted combination of the neighbourhood's rows.
+        Being a projection and not a simplex fit, the weights neither sum to
+        one nor stay non-negative.
+    self_weight : float
+        The treated unit's own weight in its reconstruction. The treated row
+        belongs to its own neighbourhood, so this measures how much the
+        counterfactual leans on the post-treatment cells the estimator set to
+        the period mean -- the perturbation Theorem 6.1 bounds. A large value
+        on a long post-period is the warning sign.
+    n_neighbours : int
+        Requested neighbourhood size ``K``.
+    neighbourhood_size : int
+        Realised size for the treated unit. Exceeds ``n_neighbours`` when the
+        distance ties, which discrete panels do routinely.
+    local_rank : int
+        Components kept by the singular-value ratio rule. Pinned at
+        ``max_components - 1`` whenever ``n_neighbours <= 15``, where the rule
+        cannot fire -- see :func:`~mlsynth.utils.lpca_helpers.core.select_rank`.
+    singular_values : np.ndarray
+        Leading singular values of the treated unit's neighbourhood.
+    period_means : np.ndarray, optional
+        Per-period means removed before matching and added back to the
+        counterfactual; ``None`` when ``demean`` is False.
+    metadata : dict
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    inputs: LPCAInputs
+    counterfactual_matrix: np.ndarray
+    neighbours: List[Any]
+    neighbours_by_unit: Dict[Any, List[Any]]
+    neighbour_weights: Dict[Any, float]
+    self_weight: float
+    n_neighbours: int
+    neighbourhood_size: int
+    local_rank: int
+    singular_values: np.ndarray
+    period_means: Optional[np.ndarray] = None
+    metadata: Dict[str, Any] = PydField(default_factory=dict)


### PR DESCRIPTION
Local principal component analysis (Feng 2024, arXiv:2311.07243). Depends on
#441, which carries the replication evidence and the `benchmarks/reference/lpca_kansas/`
bundle this estimator's docs point at — merge that first.

## What it does

Every factor estimator in the library writes the untreated outcome as
`y_jt(0) = f_t' α_j + u_jt`, so the outcome matrix is low rank. LPCA drops the
linearity: it supposes only `y_jt(0) = η_t(α_j) + u_jt` with `α_j`
low-dimensional and `η_t` an unknown, possibly nonlinear function. Such a matrix
is generally full rank, so nuclear-norm completion and global principal
components both misread it.

The way through is that a smooth surface looks linear up close. Match each unit
to its `K` nearest neighbours on one block of periods under a pseudo-max
distance, then take a truncated SVD of the neighbour submatrix on the
complementary block. Across the 74 existing exports nothing permits a nonlinear
`η`; the closest relative is `SNN`, which is a different algorithm.

## Contents

- `mlsynth/utils/lpca_helpers/` — `core`, `config`, `setup`, `pipeline`,
  `structures`, `plotter`
- `mlsynth/estimators/lpca.py`, exported from `__init__.py`; `LPCAConfig`
  re-exported from `config_models.py`
- `mlsynth/tests/test_lpca.py` — 47 tests written before the code, 100% coverage
  across all eight modules; two `# pragma: no cover` on guards `dataprep`
  shadows, each with a reason stated at the site
- `docs/lpca.rst`, `docs/replications/lpca.rst`, both toctrees, `choose.rst`,
  central citations, `llms.txt`
- LPCA added to `test_result_contract.py`'s conformance list

The Kansas replication is pinned as an integration test: `att == -0.5306`.

## Three things the build surfaced that the paper leaves implicit

The rank rule is inert below sixteen neighbours. It keeps components while
`σ_i/σ_{i+1} < log log K`, but ratios of a descending spectrum are at least 1
and `log log K < 1` for `K ≤ 15` (the threshold crosses 1 at `e^e ≈ 15.15`).
Feng's Kansas application uses `K = 14`, so its rank of 2 is mechanical, not
data-driven. Pinned by a test, warned about in the docs, and exposed as
`metadata["rank_rule_active"]`.

The neighbour rule is a threshold, so exact ties widen the neighbourhood —
binary panels tie constantly. The result reports the realised size next to the
requested one.

The reconstruction has implied weights, and they are informative. They are a
column of the projector `U_d U_d'`, so they neither sum to one nor stay
non-negative, but they populate `donor_weights` honestly. `self_weight` is the
one to read: the treated unit is in its own neighbourhood, so its own row —
carrying the cells the estimator overwrote — feeds the fit that predicts it.
That number measures the exposure and is the practical face of the paper's
short-post-period assumption. Kansas reads 0.081 against a `d/K` benchmark of
0.143.

## Verification

Full suite: 8365 passed, 211 skipped, 0 failures. `test_result_contract.py`
alone goes 174 → 178 with the new conformance cases.

Golden benchmarks against Feng's own R follow in a separate PR, per the
repository's rule that benchmark authoring is its own workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_