### PR TITLE
Contain a raising benchmark case, stop pinning two cells the Panic panel does not identify, and gate pull requests on the suite

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -190,7 +190,15 @@ jobs:
   pr-suite:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # Matches the daily suite, which runs this registry to completion with R
+    # provisioning on top. Round-robin balances case count, not case cost: on
+    # the first PR run the shards' benchmark steps ranged from 6 to 19 minutes
+    # while shard 7, holding most of the Monte Carlo cases, exceeded a 45-minute
+    # cap and was cancelled -- and a cancelled shard neither passes nor fails
+    # its cases, writes no report, and leaves the run merely "unstable". Adding
+    # heavy cases moves the slowest shard, not the average, so raise the shard
+    # count when one next approaches this.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,14 +38,21 @@ on:
     # Eastern in summer (EDT). Runs every day regardless of whether code changed.
     - cron: "0 7 * * *"
   workflow_dispatch:
+  # Every pull request runs the pure-Python suite (see the pr-suite job). The
+  # daily run is the full gate; this is the one that fails a change before it
+  # lands. A regression that reaches main is otherwise invisible until 07:00 UTC.
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read
 
-# One benchmark run at a time; let an in-flight run finish rather than cancel it.
+# One scheduled/dispatched benchmark run at a time; let an in-flight run finish
+# rather than cancel it. Pull requests get a group per ref instead, so a PR never
+# queues behind the daily run, and a new push supersedes its own stale run.
 concurrency:
