### PR TITLE
Certify a ridged design instead of factorising it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,33 @@ now returns and the back-compat guarantee.
   several treated units at once can build its own scores in a single pass and
   reuse the same calibration.
 
+### Added
+- `utils/bilevel/minnorm.py::ridged_gram_reduction_is_safe`: the Gram-reduction
+  guard for a design the caller is about to augment with `sqrt(ridge) * I`,
+  answered without building or factorising that matrix wherever the ridge
+  settles it. The augmented Gram is `X'X + ridge I`, so `lambda_min >= ridge`
+  and `lambda_max <= ||X||_F^2 + ridge`, giving
+  `sv_min / sv_max >= sqrt(ridge / (||X||_F^2 + ridge))` from one Frobenius
+  norm. The bound is one-sided in the safe direction -- clearing it proves the
+  answer is `True`, failing to clear it proves nothing and the spectrum runs --
+  so decisions are identical to asking `gram_reduction_is_safe` about the
+  augmented matrix, by construction rather than by tuning.
+
+### Changed
+- SDID's placebo loop asks the Gram-reduction guard through
+  `ridged_gram_reduction_is_safe`. A default `vce="placebo"` fit posed 1000
+  simplex programs and asked the guard about every one, each answer a full
+  singular spectrum, and on a 101x120 panel all 1000 came back `True` decided by
+  a ratio four to seven orders of magnitude clear of the 1e-8 tolerance. Nothing
+  said a guard must cost less than the solve it protects, so it had grown past
+  it: 4.25 s of a 16.6 s three-fit profile, against the batched solver's own
+  4.33 s. The unit-weight program carries a ridge and is now certified without a
+  factorisation; 1000 SVDs become 500 and the fit goes 4.28 s to 3.64 s with the
+  ATT and its standard error unchanged at `0.0e+00`. The time-weight program
+  carries no ridge, so the bound is vacuous there and it still pays -- asserted
+  in `test_sdid_placebo_guard_cost.py::TestReachOfTheFix` so the limit of the
+  fix is visible rather than assumed.
+
 ### Changed
 - The FISTA warm start that seeds the exact simplex active set is computed in
   `utils/bilevel/active_set.py::solve_simplex_qp` instead of in

