### PR TITLE
Seed the simplex active set in the solver, not at one call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,12 +66,19 @@ now returns and the back-compat guarantee.
   still determines the weights, and on SDID the two paths agree to 0.0e+00. Pass
   `accelerate=False` for the cold path.
 - `fista_warm_start` stops once the seed's support has held for
-  `SUPPORT_PATIENCE` consecutive iterations (25), read at the `SUPPORT_TOL` the
-  active set itself pins variables at. Its `tol=1e-7` rule tests how far the
-  iterate moved, which is the wrong question for a seed whose job is to name the
-  support: on the two SDID programs of a 101x120 panel the support was final by
-  iteration ~150 and the loop ran to 400. Pass `support_patience=None` for the
-  old behaviour.
+  `SUPPORT_PATIENCE` iterations (100, sampled every `SUPPORT_CHECK_EVERY`),
+  read at the `SUPPORT_TOL` the active set itself pins variables at. Its
+  `tol=1e-7` rule tests how far the iterate moved, which is the wrong question
+  for a seed whose job is to name the support: on the two SDID programs of a
+  101x120 panel the support was final by iteration ~150 and the loop ran to 400.
+  The stop now fires at 261 and 231 and takes those two programs from 50.0 ms to
+  36.7 ms. The counter arms only after the first coordinate is pinned, since
+  FISTA starts at the uniform point where the support is the whole pool and has
+  not moved because it has not started. Sizing: one saved iteration is worth
+  ~44 us and one pivot the seed fails to save costs about 27 of them, so the
+  default is set where the stop fires only on a support that has durably
+  settled -- across 27 designs it costs zero pivots against the full run. Pass
+  `support_patience=None` for the old behaviour.
 
 ### Changed
 - `VanillaSC`'s per-fold refit closure is defined once and shared by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,29 @@ now returns and the back-compat guarantee.
   reuse the same calibration.
 
 ### Changed
+- The FISTA warm start that seeds the exact simplex active set is computed in
+  `utils/bilevel/active_set.py::solve_simplex_qp` instead of in
+  `ridge_augment.simplex_qp`. Being accelerated was a property of one entry
+  point, and of the thirteen call sites in the library twelve never supplied a
+  warm start: MEDSC, SCD, COMPSC, StackedSC, mlSC, the proximal over-identified
+  weights, the two `minnorm` fallbacks and SDID's two simplex programs all
+  started from the uniform point. From there the active set sheds one donor per
+  pivot, so its work tracked the donor pool and not the support it ends on --
+  0.62 to 0.87 pivots per donor from J = 20 to J = 320, against a support that
+  grows 7 to 43. Seeded, the same problems take 0 or 1 pivot. That is why SDID
+  took 117 inner least-squares solves on a 101x120 panel where `VanillaSC`, which
+  entered through the accelerated door, took 31. Speed only: the exact active set
+  still determines the weights, and on SDID the two paths agree to 0.0e+00. Pass
+  `accelerate=False` for the cold path.
+- `fista_warm_start` stops once the seed's support has held for
+  `SUPPORT_PATIENCE` consecutive iterations (25), read at the `SUPPORT_TOL` the
+  active set itself pins variables at. Its `tol=1e-7` rule tests how far the
+  iterate moved, which is the wrong question for a seed whose job is to name the
+  support: on the two SDID programs of a 101x120 panel the support was final by
+  iteration ~150 and the loop ran to 400. Pass `support_patience=None` for the
+  old behaviour.
+
+### Changed
 - `VanillaSC`'s per-fold refit closure is defined once and shared by
   `inference="ttest"` and `inference="conformal_cumulative"`, and takes period
   indices rather than sliced arrays so a covariate-aware refit can subset its

--- a/mlsynth/tests/test_fista_support_patience.py
+++ b/mlsynth/tests/test_fista_support_patience.py
@@ -7,9 +7,18 @@ wrong thing for that job: on the two SDID programs of a 101x120 panel the
 support is final by iteration ~150 while the iterate is still moving at
 iteration 400, so more than half the work buys nothing.
 
+The margin is asymmetric, which is why the default is as large as it is. One
+saved iteration is worth ~44 us; one pivot the seed fails to save costs about
+27 of them. A stop that fires while the support is still moving therefore loses
+even when it saves most of the loop, and a design whose support never settles
+must run to ``max_iter`` and pay nothing for the attempt.
+
 The stop tested here is: once the support -- ``w > 1e-9``, the same threshold
 ``solve_simplex_qp`` reads when it seeds its active set -- has been unchanged
-for ``support_patience`` consecutive iterations, return.
+for ``support_patience`` consecutive iterations, return. The counter arms only
+after the first coordinate is pinned, because FISTA starts at the uniform point
+where the support is the whole pool and has not moved for the reason that it has
+not started.
 
 It is speed only. A warm start cannot change what ``solve_simplex_qp`` returns:
 the active set certifies KKT optimality on the design whatever point it starts
@@ -22,6 +31,7 @@ import pytest
 
 from mlsynth.utils.bilevel import accelerate
 from mlsynth.utils.bilevel.accelerate import (
+    SUPPORT_CHECK_EVERY,
     SUPPORT_PATIENCE,
     SUPPORT_TOL,
     fista_warm_start,
@@ -85,6 +95,7 @@ class TestSmoke:
         assert isinstance(SUPPORT_PATIENCE, int)
         assert SUPPORT_PATIENCE > 0
         assert 0.0 < SUPPORT_TOL < 1e-6
+        assert 1 <= SUPPORT_CHECK_EVERY <= SUPPORT_PATIENCE
 
 
 # --------------------------------------------------------------------------- #
@@ -159,7 +170,63 @@ class TestAnswerUnchanged:
 
 
 # --------------------------------------------------------------------------- #
-# 4. edges
+# 4. the counter arms only after the first coordinate is pinned
+# --------------------------------------------------------------------------- #
+class TestTheCounterArms:
+    """The stop must not fire on the plateau it starts on.
+
+    FISTA begins at the uniform point, where every coordinate is positive. A
+    counter that does not wait for the first coordinate to be pinned reads that
+    as a support which has settled, returns the whole pool, and leaves the
+    active set exactly the work it was meant to save.
+    """
+
+    def test_seed_support_is_a_strict_subset_when_the_optimum_is_sparse(self):
+        A, B = _factor_panel(100, 96, seed=1)
+        w_star = solve_simplex_qp(B, A, accelerate=False)
+        support = int((w_star > SUPPORT_TOL).sum())
+        assert support < 100, "fixture must have a sparse optimum"
+        seed = fista_warm_start(B, A)
+        assert int((seed > SUPPORT_TOL).sum()) < 100
+
+    def test_seed_saves_pivots_on_a_design_the_unarmed_rule_gave_up_on(self):
+        A, B = _factor_panel(100, 96, seed=1)
+        _, cold = solve_simplex_qp(B, A, return_info=True, accelerate=False)
+        _, seeded = solve_simplex_qp(B, A, return_info=True)
+        assert seeded["pivots"] < 0.75 * cold["pivots"]
+
+    @pytest.mark.parametrize("J,T0", [(100, 96), (100, 200), (150, 120),
+                                      (90, 90), (250, 500), (300, 150)])
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_the_stop_never_costs_a_pivot(self, J, T0, seed):
+        """The other half of the guarantee, and the one the default is sized
+        for. Stopping early gives a coarser seed, so the risk is that it names a
+        support the active set then has to correct -- and a pivot costs about 27
+        iterations, so even one wipes out the saving. The seed may differ from
+        the full run's; the pivot count it leads to may not be worse.
+        """
+        A, B = _factor_panel(J, T0, seed=seed)
+        _, full = solve_simplex_qp(
+            B, A, warm_start=fista_warm_start(B, A, support_patience=None),
+            return_info=True)
+        _, shipped = solve_simplex_qp(
+            B, A, warm_start=fista_warm_start(B, A), return_info=True)
+        assert shipped["pivots"] <= full["pivots"]
+
+    def test_a_pool_that_is_all_support_is_not_starved(self):
+        """When the optimum really does use every donor there is nothing to
+        pin, so the counter never arms and the run is bounded by ``max_iter``
+        -- correct, and not a hang."""
+        rng = np.random.default_rng(21)
+        B = rng.standard_normal((200, 100))
+        A = B @ np.full(100, 1.0 / 100)          # the uniform point is optimal
+        w, n_iter = _count_iterations(B, A, max_iter=50)
+        assert n_iter <= 50
+        _assert_feasible(w, 100)
+
+
+# --------------------------------------------------------------------------- #
+# 5. edges
 # --------------------------------------------------------------------------- #
 class TestEdges:
     def test_single_donor_returns_the_vertex_without_iterating(self):
@@ -210,7 +277,7 @@ class TestEdges:
 
 
 # --------------------------------------------------------------------------- #
-# 5. failure -- a bad knob is reported, not absorbed
+# 6. failure -- a bad knob is reported, not absorbed
 # --------------------------------------------------------------------------- #
 class TestFailures:
     @pytest.mark.parametrize("bad", [0, -1, -25])

--- a/mlsynth/tests/test_fista_support_patience.py
+++ b/mlsynth/tests/test_fista_support_patience.py
@@ -290,13 +290,14 @@ class TestTheCounterMechanics:
                    + [flicker] * 10 + [settled] * 340)
         script = [self._point(pattern[k], J, 0.001 * (1 + k % 5))
                   for k in range(400)]