-  group: benchmarks
-  cancel-in-progress: false
+  group: benchmarks-${{ github.event_name == 'pull_request' && github.ref || 'default' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   PYTHONUNBUFFERED: "1"
@@ -70,6 +77,8 @@ jobs:
   # run (best-effort, into the system library).
   # ---------------------------------------------------------------------------
   suite:
+    # Reference-provisioning is the expensive half; pull requests get pr-suite.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -164,6 +173,67 @@ jobs:
           if-no-files-found: warn
 
   # ---------------------------------------------------------------------------
+  # Pull-request suite: every registered case, no reference toolchain.
+  #
+  # NEEDS_REFERENCE is empty, so --with-reference gates nothing: all cases are
+  # selected either way, and the ones wanting an external reference raise
+  # BenchmarkSkipped when it is absent. So dropping the R stack costs coverage
+  # only of the live cross-checks, not of the estimators themselves -- the daily
+  # run remains the full gate. What is left is the pure-Python numerical suite,
+  # which is what a code change can actually break.
+  #
+  # Provisioning R is the slow half of `suite`; without it the wall-clock is the
+  # cases themselves, so the shard count goes up to buy the time back. Shard
+  # width and NUM_SHARDS are pinned together by
+  # benchmarks/tests/test_workflow_sharding.py.
+  # ---------------------------------------------------------------------------
+  pr-suite:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+    env:
+      NUM_SHARDS: "8"
+      # Same determinism pinning as `suite`; see the note there.
+      OMP_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+      NUMEXPR_NUM_THREADS: "1"
+      VECLIB_MAXIMUM_THREADS: "1"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install mlsynth + optional backends (design + bayes)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[all]' -c benchmarks/constraints.txt
+
+      - name: Run benchmark suite shard
+        run: |
+          python -u benchmarks/run_benchmarks.py --all --report \
+            --shard "${{ matrix.shard }}" --num-shards "${NUM_SHARDS}"
+
+      - name: Upload benchmark report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-benchmark-report-shard-${{ matrix.shard }}
+          path: |
+            benchmarks/REPORT.md
+            benchmarks/report.json
+          if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
   # Python reference cross-checks. These packages pull numpy<2 (incompatible with
   # the JAX backend in `suite`), so they get clean environments WITHOUT the bayes
   # extra and run only the cases that call them live. They are split into two jobs
@@ -179,6 +249,7 @@ jobs:
   # references, so they need no Python reference package and run in the main suite.)
   # ---------------------------------------------------------------------------
   python-refs-relax:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -215,6 +286,7 @@ jobs:
   # spsydid's spatial reference needs libpysal but NOT scmrelax -- isolating it
   # keeps mosek out of the env so cvxpy uses CLARABEL (see note above).
   python-refs-spsydid:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -249,6 +321,9 @@ jobs:
   # changed, and commits only when the page changed.
   # ---------------------------------------------------------------------------
   validation-dashboard:
+    # Never on a pull request: this job commits the rebuilt dashboard
+    # back to the default branch.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/benchmarks/cases/lexscm_design_mc.py
+++ b/benchmarks/cases/lexscm_design_mc.py
@@ -91,6 +91,13 @@ def _design_mae(sample, m: int):
 
 
 def run() -> dict:
+    try:
+        import pyscipopt  # noqa: F401
+    except ImportError as exc:
+        from benchmarks.compare import BenchmarkSkipped
+        raise BenchmarkSkipped(
+            "LEXSCM needs the SCIP MIP solver (pip install 'mlsynth[design]')."
+        ) from exc
     from mlsynth.utils.marex_helpers.simulation import generate_marex_sample
 
     ratios, maes = {}, {}

--- a/benchmarks/cases/lexscm_walmart.py
+++ b/benchmarks/cases/lexscm_walmart.py
@@ -33,6 +33,13 @@ _BASE = Path(__file__).resolve().parents[2] / "basedata"
 
 
 def run() -> dict:
+    try:
+        import pyscipopt  # noqa: F401
+    except ImportError as exc:
+        from benchmarks.compare import BenchmarkSkipped
+        raise BenchmarkSkipped(
+            "LEXSCM needs the SCIP MIP solver (pip install 'mlsynth[design]')."
+        ) from exc
     from mlsynth import LEXSCM
 
     df = pd.read_csv(_BASE / "walmart_weekly_sales.csv")

--- a/benchmarks/cases/marex_scdesign_sim.py
+++ b/benchmarks/cases/marex_scdesign_sim.py
@@ -98,6 +98,13 @@ def _fit(df: pd.DataFrame, k_cardinality: int):
 
 
 def run() -> dict:
+    try:
+        import pyscipopt  # noqa: F401
+    except ImportError as exc:
+        from benchmarks.compare import BenchmarkSkipped
+        raise BenchmarkSkipped(
+            "MAREX needs the SCIP MIP solver (pip install 'mlsynth[design]')."
+        ) from exc
     ref = load_reference(_CASE)
     values, weights = ref["values"], ref["weights"]
     n_reps = int(values["n_panels"])

--- a/benchmarks/cases/marex_section5_mc.py
+++ b/benchmarks/cases/marex_section5_mc.py
@@ -149,6 +149,13 @@ def _cell(weights, setting, m_sims: int, design="standard", beta=None) -> dict:
 
 
 def run() -> dict:
+    try:
+        import pyscipopt  # noqa: F401
+    except ImportError as exc:
+        from benchmarks.compare import BenchmarkSkipped
+        raise BenchmarkSkipped(
+            "MAREX needs the SCIP MIP solver (pip install 'mlsynth[design]')."
+        ) from exc
     from benchmarks.reference import load_reference
 
     ref = load_reference(_REF_CASE)

--- a/benchmarks/cases/marex_table3.py
+++ b/benchmarks/cases/marex_table3.py
@@ -121,6 +121,13 @@ def _sc_rmse(weights: dict, m: int, n_panels: int) -> float:
 
 
 def run() -> dict:
+    try:
+        import pyscipopt  # noqa: F401
+    except ImportError as exc:
+        from benchmarks.compare import BenchmarkSkipped
+        raise BenchmarkSkipped(
+            "MAREX needs the SCIP MIP solver (pip install 'mlsynth[design]')."
+        ) from exc
     ref = load_reference(_REF_CASE)
     weights = ref["weights"]
     n_panels = int(ref["values"]["n_panels"])

--- a/benchmarks/cases/marex_walmart.py
+++ b/benchmarks/cases/marex_walmart.py
@@ -88,6 +88,13 @@ def _fit():
 
 
 def run() -> dict:
+    try:
+        import pyscipopt  # noqa: F401
+    except ImportError as exc:
+        from benchmarks.compare import BenchmarkSkipped
+        raise BenchmarkSkipped(
+            "MAREX needs the SCIP MIP solver (pip install 'mlsynth[design]')."
+        ) from exc
     return _fit()[0]
 
 

--- a/benchmarks/cases/proximal_panic1907.py
+++ b/benchmarks/cases/proximal_panic1907.py
@@ -20,10 +20,32 @@ mlsynth reproduces the reference / Table-3 full-window ATTs closely:
   ========  ===============  =====================
 
 (The PI/PI-S gaps are ~0.01 implementation slack; PI-Post matches to the printed
-digits.) The case also pins the no-proxy SPSC, the doubly-robust DR, and the
-PIPW (weighting) estimators as regression guards. Path A (scenario 3): the data
-and reference are the authors'; cross-validation is mandatory and done here.
-The case **skips gracefully** when the reference clone is unavailable.
+digits.) The case also pins the no-proxy SPSC estimator as a regression guard.
+Path A (scenario 3): the data and reference are the authors'; cross-validation
+is mandatory and done here. The case **skips gracefully** when the reference
+clone is unavailable.
+
+DR and PIPW are not estimated on this panel. Both route through
+``fit_treatment_bridge``, which solves the square moment system
+
+    E_pre[exp((1,Z) beta) (1,W)] = E_post[(1,W)]
+
+and here it has no solution: the largest absolute residual is 0.401 against a
+tolerance of 1e-06. The system is 49-dimensional -- an intercept and 48
+donor-trust proxies -- and asks for the post-period mean of ``(1,W)`` to be
+reproducible by an exponential tilt of the pre-period, which at T0 = 229 against
+T1 = 182 it is not. That is a property of the design, so the estimator reports
+it instead of retrying.
+
+Both cells were pinned here (``dr_att`` -1.194, ``pipw_att`` -0.854) until #420
+made the stalled solve raise. Before that the root finder returned its
+non-converged iterate, the ATT built from it was an ordinary-looking number, and
+those numbers became the regression guards -- so the two cells recorded the
+solver's failure, not the estimator's answer. They are removed rather than
+re-pinned or given a wider tolerance: the quantities are not identified on this
+panel, and a tolerance cannot supply an identification the design withholds.
+``benchmarks/tests/test_panic1907_bridge_infeasible.py`` holds the diagnosis so
+they cannot come back without the panel or the estimator having changed.
 """
 from __future__ import annotations
 
@@ -66,8 +88,8 @@ def run() -> dict:
     df, donors, surrogates = _panel()
     pi = _att(df, donors, surrogates, ["PI", "PIS", "PIPost"])
     spsc = _att(df, donors, surrogates, ["SPSC"])["SPSC"]
-    dr = _att(df, donors, surrogates, ["DR"])["DR"]
-    pipw = _att(df, donors, surrogates, ["PIPW"])["PIPW"]
+    # DR and PIPW are not requested: both route through the treatment bridge,
+    # which this panel does not identify. See the module docstring.
     return {
         "pi_att": pi["PI"],
         "pis_att": pi["PIS"],
@@ -76,8 +98,6 @@ def run() -> dict:
         "pis_vs_ref": abs(pi["PIS"] - ref["PIS"]),
         "pipost_vs_ref": abs(pi["PIPost"] - ref["PIPost"]),
         "spsc_att": spsc,
-        "dr_att": dr,
-        "pipw_att": pipw,
         "n_donors": float(len(donors)),
         "n_surrogates": float(len(surrogates)),
     }
@@ -126,8 +146,6 @@ EXPECTED = {
     "pis_vs_ref": (0.014, 0.03),         # reproduces freshtaste PI-S
     "pipost_vs_ref": (0.0, 0.01),        # reproduces freshtaste PI-P exactly
     "spsc_att": (-0.892, 0.12),          # single-proxy SC (no surrogates needed)
-    "dr_att": (-1.194, 0.12),            # doubly-robust
-    "pipw_att": (-0.854, 0.12),          # proximal IPW
     "n_donors": (48.0, 0.0),
     "n_surrogates": (3.0, 0.0),
 }

--- a/benchmarks/cases/syndes_bls.py
+++ b/benchmarks/cases/syndes_bls.py
@@ -87,6 +87,13 @@ def _run_cell(Y, K, n_sims, seed):
 
 
 def run() -> dict:
+    try:
+        import pyscipopt  # noqa: F401
+    except ImportError as exc:
+        from benchmarks.compare import BenchmarkSkipped
+        raise BenchmarkSkipped(
+            "SYNDES needs the SCIP MIP solver (pip install 'mlsynth[design]')."
+        ) from exc
     Y = np.loadtxt(_DATA, delimiter=",")                # (40 months, 50 states)
     out = {}
     with warnings.catch_warnings():

--- a/benchmarks/cases/syndes_exact_vs_mip.py
+++ b/benchmarks/cases/syndes_exact_vs_mip.py
@@ -49,6 +49,13 @@ def _subpanel(Y: np.ndarray, n_units: int, n_periods: int, seed: int) -> np.ndar
 
 
 def run() -> dict:
+    try:
+        import pyscipopt  # noqa: F401
+    except ImportError as exc:
+        from benchmarks.compare import BenchmarkSkipped
+        raise BenchmarkSkipped(
+            "SYNDES needs the SCIP MIP solver (pip install 'mlsynth[design]')."
+        ) from exc
     from mlsynth.utils.syndes_helpers.exact import solve_synthetic_design_exact
     from mlsynth.utils.syndes_helpers.optimization import solve_synthetic_design
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import sys
 import time
+import traceback
 from pathlib import Path
 
 # allow "python benchmarks/run_benchmarks.py" from the repo root
@@ -25,15 +26,29 @@ _REF = Path(__file__).resolve().parent / "reference"
 
 def run_one(name: str):
     """Run a single case. Returns a structured result dict (status in
-    pass/fail/skip, per-metric rows, timing) -- and prints the usual summary."""
-    mod = registry.load(name)
+    pass/fail/skip/error, per-metric rows, timing) -- and prints the usual
+    summary.
+
+    A case that raises anything other than :class:`BenchmarkSkipped` is reported
+    as ``error`` against its own name and the suite carries on. The suite is a
+    survey: a case that raises is a result about that case, and the remaining
+    cases are still worth collecting. ``error`` counts against the exit code
+    exactly as ``fail`` does, so containing it is reporting rather than
+    swallowing -- the traceback is printed in full.
+    """
     t0 = time.time()
+    try:
+        mod = registry.load(name)
+    except Exception as exc:                       # unimportable case module
+        return _error(name, exc, t0)
     try:
         got = mod.run()
     except BenchmarkSkipped as exc:
         print(f"\n[SKIP] {name}   ({exc})")
         return {"name": name, "status": "skip", "reason": str(exc),
                 "seconds": round(time.time() - t0, 1), "metrics": []}
+    except Exception as exc:
+        return _error(name, exc, t0)
     expected = mod.EXPECTED
     ok, report = compare(got, expected)
     rows = []
@@ -46,6 +61,20 @@ def run_one(name: str):
     return {"name": name, "status": "pass" if ok else "fail",
             "seconds": round(time.time() - t0, 1), "metrics": rows,
             **_case_meta(name)}
+
+
+def _error(name: str, exc: BaseException, t0: float) -> dict:
+    """Report a case that raised, name it, and keep going.
+
+    The name is printed on its own line before the traceback because the log is
+    read by grepping for the status tags: without it a raising case is
+    anonymous, which is how the 2026-08-13 shard failure hid which case broke it.
+    """
+    print(f"\n[ERROR] {name}   ({time.time() - t0:.0f}s)")
+    traceback.print_exc()
+    return {"name": name, "status": "error",
+            "reason": f"{type(exc).__name__}: {exc}",
+            "seconds": round(time.time() - t0, 1), "metrics": []}
 
 
 def _case_meta(name: str) -> dict:
@@ -80,7 +109,8 @@ def write_report(results: list, out_dir: Path) -> None:
              "the exact reference run and its provenance.", "",
              "| Case | Status | Type | Reference | Bundle | Side-by-side |",
              "|------|--------|------|-----------|--------|--------------|"]
