### PR TITLE
Refuse a row that carries no unit or no time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,24 @@ now returns and the back-compat guarantee.
   reuse the same calibration.
 
 ### Changed
+- A row whose unit or time key is missing is refused, at three points:
+  `BaseEstimatorConfig`, `datautils.balance`, and `datautils._fast_pivot`.
+  `balance` counted with `nunique` and `groupby`, both of which skip missing
+  values, so a panel whose blanks were symmetric across units satisfied every
+  check it made; `_wide_pivot` then pivoted the same frame and pandas kept the
+  blank as a level. The two disagreed about what a key is, and the consequence
+  moved the estimand: on a 3-unit, 4-period panel treated from period 3, rows
+  with a blank time key produced a fifth period sorted to the front and took
+  `pre_periods` from 2 to 3, with nothing raised. A blank unit key produced a
+  donor column named `nan`. `BaseMAREXConfig` has rejected these all along but
+  is referenced 14 times against `BaseEstimatorConfig`'s 150, and 38 modules
+  reach ingestion with neither a config nor `balance` in the call path, so the
+  refusal lives at all three. Scoped to the keys: a blank outcome still
+  constructs and still ingests, which is where this stays narrower than the
+  MAREX contract. Breaking for panels that previously passed with blank keys —
+  those results were computed against a shifted pre/post window.
+
+### Changed
 - `datautils.balance` answers from the panel's key codes instead of two hash
   passes over the frame. Every estimator validates with `balance` and then reads
   with `dataprep`, and between them the `(unit, time)` key structure was

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -166,6 +166,26 @@ class BaseEstimatorConfig(BaseModel):
             raise MlsynthDataError(
                 f"Missing required columns in DataFrame 'df': {', '.join(sorted(list(missing_columns)))}"
             )
+
+        # A row without a unit or a time is not an observation. Ingestion refuses
+        # it as well, but catching it here names the fault before any pivot
+        # exists -- and this is the base 150 of the library's config references
+        # use, against 14 for ``BaseMAREXConfig``, which has had the check all
+        # along. Scoped to the keys: a blank outcome is a modelling question and
+        # the estimators that tolerate one keep doing so, which is where this
+        # stays narrower than the MAREX contract.
+        blank_keys = {
+            column: int(df[column].isna().sum())
+            for column in (unitid, time)
+            if df[column].isna().any()
+        }
+        if blank_keys:
+            details = ", ".join(f"{col}: {n}" for col, n in blank_keys.items())
+            raise MlsynthDataError(
+                f"Missing values found in the panel's key columns -> {details}. "
+                "Every observation must carry both a unit and a time period; "
+                "clean or drop these rows before passing the panel."
+            )
         return values
 
 # TSSCConfig has been relocated to mlsynth/utils/tssc_helpers/config.py

--- a/mlsynth/tests/test_balance_key_structure.py
+++ b/mlsynth/tests/test_balance_key_structure.py
@@ -60,6 +60,18 @@ def _balance_oracle(df, unit_id_column_name, time_period_column_name):
         )
 
 
+def _has_blank_key(df):
+    """Whether the frame carries a row with no unit or no time.
+
+    Such frames leave the differential's scope. The oracle is the implementation
+    as it stood before this rewrite, and #453 changed the verdict on them
+    deliberately -- from silently admitted to refused -- so asking whether the
+    two agree is the wrong question. ``test_missing_key_rejection.py`` asserts
+    the refusal directly instead.
+    """
+    return bool(df["id"].isna().any() or df["time"].isna().any())
+
+
 def _outcome(fn, df):
     """``None`` if it passes, else ``(type name, message)``."""
     try:
@@ -136,6 +148,9 @@ class TestDecisionsAreIdentical:
     @pytest.mark.parametrize("name", sorted(CORPUS))
     def test_matches_the_oracle_on_the_corpus(self, name):
         df = CORPUS[name]
+        if _has_blank_key(df):
+            pytest.skip("verdict changed deliberately by #453; asserted in "
+                        "test_missing_key_rejection.py")
         assert _outcome(balance, df) == _outcome(_balance_oracle, df), name
 
     @pytest.mark.parametrize("seed", range(8))
@@ -154,6 +169,8 @@ class TestDecisionsAreIdentical:
             elif damage == 3 and len(df):
                 df = df.copy()
                 df.loc[int(rng.integers(len(df))), "id"] = None
+            if _has_blank_key(df):
+                continue
             assert _outcome(balance, df) == _outcome(_balance_oracle, df)
 
     def test_an_unused_categorical_level_is_not_a_unit(self):

--- a/mlsynth/tests/test_balance_properties.py
+++ b/mlsynth/tests/test_balance_properties.py
@@ -60,6 +60,18 @@ def _balance_oracle(df, unit_id_column_name, time_period_column_name):
         )
 
 
