### PR TITLE
Give PDA a cumulative band, and let a caller reach Remark 2.2

### DIFF
--- a/docs/pda.rst
+++ b/docs/pda.rst
@@ -1199,6 +1199,59 @@ out-of-sample prediction error on top of the estimation error, and it tightens
 or widens quarter by quarter as the fitted controls track each period better or
 worse.
 
+The cumulative effect
+---------------------
+
+The intervals above bound one period at a time. The number an event study is
+usually quoted by is the running total -- how much the treated unit gained over
+the first :math:`L` periods -- and ``cumulative_band=True`` attaches a band for
+it:
+
+.. code-block:: python
+
+   res = PDA({..., "prediction_intervals": True, "cumulative_band": True}).fit()
+   band = res.fits["lasso"].cumulative_band
+   for L in (1, 4, 8):
+       i = L - 1
+       print(f"L={L}: {band.point[i]:+.3f}  ({band.lower[i]:+.3f}, {band.upper[i]:+.3f})")
+
+An interval for a running total is not the running total of the period
+intervals, and the two obvious shortcuts are both wrong. Adding the period
+endpoints treats every period's error as moving in lockstep, so the width grows
+in proportion to :math:`L` whatever the data does. Rescaling a single period's
+interval by :math:`\sqrt{L}` assumes the opposite, that the errors are
+independent, and for a donor fit the estimation error persists across horizons,
+so that one is wrong as well. Neither measures anything.
+
+What mlsynth does instead is accumulate each bootstrap replicate's error path
+first and take the standard error afterwards. Whatever correlation the period
+errors have is then carried into the band rather than assumed into it:
+independent errors widen it like :math:`\sqrt{L}`, perfectly correlated ones
+like :math:`L`, and the replicates decide which. On the Oregon opioid panel of
+Wheeler's ``LassoSynth`` -- 13 post-periods, one treated state -- the standard
+error grows by a factor of 4.43, against :math:`\sqrt{13} = 3.61` for
+independence and :math:`13` for lockstep. It sits between them, which is the
+whole point of measuring it. The resulting half-width is 1.37 where summing the
+period endpoints would have given 3.78, against a cumulative point estimate of
+7.59.
+
+The band is simultaneous over horizons rather than pointwise. A cumulative path
+is read as a path -- "positive by period six and never back" is a claim about
+every horizon at once -- and a pointwise band read that way covers at well below
+its nominal level. One shared critical value
+(:func:`mlsynth.utils.supt.supt_critical_value`, following Montiel Olea and
+Plagborg-Moller) restores the level for the path as a whole; on the Oregon panel
+it is 2.54 where the pointwise normal quantile would be 1.96.
+
+The band reuses the replicate paths the prediction-interval bootstrap already
+produced, so it costs no extra refits, and it therefore requires
+``prediction_intervals=True``. Asking for it without the bootstrap raises rather
+than returning an empty field, since a caller reading a missing band as an
+absent effect is the one failure worth ruling out. PPSCM's ``cumulative_band``
+is the same object built the same way, sharing
+:mod:`mlsynth.utils.supt`, so the two estimators cannot drift apart in what the
+phrase means.
+
 ``hcw`` produces these same intervals, with one practical caveat: the bootstrap
 refits the entire selection on every draw, and HCW's refit re-runs the
 best-subset search. On the 24-economy pool that is roughly ten seconds a draw, so

--- a/docs/pda.rst
+++ b/docs/pda.rst
@@ -1162,7 +1162,18 @@ fixed tuning parameter, and reads quantiles of the self-normalized statistic
 :math:`\widehat e_t / \sqrt{\widehat V_t + \widehat\sigma^2}`.
 
 The implementation lives at the shared :func:`mlsynth.utils.inferutils.pda_prediction_intervals`
-so any panel-data estimator can reuse it. Both the equal-tailed (``eq``) and
+so any panel-data estimator can reuse it. The pre-period error is resampled
+with the dependent wild bootstrap of their Algorithm 2.1 -- Bartlett-correlated
+multipliers whose dependence range is a bandwidth in :math:`T_0`, so a persistent
+error is resampled as a persistent one. ``pi_dependent=False`` switches to the
+ordinary i.i.d. multipliers of their Remark 2.2, which is cheaper and valid only
+when the errors are independent to begin with; the choice is recorded on the
+result, since a band built under each is not the same number. The correction is
+modest and shows up on average rather than on every panel -- over eight simulated
+panels the dependent scheme gave the wider band on five to eight of them, with a
+mean width ratio of 1.015 under white noise and 1.043 at :math:`\rho = 0.9`.
+Persistence is what makes it matter, which is why the paper's algorithm is the
+default. Both the equal-tailed (``eq``) and
 symmetric (``sy``) intervals are returned, and each variant reports which
 studentization it used: ``sandwich`` for the post-selection OLS HAC variance
 :math:`\widehat V_t` (``hcw``, ``lasso`` and ``fs``, which all select then run

--- a/mlsynth/estimators/pda.py
+++ b/mlsynth/estimators/pda.py
@@ -110,6 +110,7 @@ class PDA:
                        prediction_intervals=self.config.prediction_intervals,
                        cumulative_band=self.config.cumulative_band,
                        pi_n_boot=self.config.pi_n_boot,
+                       pi_dependent=self.config.pi_dependent,
                        pi_seed=self.config.pi_seed)
         results = assemble_pda_results(inputs, fits, selected_variant=methods[0])
 

--- a/mlsynth/estimators/pda.py
+++ b/mlsynth/estimators/pda.py
@@ -108,6 +108,7 @@ class PDA:
                        hcw_nvmax=self.config.hcw_nvmax,
                        hcw_backend=self.config.hcw_backend,
                        prediction_intervals=self.config.prediction_intervals,
+                       cumulative_band=self.config.cumulative_band,
                        pi_n_boot=self.config.pi_n_boot,
                        pi_seed=self.config.pi_seed)
         results = assemble_pda_results(inputs, fits, selected_variant=methods[0])