-    icon = {"pass": "PASS", "fail": "FAIL", "skip": "skip"}
+    icon = {"pass": "PASS", "fail": "FAIL", "skip": "skip",
+            "error": "ERROR"}
     for r in results:
         bundle = (f"[`{r['reference_bundle']}`]({r['reference_bundle']})"
                   if r.get("reference_bundle") else "—")
@@ -91,7 +121,14 @@ def write_report(results: list, out_dir: Path) -> None:
     n_pass = sum(r["status"] == "pass" for r in results)
     n_fail = sum(r["status"] == "fail" for r in results)
     n_skip = sum(r["status"] == "skip" for r in results)
-    lines += ["", f"{n_pass} passed, {n_fail} failed, {n_skip} skipped.", ""]
+    n_error = sum(r["status"] == "error" for r in results)
+    lines += ["", f"{n_pass} passed, {n_fail} failed, {n_skip} skipped, "
+                  f"{n_error} errored.", ""]
+    if n_error:
+        lines += ["Cases that raised before producing metrics:", ""]
+        lines += [f"- `{r['name']}`: {r.get('reason', '')}"
+                  for r in results if r["status"] == "error"]
+        lines += [""]
     (out_dir / "REPORT.md").write_text("\n".join(lines) + "\n")
     print(f"\nwrote {report_json} and {out_dir / 'REPORT.md'}")
 
