### PR TITLE
Scan the panel's key structure once per panel, not once per pivot

### DIFF
--- a/mlsynth/tests/test_balance_key_structure.py
+++ b/mlsynth/tests/test_balance_key_structure.py
@@ -137,8 +137,10 @@ class TestSmoke:
     def test_a_balanced_panel_passes(self):
         balance(_panel(5, 4), "id", "time")
 
-    def test_returns_none(self):
-        assert balance(_panel(3, 3), "id", "time") is None
+    def test_returns_the_panel_scan(self):
+        df = _panel(3, 3)
+        keys = balance(df, "id", "time")
+        assert keys.is_for(df, "id", "time")
 
 
 # --------------------------------------------------------------------------- #
@@ -192,7 +194,7 @@ class TestDecisionsAreIdentical:
         df = pd.DataFrame({"id": pd.Categorical(["a", "a", "b", "b"],
                                                 categories=["a", "b", "c"]),
                            "time": [1, 2, 1, 2], "y": 1.0})
-        assert balance(df, "id", "time") is None
+        assert balance(df, "id", "time") is not None
 
         counted = df.groupby("id", observed=False)["time"].nunique()
         assert 0 in set(counted.values), (

--- a/mlsynth/tests/test_balance_properties.py
+++ b/mlsynth/tests/test_balance_properties.py
@@ -150,7 +150,7 @@ def test_same_verdict_as_the_previous_implementation(df):
 @SETTINGS
 @given(df=_rectangular())
 def test_a_rectangular_panel_is_always_accepted(df):
-    assert balance(df, "id", "time") is None
+    assert balance(df, "id", "time") is not None
 
 
 # --------------------------------------------------------------------------- #

--- a/mlsynth/tests/test_datautils.py
+++ b/mlsynth/tests/test_datautils.py
@@ -612,9 +612,9 @@ def test_wide_pivot_falls_back_when_fast_path_layout_differs(monkeypatch):
     exp = df.pivot(index="time", columns="unit", values="y")
     _real_fast_pivot = du._fast_pivot                        # capture before patching
 
-    def _f_contiguous_fast(d, index, columns, values):
+    def _f_contiguous_fast(d, index, columns, values, keys=None):
         # value-identical to the real fast path but F-contiguous .to_numpy()
-        frame = _real_fast_pivot(d, index, columns, values)
+        frame = _real_fast_pivot(d, index, columns, values, keys)
         return pd.DataFrame(
             np.asfortranarray(frame.to_numpy()),
             index=frame.index, columns=frame.columns)

--- a/mlsynth/tests/test_missing_key_rejection.py
+++ b/mlsynth/tests/test_missing_key_rejection.py
@@ -53,7 +53,7 @@ def _prep(df):
 # --------------------------------------------------------------------------- #
 class TestSmoke:
     def test_clean_panel_still_validates(self):
-        assert balance(_panel(), "id", "time") is None
+        assert balance(_panel(), "id", "time") is not None
 
     def test_clean_panel_still_ingests(self):
         prep = _prep(_panel())
@@ -177,18 +177,18 @@ class TestEdges:
         """An empty string is a label, not an absence."""
         df = pd.DataFrame({"id": ["a", "a", "", ""], "time": [1, 2, 1, 2],
                            "y": 1.0})
-        assert balance(df, "id", "time") is None
+        assert balance(df, "id", "time") is not None
 
     def test_zero_and_negative_keys_are_values(self):
         df = pd.DataFrame({"id": ["a", "a", "b", "b"], "time": [0, -1, 0, -1],
                            "y": 1.0})
-        assert balance(df, "id", "time") is None
+        assert balance(df, "id", "time") is not None
 
     def test_categorical_keys_with_unused_levels_are_unaffected(self):
         df = pd.DataFrame({"id": pd.Categorical(["a", "a", "b", "b"],
                                                 categories=["a", "b", "c"]),
                            "time": [1, 2, 1, 2], "y": 1.0})
-        assert balance(df, "id", "time") is None
+        assert balance(df, "id", "time") is not None
 
     def test_still_rejects_the_faults_it_rejected_before(self):
         """The new refusal is additive: duplicated and short panels are still

--- a/mlsynth/tests/test_panel_key_scan.py
+++ b/mlsynth/tests/test_panel_key_scan.py
@@ -1,0 +1,394 @@
+"""The panel's key structure is scanned once per panel, not once per pivot.
+
+``dataprep`` reads a long panel by pivoting it, and every pivot begins by
+establishing the same thing: which unit and which period each row belongs to.
+``_fast_pivot`` factorizes both key columns, builds a linear cell index, counts
+it to rule out duplicate keys, and sorts both axes -- and all of that depends
+on ``(df, index, columns)`` alone, never on ``values``. A single-treated
+``dataprep`` calls it twice, once for the treatment indicator and once for the
+outcome, so the second call recomputes the first's answer exactly. The cohort
+branch is worse: it rebuilds the whole treatment pivot that the pre-branch code
+already built.
+
+Two kinds of test live here, red for different reasons.
+
+The work assertions start red. They count key-column ``factorize`` calls and
+``_wide_pivot`` calls per ``dataprep`` and hold them to one scan per panel and
+one pivot per distinct ``values`` column. That is the contract rung 4 of the
+analysis in #459 found nobody had written down: ``dataprep``'s contract names
+its outputs and says nothing about how many passes over the panel may be spent
+producing them, so a second pivot conformed and cost nothing at review.
+Counting is deterministic, which is why the assertion is a count and not a
+wall-clock threshold.
+
+The equivalence tests pass before the change and must pass after it. They are
+the whole acceptance bar, since 51 modules read what ``dataprep`` returns. They
+check three layers, and the third is easy to lose: the values, the failures and
+which one fires, and the memory layout -- ``_wide_pivot`` verifies that its fast
+path reproduces ``df.pivot``'s C-contiguous ``.to_numpy()``, because a
+value-equal but F-contiguous array changes BLAS reduction order and moves
+float-sensitive downstream code at ~1e-16.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthDataError
+from mlsynth.utils import datautils as DU
+from mlsynth.utils.datautils import balance, dataprep
+
+
+# --------------------------------------------------------------------------- #
+# panels
+# --------------------------------------------------------------------------- #
+def make_panel(n_units=6, n_periods=10, n_treated=1, onset=7, seed=0,
+               unit="id", time="time", outcome="y", treat="d",
+               covariates=None):
+    """A balanced long panel with ``n_treated`` units adopting at ``onset``."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    for u in range(n_units):
+        for t in range(1, n_periods + 1):
+            treated = int(u < n_treated and t >= onset)
+            rows.append((u, t, float(rng.normal()) + 2.0 * treated, treated))
+    df = pd.DataFrame(rows, columns=[unit, time, outcome, treat])
+    if covariates:
+        for k, name in enumerate(covariates):
+            df[name] = rng.normal(size=len(df)) + k
+    return df
+
+
+def make_staggered(n_units=9, n_periods=12, onsets=(7, 9), seed=1):
+    """A panel whose treated units adopt at different times (cohort mode)."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    for u in range(n_units):
+        onset = onsets[u] if u < len(onsets) else None
+        for t in range(1, n_periods + 1):
+            treated = int(onset is not None and t >= onset)
+            rows.append((u, t, float(rng.normal()) + 2.0 * treated, treated))
+    return pd.DataFrame(rows, columns=["id", "time", "y", "d"])
+
+
+ARGS = ("id", "time", "y", "d")
+
+
+# --------------------------------------------------------------------------- #
+# counters
+# --------------------------------------------------------------------------- #
+class KeyScanCounter:
+    """Counts ``pd.factorize`` calls on the panel's key columns."""
+
+    def __init__(self, monkeypatch, *key_columns):
+        self.key_columns = set(key_columns)
+        self.calls: list[str] = []
+        real = pd.factorize
+
+        def traced(values, *a, **kw):
+            name = getattr(values, "name", None)
+            if name in self.key_columns:
+                self.calls.append(name)
+            return real(values, *a, **kw)
+
+        monkeypatch.setattr(pd, "factorize", traced)
+        monkeypatch.setattr(DU.pd, "factorize", traced)
+
+    @property
+    def total(self) -> int:
+        return len(self.calls)
+
+    def per_column(self, column: str) -> int:
+        return self.calls.count(column)
+
+
+class PivotCounter:
+    """Records the ``(index, columns, values)`` of every ``_wide_pivot`` call."""
+
+    def __init__(self, monkeypatch):
+        self.calls: list[tuple] = []
+        real = DU._wide_pivot
+
+        def traced(df, index, columns, values, **kw):
+            self.calls.append((index, columns, values))
+            return real(df, index=index, columns=columns, values=values, **kw)
+
+        monkeypatch.setattr(DU, "_wide_pivot", traced)
+
+    @property
+    def total(self) -> int:
+        return len(self.calls)
+
+    @property
+    def distinct(self) -> int:
+        return len(set(self.calls))
+
+
+# =========================================================================== #
+# work assertions -- these start red
+# =========================================================================== #
+class TestScanCount:
+    """One scan per panel, whatever the branch."""
+
+    def test_single_treated_dataprep_scans_each_key_column_once(self, monkeypatch):
+        df = make_panel()
+        counter = KeyScanCounter(monkeypatch, "id", "time")
+        dataprep(df, *ARGS)
+        assert counter.per_column("id") == 1
+        assert counter.per_column("time") == 1
+
+    def test_cohort_dataprep_scans_each_key_column_once(self, monkeypatch):
+        df = make_staggered()
+        counter = KeyScanCounter(monkeypatch, "id", "time")
+        out = dataprep(df, *ARGS)
+        assert "cohorts" in out, "fixture must exercise the cohort branch"
+        assert counter.per_column("id") == 1
+        assert counter.per_column("time") == 1
+
+    def test_dataprep_with_covariates_scans_each_key_column_once(self, monkeypatch):
+        df = make_panel(covariates=["x1", "x2"])
+        counter = KeyScanCounter(monkeypatch, "id", "time")
+        dataprep(df, *ARGS, covariates=["x1", "x2"])
+        assert counter.per_column("id") == 1
+        assert counter.per_column("time") == 1
+
+    def test_supplied_keys_remove_the_scan_entirely(self, monkeypatch):
+        df = make_panel()
+        keys = balance(df, "id", "time")
+        counter = KeyScanCounter(monkeypatch, "id", "time")
+        dataprep(df, *ARGS, keys=keys)
+        assert counter.total == 0
+
+    def test_a_fit_shaped_call_pair_scans_once(self, monkeypatch):
+        """``balance`` then ``dataprep`` -- the pattern at nine call sites."""
+        df = make_panel()
+        counter = KeyScanCounter(monkeypatch, "id", "time")
+        keys = balance(df, "id", "time")
+        dataprep(df, *ARGS, keys=keys)
+        assert counter.per_column("id") == 1
+        assert counter.per_column("time") == 1
+
+
+class TestPivotCount:
+    """A pivot per distinct ``values`` column, and no more."""
+
+    def test_single_treated_pivots_twice(self, monkeypatch):
+        df = make_panel()
+        counter = PivotCounter(monkeypatch)
+        dataprep(df, *ARGS)
+        assert counter.total == 2
+        assert counter.distinct == 2
+
+    def test_cohort_does_not_pivot_the_treatment_indicator_twice(self, monkeypatch):
+        df = make_staggered()
+        counter = PivotCounter(monkeypatch)
+        out = dataprep(df, *ARGS)
+        assert "cohorts" in out, "fixture must exercise the cohort branch"
+        assert counter.total == counter.distinct, (
+            f"a (index, columns, values) signature was pivoted twice: "
+            f"{counter.calls}")
+        assert counter.total == 2
+
+
+# =========================================================================== #
+# equivalence -- green before and after
+# =========================================================================== #
+def _compare(a, b, path="prep"):
+    """Assert two ``dataprep`` payloads agree, recursing into containers."""
+    assert type(a) is type(b), f"{path}: {type(a)} vs {type(b)}"
+    if isinstance(a, dict):
+        assert set(a) == set(b), f"{path}: keys differ"
+        for k in a:
+            _compare(a[k], b[k], f"{path}[{k!r}]")
+    elif isinstance(a, pd.DataFrame):
+        pd.testing.assert_frame_equal(a, b, check_exact=True, obj=path)
+        assert (a.to_numpy().flags["C_CONTIGUOUS"]
+                == b.to_numpy().flags["C_CONTIGUOUS"]), f"{path}: layout differs"
+    elif isinstance(a, pd.Series):
+        pd.testing.assert_series_equal(a, b, check_exact=True, obj=path)
+    elif isinstance(a, pd.Index):
+        pd.testing.assert_index_equal(a, b, exact=True, obj=path)
+    elif isinstance(a, np.ndarray):
+        assert a.dtype == b.dtype, f"{path}: dtype {a.dtype} vs {b.dtype}"
+        assert a.shape == b.shape, f"{path}: shape {a.shape} vs {b.shape}"
+        np.testing.assert_array_equal(a, b, err_msg=path)
+        assert a.flags["C_CONTIGUOUS"] == b.flags["C_CONTIGUOUS"], f"{path}: layout"
+    elif isinstance(a, (list, tuple)):
+        assert len(a) == len(b), f"{path}: length"
+        for i, (x, y) in enumerate(zip(a, b)):
+            _compare(x, y, f"{path}[{i}]")
+    else:
+        same = a == b
+        if hasattr(same, "__len__") or isinstance(same, np.ndarray):
+            assert np.array_equal(np.asarray(a), np.asarray(b)), f"{path}"
+        else:
+            assert same or (a != a and b != b), f"{path}: {a!r} vs {b!r}"
+
+
+PANELS = {
+    "single-treated": lambda: make_panel(),
+    "cohort": lambda: make_staggered(),
+    "one-donor": lambda: make_panel(n_units=2, n_periods=8, onset=6),
+    "single-post-period": lambda: make_panel(n_periods=6, onset=6),
+    "wide-short": lambda: make_panel(n_units=25, n_periods=4, onset=3),
+    "tall-narrow": lambda: make_panel(n_units=3, n_periods=60, onset=41),
+    "string-units": lambda: make_panel().assign(
+        id=lambda d: "u" + d["id"].astype(str)),
+    "unsorted-rows": lambda: make_panel().sample(frac=1.0, random_state=7),
+    "float-outcome-nan-free": lambda: make_panel(seed=3),
+}
+
+
+class TestOutputUnchanged:
+    """The payload, to the byte, with and without a supplied scan."""
+
+    @pytest.mark.parametrize("name", sorted(PANELS))
+    def test_supplied_keys_give_the_same_payload(self, name):
+        df = PANELS[name]()
+        without = dataprep(df, *ARGS)
+        keys = balance(df, "id", "time")
+        with_keys = dataprep(df, *ARGS, keys=keys)
+        _compare(without, with_keys)
+
+    @pytest.mark.parametrize("name", sorted(PANELS))
+    def test_pivots_still_match_pandas(self, name):
+        df = PANELS[name]()
+        keys = balance(df, "id", "time")
+        for values in ("y", "d"):
+            reference = df.pivot(index="time", columns="id", values=values)
+            shared = DU._wide_pivot(df, index="time", columns="id",
+                                    values=values, keys=keys)
+            pd.testing.assert_frame_equal(shared, reference, check_exact=True)
+            assert shared.to_numpy().flags["C_CONTIGUOUS"]
+
+    def test_covariate_payload_unchanged(self):
+        df = make_panel(covariates=["x1", "x2"])
+        without = dataprep(df, *ARGS, covariates=["x1", "x2"])
+        keys = balance(df, "id", "time")
+        with_keys = dataprep(df, *ARGS, covariates=["x1", "x2"], keys=keys)
+        _compare(without, with_keys)
+
+    def test_cohort_treatment_matrix_is_the_pre_branch_one(self):
+        """The frame the cohort branch used to rebuild equals the one built
+        before the branch, so reusing it cannot move a cohort onset."""
+        df = make_staggered()
+        first = DU._wide_pivot(df, index="time", columns="id", values="d")
+        second = DU._wide_pivot(df, index="time", columns="id", values="d")
+        pd.testing.assert_frame_equal(first, second, check_exact=True)
+        out = dataprep(df, *ARGS)
+        assert "cohorts" in out
+        assert sorted(out["cohorts"]) == sorted(
+            {7, 9}), "cohort onsets must be unchanged"
+
+
+# =========================================================================== #
+# the balance contract
+# =========================================================================== #
+class TestBalanceStillDecides:
+    """A new return value may not move which error fires, or when."""
+
+    def test_returns_a_scan_of_the_panel(self):
+        df = make_panel()
+        keys = balance(df, "id", "time")
+        assert keys is not None
+        expected_units = pd.factorize(df["id"], sort=False)[0]
+        expected_times = pd.factorize(df["time"], sort=False)[0]
+        np.testing.assert_array_equal(keys.unit_codes, expected_units)
+        np.testing.assert_array_equal(keys.time_codes, expected_times)
+
+    def test_duplicate_rows_raise(self):
+        df = pd.concat([make_panel(), make_panel().head(1)], ignore_index=True)
+        with pytest.raises(MlsynthDataError, match="Duplicate observations"):
+            balance(df, "id", "time")
+
+    def test_missing_period_raises_not_strongly_balanced(self):
+        df = make_panel().drop(index=3).reset_index(drop=True)
+        with pytest.raises(MlsynthDataError, match="not strongly balanced"):
+            balance(df, "id", "time")
+
+    def test_missing_key_raises_before_any_wide_frame(self):
+        df = make_panel()
+        df.loc[2, "time"] = np.nan
+        with pytest.raises(MlsynthDataError, match="Missing values found"):
+            balance(df, "id", "time")
+
+    def test_dataprep_alone_still_refuses_a_missing_key(self):
+        df = make_panel()
+        df.loc[2, "id"] = np.nan
+        with pytest.raises(MlsynthDataError, match="Missing values found"):
+            dataprep(df, *ARGS)
+
+    def test_ignoring_the_return_value_still_works(self):
+        """The 38 call sites that discard it must be unaffected."""
+        df = make_panel()
+        assert balance(df, "id", "time") is not None
+        balance(df, "id", "time")          # discarded, as they do
+        dataprep(df, *ARGS)                # and the fit proceeds
+
+
+# =========================================================================== #
+# the keys guard
+# =========================================================================== #
+class TestKeysGuard:
+    """A scan may only be reused for the panel and columns it was taken from."""
+
+    def test_keys_from_another_frame_are_refused(self):
+        df = make_panel()
+        other = make_panel(seed=99)
+        keys = balance(other, "id", "time")
+        with pytest.raises(MlsynthDataError, match="different panel|not for"):
+            dataprep(df, *ARGS, keys=keys)
+
+    def test_keys_for_other_columns_are_refused(self):
+        df = make_panel().rename(columns={"id": "unit"})
+        df["id"] = df["unit"]
+        keys = balance(df, "unit", "time")
+        with pytest.raises(MlsynthDataError, match="different panel|not for"):
+            dataprep(df, *ARGS, keys=keys)
+
+    def test_keys_taken_from_a_frame_that_then_changed_are_refused(self):
+        df = make_panel()
+        keys = balance(df, "id", "time")
+        shorter = df.drop(index=0)
+        with pytest.raises(MlsynthDataError, match="different panel|not for"):
+            dataprep(shorter, *ARGS, keys=keys)
+
+    def test_none_keys_are_the_default(self):
+        df = make_panel()
+        _compare(dataprep(df, *ARGS), dataprep(df, *ARGS, keys=None))
+
+
+# =========================================================================== #
+# edges the fast path declines
+# =========================================================================== #
+class TestFastPathDeclines:
+    """A shared scan may not change when pandas takes over."""
+
+    def test_sparse_grid_falls_back_and_still_matches_pandas(self):
+        # one row per unit: the grid is n_units x n_units, far sparser than 2n
+        rows = [(u, u, float(u), 0) for u in range(40)]
+        df = pd.DataFrame(rows, columns=["id", "time", "y", "d"])
+        assert DU._fast_pivot(df, "time", "id", "y") is None
+        pd.testing.assert_frame_equal(
+            DU._wide_pivot(df, index="time", columns="id", values="y"),
+            df.pivot(index="time", columns="id", values="y"),
+            check_exact=True)
+
+    def test_duplicate_keys_reach_pandas(self):
+        df = pd.concat([make_panel(), make_panel().head(1)], ignore_index=True)
+        assert DU._fast_pivot(df, "time", "id", "y") is None
+        with pytest.raises(ValueError):
+            DU._wide_pivot(df, index="time", columns="id", values="y")
+
+    def test_empty_frame_declines(self):
+        df = pd.DataFrame({"id": [], "time": [], "y": [], "d": []})
+        assert DU._fast_pivot(df, "time", "id", "y") is None
+
+    def test_single_cell_panel(self):
+        df = pd.DataFrame({"id": [0], "time": [1], "y": [1.5], "d": [0]})
+        pd.testing.assert_frame_equal(
+            DU._wide_pivot(df, index="time", columns="id", values="y"),
+            df.pivot(index="time", columns="id", values="y"),
+            check_exact=True)

--- a/mlsynth/utils/compsc_helpers/setup.py
+++ b/mlsynth/utils/compsc_helpers/setup.py
@@ -52,9 +52,10 @@ def prepare_compsc_inputs(
         pre-treatment periods, negative shares, or zeros that cannot be
         repaired.
     """
-    balance(df, unitid, time)
+    keys = balance(df, unitid, time)
 
-    prep0 = dataprep(df, unitid, time, outcomes[0], treat, allow_no_donors=True)
+    prep0 = dataprep(df, unitid, time, outcomes[0], treat, allow_no_donors=True,
+                     keys=keys)
     Ywide0 = prep0["Ywide"]                       # (T, N) frame
     time_labels = np.asarray(prep0["time_labels"])
     units = list(Ywide0.columns)

--- a/mlsynth/utils/cscm_helpers/setup.py
+++ b/mlsynth/utils/cscm_helpers/setup.py
@@ -18,12 +18,12 @@ def prepare_cscm_inputs(df, outcome: str, treat: str, unitid: str, time: str
     ``pre_periods`` (T0), ``post_periods`` (T1), and ``time_labels``.
     """
     try:
-        balance(df, unitid, time)
+        keys = balance(df, unitid, time)
     except Exception as e:  # noqa: BLE001 - defensive re-wrap of balancing errors
         raise MlsynthDataError(f"Error balancing panel data: {e}") from e  # pragma: no cover
 
     try:
-        prep = dataprep(df, unitid, time, outcome, treat)
+        prep = dataprep(df, unitid, time, outcome, treat, keys=keys)
     except MlsynthDataError:
         raise
     except Exception as e:  # noqa: BLE001 - defensive re-wrap of dataprep errors

--- a/mlsynth/utils/datautils.py
+++ b/mlsynth/utils/datautils.py
@@ -27,8 +27,155 @@ KEY_DONOR_PROXIES = "donorproxies"
 KEY_SURROGATE_VARS = "surrogatevars"
 
 
+class PanelKeys:
+    """A panel's ``(unit, time)`` key structure, scanned once.
+
+    Establishing which unit and which period a row belongs to is the first
+    thing every pivot does and the only thing ``balance`` does, and the answer
+    depends on the frame and its two key columns alone -- never on the values
+    being pivoted. Holding the scan in an object lets one pass serve the
+    validation and both pivots of a fit; without it each consumer starts again
+    from the raw columns, because a pivot returns a frame and ``balance``
+    returns a verdict, so neither can hand on what it computed.
+
+    Everything past the two ``factorize`` calls is derived on demand: a caller
+    that only validates never pays for the axis sorts a pivot needs, and a
+    caller that only pivots a dense grid never pays for the hash fallback.
+
+    Rows with a missing key are refused at construction. ``factorize`` sends
+    them to code ``-1`` and leaves them out of the levels, so every later count
+    here would silently omit them while ``df.pivot`` would give the blank a
+    level of its own -- which is how a blank time period used to add a period
+    and move ``pre_periods`` by one.
+    """
+
+    __slots__ = ("unit_column", "time_column", "unit_codes", "time_codes",
+                 "unit_levels", "time_levels", "n_rows", "n_units", "n_periods",
+                 "_frame", "_cell", "_has_duplicate", "_unit_order",
+                 "_time_order")
+
+    def __init__(self, df: pd.DataFrame, unit_column: str, time_column: str) -> None:
+        self.unit_column = unit_column
+        self.time_column = time_column
+        self.unit_codes, self.unit_levels = pd.factorize(df[unit_column], sort=False)
+        self.time_codes, self.time_levels = pd.factorize(df[time_column], sort=False)
+        self.n_rows = len(df)
+        self.n_units = len(self.unit_levels)
+        self.n_periods = len(self.time_levels)
+        # Held so ``is_for`` can answer by identity. A scan is only valid for
+        # the frame it was taken from, and comparing contents to find that out
+        # would cost the pass this class exists to avoid.
+        self._frame = df
+        self._cell: Optional[np.ndarray] = None
+        self._has_duplicate: Optional[bool] = None
+        self._unit_order: Optional[np.ndarray] = None
+        self._time_order: Optional[np.ndarray] = None
+
+        blank = {
+            name: int((codes < 0).sum())
+            for name, codes in ((unit_column, self.unit_codes),
+                                (time_column, self.time_codes))
+            if (codes < 0).any()
+        }
+        if blank:
+            details = ", ".join(f"{name}: {count}" for name, count in blank.items())
+            raise MlsynthDataError(
+                f"Missing values found in the panel's key columns -> {details}. "
+                "Every observation must carry both a unit and a time period; clean "
+                "or drop these rows before passing the panel."
+            )
+
+    def is_for(self, df: pd.DataFrame, unit_column: str, time_column: str) -> bool:
+        """Whether this scan describes ``df`` keyed on these two columns."""
+        return (df is self._frame
+                and unit_column == self.unit_column
+                and time_column == self.time_column)
+
+    @property
+    def cell(self) -> np.ndarray:
+        """One integer per row identifying its ``(time, unit)`` grid cell.
+
+        Unit-minor, matching the ``(n_periods, n_units)`` block a pivot fills.
+        Codes are non-negative here -- missing keys were refused -- so the
+        plain linear index cannot collide.
+        """
+        if self._cell is None:
+            self._cell = self.time_codes.astype(np.int64) * self.n_units + self.unit_codes
+        return self._cell
+
+    @property
+    def grid(self) -> int:
+        return self.n_units * self.n_periods
+
+    @property
+    def has_duplicate(self) -> bool:
+        """Whether any ``(unit, time)`` pair appears more than once.
+
+        Counting cells directly is the cheapest route, but only where the grid
+        is not much larger than the data. An unbalanced panel is precisely the
+        case where it is: 4000 singleton units would ask for a 16-million-cell
+        count to report an error, so beyond the bound the cells are hashed
+        instead, which is bounded by the row count.
+        """
+        if self._has_duplicate is None:
+            if self.n_rows == 0:
+                self._has_duplicate = False
+            elif self.grid <= 2 * self.n_rows:
+                counts = np.bincount(self.cell, minlength=self.grid)
+                self._has_duplicate = bool(counts.max() > 1)
+            else:
+                self._has_duplicate = len(pd.factorize(self.cell, sort=False)[1]) != self.n_rows
+        return self._has_duplicate
+
+    @property
+    def unit_order(self) -> np.ndarray:
+        """Permutation putting the unit levels in the order ``df.pivot`` uses."""
+        if self._unit_order is None:
+            self._unit_order = np.argsort(np.asarray(self.unit_levels), kind="stable")
+        return self._unit_order
+
+    @property
+    def time_order(self) -> np.ndarray:
+        if self._time_order is None:
+            self._time_order = np.argsort(np.asarray(self.time_levels), kind="stable")
+        return self._time_order
+
+    def observations_per_unit(self) -> np.ndarray:
+        """Rows per unit.
+
+        With duplicate pairs ruled out, each unit's rows carry distinct time
+        codes, so this counts a unit's distinct observed periods.
+        """
+        return np.bincount(self.unit_codes, minlength=self.n_units)
+
+
+def _keys_for(
+    df: pd.DataFrame, unit_column: str, time_column: str,
+    keys: Optional[PanelKeys],
+) -> PanelKeys:
+    """Return ``keys`` if it describes this panel, otherwise scan.
+
+    A scan supplied for some other frame or some other pair of columns is a
+    caller error and not something to work around: reusing it would scatter
+    values into cells derived from a different panel, and the result would be
+    wrong without being obviously wrong.
+    """
+    if keys is None:
+        return PanelKeys(df, unit_column, time_column)
+    if not keys.is_for(df, unit_column, time_column):
+        raise MlsynthDataError(
+            "The supplied key scan is not for this panel: it was taken from a "
+            f"different panel or different key columns (scanned "
+            f"{keys.unit_column!r}/{keys.time_column!r}, asked for "
+            f"{unit_column!r}/{time_column!r}). Pass the scan returned by "
+            "``balance`` on the same frame, or omit it."
+        )
+    return keys
+
+
 def _fast_pivot(
-    df: pd.DataFrame, index: str, columns: str, values: str
+    df: pd.DataFrame, index: str, columns: str, values: str,
+    keys: Optional[PanelKeys] = None,
 ) -> Optional[pd.DataFrame]:
     """O(n) equivalent of ``df.pivot`` for panels with unique (index, columns) keys.
 
@@ -38,42 +185,35 @@ def _fast_pivot(
     built by a single hash-``factorize`` + scatter -- several times faster and
     byte-identical to ``pivot`` (same sorted labels, index/column names, and
     dtype). Returns ``None`` (so the caller falls back to ``df.pivot``) when the
-    fast path does not apply: empty input, missing (NaN) keys, a grid too sparse
-    to be worth materialising, or duplicate (index, columns) pairs -- which
-    ``pivot`` itself rejects.
+    fast path does not apply: empty input, a grid too sparse to be worth
+    materialising, or duplicate (index, columns) pairs -- which ``pivot`` itself
+    rejects. A missing (NaN) key is not a reason to fall back but an error, and
+    :class:`PanelKeys` raises on it.
+
+    ``keys`` is the panel's key structure if a caller already scanned it. Every
+    step up to the scatter -- the two ``factorize``s, the cell index, the
+    duplicate count, the two axis sorts -- depends on ``(df, index, columns)``
+    and not on ``values``, so a caller pivoting the same panel twice can hand
+    the same scan to both calls and pay for it once.
     """
     n = len(df)
     if n == 0:
         return None
-    u_codes, u_uniq = pd.factorize(df[columns], sort=False)   # O(n) hash, no sort
-    t_codes, t_uniq = pd.factorize(df[index], sort=False)
-    # A missing key is not a reason to fall back -- it is an error. Deferring to
-    # ``df.pivot`` here is what gave the blank a level named ``nan``, adding a
-    # donor column or a period and shifting ``pre_periods`` with nothing raised.
-    # The codes are already computed, so refusing costs no extra pass.
-    blank = {name: int((codes < 0).sum())
-             for name, codes in ((columns, u_codes), (index, t_codes))
-             if (codes < 0).any()}
-    if blank:
-        details = ", ".join(f"{name}: {count}" for name, count in blank.items())
-        raise MlsynthDataError(
-            f"Missing values found in the panel's key columns -> {details}. "
-            "Every observation must carry both a unit and a time period; clean "
-            "or drop these rows before passing the panel."
-        )
-    n_u, n_t = len(u_uniq), len(t_uniq)
-    grid = n_u * n_t
+    keys = _keys_for(df, columns, index, keys)
+    n_u, n_t = keys.n_units, keys.n_periods
+    grid = keys.grid
     if grid > 2 * n:                     # too sparse: not worth it / avoid huge alloc
         return None
-    lin = t_codes.astype(np.int64) * n_u + u_codes
-    if np.bincount(lin, minlength=grid).max() > 1:            # duplicate key -> pandas
+    lin = keys.cell
+    if keys.has_duplicate:                                    # duplicate key -> pandas
         return None
+    u_uniq, t_uniq = keys.unit_levels, keys.time_levels
     vals = df[values].to_numpy()
     wide = (np.empty((n_t, n_u), dtype=vals.dtype) if n == grid
             else np.full((n_t, n_u), np.nan))
     wide.reshape(-1)[lin] = vals
-    su = np.argsort(np.asarray(u_uniq), kind="stable")        # match pivot's sorted axes
-    st = np.argsort(np.asarray(t_uniq), kind="stable")
+    su = keys.unit_order                  # match pivot's sorted axes
+    st = keys.time_order
     # ``pivot`` returns a C-contiguous values block; match its memory *layout*,
     # not just its values. A value-equal but F-contiguous array changes BLAS
     # reduction order, perturbing float-sensitive downstream code (e.g. a seeded
@@ -92,11 +232,14 @@ def _fast_pivot(
 
 
 def _wide_pivot(
-    df: pd.DataFrame, index: str, columns: str, values: str
+    df: pd.DataFrame, index: str, columns: str, values: str,
+    keys: Optional[PanelKeys] = None,
 ) -> pd.DataFrame:
     """``df.pivot(index=index, columns=columns, values=values)`` with an O(n)
     fast path (:func:`_fast_pivot`) for balanced/unique panels, falling back to
     the pandas pivot otherwise (which also raises on duplicate keys).
+
+    ``keys`` is forwarded to the fast path: see :func:`_fast_pivot`.
 
     The fast path is used only when it reproduces ``df.pivot``'s C-contiguous
     ``.to_numpy()`` layout -- not just its values. The layout that a transposed
@@ -108,7 +251,7 @@ def _wide_pivot(
     is reliably C-contiguous, keeping the output byte- and layout-identical on
     every pandas version.
     """
-    fast = _fast_pivot(df, index, columns, values)
+    fast = _fast_pivot(df, index, columns, values, keys)
     if fast is not None and fast.to_numpy().flags["C_CONTIGUOUS"]:
         return fast
     return df.pivot(index=index, columns=columns, values=values)
@@ -278,6 +421,7 @@ def build_covariate_matrix(
     *,
     aggregation: str = "pre_mean",
     normalize: bool = True,
+    keys: Optional[PanelKeys] = None,
 ) -> Tuple[np.ndarray, Tuple[str, ...], np.ndarray, np.ndarray]:
     """Per-unit covariate matrix aligned to ``unit_order``.
 
@@ -291,6 +435,10 @@ def build_covariate_matrix(
     ``unit_order``) so all covariates are unit-free, which is the standard
     pre-step before applying SCM-style predictor weights or computing
     standardized mean differences for balance diagnostics.
+    keys : PanelKeys, optional
+        The panel's key structure, if the caller already scanned it. One pivot
+        per covariate follows, all keyed on the same two columns, so a supplied
+        scan serves every one of them.
 
     Returns
     -------
@@ -310,7 +458,8 @@ def build_covariate_matrix(
         if cov not in df.columns:
             raise MlsynthDataError(f"covariate {cov!r} not present in df.columns")
         pivot = _wide_pivot(df, index=time_period_column_name,
-                            columns=unit_id_column_name, values=cov)
+                            columns=unit_id_column_name, values=cov,
+                            keys=keys)
         if aggregation == "pre_mean":
             if pre_periods <= 0:
                 raise MlsynthDataError(
@@ -355,6 +504,7 @@ def dataprep(
     covariate_aggregation: Literal["pre_mean"] = "pre_mean",
     normalize_covariates: bool = True,
     marex: bool = False,
+    keys: Optional[PanelKeys] = None,
 ) -> Dict[str, Any]:
     """Prepare data for synthetic control methods.
 
@@ -401,6 +551,13 @@ def dataprep(
         predictor matrix ``X = [Y_pre; covariates^T]`` plus its
         population-weighted aggregate, surfacing the inputs that the
         MAREX-family experimental-design estimators consume.
+    keys : PanelKeys, optional
+        The panel's key structure, if the caller already scanned it -- the
+        value :func:`balance` returns. Both pivots below key on the same two
+        columns, so the scan is taken once here and shared between them; a
+        caller that validated the same frame first can supply its scan and the
+        panel is read once for the whole fit. A scan taken from a different
+        frame or different columns is refused.
 
     Returns
     -------
@@ -432,12 +589,19 @@ def dataprep(
         - If a covariate column name is not present in ``df.columns``.
         - If ``covariate_aggregation`` is unknown.
     """
+    # Both pivots below key on the same two columns and differ only in which
+    # values they scatter, so the panel is scanned once here and the scan is
+    # handed to each of them. A scan supplied by the caller is checked against
+    # this frame before it is used.
+    keys = _keys_for(df, unit_id_column_name, time_period_column_name, keys)
+
     # Pivot the treatment indicator column to a wide format (time x units).
     treatment_matrix_wide = _wide_pivot(
         df,
         index=time_period_column_name,
         columns=unit_id_column_name,
         values=treatment_indicator_column_name,
+        keys=keys,
     )
     treatment_array_wide = treatment_matrix_wide.to_numpy()
     treatment_analysis_results = logictreat(treatment_array_wide)
@@ -454,6 +618,7 @@ def dataprep(
             index=time_period_column_name,
             columns=unit_id_column_name,
             values=outcome_column_name,
+            keys=keys,
         )
         treated_unit_name = outcome_matrix_wide.columns[treated_unit_column_index[0]]
         treated_unit_outcome_vector = outcome_matrix_wide[treated_unit_name].to_numpy()
@@ -492,6 +657,7 @@ def dataprep(
                 covariates, num_pre_treatment_periods, unit_order,
                 aggregation=covariate_aggregation,
                 normalize=normalize_covariates,
+                keys=keys,
             )
             n_donors = len(donor_names)
             out["covariate_matrix"] = cov_matrix                      # (N, M)
@@ -541,13 +707,12 @@ def dataprep(
             index=time_period_column_name,
             columns=unit_id_column_name,
             values=outcome_column_name,
+            keys=keys,
         )
-        treatment_matrix_wide_multi = _wide_pivot(
-            df,
-            index=time_period_column_name,
-            columns=unit_id_column_name,
-            values=treatment_indicator_column_name,
-        )
+        # The treatment pivot built before the branch. It is read only above
+        # (``.to_numpy()`` into ``logictreat``), so rebuilding it here produced
+        # an equal frame from unchanged inputs.
+        treatment_matrix_wide_multi = treatment_matrix_wide
 
         first_treatment_time_by_unit = (treatment_matrix_wide_multi == 1).idxmax().to_dict()
         cohort_treatment_start_times_map: Dict[Any, List[Any]] = {}
@@ -595,6 +760,7 @@ def dataprep(
                 covariates, max(min_pre, 1), unit_order,
                 aggregation=covariate_aggregation,
                 normalize=normalize_covariates,
+                keys=keys,
             )
             out_multi["covariate_matrix"] = cov_matrix
             out_multi["covariate_names"] = cov_names
@@ -774,7 +940,9 @@ def geoex_dataprep(
     }
 
 
-def balance(df: pd.DataFrame, unit_id_column_name: str, time_period_column_name: str) -> None:
+def balance(
+    df: pd.DataFrame, unit_id_column_name: str, time_period_column_name: str
+) -> PanelKeys:
     """Check if the panel is strongly balanced.
 
     A strongly balanced panel means every unit has an observation for every
@@ -792,13 +960,16 @@ def balance(df: pd.DataFrame, unit_id_column_name: str, time_period_column_name:
 
     Returns
     -------
-    None
-        This function does not return a value but raises an error if the
-        panel is not strongly balanced or contains duplicates.
+    PanelKeys
+        The key scan these checks were answered from. A caller that goes on to
+        read the same frame with :func:`dataprep` passes it as ``keys=`` and the
+        panel is scanned once for the whole fit instead of once per pivot.
+        Callers that discard the return value are unaffected.
 
     Raises
     ------
     MlsynthDataError
+        If a row is missing its unit or its time period.
         If duplicate unit-time observations are found.
         If the panel is not strongly balanced (i.e., not all units have
         observations for all time periods).
@@ -809,62 +980,23 @@ def balance(df: pd.DataFrame, unit_id_column_name: str, time_period_column_name:
     # ``factorize`` has already reduced to integers, and they were 35 to 47
     # percent of ingestion cost -- more than the pivot they precede.
     #
-    # ``factorize`` sends a missing key to code -1 and leaves it out of the
-    # levels, which is what makes both the refusal below and the counts after it
-    # readable off the codes alone.
-    unit_codes, unit_levels = pd.factorize(df[unit_id_column_name], sort=False)
-    time_codes, time_levels = pd.factorize(df[time_period_column_name], sort=False)
-    n_rows = len(df)
-    n_units, n_periods = len(unit_levels), len(time_levels)
+    # The scan is returned, so the pivots that follow can read it instead of
+    # taking it again. Scanning here also puts the missing-key refusal first: a
+    # blank key has no level, so every count below would omit it while
+    # ``df.pivot`` would give it a level named ``nan``, adding a period and
+    # moving ``pre_periods`` by one.
+    keys = PanelKeys(df, unit_id_column_name, time_period_column_name)
+    n_periods = keys.n_periods
 
-    # A row without a unit or without a time is not an observation, and the
-    # checks below cannot see it: they count with the levels, and a missing key
-    # has no level. That silence used to reach the pivot, which *does* give the
-    # blank a level -- one named ``nan`` -- so a blank time added a period and
-    # moved ``pre_periods`` by one with nothing raised. Reading the codes for it
-    # costs nothing, because they are already here.
-    missing = {
-        name: int((codes < 0).sum())
-        for name, codes in ((unit_id_column_name, unit_codes),
-                            (time_period_column_name, time_codes))
-        if (codes < 0).any()
-    }
-    if missing:
-        details = ", ".join(f"{name}: {count}" for name, count in missing.items())
-        raise MlsynthDataError(
-            f"Missing values found in the panel's key columns -> {details}. "
-            "Every observation must carry both a unit and a time period; clean "
-            "or drop these rows before passing the panel."
-        )
-
-    # One integer per row identifying its cell. Codes are shifted so the missing
-    # key (-1) becomes 0 and cannot collide with a real pair: without the shift,
-    # (unit=-1, time=0) and (unit=n_units-1, time=-1) both land on -1.
-    cell = (time_codes.astype(np.int64) + 1) * (n_units + 1) + (unit_codes + 1)
-
-    # A duplicated pair is a repeated cell. Counting cells directly is the
-    # cheapest route, but only where the grid is not much larger than the data:
-    # an unbalanced panel is precisely the case where it is, and a panel of
-    # 4000 singleton units would ask for a 16-million-cell count to report an
-    # error. The bound matches the one ``_fast_pivot`` applies for the same
-    # reason; beyond it, hashing the cells is bounded by the row count.
-    grid = (n_units + 1) * (n_periods + 1)
-    if grid <= 2 * max(n_rows, 1):
-        has_duplicate = bool(np.bincount(cell, minlength=grid).max() > 1) if n_rows else False
-    else:
-        has_duplicate = len(pd.factorize(cell, sort=False)[1]) != n_rows
-    if has_duplicate:
+    if keys.has_duplicate:
         raise MlsynthDataError(
             "Duplicate observations found. Ensure each combination of unit and time is unique."
         )
 
     # With duplicate pairs ruled out, each unit's rows carry distinct time codes,
-    # so counting a unit's rows that have a non-missing time *is* counting its
-    # distinct observed periods -- what ``groupby(unit)[time].nunique()``
-    # returned. Rows whose unit key is missing are dropped, as ``groupby``
-    # dropped them.
-    observed = (unit_codes >= 0) & (time_codes >= 0)
-    observations_per_unit = np.bincount(unit_codes[observed], minlength=n_units)
+    # so counting a unit's rows *is* counting its distinct observed periods --
+    # what ``groupby(unit)[time].nunique()`` returned.
+    observations_per_unit = keys.observations_per_unit()
 
     if not bool((observations_per_unit == n_periods).all()):
         raise MlsynthDataError(
@@ -877,6 +1009,7 @@ def balance(df: pd.DataFrame, unit_id_column_name: str, time_period_column_name:
         raise MlsynthDataError(
             "The panel is not strongly balanced. Units have different numbers of observations."
             )
+    return keys
 
 
 def clean_surrogates2(

--- a/mlsynth/utils/fdid_helpers/setup.py
+++ b/mlsynth/utils/fdid_helpers/setup.py
@@ -43,12 +43,12 @@ def prepare_fdid_inputs(
         If fewer than two pre-treatment periods are available.
     """
     try:
-        balance(df, unitid, time)
+        keys = balance(df, unitid, time)
     except Exception as e:  # noqa: BLE001 - re-wrap as repository error
         raise MlsynthDataError(f"Error balancing panel data: {str(e)}") from e
 
     try:
-        prepped = dataprep(df, unitid, time, outcome, treat)
+        prepped = dataprep(df, unitid, time, outcome, treat, keys=keys)
     except MlsynthDataError:
         raise
     except Exception as e:  # noqa: BLE001

--- a/mlsynth/utils/mlsc_helpers/setup.py
+++ b/mlsynth/utils/mlsc_helpers/setup.py
@@ -107,11 +107,11 @@ def prepare_mlsc_inputs(
     """
 
     # Balance both panels independently.
-    balance(df_agg, unitid_agg, time)
+    keys_agg = balance(df_agg, unitid_agg, time)
     balance(df_disagg, unitid_disagg, time)
 
     # ``dataprep`` on the aggregate panel: standard single-treated path.
-    prep_agg = dataprep(df_agg, unitid_agg, time, outcome, treat)
+    prep_agg = dataprep(df_agg, unitid_agg, time, outcome, treat, keys=keys_agg)
     if "cohorts" in prep_agg:
         raise MlsynthDataError(
             "mlSC requires a single treated aggregate; the aggregate panel "

--- a/mlsynth/utils/propsc_helpers/setup.py
+++ b/mlsynth/utils/propsc_helpers/setup.py
@@ -41,10 +41,11 @@ def prepare_propsc_inputs(
     -------
     PropscInputs
     """
-    balance(df, unitid, time)
+    keys = balance(df, unitid, time)
 
     # Canonical time/unit axes from the first proportion's pivot.
-    prep0 = dataprep(df, unitid, time, outcomes[0], treat, allow_no_donors=True)
+    prep0 = dataprep(df, unitid, time, outcomes[0], treat, allow_no_donors=True,
+                     keys=keys)
     Ywide0 = prep0["Ywide"]                      # (T, N) frame
     time_labels = np.asarray(prep0["time_labels"])
     units = list(Ywide0.columns)

--- a/mlsynth/utils/sdid_helpers/setup.py
+++ b/mlsynth/utils/sdid_helpers/setup.py
@@ -202,8 +202,8 @@ def prepare_sdid_inputs(
         Pre-processed cohorts payload and metadata.
     """
 
-    balance(df, unitid, time)
-    prep: Dict[str, Any] = dataprep(df, unitid, time, outcome, treat)
+    keys = balance(df, unitid, time)
+    prep: Dict[str, Any] = dataprep(df, unitid, time, outcome, treat, keys=keys)
 
     if "cohorts" in prep:
         # ``dataprep`` keys cohorts by the actual time *label* (e.g. 2010),

--- a/mlsynth/utils/seq_sdid_helpers/setup.py
+++ b/mlsynth/utils/seq_sdid_helpers/setup.py
@@ -54,8 +54,8 @@ def prepare_seq_sdid_inputs(
         estimable effect fits inside the panel.
     """
 
-    balance(df, unitid, time)
-    prep: Dict[str, Any] = dataprep(df, unitid, time, outcome, treat)
+    keys = balance(df, unitid, time)
+    prep: Dict[str, Any] = dataprep(df, unitid, time, outcome, treat, keys=keys)
 
     Ywide = prep["Ywide"]
     time_labels = np.asarray(prep["time_labels"])

--- a/mlsynth/utils/sparse_sc_helpers/setup.py
+++ b/mlsynth/utils/sparse_sc_helpers/setup.py
@@ -116,8 +116,8 @@ def prepare_sparse_sc_inputs(
         across all units. Default ``True``.
     """
 
-    balance(df, unitid, time)
-    prep = dataprep(df, unitid, time, outcome, treat)
+    keys = balance(df, unitid, time)
+    prep = dataprep(df, unitid, time, outcome, treat, keys=keys)
     if "cohorts" in prep:
         raise MlsynthDataError(
             "SparseSC currently supports a single treated unit; the panel "

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -818,15 +818,15 @@ test-command = "python -m pytest mlsynth/tests/test_balance_key_structure.py mls
 timeout = 900.0
 
   [[target.mutant]]
-  id = "cell-index-built-without-the-missing-key-shift"
-  find = "    cell = (time_codes.astype(np.int64) + 1) * (n_units + 1) + (unit_codes + 1)"
-  replace = "    cell = time_codes.astype(np.int64) * n_units + unit_codes"
-  models = "the linear cell index formed straight from the codes. A missing key is -1, so (unit=-1, period=0) and (unit=n_units-1, period=-1) both land on the same cell and are reported as a duplicate observation -- a panel rejected for a fault it does not have, and only on frames carrying missing keys in both columns"
+  id = "cell-index-built-time-minor"
+  find = "            self._cell = self.time_codes.astype(np.int64) * self.n_units + self.unit_codes"
+  replace = "            self._cell = self.unit_codes.astype(np.int64) * self.n_periods + self.time_codes"
+  models = "the cell index laid out unit-major instead of unit-minor. The cells are still distinct so the duplicate check still passes, and on a square panel the scatter still lands somewhere plausible -- but every value goes to the transposed cell, so the wide frame is the transpose of the panel and each unit's series is read off as a period's cross-section"
 
   [[target.mutant]]
   id = "grid-guard-dropped"
-  find = "    if grid <= 2 * max(n_rows, 1):"
-  replace = "    if True:"
+  find = "            elif self.grid <= 2 * self.n_rows:"
+  replace = "            elif True:"
   models = "the bound that keeps the rejection path proportional to the data. Without it a panel of singleton units counts over a grid quadratic in the row count: 4000 rows asks for 16 million cells, 128 MB, to report that the panel is unbalanced"
 
   [[target.mutant]]
@@ -836,10 +836,10 @@ timeout = 900.0
   models = "each unit's observed periods compared against the number of units instead of the number of periods. Every square panel still passes, so it is invisible on any fixture where units and periods happen to match"
 
   [[target.mutant]]
-  id = "missing-time-rows-counted-as-observed"
-  find = "    observed = (unit_codes >= 0) & (time_codes >= 0)"
-  replace = "    observed = unit_codes >= 0"
-  models = "a row whose period key is missing counted toward that unit's observed periods. The count then matches for a unit that is short one real period but carries one blank, and the panel is admitted -- the previous implementation excluded it, because nunique skips missing values"
+  id = "duplicate-panel-admitted-before-the-counts"
+  find = "    if keys.has_duplicate:\n        raise MlsynthDataError("
+  replace = "    if False:\n        raise MlsynthDataError("
+  models = "the duplicate check dropped, which also removes the precondition the counts below rely on. Counting a unit's rows only counts its distinct periods once duplicate pairs are ruled out, so a panel where one unit has the same period twice and is short another now passes both checks with the right total for the wrong reason"
 
   [[target.mutant]]
   id = "empty-panel-admitted"
@@ -855,21 +855,21 @@ timeout = 900.0
 
   [[target.mutant]]
   id = "ingestion-defers-a-missing-key-to-pandas-again"
-  find = "    if blank:\n        details = \", \".join(f\"{name}: {count}\" for name, count in blank.items())"
-  replace = "    if False:\n        details = \", \".join(f\"{name}: {count}\" for name, count in blank.items())"
+  find = "        if blank:\n            details = \", \".join(f\"{name}: {count}\" for name, count in blank.items())"
+  replace = "        if False:\n            details = \", \".join(f\"{name}: {count}\" for name, count in blank.items())"
   models = "the refusal reduced to the fallback it replaced. The pivot defers to df.pivot again, which keeps the blank as a level named nan, so a blank time adds a period and shifts pre_periods -- the silent estimand change #453 exists to stop. The validator still catches it, so only a caller reaching ingestion directly is exposed, which is 38 of the modules that do"
 
   [[target.mutant]]
   id = "only-the-unit-key-is-checked-at-ingestion"
-  find = "             for name, codes in ((columns, u_codes), (index, t_codes))"
-  replace = "             for name, codes in ((columns, u_codes),)"
+  find = "            for name, codes in ((unit_column, self.unit_codes),\n                                (time_column, self.time_codes))"
+  replace = "            for name, codes in ((unit_column, self.unit_codes),)"
   models = "half the check. A missing unit is refused and a missing time is not, so the phantom donor is caught and the shifted pre_periods -- the one that moves the estimand -- goes through"
 
   [[target.mutant]]
   id = "validator-refuses-only-when-both-keys-are-blank"
-  find = "        if (codes < 0).any()\n    }\n    if missing:"
-  replace = "        if (codes < 0).any()\n    }\n    if len(missing) > 1:"
-  models = "a frame blank in one key column only is admitted by the validator. Ingestion still catches it, so the estimand is safe, but the error arrives from inside the pivot instead of from the check whose job it is, and every caller matching on balance's message stops seeing it"
+  find = "            if (codes < 0).any()\n        }\n        if blank:"
+  replace = "            if (codes < 0).any()\n        }\n        if len(blank) > 1:"
+  models = "a frame blank in one key column only is admitted. Both the validator and ingestion now read the same scan, so weakening it here removes the refusal from every path at once: a blank unit adds a donor column and a blank period adds a period, which moves pre_periods"
 
 [[target]]
 name = "missing-key-refusal-config"
@@ -882,3 +882,51 @@ timeout = 600.0
   find = "            for column in (unitid, time)"
   replace = "            for column in (unitid, outcome)"
   models = "the config guarding the wrong columns: a blank outcome is refused, which the estimators that tolerate missing outcomes rely on being allowed, and a blank time period -- the one that moves pre_periods -- passes construction untouched"
+
+[[target]]
+name = "shared-key-scan"
+module-path = "mlsynth/utils/datautils.py"
+test-command = "python -m pytest mlsynth/tests/test_panel_key_scan.py mlsynth/tests/test_datautils.py mlsynth/tests/test_missing_key_rejection.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "supplied-scan-used-without-checking-whose-it-is"
+  find = "    if not keys.is_for(df, unit_column, time_column):"
+  replace = "    if False:"
+  models = "a scan taken from one panel applied to another. The codes index cells of the first panel, so the second panel's values scatter into positions derived from a frame they have nothing to do with -- and the result is a well-formed wide frame of the right shape holding the wrong numbers, which no shape or dtype check downstream can see"
+
+  [[target.mutant]]
+  id = "scan-identity-answered-by-shape"
+  find = "        return (df is self._frame\n                and unit_column == self.unit_column\n                and time_column == self.time_column)"
+  replace = "        return (len(df) == self.n_rows\n                and unit_column == self.unit_column\n                and time_column == self.time_column)"
+  models = "identity weakened to a row count. Two panels of the same length with different unit orderings then share a scan, so the values land in each other's cells while every count still agrees"
+
+  [[target.mutant]]
+  id = "dataprep-rescans-per-pivot-again"
+  find = "    keys = _keys_for(df, unit_id_column_name, time_period_column_name, keys)\n\n    # Pivot the treatment indicator"
+  replace = "    keys = None\n\n    # Pivot the treatment indicator"
+  models = "the scan discarded at the top of dataprep, so each pivot takes its own again. Every number is still right -- this is the state the fix left -- and only a count of the passes over the panel can see it"
+
+  [[target.mutant]]
+  id = "cohort-branch-rebuilds-the-treatment-pivot"
+  find = "        treatment_matrix_wide_multi = treatment_matrix_wide"
+  replace = "        treatment_matrix_wide_multi = _wide_pivot(df, index=time_period_column_name, columns=unit_id_column_name, values=treatment_indicator_column_name, keys=keys)"
+  models = "the cohort branch building the treatment pivot a second time. The frames are equal, so no cohort onset moves and no output changes; the only visible difference is a third pivot of a panel that was already pivoted"
+
+  [[target.mutant]]
+  id = "axis-sorts-recomputed-per-pivot"
+  find = "    su = keys.unit_order                  # match pivot's sorted axes\n    st = keys.time_order"
+  replace = "    su = np.argsort(np.asarray(u_uniq), kind=\"stable\")\n    st = np.argsort(np.asarray(t_uniq), kind=\"stable\")"
+  models = "the axis sorts taken again on every pivot instead of once per panel. The permutations are identical, so the frames are identical, and the cost returns without any output moving"
+
+  [[target.mutant]]
+  id = "cached-scan-recomputed-on-every-read"
+  find = "        if self._cell is None:"
+  replace = "        if True:"
+  models = "the cell index rebuilt on every access instead of once. The value is the same each time, so the panel still reads correctly and the duplicate check still agrees -- it is the caching, not the arithmetic, that the shared scan is for"
+
+  [[target.mutant]]
+  id = "covariate-pivots-rescan-the-panel"
+  find = "        pivot = _wide_pivot(df, index=time_period_column_name,\n                            columns=unit_id_column_name, values=cov,\n                            keys=keys)"
+  replace = "        pivot = _wide_pivot(df, index=time_period_column_name,\n                            columns=unit_id_column_name, values=cov)"
+  models = "one scan per covariate instead of one for the panel. A ten-covariate panel is scanned eleven times, and every covariate matrix is correct, so nothing but a pass count reports it"


### PR DESCRIPTION
Closes #459.

## What was wrong

Establishing which unit and which period a row belongs to depends on `(df, index, columns)` alone and never on the values being pivoted, yet every consumer started again from the raw columns. `_fast_pivot` returns a frame and `balance` returned a verdict, so neither could hand on what it computed. A single-treated SDID fit factorized the two key columns six times over the same 840 rows:

```
1x id / 1x time  <- sdid_helpers/setup.py:205   (balance)
2x id / 2x time  <- sdid_helpers/setup.py:206   (dataprep, one scan per pivot)
```

and the cohort branch went further: it rebuilt the entire treatment pivot that the pre-branch code had already built, from the same frame with the same arguments.

The full ladder, the measurements, and the corrections to two earlier claims are in #459.

## What changed

`PanelKeys` holds one scan of the panel. Everything past the two `factorize` calls -- the cell index, the duplicate count, the two axis sorts -- is derived on demand, so a caller that only validates never pays for the sorts a pivot needs, and a caller that only pivots a dense grid never pays for the hash fallback. Rows with a missing key are refused at construction, which puts the #453/#455 refusal ahead of every count that would otherwise omit them.

- `balance` returns the scan it answered from. Callers that discard it are unaffected.
- `dataprep` takes an optional `keys=` and shares one scan across both pivots and every covariate pivot.
- The nine call sites where `balance` and `dataprep` are adjacent pass it along.
- The cohort branch reuses the treatment frame built before it. That frame is read only -- `.to_numpy()` into `logictreat`, which does not write into it -- so rebuilding it produced an equal frame from unchanged inputs.
- A scan supplied for a different frame or different key columns is refused, since reusing it would scatter values into cells derived from a panel they have nothing to do with and produce a well-formed frame of the right shape holding the wrong numbers.

## Effect

Key-column scans per fit, same panel:

| estimator | before | after |
|---|---:|---:|
| SDID | 6 | 2 |
| FDID | 6 | 2 |
| VanillaSC | 4 | 2 |
| TSSC | 6 | 4 |
| CLUSTERSC | 6 | 4 |
| PDA | 2 | 2 |

TSSC and CLUSTERSC are among the 38 modules whose `balance` sits in the estimator and whose `dataprep` sits in a helper, so they take the intra-`dataprep` half only. Threading the scan across that boundary is a per-estimator change and is left for each of them.

`vce="noinference"` SDID, single-threaded, minimum of 25:

| shape | rows | fit before | fit after | ingestion before | ingestion after | ingestion share |
|---:|---:|---:|---:|---:|---:|---|
| 21 x 40 | 840 | 7.93 ms | 6.76 ms | 4.29 ms | 3.18 ms | 53.1% -> 46.2% |
| 51 x 100 | 3,570 | 14.99 ms | 13.90 ms | 4.73 ms | 3.49 ms | 31.6% -> 25.1% |
| 101 x 200 | 12,120 | 27.93 ms | 26.39 ms | 6.34 ms | 4.44 ms | 22.7% -> 16.8% |
| 201 x 200 | 24,120 | 55.08 ms | 52.13 ms | 8.65 ms | 5.85 ms | 15.7% -> 11.2% |

Against `coresynth` at 21 x 40 that moves 0.47x to 0.55x. It does not close the small-panel gap, and #459 says so: the remainder is `dataprep`'s fixed cost, which needs its own descent.

## Tests

New `test_panel_key_scan.py`, 41 tests. Two kinds.

The work assertions are the contract rung 4 of the analysis found nobody had written down. They count key-column `factorize` calls and `_wide_pivot` signatures per `dataprep` and hold them to one scan per panel and one pivot per distinct `values` column, in the single-treated branch, the cohort branch and the covariate path. Counting is deterministic, so these are assertions and not wall-clock thresholds -- the form the three preceding issues in this series all lacked.

The equivalence tests are the acceptance bar, since 51 modules read what `dataprep` returns. Across nine panel shapes (single-treated, cohort, one donor, single post-period, wide-short, tall-narrow, string units, unsorted rows) the payload is compared recursively, frame by frame and array by array, for values, dtype, index and column labels and C-contiguity -- the layer that matters because a value-equal but F-contiguous array changes BLAS reduction order and moves float-sensitive downstream code at ~1e-16. The pivots are compared against `df.pivot` directly. The `balance` contract is re-pinned: all four `MlsynthDataError` messages, which one fires, and that the refusal still precedes any wide frame. The guard is tested from three directions, and the paths where the fast path declines (sparse grid, duplicate keys, empty frame, single cell) are pinned to still reach pandas.

`tools/mutation/targets.toml` gains a `shared-key-scan` target with seven mutants, three of which are output-invisible by construction -- a rescan, a rebuilt pivot, recomputed axis sorts -- so only a pass count can kill them. Six mutants in the existing `balance-key-structure` and `missing-key-refusal` targets were re-anchored to where their code now lives; the whole catalogue is verified to match at exactly one site.

Green locally: 1108 passed / 4 skipped across the datautils, SDID, FDID, CompSC, CSCM, mlSC, PropSC, SparseSC, balance, missing-key and unit-index suites; the new datautils code is fully covered. Replications re-run and passing: `sdid_prop99`, `sdid_euets`, `sdid_ddd_hpv`, `fdid_table5`, `fdid_hongkong`, `compsc_pennsylvania`, `cscm_viszero`, `mlsc_bottmer`, `propsc_spain`, `seq_sdid_mc`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_