--- a/mlsynth/tests/test_ridged_gram_guard.py
+++ b/mlsynth/tests/test_ridged_gram_guard.py
@@ -1,0 +1,281 @@
+"""A ridge-augmented design carries a certificate the guard need not factorise.
+
+``gram_reduction_is_safe`` asks whether ``sv_min / sv_max > tol`` on the design
+the solve actually sees, and answers it with a full singular spectrum. Where
+that design is ridge augmented -- ``[X_c; sqrt(r) I]``, which is what SDID's
+unit-weight program hands it -- the answer is often settled without factorising
+anything. The Gram is ``X_c' X_c + r I``, so
+
+    lambda_min >= r                      (``X_c' X_c`` is positive semidefinite)
+    lambda_max <= ||X_c||_F^2 + r        (the trace bounds the largest eigenvalue)
+
+and therefore
+
+    sv_min / sv_max >= sqrt(r / (||X_c||_F^2 + r)).
+
+One Frobenius norm, no factorisation. The bound is one-sided in the safe
+direction: clearing it proves the guard's answer is ``True``, and failing to
+clear it proves nothing, so the SVD still runs. Decisions are therefore
+identical by construction, not by tuning -- which is the acceptance bar for
+touching a correctness guard at all.
+
+On the placebo family of a 101x120 panel the bound is 7.21e-2 against a true
+ratio of 7.43e-2, tight to three percent, and both clear the 1e-8 tolerance by
+six orders of magnitude.
+
+The time-weight program carries no ridge, so ``lambda_min >= 0`` is vacuous and
+it keeps paying for its SVD. That is recorded here rather than papered over.
+"""
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.minnorm import (
+    gram_reduction_is_safe,
+    ridged_gram_reduction_is_safe,
+)
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _augment(design_c, ridge):
+    """The matrix the shipped guard is handed today."""
+    if ridge <= 0.0:
+        return design_c
+    J = design_c.shape[1]
+    return np.vstack([design_c, np.sqrt(ridge) * np.eye(J)])
+
+
+def _shipped(design_c, ridge, tol=1e-8):
+    return gram_reduction_is_safe(_augment(design_c, ridge), tol)
+
+
+def _true_ratio(design_c, ridge):
+    aug = _augment(design_c, ridge)
+    if aug.shape[0] < aug.shape[1] or min(aug.shape) == 0:
+        return None
+    sv = np.linalg.svd(aug, compute_uv=False)
+    return float(sv[-1] / sv[0]) if sv[0] > 0 else 0.0
+
+
+def _bound(design_c, ridge):
+    if ridge <= 0.0:
+        return 0.0
+    return float(np.sqrt(ridge / (float(np.sum(design_c ** 2)) + ridge)))
+
+
+def _centred(rng, m, J, scale=1.0):
+    X = rng.standard_normal((m, J)) * scale
+    return X - X.mean(axis=0)
+
+
+class _SvdSpy:
+    """Counts the SVDs the guard performs."""
+
+    def __init__(self, monkeypatch):
+        self.n = 0
+        real = np.linalg.svd
+
+        def counting(*args, **kwargs):
+            self.n += 1
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(np.linalg, "svd", counting)
+
+
+# --------------------------------------------------------------------------- #
+# 1. smoke
+# --------------------------------------------------------------------------- #
+class TestSmoke:
+    def test_returns_a_bool(self):
+        rng = np.random.default_rng(0)
+        out = ridged_gram_reduction_is_safe(_centred(rng, 30, 12), 1.0)
+        assert isinstance(out, bool)
+
+    def test_a_well_conditioned_ridged_design_is_safe(self):
+        rng = np.random.default_rng(1)
+        assert ridged_gram_reduction_is_safe(_centred(rng, 40, 15), 0.5) is True
+
+
+# --------------------------------------------------------------------------- #
+# 2. the acceptance bar -- identical decisions, never merely close
+# --------------------------------------------------------------------------- #
+class TestDecisionsAreIdentical:
+    @pytest.mark.parametrize("seed", range(6))
+    def test_agrees_with_the_shipped_guard_over_a_fuzz(self, seed):
+        rng = np.random.default_rng(seed)
+        for _ in range(120):
+            m = int(rng.integers(2, 60))
+            J = int(rng.integers(1, 60))
+            design = _centred(rng, m, J, scale=rng.uniform(1e-4, 1e4))
+            if rng.random() < 0.3:                       # collinear columns
+                k = max(1, J // 3)
+                design[:, :k] = design[:, k:2 * k][:, :k] if 2 * k <= J \
+                    else design[:, :k]
+            if rng.random() < 0.2:                       # a near-null column
+                design[:, 0] *= 1e-12
+            ridge = float(rng.choice([0.0, 1e-16, 1e-12, 1e-6, 1e-2, 1.0, 1e3]))
+            assert (ridge, m, J, ridged_gram_reduction_is_safe(design, ridge)) == \
+                   (ridge, m, J, _shipped(design, ridge))
+
+    @pytest.mark.parametrize("ridge", [1e-16, 1e-13, 1e-10, 1e-8, 1e-6])
+    def test_agrees_where_the_bound_cannot_certify(self, ridge):
+        """A ridge too small to certify must fall through to the SVD and give
+        the SVD's answer -- including when that answer is ``False``.
+
+        The design is scaled so ``||X||_F^2`` exceeds ``ridge / tol^2`` for every
+        ridge listed, which is what puts the bound below the tolerance.
+        """
+        rng = np.random.default_rng(7)
+        design = _centred(rng, 50, 40, scale=1e4)
+        assert _bound(design, ridge) <= 1e-8, "fixture must not be certifiable"
+        assert ridged_gram_reduction_is_safe(design, ridge) == _shipped(design, ridge)
+
+    def test_agrees_on_a_rank_deficient_design(self):
+        rng = np.random.default_rng(8)
+        core = _centred(rng, 30, 10)
+        design = np.hstack([core, core])                 # every column duplicated
+        for ridge in (0.0, 1e-14, 1e-6, 1.0):
+            assert ridged_gram_reduction_is_safe(design, ridge) == \
+                   _shipped(design, ridge)
+
+
+# --------------------------------------------------------------------------- #
+# 3. the bound is one-sided -- it can only certify what is true
+# --------------------------------------------------------------------------- #
+class TestTheBoundIsSound:
+    @pytest.mark.parametrize("seed", range(4))
+    def test_bound_never_exceeds_the_true_ratio(self, seed):
+        rng = np.random.default_rng(100 + seed)
+        for _ in range(120):
+            m = int(rng.integers(2, 60))
+            J = int(rng.integers(1, 60))
+            design = _centred(rng, m, J, scale=rng.uniform(1e-3, 1e3))
+            ridge = float(rng.uniform(1e-14, 1e3))
+            true = _true_ratio(design, ridge)
+            assert true is not None
+            assert _bound(design, ridge) <= true + 1e-15
+
+    def test_certifying_implies_the_guard_says_yes(self):
+        """The only direction that matters: whenever the bound clears the
+        tolerance, the shipped guard's answer is ``True``."""
+        rng = np.random.default_rng(11)
+        certified = 0
+        for _ in range(300):
+            m = int(rng.integers(2, 50))
+            J = int(rng.integers(1, 50))
+            design = _centred(rng, m, J, scale=rng.uniform(1e-3, 1e3))
+            ridge = float(rng.uniform(1e-12, 1e3))
+            if _bound(design, ridge) > 1e-8:
+                certified += 1
+                assert _shipped(design, ridge) is True
+        assert certified > 50, "fixture should certify often enough to mean something"
+
+
+# --------------------------------------------------------------------------- #
+# 4. the work it removes
+# --------------------------------------------------------------------------- #
+class TestWorkRemoved:
+    def test_no_svd_when_the_certificate_fires(self, monkeypatch):
+        rng = np.random.default_rng(12)
+        design = _centred(rng, 96, 99)
+        ridge = 225.0
+        assert _bound(design, ridge) > 1e-8, "fixture must be certifiable"
+        spy = _SvdSpy(monkeypatch)
+        assert ridged_gram_reduction_is_safe(design, ridge) is True
+        assert spy.n == 0
+
+    def test_svd_still_runs_when_it_cannot_certify(self, monkeypatch):
+        rng = np.random.default_rng(13)
+        design = _centred(rng, 50, 40, scale=1e3)
+        spy = _SvdSpy(monkeypatch)
+        ridged_gram_reduction_is_safe(design, 1e-16)
+        assert spy.n == 1
+
+    def test_no_augmented_matrix_is_built_on_the_fast_path(self, monkeypatch):
+        """The shipped path allocates an ``(m + J, J)`` copy per call. The
+        certificate reads the design in place."""
+        rng = np.random.default_rng(14)
+        design = _centred(rng, 96, 99)
+        calls = {"vstack": 0, "eye": 0}
+        real_vstack, real_eye = np.vstack, np.eye
+        monkeypatch.setattr(np, "vstack",
+                            lambda *a, **k: (calls.__setitem__("vstack", calls["vstack"] + 1),
+                                             real_vstack(*a, **k))[1])
+        monkeypatch.setattr(np, "eye",
+                            lambda *a, **k: (calls.__setitem__("eye", calls["eye"] + 1),
+                                             real_eye(*a, **k))[1])
+        ridged_gram_reduction_is_safe(design, 225.0)
+        assert calls == {"vstack": 0, "eye": 0}
+
+
+# --------------------------------------------------------------------------- #
+# 5. edges
+# --------------------------------------------------------------------------- #
+class TestEdges:
+    def test_zero_ridge_is_the_shipped_guard_exactly(self):
+        rng = np.random.default_rng(15)
+        for m, J in [(40, 12), (8, 39), (5, 5), (30, 30)]:
+            design = _centred(rng, m, J)
+            assert ridged_gram_reduction_is_safe(design, 0.0) == \
+                   gram_reduction_is_safe(design)
+
+    def test_single_column(self):
+        rng = np.random.default_rng(16)
+        design = _centred(rng, 20, 1)
+        for ridge in (0.0, 1.0):
+            assert ridged_gram_reduction_is_safe(design, ridge) == \
+                   _shipped(design, ridge)
+
+    def test_wide_design_with_ridge_is_still_decidable(self):
+        """More columns than rows: the un-augmented design is rank deficient,
+        and the ridge is the only thing separating the columns -- exactly the
+        case the guard exists for."""
+        rng = np.random.default_rng(17)
+        design = _centred(rng, 10, 40)
+        assert ridged_gram_reduction_is_safe(design, 1.0) == _shipped(design, 1.0)
+        assert ridged_gram_reduction_is_safe(design, 1e-18) == \
+               _shipped(design, 1e-18)
+
+    def test_all_zero_design(self):
+        design = np.zeros((12, 5))
+        assert ridged_gram_reduction_is_safe(design, 1.0) is True   # r I is perfect
+        assert ridged_gram_reduction_is_safe(design, 0.0) is False
+
+    def test_extreme_scales(self):
+        rng = np.random.default_rng(18)
+        for scale in (1e-8, 1e8):
+            design = _centred(rng, 30, 20, scale=scale)
+            for ridge in (1e-6, 1.0, 1e6):
+                assert ridged_gram_reduction_is_safe(design, ridge) == \
+                       _shipped(design, ridge)
+
+    def test_non_finite_design_is_not_certified(self):
+        design = np.full((10, 4), np.nan)
+        assert ridged_gram_reduction_is_safe(design, 1.0) is False
+
+    def test_empty_design(self):
+        assert ridged_gram_reduction_is_safe(np.zeros((0, 3)), 1.0) is False
+        assert ridged_gram_reduction_is_safe(np.zeros((5, 0)), 1.0) is False
+
+
+# --------------------------------------------------------------------------- #
+# 6. failure -- a bad ridge is reported, not absorbed
+# --------------------------------------------------------------------------- #
+class TestFailures:
+    @pytest.mark.parametrize("bad", [-1.0, -1e-12])
+    def test_negative_ridge_raises(self, bad):
+        rng = np.random.default_rng(19)
+        with pytest.raises(ValueError, match="ridge"):
+            ridged_gram_reduction_is_safe(_centred(rng, 20, 5), bad)
+
+    def test_non_finite_ridge_raises(self):
+        rng = np.random.default_rng(20)
+        for bad in (np.nan, np.inf):
+            with pytest.raises(ValueError, match="ridge"):
+                ridged_gram_reduction_is_safe(_centred(rng, 20, 5), bad)
+
+    def test_non_2d_design_raises(self):
+        with pytest.raises(ValueError, match="2-D"):
+            ridged_gram_reduction_is_safe(np.zeros(10), 1.0)

--- a/mlsynth/tests/test_ridged_gram_guard.py
+++ b/mlsynth/tests/test_ridged_gram_guard.py
@@ -24,7 +24,7 @@ ratio of 7.43e-2, tight to three percent, and both clear the 1e-8 tolerance by
 six orders of magnitude.
 
 The time-weight program carries no ridge, so ``lambda_min >= 0`` is vacuous and
-it keeps paying for its SVD. That is recorded here rather than papered over.
+it keeps paying for its SVD, which is asserted here so the limit is visible.
 """
 
 import numpy as np

--- a/mlsynth/tests/test_sdid_placebo_guard_cost.py
+++ b/mlsynth/tests/test_sdid_placebo_guard_cost.py
@@ -1,0 +1,168 @@
+"""What the guard costs a placebo fit, asserted rather than left to a profiler.
+
+A default ``vce="placebo"`` fit poses 1000 simplex programs and asked
+``gram_reduction_is_safe`` about every one of them, each answer a full singular
+spectrum. On a 101x120 panel all 1000 came back ``True``, decided by a ratio
+that clears the 1e-8 tolerance by four to seven orders of magnitude.
+
+The cause was not that the guard is wrong. It is that nothing anywhere said a
+guard must cost less than the solve it protects, so the cost was free to grow
+past it: 4.25 s of a 16.6 s three-fit profile, against the batched solver's own
+4.33 s. These tests write that contract down.
+
+Two families, and only one of them can be certified:
+
+* the unit-weight program is ridge augmented, so ``lambda_min >= r`` gives a
+  free lower bound on its conditioning and its SVD goes away entirely;
+* the time-weight program carries no ridge, so the same bound is vacuous and it
+  keeps paying. Asserted here as a fact about the fix's reach, so that half is
+  visible rather than assumed away.
+
+The binding assertions are counts, not clocks -- wall time carries enough
+run-to-run noise at these sizes to hide a regression this size.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SDID
+from mlsynth.utils.bilevel import minnorm
+from mlsynth.utils.sdid_helpers import weights as sdid_weights
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _panel(n_donors=24, n_periods=20, n_pre=14, effect=-2.0, seed=5):
+    """Small enough to fit repeatedly, wide enough that both programs run."""
+    rng = np.random.default_rng(seed)
+    n_units = n_donors + 1
+    factors = np.cumsum(rng.standard_normal((n_periods, 3)) * 0.3, axis=0)
+    loadings = rng.uniform(0.2, 1.2, (n_units, 3))
+    outcome = (loadings @ factors.T
+               + rng.standard_normal((n_units, n_periods)) * 0.4 + 10.0)
+    treat = np.zeros((n_units, n_periods), dtype=int)
+    treat[0, n_pre:] = 1
+    outcome[0, n_pre:] += effect
+    return pd.DataFrame(
+        [{"id": f"u{i:03d}", "time": t + 1, "y": outcome[i, t], "d": treat[i, t]}
+         for i in range(n_units) for t in range(n_periods)]
+    )
+
+
+def _fit(df, draws=40, **overrides):
+    config = {"df": df, "outcome": "y", "treat": "d", "unitid": "id",
+              "time": "time", "display_graphs": False, "vce": "placebo",
+              "B": draws}
+    config.update(overrides)
+    return SDID(config).fit()
+
+
+class _SvdSpy:
+    def __init__(self, monkeypatch):
+        self.shapes = []
+        real = np.linalg.svd
+
+        def counting(a, *args, **kwargs):
+            self.shapes.append(np.asarray(a).shape)
+            return real(a, *args, **kwargs)
+
+        monkeypatch.setattr(np.linalg, "svd", counting)
+
+    def __len__(self):
+        return len(self.shapes)
+
+
+def _force_slow_guard(monkeypatch):
+    """Restore the pre-change behaviour: every problem gets its own spectrum."""
+    monkeypatch.setattr(
+        sdid_weights, "ridged_gram_reduction_is_safe",
+        lambda design, ridge, tol=1e-8: minnorm.gram_reduction_is_safe(
+            np.vstack([design, np.sqrt(ridge) * np.eye(design.shape[1])])
+            if ridge > 0.0 else design, tol))
+
+
+# --------------------------------------------------------------------------- #
+# 1. smoke
+# --------------------------------------------------------------------------- #
+class TestSmoke:
+    def test_placebo_fit_runs(self):
+        result = _fit(_panel())
+        assert np.isfinite(result.effects.att)
+        assert np.isfinite(result.inference.standard_error)
+
+
+# --------------------------------------------------------------------------- #
+# 2. the numbers do not move
+# --------------------------------------------------------------------------- #
+class TestAnswerUnchanged:
+    def test_att_and_standard_error_identical(self, monkeypatch):
+        df = _panel()
+        fast = _fit(df)
+        _force_slow_guard(monkeypatch)
+        slow = _fit(df)
+        assert fast.effects.att == pytest.approx(slow.effects.att, rel=0, abs=1e-12)
+        assert (fast.inference.standard_error
+                == pytest.approx(slow.inference.standard_error, rel=0, abs=1e-12))
+
+    def test_weights_identical(self, monkeypatch):
+        df = _panel()
+        fast = _fit(df)
+        _force_slow_guard(monkeypatch)
+        slow = _fit(df)
+        for name in ("donor_weights", "time_weights", "unit_weights"):
+            got, want = getattr(fast.weights, name), getattr(slow.weights, name)
+            if want is None:
+                assert got is None
+                continue
+            assert set(got) == set(want)
+            np.testing.assert_allclose(
+                [got[k] for k in want], [want[k] for k in want], rtol=0, atol=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# 3. the cost contract
+# --------------------------------------------------------------------------- #
+class TestCostContract:
+    def test_the_ridged_family_stops_paying_for_a_spectrum(self, monkeypatch):
+        """The unit-weight program is ridge augmented, so its conditioning is
+        bounded below for free and its SVD goes away."""
+        df = _panel()
+        spy_fast = _SvdSpy(monkeypatch)
+        _fit(df)
+        fast = len(spy_fast)
+
+        monkeypatch.undo()
+        _force_slow_guard(monkeypatch)
+        spy_slow = _SvdSpy(monkeypatch)
+        _fit(df)
+        slow = len(spy_slow)
+
+        assert slow > fast, "the certificate removed no work"
+        assert fast <= slow * 0.6, (
+            f"expected the ridged half of the guard's SVDs to go; {fast} of {slow}")
+
+    def test_a_guard_costs_less_than_what_it_guards(self, monkeypatch):
+        """The invariant nobody had written down. Counted in SVDs per placebo
+        draw, not in seconds."""
+        draws = 40
+        spy = _SvdSpy(monkeypatch)
+        _fit(_panel(), draws=draws)
+        assert len(spy) <= draws, (
+            f"{len(spy)} spectra for {draws} placebo draws -- the guard is "
+            "again costing more than one factorisation per draw")
+
+
+# --------------------------------------------------------------------------- #
+# 4. the half that is not fixed, recorded
+# --------------------------------------------------------------------------- #
+class TestReachOfTheFix:
+    def test_the_unridged_program_still_factorises(self, monkeypatch):
+        """``lambda_min >= r`` is vacuous at ``r = 0``, so the time-weight
+        program keeps its SVD. Asserted so the limit of the fix is visible."""
+        spy = _SvdSpy(monkeypatch)
+        _fit(_panel(), draws=12)
+        assert len(spy) > 0, (
+            "no spectra at all would mean the unridged family found a "
+            "certificate this test does not know about")

--- a/mlsynth/tests/test_sdid_placebo_guard_cost.py
+++ b/mlsynth/tests/test_sdid_placebo_guard_cost.py
@@ -1,4 +1,5 @@
-"""What the guard costs a placebo fit, asserted rather than left to a profiler.
+"""What the guard costs a placebo fit, asserted in the suite and not left to a
+profiler.
 
 A default ``vce="placebo"`` fit poses 1000 simplex programs and asked
 ``gram_reduction_is_safe`` about every one of them, each answer a full singular
@@ -16,7 +17,7 @@ Two families, and only one of them can be certified:
   free lower bound on its conditioning and its SVD goes away entirely;
 * the time-weight program carries no ridge, so the same bound is vacuous and it
   keeps paying. Asserted here as a fact about the fix's reach, so that half is
-  visible rather than assumed away.
+  visible.
 
 The binding assertions are counts, not clocks -- wall time carries enough
 run-to-run noise at these sizes to hide a regression this size.

--- a/mlsynth/utils/bilevel/minnorm.py
+++ b/mlsynth/utils/bilevel/minnorm.py
@@ -123,7 +123,7 @@ def ridged_gram_reduction_is_safe(
 
     A caller that folds an L2 penalty into a least-squares program by stacking
     ``sqrt(ridge) * I`` beneath the design is asking the guard about a matrix it
-    can describe rather than one it has to look at. The augmented Gram is
+    can describe, not one it has to look at. The augmented Gram is
     ``design' design + ridge I``, so
 
     * ``lambda_min >= ridge``, since ``design' design`` is positive

--- a/mlsynth/utils/bilevel/minnorm.py
+++ b/mlsynth/utils/bilevel/minnorm.py
@@ -115,6 +115,75 @@ def gram_reduction_is_safe(B: np.ndarray, tol: float = 1e-8) -> bool:
     return bool(sv[-1] / sv[0] > tol)
 
 
+def ridged_gram_reduction_is_safe(
+    design: np.ndarray, ridge: float, tol: float = 1e-8
+) -> bool:
+    """:func:`gram_reduction_is_safe` for ``[design; sqrt(ridge) I]``, usually
+    without factorising it.
+
+    A caller that folds an L2 penalty into a least-squares program by stacking
+    ``sqrt(ridge) * I`` beneath the design is asking the guard about a matrix it
+    can describe rather than one it has to look at. The augmented Gram is
+    ``design' design + ridge I``, so
+
+    * ``lambda_min >= ridge``, since ``design' design`` is positive
+      semidefinite, and
+    * ``lambda_max <= ||design||_F^2 + ridge``, since the trace bounds the
+      largest eigenvalue,
+
+    giving ``sv_min / sv_max >= sqrt(ridge / (||design||_F^2 + ridge))``. That
+    costs one Frobenius norm and settles the question whenever it clears
+    ``tol``.
+
+    The bound is one-sided in the safe direction. Clearing it *proves* the
+    answer is ``True``; failing to clear it proves nothing, so the spectrum is
+    computed as before. The decisions are therefore identical to asking
+    :func:`gram_reduction_is_safe` about the augmented matrix -- identical by
+    construction, not by choosing a tolerance that happens to agree.
+
+    Where it pays: SDID's placebo loop poses 1000 of these per fit at ``B=500``,
+    and on a 101x120 panel the ridged half of them had a true ratio of 7.43e-2
+    against a bound of 7.21e-2 -- tight to three percent, and six orders of
+    magnitude clear of ``tol``. The unridged half gets no help, because at
+    ``ridge = 0`` the lower bound is vacuous and the design's conditioning
+    genuinely has to be measured.
+
+    Parameters
+    ----------
+    design : np.ndarray, shape (m, J)
+        The design *before* augmentation, centred if the caller centres it.
+    ridge : float
+        Non-negative penalty coefficient. ``0`` defers to
+        :func:`gram_reduction_is_safe` on ``design`` itself.
+    tol : float
+        Smallest acceptable ratio of the smallest to the largest singular value.
+
+    Returns
+    -------
+    bool
+    """
+    design = np.asarray(design, dtype=float)
+    if design.ndim != 2:
+        raise ValueError(
+            f"design must be a 2-D (m, J) matrix; got shape {design.shape}.")
+    ridge = float(ridge)
+    if not np.isfinite(ridge) or ridge < 0.0:
+        raise ValueError(f"ridge must be finite and non-negative; got {ridge!r}.")
+    if ridge == 0.0:
+        return gram_reduction_is_safe(design, tol)
+    if min(design.shape) == 0:
+        return False
+    flat = design.ravel()
+    frob_sq = float(flat @ flat)
+    if not np.isfinite(frob_sq):
+        return False
+    if np.sqrt(ridge / (frob_sq + ridge)) > tol:
+        return True
+    J = design.shape[1]
+    return gram_reduction_is_safe(
+        np.vstack([design, np.sqrt(ridge) * np.eye(J)]), tol)
+
+
 def simplex_point_is_optimal(
     B: np.ndarray, A: np.ndarray, w: np.ndarray, tol: float = 1e-7
 ) -> bool:

--- a/mlsynth/utils/sdid_helpers/weights.py
+++ b/mlsynth/utils/sdid_helpers/weights.py
@@ -54,7 +54,7 @@ from typing import Dict, List, Optional, Sequence, Tuple
 
 from mlsynth.exceptions import MlsynthDataError, MlsynthConfigError
 from mlsynth.utils.bilevel.active_set import solve_simplex_qp
-from mlsynth.utils.bilevel.minnorm import gram_reduction_is_safe
+from mlsynth.utils.bilevel.minnorm import ridged_gram_reduction_is_safe
 
 
 def _solve_intercept_simplex(
@@ -129,11 +129,18 @@ def solve_intercept_simplex_many(
     Notes
     -----
     A group is batched only where
-    :func:`~mlsynth.utils.bilevel.minnorm.gram_reduction_is_safe` passes on its
-    centred design, and solved one at a time otherwise. Forming the Gram squares
-    the design's condition number, and on a rank-deficient design the optimum is
-    a face whose points the two solvers pick differently -- the same fit, other
-    weights. The guard is on the design, not on the caller.
+    :func:`~mlsynth.utils.bilevel.minnorm.ridged_gram_reduction_is_safe` passes
+    on its centred design, and solved one at a time otherwise. Forming the Gram
+    squares the design's condition number, and on a rank-deficient design the
+    optimum is a face whose points the two solvers pick differently -- the same
+    fit, other weights. The guard is on the design, not on the caller.
+
+    That guard was the fit's largest single cost before it was asked this way:
+    1000 problems per fit at ``B=500``, each answered with a full singular
+    spectrum, all 1000 answering yes. The unit-weight program carries a ridge,
+    and a ridge bounds the augmented Gram's smallest eigenvalue from below for
+    free, so its half of those spectra is now never computed. The time-weight
+    program carries none and still pays.
 
     Which of SDID's two programs clears that guard depends on the panel's shape.
     The unit-weight design is ``T0`` by ``N0`` and carries the ridge, so it
@@ -172,10 +179,12 @@ def solve_intercept_simplex_many(
         # The safety test is on the design the solve actually sees, ridge block
         # included: a ridge large enough to condition the problem is what makes
         # an otherwise rank-deficient design safe, and one too small to do that
-        # is precisely the case the guard exists to catch.
-        augmented = (np.vstack([design_c, np.sqrt(ridge) * np.eye(J)])
-                     if ridge > 0.0 else design_c)
-        if J == 1 or not gram_reduction_is_safe(augmented):
+        # is precisely the case the guard exists to catch. Asked through
+        # ``ridged_gram_reduction_is_safe``, which describes that block instead
+        # of building and factorising it wherever the ridge alone settles the
+        # question -- the same decision, and for the unit-weight family no
+        # spectrum at all.
+        if J == 1 or not ridged_gram_reduction_is_safe(design_c, ridge):
             shape = design_c.shape
             solved = _solve_intercept_simplex(
                 design, target, ridge, warm_start=last_fallback.get(shape)

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -780,3 +780,33 @@ timeout = 600.0
   find = "SUPPORT_TOL = 1e-9"
   replace = "SUPPORT_TOL = 1e-3"
   models = "the seed's support read at a coarser threshold than the one solve_simplex_qp pins variables at, so the two disagree about what the seed says and the loop stops on a support the active set will not adopt"
+
+[[target]]
+name = "ridged-gram-guard"
+module-path = "mlsynth/utils/bilevel/minnorm.py"
+test-command = "python -m pytest mlsynth/tests/test_ridged_gram_guard.py mlsynth/tests/test_sdid_placebo_guard_cost.py -q -p no:cacheprovider"
+timeout = 600.0
+
+  [[target.mutant]]
+  id = "certificate-bounds-the-spectrum-by-a-norm-that-does-not-bound-it"
+  find = "    if np.sqrt(ridge / (frob_sq + ridge)) > tol:"
+  replace = "    if np.sqrt(ridge / (np.sqrt(frob_sq) + ridge)) > tol:"
+  models = "the largest eigenvalue bounded by the Frobenius norm instead of by its square. The bound is then too large on any design whose norm exceeds one, so it certifies designs whose true ratio is below the tolerance -- the one direction a guard must never fail in, and invisible to anything that only checks the certified cases were fine"
+
+  [[target.mutant]]
+  id = "certificate-fires-on-a-bound-it-did-not-clear"
+  find = "    if np.sqrt(ridge / (frob_sq + ridge)) > tol:\n        return True"
+  replace = "    if np.sqrt(ridge / (frob_sq + ridge)) > tol * tol:\n        return True"
+  models = "the bound compared against the square of the tolerance, so it certifies eight orders of magnitude too eagerly. Every design mlsynth ships still passes, because they clear the real tolerance by four to seven orders -- so only a design built near the threshold can see it"
+
+  [[target.mutant]]
+  id = "zero-ridge-takes-the-certificate-instead-of-the-spectrum"
+  find = "    if ridge == 0.0:\n        return gram_reduction_is_safe(design, tol)"
+  replace = "    if ridge < 0.0:\n        return gram_reduction_is_safe(design, tol)"
+  models = "an unridged design falling through to a bound that is vacuous at ridge zero. sqrt(0 / ||X||^2) is zero, never clears the tolerance, and the spectrum runs anyway -- so the answer stays right and only the wide and empty shape tests, which the shipped guard applies first, are skipped"
+
+  [[target.mutant]]
+  id = "non-finite-design-certified-instead-of-refused"
+  find = "    if not np.isfinite(frob_sq):\n        return False"
+  replace = "    if not np.isfinite(frob_sq):\n        return True"
+  models = "a design carrying nan or inf declared safe. The batched Gram solver then runs on it and returns weights that are nan without anything having refused the input"


### PR DESCRIPTION
## Related Links

- Closes #449 — the issue carries the full five-why ladder, which is the audit record for this change
- `mlsynth/utils/bilevel/minnorm.py`, `mlsynth/utils/sdid_helpers/weights.py`
- Follows #450, which fixed the other half of the SDID profile

## What

- Added `minnorm.ridged_gram_reduction_is_safe`: the Gram-reduction guard for a design about to be augmented with `sqrt(ridge) * I`, answered without building or factorising that matrix wherever the ridge settles it
- Routed SDID's placebo loop through it, which also drops the per-draw `vstack` and `eye` allocation
- Two test files, four semantic mutants in a new catalogue target

## Why

A default `vce="placebo"` fit posed 1000 simplex programs and asked
`gram_reduction_is_safe` about every one, each answer a full singular spectrum.
On a 101x120 panel all 1000 came back `True`, decided by a ratio that clears the
1e-8 tolerance by four to seven orders of magnitude:

```
calls in one vce='placebo' fit: 1000
  shape   (99, 96)  n=500  True 500  False 0  ratio min 1.706e-04 max 7.363e-04
  shape  (195, 99)  n=500  True 500  False 0  ratio min 7.413e-02 max 7.490e-02
```

The guard is not wrong. What was missing is that nothing said a guard must cost
less than the solve it protects, so its cost was free to grow past it: 4.25 s of
a 16.6 s three-fit profile, against the batched solver's own 4.33 s.

## How

Two routes were measured and rejected before this one.

Computing the same predicate more cheaply is a dead end. QR-then-SVD is
*slower* than the direct SVD (0.52–0.87x across the shapes involved) because
numpy's `gesdd` already QR-preconditions internally, and `eigh` on the Gram is
2x faster but squares the condition number — the exact failure the guard exists
to prevent.

A family-level certificate is only half sound. Centring commutes with column
subsetting, so Cauchy interlacing lets one factorisation of a base design
certify every column subset of it. Instrumenting the real problems, the
unit-weight family shares 98 of 99 columns between draws and qualifies — but the
time-weight family shares 98 of 99 *rows*, and dropping rows can shrink
`sv_min`, so the certificate would be unsound there.

What shipped needs no family structure at all. A ridge-augmented design
certifies itself: the Gram is `X'X + rI`, so `lambda_min >= r` and
`lambda_max <= ||X||_F^2 + r`, giving

```
sv_min / sv_max  >=  sqrt(r / (||X||_F^2 + r))
```

from one Frobenius norm. On the real family that bound is 7.21e-2 against a true
ratio of 7.43e-2 — tight to three percent.

## Verification

- Path: not applicable — a speed change to a shared guard, whose correctness
  criterion is that no decision and no number moves.
- Decisions are identical *by construction*, not by tuning. The bound is
  one-sided: clearing it proves the answer is `True`, failing to clear it proves
  nothing and the spectrum runs as before. Pinned by a fuzz over 720
  design/ridge combinations in `TestDecisionsAreIdentical`, including
  rank-deficient designs, near-null columns, and ridges from 1e-16 to 1e3.
- Soundness of the bound pinned separately in `TestTheBoundIsSound` — over 480
  draws the bound never exceeds the true ratio, and every design it certifies is
  one the shipped guard passes.
- SDID placebo ATT, standard error and all three weight vectors identical at
  `atol=1e-12` against a monkeypatched pre-change guard.
- Cost contract asserted in SVDs per placebo draw, not in seconds — wall time
  carries enough run-to-run noise at these sizes to hide a regression this size.
- Mutants: four, killed 4/4 on the first pass — a Frobenius norm that does not
  bound the spectrum, a comparison against the squared tolerance, an unridged
  design taking the vacuous bound, and a non-finite design certified instead of
  refused.

Measured on a 101x120 panel, single-threaded:

| | before | after |
|---|---:|---:|
| guard SVDs per fit | 1000 | 500 |
| `vce="placebo"` fit | 4.28 s | 3.64 s |
| ATT / standard error | — | unchanged, `0.0e+00` |

Suites: 33 + 6 new tests green; `-k "sdid or simplex or bilevel or minnorm or
mlsc or gram"` 1317 passed, 2 skipped.

## Scope checks

Shared-helper change, so none of the four blocks applies. Own branch, carrying
only this work.

## Designs

No visual output changes.

## Test Steps

- [x] `pytest mlsynth/tests/test_ridged_gram_guard.py mlsynth/tests/test_sdid_placebo_guard_cost.py` — 39 passed
- [x] `pytest -k "sdid or simplex or bilevel or minnorm or mlsc or gram"` — 1317 passed, 2 skipped
- [x] `python tools/mutation/run_mutants.py --target ridged-gram-guard` — 4/4 killed
- [ ] `pytest mlsynth/tests/` — full suite runs in CI across 3.10 / 3.12 / 3.13

## Other Notes

- Half the guard's cost remains. The time-weight program carries no ridge, so
  `lambda_min >= 0` is vacuous and its 500 spectra still run. Any Gram-based
  bound there reintroduces the conditioning hazard the guard exists for.
  `TestReachOfTheFix` asserts that limit so it stays visible rather than being
  mistaken for done.
- With this landed, `solve_simplex_minnorm_batch`'s own 4.33 s is the dominant
  remaining cost in a placebo fit. Recorded in #449 as a second-order finding
  and not yet diagnosed.
- Separately, a shape sweep against `coresynth` puts SDID's crossover near 100
  donors: mlsynth is 1.45–1.67x ahead at 200 donors and behind below ~100, where
  78 percent of a fit is ingestion and result assembly instead of solving. That
  is a different fault from this one and from #447, and is being root-caused on
  its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_