@@ -141,11 +178,19 @@ def main() -> int:
     n_pass = sum(r["status"] == "pass" for r in results)
     n_skip = sum(r["status"] == "skip" for r in results)
     n_fail = sum(r["status"] == "fail" for r in results)
+    n_error = sum(r["status"] == "error" for r in results)
     if args.report:
         write_report(results, Path(__file__).resolve().parent)
-    tail = f" ({n_skip} skipped)" if n_skip else ""
-    print(f"\n==== {n_pass}/{n_pass + n_fail} benchmarks passed{tail} ====")
-    return 0 if n_fail == 0 else 1
+    notes = ([f"{n_skip} skipped"] if n_skip else []) + \
+            ([f"{n_error} errored"] if n_error else [])
+    tail = f" ({', '.join(notes)})" if notes else ""
+    print(f"\n==== {n_pass}/{n_pass + n_fail + n_error} benchmarks "
+          f"passed{tail} ====")
+    if n_error:
+        for r in results:
+            if r["status"] == "error":
+                print(f"  ERROR  {r['name']}: {r['reason']}")
+    return 0 if (n_fail == 0 and n_error == 0) else 1
 
 
 if __name__ == "__main__":

--- a/benchmarks/tests/test_panic1907_bridge_infeasible.py
+++ b/benchmarks/tests/test_panic1907_bridge_infeasible.py
@@ -1,0 +1,100 @@
+"""The Panic-of-1907 panel does not identify the bridge-based proximal methods.
+
+``proximal_panic1907`` pinned ``dr_att`` and ``pipw_att`` alongside the PI /
+PI-S / PI-P cells. Both of those methods route through
+``fit_treatment_bridge``, which solves the square moment system
+
+    E_pre[exp((1,Z) beta) (1,W)] = E_post[(1,W)]
+
+and on this panel it does not solve: the largest absolute residual is 0.401
+against a tolerance of 1e-06. Until #420 the solver returned its stalled
+``sol.x`` regardless, so the case passed on two numbers built from a vector that
+satisfied nothing, and those numbers were then pinned as regression guards.
+
+The design is what makes it unsolvable, so it is reported rather than retried.
+The system is 49-dimensional -- an intercept and 48 donor-trust proxies -- and
+asks for the post-period mean of ``(1,W)`` to be reproducible by an exponential
+tilt of the pre-period. With T0 = 229 against T1 = 182 that tilt does not exist
+in this sample.
+
+These tests pin the diagnosis, so that the two cells cannot be restored without
+the panel or the estimator having changed: DR and PIPW raise here, the four
+bridge-free methods do not, and the case asks for exactly the latter.
+"""
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from mlsynth.exceptions import MlsynthEstimationError
+
+pytest.importorskip("pandas")
+
+BRIDGE_FREE = ["PI", "PIS", "PIPost", "SPSC"]
+BRIDGE_BASED = ["DR", "PIPW"]
+
+
+@pytest.fixture(scope="module")
+def panel():
+    from benchmarks.cases.proximal_panic1907 import _panel
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return _panel()
+
+
+def _att(panel, methods):
+    from benchmarks.cases.proximal_panic1907 import _att as att
+    df, donors, surrogates = panel
+    return att(df, donors, surrogates, methods)
+
+
+class TestTheBridgeIsInfeasibleOnThisPanel:
+    @pytest.mark.parametrize("method", BRIDGE_BASED)
+    def test_the_bridge_methods_raise(self, panel, method):
+        with pytest.raises(MlsynthEstimationError):
+            _att(panel, [method])
+
+    @pytest.mark.parametrize("method", BRIDGE_BASED)
+    def test_the_raise_names_the_moment_condition(self, panel, method):
+        with pytest.raises(MlsynthEstimationError, match="moment condition"):
+            _att(panel, [method])
+
+    def test_the_residual_is_far_above_tolerance(self, panel):
+        """Not a near miss a tighter solve would close."""
+        with pytest.raises(MlsynthEstimationError) as exc:
+            _att(panel, ["DR"])
+        assert "0.4" in str(exc.value)
+
+
+class TestTheBridgeFreeMethodsAreUnaffected:
+    @pytest.mark.parametrize("method", BRIDGE_FREE)
+    def test_they_still_estimate(self, panel, method):
+        got = _att(panel, [method])[method]
+        assert got == pytest.approx(got)   # finite, not nan
+
+    def test_they_match_the_pinned_table3_values(self, panel):
+        got = _att(panel, ["PI", "PIS", "PIPost"])
+        assert got["PI"] == pytest.approx(-1.148, abs=0.05)
+        assert got["PIS"] == pytest.approx(-1.148, abs=0.05)
+        assert got["PIPost"] == pytest.approx(-1.220, abs=0.05)
+
+
+class TestTheCaseAsksOnlyForWhatIsIdentified:
+    def test_it_does_not_pin_the_bridge_methods(self):
+        from benchmarks.cases import proximal_panic1907 as case
+        assert not {"dr_att", "pipw_att"} & set(case.EXPECTED)
+
+    def test_it_still_pins_the_bridge_free_methods(self):
+        from benchmarks.cases import proximal_panic1907 as case
+        assert {"pi_att", "pis_att", "pipost_att", "spsc_att"} <= set(case.EXPECTED)
+
+    def test_the_case_runs_without_raising(self):
+        """The whole point: the suite gets an answer from this case again."""
+        from benchmarks.cases import proximal_panic1907 as case
+        from benchmarks.compare import BenchmarkSkipped
+        try:
+            got = case.run()
+        except BenchmarkSkipped:
+            pytest.skip("reference clone unavailable")
+        assert set(case.EXPECTED) <= set(got)