--- a/mlsynth/tests/test_pda_cumulative_band.py
+++ b/mlsynth/tests/test_pda_cumulative_band.py
@@ -1,0 +1,250 @@
+"""A cumulative band for PDA, built from the bootstrap's own replicate paths.
+
+PDA reports a per-period prediction interval for every post-treatment period
+(Jiang, Li, Shen & Zhou 2025) and an asymptotic interval for the mean effect, but
+nothing for the running total -- which is the number a reader of an event study
+actually quotes ("the programme cost N lives over the first year"). PPSCM has had
+``cumulative_band`` since #439; this is the same object for PDA, built the same
+way and sharing the same sup-t machinery, so the two estimators cannot drift
+apart in how they define it.
+
+The construction is forced by what goes wrong otherwise. An interval for a
+running total is not the running total of the period intervals: adding endpoints
+treats every period's error as moving in lockstep, so the width grows like ``L``
+whatever the data does, and on the Oregon opioid panel that inflates a
+half-width of 0.9 to 3.8 against a point estimate of 7.6. Rescaling a single
+period's interval by ``sqrt(L)`` makes the opposite assumption and is wrong
+whenever the estimation error is persistent, which for a donor fit it is.
+
+So the replicate paths are accumulated *first* and the standard error is taken
+after. Whatever correlation the period errors have is then carried into the
+band rather than assumed into it. The bootstrap supplies those paths already:
+each draw's post-period prediction error is a path over horizons, and
+``pda_prediction_intervals`` keeps them.
+
+The band is simultaneous over horizons for the reason ``supt.py`` exists -- a
+cumulative path is read as a path, and a pointwise band read that way covers at
+much less than its nominal level.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PDA
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.pda_helpers.inference import cumulative_supt_band
+
+
+def _panel(n_donors=8, T0=30, T1=6, effect=1.0, seed=0, rho=0.0):
+    """Factor panel with one treated unit adopting at ``T0``."""
+    rng = np.random.default_rng(seed)
+    T = T0 + T1
+    f = rng.standard_normal((T, 2))
+    load_d = rng.standard_normal((n_donors, 2)) * 0.5
+    e = rng.standard_normal((n_donors + 1, T)) * 0.3
+    if rho:
+        for t in range(1, T):
+            e[:, t] = rho * e[:, t - 1] + np.sqrt(1 - rho ** 2) * e[:, t]
+    rec = []
+    y = f @ load_d.mean(axis=0) + e[0]
+    y[T0:] += effect
+    rec += [{"unit": "treated", "t": t, "y": float(y[t]), "d": int(t >= T0)}
+            for t in range(T)]
+    for j in range(n_donors):
+        s = f @ load_d[j] + e[j + 1]
+        rec += [{"unit": f"d{j}", "t": t, "y": float(s[t]), "d": 0} for t in range(T)]
+    return pd.DataFrame(rec)
+
+
+def _fit(df=None, **kw):
+    cfg = dict(df=_panel() if df is None else df, outcome="y", treat="d",
+               unitid="unit", time="t", method="LASSO", display_graphs=False)
+    cfg.update(kw)
+    return PDA(cfg).fit()
+
+
+def _band(res, method="lasso"):
+    fit = res.fits[method] if isinstance(res.fits, dict) else res.fits[0]
+    return fit.cumulative_band
+
+
+# --------------------------------------------------------------------------- #
+# smoke                                                                        #
+# --------------------------------------------------------------------------- #
+def test_asking_for_it_attaches_one_entry_per_post_period():
+    b = _band(_fit(prediction_intervals=True, cumulative_band=True, pi_n_boot=200))
+    assert b is not None
+    for arr in (b.horizons, b.point, b.lower, b.upper, b.se):
+        assert np.asarray(arr).shape == (6,)
+    assert np.isfinite(np.asarray(b.point)).all()
+
+
+def test_it_is_off_unless_asked_for():
+    """Nothing changes for a caller who did not request it."""
+    assert _band(_fit(prediction_intervals=True, pi_n_boot=200)) is None
+    assert _band(_fit()) is None
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants                                                              #
+# --------------------------------------------------------------------------- #
+def test_the_point_is_the_running_total_of_the_period_effects():
+    res = _fit(prediction_intervals=True, cumulative_band=True, pi_n_boot=200)
+    fit = res.fits["lasso"] if isinstance(res.fits, dict) else res.fits[0]
+    gap = np.asarray(fit.gap, dtype=float)[-6:]
+    np.testing.assert_allclose(_band(res).point, np.cumsum(gap), rtol=1e-10)
+
+
+def test_the_band_brackets_its_point_at_every_horizon():
+    b = _band(_fit(prediction_intervals=True, cumulative_band=True, pi_n_boot=200))
+    assert (np.asarray(b.lower) <= np.asarray(b.point)).all()
+    assert (np.asarray(b.point) <= np.asarray(b.upper)).all()
+
+
+def test_horizons_are_one_through_H():
+    b = _band(_fit(prediction_intervals=True, cumulative_band=True, pi_n_boot=200))
+    np.testing.assert_array_equal(b.horizons, np.arange(1, 7))
+
+
+def test_it_is_narrower_than_summing_the_period_interval_endpoints():
+    """The failure mode the band exists to avoid.
+
+    Adding per-period endpoints asserts perfectly correlated period errors. It is
+    the widest thing anyone builds and it is never right unless the errors really
+    do move in lockstep, which the replicates would then show.
+    """
+    res = _fit(prediction_intervals=True, cumulative_band=True, pi_n_boot=400)
+    fit = res.fits["lasso"] if isinstance(res.fits, dict) else res.fits[0]
+    e = fit.prediction_intervals["effect"]
+    naive = np.cumsum((np.asarray(e["sy_upper"]) - np.asarray(e["sy_lower"])) / 2.0)
+    b = _band(res)
+    half = (np.asarray(b.upper) - np.asarray(b.lower)) / 2.0
+    assert half[-1] < naive[-1]
+
+
+def test_the_growth_is_measured_not_assumed():
+    """The builder's whole purpose, tested where it can be stated exactly.
+
+    Independent period errors accumulate like ``sqrt(L)``; errors that move
+    together accumulate like ``L``. The same code must return both, because it
+    reads the correlation off the paths rather than choosing one.
+    """
+    rng = np.random.default_rng(0)
+    L, B = 8, 4000
+    point = np.zeros(L)
+    indep = rng.standard_normal((B, L))
+    lock = np.repeat(rng.standard_normal((B, 1)), L, axis=1)
+    se_i = np.asarray(cumulative_supt_band(point, indep, alpha=0.05).se)
+    se_l = np.asarray(cumulative_supt_band(point, lock, alpha=0.05).se)
+    assert se_i[-1] / se_i[0] == pytest.approx(np.sqrt(L), rel=0.10)
+    assert se_l[-1] / se_l[0] == pytest.approx(L, rel=0.10)
+
+
+def test_the_critical_value_is_simultaneous_not_pointwise():
+    """One shared multiplier covering every horizon at once must exceed the
+    pointwise normal quantile, and must grow as more horizons are covered."""
+    from scipy.stats import norm
+    rng = np.random.default_rng(1)
+    small = cumulative_supt_band(np.zeros(3), rng.standard_normal((3000, 3)), alpha=0.05)
+    big = cumulative_supt_band(np.zeros(12), rng.standard_normal((3000, 12)), alpha=0.05)
+    assert small.critical_value > float(norm.ppf(0.975))
+    assert big.critical_value > small.critical_value
+
+
+def test_a_tighter_level_never_narrows_the_band():
+    rng = np.random.default_rng(2)
+    P = rng.standard_normal((3000, 6))
+    tight = cumulative_supt_band(np.zeros(6), P, alpha=0.01)
+    loose = cumulative_supt_band(np.zeros(6), P, alpha=0.20)
+    assert tight.critical_value > loose.critical_value
+
+
+def test_it_records_what_produced_it():
+    b = _band(_fit(prediction_intervals=True, cumulative_band=True, pi_n_boot=200))
+    assert b.alpha == pytest.approx(0.05)
+    assert b.method == "bootstrap"
+    assert b.n_replicates >= 2
+
+
+def test_the_band_leaves_the_rest_of_the_fit_untouched():
+    """It is additional. The ATT and the per-period intervals must not move."""
+    base = _fit(prediction_intervals=True, pi_n_boot=200, pi_seed=0)
+    with_b = _fit(prediction_intervals=True, cumulative_band=True, pi_n_boot=200, pi_seed=0)
+    fb = base.fits["lasso"] if isinstance(base.fits, dict) else base.fits[0]
+    fw = with_b.fits["lasso"] if isinstance(with_b.fits, dict) else with_b.fits[0]
+    assert fw.att == pytest.approx(fb.att)
+    assert fw.att_se == pytest.approx(fb.att_se)
+    np.testing.assert_allclose(fw.counterfactual, fb.counterfactual)
+    np.testing.assert_allclose(fw.prediction_intervals["effect"]["eq_lower"],
+                               fb.prediction_intervals["effect"]["eq_lower"])
+
+
+def test_the_bootstrap_hands_back_one_error_path_per_usable_draw():
+    """The paths the band is built from, pinned at their source."""
+    res = _fit(prediction_intervals=True, cumulative_band=True, pi_n_boot=200)
+    fit = res.fits["lasso"] if isinstance(res.fits, dict) else res.fits[0]
+    pi = fit.prediction_intervals
+    paths = np.asarray(pi["error_paths"], dtype=float)
+    assert paths.shape == (pi["n_boot_effective"], pi["post_periods"])
+    assert np.isfinite(paths).all()
+
+
+# --------------------------------------------------------------------------- #
+# edge                                                                         #
+# --------------------------------------------------------------------------- #
+def test_a_single_post_period_is_a_band_of_one():
+    b = _band(_fit(df=_panel(T1=1), prediction_intervals=True,
+                   cumulative_band=True, pi_n_boot=200))
+    assert np.asarray(b.point).shape == (1,)
+    assert b.lower[0] <= b.point[0] <= b.upper[0]
+
+
+def test_serially_correlated_errors_widen_it_relative_to_independent_ones():
+    """Not a fixed number -- a direction. Persistent errors accumulate faster."""
+    kw = dict(prediction_intervals=True, cumulative_band=True, pi_n_boot=300, pi_seed=0)
+    flat = _band(_fit(df=_panel(rho=0.0, seed=3), **kw))
+    slow = _band(_fit(df=_panel(rho=0.9, seed=3), **kw))
+    ratio = lambda b: np.asarray(b.se)[-1] / np.asarray(b.se)[0]
+    assert ratio(slow) > ratio(flat)
+
+
+# --------------------------------------------------------------------------- #
+# failure -- reported, not swallowed                                           #
+# --------------------------------------------------------------------------- #
+def test_asking_for_the_band_without_the_bootstrap_is_refused_by_name():
+    """The band is built from the bootstrap's replicate paths. Without
+    ``prediction_intervals`` there are none, and silently producing nothing would
+    leave a caller reading a missing field as an absent effect."""
+    with pytest.raises(MlsynthConfigError, match="cumulative_band"):
+        PDA(dict(df=_panel(), outcome="y", treat="d", unitid="unit", time="t",
+                 method="LASSO", cumulative_band=True, display_graphs=False))
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1, 1.5])
+def test_an_invalid_level_is_refused(bad):
+    rng = np.random.default_rng(4)
+    with pytest.raises(MlsynthConfigError):
+        cumulative_supt_band(np.zeros(4), rng.standard_normal((100, 4)), alpha=bad)
+
+
+def test_mismatched_path_length_is_refused():
+    rng = np.random.default_rng(5)
+    with pytest.raises(MlsynthDataError):
+        cumulative_supt_band(np.zeros(4), rng.standard_normal((100, 7)), alpha=0.05)
+
+
+def test_too_few_replicates_is_refused():
+    with pytest.raises(MlsynthDataError):
+        cumulative_supt_band(np.zeros(3), np.ones((1, 3)), alpha=0.05)
+
+
+def test_a_replicate_with_a_hole_is_dropped_not_counted_as_zero():
+    """A refit that failed must be absent, not silently contribute a zero path
+    that shrinks the standard error toward a band nobody earned."""
+    rng = np.random.default_rng(6)
+    P = rng.standard_normal((50, 4))
+    P[7, 2] = np.nan
+    b = cumulative_supt_band(np.zeros(4), P, alpha=0.05)
+    assert b.n_replicates == 49

--- a/mlsynth/tests/test_pda_pi_dependent.py
+++ b/mlsynth/tests/test_pda_pi_dependent.py
@@ -1,0 +1,219 @@
+"""Whether the prediction-interval bootstrap may assume independent errors.
+
+Jiang, Li, Shen and Zhou's Algorithm 2.1 resamples the pre-period prediction
+error with a *dependent* wild bootstrap: Bartlett-correlated multipliers whose
+dependence range is a bandwidth in ``T0``, so a persistent error is resampled as
+a persistent error. Their Remark 2.2 gives the cheaper alternative -- ordinary
+i.i.d. standard-normal multipliers -- and states its condition, that the errors
+are independent to begin with.
+
+``pda_prediction_intervals`` has always taken ``dependent`` and defaulted it to
+``True``. What it did not have was a way for a caller to say otherwise:
+``PDAConfig`` never passed the argument, so Remark 2.2 was unreachable from the
+estimator. This suite pins the field that exposes it and, more to the point, pins
+the difference it makes -- a flag that changes nothing is worse than no flag,
+because it invites a caller to believe they chose something.
+
+The difference is a directional claim, not a number, and it is a claim about the
+average panel rather than every panel. The flag reaches only the pre-period
+multipliers, so what it moves is the estimation-error variance; on any single
+draw that shift is comparable to the bootstrap's own Monte Carlo noise. Measured
+over eight panels the dependent scheme gave the wider band on five to eight of
+them, mean ratio 1.015 on white noise and 1.043 at rho = 0.9. So the tests below
+assert the mean over panels and the ordering between persistence levels -- the
+level at which the claim is actually true. An earlier draft of this suite
+asserted it per panel and failed on three seeds of six, which is how the scope of
+the claim was established.
+
+Levels: smoke, unit invariants, property, edge, failure.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PDA
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.inferutils import pda_prediction_intervals
+
+
+def _panel(n_donors=8, T0=30, T1=6, effect=1.0, seed=0, rho=0.0):
+    """Factor panel with one treated unit adopting at ``T0``.
+
+    ``rho`` is the AR(1) coefficient of the idiosyncratic errors -- the thing the
+    dependent wild bootstrap exists to carry and the i.i.d. scheme discards.
+    """
+    rng = np.random.default_rng(seed)
+    T = T0 + T1
+    f = rng.standard_normal((T, 2))
+    load_d = rng.standard_normal((n_donors, 2)) * 0.5
+    e = rng.standard_normal((n_donors + 1, T)) * 0.3
+    if rho:
+        for t in range(1, T):
+            e[:, t] = rho * e[:, t - 1] + np.sqrt(1 - rho ** 2) * e[:, t]
+    rec = []
+    y = f @ load_d.mean(axis=0) + e[0]
+    y[T0:] += effect
+    rec += [{"unit": "treated", "t": t, "y": float(y[t]), "d": int(t >= T0)}
+            for t in range(T)]
+    for j in range(n_donors):
+        s = f @ load_d[j] + e[j + 1]
+        rec += [{"unit": f"d{j}", "t": t, "y": float(s[t]), "d": 0} for t in range(T)]
+    return pd.DataFrame(rec)
+
+
+def _fit(df=None, **kw):
+    cfg = dict(df=_panel() if df is None else df, outcome="y", treat="d",
+               unitid="unit", time="t", method="LASSO", display_graphs=False,
+               prediction_intervals=True, pi_n_boot=300, pi_seed=0)
+    cfg.update(kw)
+    return PDA(cfg).fit()
+
+
+def _pi(res, method="lasso"):
+    fit = res.fits[method] if isinstance(res.fits, dict) else res.fits[0]
+    return fit.prediction_intervals
+
+
+# --------------------------------------------------------------------------- #
+# smoke                                                                        #
+# --------------------------------------------------------------------------- #
+def test_both_settings_produce_a_usable_fit():
+    for dep in (True, False):
+        pi = _pi(_fit(pi_dependent=dep))
+        assert np.isfinite(np.asarray(pi["effect"]["eq_lower"])).all()
+        assert np.isfinite(np.asarray(pi["effect"]["eq_upper"])).all()
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants                                                              #
+# --------------------------------------------------------------------------- #
+def test_the_paper_s_algorithm_is_the_default():
+    """Algorithm 2.1 is the method; Remark 2.2 is the caller's exception to it."""
+    from mlsynth.utils.pda_helpers.config import PDAConfig
+    assert PDAConfig.model_fields["pi_dependent"].default is True
+    assert _pi(_fit())["dependent"] is True
+
+
+def test_the_choice_is_recorded_on_the_result():
+    """A band built under Remark 2.2 and one built under Algorithm 2.1 are not
+    interchangeable numbers, so the result has to say which it is."""
+    assert _pi(_fit(pi_dependent=False))["dependent"] is False
+    assert _pi(_fit(pi_dependent=True))["dependent"] is True
+
+
+def test_the_flag_actually_reaches_the_bootstrap():
+    """Guards the plumbing itself: the field existed to be passed, and a config
+    field that is silently dropped is the failure this test is here to catch."""
+    a = _pi(_fit(df=_panel(rho=0.9, seed=1), pi_dependent=True))
+    b = _pi(_fit(df=_panel(rho=0.9, seed=1), pi_dependent=False))
+    assert not np.allclose(a["effect"]["eq_lower"], b["effect"]["eq_lower"])
+
+
+def test_it_leaves_the_point_estimates_alone():
+    """It is a resampling choice. The fit it resamples must not move."""
+    base = _fit(pi_dependent=True)
+    other = _fit(pi_dependent=False)
+    fb = base.fits["lasso"] if isinstance(base.fits, dict) else base.fits[0]
+    fo = other.fits["lasso"] if isinstance(other.fits, dict) else other.fits[0]
+    assert fo.att == pytest.approx(fb.att)
+    np.testing.assert_allclose(fo.counterfactual, fb.counterfactual)
+    np.testing.assert_allclose(fo.beta, fb.beta)
+
+
+# --------------------------------------------------------------------------- #
+# property: the two agree on white noise and separate as errors persist        #
+# --------------------------------------------------------------------------- #
+def _mean_width_ratio(rho, n_seeds=6, n_boot=250):
+    """Mean of ``se_dependent / se_iid`` at the last cumulative horizon.
+
+    Averaged over panels because the per-panel ordering is not guaranteed: the
+    flag changes only the pre-period multipliers, so it moves the estimation-error
+    variance, and on a single draw that shift is comparable to the bootstrap's own
+    Monte Carlo noise. Measured over eight panels the dependent scheme was the
+    wider one on five to eight of them depending on persistence, with a mean
+    ratio of 1.015 (white noise) and 1.043 (rho = 0.9). The mean is the level at
+    which the claim is true, so the mean is what is asserted.
+    """
+    r = []
+    for seed in range(n_seeds):
+        kw = dict(df=_panel(rho=rho, seed=seed), cumulative_band=True, pi_n_boot=n_boot)
+        a = _fit(pi_dependent=True, **kw)
+        b = _fit(pi_dependent=False, **kw)
+        fa = a.fits["lasso"] if isinstance(a.fits, dict) else a.fits[0]
+        fb = b.fits["lasso"] if isinstance(b.fits, dict) else b.fits[0]
+        r.append(float(np.asarray(fa.cumulative_band.se)[-1]
+                       / np.asarray(fb.cumulative_band.se)[-1]))
+    return float(np.mean(r))
+
+
+def test_the_dependent_bootstrap_is_the_wider_choice_on_average():
+    """Remark 2.2 is the cheaper option, and cheaper here means narrower.
+
+    Correlated multipliers carry variance that i.i.d. ones discard, so dropping
+    to the i.i.d. scheme can only lose width, never gain it. Asserted as a mean
+    over panels -- see :func:`_mean_width_ratio` for why not per panel.
+    """
+    assert _mean_width_ratio(rho=0.9) > 1.0
+
+
+def test_persistence_is_what_makes_the_choice_matter():
+    """The directional claim behind the default.
+
+    On white noise the two schemes are resampling the same object and the
+    correction is near nothing. As the errors persist, the i.i.d. scheme keeps
+    drawing them as if they did not, and the gap widens. If this ordering ever
+    reversed, the default would be indefensible.
+    """
+    assert _mean_width_ratio(rho=0.9) > _mean_width_ratio(rho=0.0)
+
+
+@pytest.mark.parametrize("rho", [0.0, 0.5, 0.9])
+def test_the_band_stays_valid_at_every_persistence(rho):
+    """Whatever the errors do, the band must still bracket its point and be
+    finite -- the flag changes the width, never the well-formedness."""
+    for dep in (True, False):
+        res = _fit(df=_panel(rho=rho, seed=7), cumulative_band=True,
+                   pi_dependent=dep, pi_n_boot=300)
+        fit = res.fits["lasso"] if isinstance(res.fits, dict) else res.fits[0]
+        b = fit.cumulative_band
+        assert np.isfinite(np.asarray(b.se)).all()
+        assert (np.asarray(b.lower) <= np.asarray(b.point)).all()
+        assert (np.asarray(b.point) <= np.asarray(b.upper)).all()
+
+
+# --------------------------------------------------------------------------- #
+# edge                                                                         #
+# --------------------------------------------------------------------------- #
+def test_a_single_post_period_still_honours_the_flag():
+    """With one horizon there is nothing to accumulate, but the pre-period
+    resampling still differs, so the interval still moves."""
+    df = _panel(T1=1, rho=0.9, seed=2)
+    a = _pi(_fit(df=df, pi_dependent=True))
+    b = _pi(_fit(df=df, pi_dependent=False))
+    assert a["dependent"] is True and b["dependent"] is False
+    assert np.asarray(a["effect"]["eq_lower"]).shape == (1,)
+
+
+def test_it_is_honoured_by_every_variant_not_just_lasso():
+    res = _fit(methods=["l2", "LASSO", "fs"], pi_dependent=False, pi_n_boot=200)
+    for name, fit in res.fits.items():
+        assert fit.prediction_intervals["dependent"] is False
+
+
+# --------------------------------------------------------------------------- #
+# failure -- reported, not swallowed                                           #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", ["yes", 1.5, None, "dependent"])
+def test_a_non_boolean_is_refused_at_config_time(bad):
+    with pytest.raises(MlsynthConfigError):
+        PDA(dict(df=_panel(), outcome="y", treat="d", unitid="unit", time="t",
+                 method="LASSO", prediction_intervals=True, pi_dependent=bad,
+                 display_graphs=False))
+
+
+def test_the_helper_still_defaults_to_the_paper_s_algorithm():
+    """The estimator-agnostic entry point is reused by other estimators, so its
+    own default must not drift when the config field is added above it."""
+    import inspect
+    sig = inspect.signature(pda_prediction_intervals)
+    assert sig.parameters["dependent"].default is True