-        # holds_needed = 3 at patience 30, samples every 10 iterations.
-        stopped = self._run(script, support_patience=30)
-        # Consecutive: the runs of `settled` are broken twice, so the third
-        # consecutive hold only lands after the last break. Cumulative counting
-        # would have reached three holds during the earlier runs and stopped
-        # sooner.
-        assert stopped > 60
+        # holds_needed = 3 at patience 30, samples every 10 iterations. The
+        # sampled supports run: full, {0,1}, {0,1}, {0,1,2}, {0,1}, {0,1,2},
+        # {0,1}, {0,1}, ... The first sample is the uniform plateau and does
+        # not arm; the two flickers each break the run. The third *consecutive*
+        # hold therefore lands at iteration 91. Counting holds cumulatively
+        # reaches three at 81, ten iterations early and on a support that has
+        # changed twice since the first of them.
+        assert self._run(script, support_patience=30) == 91
 
     def test_sampling_interval_is_honoured(self):
         """The support is read every ``SUPPORT_CHECK_EVERY`` iterations, so a

--- a/mlsynth/tests/test_fista_support_patience.py
+++ b/mlsynth/tests/test_fista_support_patience.py
@@ -1,0 +1,225 @@
+"""The FISTA warm start stops once the support stops moving.
+
+``fista_warm_start`` exists to name the *support* of the simplex optimum, not to
+converge to it -- the exact active set does the converging, and it only needs to
+be told which donors to start from. Its ``tol=1e-7`` stopping rule tests the
+wrong thing for that job: on the two SDID programs of a 101x120 panel the
+support is final by iteration ~150 while the iterate is still moving at
+iteration 400, so more than half the work buys nothing.
+
+The stop tested here is: once the support -- ``w > 1e-9``, the same threshold
+``solve_simplex_qp`` reads when it seeds its active set -- has been unchanged
+for ``support_patience`` consecutive iterations, return.
+
+It is speed only. A warm start cannot change what ``solve_simplex_qp`` returns:
+the active set certifies KKT optimality on the design whatever point it starts
+from, and rejects a start it cannot use. So the tests here assert two separate
+things -- that the stop fires, and that the certified answer is untouched.
+"""
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel import accelerate
+from mlsynth.utils.bilevel.accelerate import (
+    SUPPORT_PATIENCE,
+    SUPPORT_TOL,
+    fista_warm_start,
+)
+from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _factor_panel(J, T0, seed=0):
+    """A factor-structure SC design: two AR-free factors, ``J`` donors."""
+    rng = np.random.default_rng(seed)
+    F = rng.standard_normal((T0, 2))
+    Mu = np.zeros((J + 1, 2))
+    half = J // 2
+    Mu[: 1 + half, 0] = 1.0
+    Mu[1 + half:, 1] = 1.0
+    Y = F @ Mu.T + rng.standard_normal((T0, J + 1))
+    return Y[:, 0], Y[:, 1:]                       # A (T0,), B (T0, J)
+
+
+def _count_iterations(B, A, **kwargs):
+    """Run ``fista_warm_start`` and report how many iterations it took.
+
+    Counted by wrapping the projection, which the loop calls exactly once per
+    iteration, so the count needs no new return value on the public function.
+    """
+    calls = {"n": 0}
+    real = accelerate.simplex_project
+
+    def counting(v):
+        calls["n"] += 1
+        return real(v)
+
+    accelerate.simplex_project = counting
+    try:
+        w = fista_warm_start(B, A, **kwargs)
+    finally:
+        accelerate.simplex_project = real
+    return w, calls["n"]
+
+
+def _assert_feasible(w, J):
+    w = np.asarray(w, float).ravel()
+    assert w.shape == (J,)
+    assert np.all(np.isfinite(w))
+    assert w.min() >= -1e-12
+    assert abs(w.sum() - 1.0) <= 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# 1. smoke
+# --------------------------------------------------------------------------- #
+class TestSmoke:
+    def test_returns_a_simplex_point(self):
+        A, B = _factor_panel(100, 200)
+        _assert_feasible(fista_warm_start(B, A), 100)
+
+    def test_default_patience_is_exposed_and_positive(self):
+        assert isinstance(SUPPORT_PATIENCE, int)
+        assert SUPPORT_PATIENCE > 0
+        assert 0.0 < SUPPORT_TOL < 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# 2. the stop fires, and it is what makes the warm start cheap
+# --------------------------------------------------------------------------- #
+class TestTheStopFires:
+    def test_stops_well_short_of_max_iter(self):
+        """On a design whose support settles, the loop must not run to 400."""
+        A, B = _factor_panel(120, 240)
+        _, n_iter = _count_iterations(B, A)
+        assert n_iter < 400, "support-patience stop never fired"
+
+    def test_disabling_patience_restores_the_full_run(self):
+        """``support_patience=None`` is the pre-change behaviour: only ``tol``
+        and ``max_iter`` stop the loop."""
+        A, B = _factor_panel(120, 240)
+        _, n_patient = _count_iterations(B, A)
+        _, n_full = _count_iterations(B, A, support_patience=None)
+        assert n_full == 400
+        assert n_patient < n_full
+
+    def test_patience_above_max_iter_never_fires(self):
+        A, B = _factor_panel(120, 240)
+        _, n_iter = _count_iterations(B, A, max_iter=60, support_patience=500)
+        assert n_iter == 60
+
+    def test_larger_patience_never_stops_earlier(self):
+        """Monotone in the knob: waiting longer for the support to hold cannot
+        make the loop exit sooner."""
+        A, B = _factor_panel(120, 240)
+        counts = [_count_iterations(B, A, support_patience=p)[1]
+                  for p in (10, 20, 40, 80)]
+        assert counts == sorted(counts)
+
+
+# --------------------------------------------------------------------------- #
+# 3. speed only -- the certified answer does not move
+# --------------------------------------------------------------------------- #
+class TestAnswerUnchanged:
+    @pytest.mark.parametrize("J,T0", [(100, 200), (120, 240), (90, 90), (150, 120)])
+    def test_seeded_solve_equals_cold_solve(self, J, T0):
+        A, B = _factor_panel(J, T0)
+        cold = solve_simplex_qp(B, A)
+        seeded = solve_simplex_qp(B, A, warm_start=fista_warm_start(B, A))
+        np.testing.assert_allclose(seeded, cold, rtol=0, atol=1e-12)
+
+    def test_seeded_solve_equals_solve_from_the_full_run(self):
+        """Stopping early changes the seed; it must not change the answer the
+        seed leads to."""
+        A, B = _factor_panel(150, 300)
+        early = fista_warm_start(B, A)
+        full = fista_warm_start(B, A, support_patience=None)
+        assert not np.array_equal(early, full), "the two seeds should differ"
+        w_early = solve_simplex_qp(B, A, warm_start=early)
+        w_full = solve_simplex_qp(B, A, warm_start=full)
+        np.testing.assert_allclose(w_early, w_full, rtol=0, atol=1e-12)
+
+    def test_still_deterministic(self):
+        A, B = _factor_panel(120, 240)
+        assert np.array_equal(fista_warm_start(B, A), fista_warm_start(B, A))
+
+    def test_seed_is_feasible_so_the_active_set_can_use_it(self):
+        """An infeasible seed is silently discarded, which would make the stop
+        a pure loss instead of a saving."""
+        A, B = _factor_panel(120, 240)
+        seed = fista_warm_start(B, A)
+        _assert_feasible(seed, 120)
+        _, info = solve_simplex_qp(B, A, warm_start=seed, return_info=True)
+        _, cold_info = solve_simplex_qp(B, A, return_info=True, accelerate=False)
+        assert info["converged"]
+        assert info["pivots"] < cold_info["pivots"]
+
+
+# --------------------------------------------------------------------------- #
+# 4. edges
+# --------------------------------------------------------------------------- #
+class TestEdges:
+    def test_single_donor_returns_the_vertex_without_iterating(self):
+        rng = np.random.default_rng(0)
+        B = rng.standard_normal((20, 1))
+        A = rng.standard_normal(20)
+        w, n_iter = _count_iterations(B, A)
+        assert n_iter == 0
+        np.testing.assert_array_equal(w, np.ones(1))
+
+    def test_degenerate_design_returns_uniform(self):
+        """All-zero donors: the Lipschitz bound collapses and the warm start
+        falls back to the uniform point before any iteration."""
+        B = np.zeros((10, 5))
+        A = np.arange(10.0)
+        w, n_iter = _count_iterations(B, A)
+        assert n_iter == 0
+        np.testing.assert_allclose(w, np.full(5, 0.2))
+
+    def test_support_that_never_settles_still_terminates(self):
+        """Duplicate donors leave the support free to swap between equivalent
+        optima; the loop must still stop at ``max_iter``."""
+        rng = np.random.default_rng(5)
+        core = rng.standard_normal((30, 6))
+        B = np.hstack([core, core, core])           # every donor has two twins
+        A = rng.standard_normal(30)
+        w, n_iter = _count_iterations(B, A, max_iter=120)
+        assert n_iter <= 120
+        _assert_feasible(w, 18)
+
+    def test_patience_of_one_still_returns_a_usable_seed(self):
+        A, B = _factor_panel(100, 200)
+        w = fista_warm_start(B, A, support_patience=1)
+        _assert_feasible(w, 100)
+        np.testing.assert_allclose(
+            solve_simplex_qp(B, A, warm_start=w), solve_simplex_qp(B, A),
+            rtol=0, atol=1e-12)
+
+    def test_target_reachable_exactly_by_one_donor(self):
+        """More rows than donors, so ``B`` has full column rank and the vertex
+        is the *unique* exact reproduction -- the seed has to find it."""
+        rng = np.random.default_rng(9)
+        B = rng.standard_normal((120, 100))
+        A = B[:, 7].copy()
+        w = fista_warm_start(B, A)
+        _assert_feasible(w, 100)
+        assert np.argmax(w) == 7
+
+
+# --------------------------------------------------------------------------- #
+# 5. failure -- a bad knob is reported, not absorbed
+# --------------------------------------------------------------------------- #
+class TestFailures:
+    @pytest.mark.parametrize("bad", [0, -1, -25])
+    def test_non_positive_patience_raises(self, bad):
+        A, B = _factor_panel(20, 40)
+        with pytest.raises(ValueError, match="support_patience"):
+            fista_warm_start(B, A, support_patience=bad)
+
+    def test_non_integer_patience_raises(self):
+        A, B = _factor_panel(20, 40)
+        with pytest.raises(ValueError, match="support_patience"):
+            fista_warm_start(B, A, support_patience=2.5)

--- a/mlsynth/tests/test_fista_support_patience.py
+++ b/mlsynth/tests/test_fista_support_patience.py
@@ -226,7 +226,91 @@ class TestTheCounterArms:
 
 
 # --------------------------------------------------------------------------- #
-# 5. edges
+# 5. the counter's mechanics, on scripted iterates
+# --------------------------------------------------------------------------- #
+class TestTheCounterMechanics:
+    """The two rules the counter runs on, tested where they bite.
+
+    Which iteration the stop fires at is a property of the counter, not of any
+    design, and on an easy design both the right rule and a wrong one land in
+    the same place. So these drive the loop with a scripted sequence of iterates
+    and assert the firing iteration directly.
+    """
+
+    @staticmethod
+    def _run(script, **kwargs):
+        """Run the loop on ``script[i]`` as the i-th iterate; return the
+        iteration it stopped at."""
+        rng = np.random.default_rng(0)
+        J = script[0].shape[0]
+        B = rng.standard_normal((3 * J, J))
+        A = rng.standard_normal(3 * J)
+        calls = {"n": 0}
+        real = accelerate.simplex_project
+
+        def scripted(_v):
+            i = calls["n"]
+            calls["n"] += 1
+            return script[min(i, len(script) - 1)].copy()
+
+        accelerate.simplex_project = scripted
+        try:
+            fista_warm_start(B, A, **kwargs)
+        finally:
+            accelerate.simplex_project = real
+        return calls["n"]
+
+    @staticmethod
+    def _point(support, J, jitter):
+        """A simplex point supported on ``support``, moved by ``jitter`` so the
+        ``tol`` rule never fires and only the support rule is under test."""
+        w = np.zeros(J)
+        w[list(support)] = 1.0 / len(support)
+        w[support[0]] += jitter
+        w[support[-1]] -= jitter
+        return w
+
+    def test_the_uniform_plateau_does_not_count(self):
+        """Every coordinate positive is the state the loop *starts* in. Counting
+        it means firing on a support that has not moved because it has not
+        started, and returning the whole pool as the seed."""
+        J = 6
+        full = list(range(J))
+        script = [self._point(full, J, 0.01 * (1 + k % 3)) for k in range(400)]
+        assert self._run(script, support_patience=30) == 400
+
+    def test_holds_must_be_consecutive(self):
+        """A support that keeps changing must reset the counter. Accumulating
+        holds instead lets a flickering support reach the threshold and stop the
+        loop while the seed is still moving."""
+        J = 6
+        settled, flicker = [0, 1], [0, 1, 2]
+        pattern = ([full_pool := list(range(J))] * 10
+                   + [settled] * 20 + [flicker] * 10 + [settled] * 10
+                   + [flicker] * 10 + [settled] * 340)
+        script = [self._point(pattern[k], J, 0.001 * (1 + k % 5))
+                  for k in range(400)]
+        # holds_needed = 3 at patience 30, samples every 10 iterations.
+        stopped = self._run(script, support_patience=30)
+        # Consecutive: the runs of `settled` are broken twice, so the third
+        # consecutive hold only lands after the last break. Cumulative counting
+        # would have reached three holds during the earlier runs and stopped
+        # sooner.
+        assert stopped > 60
+
+    def test_sampling_interval_is_honoured(self):
+        """The support is read every ``SUPPORT_CHECK_EVERY`` iterations, so a
+        patience of one interval fires on the second sample -- the first has
+        nothing to compare against."""
+        J = 5
+        settled = [0, 1]
+        script = [self._point(settled, J, 0.001 * (1 + k % 4)) for k in range(400)]
+        stopped = self._run(script, support_patience=SUPPORT_CHECK_EVERY)
+        assert stopped == SUPPORT_CHECK_EVERY + 1
+
+
+# --------------------------------------------------------------------------- #
+# 6. edges
 # --------------------------------------------------------------------------- #
 class TestEdges:
     def test_single_donor_returns_the_vertex_without_iterating(self):
@@ -277,7 +361,7 @@ class TestEdges:
 
 
 # --------------------------------------------------------------------------- #
-# 6. failure -- a bad knob is reported, not absorbed
+# 7. failure -- a bad knob is reported, not absorbed
 # --------------------------------------------------------------------------- #
 class TestFailures:
     @pytest.mark.parametrize("bad", [0, -1, -25])

--- a/mlsynth/tests/test_sdid_warm_start_accel.py
+++ b/mlsynth/tests/test_sdid_warm_start_accel.py
@@ -1,0 +1,299 @@
+"""Every cold entry into the simplex solver seeds itself, SDID's two included.
+
+The FISTA warm start used to be computed in ``ridge_augment.simplex_qp``, so
+being accelerated was a property of that one entry point. Of the thirteen call
+sites in the library, twelve never supplied a warm start -- MEDSC, SCD, COMPSC,
+StackedSC, mlSC, the proximal over-identified weights, the ``minnorm`` fallbacks,
+and SDID's two simplex programs -- so they called ``solve_simplex_qp`` cold.
+Starting cold means starting from the uniform point, and the active set then
+sheds one donor per pivot until only the support is left: work proportional to
+the pool, not to the answer.
+
+That is what made SDID slow. On a 101x120 panel its two programs took 117 inner
+least-squares solves between them, while ``VanillaSC`` on the same panel took 31
+through the accelerated door.
+
+The gate now lives in the solver. These tests pin the consequences: SDID's
+weights are unchanged to the last bit, its pivot count collapses, and the gate
+still respects the two cases that must skip it.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SDID
+from mlsynth.utils.bilevel import active_set
+from mlsynth.utils.bilevel.accelerate import ACCEL_MIN_DONORS
+from mlsynth.utils.bilevel.active_set import solve_simplex_qp
+from mlsynth.utils.sdid_helpers.weights import _solve_intercept_simplex
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _panel(n_donors=90, n_periods=40, n_pre=30, effect=-2.0, seed=3):
+    """A factor-structure panel with one treated unit."""
+    rng = np.random.default_rng(seed)
+    n_units = n_donors + 1
+    factors = np.cumsum(rng.standard_normal((n_periods, 3)) * 0.3, axis=0)
+    loadings = rng.uniform(0.2, 1.2, (n_units, 3))
+    outcome = (loadings @ factors.T
+               + rng.standard_normal((n_units, n_periods)) * 0.4 + 10.0)
+    treat = np.zeros((n_units, n_periods), dtype=int)
+    treat[0, n_pre:] = 1
+    outcome[0, n_pre:] += effect
+    return pd.DataFrame(
+        [{"id": f"u{i:03d}", "time": t + 1, "y": outcome[i, t], "d": treat[i, t]}
+         for i in range(n_units) for t in range(n_periods)]
+    )
+
+
+def _fit(df, **overrides):
+    config = {"df": df, "outcome": "y", "treat": "d", "unitid": "id",
+              "time": "time", "display_graphs": False, "vce": "noinference"}
+    config.update(overrides)
+    return SDID(config).fit()
+
+
+def _cold(monkeypatch):
+    """Raise the gate out of reach, restoring the pre-change cold path."""
+    monkeypatch.setattr(active_set, "ACCEL_MIN_DONORS", 10 ** 9)
+
+
+class _Spy:
+    """Counts calls to ``fista_warm_start`` as the solver makes them."""
+
+    def __init__(self, monkeypatch):
+        self.calls = []
+        real = active_set.fista_warm_start
+
+        def spy(design, target, **kwargs):
+            self.calls.append(np.asarray(design).shape)
+            return real(design, target, **kwargs)
+
+        monkeypatch.setattr(active_set, "fista_warm_start", spy)
+
+    def __len__(self):
+        return len(self.calls)
+
+
+# --------------------------------------------------------------------------- #
+# 1. smoke
+# --------------------------------------------------------------------------- #
+class TestSmoke:
+    def test_wide_panel_fits(self):
+        result = _fit(_panel())
+        assert np.isfinite(result.effects.att)
+        assert len(result.weights.donor_weights) == 90
+
+    def test_the_panel_is_wide_enough_to_engage_the_gate(self):
+        """The premise of the file: 90 donors clears ``ACCEL_MIN_DONORS``."""
+        assert 90 >= ACCEL_MIN_DONORS
+
+
+# --------------------------------------------------------------------------- #
+# 2. the binding invariant -- the seam changes cost, not weights
+# --------------------------------------------------------------------------- #
+class TestAnswerUnchanged:
+    def test_att_and_weights_identical_to_the_cold_path(self, monkeypatch):
+        seeded = _fit(_panel())
+        _cold(monkeypatch)
+        cold = _fit(_panel())
+
+        assert seeded.effects.att == pytest.approx(cold.effects.att, rel=0, abs=1e-12)
+        for name in ("donor_weights", "time_weights", "unit_weights"):
+            got, want = getattr(seeded.weights, name), getattr(cold.weights, name)
+            if want is None:
+                assert got is None
+                continue
+            assert set(got) == set(want)
+            np.testing.assert_allclose(
+                [got[k] for k in want], [want[k] for k in want], rtol=0, atol=1e-12)
+
+    def test_counterfactual_series_identical(self, monkeypatch):
+        seeded = _fit(_panel())
+        _cold(monkeypatch)
+        cold = _fit(_panel())
+        np.testing.assert_allclose(
+            np.asarray(seeded.time_series.counterfactual_outcome, float),
+            np.asarray(cold.time_series.counterfactual_outcome, float),
+            rtol=0, atol=1e-10)
+
+    def test_intercept_program_agrees_with_its_own_cold_path(self, monkeypatch):
+        """Straight at SDID's solver call, ridge on and off."""
+        rng = np.random.default_rng(11)
+        design = rng.standard_normal((60, 120))
+        target = design @ rng.dirichlet(np.ones(120)) + rng.standard_normal(60) * 0.1
+        for ridge in (0.0, 0.75):
+            intercept_a, weights_a = _solve_intercept_simplex(design, target, ridge)
+            _cold(monkeypatch)
+            intercept_b, weights_b = _solve_intercept_simplex(design, target, ridge)
+            monkeypatch.setattr(active_set, "ACCEL_MIN_DONORS", ACCEL_MIN_DONORS)
+            np.testing.assert_allclose(weights_a, weights_b, rtol=0, atol=1e-12)
+            assert intercept_a == pytest.approx(intercept_b, rel=0, abs=1e-10)
+
+
+# --------------------------------------------------------------------------- #
+# 3. the work the seam removes
+# --------------------------------------------------------------------------- #
+class TestWorkReduction:
+    def test_sdid_takes_fewer_pivots(self, monkeypatch):
+        pivots = {"seeded": [], "cold": []}
+        real = solve_simplex_qp
+
+        def recording(bucket):
+            def wrapper(B, A, **kwargs):
+                w, info = real(B, A, **{**kwargs, "return_info": True})
+                bucket.append(info["pivots"])
+                return (w, info) if kwargs.get("return_info") else w
+            return wrapper
+
+        import mlsynth.utils.sdid_helpers.weights as sdid_weights
+
+        monkeypatch.setattr(sdid_weights, "solve_simplex_qp",
+                            recording(pivots["seeded"]))
+        _fit(_panel())
+
+        _cold(monkeypatch)
+        monkeypatch.setattr(sdid_weights, "solve_simplex_qp",
+                            recording(pivots["cold"]))
+        _fit(_panel())
+
+        assert len(pivots["seeded"]) == len(pivots["cold"]) > 0
+        assert sum(pivots["seeded"]) < sum(pivots["cold"])
+
+    @pytest.mark.parametrize("J", [100, 160, 240])
+    def test_cold_work_scales_with_the_pool_and_seeded_work_does_not(self, J):
+        """The invariant nobody had written down. Cold pivots track ``J``;
+        seeded pivots track the support, which is far smaller."""
+        rng = np.random.default_rng(J)
+        factors = rng.standard_normal((2 * J, 2))
+        loadings = np.zeros((J, 2))
+        loadings[: J // 2, 0] = 1.0
+        loadings[J // 2:, 1] = 1.0
+        B = factors @ loadings.T + rng.standard_normal((2 * J, J))
+        A = factors @ np.array([1.0, 1.0]) + rng.standard_normal(2 * J)
+
+        w_cold, cold = solve_simplex_qp(B, A, return_info=True, accelerate=False)
+        w_seed, seeded = solve_simplex_qp(B, A, return_info=True)
+        support = int((w_cold > 1e-9).sum())
+
+        assert cold["pivots"] >= J // 2, "cold path should walk most of the pool"
+        assert seeded["pivots"] <= support
+        np.testing.assert_allclose(w_seed, w_cold, rtol=0, atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# 4. the gate
+# --------------------------------------------------------------------------- #
+class TestGate:
+    def test_engages_on_a_wide_pool(self, monkeypatch):
+        spy = _Spy(monkeypatch)
+        _fit(_panel())
+        assert len(spy) > 0
+
+    def test_skipped_below_the_donor_floor(self, monkeypatch):
+        spy = _Spy(monkeypatch)
+        _fit(_panel(n_donors=ACCEL_MIN_DONORS - 2, n_periods=30, n_pre=20))
+        assert len(spy) == 0
+
+    def test_skipped_when_the_caller_already_warm_starts(self, monkeypatch):
+        """The placebo fallback chains the previous draw's solution; a chained
+        seed must not be thrown away to recompute one."""
+        spy = _Spy(monkeypatch)
+        rng = np.random.default_rng(4)
+        design = rng.standard_normal((50, 120))
+        target = rng.standard_normal(50)
+        _solve_intercept_simplex(design, target, 0.0,
+                                 warm_start=np.full(120, 1.0 / 120))
+        assert len(spy) == 0
+
+    def test_gate_reads_the_design_the_solver_sees(self, monkeypatch):
+        """SDID stacks the ridge block *beneath* the design, so it adds rows and
+        not donors: the seed is computed on the augmented design."""
+        spy = _Spy(monkeypatch)
+        rng = np.random.default_rng(6)
+        design = rng.standard_normal((40, 100))
+        target = rng.standard_normal(40)
+        _solve_intercept_simplex(design, target, 2.0)
+        assert spy.calls == [(140, 100)]
+
+    def test_accelerate_false_forces_the_cold_path(self, monkeypatch):
+        spy = _Spy(monkeypatch)
+        rng = np.random.default_rng(7)
+        B = rng.standard_normal((150, 120))
+        A = rng.standard_normal(150)
+        solve_simplex_qp(B, A, accelerate=False)
+        assert len(spy) == 0
+
+
+# --------------------------------------------------------------------------- #
+# 5. edges
+# --------------------------------------------------------------------------- #
+class TestEdges:
+    def test_single_donor(self, monkeypatch):
+        spy = _Spy(monkeypatch)
+        rng = np.random.default_rng(8)
+        _, weights = _solve_intercept_simplex(
+            rng.standard_normal((12, 1)), rng.standard_normal(12), 0.0)
+        np.testing.assert_allclose(weights, np.ones(1))
+        assert len(spy) == 0
+
+    def test_collinear_donors_still_agree_with_the_cold_path(self, monkeypatch):
+        rng = np.random.default_rng(12)
+        core = rng.standard_normal((40, 45))
+        design = np.hstack([core, core])              # every donor duplicated
+        target = rng.standard_normal(40)
+        _, seeded = _solve_intercept_simplex(design, target, 0.0)
+        _cold(monkeypatch)
+        _, cold = _solve_intercept_simplex(design, target, 0.0)
+        assert (np.sum((design @ seeded - target) ** 2)
+                == pytest.approx(np.sum((design @ cold - target) ** 2),
+                                 rel=0, abs=1e-9))
+
+    def test_more_donors_than_rows(self):
+        rng = np.random.default_rng(13)
+        _, weights = _solve_intercept_simplex(
+            rng.standard_normal((15, 120)), rng.standard_normal(15), 0.0)
+        assert weights.min() >= -1e-12
+        assert weights.sum() == pytest.approx(1.0, abs=1e-9)
+
+    def test_all_zero_donors(self):
+        """A degenerate design makes the FISTA Lipschitz bound collapse; the
+        seed falls back to uniform and the solve still returns a simplex point."""
+        weights = solve_simplex_qp(np.zeros((20, 100)), np.arange(20.0))
+        assert weights.min() >= 0.0
+        assert weights.sum() == pytest.approx(1.0, abs=1e-9)
+
+    def test_placebo_inference_unchanged(self, monkeypatch):
+        """The batched placebo path routes around the solver; it must still land
+        on the same numbers."""
+        df = _panel(n_donors=90, n_periods=24, n_pre=18)
+        seeded = _fit(df, vce="placebo")
+        _cold(monkeypatch)
+        cold = _fit(df, vce="placebo")
+        assert seeded.effects.att == pytest.approx(cold.effects.att, rel=0, abs=1e-12)
+        assert (seeded.inference.standard_error
+                == pytest.approx(cold.inference.standard_error, rel=0, abs=1e-10))
+
+
+# --------------------------------------------------------------------------- #
+# 6. failure -- bad input is reported before any seeding work
+# --------------------------------------------------------------------------- #
+class TestFailures:
+    def test_empty_design_raises(self):
+        with pytest.raises(ValueError, match="at least one donor"):
+            solve_simplex_qp(np.zeros((10, 0)), np.zeros(10))
+
+    def test_length_mismatch_raises(self):
+        rng = np.random.default_rng(2)
+        with pytest.raises(ValueError, match="must equal"):
+            solve_simplex_qp(rng.standard_normal((10, 100)), np.zeros(9))
+
+    def test_mismatch_raises_before_the_seed_is_computed(self, monkeypatch):
+        spy = _Spy(monkeypatch)
+        rng = np.random.default_rng(14)
+        with pytest.raises(ValueError):
+            solve_simplex_qp(rng.standard_normal((10, 100)), np.zeros(9))
+        assert len(spy) == 0

--- a/mlsynth/tests/test_simplex_qp_accelerate.py
+++ b/mlsynth/tests/test_simplex_qp_accelerate.py
@@ -12,6 +12,10 @@ fallback) still determines the weights. These tests pin four things:
    (where the accelerator fires) *and* small ones (where it does not);
 4. the accelerator engages only when it should -- large ``J``, no caller warm
    start -- and the accelerated and cold paths agree on the fitted values.
+
+The gate itself lives in ``active_set.solve_simplex_qp``, so every caller gets
+it; ``simplex_qp`` is one call site of thirteen and is exercised here because it
+is the one with the cvxpy fallback behind it.
 """
 from __future__ import annotations
 
@@ -20,7 +24,7 @@ import pytest
 
 cp = pytest.importorskip("cvxpy")
 
-from mlsynth.utils.bilevel import ridge_augment
+from mlsynth.utils.bilevel import active_set
 from mlsynth.utils.bilevel.accelerate import (
     ACCEL_MIN_DONORS, fista_warm_start, simplex_project)
 from mlsynth.utils.bilevel.active_set import solve_simplex_qp
@@ -170,7 +174,7 @@ def test_accelerated_equals_cold_fitted_values():
     for J, T0 in [(100, 200), (150, 120), (250, 500), (90, 90)]:
         A, B = _factor_panel(J, T0)
         w_accel = simplex_qp(B, A)
-        w_cold, _ = solve_simplex_qp(B, A, return_info=True)
+        w_cold, _ = solve_simplex_qp(B, A, return_info=True, accelerate=False)
         assert np.max(np.abs(B @ w_accel - B @ w_cold)) < 1e-6
         assert _obj(B, A, w_accel) == pytest.approx(_obj(B, A, w_cold), abs=1e-6)
 
@@ -189,10 +193,16 @@ def test_accelerated_matches_clarabel_value_for_value():
 
 def test_accelerator_faster_than_cold_on_large_J():
     """Speed regression: the FISTA warm start makes the exact solve markedly
-    faster on a wide donor pool. Conservative 2x margin (measured ~13x at J=250)."""
+    faster on a wide donor pool. Conservative 2x margin (measured ~13x at J=250).
+
+    The cold baseline is taken with ``accelerate=False``, since the solver now
+    seeds itself: before, a plain ``solve_simplex_qp`` call *was* the cold path.
+    """
     import time
     A, B = _factor_panel(250, 500)
-    t = time.perf_counter(); w_cold, _ = solve_simplex_qp(B, A, return_info=True); t_cold = time.perf_counter() - t
+    t = time.perf_counter()
+    w_cold, _ = solve_simplex_qp(B, A, return_info=True, accelerate=False)
+    t_cold = time.perf_counter() - t
     t = time.perf_counter(); w_acc = simplex_qp(B, A); t_acc = time.perf_counter() - t
     assert np.max(np.abs(B @ w_acc - B @ w_cold)) < 1e-6    # same answer
     assert t_acc < 0.5 * t_cold, f"accel {t_acc:.3f}s not < half of cold {t_cold:.3f}s"
@@ -203,13 +213,13 @@ def test_accelerator_faster_than_cold_on_large_J():
 # --------------------------------------------------------------------------- #
 def test_accelerator_engaged_for_large_J(monkeypatch):
     calls = {"n": 0}
-    real = ridge_augment.fista_warm_start
+    real = active_set.fista_warm_start
 
     def spy(B, A, **kw):
         calls["n"] += 1
         return real(B, A, **kw)
 
-    monkeypatch.setattr(ridge_augment, "fista_warm_start", spy)
+    monkeypatch.setattr(active_set, "fista_warm_start", spy)
     A, B = _factor_panel(ACCEL_MIN_DONORS + 20, 2 * (ACCEL_MIN_DONORS + 20))
     simplex_qp(B, A)
     assert calls["n"] == 1
@@ -217,7 +227,7 @@ def test_accelerator_engaged_for_large_J(monkeypatch):
 
 def test_accelerator_skipped_for_small_J(monkeypatch):
     calls = {"n": 0}
-    monkeypatch.setattr(ridge_augment, "fista_warm_start",
+    monkeypatch.setattr(active_set, "fista_warm_start",
                         lambda *a, **k: calls.__setitem__("n", calls["n"] + 1))
     A, B = _factor_panel(max(2, ACCEL_MIN_DONORS - 30), 60)
     simplex_qp(B, A)
@@ -226,7 +236,7 @@ def test_accelerator_skipped_for_small_J(monkeypatch):
 
 def test_accelerator_skipped_when_caller_supplies_warm_start(monkeypatch):
     calls = {"n": 0}
-    monkeypatch.setattr(ridge_augment, "fista_warm_start",
+    monkeypatch.setattr(active_set, "fista_warm_start",
                         lambda *a, **k: calls.__setitem__("n", calls["n"] + 1))
     A, B = _factor_panel(ACCEL_MIN_DONORS + 20, 2 * (ACCEL_MIN_DONORS + 20))
     J = B.shape[1]

--- a/mlsynth/utils/bilevel/accelerate.py
+++ b/mlsynth/utils/bilevel/accelerate.py
@@ -47,14 +47,28 @@ ACCEL_MIN_DONORS = 80
 # set (``active = w <= tol``, ``tol = 1e-9``), so the two agree on what the seed
 # is saying.
 SUPPORT_TOL = 1e-9
-# Consecutive iterations the support must hold before the warm start returns.
-# The seed's job is to name the support, so once it stops moving the remaining
-# iterations refine weights the exact solve is about to recompute. Measured on
-# the SDID programs of a 101x120 panel: the support is final by iteration ~150
-# of 400, and a patience of 10 stops too early -- the support is still moving,
-# the seed is rejected coordinate by coordinate, and the solve pays the full 32
-# pivots anyway. 25 sits clear of that edge.
-SUPPORT_PATIENCE = 25
+# Consecutive iterations the support must hold before the warm start returns --
+# a quarter of the default budget. The seed's job is to name the support, so
+# once it stops moving the remaining iterations refine weights the exact solve
+# is about to recompute: on the SDID programs of a 101x120 panel the support is
+# final by iteration ~150 of 400.
+#
+# The margin is what the number is for, and it is asymmetric. One saved
+# iteration is worth ~44 us; one extra pivot the seed fails to save costs
+# ~1.2 ms on a 96x99 free set, or about 27 iterations. A stop that fires while
+# the support is still moving therefore loses even when it saves most of the
+# loop, and a design whose support never settles -- the outcome-only SC program
+# of that same panel -- must simply run to ``max_iter``. At a patience of 25
+# that program stopped at iteration 376 with a seed three donors worse and paid
+# 12 percent for it; at 100 the stop does not fire there at all, while SDID's
+# two programs still stop at 261 and 231.
+SUPPORT_PATIENCE = 100
+# Iterations between support samples. The test is three numpy calls on a
+# J-vector, which is ~11 percent of an iteration at these sizes -- enough that
+# checking every iteration cost more than the stop saved on any design where it
+# did not fire. Sampling makes the bookkeeping free and costs at most one
+# sampling interval of lateness.
+SUPPORT_CHECK_EVERY = 10
 
 
 def simplex_project(v: np.ndarray) -> np.ndarray:
@@ -114,8 +128,17 @@ def fista_warm_start(B: np.ndarray, A: np.ndarray, *,
     set already has everything this function can tell it, and the remaining
     iterations only refine weights the exact solve is about to recompute. On the
     two SDID programs of a 101x120 panel the support is final by iteration ~150
-    while the iterate is still moving at 400, so the rule cuts the warm start by
-    about 2.7x. Pass ``None`` to stop on ``tol`` and ``max_iter`` alone.
+    while the iterate is still moving at 400; the stop fires at 261 and 231 and
+    takes those two programs from 50.0 ms to 36.7 ms end to end. Pass ``None`` to
+    stop on ``tol`` and ``max_iter`` alone.
+
+    The support is sampled every ``SUPPORT_CHECK_EVERY`` iterations, and the
+    counter arms only after the first coordinate is pinned. Both exist because a
+    seed that is *nearly* right is not most of the benefit: an extra pivot costs
+    about 27 iterations, so a stop that fires while the support is still moving
+    is a loss even when it saves most of the loop. On the outcome-only SC program
+    of that same panel the support never settles and the loop correctly runs to
+    ``max_iter``.
 
     Stopping earlier gives a coarser seed, never a wrong answer: the active set
     certifies KKT optimality on the design, whatever point it starts from.
@@ -132,7 +155,8 @@ def fista_warm_start(B: np.ndarray, A: np.ndarray, *,
         Stop when the iterate moves less than this in the sup norm.
     support_patience : int or None
         Stop when the support (``w > SUPPORT_TOL``) has held for this many
-        consecutive iterations. ``None`` disables the rule.
+        consecutive iterations, sampled every ``SUPPORT_CHECK_EVERY`` of them.
+        ``None`` disables the rule.
 
     Returns
     -------
@@ -160,19 +184,30 @@ def fista_warm_start(B: np.ndarray, A: np.ndarray, *,
     t = 1.0
     support = None
     held = 0
-    for _ in range(max_iter):
+    holds_needed = (None if support_patience is None
+                    else max(1, -(-support_patience // SUPPORT_CHECK_EVERY)))
+    for i in range(max_iter):
         w_new = simplex_project(y - (2.0 * (G @ y - c)) / L)
         t_new = 0.5 * (1.0 + np.sqrt(1.0 + 4.0 * t * t))
         y = w_new + ((t - 1.0) / t_new) * (w_new - w)
         if np.max(np.abs(w_new - w)) < tol:
             w = w_new
             break
-        if support_patience is not None:
+        if holds_needed is not None and i % SUPPORT_CHECK_EVERY == 0:
             current = w_new > SUPPORT_TOL
-            held = held + 1 if (support is not None
+            # The counter arms only once FISTA has begun pinning coordinates.
+            # It starts at the uniform point, where every coordinate is
+            # positive, so an unarmed counter reads that plateau as a support
+            # that has settled and returns the whole pool as the seed -- which
+            # is the uniform start under another name, and leaves the active set
+            # the full cold pivot count. Measured on a 96x100 SC design whose
+            # optimum has 16 donors: unarmed, the seed named all 100 and the
+            # solve took the cold 84 pivots; armed, it names 49 and takes 33.
+            armed = int(current.sum()) < J
+            held = held + 1 if (armed and support is not None
                                 and np.array_equal(current, support)) else 0
             support = current
-            if held >= support_patience:
+            if held >= holds_needed:
                 w = w_new
                 break
         w = w_new

--- a/mlsynth/utils/bilevel/accelerate.py
+++ b/mlsynth/utils/bilevel/accelerate.py
@@ -16,6 +16,12 @@ FISTA converges to the neighbourhood of the optimum -- and hence the right
 support -- in a few hundred cheap iterations; the exact active-set then certifies
 from that warm start in a handful of pivots.
 
+The support arrives before the weights do, and the support is all the active set
+is being told, so the loop stops on the support and not on the iterate: see
+``SUPPORT_PATIENCE``. :func:`mlsynth.utils.bilevel.active_set.solve_simplex_qp`
+calls this itself for a wide enough pool, so the seed is a property of the solver
+and reaches every caller.
+
 The accelerator is *speed only*. It supplies a feasible warm start; the exact
 active-set (with the cvxpy fallback) still determines the returned weights, so
 the answer is unchanged for any warm start. Correctness therefore never depends
@@ -23,6 +29,9 @@ on FISTA converging, the Lipschitz estimate being tight, or the problem being
 well-conditioned -- only the runtime does.
 """
 from __future__ import annotations
+
+import numbers
+from typing import Optional
 
 import numpy as np
 
@@ -32,6 +41,20 @@ import numpy as np
 # J = 16 -- stay comfortably on the untouched fast path). Also skipped whenever
 # the caller already supplies a warm start (e.g. the conformal / placebo loops).
 ACCEL_MIN_DONORS = 80
+
+# A coordinate counts as in the support above this. It is the tolerance
+# ``solve_simplex_qp`` itself reads when it turns a warm start into an active
+# set (``active = w <= tol``, ``tol = 1e-9``), so the two agree on what the seed
+# is saying.
+SUPPORT_TOL = 1e-9
+# Consecutive iterations the support must hold before the warm start returns.
+# The seed's job is to name the support, so once it stops moving the remaining
+# iterations refine weights the exact solve is about to recompute. Measured on
+# the SDID programs of a 101x120 panel: the support is final by iteration ~150
+# of 400, and a patience of 10 stops too early -- the support is still moving,
+# the seed is rejected coordinate by coordinate, and the solve pays the full 32
+# pivots anyway. 25 sits clear of that edge.
+SUPPORT_PATIENCE = 25
 
 
 def simplex_project(v: np.ndarray) -> np.ndarray:
@@ -76,13 +99,52 @@ def _spectral_bound(G: np.ndarray, iters: int = 50) -> float:
 
 
 def fista_warm_start(B: np.ndarray, A: np.ndarray, *,
-                     max_iter: int = 400, tol: float = 1e-7) -> np.ndarray:
+                     max_iter: int = 400, tol: float = 1e-7,
+                     support_patience: Optional[int] = SUPPORT_PATIENCE
+                     ) -> np.ndarray:
     """A feasible, near-optimal warm start for ``min ||A - B w||^2`` on the
     simplex, via Gram-collapsed FISTA.
 
     Deterministic. Returns a point on the simplex; it is intended to seed the
     exact active-set solver, not to be used as the final solution.
+
+    Two rules stop the loop. ``tol`` is the usual one, on how far the iterate
+    moved. ``support_patience`` is the one that matters for the job: once the
+    support has been unchanged for that many consecutive iterations, the active
+    set already has everything this function can tell it, and the remaining
+    iterations only refine weights the exact solve is about to recompute. On the
+    two SDID programs of a 101x120 panel the support is final by iteration ~150
+    while the iterate is still moving at 400, so the rule cuts the warm start by
+    about 2.7x. Pass ``None`` to stop on ``tol`` and ``max_iter`` alone.
+
+    Stopping earlier gives a coarser seed, never a wrong answer: the active set
+    certifies KKT optimality on the design, whatever point it starts from.
+
+    Parameters
+    ----------
+    B : numpy.ndarray, shape (m, J)
+        Donor matching matrix.
+    A : numpy.ndarray, shape (m,)
+        Treated unit's matching vector.
+    max_iter : int
+        Hard cap on iterations.
+    tol : float
+        Stop when the iterate moves less than this in the sup norm.
+    support_patience : int or None
+        Stop when the support (``w > SUPPORT_TOL``) has held for this many
+        consecutive iterations. ``None`` disables the rule.
+
+    Returns
+    -------
+    numpy.ndarray, shape (J,)
     """
+    if support_patience is not None and (
+            not isinstance(support_patience, numbers.Integral)
+            or support_patience < 1):
+        raise ValueError(
+            "support_patience must be a positive integer or None, got "
+            f"{support_patience!r}."
+        )
     B = np.asarray(B, dtype=float)
     A = np.asarray(A, dtype=float).ravel()
     J = B.shape[1]
@@ -96,6 +158,8 @@ def fista_warm_start(B: np.ndarray, A: np.ndarray, *,
     w = np.full(J, 1.0 / J)
     y = w.copy()
     t = 1.0
+    support = None
+    held = 0
     for _ in range(max_iter):
         w_new = simplex_project(y - (2.0 * (G @ y - c)) / L)
         t_new = 0.5 * (1.0 + np.sqrt(1.0 + 4.0 * t * t))
@@ -103,6 +167,14 @@ def fista_warm_start(B: np.ndarray, A: np.ndarray, *,
         if np.max(np.abs(w_new - w)) < tol:
             w = w_new
             break
+        if support_patience is not None:
+            current = w_new > SUPPORT_TOL
+            held = held + 1 if (support is not None
+                                and np.array_equal(current, support)) else 0
+            support = current
+            if held >= support_patience:
+                w = w_new
+                break
         w = w_new
         t = t_new
     return w

--- a/mlsynth/utils/bilevel/active_set.py
+++ b/mlsynth/utils/bilevel/active_set.py
@@ -10,6 +10,18 @@ canonicalisation overhead in the hot conformal / market-selection loops.
 ``scipy.linalg.lstsq``. The free sets here are small enough that the wrapper's
 fixed per-call cost exceeded the LAPACK work it wrapped.
 
+A cold solve seeds itself. Starting from the uniform point, the active set has
+to shed one donor per pivot until only the support is left, so its work scales
+with the *pool* and not with the support it ends on: on factor panels the pivot
+count runs 0.6 to 0.9 times ``J`` from ``J = 20`` to ``J = 320``, while the
+support grows 7 to 43. A Gram-collapsed FISTA warm start
+(:func:`mlsynth.utils.bilevel.accelerate.fista_warm_start`) names that support
+up front and the same pivot counts drop to 0 or 1. So for a pool of at least
+``ACCEL_MIN_DONORS``, with no warm start from the caller, the seed is computed
+here -- once, for every caller -- instead of at a call site. It is speed only:
+the exact active set still determines the weights, and a seed it cannot use is
+discarded. Pass ``accelerate=False`` to force the cold path.
+
 The correctness contract -- cvxpy parity, a solver-independent KKT certificate,
 and a fuzzed differential test -- is pinned in
 ``tests/test_simplex_active_set.py``; the LAPACK call's bit-identity to the
@@ -21,6 +33,8 @@ from typing import Dict, Optional, Tuple
 
 import numpy as np
 from scipy.linalg import get_lapack_funcs
+
+from .accelerate import ACCEL_MIN_DONORS, fista_warm_start
 
 # Workspace size and LAPACK handle per free-set shape. The active set solves a
 # sequence of small systems whose shapes repeat across pivots, units and
@@ -70,6 +84,7 @@ def solve_simplex_qp(
     tol: float = 1e-9,
     max_iter: Optional[int] = None,
     return_info: bool = False,
+    accelerate: bool = True,
 ):
     """Minimise ``||A - B w||^2`` over ``w >= 0, sum(w) == 1``.
 
@@ -90,6 +105,10 @@ def solve_simplex_qp(
     return_info : bool
         If ``True`` also return a diagnostics dict (``iterations``, ``pivots``,
         ``converged``) so the performance tests can assert bounded work.
+    accelerate : bool
+        Whether a cold solve on a pool of at least ``ACCEL_MIN_DONORS`` may seed
+        itself with a FISTA warm start (default ``True``). Set ``False`` for the
+        cold path -- it changes the work, not the weights.
 
     Returns
     -------
@@ -124,7 +143,10 @@ def solve_simplex_qp(
     c = B.T @ A
 
     # Feasible start: a valid warm start (on the simplex) seeds the active set;
-    # otherwise the uniform point.
+    # otherwise the uniform point. A wide pool with nothing from the caller
+    # seeds itself, since the uniform point costs a pivot per donor.
+    if warm_start is None and accelerate and J >= ACCEL_MIN_DONORS:
+        warm_start = fista_warm_start(B, A)
     w = None
     if warm_start is not None:
         ws = np.asarray(warm_start, dtype=float).ravel()

--- a/mlsynth/utils/bilevel/ridge_augment.py
+++ b/mlsynth/utils/bilevel/ridge_augment.py
@@ -44,7 +44,6 @@ from typing import Any, Dict, Optional, Tuple
 import numpy as np
 
 from ...exceptions import MlsynthEstimationError
-from .accelerate import ACCEL_MIN_DONORS, fista_warm_start
 
 _EPS = 1e-12
 
@@ -71,14 +70,15 @@ def simplex_qp(B: np.ndarray, A: np.ndarray, warm_start=None) -> np.ndarray:
     convergence (degenerate cycling), keeping the result no worse than before.
 
     For a large donor pool (``J >= ACCEL_MIN_DONORS``) with no caller-supplied
-    warm start, a Gram-collapsed FISTA warm start
-    (:func:`mlsynth.utils.bilevel.accelerate.fista_warm_start`) is computed first
-    so the active set is certified from the right support instead of built up
-    pivot by pivot -- up to ~20x faster on a few hundred donors, and faster than a
-    general interior-point solver (CLARABEL) on the same problem. This is
-    speed-only: the exact active-set (with the cvxpy fallback) still determines
-    the weights, so the answer is unchanged; the small-``J`` hot path and any
-    caller that already warm-starts are untouched.
+    warm start, ``solve_simplex_qp`` seeds itself with a Gram-collapsed FISTA
+    warm start (:func:`mlsynth.utils.bilevel.accelerate.fista_warm_start`) so the
+    active set is certified from the right support instead of built up pivot by
+    pivot -- up to ~20x faster on a few hundred donors, and faster than a general
+    interior-point solver (CLARABEL) on the same problem. That seeding used to
+    happen here, which made it a property of this entry point and not of the
+    solver: of the thirteen call sites in the library, twelve never supplied a
+    warm start, SDID's two simplex programs among them, so they went in cold. It
+    now happens in the solver, so this function only chooses the fallback.
 
     Parameters
     ----------
@@ -95,8 +95,6 @@ def simplex_qp(B: np.ndarray, A: np.ndarray, warm_start=None) -> np.ndarray:
 
     B = np.asarray(B, dtype=float)
     A = np.asarray(A, dtype=float).ravel()
-    if warm_start is None and B.shape[1] >= ACCEL_MIN_DONORS:
-        warm_start = fista_warm_start(B, A)
     w, info = solve_simplex_qp(B, A, warm_start=warm_start, return_info=True)
     if info["converged"]:
         return w

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -747,8 +747,8 @@ timeout = 600.0
 
   [[target.mutant]]
   id = "seeding-is-a-property-of-one-call-site"
-  find = "    if warm_start is None and accelerate and J >= ACCEL_MIN_DONORS:\n        warm_start = fista_warm_start(B, A)\n"
-  replace = ""
+  find = "    if warm_start is None and accelerate and J >= ACCEL_MIN_DONORS:\n        warm_start = fista_warm_start(B, A)"
+  replace = "    if False:\n        warm_start = fista_warm_start(B, A)"
   models = "the defect this change fixed. With the seed computed in one caller instead of in the solver, the other twelve call sites start from the uniform point and the active set sheds one donor per pivot: 117 inner solves for SDID on a 101x120 panel against 31 for VanillaSC on the same panel. Every weight is still correct, so only a work assertion can see it"
 
   [[target.mutant]]

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -738,3 +738,33 @@ timeout = 400.0
   find = "                dependent=pi_dependent)"
   replace = "                dependent=not pi_dependent)"
   models = "passing the flag through backwards. The result then records the opposite of what was run, so a band built under the i.i.d. multipliers is labelled as the paper's algorithm -- the one failure that survives being written down"
+
+[[target]]
+name = "simplex-active-set-seeding"
+module-path = "mlsynth/utils/bilevel/active_set.py"
+test-command = "python -m pytest mlsynth/tests/test_sdid_warm_start_accel.py mlsynth/tests/test_fista_support_patience.py -q -p no:cacheprovider"
+timeout = 600.0
+
+  [[target.mutant]]
+  id = "seeding-is-a-property-of-one-call-site"
+  find = "    if warm_start is None and accelerate and J >= ACCEL_MIN_DONORS:\n        warm_start = fista_warm_start(B, A)\n"
+  replace = ""
+  models = "the defect this change fixed. With the seed computed in one caller instead of in the solver, the other twelve call sites start from the uniform point and the active set sheds one donor per pivot: 117 inner solves for SDID on a 101x120 panel against 31 for VanillaSC on the same panel. Every weight is still correct, so only a work assertion can see it"
+
+  [[target.mutant]]
+  id = "seeding-overrides-the-callers-warm-start"
+  find = "    if warm_start is None and accelerate and J >= ACCEL_MIN_DONORS:"
+  replace = "    if accelerate and J >= ACCEL_MIN_DONORS:"
+  models = "a seed recomputed on top of one the caller already has. The placebo loop chains the previous draw's solution through this argument, so discarding it pays for a FISTA run per draw to replace a start that was already on the answer"
+
+  [[target.mutant]]
+  id = "support-patience-counts-total-instead-of-consecutive-holds"
+  find = "            held = held + 1 if (support is not None\n                                and np.array_equal(current, support)) else 0"
+  replace = "            held = held + 1 if (support is not None\n                                and np.array_equal(current, support)) else held"
+  models = "a patience counter that never resets, so a support that flickers still accumulates holds and the warm start returns while the support is moving -- the seed is then rejected coordinate by coordinate and the solve pays the cold pivot count anyway"
+
+  [[target.mutant]]
+  id = "support-read-at-a-tolerance-the-solver-does-not-use"
+  find = "SUPPORT_TOL = 1e-9"
+  replace = "SUPPORT_TOL = 1e-3"
+  models = "the seed's support read at a coarser threshold than the one solve_simplex_qp pins variables at, so the two disagree about what the seed says and the loop stops on a support the active set will not adopt"

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -757,11 +757,23 @@ timeout = 600.0
   replace = "    if accelerate and J >= ACCEL_MIN_DONORS:"
   models = "a seed recomputed on top of one the caller already has. The placebo loop chains the previous draw's solution through this argument, so discarding it pays for a FISTA run per draw to replace a start that was already on the answer"
 
+[[target]]
+name = "fista-support-stop"
+module-path = "mlsynth/utils/bilevel/accelerate.py"
+test-command = "python -m pytest mlsynth/tests/test_fista_support_patience.py mlsynth/tests/test_sdid_warm_start_accel.py -q -p no:cacheprovider"
+timeout = 600.0
+
   [[target.mutant]]
   id = "support-patience-counts-total-instead-of-consecutive-holds"
-  find = "            held = held + 1 if (support is not None\n                                and np.array_equal(current, support)) else 0"
-  replace = "            held = held + 1 if (support is not None\n                                and np.array_equal(current, support)) else held"
+  find = "            held = held + 1 if (armed and support is not None\n                                and np.array_equal(current, support)) else 0"
+  replace = "            held = held + 1 if (armed and support is not None\n                                and np.array_equal(current, support)) else held"
   models = "a patience counter that never resets, so a support that flickers still accumulates holds and the warm start returns while the support is moving -- the seed is then rejected coordinate by coordinate and the solve pays the cold pivot count anyway"
+
+  [[target.mutant]]
+  id = "counter-arms-on-the-uniform-plateau"
+  find = "            armed = int(current.sum()) < J"
+  replace = "            armed = True"
+  models = "the counter allowed to run before the first coordinate is pinned. FISTA starts at the uniform point, where every coordinate is positive and the support has therefore not changed for the reason that it has not started, so the stop fires immediately and hands back the whole pool -- the uniform start under another name. On a 96x100 design whose optimum has 16 donors it took the solve from 33 pivots back to the cold 84"
 
   [[target.mutant]]
   id = "support-read-at-a-tolerance-the-solver-does-not-use"


### PR DESCRIPTION
## Related Links

- Closes #447 — the issue carries the full five-why ladder, which is the audit record for this change
- `mlsynth/utils/bilevel/active_set.py`, `mlsynth/utils/bilevel/accelerate.py`
- Head-to-head baseline: [`yo5uke/coresynth`](https://github.com/yo5uke/coresynth)
- Follow-on finding filed separately as #449

## What

- Moved the FISTA warm-start gate out of `ridge_augment.simplex_qp` and into `active_set.solve_simplex_qp`, behind a new `accelerate=True` parameter
- Added a support-based stopping rule to `fista_warm_start` (`SUPPORT_PATIENCE`, `SUPPORT_CHECK_EVERY`, `SUPPORT_TOL`)
- Added two test files and five semantic mutants across two new catalogue targets
- Updated the four existing accelerator tests that named `ridge_augment` as the gate's home

## Why

`SDID` was ~1.5x slower than an equivalent compiled implementation on a 101x120
panel while `VanillaSC` on the same panel was 3.5x faster. The gap was one
thing: which door each estimator used to reach the exact simplex solver.

The seed was computed in `ridge_augment.simplex_qp`, so being accelerated was a
property of that call site. Of the thirteen call sites in the library twelve
never supplied a warm start — MEDSC, SCD, COMPSC, StackedSC, mlSC, the proximal
over-identified weights, the two `minnorm` fallbacks, and SDID's two simplex
programs — so they entered cold. A cold solve starts from the uniform point and
the active set sheds one donor per pivot, so its work tracks the pool and not
the support it ends on: 0.62 to 0.87 pivots per donor from `J` = 20 to `J` = 320,
against a support that grows 7 to 43. That is the whole 117-versus-31 difference
in inner least-squares solves between SDID and VanillaSC.

No test said otherwise, which is the root cause rather than the symptom: the
perf contract bounds pivots at `2 * J`, a bound proportional to the pool, so the
defect satisfied it.

## How

The fix is entirely in the shared helper — `sdid_helpers/weights.py` is
untouched, which is itself the confirmation that the fault was in the solver and
not in SDID.

The stopping rule took three attempts, and the two failed ones are recorded in
#447 and in the commit messages because they are the interesting part:

- the patience counter armed immediately, but FISTA starts at the uniform point
  where every coordinate is positive, so the support had not changed for the
  reason that it had not started. The stop fired on that plateau and the seed
  named the whole pool — the uniform start under another name. On a 96x100
  design whose optimum has 16 donors the solve then took the cold 84 pivots;
- the bookkeeping was three numpy calls on a `J`-vector per iteration, about 11
  percent of an iteration, so checking every iteration cost more than the stop
  saved on any design where it did not fire.

With both fixed the default is sized against the trade rather than against one
estimator: a saved iteration is worth ~44 us, a pivot the seed fails to save
costs ~1.2 ms on a 96x99 free set — about 27 iterations. So a stop that fires
while the support is still moving loses even when it saves most of the loop, and
the default sits where it fires only on a support that has durably settled.

The QR-insert/delete approach proposed in #447 was measured and not taken:
2.5–6.9x per solve on large overdetermined systems, but 0.5–0.8x on small or
underdetermined ones, and it is moot once the seed removes the pivots entirely.

## Verification

- Path: not applicable — this is a speed change to a shared solver, and its
  correctness criterion is that no number moves.
- Quantities compared: SDID and VanillaSC ATT, donor weights, unit weights, time
  weights and the counterfactual series, seeded against cold. Drift `0.0e+00`
  on both estimators — identical, not close. Pinned at `atol=1e-12` in
  `test_sdid_warm_start_accel.py::TestAnswerUnchanged`.
- Pinned durably: `mlsynth/tests/test_sdid_warm_start_accel.py` (weights
  identical, pivot count strictly lower, gate honoured, `accelerate=False`
  reaches the cold path) and `mlsynth/tests/test_fista_support_patience.py`
  (the stop fires, the answer is untouched, the counter arms, and the stop never
  costs a pivot across 18 design/seed combinations).
- Machine-independent where possible: wall clock carries ~1.5 ms of run-to-run
  noise at these sizes, so the binding assertions are pivot counts and weight
  equality, not timings.
- Mutants: five, across `simplex-active-set-seeding` and `fista-support-stop`,
  covering the defect itself, a seed that discards the caller's warm start, a
  counter that never resets, a counter that arms on the uniform plateau, and a
  support read at a tolerance the solver does not use.

Measured, single-threaded OpenBLAS, best of 15:

| | before | after | |
|---|---:|---:|---|
| SDID `vce="noinference"` | 58.0 ms | 35.3 ms | 1.64x |
| — unit weights (196x100) | 23.1 ms, 32 pivots | 8.7 ms, 0 pivots | |
| — time weights (100x96) | 23.4 ms, 83 pivots | 8.7 ms, 0 pivots | |
| VanillaSC (fit only) | unchanged | unchanged | seed bit-identical |

coresynth on the same panel is 38.2 ms.

## Scope checks

Shared-helper change, so none of the four blocks applies. Per `CLAUDE.md` it
lands on its own branch, which carries only this work.

## Designs

No visual output changes — every series this touches is identical to the last
bit.

## Test Steps

- [x] `pytest mlsynth/tests/test_fista_support_patience.py mlsynth/tests/test_sdid_warm_start_accel.py mlsynth/tests/test_simplex_qp_accelerate.py` — 89 passed
- [x] `pytest -k "sdid or simplex or bilevel or medsc or scd or compsc or stackedsc or mlsc or proximal or active_set or vanilla or fscm or minnorm or fista"` — 1990 passed, 3 skipped, covering every caller of the changed helpers
- [ ] `pytest mlsynth/tests/` — full suite, running at time of writing; result posted below before merge

## Other Notes

- #449 records the next bottleneck found while root-causing this one: a default
  `vce="placebo"` fit spends 26 percent of its time in `gram_reduction_is_safe`,
  which runs a full SVD 1000 times per fit to answer `True` every time, decided
  by a ratio never within four orders of magnitude of its threshold. Its own
  branch, with the guard's decisions held identical.
- The second-order finding in that profile — `solve_simplex_minnorm_batch`'s own
  4.33 s of `tottime` — is noted in #449 and not yet diagnosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_