--- a/benchmarks/tests/test_runner_isolation.py
+++ b/benchmarks/tests/test_runner_isolation.py
@@ -1,0 +1,163 @@
+"""One broken case does not take the suite down with it.
+
+``run_one`` caught only ``BenchmarkSkipped``, so any other exception a case
+raised propagated through the list comprehension in ``main`` and ended the
+process. The daily run of 2026-08-13 shows what that costs: shard 3 of 4 died on
+``proximal_panic1907``, 45 of its 46 cases never ran, ``REPORT.md`` was never
+written so the upload step found no artifact, and the failing case's name
+appeared nowhere in the log -- ``run_one`` prints its ``[PASS]``/``[FAIL]`` line
+only after ``mod.run()`` returns, so a case that raises is anonymous. The case
+had to be identified by reconstructing shard membership.
+
+The suite is a survey instrument. A case that raises is a result about that
+case, and the other 188 answers are still worth collecting and still worth
+reporting. So the error is caught, attributed to its case, and counted against
+the exit code -- which is reporting, not swallowing.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from benchmarks import run_benchmarks
+from benchmarks.compare import BenchmarkSkipped
+
+
+def _case(name, run):
+    """Register a synthetic case module under ``name`` and return the name."""
+    mod = types.ModuleType(name)
+    mod.run = run
+    mod.EXPECTED = {"x": (1.0, 0.1)}
+    mod.__doc__ = f"synthetic case {name}"
+    sys.modules[f"benchmarks.cases.{name}"] = mod
+    return name
+
+
+@pytest.fixture
+def registered(monkeypatch):
+    """Three cases: one passes, one raises, one passes after the raiser."""
+    from benchmarks import registry
+
+    names = {
+        "ok_before": _case("ok_before", lambda: {"x": 1.0}),
+        "boom": _case("boom", lambda: (_ for _ in ()).throw(
+            RuntimeError("the treatment bridge did not solve its moment"))),
+        "ok_after": _case("ok_after", lambda: {"x": 1.0}),
+    }
+    monkeypatch.setattr(
+        registry, "CASES",
+        {n: f"benchmarks.cases.{n}" for n in names}, raising=False)
+    yield list(names)
+    for n in names:
+        sys.modules.pop(f"benchmarks.cases.{n}", None)
+
+
+class TestARaisingCaseIsContained:
+    def test_it_is_reported_as_error_not_propagated(self, registered):
+        got = run_benchmarks.run_one("boom")
+        assert got["status"] == "error"
+
+    def test_the_case_is_named_in_its_own_result(self, registered):
+        assert run_benchmarks.run_one("boom")["name"] == "boom"
+
+    def test_the_exception_message_is_kept(self, registered):
+        got = run_benchmarks.run_one("boom")
+        assert "did not solve its moment" in got["reason"]
+
+    def test_the_exception_type_is_kept(self, registered):
+        assert "RuntimeError" in run_benchmarks.run_one("boom")["reason"]
+
+    def test_it_prints_the_case_name(self, registered, capsys):
+        run_benchmarks.run_one("boom")
+        assert "boom" in capsys.readouterr().out
+
+    def test_cases_after_it_still_run(self, registered):
+        results = [run_benchmarks.run_one(n) for n in registered]
+        assert [r["status"] for r in results] == ["pass", "error", "pass"]
+
+
+class TestTheExitCodeStillFails:
+    def test_an_error_is_not_a_pass(self, registered, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["run_benchmarks.py", "--all"])
+        assert run_benchmarks.main() != 0
+
+    def test_a_clean_suite_still_returns_zero(self, monkeypatch):
+        from benchmarks import registry
+        name = _case("only_ok", lambda: {"x": 1.0})
+        monkeypatch.setattr(registry, "CASES",
+                            {name: f"benchmarks.cases.{name}"}, raising=False)
+        monkeypatch.setattr(sys, "argv", ["run_benchmarks.py", "--all"])
+        try:
+            assert run_benchmarks.main() == 0
+        finally:
+            sys.modules.pop(f"benchmarks.cases.{name}", None)
+
+
+class TestSkipIsStillDistinctFromError:
+    def test_a_skip_is_not_an_error(self, monkeypatch):
+        from benchmarks import registry
+        name = _case("skipper", lambda: (_ for _ in ()).throw(
+            BenchmarkSkipped("reference clone unavailable")))
+        monkeypatch.setattr(registry, "CASES",
+                            {name: f"benchmarks.cases.{name}"}, raising=False)
+        try:
+            assert run_benchmarks.run_one(name)["status"] == "skip"
+        finally:
+            sys.modules.pop(f"benchmarks.cases.{name}", None)
+
+    def test_a_skip_does_not_fail_the_suite(self, monkeypatch):
+        from benchmarks import registry
+        name = _case("skipper2", lambda: (_ for _ in ()).throw(
+            BenchmarkSkipped("reference clone unavailable")))
+        monkeypatch.setattr(registry, "CASES",
+                            {name: f"benchmarks.cases.{name}"}, raising=False)
+        monkeypatch.setattr(sys, "argv", ["run_benchmarks.py", "--all"])
+        try:
+            assert run_benchmarks.main() == 0
+        finally:
+            sys.modules.pop(f"benchmarks.cases.{name}", None)
+
+
+class TestAnUnimportableCaseIsAlsoContained:
+    def test_a_case_that_will_not_import_is_an_error(self, monkeypatch):
+        from benchmarks import registry
+        monkeypatch.setattr(
+            registry, "CASES",
+            {"no_such_case": "benchmarks.cases.no_such_case_at_all"},
+            raising=False)
+        got = run_benchmarks.run_one("no_such_case")
+        assert got["status"] == "error"
+
+
+class TestTheReportSurvivesAnError:
+    """The report is the artifact CI uploads, so it has to be written even when
+    a case raised -- that is the whole point of containing the error. An
+    ``error`` row must be legible in it and counted in its totals."""
+
+    def _write(self, tmp_path, results):
+        run_benchmarks.write_report(results, tmp_path)
+        return (tmp_path / "REPORT.md").read_text()
+
+    def _results(self):
+        return [{"name": "ok", "status": "pass", "seconds": 1.0, "metrics": []},
+                {"name": "boom", "status": "error", "seconds": 0.1,
+                 "reason": "RuntimeError: bridge did not solve", "metrics": []}]
+
+    def test_the_report_file_is_written(self, tmp_path):
+        self._write(tmp_path, self._results())
+        assert (tmp_path / "REPORT.md").exists()
+
+    def test_the_json_is_written(self, tmp_path):
+        self._write(tmp_path, self._results())
+        assert (tmp_path / "report.json").exists()
+
+    def test_the_errored_case_is_named_in_the_table(self, tmp_path):
+        assert "`boom`" in self._write(tmp_path, self._results())
+
+    def test_the_error_status_is_shown(self, tmp_path):
+        assert "ERROR" in self._write(tmp_path, self._results())
+
+    def test_errors_are_counted_in_the_totals(self, tmp_path):
+        assert "1 errored" in self._write(tmp_path, self._results())

--- a/benchmarks/tests/test_workflow_sharding.py
+++ b/benchmarks/tests/test_workflow_sharding.py
@@ -1,0 +1,121 @@
+"""The benchmark workflow's shard count and its trigger guards.
+
+Two invariants live in YAML, where nothing else checks them.
+
+The shard count is written twice per job -- once as the matrix list the runners
+fan out over, once as the ``NUM_SHARDS`` the driver slices with -- and the two
+must agree. They are separated by thirty lines and a comment asking whoever
+edits one to remember the other. If the matrix grows and ``NUM_SHARDS`` does
+not, the extra shards re-run cases another shard already ran; if it shrinks and
+``NUM_SHARDS`` does not, the tail of the registry is never run at all and the
+suite goes green having silently skipped it. That is the failure this file
+exists to prevent, because it is invisible in a passing log.
+
+The trigger guards matter because the pull-request run shares a file with jobs
+that must not see a pull request. ``validation-dashboard`` commits the rebuilt
+dashboard back to the default branch; running it from a fork's PR is a write
+this workflow should never make. The heavy reference jobs are excluded for cost
+rather than safety, but the dashboard exclusion is load-bearing and is asserted
+as such.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+_WORKFLOW = (Path(__file__).resolve().parents[2]
+             / ".github" / "workflows" / "benchmarks.yml")
+
+#: Jobs that fan out over shards; each must keep its matrix and NUM_SHARDS in step.
+SHARDED_JOBS = ("suite", "pr-suite")
+
+#: Jobs that must never run for a pull request.
+NON_PR_JOBS = ("suite", "validation-dashboard")
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    # GitHub's "on:" key parses as the boolean True in YAML 1.1; normalise it.
+    doc = yaml.safe_load(_WORKFLOW.read_text())
+    doc["on"] = doc.get("on", doc.get(True))
+    return doc
+
+
+@pytest.fixture(scope="module")
+def jobs(workflow):
+    return workflow["jobs"]
+
+
+class TestTheShardCountIsWrittenConsistently:
+    @pytest.mark.parametrize("job", SHARDED_JOBS)
+    def test_the_job_exists(self, jobs, job):
+        assert job in jobs
+
+    @pytest.mark.parametrize("job", SHARDED_JOBS)
+    def test_the_matrix_length_equals_num_shards(self, jobs, job):
+        shards = jobs[job]["strategy"]["matrix"]["shard"]
+        assert len(shards) == int(jobs[job]["env"]["NUM_SHARDS"])
+
+    @pytest.mark.parametrize("job", SHARDED_JOBS)
+    def test_the_shards_are_zero_based_and_contiguous(self, jobs, job):
+        """``--shard`` is validated as ``0 <= shard < num_shards``."""
+        shards = jobs[job]["strategy"]["matrix"]["shard"]
+        assert sorted(shards) == list(range(len(shards)))
+
+    @pytest.mark.parametrize("job", SHARDED_JOBS)
+    def test_the_shards_partition_the_registry(self, jobs, job):
+        """Round-robin shards must be disjoint and, unioned, exhaustive."""
+        from benchmarks import registry
+        from benchmarks.run_benchmarks import select_cases
+
+        n = int(jobs[job]["env"]["NUM_SHARDS"])
+        names = list(registry.CASES)
+        seen: list[str] = []
+        for shard in range(n):
+            seen += select_cases(names, registry.NEEDS_REFERENCE,
+                                 with_reference=True, shard=shard, num_shards=n)
+        assert sorted(seen) == sorted(names)
+
+
+class TestPullRequestsRunTheSuite:
+    def test_pull_request_is_a_trigger(self, workflow):
+        assert "pull_request" in workflow["on"]
+
+    def test_the_pr_job_is_guarded_to_pull_requests(self, jobs):
+        assert "pull_request" in jobs["pr-suite"]["if"]
+
+    def test_the_pr_job_does_not_provision_r(self, jobs):
+        """The R stack is the slow half; its cases self-skip without it."""
+        steps = " ".join(str(s) for s in jobs["pr-suite"]["steps"])
+        assert "r-base" not in steps
+
+    def test_the_pr_job_still_reports(self, jobs):
+        steps = " ".join(str(s) for s in jobs["pr-suite"]["steps"])
+        assert "--report" in steps
+
+    def test_the_pr_job_shards_more_finely_than_the_daily_one(self, jobs):
+        """Without R the wall-clock is the driver, so buy it back with width."""
+        assert (int(jobs["pr-suite"]["env"]["NUM_SHARDS"])
+                >= int(jobs["suite"]["env"]["NUM_SHARDS"]))
+
+
+class TestJobsThatMustNotSeeAPullRequest:
+    @pytest.mark.parametrize("job", NON_PR_JOBS)
+    def test_it_is_guarded_against_pull_requests(self, jobs, job):
+        assert "pull_request" in jobs[job].get("if", "")
+
+    def test_the_dashboard_never_runs_on_a_pull_request(self, jobs):
+        """It commits the rebuilt dashboard back to the default branch."""
+        guard = jobs["validation-dashboard"].get("if", "")
+        assert "!=" in guard and "pull_request" in guard
+
+
+class TestConcurrency:
+    def test_a_pull_request_does_not_queue_behind_the_daily_run(self, workflow):
+        assert "github.ref" in str(workflow["concurrency"]["group"])
+
+    def test_a_superseded_pull_request_run_is_cancelled(self, workflow):
+        assert "pull_request" in str(workflow["concurrency"]["cancel-in-progress"])