+def _has_blank_key(df):
+    """Whether the frame carries a row with no unit or no time.
+
+    Those frames leave the differential's scope. The oracle is the
+    implementation as it stood before the key-code rewrite, and #453 changed the
+    verdict on them deliberately -- from silently admitted to refused -- so
+    agreement with the oracle is the wrong question to ask about them. They are
+    asserted directly in ``test_missing_key_rejection.py`` instead.
+    """
+    return bool(df["id"].isna().any() or df["time"].isna().any())
+
+
 def _outcome(fn, df):
     """``None`` if the frame is accepted, else ``(exception type, message)``."""
     try:
@@ -131,6 +143,7 @@ SETTINGS = settings(max_examples=250, deadline=None,
 @SETTINGS
 @given(df=_panel())
 def test_same_verdict_as_the_previous_implementation(df):
+    assume(not _has_blank_key(df))
     assert _outcome(balance, df) == _outcome(_balance_oracle, df)
 
 
@@ -189,44 +202,44 @@ def test_accepting_means_every_unit_carries_every_observed_period(df):
     """
     if _outcome(balance, df) is not None:
         return
+    assert not _has_blank_key(df), "an accepted frame carries no blank key"
     n_periods = df["time"].nunique()
     per_unit = df.dropna(subset=["id"]).groupby("id")["time"].nunique()
     assert set(per_unit.unique()) <= {n_periods}
 
 
-def test_a_panel_whose_periods_are_all_missing_is_accepted():
-    """A corner of the shipped contract, characterised rather than corrected.
+def test_a_panel_whose_periods_are_all_missing_is_refused():
+    """This corner was characterised first and corrected second, in that order.
 
     ``nunique`` excludes missing values on both sides of the comparison, so a
-    panel where every unit is missing the same period passes: with one unit and
-    times ``[1, NaN]`` there is one distinct period and the unit is observed in
-    one, so the check is satisfied. It is preserved here because 35 estimator
-    modules depend on this verdict, and changing which frames are admitted is a
-    behaviour change and not a speed one.
+    panel where every unit is missing the same period used to pass: one distinct
+    period, and each unit observed in one, so the check was satisfied. The pivot
+    disagreed and gave the blank a level named ``nan``, which added a period and
+    shifted ``pre_periods``. Refused since #453, on both the symmetric frame and
+    the asymmetric one that was already rejected for a different reason.
     """
-    accepted = pd.DataFrame({"id": ["a", "a", "b", "b"],
-                             "time": [1, None, 1, None], "y": 1.0})
-    assert balance(accepted, "id", "time") is None
+    symmetric = pd.DataFrame({"id": ["a", "a", "b", "b"],
+                              "time": [1, None, 1, None], "y": 1.0})
+    with pytest.raises(MlsynthDataError, match="Missing values"):
+        balance(symmetric, "id", "time")
 
-    # Asymmetric, so the counts disagree and it is rejected.
-    rejected = pd.DataFrame({"id": ["a", "a", "b", "b"],
-                             "time": [1, None, 1, 2], "y": 1.0})
-    with pytest.raises(MlsynthDataError,
-                       match="Not all units have observations"):
-        balance(rejected, "id", "time")
+    asymmetric = pd.DataFrame({"id": ["a", "a", "b", "b"],
+                               "time": [1, None, 1, 2], "y": 1.0})
+    with pytest.raises(MlsynthDataError, match="Missing values"):
+        balance(asymmetric, "id", "time")
 
 
-def test_a_row_whose_unit_key_is_missing_is_invisible_to_the_check():
+def test_a_row_whose_unit_key_is_missing_is_refused():
     """The same corner on the other axis, and the sharper one.
 
-    ``groupby`` forms no group for a missing unit key, so rows carrying one are
-    not counted, not compared, and not reported -- the frame is accepted and the
-    row survives into ``dataprep``. Characterised, not corrected: admitting
-    fewer frames is a behaviour change across 35 estimator modules and belongs
-    with the validator's semantics, not with its cost.
+    ``groupby`` formed no group for a missing unit key, so such rows were not
+    counted, not compared and not reported -- and the row then reached the
+    pivot, which turned it into a donor column named ``nan``. Refused since
+    #453.
     """
     df = pd.DataFrame({"id": ["a", None], "time": [1, 1], "y": 1.0})
-    assert balance(df, "id", "time") is None
+    with pytest.raises(MlsynthDataError, match="Missing values"):
+        balance(df, "id", "time")
 
 
 @SETTINGS

--- a/mlsynth/tests/test_datautils.py
+++ b/mlsynth/tests/test_datautils.py
@@ -558,12 +558,15 @@ def test_wide_pivot_duplicate_keys_fall_back_and_raise():
         _wide_pivot(df, index="time", columns="unit", values="y")
 
 
-def test_wide_pivot_matches_on_nan_key():
+def test_wide_pivot_refuses_a_nan_key():
+    """A missing key used to send the pivot down the pandas fallback, which
+    kept the blank as a level named ``nan`` -- a phantom donor column, or a
+    phantom period that shifted ``pre_periods``. It is an error now, raised off
+    the codes the fast path had already computed to choose its route."""
     df = _long(5, 4, seed=9)
-    df.loc[0, "unit"] = np.nan                                # NaN key -> fall back
-    got = _wide_pivot(df, index="time", columns="unit", values="y")
-    exp = df.pivot(index="time", columns="unit", values="y")
-    assert got.equals(exp)
+    df.loc[0, "unit"] = np.nan
+    with pytest.raises(MlsynthDataError, match="Missing values"):
+        _wide_pivot(df, index="time", columns="unit", values="y")
 
 
 def test_wide_pivot_empty_frame_falls_back():

--- a/mlsynth/tests/test_missing_key_rejection.py
+++ b/mlsynth/tests/test_missing_key_rejection.py
@@ -233,3 +233,59 @@ class TestCost:
         _prep(_panel(10, 10))
         assert calls["isna"] <= 2, (
             f"{calls['isna']} isna passes -- the check should read the codes")
+
+
+# --------------------------------------------------------------------------- #
+# 7. the config layer -- the earliest refusal, with the best message
+# --------------------------------------------------------------------------- #
+class TestConfigRefuses:
+    """``BaseMAREXConfig`` has rejected missing keys all along, but it is
+    referenced 14 times; ``BaseEstimatorConfig`` is referenced 150 and checked
+    only that the frame was non-empty. Catching it at construction names the
+    problem before any pivot exists, which is a better error than one raised
+    from inside ingestion. Ingestion still refuses independently -- 38 modules
+    reach it without a config in the call path at all.
+    """
+
+    @staticmethod
+    def _config(df):
+        from mlsynth.config_models import BaseEstimatorConfig
+        return BaseEstimatorConfig(df=df, outcome="y", treat="d", unitid="id",
+                                   time="time")
+
+    def test_clean_panel_still_constructs(self):
+        assert self._config(_panel()) is not None
+
+    def test_missing_time_key_is_refused(self):
+        df = _panel()
+        df.loc[1, "time"] = None
+        with pytest.raises(MlsynthDataError, match="Missing values"):
+            self._config(df)
+
+    def test_missing_unit_key_is_refused(self):
+        df = _panel()
+        df.loc[1, "id"] = None
+        with pytest.raises(MlsynthDataError, match="Missing values"):
+            self._config(df)
+
+    def test_the_message_names_the_column(self):
+        df = _panel()
+        df.loc[1, "time"] = None
+        with pytest.raises(MlsynthDataError) as excinfo:
+            self._config(df)
+        assert "time" in str(excinfo.value)
+
+    def test_a_missing_outcome_still_constructs(self):
+        """Scoped to the keys. A blank outcome is a modelling question and the
+        estimators that tolerate it keep doing so -- which is where this differs
+        from ``BaseMAREXConfig``, whose stricter contract covers the outcome
+        column too.
+        """
+        df = _panel()
+        df.loc[1, "y"] = np.nan
+        assert self._config(df) is not None
+
+    def test_a_missing_treatment_indicator_still_constructs(self):
+        df = _panel()
+        df.loc[1, "d"] = np.nan
+        assert self._config(df) is not None

--- a/mlsynth/tests/test_missing_key_rejection.py
+++ b/mlsynth/tests/test_missing_key_rejection.py
@@ -1,0 +1,235 @@
+"""A row without a unit or a time is not an observation, and is refused.
+
+``balance`` counted with ``nunique`` and ``groupby``, both of which skip missing
+values, so a panel whose blank keys were symmetric across units satisfied every
+check it made. ``_wide_pivot`` then pivoted the same frame and pandas kept the
+blank as a level. The two disagreed about what a key is: the validator read a
+missing key as *not an observation*, the pivot read it as *a level named nan*.
+
+The consequence was silent and it moved the estimand. On a 3-unit, 4-period
+panel treated from period 3, adding rows with a blank time key produced a fifth
+period sorted to the front and took ``pre_periods`` from 2 to 3 -- the pre/post
+split every estimator works from, moved by one, with nothing raised. A blank
+unit key produced a fourth donor column named ``nan`` carrying only missing
+observations.
+
+Both ends now refuse it, and they have to be both ends: 38 modules reach
+``dataprep`` without ``balance`` anywhere in them, because the estimator class
+calls the validator and its setup helper calls ingestion. Ingestion cannot
+assume its caller validated.
+
+The refusal costs nothing. ``_fast_pivot`` already computed
+``(codes < 0).any()`` to decide whether it could take its fast path, and threw
+that answer away by deferring to ``df.pivot`` -- the very call that manufactures
+the level. This turns a discarded observation into the error it always was.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthDataError
+from mlsynth.utils.datautils import _wide_pivot, balance, dataprep
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _panel(n_units=3, n_periods=4, treated_from=3):
+    rows = [{"id": u, "time": t, "y": float(ord(u) + t),
+             "d": int(u == "a" and t >= treated_from)}
+            for u in [chr(97 + i) for i in range(n_units)]
+            for t in range(1, n_periods + 1)]
+    return pd.DataFrame(rows)
+
+
+def _prep(df):
+    return dataprep(df, unit_id_column_name="id", time_period_column_name="time",
+                    outcome_column_name="y", treatment_indicator_column_name="d")
+
+
+# --------------------------------------------------------------------------- #
+# 1. smoke -- a clean panel is untouched
+# --------------------------------------------------------------------------- #
+class TestSmoke:
+    def test_clean_panel_still_validates(self):
+        assert balance(_panel(), "id", "time") is None
+
+    def test_clean_panel_still_ingests(self):
+        prep = _prep(_panel())
+        assert prep["Ywide"].shape == (4, 3)
+        assert prep["pre_periods"] == 2
+        assert list(prep["Ywide"].columns) == ["a", "b", "c"]
+
+
+# --------------------------------------------------------------------------- #
+# 2. the defect, at the validator
+# --------------------------------------------------------------------------- #
+class TestBalanceRefuses:
+    def test_missing_time_key_symmetric_across_units(self):
+        """The frame that used to pass: every unit missing the same period, so
+        the counts agreed on both sides of the comparison."""
+        df = pd.DataFrame({"id": ["a", "a", "b", "b"],
+                           "time": [1, None, 1, None], "y": 1.0})
+        with pytest.raises(MlsynthDataError, match="Missing values"):
+            balance(df, "id", "time")
+
+    def test_missing_unit_key(self):
+        """A row with no unit formed no group, so it was neither counted nor
+        reported."""
+        df = pd.DataFrame({"id": ["a", None], "time": [1, 1], "y": 1.0})
+        with pytest.raises(MlsynthDataError, match="Missing values"):
+            balance(df, "id", "time")
+
+    def test_the_message_names_the_columns_and_counts(self):
+        df = pd.DataFrame({"id": ["a", None, None], "time": [1, None, 3],
+                           "y": 1.0})
+        with pytest.raises(MlsynthDataError) as excinfo:
+            balance(df, "id", "time")
+        message = str(excinfo.value)
+        assert "id" in message and "time" in message
+        assert "2" in message and "1" in message
+
+    def test_missing_keys_are_reported_before_duplicates(self):
+        """A row that cannot be identified is the more fundamental fault, so it
+        is named first even when the frame is also duplicated."""
+        df = pd.DataFrame({"id": ["a", "a", None], "time": [1, 1, 2], "y": 1.0})
+        with pytest.raises(MlsynthDataError, match="Missing values"):
+            balance(df, "id", "time")
+
+    @pytest.mark.parametrize("blank", [None, np.nan, pd.NaT])
+    def test_every_spelling_of_missing(self, blank):
+        df = pd.DataFrame({"id": ["a", "b"], "time": [1, blank], "y": 1.0})
+        with pytest.raises(MlsynthDataError, match="Missing values"):
+            balance(df, "id", "time")
+
+
+# --------------------------------------------------------------------------- #
+# 3. the defect, at ingestion -- reached by 38 modules that never call balance
+# --------------------------------------------------------------------------- #
+class TestDataprepRefuses:
+    def test_missing_time_key_no_longer_invents_a_period(self):
+        df = _panel()
+        for unit in ("a", "b", "c"):
+            df.loc[len(df)] = {"id": unit, "time": None, "y": 999.0, "d": 0}
+        with pytest.raises(MlsynthDataError, match="Missing values"):
+            _prep(df)
+
+    def test_missing_unit_key_no_longer_invents_a_donor(self):
+        df = _panel()
+        df.loc[len(df)] = {"id": None, "time": 2, "y": 999.0, "d": 0}
+        with pytest.raises(MlsynthDataError, match="Missing values"):
+            _prep(df)
+
+    def test_pivot_helper_refuses_directly(self):
+        """The check sits where the codes are computed, so any caller of the
+        pivot is covered and not only ``dataprep``."""
+        df = pd.DataFrame({"id": ["a", "b"], "time": [1, None], "y": 1.0})
+        with pytest.raises(MlsynthDataError, match="Missing values"):
+            _wide_pivot(df, index="time", columns="id", values="y")
+
+    def test_missing_value_in_a_non_key_column_is_still_allowed(self):
+        """Only the keys identify an observation. A missing outcome is a
+        modelling question, not an ingestion one, and is left alone."""
+        df = _panel()
+        df.loc[2, "y"] = np.nan
+        prep = _prep(df)
+        assert prep["Ywide"].shape == (4, 3)
+        assert np.isnan(prep["Ywide"].to_numpy(dtype=float)).sum() == 1
+
+
+# --------------------------------------------------------------------------- #
+# 4. the estimand this protects
+# --------------------------------------------------------------------------- #
+class TestTheEstimandIsProtected:
+    def test_pre_periods_cannot_be_moved_by_a_blank_key(self):
+        """The failure that motivated this: one blank-keyed row per unit took
+        ``pre_periods`` from 2 to 3, silently."""
+        clean = _prep(_panel())
+        assert clean["pre_periods"] == 2
+
+        damaged = _panel()
+        for unit in ("a", "b", "c"):
+            damaged.loc[len(damaged)] = {"id": unit, "time": None, "y": 0.0,
+                                         "d": 0}
+        with pytest.raises(MlsynthDataError):
+            _prep(damaged)
+
+    def test_no_nan_labels_survive_into_the_wide_frame(self):
+        prep = _prep(_panel())
+        assert not any(pd.isna(c) for c in prep["Ywide"].columns)
+        assert not any(pd.isna(i) for i in prep["Ywide"].index)
+
+
+# --------------------------------------------------------------------------- #
+# 5. edges -- the refusal must not fire on frames that are merely awkward
+# --------------------------------------------------------------------------- #
+class TestEdges:
+    def test_empty_frame_is_unchanged(self):
+        """An empty panel has no missing keys, so it reaches the balance checks
+        it reached before."""
+        df = _panel().iloc[0:0]
+        with pytest.raises(MlsynthDataError,
+                           match="not strongly balanced|Missing values"):
+            balance(df, "id", "time")
+
+    def test_string_keys_that_look_blank_are_values_not_missing(self):
+        """An empty string is a label, not an absence."""
+        df = pd.DataFrame({"id": ["a", "a", "", ""], "time": [1, 2, 1, 2],
+                           "y": 1.0})
+        assert balance(df, "id", "time") is None
+
+    def test_zero_and_negative_keys_are_values(self):
+        df = pd.DataFrame({"id": ["a", "a", "b", "b"], "time": [0, -1, 0, -1],
+                           "y": 1.0})
+        assert balance(df, "id", "time") is None
+
+    def test_categorical_keys_with_unused_levels_are_unaffected(self):
+        df = pd.DataFrame({"id": pd.Categorical(["a", "a", "b", "b"],
+                                                categories=["a", "b", "c"]),
+                           "time": [1, 2, 1, 2], "y": 1.0})
+        assert balance(df, "id", "time") is None
+
+    def test_still_rejects_the_faults_it_rejected_before(self):
+        """The new refusal is additive: duplicated and short panels are still
+        reported, and with their own messages."""
+        base = _panel(2, 2)
+        with pytest.raises(MlsynthDataError, match="Duplicate observations"):
+            balance(pd.concat([base, base.iloc[[0]]], ignore_index=True),
+                    "id", "time")
+        with pytest.raises(MlsynthDataError, match="not strongly balanced"):
+            balance(base.drop(index=0), "id", "time")
+
+
+# --------------------------------------------------------------------------- #
+# 6. cost -- the refusal reuses a scan that already ran
+# --------------------------------------------------------------------------- #
+class TestCost:
+    def test_no_extra_pass_over_the_frame(self, monkeypatch):
+        """``balance`` already factorizes both key columns; detecting a missing
+        key is reading the codes it produced, not another scan."""
+        seen = []
+        real = pd.factorize
+
+        def spy(values, *a, **k):
+            seen.append(len(values))
+            return real(values, *a, **k)
+
+        monkeypatch.setattr(pd, "factorize", spy)
+        balance(_panel(20, 20), "id", "time")
+        assert len(seen) == 2
+
+    def test_ingestion_adds_no_scan_either(self, monkeypatch):
+        """``_fast_pivot`` computed ``(codes < 0).any()`` already, to decide
+        whether it could take its fast path."""
+        calls = {"isna": 0}
+        real = pd.Series.isna
+
+        def spy(self, *a, **k):
+            calls["isna"] += 1
+            return real(self, *a, **k)
+
+        monkeypatch.setattr(pd.Series, "isna", spy)
+        _prep(_panel(10, 10))
+        assert calls["isna"] <= 2, (
+            f"{calls['isna']} isna passes -- the check should read the codes")

--- a/mlsynth/tests/test_missing_key_rejection.py
+++ b/mlsynth/tests/test_missing_key_rejection.py
@@ -220,8 +220,11 @@ class TestCost:
         assert len(seen) == 2
 
     def test_ingestion_adds_no_scan_either(self, monkeypatch):
-        """``_fast_pivot`` computed ``(codes < 0).any()`` already, to decide
-        whether it could take its fast path."""
+        """The refusal sits inside ``_fast_pivot``, on codes it had already
+        computed to choose its path -- so ingestion gains no pass over the
+        frame. Checking ``isna`` in ``_wide_pivot`` instead would have cost one
+        scan per key column per pivot, and ``dataprep`` pivots twice.
+        """
         calls = {"isna": 0}
         real = pd.Series.isna
 
@@ -231,7 +234,7 @@ class TestCost:
 
         monkeypatch.setattr(pd.Series, "isna", spy)
         _prep(_panel(10, 10))
-        assert calls["isna"] <= 2, (
+        assert calls["isna"] == 0, (
             f"{calls['isna']} isna passes -- the check should read the codes")
 
 

--- a/mlsynth/utils/datautils.py
+++ b/mlsynth/utils/datautils.py
@@ -47,8 +47,20 @@ def _fast_pivot(
         return None
     u_codes, u_uniq = pd.factorize(df[columns], sort=False)   # O(n) hash, no sort
     t_codes, t_uniq = pd.factorize(df[index], sort=False)
-    if (u_codes < 0).any() or (t_codes < 0).any():            # NaN key -> pandas
-        return None
+    # A missing key is not a reason to fall back -- it is an error. Deferring to
+    # ``df.pivot`` here is what gave the blank a level named ``nan``, adding a
+    # donor column or a period and shifting ``pre_periods`` with nothing raised.
+    # The codes are already computed, so refusing costs no extra pass.
+    blank = {name: int((codes < 0).sum())
+             for name, codes in ((columns, u_codes), (index, t_codes))
+             if (codes < 0).any()}
+    if blank:
+        details = ", ".join(f"{name}: {count}" for name, count in blank.items())
+        raise MlsynthDataError(
+            f"Missing values found in the panel's key columns -> {details}. "
+            "Every observation must carry both a unit and a time period; clean "
+            "or drop these rows before passing the panel."
+        )
     n_u, n_t = len(u_uniq), len(t_uniq)
     grid = n_u * n_t
     if grid > 2 * n:                     # too sparse: not worth it / avoid huge alloc
@@ -797,14 +809,33 @@ def balance(df: pd.DataFrame, unit_id_column_name: str, time_period_column_name:
     # ``factorize`` has already reduced to integers, and they were 35 to 47
     # percent of ingestion cost -- more than the pivot they precede.
     #
-    # NaN handling is not incidental. ``factorize`` sends missing keys to code
-    # -1 and leaves them out of the levels, so ``len(levels)`` equals the
-    # ``nunique()`` this used to call, and a unit or period that is missing its
-    # key is excluded from the counts exactly as ``groupby`` excluded it.
+    # ``factorize`` sends a missing key to code -1 and leaves it out of the
+    # levels, which is what makes both the refusal below and the counts after it
+    # readable off the codes alone.
     unit_codes, unit_levels = pd.factorize(df[unit_id_column_name], sort=False)
     time_codes, time_levels = pd.factorize(df[time_period_column_name], sort=False)
     n_rows = len(df)
     n_units, n_periods = len(unit_levels), len(time_levels)
+
+    # A row without a unit or without a time is not an observation, and the
+    # checks below cannot see it: they count with the levels, and a missing key
+    # has no level. That silence used to reach the pivot, which *does* give the
+    # blank a level -- one named ``nan`` -- so a blank time added a period and
+    # moved ``pre_periods`` by one with nothing raised. Reading the codes for it
+    # costs nothing, because they are already here.
+    missing = {
+        name: int((codes < 0).sum())
+        for name, codes in ((unit_id_column_name, unit_codes),
+                            (time_period_column_name, time_codes))
+        if (codes < 0).any()
+    }
+    if missing:
+        details = ", ".join(f"{name}: {count}" for name, count in missing.items())
+        raise MlsynthDataError(
+            f"Missing values found in the panel's key columns -> {details}. "
+            "Every observation must carry both a unit and a time period; clean "
+            "or drop these rows before passing the panel."
+        )
 
     # One integer per row identifying its cell. Codes are shifted so the missing
     # key (-1) becomes 0 and cannot collide with a real pair: without the shift,

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -855,9 +855,9 @@ timeout = 900.0
 
   [[target.mutant]]
   id = "ingestion-defers-a-missing-key-to-pandas-again"
-  find = "    blank = {name: int((codes < 0).sum())"
-  replace = "    blank = {name: 0 for name in () if False} or {name: int((codes < 0).sum())"
-  models = "the refusal reduced to the fallback it replaced -- an empty mapping short-circuits the check and the pivot defers to df.pivot, which keeps the blank as a level named nan. A blank time then adds a period and shifts pre_periods, exactly the silent estimand change #453 exists to stop"
+  find = "    if blank:\n        details = \", \".join(f\"{name}: {count}\" for name, count in blank.items())"
+  replace = "    if False:\n        details = \", \".join(f\"{name}: {count}\" for name, count in blank.items())"
+  models = "the refusal reduced to the fallback it replaced. The pivot defers to df.pivot again, which keeps the blank as a level named nan, so a blank time adds a period and shifts pre_periods -- the silent estimand change #453 exists to stop. The validator still catches it, so only a caller reaching ingestion directly is exposed, which is 38 of the modules that do"
 
   [[target.mutant]]
   id = "only-the-unit-key-is-checked-at-ingestion"

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -846,3 +846,39 @@ timeout = 900.0
   find = "    if len(np.unique(observations_per_unit)) != 1:"
   replace = "    if len(np.unique(observations_per_unit)) > 1:"
   models = "the check that every unit carries the same count, weakened so that having no units at all satisfies it. An empty frame is then accepted where it used to be rejected, and the emptiness surfaces later as a shape error inside an estimator"
+
+[[target]]
+name = "missing-key-refusal"
+module-path = "mlsynth/utils/datautils.py"
+test-command = "python -m pytest mlsynth/tests/test_missing_key_rejection.py mlsynth/tests/test_balance_properties.py mlsynth/tests/test_datautils.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "ingestion-defers-a-missing-key-to-pandas-again"
+  find = "    blank = {name: int((codes < 0).sum())"
+  replace = "    blank = {name: 0 for name in () if False} or {name: int((codes < 0).sum())"
+  models = "the refusal reduced to the fallback it replaced -- an empty mapping short-circuits the check and the pivot defers to df.pivot, which keeps the blank as a level named nan. A blank time then adds a period and shifts pre_periods, exactly the silent estimand change #453 exists to stop"
+
+  [[target.mutant]]
+  id = "only-the-unit-key-is-checked-at-ingestion"
+  find = "             for name, codes in ((columns, u_codes), (index, t_codes))"
+  replace = "             for name, codes in ((columns, u_codes),)"
+  models = "half the check. A missing unit is refused and a missing time is not, so the phantom donor is caught and the shifted pre_periods -- the one that moves the estimand -- goes through"
+
+  [[target.mutant]]
+  id = "validator-refuses-only-when-both-keys-are-blank"
+  find = "        if (codes < 0).any()\n    }\n    if missing:"
+  replace = "        if (codes < 0).any()\n    }\n    if len(missing) > 1:"
+  models = "a frame blank in one key column only is admitted by the validator. Ingestion still catches it, so the estimand is safe, but the error arrives from inside the pivot instead of from the check whose job it is, and every caller matching on balance's message stops seeing it"
+
+[[target]]
+name = "missing-key-refusal-config"
+module-path = "mlsynth/config_models.py"
+test-command = "python -m pytest mlsynth/tests/test_missing_key_rejection.py -q -p no:cacheprovider"
+timeout = 600.0
+
+  [[target.mutant]]
+  id = "config-checks-the-outcome-instead-of-the-keys"
+  find = "            for column in (unitid, time)"
+  replace = "            for column in (unitid, outcome)"
+  models = "the config guarding the wrong columns: a blank outcome is refused, which the estimators that tolerate missing outcomes rely on being allowed, and a blank time period -- the one that moves pre_periods -- passes construction untouched"


### PR DESCRIPTION
## Related Links

- Closes #453 — the issue carries the ladder, which is the audit record
- `mlsynth/config_models.py`, `mlsynth/utils/datautils.py`
- Follows #454, which is what makes the refusal free: `balance` now factorizes the key columns, so reading the codes for a blank costs nothing
- Surfaced by property tests written for #452

## What

- `BaseEstimatorConfig` rejects missing values in the key columns
- `datautils.balance` rejects them, off the codes it already computes
- `datautils._fast_pivot` rejects them instead of deferring to `df.pivot`
- A new test file (28 tests) across the three layers; four semantic mutants in two new catalogue targets
- Two blank-key frames leave #452's differential corpus, and two characterisation tests become corrections

## Why

`balance` counted with `nunique` and `groupby`, both of which skip missing
values, so a panel whose blanks were symmetric across units satisfied every check
it made. `_wide_pivot` then pivoted the same frame and pandas kept the blank as a
level. The two disagreed about what a key is: the validator read a missing key as
*not an observation*, the pivot read it as *a level named `nan`*.

The consequence was silent and it moved the estimand. A 3-unit, 4-period panel
treated from period 3, so `pre_periods` should be 2:

```
clean       : admitted -> Ywide (4, 3), cols ['a','b','c'],       periods [1,2,3,4],     pre=2
+NaN unit   : admitted -> Ywide (4, 4), cols [nan,'a','b','c'],   periods [1,2,3,4],     pre=2
+NaN time   : admitted -> Ywide (5, 3), cols ['a','b','c'],       periods [nan,1,2,3,4], pre=3
```

A blank unit key becomes a fourth donor carrying only missing observations. A
blank time key adds a period and moves the pre/post split by one — the quantity
every estimator works from — with nothing raised.

## How

Three points, because no one of them covers the library:

* **`BaseEstimatorConfig`** — the earliest refusal and the best message.
  `BaseMAREXConfig` has had this check all along, but it is referenced 14 times
  against `BaseEstimatorConfig`'s 150, which checked only that the frame was
  non-empty.
* **`balance`** — the declared validator, 39 direct call sites, reading the codes
  #454 already factorizes.
* **`_fast_pivot`** — where the fault actually bites. It computed
  `(codes < 0).any()` to choose its path and then *threw the answer away* by
  returning `None`, deferring to `df.pivot` — the very call that manufactures the
  level. 38 modules reach ingestion with neither a config nor `balance` anywhere
  in them, because the estimator class calls the validator and its setup helper
  calls ingestion, so ingestion cannot assume its caller validated.

Putting it in `_fast_pivot` rather than in `_wide_pivot` is what keeps it free: a
check in the wrapper would cost an `isna` scan per key column per pivot, and
`dataprep` pivots twice. Asserted — ingestion performs zero `isna` passes.

Scoped to the keys. A blank outcome still constructs and still ingests, which
leaves the estimators that tolerate missing outcomes alone and is where this
stays narrower than the MAREX contract.

## Verification

- 28 tests across the three layers: the two frames that used to pass, every
  spelling of missing (`None`, `np.nan`, `pd.NaT`), the message naming columns
  and counts, precedence against the duplicate check, the estimand that this
  protects, and the edges that must *not* trip it — empty strings and zero and
  negative values are labels, not absences; unused categorical levels are
  unaffected; duplicated and short panels still report their own errors.
- The cost contract is asserted, not assumed: `balance` still makes exactly two
  `factorize` passes, and ingestion makes zero `isna` passes.
- Mutants: four, killed 4/4 — ingestion deferring again, only the unit key
  checked, the validator refusing only when both keys are blank, and the config
  guarding the outcome instead of the keys.
- One mutant survived on the first run and is recorded as *equivalent*, not as a
  weak assertion: it was written as `{} or {original}`, which short-circuits back
  to the original. Replaced with one that disables the refusal outright.

## Scope checks

BUG FIX.

- [x] A test reproduces the defect and fails without the fix — 12 of the 28 were red before the implementation
- [x] It asserts the correct behaviour, not merely the absence of a crash — `pre_periods` is asserted at 2 on the clean panel and the damaged one is refused
- [x] No docs page, docstring or comment still states the old behaviour — `_fast_pivot`'s "NaN key -> pandas" comment is gone, and the two characterisation tests written for #452 are now corrections
- [x] Any pinned value that moved is justified — none moved; frames that used to pass now raise

## Designs

No visual output changes for any panel that was previously valid.

## Test Steps

- [x] `pytest mlsynth/tests/test_missing_key_rejection.py` — 28 passed
- [x] `pytest test_balance_key_structure.py test_balance_properties.py test_missing_key_rejection.py test_datautils.py test_datautils_properties.py` — 140 passed, 2 skipped
- [x] `python tools/mutation/run_mutants.py --target missing-key-refusal` and `--target missing-key-refusal-config` — 4/4 killed
- [ ] `pytest mlsynth/tests/` — full suite, sharded across 3.10 / 3.12 / 3.13 in CI

## Other Notes

- **Breaking**, deliberately, for panels that previously passed with blank keys.
  Those results were computed against a shifted pre/post window or a phantom
  donor, so the frames were never giving the answer they appeared to give.
- The two skipped tests are the blank-key frames in #452's differential corpus.
  The oracle there is the implementation as it stood before the key-code rewrite,
  and this PR changes their verdict on purpose, so agreement with the oracle is
  the wrong question to ask about them; they are asserted directly in the new
  file instead.
- #452's RCA recorded a related survey I have **not** acted on and am not
  claiming: 76 `groupby` call sites across the library pass no `observed=`, and
  the per-unit maps in `lexscm` and the `.mean()` reductions in
  `ppscm`/`medsc`/`pangeo` would gain a `NaN` row for a unit with no
  observations. Whether any of those reaches a number is undemonstrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_