--- a/mlsynth/utils/inferutils.py
+++ b/mlsynth/utils/inferutils.py
@@ -586,6 +586,10 @@ def pda_prediction_intervals(
         "n_boot_effective": int(n_boot - n_degenerate),
         "post_periods": int(T1),
         "studentization": studentization,
+        # Which multiplier scheme produced these -- Algorithm 2.1's dependent
+        # wild bootstrap or Remark 2.2's i.i.d. one. A band built under each
+        # is not the same number, so the result has to say which it is.
+        "dependent": bool(dependent),
         "se": se if np.ndim(se) else np.full(T1, float(se)),
         # Raw (unstudentized) post-period prediction errors, one row per usable
         # draw. The per-period intervals do not need them -- a cumulative band

--- a/mlsynth/utils/inferutils.py
+++ b/mlsynth/utils/inferutils.py
@@ -502,6 +502,13 @@ def pda_prediction_intervals(
     # Bootstrap.
     resid_centered = resid_pre - resid_pre.mean()
     S = np.empty((n_boot, T1))
+    # The unstudentized post-period prediction errors. The per-period
+    # intervals below need only the studentized ``S``, but a cumulative band
+    # has to accumulate the errors on their own scale before taking a
+    # standard error -- studentizing per period first would divide each
+    # horizon by a different number and destroy the correlation the running
+    # total depends on.
+    E = np.empty((n_boot, T1))
     # A draw whose refit saturates the bootstrap pre-period leaves a residual
     # scale of order 1e-15 while its post-period extrapolation error stays O(1),
     # so the studentized statistic reaches ~1e15 and drags the quantiles with
@@ -532,11 +539,14 @@ def pda_prediction_intervals(
         ):
             degenerate[b] = True
             S[b] = 0.0          # excluded below; keeps the array finite
+            E[b] = 0.0
             continue
         S[b] = e_star_post / np.where(se_star > 0, se_star, np.inf)
+        E[b] = e_star_post
 
     n_degenerate = int(degenerate.sum())
     S = S[~degenerate]
+    E = E[~degenerate]
     if S.shape[0] < 2:
         raise MlsynthEstimationError(
             f"{n_degenerate} of {n_boot} bootstrap draws were degenerate "
@@ -577,6 +587,11 @@ def pda_prediction_intervals(
         "post_periods": int(T1),
         "studentization": studentization,
         "se": se if np.ndim(se) else np.full(T1, float(se)),
+        # Raw (unstudentized) post-period prediction errors, one row per usable
+        # draw. The per-period intervals do not need them -- a cumulative band
+        # does, because the running total's standard error has to come from
+        # accumulating the errors before scaling, not after.
+        "error_paths": E,
         "effect": eff_block,
         "counterfactual": cf_block,
     }

--- a/mlsynth/utils/pda_helpers/config.py
+++ b/mlsynth/utils/pda_helpers/config.py
@@ -7,7 +7,7 @@ Co-located with the helper package; re-exported from
 from __future__ import annotations
 
 from typing import List, Optional
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 from ...config_models import BaseEstimatorConfig
 from ...exceptions import MlsynthConfigError
 
@@ -29,6 +29,7 @@ class PDAConfig(BaseEstimatorConfig):
     prediction_intervals: bool = Field(default=False, description="Attach Jiang, Li, Shen & Zhou (2025) bootstrap prediction intervals for the per-period treatment effect and counterfactual to every fitted PDA variant. Equal-tailed and symmetric intervals are returned; each variant reports whether the post-selection OLS HAC sandwich studentization was used or the sigma^2-only fallback (e.g. for the dense L2-relaxation in high dimensions).")
     pi_n_boot: int = Field(default=999, ge=2, description="Number of bootstrap replications for the prediction intervals (only used when prediction_intervals is True).")
     pi_seed: Optional[int] = Field(default=0, description="Seed for the prediction-interval bootstrap RNG (reproducible by default; set None for a fresh draw).")
+    pi_dependent: bool = Field(default=True, description="Resample the pre-period prediction error with the dependent wild bootstrap of Jiang et al. (2025) Algorithm 2.1 -- Bartlett-correlated multipliers whose dependence range is a bandwidth in T0, so a persistent error is resampled as a persistent error. False uses the ordinary i.i.d. standard-normal multipliers of their Remark 2.2, which is cheaper and valid only when the errors are already independent. The choice compounds in the cumulative band, which accumulates the period errors, so drawing persistent errors as independent understates how fast the running total's uncertainty grows. True (the paper's algorithm) by default.")
     cumulative_band: bool = Field(default=False, description="Attach a simultaneous (sup-t) band for the CUMULATIVE effect path -- the running total over post-periods, with one shared critical value so the whole path is covered at 1 - alpha at once, which is how a cumulative path is read. Built from the replicate paths the prediction-interval bootstrap already produces, so it costs no extra refits. Its growth is measured rather than assumed: the replicates are accumulated before the standard error is taken, so independent period errors widen it like sqrt(L) and perfectly correlated ones like L, where adding up per-period interval endpoints would always give the latter. Needs prediction_intervals. Off by default.")
 
     @model_validator(mode="after")
@@ -40,3 +41,15 @@ class PDAConfig(BaseEstimatorConfig):
                 "produces, and with the bootstrap off there are none."
             )
         return self
+
+    @field_validator("pi_dependent", "prediction_intervals", "cumulative_band",
+                     mode="before")
+    @classmethod
+    def _strict_bool(cls, v, info):
+        if not isinstance(v, bool):
+            raise MlsynthConfigError(
+                f"{info.field_name} must be True or False; got {v!r}. Pydantic "
+                "would otherwise coerce a string or a number into a boolean, so "
+                "a typo becomes a silent choice about how inference is run."
+            )
+        return v

--- a/mlsynth/utils/pda_helpers/config.py
+++ b/mlsynth/utils/pda_helpers/config.py
@@ -7,8 +7,9 @@ Co-located with the helper package; re-exported from
 from __future__ import annotations
 
 from typing import List, Optional
-from pydantic import Field
+from pydantic import Field, model_validator
 from ...config_models import BaseEstimatorConfig
+from ...exceptions import MlsynthConfigError
 
 
 class PDAConfig(BaseEstimatorConfig):
@@ -28,3 +29,14 @@ class PDAConfig(BaseEstimatorConfig):
     prediction_intervals: bool = Field(default=False, description="Attach Jiang, Li, Shen & Zhou (2025) bootstrap prediction intervals for the per-period treatment effect and counterfactual to every fitted PDA variant. Equal-tailed and symmetric intervals are returned; each variant reports whether the post-selection OLS HAC sandwich studentization was used or the sigma^2-only fallback (e.g. for the dense L2-relaxation in high dimensions).")
     pi_n_boot: int = Field(default=999, ge=2, description="Number of bootstrap replications for the prediction intervals (only used when prediction_intervals is True).")
     pi_seed: Optional[int] = Field(default=0, description="Seed for the prediction-interval bootstrap RNG (reproducible by default; set None for a fresh draw).")
+    cumulative_band: bool = Field(default=False, description="Attach a simultaneous (sup-t) band for the CUMULATIVE effect path -- the running total over post-periods, with one shared critical value so the whole path is covered at 1 - alpha at once, which is how a cumulative path is read. Built from the replicate paths the prediction-interval bootstrap already produces, so it costs no extra refits. Its growth is measured rather than assumed: the replicates are accumulated before the standard error is taken, so independent period errors widen it like sqrt(L) and perfectly correlated ones like L, where adding up per-period interval endpoints would always give the latter. Needs prediction_intervals. Off by default.")
+
+    @model_validator(mode="after")
+    def _check_cumulative_band(self):
+        if self.cumulative_band and not self.prediction_intervals:
+            raise MlsynthConfigError(
+                "cumulative_band needs prediction_intervals=True: the band is "
+                "built from the replicate paths the Jiang et al. (2025) bootstrap "
+                "produces, and with the bootstrap off there are none."
+            )
+        return self

--- a/mlsynth/utils/pda_helpers/inference.py
+++ b/mlsynth/utils/pda_helpers/inference.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import numpy as np
 from scipy.stats import norm
 
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+
 
 def newey_west_lag(n: int) -> int:
     """Newey-West (1994) automatic truncation lag ``floor(4 (n/100)^(2/9))``."""
@@ -126,3 +128,81 @@ def normal_test(att: float, se: float, alpha: float = 0.05):
     p = 2.0 * (1.0 - norm.cdf(abs(z)))
     crit = norm.ppf(1.0 - alpha / 2.0)
     return float(p), (att - crit * se, att + crit * se)
+
+
+def cumulative_supt_band(
+    effect_path, error_paths, *, alpha: float = 0.05,
+    n_sims: int = 200_000, seed=0, method: str = "bootstrap",
+):
+    """Simultaneous band for the running total, from the bootstrap's own paths.
+
+    The counterpart of :func:`mlsynth.utils.ppscm_helpers.inference.cumulative_supt_band`
+    for PDA, sharing :mod:`mlsynth.utils.supt` so the two estimators cannot drift
+    apart in what "cumulative band" means.
+
+    An interval for a cumulative effect is not the running total of the
+    per-period intervals. Adding endpoints treats the period errors as moving in
+    lockstep, so the width grows like ``L`` whatever the data does; rescaling one
+    period's interval by ``sqrt(L)`` assumes they are independent. Here each
+    replicate's error path is accumulated first and the standard error taken
+    after, so the correlation the errors actually have is the correlation the
+    band inherits.
+
+    The band is simultaneous over horizons, because a cumulative path is read as
+    a path -- "positive by period six and never back" is a statement about all of
+    them at once, which a pointwise band does not cover at its nominal level.
+
+    Parameters
+    ----------
+    effect_path : array-like, shape (H,)
+        The per-period effect from the full fit; the band centres on its cumsum.
+    error_paths : array-like, shape (B, H)
+        One post-period prediction-error path per bootstrap replicate, as
+        returned in ``error_paths`` by
+        :func:`mlsynth.utils.inferutils.pda_prediction_intervals`. Rows holding a
+        non-finite entry are dropped, so a draw whose refit failed is absent
+        rather than counted as a zero that would shrink the band.
+    alpha : float, default 0.05
+        The band is simultaneous at ``1 - alpha``.
+    n_sims, seed
+        Tabulation of the sup-t critical value.
+    method : str, default "bootstrap"
+        Recorded on the result; PDA's replicates are bootstrap draws, already on
+        the estimator's scale, so no delete-one inflation is applied.
+
+    Returns
+    -------
+    PDACumulativeBand
+    """
+    from ..supt import cumulative_from_paths, jackknife_se, supt_critical_value
+    from .structures import PDACumulativeBand
+
+    if (isinstance(alpha, bool) or not isinstance(alpha, (int, float, np.floating))
+            or not 0.0 < float(alpha) < 1.0):
+        raise MlsynthConfigError(
+            f"alpha must be a number in the open interval (0, 1); got {alpha!r}."
+        )
+    pt = np.asarray(effect_path, dtype=float).ravel()
+    R = np.asarray(error_paths, dtype=float)
+    if R.ndim != 2 or R.shape[1] != pt.size:
+        raise MlsynthDataError(
+            f"error_paths must be (n_replicates, {pt.size}); got shape {R.shape}."
+        )
+    R = R[np.isfinite(R).all(axis=1)]
+    if R.shape[0] < 2:
+        raise MlsynthDataError(
+            "need at least 2 complete replicate paths to form a cumulative band; "
+            f"got {R.shape[0]}. The bootstrap support is saturating -- refit with "
+            "fewer donors than pre-periods, or raise pi_n_boot."
+        )
+
+    cum = cumulative_from_paths(R)
+    se = jackknife_se(cum, jackknife=False)      # bootstrap draws, no LOO inflation
+    q = supt_critical_value(cum, alpha=float(alpha), n_sims=n_sims, seed=seed)
+    point = np.cumsum(pt)
+    return PDACumulativeBand(
+        horizons=np.arange(1, pt.size + 1),
+        point=point, lower=point - q * se, upper=point + q * se, se=se,
+        critical_value=float(q), alpha=float(alpha),
+        n_replicates=int(R.shape[0]), method=str(method),
+    )

--- a/mlsynth/utils/pda_helpers/orchestration.py
+++ b/mlsynth/utils/pda_helpers/orchestration.py
@@ -94,7 +94,7 @@ def run_pda(
     hcw_criterion: str = "AICc", hcw_nvmax: Optional[int] = None,
     hcw_backend: str = "fw",
     prediction_intervals: bool = False, cumulative_band: bool = False,
-    pi_n_boot: int = 999,
+    pi_n_boot: int = 999, pi_dependent: bool = True,
     pi_seed: Optional[int] = 0,
 ) -> Dict[str, PDAMethodFit]:
     """Fit each requested PDA variant with its own paper's inference.
@@ -166,7 +166,8 @@ def run_pda(
                 hcw_nvmax=hcw_nvmax, hcw_backend=hcw_backend)
             pis = pda_prediction_intervals(
                 y, X, T0, counterfactual=cf, support=support_idx, refit=refit,
-                alpha=alpha, n_boot=pi_n_boot, seed=pi_seed)
+                alpha=alpha, n_boot=pi_n_boot, seed=pi_seed,
+                dependent=pi_dependent)
             if cumulative_band:
                 cum_band = cumulative_supt_band(
                     (y - cf)[T0:], pis["error_paths"], alpha=alpha)

--- a/mlsynth/utils/pda_helpers/orchestration.py
+++ b/mlsynth/utils/pda_helpers/orchestration.py
@@ -18,6 +18,7 @@ from .lasso import (
 from .fs import forward_select, fs_ate_inference
 from .hcw import fit_hcw, hcw_ate_inference
 from ..inferutils import pda_prediction_intervals
+from .inference import cumulative_supt_band
 
 # Map config method strings to internal keys.
 _NORMALIZE = {"l2": L2, "L2": L2, "LASSO": LASSO, "lasso": LASSO, "fs": FS,
@@ -92,7 +93,8 @@ def run_pda(
     lasso_criterion: str = "cv", lasso_mbic_const: float = MBIC_CONST,
     hcw_criterion: str = "AICc", hcw_nvmax: Optional[int] = None,
     hcw_backend: str = "fw",
-    prediction_intervals: bool = False, pi_n_boot: int = 999,
+    prediction_intervals: bool = False, cumulative_band: bool = False,
+    pi_n_boot: int = 999,
     pi_seed: Optional[int] = 0,
 ) -> Dict[str, PDAMethodFit]:
     """Fit each requested PDA variant with its own paper's inference.
@@ -151,6 +153,7 @@ def run_pda(
             raise ValueError(f"Unknown PDA method: {m!r}")
 
         pis = None
+        cum_band = None
         if prediction_intervals:
             if m == LASSO and lasso_alpha is None:
                 lasso_alpha = lasso_cv_alpha(y, X, T0)
@@ -164,11 +167,14 @@ def run_pda(
             pis = pda_prediction_intervals(
                 y, X, T0, counterfactual=cf, support=support_idx, refit=refit,
                 alpha=alpha, n_boot=pi_n_boot, seed=pi_seed)
+            if cumulative_band:
+                cum_band = cumulative_supt_band(
+                    (y - cf)[T0:], pis["error_paths"], alpha=alpha)
 
         fits[m] = PDAMethodFit(
             name=m, beta=beta, intercept=intercept, counterfactual=cf,
             gap=y - cf, att=att, att_se=se, ci=ci, p_value=p,
             donor_weights=_weights_dict(beta, labels),
-            selected_donors=selected, prediction_intervals=pis, metadata=meta,
+            selected_donors=selected, prediction_intervals=pis, cumulative_band=cum_band, metadata=meta,
         )
     return fits

--- a/mlsynth/utils/pda_helpers/structures.py
+++ b/mlsynth/utils/pda_helpers/structures.py
@@ -90,6 +90,32 @@ class PDAInputs:
 
 
 @dataclass(frozen=True)
+class PDACumulativeBand:
+    """Simultaneous band for the cumulative (running-total) effect path.
+
+    ``lower[L]`` and ``upper[L]`` bound the total effect over horizons ``0..L``,
+    and the band covers *every* ``L`` at once with probability ``1 - alpha``, so a
+    statement about the path is covered at the level it claims.
+
+    ``se`` is the standard error of the running total at each horizon, taken from
+    the replicate paths themselves -- which is what makes the band's growth an
+    observation rather than an assumption: independent period errors grow it like
+    ``sqrt(L)``, perfectly correlated ones like ``L``, and the replicates carry
+    whichever is true.
+    """
+
+    horizons: np.ndarray          # 1, 2, ..., H
+    point: np.ndarray             # cumulative effect at each horizon
+    lower: np.ndarray
+    upper: np.ndarray
+    se: np.ndarray
+    critical_value: float         # the shared sup-t multiplier
+    alpha: float
+    n_replicates: int
+    method: str
+
+
+@dataclass(frozen=True)
 class PDAMethodFit:
     """A single PDA-variant fit (l2 / lasso / fs)."""
 
@@ -105,6 +131,7 @@ class PDAMethodFit:
     donor_weights: Dict[Any, float]
     selected_donors: Optional[List[Any]] = None      # fs / lasso support
     prediction_intervals: Optional[Dict[str, Any]] = None  # Jiang et al. (2025) PIs
+    cumulative_band: Optional[PDACumulativeBand] = None     # sup-t running total
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -689,3 +689,33 @@ timeout = 300.0
     best = max(runs, key=len)
     return float(best.min()), float(best.max())"""
   models = "reporting the largest contiguous accepted run instead of the range of the accepted set. A conformal p-value need not be unimodal in the candidate, so the accepted set can have interior gaps; taking the longest run drops candidates the test accepted and reports an interval narrower than the one the procedure defines"
+
+[[target]]
+name = "pda-cumulative-band"
+module-path = "mlsynth/utils/pda_helpers/inference.py"
+test-command = "python -m pytest mlsynth/tests/test_pda_cumulative_band.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "scale-one-period-instead-of-accumulating"
+  find = "    cum = cumulative_from_paths(R)"
+  replace = "    cum = np.sqrt(np.arange(1, R.shape[1] + 1))[None, :] * R[:, :1]"
+  models = "the sqrt(L) shortcut: take the first period's error and grow it by the square root of the horizon. It is the textbook width for independent errors and looks right on any panel whose estimation error happens to be negligible, but it stops reading the replicates, so a persistent donor-fit error -- the normal case -- is invisible and the band is too narrow"
+
+  [[target.mutant]]
+  id = "sum-the-period-standard-errors"
+  find = "    se = jackknife_se(cum, jackknife=False)      # bootstrap draws, no LOO inflation"
+  replace = "    se = np.cumsum(jackknife_se(R, jackknife=False))"
+  models = "accumulating the standard errors rather than the paths -- the endpoint-summing error written in the scale rather than the interval. It asserts perfectly correlated period errors, so the band grows like L on every panel and is the widest thing anyone builds"
+
+  [[target.mutant]]
+  id = "pointwise-critical-value"
+  find = "    q = supt_critical_value(cum, alpha=float(alpha), n_sims=n_sims, seed=seed)"
+  replace = "    q = float(norm.ppf(1.0 - float(alpha) / 2.0))"
+  models = "reading the cumulative path with a pointwise multiplier. Every individual horizon still covers at 1 - alpha, so nothing looks wrong at any single L, but the path as a whole -- which is how a cumulative band is read -- covers at well below the stated level"
+
+  [[target.mutant]]
+  id = "keep-the-failed-replicates"
+  find = "    R = R[np.isfinite(R).all(axis=1)]"
+  replace = "    R = np.nan_to_num(R, nan=0.0)"
+  models = "letting a replicate whose refit failed contribute a zero path instead of dropping it. Zeros sit at the centre of the distribution, so they shrink the standard error and hand back a tighter band than the surviving draws support"

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -719,3 +719,22 @@ timeout = 300.0
   find = "    R = R[np.isfinite(R).all(axis=1)]"
   replace = "    R = np.nan_to_num(R, nan=0.0)"
   models = "letting a replicate whose refit failed contribute a zero path instead of dropping it. Zeros sit at the centre of the distribution, so they shrink the standard error and hand back a tighter band than the surviving draws support"
+
+[[target]]
+name = "pda-pi-dependent"
+module-path = "mlsynth/utils/pda_helpers/orchestration.py"
+test-command = "python -m pytest mlsynth/tests/test_pda_pi_dependent.py -q -p no:cacheprovider"
+timeout = 400.0
+
+  [[target.mutant]]
+  id = "drop-the-flag-on-the-floor"
+  find = """                alpha=alpha, n_boot=pi_n_boot, seed=pi_seed,
+                dependent=pi_dependent)"""
+  replace = "                alpha=alpha, n_boot=pi_n_boot, seed=pi_seed)"
+  models = "the defect the plumbing removes, and the one that was actually there: a config field the caller can set that never reaches the bootstrap. Every fit still succeeds and the default behaviour is unchanged, so nothing looks wrong -- the flag simply does nothing, which is worse than its absence because it invites a caller to believe they chose Remark 2.2 when they are still running Algorithm 2.1"
+
+  [[target.mutant]]
+  id = "invert-the-flag"
+  find = "                dependent=pi_dependent)"
+  replace = "                dependent=not pi_dependent)"
+  models = "passing the flag through backwards. The result then records the opposite of what was run, so a band built under the i.i.d. multipliers is labelled as the paper's algorithm -- the one failure that survives being written down"


### PR DESCRIPTION
## Related Links

- Docs page: `docs/pda.rst` — new "The cumulative effect" section, and the `pi_dependent` paragraph under "Prediction intervals"
- Source paper: Jiang, Li, Shen & Zhou (2025), Algorithm 2.1 and Remark 2.2 — the bootstrap this builds on
- The sibling object it mirrors: PPSCM's `cumulative_band` (#439), sharing `mlsynth/utils/supt.py`
- Montiel Olea & Plagborg-Moller (2019) for the sup-t critical value, already implemented in `supt.py`

## What

- Added `cumulative_band` to `PDAConfig` — a simultaneous (sup-t) band for the running-total effect path, with `PDACumulativeBand` on each `PDAMethodFit` and `cumulative_supt_band` in `pda_helpers/inference.py`.
- Added `error_paths` to what `pda_prediction_intervals` returns: the raw, unstudentized post-period prediction errors, one row per usable draw.
- Added `pi_dependent` to `PDAConfig`, exposing the `dependent` argument the bootstrap has always taken but no caller could reach, and recorded the choice on the result.
- Added a strict-bool validator for `pi_dependent`, `prediction_intervals` and `cumulative_band`.
- Documented both, and added two mutation targets covering four defects in the band and two in the plumbing.

## Why

PDA reported a prediction interval per post-period and an asymptotic interval for the mean effect, but nothing for the running total — which is the number an event study is usually quoted by. Readers who need it aggregate the per-period intervals by hand, and the natural way to do that (adding endpoints) asserts perfectly correlated period errors. On the Oregon opioid panel that turns a half-width of 1.37 into 3.78 against a point estimate of 7.59.

PPSCM has had this object since #439. Having it on one estimator and not the other is the asymmetry this closes, and sharing `supt.py` is what keeps the two from drifting apart in what the phrase means.

`pi_dependent` is a smaller gap of the same kind: the bootstrap implemented Remark 2.2 all along and `PDAConfig` never passed the argument, so the paper's own cheaper variant was unreachable.

## How

An interval for a running total is not the running total of the period intervals, and both obvious shortcuts are wrong — adding endpoints assumes lockstep errors and grows like `L`; rescaling one period by `sqrt(L)` assumes independence, and a donor fit's estimation error persists across horizons. So each replicate's error path is accumulated first and the standard error taken after, which lets the replicates carry whatever correlation is actually there.

The bootstrap already produced those paths; they just weren't kept. Storing the raw errors rather than the studentized statistic matters, because studentizing per period divides each horizon by a different number and destroys the correlation the running total depends on.

The band is simultaneous rather than pointwise: a cumulative path is read as a path, and one shared critical value is what covers it at the stated level.

One thing I got wrong and corrected. The first draft of the `pi_dependent` suite asserted per panel that persistent errors accumulate faster under the dependent bootstrap. It failed on three seeds of six. The flag reaches only the pre-period multipliers, so what it moves is the estimation-error variance, and on a single draw that shift is comparable to the bootstrap's own Monte Carlo noise. Measured over eight panels the dependent scheme was the wider one on five to eight of them, mean ratio 1.015 on white noise and 1.043 at `rho = 0.9`. The property tests now assert the mean over panels and the ordering between persistence levels, which is the level at which the claim is true.

## Verification

- Path: not applicable as a paper replication — this adds an interval to an existing, already-validated point estimator and does not change any estimate.
- Sanity-checked end to end on Andrew Wheeler's Oregon opioid panel (`apwheele/Blog_Code`, `Python/LassoSynth`), which is also where the docs numbers come from. `PDA(method="LASSO")` reproduces his `LassoSynth` counterfactual to six decimals on that panel — ATT 0.583778, cumulative 7.589112, pre-period RMSE 0.115895, weights West Virginia 0.1223 and DC 0.0274 — so the fit the band sits on is independently corroborated.
- The band's central claim is pinned as a property rather than a number: constructed replicate paths that are independent give `se(L)/se(1) = sqrt(L)` and paths in lockstep give `L`, both to 10%, from the same code. On the real panel it lands at 4.43 against `sqrt(13) = 3.61` and `13`.
- Durably pinned by `mlsynth/tests/test_pda_cumulative_band.py` (22 tests) and `test_pda_pi_dependent.py` (17), plus mutation targets `pda-cumulative-band` (4/4 killed) and `pda-pi-dependent` (2/2 killed).
- Nothing fails to match.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR

- [x] The default preserves existing behaviour exactly — `cumulative_band` defaults to `False`, and `pi_dependent` defaults to `True`, which is the value the bootstrap already used.
- [x] Existing pinned benchmark values unchanged; none moved.
- [x] Tests pin that the default is unchanged: `test_it_is_off_unless_asked_for`, `test_the_band_leaves_the_rest_of_the_fit_untouched`, `test_the_paper_s_algorithm_is_the_default`, `test_the_helper_still_defaults_to_the_paper_s_algorithm`.
- [x] Both new config fields carry `Field(...)` descriptions saying when to reach for them.

## Designs

No plotter change. The band is numeric output on `PDAMethodFit.cumulative_band`; the docs section shows the access pattern and the Oregon numbers.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_pda_cumulative_band.py -q` — 22 passed
- [x] `pytest mlsynth/tests/test_pda_pi_dependent.py -q` — 17 passed
- [x] `pytest mlsynth/tests/ -k "pda or result_contract or inferutils or supt or config"` — 1570 passed
- [x] `python tools/mutation/run_mutants.py --target pda-cumulative-band` — 4/4 killed
- [x] `python tools/mutation/run_mutants.py --target pda-pi-dependent` — 2/2 killed
- [ ] Full `pytest mlsynth/tests/` — not run end to end here; the selection above covers every module this touches. Worth letting CI carry it.

## Other Notes

- The band is attached per variant on `PDAMethodFit` and is not lifted onto the top-level `PDAResults` sub-models. That matches how `prediction_intervals` already behaves, but if the standardized `InferenceResults` should carry it for the selected variant, that is a small fast-follow.
- `pda_prediction_intervals` is estimator-agnostic and now returns `error_paths` for every caller. Only PDA consumes it today; any other estimator adopting that bootstrap gets a cumulative band nearly for free.
- The Oregon comparison against `LassoSynth` lives only in this PR's description. If it is worth keeping, it belongs as a `benchmarks/cases/` entry — deliberately not bundled here, per the separate-workstream rule in `CLAUDE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKrMz8fQvjDNM1eur5kQ2V)_