--- a/benchmarks/tests/test_workflow_sharding.py
+++ b/benchmarks/tests/test_workflow_sharding.py
@@ -119,3 +119,33 @@ class TestConcurrency:
 
     def test_a_superseded_pull_request_run_is_cancelled(self, workflow):
         assert "pull_request" in str(workflow["concurrency"]["cancel-in-progress"])
+
+
+class TestTheTimeoutFitsTheSlowestShard:
+    """Round-robin balances case count, not case cost.
+
+    On the first pull-request run the eight shards' benchmark steps took 6, 17,
+    8, 10, 19, 10, 14 minutes -- and shard 7, which drew most of the Monte Carlo
+    cases, was still running when a 45-minute cap killed it. A killed shard is
+    the worst outcome available: its cases neither pass nor fail, no report is
+    written, and the run reports `cancelled` rather than red, so roughly an
+    eighth of the suite goes unexamined while the PR looks merely unstable.
+
+    The floor is set against the daily suite, which has run this registry to
+    completion for months at 90 minutes with R provisioning on top. Adding heavy
+    cases moves the slowest shard, not the average, so this is the number to
+    revisit -- by raising the shard count -- when a shard next approaches it.
+    """
+
+    #: Minutes. Below this a heavy shard is at risk of being cancelled.
+    FLOOR = 60
+
+    @pytest.mark.parametrize("job", SHARDED_JOBS)
+    def test_the_timeout_clears_the_floor(self, jobs, job):
+        assert jobs[job]["timeout-minutes"] >= self.FLOOR
+
+    def test_the_pr_timeout_is_not_tighter_than_the_daily_one(self, jobs):
+        """The PR job runs the same cases on more shards but without R, so its
+        per-shard work is lower -- never give it a tighter cap than the run
+        that is known to complete."""
+        assert jobs["pr-suite"]["timeout-minutes"] >= jobs["suite"]["timeout-minutes"]


