### PR TITLE
State observed at every groupby, and pin the index as authority

### DIFF
--- a/mlsynth/estimators/lexscm.py
+++ b/mlsynth/estimators/lexscm.py
@@ -321,7 +321,7 @@ class LEXSCM:
         # --- Treated-unit size band: drop candidates outside [min_size, max_size]
         # from the TREATABLE pool (they remain eligible as donors). ---
         if self.size_col is not None:
-            size_map = (self.df.groupby(self.unitid)[self.size_col]
+            size_map = (self.df.groupby(self.unitid, observed=True)[self.size_col]
                         .first().to_dict())
             sizes = np.array([size_map.get(lab, np.nan)
                               for lab in unit_index.labels], dtype=float)
@@ -408,7 +408,7 @@ class LEXSCM:
         # --- Cost Alignment Logic ---
         if self.unit_cost_col and self.unit_cost_col in self.df.columns:
             # Map costs to Unit IDs
-            unit_to_cost_map = self.df.groupby(self.unitid)[self.unit_cost_col].first().to_dict()
+            unit_to_cost_map = self.df.groupby(self.unitid, observed=True)[self.unit_cost_col].first().to_dict()
 
             # Align to the IndexSet
             costs_aligned = np.array([
@@ -428,7 +428,7 @@ class LEXSCM:
         # units) and Stage-2 (no conflicting unit as a treated unit's donor).
         cluster_of = None
         if self.cluster_col is not None:
-            cluster_of = (self.df.groupby(self.unitid)[self.cluster_col]
+            cluster_of = (self.df.groupby(self.unitid, observed=True)[self.cluster_col]
                           .first().to_dict())
         conflict = build_conflict_matrix(
             unit_index,
@@ -441,7 +441,7 @@ class LEXSCM:
         from ..utils.fast_scm_helpers.strata import build_strata
         stratum_of = None
         if self.stratum_col is not None:
-            stratum_of = (self.df.groupby(self.unitid)[self.stratum_col]
+            stratum_of = (self.df.groupby(self.unitid, observed=True)[self.stratum_col]
                           .first().to_dict())
         strata = build_strata(unit_index, stratum_of)
 

--- a/mlsynth/estimators/spcd.py
+++ b/mlsynth/estimators/spcd.py
@@ -307,13 +307,13 @@ class SPCD:
             if self.arm not in self.df.columns:
                 raise MlsynthDataError(
                     f"Arm column {self.arm!r} not found in the data.")
-            if self.df.groupby(self.unitid)[self.arm].nunique().max() > 1:
+            if self.df.groupby(self.unitid, observed=True)[self.arm].nunique().max() > 1:
                 raise MlsynthDataError(
                     "The arm column varies within a unit over time.")
 
             arm_designs = {
                 arm_label: self._fit_single(sub.copy())
-                for arm_label, sub in self.df.groupby(self.arm, sort=True)
+                for arm_label, sub in self.df.groupby(self.arm, sort=True, observed=True)
             }
             pooled_power = self._pooled_average_power(arm_designs)
             results = SPCDMultiArmResults(

--- a/mlsynth/estimators/syndes.py
+++ b/mlsynth/estimators/syndes.py
@@ -378,14 +378,14 @@ class SYNDES:
                 raise MlsynthDataError(
                     f"Arm column {self.arm!r} not found in the data."
                 )
-            if self.df.groupby(self.unitid)[self.arm].nunique().max() > 1:
+            if self.df.groupby(self.unitid, observed=True)[self.arm].nunique().max() > 1:
                 raise MlsynthDataError(
                     "The arm column varies within a unit over time."
                 )
 
             arm_designs = {
                 arm_label: self._fit_single(sub.copy())
-                for arm_label, sub in self.df.groupby(self.arm, sort=True)
+                for arm_label, sub in self.df.groupby(self.arm, sort=True, observed=True)
             }
             return SYNDESMultiArmResults(arm_designs=arm_designs, arm=self.arm)
 

--- a/mlsynth/tests/test_unit_index_authority.py
+++ b/mlsynth/tests/test_unit_index_authority.py
@@ -1,0 +1,269 @@
+"""The index set is the only thing that says which units exist.
+
+``dataprep`` returns the panel's units -- ``unit_names``, ``donor_names`` -- and
+that index is the authority. Everything else that looks like a unit list is
+derived and has to be projected onto it before it means anything: the key set of
+a ``groupby`` result, a dict built from ``.to_dict()``, the column labels of a
+pivot, a ``Categorical``'s ``categories``. Any of them can carry a unit the panel
+does not contain, and none is entitled to be believed on its own.
+
+Nothing asserted that until now, and one derived list could disagree. pandas
+changed ``groupby``'s ``observed`` default from ``False`` to ``True`` in 3.0, so
+below that a unit column typed as a ``Categorical`` with a level no row uses
+manufactures a group with no observations. ``pyproject.toml`` asks for
+``pandas>=2.0.0``, so both behaviours are in range, and the library left the
+argument unset at every one of its call sites.
+
+No wrong number came of it -- every consumption site read at the time reindexed
+by the observed unit list first. But that was a property each site happened to
+have, guaranteed by nothing, and a new call site that reads a reduction wholesale
+would break it silently and only on the older pandas.
+
+These tests are written so they can fail on *any* pandas. The runtime ones force
+``observed=False``, which is the older default, and assert the answer is
+unaffected. The static one asserts the argument is never left to the default at
+all, which is what a future call site would trip.
+
+An assertion on the estimate alone would not do. A phantom unit can appear in a
+donor-weight dict while leaving the ATT untouched -- that is the shape of the
+worked example in ``agents/agents_tests.md``, where the headline number moved 0.3
+percent and the weights were the entire result. So these assert the unit-labelled
+outputs, not the number.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import FDID, SDID, VanillaSC
+from mlsynth.utils.datautils import dataprep
+
+_REAL_GROUPBY = pd.DataFrame.groupby
+
+
+@pytest.fixture
+def older_pandas_grouping(monkeypatch):
+    """Force ``groupby(observed=False)``, the default below pandas 3.0.
+
+    A call site that states ``observed=True`` is unaffected; one that leaves the
+    argument out inherits the phantom group, which is the whole point.
+    """
+
+    def grouping(self, *args, **kwargs):
+        kwargs.setdefault("observed", False)
+        try:
+            return _REAL_GROUPBY(self, *args, **kwargs)
+        except TypeError:                      # a grouper that takes no observed
+            kwargs.pop("observed", None)
+            return _REAL_GROUPBY(self, *args, **kwargs)
+
+    monkeypatch.setattr(pd.DataFrame, "groupby", grouping)
+
+
+def _panel(categorical, n_units=8, n_periods=12, n_pre=8, seed=4):
+    rng = np.random.default_rng(seed)
+    factors = np.cumsum(rng.standard_normal((n_periods, 2)) * 0.3, axis=0)
+    loadings = rng.uniform(0.3, 1.1, (n_units, 2))
+    outcome = (loadings @ factors.T
+               + rng.standard_normal((n_units, n_periods)) * 0.3 + 10.0)
+    outcome[0, n_pre:] -= 2.0
+    names = [f"u{i}" for i in range(n_units)]
+    df = pd.DataFrame([{"id": names[i], "time": t + 1, "y": outcome[i, t],
+                        "d": int(i == 0 and t >= n_pre)}
+                       for i in range(n_units) for t in range(n_periods)])
+    if categorical:
+        # A spare level: a category the panel never uses. Legitimate input --
+        # it is what survives filtering a larger frame down to a subset.
+        df["id"] = pd.Categorical(df["id"], categories=names + ["never_used"])
+    return df
+
+
+def _authoritative_units(df):
+    """The index set: the columns of the wide frame ``dataprep`` builds.
+
+    On the single-treated path the same set is spelled
+    ``{treated_unit_name} | set(donor_names)``; both are asserted to agree
+    below, since two spellings of the authority that disagree would be the
+    fault this file is about.
+    """
+    prep = dataprep(df, unit_id_column_name="id", time_period_column_name="time",
+                    outcome_column_name="y", treatment_indicator_column_name="d")
+    return set(map(str, prep["Ywide"].columns))
+
+
+def _fit(cls, df, **extra):
+    config = {"df": df, "outcome": "y", "treat": "d", "unitid": "id",
+              "time": "time", "display_graphs": False, **extra}
+    return cls(config).fit()
+
+
+ESTIMATORS = [
+    pytest.param(SDID, {"vce": "noinference"}, id="SDID"),
+    pytest.param(VanillaSC, {"inference": False}, id="VanillaSC"),
+    pytest.param(FDID, {}, id="FDID"),
+]
+
+
+# --------------------------------------------------------------------------- #
+# 1. the fixture is doing what it claims
+# --------------------------------------------------------------------------- #
+class TestTheFixtureBites:
+    def test_forcing_the_older_default_manufactures_a_group(
+            self, older_pandas_grouping):
+        """Without this, the tests below would pass on pandas 3.0 whatever the
+        call sites did, and prove nothing."""
+        df = _panel(categorical=True)
+        keys = list(df.groupby("id")["y"].mean().index)
+        assert "never_used" in keys
+        assert pd.isna(df.groupby("id")["y"].mean()["never_used"])
+
+    def test_an_explicit_observed_true_is_not_overridden(
+            self, older_pandas_grouping):
+        df = _panel(categorical=True)
+        keys = list(df.groupby("id", observed=True)["y"].mean().index)
+        assert "never_used" not in keys
+
+    def test_the_spare_level_reaches_the_estimator(self):
+        """The panel really does carry a category the data never uses, and
+        nothing upstream strips it."""
+        df = _panel(categorical=True)
+        assert "never_used" in list(df["id"].cat.categories)
+        assert "never_used" not in set(df["id"].dropna().astype(str))
+
+
+# --------------------------------------------------------------------------- #
+# 2. the authority itself
+# --------------------------------------------------------------------------- #
+class TestIndexIsAuthoritative:
+    def test_dataprep_reports_only_units_the_panel_contains(self):
+        assert _authoritative_units(_panel(categorical=True)) == {
+            f"u{i}" for i in range(8)}
+
+    def test_the_two_spellings_of_the_index_agree(self):
+        """``Ywide.columns`` and ``{treated} | donors`` are the same set. If a
+        phantom unit ever entered one and not the other, the authority would be
+        ambiguous and this file's premise would be false."""
+        df = _panel(categorical=True)
+        prep = dataprep(df, unit_id_column_name="id",
+                        time_period_column_name="time", outcome_column_name="y",
+                        treatment_indicator_column_name="d")
+        spelled = {str(prep["treated_unit_name"])} | set(map(str, prep["donor_names"]))
+        assert spelled == set(map(str, prep["Ywide"].columns))
+
+    @pytest.mark.parametrize("cls,extra", ESTIMATORS)
+    def test_unit_labelled_outputs_match_the_index(
+            self, cls, extra, older_pandas_grouping):
+        """Every list of unit names a caller can read equals the index set.
+
+        Asserted on the labels and not on the estimate, because a phantom unit
+        can ride in a weights dict without moving a number.
+        """
+        df = _panel(categorical=True)
+        units = _authoritative_units(df)
+        result = _fit(cls, df, **extra)
+
+        weights = result.weights.donor_weights if result.weights else None
+        if weights:
+            assert set(map(str, weights)) <= units
+            assert not any("never_used" in str(k) for k in weights)
+
+        for name in ("unit_weights", "time_weights"):
+            mapping = getattr(result.weights, name, None) if result.weights else None
+            if name == "unit_weights" and mapping:
+                assert set(map(str, mapping)) <= units
+
+    @pytest.mark.parametrize("cls,extra", ESTIMATORS)
+    def test_a_spare_level_changes_no_number(self, cls, extra,
+                                             older_pandas_grouping):
+        """The weaker claim, kept because it is the one a user would notice."""
+        plain = _fit(cls, _panel(categorical=False), **extra)
+        typed = _fit(cls, _panel(categorical=True), **extra)
+        assert typed.effects.att == pytest.approx(plain.effects.att,
+                                                  rel=0, abs=1e-12)
+
+    def test_counterfactual_carries_no_phantom_period_or_unit(
+            self, older_pandas_grouping):
+        result = _fit(SDID, _panel(categorical=True), vce="noinference")
+        series = np.asarray(result.time_series.counterfactual_outcome, dtype=float)
+        assert series.shape[0] == 12
+        assert np.all(np.isfinite(series))
+
+
+# --------------------------------------------------------------------------- #
+# 3. the contract, checked statically so a new call site trips it
+# --------------------------------------------------------------------------- #
+class TestNoCallSiteLeavesItToTheDefault:
+    """The runtime tests above cover the estimators they run. This one covers
+    the ones they do not, and the ones not written yet.
+
+    ``observed`` is only meaningful for a categorical grouper, so passing it
+    where the key is never categorical is redundant -- but it is redundant and
+    correct, and the alternative is a rule nobody can check. A grep is a rule
+    that holds for call sites nobody has reviewed.
+    """
+
+    @staticmethod
+    def _close_paren(text, start):
+        """Index of the paren closing the one at ``start``, or ``None``.
+
+        String-aware, so a bracket inside a column name does not throw the
+        count off.
+        """
+        depth, i, n = 0, start, len(text)
+        in_string, quote = False, ""
+        while i < n:
+            char = text[i]
+            if in_string:
+                if char == "\\":
+                    i += 2
+                    continue
+                if char == quote:
+                    in_string = False
+            elif char in "\"'":
+                in_string, quote = True, char
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    return i
+            i += 1
+        return None
+
+    @classmethod
+    def _bare_groupby_sites(cls):
+        """Call sites whose argument list omits ``observed``.
+
+        Reads the whole call rather than the line it starts on: several of these
+        wrap across lines, and a line-wise check reports them as bare when the
+        argument is simply further down.
+        """
+        root = pathlib.Path(__file__).resolve().parents[1]
+        pattern = re.compile(r"\.groupby\(")
+        found = []
+        for path in sorted(root.rglob("*.py")):
+            if "tests" in path.parts:
+                continue
+            source = path.read_text()
+            for match in pattern.finditer(source):
+                open_i = match.end() - 1
+                close_i = cls._close_paren(source, open_i)
+                if close_i is None:                       # unbalanced; not ours
+                    continue
+                if "observed=" in source[open_i + 1:close_i]:
+                    continue
+                lineno = source.count("\n", 0, match.start()) + 1
+                snippet = source[match.start():close_i + 1].split("\n")[0]
+                found.append(f"{path.relative_to(root)}:{lineno}: {snippet.strip()}")
+        return found
+
+    def test_every_groupby_states_observed(self):
+        bare = self._bare_groupby_sites()
+        assert not bare, (
+            f"{len(bare)} groupby call(s) leave `observed` to the pandas "
+            "default, which changed in 3.0:\n  " + "\n  ".join(bare[:15]))

--- a/mlsynth/utils/bpscs_helpers/setup.py
+++ b/mlsynth/utils/bpscs_helpers/setup.py
@@ -27,7 +27,7 @@ def _unit_feature_matrix(
     missing = [c for c in columns if c not in df.columns]
     if missing:
         raise MlsynthConfigError(f"BPSCS {what} column(s) not in the panel: {missing}")
-    first = df.groupby(unitid)[columns].first()
+    first = df.groupby(unitid, observed=True)[columns].first()
     try:
         mat = first.reindex(index=order).to_numpy(dtype=float)
     except Exception as exc:  # pragma: no cover - defensive

--- a/mlsynth/utils/counterfactual_compare.py
+++ b/mlsynth/utils/counterfactual_compare.py
@@ -683,7 +683,7 @@ def plot_weights_comparison(
     pivot: Dict[Any, Dict[str, float]] = {}
     totals: Dict[Any, float] = {}
     if w is not None and not w.empty:
-        for donor, grp in w.groupby("donor", sort=False):
+        for donor, grp in w.groupby("donor", sort=False, observed=True):
             by_method = dict(zip(grp["method"], grp["weight"]))
             if max(abs(v) for v in by_method.values()) < threshold:
                 continue

--- a/mlsynth/utils/ctsc_helpers/setup.py
+++ b/mlsynth/utils/ctsc_helpers/setup.py
@@ -77,7 +77,7 @@ def prepare_ctsc_inputs(
     if population_col is not None:
         if population_col not in df.columns:
             raise MlsynthDataError(f"Population column {population_col!r} missing.")
-        pop = df.groupby(unitid)[population_col].first().loc[unit_names].to_numpy(float)
+        pop = df.groupby(unitid, observed=True)[population_col].first().loc[unit_names].to_numpy(float)
         if (pop < 0).any() or pop.sum() <= 0:
             raise MlsynthDataError("Population weights must be non-negative and sum > 0.")
         population_weights = pop / pop.sum()

--- a/mlsynth/utils/design_compare.py
+++ b/mlsynth/utils/design_compare.py
@@ -187,7 +187,7 @@ def compare_pareto(
 
     df = pd.DataFrame(rows)
     df["pareto"] = False
-    for _, idx in df.groupby("method").groups.items():
+    for _, idx in df.groupby("method", observed=True).groups.items():
         sub = df.loc[idx]
         mask = _pareto_mask(sub["fit_rmse"].to_numpy(),
                             np.where(np.isfinite(sub["mde_pct"]),
@@ -552,7 +552,7 @@ def plot_compare_pareto(frame: pd.DataFrame, ax=None):
     _palette = ("purple", "orange", "brown", "olive")
 
     def _draw(ax):
-        for k, (method, sub) in enumerate(frame.groupby("method")):
+        for k, (method, sub) in enumerate(frame.groupby("method", observed=True)):
             color = _METHOD_COLORS.get(method, _palette[k % len(_palette)])
             fit = sub["fit_rmse"].to_numpy()
             mde = np.where(np.isfinite(sub["mde_pct"]), sub["mde_pct"], np.nan)

--- a/mlsynth/utils/dmlfm_helpers/setup.py
+++ b/mlsynth/utils/dmlfm_helpers/setup.py
@@ -94,7 +94,7 @@ def prepare_dmlfm_inputs(cfg) -> DMLFMInputs:
     # reference, but mlsynth ingestion has no way to carry an observation mask,
     # so an unbalanced panel is refused instead of silently fitting a panel the
     # result contract cannot describe.
-    counts = df.groupby(cfg.unitid)[cfg.time].nunique()
+    counts = df.groupby(cfg.unitid, observed=True)[cfg.time].nunique()
     if counts.nunique() != 1 or int(counts.iloc[0]) != n_periods:
         raise MlsynthDataError(
             "DMLFM needs a balanced panel: units span "

--- a/mlsynth/utils/drsc_helpers/setup.py
+++ b/mlsynth/utils/drsc_helpers/setup.py
@@ -98,7 +98,7 @@ def prepare_drsc_inputs(
 
     k = len(covariates) + 1
     cells: Dict[Tuple[Any, Any], DRSCCell] = {}
-    for (u, t), g in df.groupby([unitid, time], sort=False):
+    for (u, t), g in df.groupby([unitid, time], sort=False, observed=True):
         if u not in set(units) or t not in set(times):  # pragma: no cover
             continue
         X = np.empty((len(g), k), dtype=np.float64)

--- a/mlsynth/utils/dsc_helpers/setup.py
+++ b/mlsynth/utils/dsc_helpers/setup.py
@@ -57,7 +57,7 @@ def prepare_dsc_inputs(
         raise MlsynthDataError("Outcome column contains NaN values.")
 
     treat_by_cell = (
-        df.groupby([unitid, time])[treat].first().reset_index()
+        df.groupby([unitid, time], observed=True)[treat].first().reset_index()
     )
     treated_cells = treat_by_cell[treat_by_cell[treat] == 1]
     if treated_cells.empty:
@@ -101,7 +101,7 @@ def prepare_dsc_inputs(
     unit_names = [treated_unit_name] + donor_units
 
     cell_samples: Dict[Tuple[Any, Any], np.ndarray] = {}
-    for (u, t), grp in df.groupby([unitid, time]):
+    for (u, t), grp in df.groupby([unitid, time], observed=True):
         arr = grp[outcome].to_numpy(dtype=float)
         if arr.size == 0:
             raise MlsynthDataError(

--- a/mlsynth/utils/dtwsc_helpers/pipeline.py
+++ b/mlsynth/utils/dtwsc_helpers/pipeline.py
@@ -82,9 +82,9 @@ def _sc_via_vanillasc(y, warped, ctx, backend, covariates,
     # A warp that compresses a donor past the panel end leaves NaN; VanillaSC
     # needs a balanced frame, so carry the donor's last observed value forward
     # rather than dropping the period for every unit.
-    panel["__y"] = panel.groupby("__unit")["__y"].ffill()
+    panel["__y"] = panel.groupby("__unit", observed=True)["__y"].ffill()
     if panel["__y"].isna().any():
-        panel["__y"] = panel.groupby("__unit")["__y"].bfill()
+        panel["__y"] = panel.groupby("__unit", observed=True)["__y"].bfill()
 
     if covariates:
         src = ctx.get("covariate_frame")

--- a/mlsynth/utils/dtwsc_helpers/setup.py
+++ b/mlsynth/utils/dtwsc_helpers/setup.py
@@ -44,7 +44,7 @@ def unit_rescale_factors(
             "DTWSC: rescaling needs at least one pre-treatment period; none "
             f"of the panel's {time} values are <= {last_pre_period}."
         )
-    ranges = pre.groupby(unitid)[outcome].agg(["min", "max"])
+    ranges = pre.groupby(unitid, observed=True)[outcome].agg(["min", "max"])
     spans = ranges["max"] - ranges["min"]
     mean_span = float(spans.mean())
     factors = {}

--- a/mlsynth/utils/fast_scm_helpers/fast_scm_setup.py
+++ b/mlsynth/utils/fast_scm_helpers/fast_scm_setup.py
@@ -83,7 +83,7 @@ def build_candidate_mask(working_df, candidate_col, unit_index, unitid):
         Boolean mask of candidate units aligned with `unit_index`.
     """
     return (
-        working_df.groupby(unitid)[candidate_col]
+        working_df.groupby(unitid, observed=True)[candidate_col]
         .first()
         .reindex(unit_index)
         .fillna(False)
@@ -201,7 +201,7 @@ def build_f_vector(working_df, weight_col, unitid, unit_index):
 
     if weight_col is not None:
         weights = (
-            working_df.groupby(unitid)[weight_col]
+            working_df.groupby(unitid, observed=True)[weight_col]
             .first()
             .reindex(unit_index)
             .to_numpy(dtype=float)

--- a/mlsynth/utils/fsc_helpers/setup.py
+++ b/mlsynth/utils/fsc_helpers/setup.py
@@ -35,9 +35,9 @@ def _resolve_grid(df: pd.DataFrame, unitid: str, time: str, argument: str,
     if numeric_grid:
         return np.sort(pd.unique(df[argument].to_numpy()))
 
-    first = df.groupby([unitid, time], sort=False).ngroup() == 0
+    first = df.groupby([unitid, time], sort=False, observed=True).ngroup() == 0
     grid = pd.unique(df.loc[first, argument].to_numpy())
-    for (unit, period), cell in df.groupby([unitid, time], sort=False):
+    for (unit, period), cell in df.groupby([unitid, time], sort=False, observed=True):
         labels = cell[argument].to_numpy()
         if labels.shape != grid.shape or not np.array_equal(labels, grid):
             raise MlsynthDataError(
@@ -115,7 +115,7 @@ def prepare_fsc_inputs(df: pd.DataFrame, outcome: str, treat: str, unitid: str,
             "so at least two are needed. With a single value per cell the "
             "outcome is a scalar -- use VanillaSC.")
 
-    counts = df.groupby([unitid, time], sort=False)[argument].agg(
+    counts = df.groupby([unitid, time], sort=False, observed=True)[argument].agg(
         ["count", "nunique"])
     bad = counts[(counts["count"] != grid.size)
                  | (counts["nunique"] != grid.size)]

--- a/mlsynth/utils/geox_helpers/aggregate.py
+++ b/mlsynth/utils/geox_helpers/aggregate.py
@@ -61,7 +61,7 @@ def compute_power(cube: pd.DataFrame, *, alpha: float = 0.1) -> pd.DataFrame:
         aggs["investment"] = ("investment", "mean")
     # sort=False: candidate keys are frozensets (unorderable).
     return tmp.groupby(
-        ["candidate", "duration", "effect_size"], as_index=False, sort=False
+        ["candidate", "duration", "effect_size"], as_index=False, sort=False, observed=True
     ).agg(**aggs)
 
 
@@ -93,7 +93,7 @@ def compute_mde(power_table: pd.DataFrame, *, power_threshold: float = 0.8) -> p
 
     rows: List[dict] = []
     for (candidate, duration), group in power_table.groupby(
-        ["candidate", "duration"], sort=False
+        ["candidate", "duration"], sort=False, observed=True
     ):
         detectable = group.loc[group["power"] > power_threshold, "effect_size"].to_numpy()
         if detectable.size == 0:
@@ -142,7 +142,7 @@ def compute_exact_mde(cube: pd.DataFrame, *,
     rows: List[dict] = []
     per_sim = cube.drop_duplicates(subset=["candidate", "duration", "sim"])
     for (candidate, duration), group in per_sim.groupby(
-        ["candidate", "duration"], sort=False
+        ["candidate", "duration"], sort=False, observed=True
     ):
         ups = group["boundary_up"].to_numpy(dtype=float)
         downs = group["boundary_down"].to_numpy(dtype=float)

--- a/mlsynth/utils/geox_helpers/constraints.py
+++ b/mlsynth/utils/geox_helpers/constraints.py
@@ -51,7 +51,7 @@ def unit_attribute_map(
     """
     if attr_col not in df.columns:
         raise MlsynthConfigError(f"column {attr_col!r} not found in df.")
-    grp = df.groupby(unit_id_column_name)[attr_col]
+    grp = df.groupby(unit_id_column_name, observed=True)[attr_col]
     varying = grp.nunique(dropna=False)
     if (varying > 1).any():
         bad = list(varying[varying > 1].index)[:5]

--- a/mlsynth/utils/geox_helpers/plotter.py
+++ b/mlsynth/utils/geox_helpers/plotter.py
@@ -43,16 +43,16 @@ def _power_panel(ax, result, power_threshold):
             winner_key = candidate
             break
 
-    for candidate, group in table.groupby("candidate", sort=False):
+    for candidate, group in table.groupby("candidate", sort=False, observed=True):
         if candidate is winner_key:
             continue
-        curve = group.groupby("effect_size")["power"].mean().sort_index()
+        curve = group.groupby("effect_size", observed=True)["power"].mean().sort_index()
         ax.plot(curve.index, curve.values, color="0.8", lw=0.7, alpha=0.45,
                 zorder=1)
 
     if winner_key is not None:
         best = table[table["candidate"] == winner_key]
-        curve = best.groupby("effect_size")["power"].mean().sort_index()
+        curve = best.groupby("effect_size", observed=True)["power"].mean().sort_index()
         ax.plot(curve.index, curve.values, color="black", lw=2.0, zorder=3,
                 marker="o", ms=3.5, label=_label(winner_key))
 

--- a/mlsynth/utils/marex_helpers/config.py
+++ b/mlsynth/utils/marex_helpers/config.py
@@ -273,13 +273,13 @@ class MAREXConfig(BaseMAREXConfig):
                 col = df[cluster_col]
 
             # Ensure each unit is in only one cluster
-            unit_to_clusters = df.groupby(values.unitid)[cluster_col].apply(lambda x: set(x.dropna()))
+            unit_to_clusters = df.groupby(values.unitid, observed=True)[cluster_col].apply(lambda x: set(x.dropna()))
             non_invariant = unit_to_clusters[unit_to_clusters.apply(len) != 1]
             if not non_invariant.empty:
                 raise MlsynthDataError(f"Units with multiple cluster assignments: {non_invariant.to_dict()}")
 
             # --- m_eq / m_min / m_max validation ---
-            cluster_sizes = df.groupby(cluster_col).size()
+            cluster_sizes = df.groupby(cluster_col, observed=True).size()
             if values.m_eq is not None and values.m_eq > cluster_sizes.max():
                 raise MlsynthDataError(
                     f"m_eq ({values.m_eq}) cannot be greater than max cluster size ({cluster_sizes.max()})"

--- a/mlsynth/utils/medsc_helpers/setup.py
+++ b/mlsynth/utils/medsc_helpers/setup.py
@@ -43,7 +43,7 @@ def _covariate_block(
     benign fill that leaves fully-observed panels unchanged).
     """
     pre = df[df[time].isin(list(pre_labels))]
-    means = pre.groupby(unitid)[covariates].mean()
+    means = pre.groupby(unitid, observed=True)[covariates].mean()
     donor = means.reindex(units)
     donor = donor.fillna(donor.mean())
     treated = means.reindex([treated_name])

--- a/mlsynth/utils/microsynth_helpers/setup.py
+++ b/mlsynth/utils/microsynth_helpers/setup.py
@@ -41,7 +41,7 @@ def _validate_time_invariant(
     unitid: str,
 ) -> None:
     """Raise if ``column`` varies within any unit."""
-    n_unique = df.groupby(unitid)[column].nunique(dropna=False)
+    n_unique = df.groupby(unitid, observed=True)[column].nunique(dropna=False)
     bad = n_unique[n_unique > 1]
     if not bad.empty:
         examples = bad.index[:5].tolist()
@@ -67,7 +67,7 @@ def _infer_cohort_time(
             "No treated rows found (no unit has ``treat = 1``). "
             "MicroSynth requires at least one treated user."
         )
-    first_treat_time = treated_rows.groupby(unitid)[time].min()
+    first_treat_time = treated_rows.groupby(unitid, observed=True)[time].min()
     distinct_cohorts = first_treat_time.unique()
     if len(distinct_cohorts) > 1:
         raise MlsynthDataError(
@@ -134,7 +134,7 @@ def prepare_microsynth_inputs(
     cohort_time = _infer_cohort_time(df, treat, time, unitid)
 
     # Identify treated vs control users by whether they ever had treat=1.
-    ever_treated = df.groupby(unitid)[treat].max()
+    ever_treated = df.groupby(unitid, observed=True)[treat].max()
     treated_units = ever_treated.index[ever_treated == 1].tolist()
     control_units = ever_treated.index[ever_treated == 0].tolist()
     if not treated_units:

--- a/mlsynth/utils/mlsc_helpers/config.py
+++ b/mlsynth/utils/mlsc_helpers/config.py
@@ -194,7 +194,7 @@ class MLSCConfig(BaseModel):
 
         # Each disaggregate unit must map to exactly one aggregate.
         per_unit_aggs = (
-            df_d.groupby(self.unitid_disagg)[self.agg_id]
+            df_d.groupby(self.unitid_disagg, observed=True)[self.agg_id]
             .nunique()
         )
         offenders = per_unit_aggs[per_unit_aggs > 1]

--- a/mlsynth/utils/musc_helpers/orchestration.py
+++ b/mlsynth/utils/musc_helpers/orchestration.py
@@ -94,7 +94,7 @@ def derive_treatment_cohorts(
             "treated unit with a sharp intervention."
         )
     first_treated = (
-        treated_rows.groupby(unitid)[time].min().to_dict()
+        treated_rows.groupby(unitid, observed=True)[time].min().to_dict()
     )
     cohort_map: Dict[Any, List[Any]] = {}
     for unit, intervention_time in first_treated.items():
@@ -168,7 +168,7 @@ def collapse_cohort(
 
     cohort_rows = df.loc[df[unitid].isin(treated_set), [time, outcome]].copy()
     averaged = (
-        cohort_rows.groupby(time, as_index=False)[outcome].mean()
+        cohort_rows.groupby(time, as_index=False, observed=True)[outcome].mean()
     )
     averaged[unitid] = synthetic_label
     averaged[treat] = (averaged[time] >= intervention_time).astype(int)

--- a/mlsynth/utils/pangeo_helpers/setup.py
+++ b/mlsynth/utils/pangeo_helpers/setup.py
@@ -122,8 +122,8 @@ def prepare_pangeo_inputs(
     Y = wide.loc[unit_names, time_labels].to_numpy(dtype=float)
 
     # Arm membership is time-invariant per unit.
-    arm_by_unit = df.groupby(unitid)[arm].agg(lambda s: s.iloc[0])
-    if df.groupby(unitid)[arm].nunique().max() > 1:
+    arm_by_unit = df.groupby(unitid, observed=True)[arm].agg(lambda s: s.iloc[0])
+    if df.groupby(unitid, observed=True)[arm].nunique().max() > 1:
         raise MlsynthDataError("The arm column varies within a unit over time.")
     arm_of = {u: arm_by_unit.loc[u] for u in unit_names}
 
@@ -146,7 +146,7 @@ def prepare_pangeo_inputs(
         if df[covariates].isna().any().any():
             raise MlsynthDataError("Covariate column(s) contain NaN values.")
         cov_names = list(covariates)
-        baseline = df.groupby(unitid)[cov_names].mean()
+        baseline = df.groupby(unitid, observed=True)[cov_names].mean()
         cov = baseline.loc[unit_names].to_numpy(dtype=float)  # (N, M)
         if standardize_covariates:
             scales = cov.std(axis=0, ddof=0)
@@ -158,7 +158,7 @@ def prepare_pangeo_inputs(
     if weight_col is not None:
         if df[weight_col].isna().any():
             raise MlsynthDataError("Weight column contains NaN values.")
-        wser = df.groupby(unitid)[weight_col].mean().loc[unit_names]
+        wser = df.groupby(unitid, observed=True)[weight_col].mean().loc[unit_names]
         weights = wser.to_numpy(dtype=float)
         if np.any(weights <= 0):
             raise MlsynthConfigError("Weight column must be strictly positive.")

--- a/mlsynth/utils/ppscm_helpers/setup.py
+++ b/mlsynth/utils/ppscm_helpers/setup.py
@@ -41,7 +41,7 @@ def prepare_ppscm_inputs(df: pd.DataFrame, *, outcome: str, treat: str,
             )
 
     adopt = {}
-    for u, g in df.groupby(unitid):
+    for u, g in df.groupby(unitid, observed=True):
         yrs = g.loc[g[treat] == 1, time]
         adopt[u] = yrs.min() if len(yrs) else np.inf
     finite = [a for a in adopt.values() if _adopted(a)]
@@ -74,7 +74,7 @@ def prepare_ppscm_inputs(df: pd.DataFrame, *, outcome: str, treat: str,
         # augsynth cov_agg default: mean over periods before the FIRST adoption.
         first_adopt = min(finite)
         pre_first = df[df[time] < first_adopt]
-        agg = (pre_first.groupby(unitid)[list(covariates)].mean()
+        agg = (pre_first.groupby(unitid, observed=True)[list(covariates)].mean()
                .reindex(index=units))
         if agg.isna().any().any():
             bad = agg.index[agg.isna().any(axis=1)].tolist()

--- a/mlsynth/utils/rmsi_helpers/replication.py
+++ b/mlsynth/utils/rmsi_helpers/replication.py
@@ -164,7 +164,7 @@ def replicate_prop99(data: Union[str, pd.DataFrame, None] = None, *,
     d = pd.read_csv(data) if isinstance(data, str) else data.copy()
     covs = ["lnincome", "beer", "age15to24", "retprice"]
     for c in covs:
-        d[c] = d.groupby("state")[c].transform(lambda s: s.fillna(s.mean()))
+        d[c] = d.groupby("state", observed=True)[c].transform(lambda s: s.fillna(s.mean()))
         d[c] = d[c].fillna(d[c].mean())
     d["treated"] = ((d["state"] == "California") & (d["year"] >= 1989)).astype(int)
 

--- a/mlsynth/utils/rmsi_helpers/setup.py
+++ b/mlsynth/utils/rmsi_helpers/setup.py
@@ -83,14 +83,14 @@ def prepare_rmsi_inputs(
     # Row features X (one row per unit): unit-level mean of each unit covariate.
     if unit_covariates:
         X = np.column_stack([
-            df.groupby(unitid)[c].mean().loc[unit_names].to_numpy(dtype=float)
+            df.groupby(unitid, observed=True)[c].mean().loc[unit_names].to_numpy(dtype=float)
             for c in unit_covariates])
     else:
         X = np.zeros((N, 0))
     # Column features Z (one row per period): period-level mean of each time cov.
     if time_covariates:
         Z = np.column_stack([
-            df.groupby(time)[c].mean().loc[time_labels].to_numpy(dtype=float)
+            df.groupby(time, observed=True)[c].mean().loc[time_labels].to_numpy(dtype=float)
             for c in time_covariates])
     else:
         Z = np.zeros((T, 0))

--- a/mlsynth/utils/rolldid_helpers/setup.py
+++ b/mlsynth/utils/rolldid_helpers/setup.py
@@ -56,7 +56,7 @@ def rolldid_setup(
 
     # Per-unit cohort g = first period the indicator is on; never-treated have none.
     cohort_of: Dict[Any, Any] = {}
-    for unit, sub in work.groupby(unit_id):
+    for unit, sub in work.groupby(unit_id, observed=True):
         sub = sub.sort_values(time_id)
         on = sub[sub[treat] == 1]
         if on.empty:

--- a/mlsynth/utils/scd_helpers/setup.py
+++ b/mlsynth/utils/scd_helpers/setup.py
@@ -52,7 +52,7 @@ def prepare_scd_inputs(
         raise MlsynthDataError("Outcome column contains NaN values.")
 
     # Treated unit: identified from the treat column at the unit-time level.
-    treat_by_cell = df.groupby([unitid, time])[treat].max().reset_index()
+    treat_by_cell = df.groupby([unitid, time], observed=True)[treat].max().reset_index()
     treated_cells = treat_by_cell[treat_by_cell[treat] == 1]
     if treated_cells.empty:
         raise MlsynthDataError(

--- a/mlsynth/utils/sdid_helpers/setup.py
+++ b/mlsynth/utils/sdid_helpers/setup.py
@@ -80,10 +80,10 @@ def apply_ddd_transform(
     d[outcome] = y.to_numpy()
 
     # Treatment-group indicator g(i): 1 for units ever treated, else 0.
-    d["_ddd_grp"] = (d.groupby(unitid)[treat].transform("max") > 0).astype(int)
+    d["_ddd_grp"] = (d.groupby(unitid, observed=True)[treat].transform("max") > 0).astype(int)
 
     non_target = d[d[subgroup] != target_subgroup]
-    nt_mean = (non_target.groupby(["_ddd_grp", time])[outcome].mean()
+    nt_mean = (non_target.groupby(["_ddd_grp", time], observed=True)[outcome].mean()
                .rename("_ddd_nt").reset_index())
     d = d.merge(nt_mean, on=["_ddd_grp", time], how="left")
 
@@ -115,7 +115,7 @@ def _pre_period_covariate_means(df, unitid, treat, cols, unit_order):
     post-treatment period back into the matching.
     """
     untreated = df[df[treat] == 0]
-    means = untreated.groupby(unitid)[list(cols)].mean()
+    means = untreated.groupby(unitid, observed=True)[list(cols)].mean()
     absent = [u for u in unit_order if u not in means.index]
     if absent:
         raise MlsynthDataError(

--- a/mlsynth/utils/sdid_helpers/simulate.py
+++ b/mlsynth/utils/sdid_helpers/simulate.py
@@ -151,7 +151,7 @@ def calibrate_brabander_dgp(panel, covariates: Sequence[str] = BRABANDER_COVARIA
             "balanced panel over t=%d..%d." % (_FIRST_T, _LAST_T))
 
     cov_window = panel[(panel.t >= _FIRST_T) & (panel.t <= _LAST_COV_T)]
-    means = cov_window.groupby("country")[cols].mean().reindex(order)
+    means = cov_window.groupby("country", observed=True)[cols].mean().reindex(order)
     C = means.to_numpy(dtype=float).T                            # (K, N)
     if not np.isfinite(C).all():
         raise MlsynthDataError(

--- a/mlsynth/utils/sparse_sc_helpers/setup.py
+++ b/mlsynth/utils/sparse_sc_helpers/setup.py
@@ -38,7 +38,7 @@ def _per_unit_pre_means(
     """Return per-unit pre-treatment mean of ``column`` in ``unit_order``."""
     pre_mask = df[time].isin(pre_time_labels)
     means = (
-        df.loc[pre_mask].groupby(unitid)[column].mean()
+        df.loc[pre_mask].groupby(unitid, observed=True)[column].mean()
     )
     # Reindex to unit_order; missing units (none expected for a balanced
     # panel after `balance()`) come back NaN.

--- a/mlsynth/utils/spillsynth_helpers/sar/setup.py
+++ b/mlsynth/utils/spillsynth_helpers/sar/setup.py
@@ -105,7 +105,7 @@ def prepare_sar_inputs(
     T = int(time_labels.size)
     units = sorted(df[unitid].unique())
 
-    treated_mask = df.groupby(unitid)[treat].max()
+    treated_mask = df.groupby(unitid, observed=True)[treat].max()
     treated_units = [u for u in units if treated_mask.get(u, 0) == 1]
     if len(treated_units) != 1:
         raise MlsynthDataError(

--- a/mlsynth/utils/src_helpers/setup.py
+++ b/mlsynth/utils/src_helpers/setup.py
@@ -50,7 +50,7 @@ def prepare_src_inputs(
     # keeps the donor order as first-appearance, which downstream code reads
     # positionally.
     all_units = list(df[unitid].unique())
-    treat_totals = (df.groupby(unitid, sort=False)[treat].sum()
+    treat_totals = (df.groupby(unitid, sort=False, observed=True)[treat].sum()
                     .reindex(all_units).to_numpy())
     donors = [
         u for u, total in zip(all_units, treat_totals)

--- a/mlsynth/utils/stackedsc_helpers/setup.py
+++ b/mlsynth/utils/stackedsc_helpers/setup.py
@@ -50,7 +50,7 @@ def adoption_times(df: pd.DataFrame, unitid: str, time: str,
     if treated_rows.empty:
         raise MlsynthDataError(
             f"no rows have {treat} == 1, so there is nothing to estimate.")
-    return treated_rows.groupby(unitid)[time].min().to_dict()
+    return treated_rows.groupby(unitid, observed=True)[time].min().to_dict()
 
 
 def aggregation_weights(df: pd.DataFrame, unitid: str, column: Optional[str],
@@ -67,13 +67,13 @@ def aggregation_weights(df: pd.DataFrame, unitid: str, column: Optional[str],
         raise MlsynthDataError(
             f"agg_weights column {column!r} is not in the DataFrame.")
     sub = df[df[unitid].isin(units)]
-    spread = sub.groupby(unitid)[column].nunique(dropna=False)
+    spread = sub.groupby(unitid, observed=True)[column].nunique(dropna=False)
     varying = spread[spread > 1].index.tolist()
     if varying:
         raise MlsynthDataError(
             f"agg_weights column {column!r} varies within unit(s) "
             f"{varying[:5]}; an aggregation weight must be constant per unit.")
-    w = sub.groupby(unitid)[column].first().reindex(units).to_numpy(float)
+    w = sub.groupby(unitid, observed=True)[column].first().reindex(units).to_numpy(float)
     if not np.isfinite(w).all():
         raise MlsynthDataError(
             f"agg_weights column {column!r} has missing values for some "
@@ -99,7 +99,7 @@ def _covariate_block(df, unitid, time, units, covariates, windows,
             sub = sub[sub[time] >= lo]
         if hi is not None:
             sub = sub[sub[time] <= hi]
-        m = sub.groupby(unitid)[c].mean().reindex(units)
+        m = sub.groupby(unitid, observed=True)[c].mean().reindex(units)
         if m.isna().any():
             missing = m[m.isna()].index.tolist()[:5]
             raise MlsynthDataError(

--- a/mlsynth/utils/syndes_helpers/config.py
+++ b/mlsynth/utils/syndes_helpers/config.py
@@ -490,7 +490,7 @@ class SYNDESConfig(BaseMAREXConfig):
 
         if values.arm is not None and values.arm in df.columns:
             # K applies within each arm, so validate against the smallest arm.
-            arm_sizes = df.groupby(values.arm)[values.unitid].nunique()
+            arm_sizes = df.groupby(values.arm, observed=True)[values.unitid].nunique()
             n_units = int(arm_sizes.min()) if len(arm_sizes) else n_units
             if values.costs is not None:
                 raise MlsynthConfigError(

--- a/mlsynth/utils/syndes_helpers/eligibility.py
+++ b/mlsynth/utils/syndes_helpers/eligibility.py
@@ -39,7 +39,7 @@ def unit_attribute_map(
     """
     if attr_col not in df.columns:
         raise MlsynthConfigError(f"column {attr_col!r} not found in df.")
-    grp = df.groupby(unit_id_column_name)[attr_col]
+    grp = df.groupby(unit_id_column_name, observed=True)[attr_col]
     varying = grp.nunique(dropna=False)
     if (varying > 1).any():
         bad = list(varying[varying > 1].index)[:5]

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -160,7 +160,7 @@ def _covariate_means(
     else:
         rows = []
         for cov, years in zip(covariates, year_sets):
-            g = df[df[time].isin(years)].groupby(unitid)[cov].mean()
+            g = df[df[time].isin(years)].groupby(unitid, observed=True)[cov].mean()
             rows.append([float(g.get(u, np.nan)) for u in units])
         X = np.asarray(rows, dtype=float)
 

--- a/mlsynth/utils/vanillasc_helpers/staggered.py
+++ b/mlsynth/utils/vanillasc_helpers/staggered.py
@@ -189,7 +189,7 @@ def _covariate_observed(config):
     obs = {(str(u), int(y)): float(v) for u, y, v in zip(
         treated[config.unitid], treated[config.time], treated[config.outcome])}
     adopt = {str(u): int(y) for u, y in
-             treated.groupby(config.unitid)[config.time].min().items()}
+             treated.groupby(config.unitid, observed=True)[config.time].min().items()}
     return obs, adopt
 
 

--- a/mlsynth/utils/vanillasc_helpers/staggered_engine.py
+++ b/mlsynth/utils/vanillasc_helpers/staggered_engine.py
@@ -241,7 +241,7 @@ def scdata_multi(data, outcome_var, features, cov_adj, constant,
     treated_post = list(treated_units)
 
     treated_periods = (data.loc[data['status'] == 1, ['country', 'year']]
-                       .groupby('country').min()['year'].to_dict())
+                       .groupby('country', observed=True).min()['year'].to_dict())
 
     blocks = {}
     P_blocks = []
@@ -729,7 +729,7 @@ def df_EST(w_constr, w, B, J, KM):
 def u_des_prep_one(B, C, coig_data, constant, index, index_w):
     """u_order=1, u_lags=0."""
     if coig_data:
-        B_diff = B - B.groupby('feature').shift(1)
+        B_diff = B - B.groupby('feature', observed=True).shift(1)
         u_des_0 = pd.concat([B_diff, C], axis=1).loc[:, index]
     else:
         Z = pd.concat([B, C], axis=1)
@@ -761,7 +761,7 @@ def e_des_prep_one(B, C, P, res, Y_donors, out_feat, J, index, index_w, coig_dat
     e_res = res.loc[(outcome_var,), ]
 
     if coig_data:
-        B_diff = B - B.groupby('feature').shift(1)
+        B_diff = B - B.groupby('feature', observed=True).shift(1)
         e_des_0 = pd.concat([B_diff, C], axis=1).loc[:, index]
         if effect == "time":
             P_first = (P.iloc[[0], :J] * iota - B.iloc[T0 - 1, :].values) / iota
@@ -1023,19 +1023,19 @@ def scpi_out(y, x, preds, e_method, alpha, effect):
         fit = cond_pred(y, x, x_more, 'lm')
         e_mean = fit[:len(preds_arr)]
         if effect == "time":
-            e_mean = pd.DataFrame(e_mean, index=idx).groupby(level='Time').mean().values[:, 0]
+            e_mean = pd.DataFrame(e_mean, index=idx).groupby(level='Time', observed=True).mean().values[:, 0]
         y_fit = fit[len(preds_arr):]
         y_var = np.log((y - y_fit) ** 2)
         var_pred = cond_pred(y_var, x, x_more, 'lm')
         res_var = var_pred[len(preds_arr):]
         if effect == "time":
-            var_pred_p = pd.DataFrame(var_pred[:len(preds_arr)], index=idx).groupby(level='Time').mean().values[:, 0]
+            var_pred_p = pd.DataFrame(var_pred[:len(preds_arr)], index=idx).groupby(level='Time', observed=True).mean().values[:, 0]
         else:
             var_pred_p = var_pred[:len(preds_arr)]
         q_pred = cond_pred(y - y_fit, x, x_more, 'qreg', tau=[0.25, 0.75])
         if effect == "time":
-            q3 = pd.DataFrame(q_pred[:len(preds_arr), 1], index=idx).groupby(level='Time').mean().values[:, 0]
-            q1 = pd.DataFrame(q_pred[:len(preds_arr), 0], index=idx).groupby(level='Time').mean().values[:, 0]
+            q3 = pd.DataFrame(q_pred[:len(preds_arr), 1], index=idx).groupby(level='Time', observed=True).mean().values[:, 0]
+            q1 = pd.DataFrame(q_pred[:len(preds_arr), 0], index=idx).groupby(level='Time', observed=True).mean().values[:, 0]
         else:
             q3 = q_pred[:len(preds_arr), 1]
             q1 = q_pred[:len(preds_arr), 0]
@@ -1059,8 +1059,8 @@ def scpi_out(y, x, preds, e_method, alpha, effect):
     elif e_method == 'qreg':
         e_pred = cond_pred(y, x, preds_arr, 'qreg', tau=[alpha, 1 - alpha])
         if effect == "time":
-            lb = pd.DataFrame(e_pred[:, 0], index=idx).groupby(level='Time').mean().values[:, 0].reshape(-1, 1)
-            ub = pd.DataFrame(e_pred[:, 1], index=idx).groupby(level='Time').mean().values[:, 0].reshape(-1, 1)
+            lb = pd.DataFrame(e_pred[:, 0], index=idx).groupby(level='Time', observed=True).mean().values[:, 0].reshape(-1, 1)
+            ub = pd.DataFrame(e_pred[:, 1], index=idx).groupby(level='Time', observed=True).mean().values[:, 0].reshape(-1, 1)
         else:
             lb = e_pred[:, [0]]
             ub = e_pred[:, [1]]


### PR DESCRIPTION
## Related Links

- Closes #456 — the issue carries the ladder, including the refutation
- Follows #454, whose CI failure on Python 3.10 exposed the same divergence inside `balance`
- `agents/agents_tests.md`, "Root-Cause Analysis" — the worked example is why these assert labels rather than the estimate

## What

- `observed=True` at all 76 `groupby` call sites, across 39 files
- A new test file (13 tests) pinning the index set as the authority on which units exist
- A static contract: no `groupby` may leave `observed` to the pandas default

## Why

`dataprep`'s index set is the only thing that says which units exist. Everything
else that looks like a unit list is derived — a `groupby`'s keys, a dict from
`.to_dict()`, a pivot's labels, a `Categorical`'s `categories` — and has to be
projected onto that index before it means anything.

pandas changed `groupby`'s `observed` default from `False` to `True` in 3.0, so
below that a unit column typed as a `Categorical` with a level no row uses
manufactures a group with no observations. `pyproject.toml` asks for
`pandas>=2.0.0`, and the library left the argument unset everywhere, so which
units a reduction reported depended on the environment.

## What this does not claim

No wrong number came of it, and I looked. Under forced pandas 2.x semantics, six
estimators return bit-identical ATTs with an object key and with a categorical
key carrying a spare level:

| estimator | object key | categorical key |
|---|---:|---:|
| SDID | -2.17109771 | -2.17109771 |
| VanillaSC | -2.12447212 | -2.12447212 |
| FDID | -2.22830000 | -2.22830000 |
| CLUSTERSC | -1.95938279 | -1.95938279 |
| PPSCM (covariates) | -2.13735266 | -2.13735266 |
| MEDSC | -2.10229216 | -2.10229216 |

The phantom group is produced and then discarded, because every consumption site
reindexes by the observed unit list first — `medsc` `reindex(units)`, `ppscm`
`reindex(index=units)`, `pangeo` `.loc[unit_names]`, `lexscm`'s maps fetched by
observed name, and the `nunique().max() > 1` guards immune outright. That was a
property each site happened to have, guaranteed by nothing.

So this is a fault of omission with no current victim. Worth fixing, easy to
overstate, and the PR is written not to.

## How

The mechanical half is 76 one-line edits and is pure review noise. `observed=True`
is redundant wherever the key can never be categorical — redundant and correct,
and the alternative is a rule no grep can check.

The half that matters is the test, and two things in it took care:

**It is red on this pandas.** On 3.0.5 `observed` already defaults to `True`, so
a naive test passes without any fix and proves nothing. A fixture forces
`observed=False` — the older supported default — so the tests can fail anywhere
in the declared range. Three tests assert the fixture itself bites, otherwise the
rest would be vacuous.

**It asserts labels, not the estimate.** A phantom unit can ride in a donor-weight
dict while leaving the ATT untouched; that is the worked Basque example, where
the headline moved 0.3 percent and the weights were the entire result. So the
assertion is that every unit-labelled output is a subset of `Ywide.columns`, plus
that the two spellings of the index — `Ywide.columns` and
`{treated_unit_name} | donor_names` — agree with each other. The ATT test is kept
as the weaker claim, because it is the one a user would notice.

The static check parses whole calls with a string-aware paren matcher rather than
reading lines: three of the 76 wrap, and a line-wise check reported them as bare
when the argument was simply further down. That defect was in my first version of
the test and is worth naming, since a line-wise check would have passed once the
edit was applied and then failed to catch the next wrapped call site.

## Also checked, and harmless

`value_counts()` keeps unused categories on pandas 3.0 as well — version
independent, so a live hazard if it were used. The library never calls it (0
hits). `unique()`, `nunique()`, `factorize`, `df.pivot` and
`set_index().index.unique()` all return observed-only. The single `.categories`
read is a field on a results object, not a `Categorical`.

## Verification

- 13 tests: the fixture bites (3), the authority holds across three estimators
  with forced older-pandas grouping, the two index spellings agree, the
  counterfactual carries no phantom period, and the static contract.
- `python -c "import mlsynth"` and a `py_compile` sweep over every non-test
  module — 0 syntax errors after a 76-site mechanical edit.
- Estimator-family suite running locally; CI shards the full suite across
  3.10 / 3.12 / 3.13, which is the coverage that matters here since the whole
  fault is version-dependent.

## Scope checks

Shared change across 39 files, so none of the four blocks applies. Own branch,
carrying only this work.

## Designs

No visual output changes — no number moves.

## Test Steps

- [x] `pytest mlsynth/tests/test_unit_index_authority.py` — 13 passed
- [x] `py_compile` over all non-test modules — 0 errors
- [ ] `pytest mlsynth/tests/` — full suite, sharded across three interpreters in CI

## Other Notes

- MICROSYNTH and LEXSCM still have unread call sites: both raised a config error
  before reaching their reductions on a minimal panel, identically in both arms,
  so they contributed no signal either way. They are covered by the static
  contract but not by a runtime assertion.
- 39 estimators were not run in the differential. The six above are a sample.
- pandas 2.x was emulated by forcing `observed=False` rather than installed. The
  emulation is exact for this argument but is not the same as running the old
  library; CI on 3.10 is what actually exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_