### PR DESCRIPTION
## Related Links

- Benchmark case: [`benchmarks/cases/proximal_panic1907.py`](../blob/claude/mlsynth-golden-benchmark-tdhtul/benchmarks/cases/proximal_panic1907.py)
- New tests: [`test_runner_isolation.py`](../blob/claude/mlsynth-golden-benchmark-tdhtul/benchmarks/tests/test_runner_isolation.py), [`test_panic1907_bridge_infeasible.py`](../blob/claude/mlsynth-golden-benchmark-tdhtul/benchmarks/tests/test_panic1907_bridge_infeasible.py), [`test_workflow_sharding.py`](../blob/claude/mlsynth-golden-benchmark-tdhtul/benchmarks/tests/test_workflow_sharding.py)
- Follows from #420, which made the stalled bridge solve raise
- Reference: `freshtaste/proximal` (pinned `a67d81e`), proximal-SC Table 3

## What

- Contained a benchmark case that raises: `run_one` reports it as `error` against its own name and the suite carries on.
- Removed `dr_att` and `pipw_att` from `proximal_panic1907`; the panel does not identify them.
- Skipped the eight design cases when SCIP is absent: `syndes_bls`, `syndes_exact_vs_mip`, `marex_walmart`, `marex_section5_mc`, `marex_scdesign_sim`, `marex_table3`, `lexscm_design_mc`, `lexscm_walmart`.
- Added a `pull_request` trigger: a `pr-suite` job runs every case across eight shards without the R stack, and the jobs that must not see a PR are guarded.

## Why

The daily suite had been red since 2026-08-13, and two separate defects were involved.

The red itself is `proximal_panic1907`. DR and PIPW both route through `fit_treatment_bridge`, which solves the square moment system `E_pre[exp((1,Z) beta) (1,W)] = E_post[(1,W)]`. On this panel it has no solution: the largest absolute residual is 0.401 against a tolerance of 1e-06. The system is 49-dimensional — an intercept and 48 donor-trust proxies — and asks for the post-period mean of `(1,W)` to be reproducible by an exponential tilt of the pre-period, which at T0 = 229 against T1 = 182 it is not.

Until #420 the root finder returned its non-converged iterate anyway. The ATT built from it was an ordinary-looking number, and `dr_att` -1.194 and `pipw_att` -0.854 were pinned from it as regression guards. Those two cells recorded the solver's failure, not the estimator's answer, so #420 turning the stalled solve into a raise is what surfaced them.

The second defect is why it was hard to see. `run_one` caught only `BenchmarkSkipped`, so any other exception propagated through the list comprehension in `main` and ended the process. In the 2026-08-13 run shard 3 of 4 died on this case: 45 of its 46 cases never ran, `REPORT.md` was never written so the upload step logged "No files were found with the provided path", and the case's name appeared nowhere in the log — `run_one` prints its status line only after `mod.run()` returns, so a case that raises is anonymous. Identifying it meant reconstructing shard membership by hand.

The third change addresses why it stayed red for three days: the suite ran on `schedule` and `workflow_dispatch` only, so nothing exercised it before a change landed.

## How

The two removed cells are removed, not re-pinned and not given a wider tolerance. The quantities are not identified on this panel, and a tolerance cannot supply an identification the design withholds. PI, PI-S, PI-P and SPSC do not touch the bridge and are untouched here.

The error containment counts against the exit code exactly as `fail` does, and prints the full traceback, so it is reporting rather than swallowing. `skip` stays distinct from `error`, an unimportable case module is contained too, and `write_report` learned the status so the artifact CI uploads gets written and lists what raised.

The SCIP guards use the same `BenchmarkSkipped` idiom the NumPyro-backed cases already use; `pyscipopt` is an optional extra (`mlsynth[design]`), so its absence is not a numerical result. Six of the eight were found by the containment change itself — they error at four separate points in the registry, so before it the suite stopped at the first and reported none of the others.

For the PR job, `NEEDS_REFERENCE` is empty, so `--with-reference` gates nothing: every case is selected either way and the ones wanting an external reference self-skip. Dropping the R stack therefore costs coverage of the live cross-checks, not of the estimators, and the daily run stays the full gate. `validation-dashboard` is excluded from PRs because it commits the rebuilt dashboard back to the default branch; the reference jobs are excluded for cost. PRs get a concurrency group keyed on the ref, so they neither queue behind the daily run nor stack up on themselves.

## Verification

- Path: not applicable to the estimator — no numerical code changed. `mlsynth/utils/proximal_helpers/` is untouched; `mlsynth/tests/test_proximal.py` and `test_proximal_bridge_convergence.py` pass unchanged (54 tests).
- `proximal_panic1907` passes on its remaining cells: PI -1.148, PI-S -1.148, PI-P -1.219, SPSC -0.891, each within its existing tolerance of the Table 3 / reference values, plus `pipost_vs_ref` at 1.1e-08.
- The infeasibility is pinned durably in `test_panic1907_bridge_infeasible.py`: DR and PIPW raise on this panel, the four bridge-free methods do not, and the case's `EXPECTED` no longer names the two cells. They cannot be restored without the panel or the estimator having changed.
- What does not match, recorded rather than fixed: DR and PIPW have no value on this panel at all. That is the finding, not a gap to close.
- Full suite on CI: all eight `pr-suite` shards green on `d93d8da`, with the four non-PR jobs correctly skipped. `proximal_panic1907` is in shard 7 and passed there.

The first PR run cancelled shard 7 at a 45-minute cap. Round-robin balances case count, not case cost: the shards' benchmark steps ran 6, 17, 8, 10, 19, 10 and 14 minutes while shard 7 drew most of the Monte Carlo cases. A cancelled shard neither passes nor fails its cases and writes no report, so the cap is now the daily suite's own 90 minutes, and shard 7 completes in 45m18s. `test_workflow_sharding.py` pins a 60-minute floor and forbids the PR cap from being tighter than the daily one.

## Scope checks

- [x] A test reproduces the defect and fails without the fix — all three modules were watched red first: 8 of 11 isolation tests, 2 of 13 panic1907 tests, 14 of 18 workflow tests, then 2 more for the timeout.
- [x] It asserts the correct behaviour, not merely the absence of a crash — the error is named, attributed, counted, and reported; the bridge diagnosis is asserted on both sides.
- [x] No docs page, docstring, or comment still states the old behaviour — the case docstring's method table and the `run_one` docstring are both updated.
- [x] Any pinned value that moved is justified — none moved. Two were removed, with the reason recorded in the case docstring.

## Designs

No visual output; this is benchmark infrastructure and one case's expectations.

## Test Steps

- [x] `pytest benchmarks/tests/ -q` — 55 passed
- [x] `pytest mlsynth/tests/test_proximal.py mlsynth/tests/test_proximal_bridge_convergence.py -q` — 54 passed, no regression
- [x] `python benchmarks/run_benchmarks.py --case proximal_panic1907` — PASS
- [x] Each of the eight design cases skips cleanly without `pyscipopt`
- [x] `python benchmarks/run_benchmarks.py --all` — eight shards green on CI

## Other Notes

- The shard cost imbalance is inherent to round-robin, which balances case count rather than case cost: the slowest shard is 2.75x the average. Adding heavy cases moves the slowest shard, not the average, so the lever to reach for is the shard count rather than the timeout. Cost-aware sharding would be a separate change.
- `mergeable_state` was `unstable` on the first run because GitHub reports a timed-out job as `cancelled` rather than failed. That is worth knowing when reading this workflow's status: a cancelled shard is not a green shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)