### PR TITLE
Seed the batched min-norm solver's corrals instead of walking to them

### DIFF
--- a/mlsynth/tests/test_minnorm_support_seed.py
+++ b/mlsynth/tests/test_minnorm_support_seed.py
@@ -1,0 +1,393 @@
+"""The batched min-norm solver is told its support instead of discovering it.
+
+Wolfe's min-norm-point method adds one vertex per iteration and solves a corral
+system that grows with each addition, so an optimum supported on ``k`` donors
+costs at least ``k`` iterations of a ``(k, k)`` solve. That cost model assumes a
+sparse optimum. SDID's unit-weight program is ridged by ``zeta``, and the ridge
+is there to push weight off the vertices onto a face, so the optimum comes out
+around 70 percent dense -- median 67 of 99 donors on a 101-unit panel, 26 of 37
+on Prop 99. The solver spent 87 iterations rediscovering, one element at a time,
+a support a first-order pass names in one go (#461).
+
+Two kinds of test live here, red for different reasons.
+
+The work assertions start red. They count active-set iterations and hold a
+dense-support batch to a handful, and they check that the seed is not paid for
+where it cannot earn its keep -- a narrow pool, a caller-supplied warm start, or
+the accelerator switched off.
+
+The answer tests pass before the change and must pass after it. The seed is
+speed only: Wolfe's optimality test stays the arbiter, so a seed that is late,
+wrong, or actively adversarial may cost iterations and may not move the
+objective. That is checked against seeds chosen to be bad on purpose, because
+"the answer does not depend on the seed" is the property the whole design rests
+on -- if it fails, the accelerator is not an accelerator, it is a second
+estimator.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel import accelerate as ACC
+from mlsynth.utils.bilevel.accelerate import (
+    fista_warm_start_batch,
+    simplex_project,
+    simplex_project_batch,
+)
+from mlsynth.utils.bilevel.minnorm import solve_simplex_minnorm_batch
+
+
+# --------------------------------------------------------------------------- #
+# Grams
+# --------------------------------------------------------------------------- #
+def ridged_batch(S=40, J=90, T=30, ridge=0.5, seed=0):
+    """A stack shaped like SDID's placebo unit-weight family.
+
+    Short and wide (``T < J``) with a ridge, which is what makes the optimum a
+    dense face instead of a vertex -- the regime the seed is for.
+    """
+    rng = np.random.default_rng(seed)
+    G = np.empty((S, J, J))
+    for s in range(S):
+        B = rng.standard_normal((T, J))
+        B -= B.mean(axis=0)
+        G[s] = B.T @ B + ridge * np.eye(J)
+    return G
+
+
+def sparse_batch(S=40, J=90, T=200, seed=1):
+    """Tall and unridged: the optimum sits on a few donors."""
+    rng = np.random.default_rng(seed)
+    G = np.empty((S, J, J))
+    for s in range(S):
+        B = rng.standard_normal((T, J)) ** 2
+        G[s] = B.T @ B
+    return G
+
+
+def obj(G, W):
+    return np.einsum("sj,sjk,sk->s", W, G, W)
+
+
+def support_density(W):
+    return (W > 1e-9).sum(axis=1) / W.shape[1]
+
+
+# =========================================================================== #
+# the projection the seed is built on
+# =========================================================================== #
+class TestBatchProjection:
+    @pytest.mark.parametrize("shape", [(1, 1), (1, 5), (7, 3), (40, 90)])
+    def test_rows_land_on_the_simplex(self, shape):
+        V = np.random.default_rng(0).standard_normal(shape) * 5
+        P = simplex_project_batch(V)
+        assert P.shape == shape
+        assert (P >= 0).all()
+        np.testing.assert_allclose(P.sum(axis=1), 1.0, atol=1e-12)
+
+    def test_matches_the_scalar_projection_row_by_row(self):
+        """Differential against the shipped one-vector routine."""
+        V = np.random.default_rng(1).standard_normal((25, 12)) * 3
+        P = simplex_project_batch(V)
+        for i, row in enumerate(V):
+            np.testing.assert_allclose(P[i], simplex_project(row), atol=1e-12)
+
+    def test_a_point_already_on_the_simplex_is_fixed(self):
+        W = simplex_project_batch(np.random.default_rng(2).standard_normal((10, 8)))
+        np.testing.assert_allclose(simplex_project_batch(W), W, atol=1e-12)
+
+    def test_projection_is_the_nearest_simplex_point(self):
+        rng = np.random.default_rng(3)
+        V = rng.standard_normal((6, 5)) * 2
+        P = simplex_project_batch(V)
+        for i in range(V.shape[0]):
+            d = np.linalg.norm(V[i] - P[i])
+            for _ in range(200):
+                q = rng.dirichlet(np.ones(5))
+                assert np.linalg.norm(V[i] - q) >= d - 1e-12
+
+    def test_single_column_is_the_only_point(self):
+        np.testing.assert_allclose(
+            simplex_project_batch(np.array([[-4.0], [7.0]])), [[1.0], [1.0]])
+
+
+# =========================================================================== #
+# the seed itself
+# =========================================================================== #
+class TestSeed:
+    def test_returns_feasible_rows(self):
+        G = ridged_batch(S=8, J=40, T=15)
+        W = fista_warm_start_batch(G)
+        assert W.shape == (8, 40)
+        assert (W >= 0).all()
+        np.testing.assert_allclose(W.sum(axis=1), 1.0, atol=1e-9)
+
+    def test_is_deterministic(self):
+        G = ridged_batch(S=6, J=30, T=12)
+        np.testing.assert_array_equal(fista_warm_start_batch(G),
+                                      fista_warm_start_batch(G))
+
+    def test_finds_a_dense_support_on_a_ridged_family(self):
+        G = ridged_batch(S=10, J=60, T=20)
+        assert support_density(fista_warm_start_batch(G)).mean() > 0.3
+
+    def test_a_zero_gram_still_returns_a_feasible_row(self):
+        """A zero Gram is PSD with a flat objective: every simplex point is
+        optimal, and the seed may not return a NaN for it."""
+        G = np.zeros((3, 5, 5))
+        W = fista_warm_start_batch(G)
+        assert np.isfinite(W).all()
+        np.testing.assert_allclose(W.sum(axis=1), 1.0, atol=1e-9)
+
+    def test_single_donor(self):
+        np.testing.assert_allclose(fista_warm_start_batch(np.ones((4, 1, 1))), 1.0)
+
+    def test_single_problem(self):
+        W = fista_warm_start_batch(ridged_batch(S=1, J=20, T=8))
+        assert W.shape == (1, 20)
+
+    @pytest.mark.parametrize("bad", [0, -1, 2.5, "many", np.nan])
+    def test_a_nonsensical_patience_is_refused(self, bad):
+        with pytest.raises(ValueError, match="support_patience"):
+            fista_warm_start_batch(ridged_batch(S=2, J=10, T=5),
+                                   support_patience=bad)
+
+    def test_a_bool_patience_is_accepted_as_the_integer_it_is(self):
+        """``True`` is an ``Integral`` equal to 1, so it is a patience of one.
+
+        Asserted rather than left implicit because the scalar
+        ``fista_warm_start`` takes it the same way, and the two validators are
+        meant to agree.
+        """
+        W = fista_warm_start_batch(ridged_batch(S=2, J=10, T=5),
+                                   support_patience=True)
+        np.testing.assert_allclose(W.sum(axis=1), 1.0, atol=1e-9)
+
+    def test_none_patience_is_allowed(self):
+        W = fista_warm_start_batch(ridged_batch(S=2, J=10, T=5),
+                                   support_patience=None)
+        np.testing.assert_allclose(W.sum(axis=1), 1.0, atol=1e-9)
+
+    def test_the_support_stop_shortens_a_long_budget(self, monkeypatch):
+        """The patience rule, exercised where it can reach.
+
+        At the default budget it cannot fire: patience is 100 sampled every 10,
+        so it wants 100 iterations and the budget is 50. It is there for a
+        caller that raises the budget, and this is that caller. Counted in
+        projections, since that is one per iteration and the function reports no
+        iteration count.
+        """
+        G = ridged_batch(S=6, J=40, T=14)
+        counts = {}
+        real = ACC.simplex_project_batch
+        for label, patience in (("patience", 100), ("none", None)):
+            n = []
+            monkeypatch.setattr(ACC, "simplex_project_batch",
+                                lambda V: (n.append(1) or real(V)))
+            fista_warm_start_batch(G, max_iter=600, support_patience=patience)
+            monkeypatch.undo()
+            counts[label] = len(n)
+        assert counts["patience"] < counts["none"], counts
+
+
+# =========================================================================== #
+# work assertions -- these start red
+# =========================================================================== #
+def corral_rows_solved(monkeypatch, fn):
+    """Total rows passed through the corral solve -- ``sum(live)`` over the run.
+
+    The work assertion counts this and not iterations. Iterations are the wrong
+    metric here: a seeded batch can take the same number and still cost a
+    fraction, because the candidates certify early so the arrays shrink, and the
+    cost is ``sum(live * c^3)`` and not the iteration count. Measured on a
+    ridged 500 x 40 family, cold and seeded both run 45 iterations and the
+    seeded one is 3.6x faster.
+    """
+    rows = []
+    real = np.linalg.solve
+    monkeypatch.setattr(np.linalg, "solve",
+                        lambda A, b: (rows.append(A.shape[0]) or real(A, b)))
+    out = fn()
+    monkeypatch.undo()
+    return sum(rows), out
+
+
+class TestWorkDone:
+    def test_a_dense_support_batch_solves_far_fewer_corral_rows(self, monkeypatch):
+        G = ridged_batch(S=40, J=90, T=30)
+        cold_rows, (_, cold) = corral_rows_solved(
+            monkeypatch,
+            lambda: solve_simplex_minnorm_batch(G, accelerate=False,
+                                                return_info=True))
+        warm_rows, (_, warm) = corral_rows_solved(
+            monkeypatch,
+            lambda: solve_simplex_minnorm_batch(G, return_info=True))
+        assert warm["converged"].all() and cold["converged"].all()
+        assert warm_rows * 3 < cold_rows, (
+            f"seeded solved {warm_rows} corral rows against the cold "
+            f"{cold_rows}: the seed is not naming the support")
+
+    def test_the_seed_is_what_shrinks_the_live_set(self, monkeypatch):
+        """Live candidates fall away immediately when the support is supplied."""
+        G = ridged_batch(S=40, J=90, T=30)
+        _, (_, warm) = corral_rows_solved(
+            monkeypatch, lambda: solve_simplex_minnorm_batch(G, return_info=True))
+        _, (_, cold) = corral_rows_solved(
+            monkeypatch,
+            lambda: solve_simplex_minnorm_batch(G, accelerate=False,
+                                                return_info=True))
+        assert warm["iterations"] < cold["iterations"]
+
+    def test_a_narrow_pool_is_not_seeded(self, monkeypatch):
+        calls = []
+        real = ACC.fista_warm_start_batch
+        monkeypatch.setattr(
+            "mlsynth.utils.bilevel.minnorm.fista_warm_start_batch",
+            lambda G, **kw: (calls.append(G.shape) or real(G, **kw)))
+        solve_simplex_minnorm_batch(ridged_batch(S=10, J=4, T=6))
+        assert calls == []
+
+    def test_a_caller_warm_start_is_not_overridden(self, monkeypatch):
+        calls = []
+        real = ACC.fista_warm_start_batch
+        monkeypatch.setattr(
+            "mlsynth.utils.bilevel.minnorm.fista_warm_start_batch",
+            lambda G, **kw: (calls.append(G.shape) or real(G, **kw)))
+        G = ridged_batch(S=10, J=90, T=30)
+        solve_simplex_minnorm_batch(G, warm_start=np.full((10, 90), 1 / 90))
+        assert calls == []
+
+    def test_accelerate_false_disables_the_seed(self, monkeypatch):
+        calls = []
+        real = ACC.fista_warm_start_batch
+        monkeypatch.setattr(
+            "mlsynth.utils.bilevel.minnorm.fista_warm_start_batch",
+            lambda G, **kw: (calls.append(G.shape) or real(G, **kw)))
+        solve_simplex_minnorm_batch(ridged_batch(S=10, J=90, T=30), accelerate=False)
+        assert calls == []
+
+
+# =========================================================================== #
+# the answer does not depend on the seed
+# =========================================================================== #
+BATCHES = {
+    "ridged-dense": lambda: ridged_batch(S=30, J=70, T=25),
+    "sparse": lambda: sparse_batch(S=20, J=90, T=200),
+    "narrow": lambda: ridged_batch(S=15, J=6, T=20),
+    "square": lambda: ridged_batch(S=12, J=40, T=40),
+    "wide-ridge": lambda: ridged_batch(S=12, J=100, T=10, ridge=5.0),
+    "tiny-ridge": lambda: ridged_batch(S=12, J=50, T=20, ridge=1e-8),
+}
+
+
+def scale_of(G):
+    """The problem magnitude the solver's own KKT test is relative to."""
+    return np.einsum("sjj->sj", G).mean(axis=1)
+
+
+class TestAnswerUnchanged:
+    @pytest.mark.parametrize("name", sorted(BATCHES))
+    def test_seeded_and_unseeded_reach_the_same_optimum(self, name):
+        """Same optimum, measured the way the solver measures optimality.
+
+        The comparison is against the problem's own magnitude and not against
+        the objective value, because the solver's optimality test is: a donor
+        enters when it improves the fit by more than ``_KKT_TOL * scale``, with
+        ``scale`` the mean diagonal of ``G``. On a near-singular family the
+        optimum is a face whose objective is numerically zero -- the tiny-ridge
+        batch here reaches 1e-10 against a scale of ~20 -- so two certified
+        answers can sit 60 percent apart *relatively* while being the same
+        answer by every standard the solver applies. Ratios of zeros are not the
+        property under test.
+
+        Where the optimum is not numerically zero the check is also made
+        relatively, so the loose absolute bound cannot hide a real divergence.
+        """
+        G = BATCHES[name]()
+        W_cold, cold = solve_simplex_minnorm_batch(G, accelerate=False,
+                                                   return_info=True)
+        W_warm, warm = solve_simplex_minnorm_batch(G, return_info=True)
+        o_c, o_w = obj(G, W_cold), obj(G, W_warm)
+        s = scale_of(G)
+        gap = np.abs(o_w - o_c) / s
+        assert gap.max() < 1e-8, f"objective moved by {gap.max():.2e} of scale"
+
+        real = o_c > 1e-6 * s          # optima that are not numerically zero
+        if real.any():
+            rel = np.abs(o_w[real] - o_c[real]) / np.abs(o_c[real])
+            assert rel.max() < 1e-9, f"objective moved by {rel.max():.2e}"
+        assert warm["converged"].sum() >= cold["converged"].sum()
+
+    def test_a_face_of_optima_is_not_a_divergence(self):
+        """The near-singular case the scaled comparison above exists for."""
+        G = ridged_batch(S=12, J=50, T=20, ridge=1e-8)
+        W_cold, cold = solve_simplex_minnorm_batch(G, accelerate=False,
+                                                   return_info=True)
+        W_warm, warm = solve_simplex_minnorm_batch(G, return_info=True)
+        assert cold["converged"].all() and warm["converged"].all()
+        o_c, o_w = obj(G, W_cold), obj(G, W_warm)
+        s = scale_of(G)
+        assert (o_c / s < 1e-9).all(), "fixture must land on a near-zero optimum"
+        # Certified means no donor improves the fit by more than the tolerance,
+        # so a seeded answer is allowed to be better, and here it is.
+        assert (o_w <= o_c + 1e-10 * s).all()
+
+    @pytest.mark.parametrize("name", sorted(BATCHES))
+    def test_the_returned_weights_are_feasible(self, name):
+        W = solve_simplex_minnorm_batch(BATCHES[name]())
+        assert (W >= 0).all()
+        np.testing.assert_allclose(W.sum(axis=1), 1.0, atol=1e-9)
+
+
+class TestAdversarialSeeds:
+    """A seed may cost iterations. It may not move the answer."""
+
+    @staticmethod
+    def _bad_seeds(S, J, rng):
+        yield "uniform", np.full((S, J), 1.0 / J)
+        yield "wrong-vertex", np.eye(J)[rng.integers(0, J, S)]
+        yield "random-face", rng.dirichlet(np.ones(J), size=S)
+        one_hot = np.zeros((S, J)); one_hot[:, -1] = 1.0
+        yield "last-donor", one_hot
+        yield "not-normalised", rng.random((S, J)) * 7.0
+        yield "wrong-shape", np.full((S + 3, J), 1.0 / J)
+        yield "negative", -rng.random((S, J))
+        yield "non-finite", np.full((S, J), np.nan)
+
+    def test_a_bad_seed_never_moves_the_optimum(self):
+        rng = np.random.default_rng(7)
+        G = ridged_batch(S=12, J=50, T=18)
+        S, J = G.shape[0], G.shape[-1]
+        W_ref = solve_simplex_minnorm_batch(G, accelerate=False)
+        o_ref = obj(G, W_ref)
+        for label, seed in self._bad_seeds(S, J, rng):
+            W, info = solve_simplex_minnorm_batch(G, warm_start=seed,
+                                                  return_info=True)
+            o = obj(G, W)
+            rel = np.abs(o - o_ref) / np.maximum(np.abs(o_ref), 1e-300)
+            assert rel.max() < 1e-9, f"{label} seed moved the objective by {rel.max():.2e}"
+            assert (W >= 0).all() and np.allclose(W.sum(axis=1), 1.0, atol=1e-9), label
+
+    def test_an_exhausted_budget_is_reported_not_hidden(self):
+        G = ridged_batch(S=8, J=60, T=20)
+        _, info = solve_simplex_minnorm_batch(G, max_iter=1, return_info=True)
+        assert info["iterations"] == 1
+        assert not info["converged"].all()
+
+
+# =========================================================================== #
+# the SDID programs this was found on
+# =========================================================================== #
+class TestSdidShapedFamily:
+    def test_placebo_shaped_batch_agrees_with_the_cold_solve(self):
+        """The (S, J, J) shape and ridge of an SDID placebo unit-weight family."""
+        G = ridged_batch(S=100, J=99, T=35, ridge=0.7, seed=11)
+        W_cold = solve_simplex_minnorm_batch(G, accelerate=False)
+        W_warm, info = solve_simplex_minnorm_batch(G, return_info=True)
+        o_c, o_w = obj(G, W_cold), obj(G, W_warm)
+        np.testing.assert_allclose(o_w, o_c, rtol=1e-9)
+        assert info["converged"].all()
+        assert support_density(W_warm).mean() > 0.3, (
+            "fixture must reproduce the dense-support regime the issue is about")

--- a/mlsynth/tests/test_simplex_minnorm.py
+++ b/mlsynth/tests/test_simplex_minnorm.py
@@ -164,10 +164,21 @@ def test_full_rank_designs_agree_with_the_design_form_on_the_weights():
 
 def test_rank_deficient_designs_agree_on_the_fit_but_not_the_weights():
     """The other side of the guard, stated as a fact and not an aspiration: on a
-    face the two solvers land in different places, both optimal. The Gram form
-    concentrates the weight; the design form spreads it. Anything reading the
-    weights themselves -- a donor table, a counterfactual built from post-period
-    donor outcomes -- would change if it swapped one for the other."""
+    face the two solvers land in different places, both optimal. Anything reading
+    the weights themselves -- a donor table, a counterfactual built from
+    post-period donor outcomes -- would change if it swapped one for the other.
+
+    Which places they land in depends on where each one starts, and the Gram
+    form's start moved when it gained a first-order seed (#461). Cold, it began
+    at a vertex and certified at a sparse corner of the face: 9 donors, 0.209
+    from the design form's answer. Seeded, it begins at a spread point and
+    certifies near it: 38 donors -- the design form's own support, exactly -- and
+    0.015 away within that face. The two forms therefore agree better than they
+    did, which narrows this failure without closing it: they now pick the same
+    donors and still disagree on how much each one carries, so a donor table
+    still moves when one is swapped for the other, and the guard is still what
+    decides whether the reduction is allowed.
+    """
     rng = np.random.default_rng(2)
     from mlsynth.utils.bilevel.minnorm import gram_reduction_is_safe
 
@@ -177,8 +188,28 @@ def test_rank_deficient_designs_agree_on_the_fit_but_not_the_weights():
     w_gram = solve_simplex_minnorm(simplex_gram(B, A))
     w_design = solve_simplex_qp(B, A)
     assert np.allclose(B @ w_gram, B @ w_design, atol=1e-7)     # same fit
-    assert np.abs(w_gram - w_design).max() > 0.05               # different point
-    assert (w_gram > 1e-9).sum() < (w_design > 1e-9).sum()      # and sparser
+    assert np.abs(w_gram - w_design).max() > 1e-3               # different point
+    assert np.array_equal(w_gram > 1e-9, w_design > 1e-9)       # same donors now
+
+
+def test_the_cold_gram_solver_still_lands_at_the_sparse_corner():
+    """The behaviour above, pinned on both sides of the seed.
+
+    The seed is speed only, so it may move which optimum on a face comes back
+    and may not move the fit. Both are asserted here rather than inferred: the
+    cold and seeded answers differ from each other by more than either differs
+    in fit, and both reproduce the design form's fitted values.
+    """
+    rng = np.random.default_rng(2)
+    B = np.cumsum(rng.normal(size=(8, 39)), axis=0) + 10.0
+    A = B @ rng.dirichlet(np.ones(39)) + 0.05 * rng.normal(size=8)
+    G = simplex_gram(B, A)
+    w_cold = solve_simplex_minnorm(G, accelerate=False)
+    w_seeded = solve_simplex_minnorm(G)
+    assert (w_cold > 1e-9).sum() < (w_seeded > 1e-9).sum()
+    assert np.abs(w_cold - w_seeded).max() > 0.05
+    for w in (w_cold, w_seeded):
+        assert np.allclose(B @ w, B @ solve_simplex_qp(B, A), atol=1e-7)
 
 
 # --------------------------------------------------------------------------- #

--- a/mlsynth/utils/bilevel/accelerate.py
+++ b/mlsynth/utils/bilevel/accelerate.py
@@ -70,6 +70,20 @@ SUPPORT_PATIENCE = 100
 # sampling interval of lateness.
 SUPPORT_CHECK_EVERY = 10
 
+# Iterations of the batched seed. It has one job -- name the support -- and it
+# is paced by the hardest row in the batch, so a budget sized for the iterate
+# to converge is spent refining weights the exact solve recomputes. Measured on
+# a 500-problem, 99-donor ridged family: 50 iterations leave the exact solver 11
+# pivots and the whole solve is 7.3x the cold one; 100 leave it 4 and the solve
+# is 6.8x, the seed having cost more than the pivots it saved.
+SEED_MAX_ITER = 50
+# Power iterations for the seed's Lipschitz estimate. See ``_spectral_bound_batch``.
+SEED_SPECTRAL_ITERS = 3
+# Donor pools below this are not seeded. The batch amortises one seed over every
+# problem in the stack, so the crossover sits well below the single-problem
+# solver's ``ACCEL_MIN_DONORS``; measured per shape in the table in #461.
+BATCH_ACCEL_MIN_DONORS = 30
+
 
 def simplex_project(v: np.ndarray) -> np.ndarray:
     """Exact Euclidean projection of ``v`` onto ``{w >= 0, sum w = 1}``.
@@ -204,6 +218,157 @@ def fista_warm_start(B: np.ndarray, A: np.ndarray, *,
             # optimum has 16 donors: unarmed, the seed named all 100 and the
             # solve took the cold 84 pivots; armed, it names 49 and takes 33.
             armed = int(current.sum()) < J
+            held = held + 1 if (armed and support is not None
+                                and np.array_equal(current, support)) else 0
+            support = current
+            if held >= holds_needed:
+                w = w_new
+                break
+        w = w_new
+        t = t_new
+    return w
+
+
+def simplex_project_batch(V: np.ndarray) -> np.ndarray:
+    """Row-wise :func:`simplex_project`, vectorised over the whole stack.
+
+    Same construction, same result -- the threshold ``theta`` that makes
+    ``(v - theta)_+`` sum to one -- found for every row at once, since the batch
+    solver's seed projects a ``(S, J)`` block on every iteration and a Python
+    loop over ``S`` would cost more than the gradient step it follows.
+    """
+    V = np.atleast_2d(np.asarray(V, dtype=float))
+    S, J = V.shape
+    if J == 1:
+        return np.ones((S, 1))
+    U = -np.sort(-V, axis=1)
+    css = np.cumsum(U, axis=1) - 1.0
+    ind = np.arange(1, J + 1)
+    cond = U - css / ind > 0                  # cond[:, 0] is always True
+    # The largest index where the condition holds, per row. Reversing turns
+    # "last True" into "first True", which argmax answers in one pass.
+    rho = J - 1 - np.argmax(cond[:, ::-1], axis=1)
+    theta = css[np.arange(S), rho] / (rho + 1.0)
+    return np.maximum(V - theta[:, None], 0.0)
+
+
+def _spectral_bound_batch(G: np.ndarray, iters: int = SEED_SPECTRAL_ITERS) -> np.ndarray:
+    """Per-problem estimate of ``lambda_max``, inflated 10 percent, batched.
+
+    The scalar routine's contract carries over, and it is what lets this run on
+    a handful of iterations where that one runs fifty: a loose or invalid bound
+    only slows the seed, since the projection keeps every iterate on the
+    simplex, and it can never make the certified answer wrong. Each iteration
+    here costs a batched ``(S, J, J)`` matvec -- the same price as an iteration
+    of the seed it is sizing -- so fifty of them cost more than the seed does.
+    Measured on a 500-problem, 99-donor ridged family: at fifty the bound is 73
+    percent of the seed's total cost and the whole solve is 3.4x the cold one;
+    at three it is 7.3x, and the exact solver certifies in 11 iterations instead
+    of 12.
+    """
+    S, J = G.shape[0], G.shape[-1]
+    v = np.random.default_rng(0).standard_normal((S, J))    # fixed seed
+    v /= np.maximum(np.linalg.norm(v, axis=1, keepdims=True), 1e-300)
+    lam = np.zeros(S)
+    for _ in range(iters):
+        Gv = np.einsum("sjk,sk->sj", G, v)
+        nrm = np.linalg.norm(Gv, axis=1, keepdims=True)
+        alive = (nrm[:, 0] > 0.0)
+        v = np.where(alive[:, None], Gv / np.maximum(nrm, 1e-300), v)
+        lam = np.einsum("sj,sjk,sk->s", v, G, v)
+    return np.where(lam > 0.0, lam * 1.1, 0.0)
+
+
+def fista_warm_start_batch(
+    G: np.ndarray, *, max_iter: int = SEED_MAX_ITER, tol: float = 1e-7,
+    support_patience: Optional[int] = SUPPORT_PATIENCE,
+) -> np.ndarray:
+    """Feasible near-optimal seeds for ``min w' G_s w`` on the simplex, one row
+    per problem in the stack.
+
+    The batched counterpart of :func:`fista_warm_start`, and the same job: name
+    the support so the exact solver does not have to discover it. The two differ
+    only in what they are handed. The single-problem form takes a design and a
+    target and collapses them into a Gram; a batch solver already holds its
+    Grams, and its objective is the pure quadratic ``w' G w``, so the gradient
+    is ``2 G w`` with no cross term.
+
+    Naming the support is worth more here than it is there. Wolfe's method adds
+    one vertex per iteration and solves a corral system that grows with each
+    addition, so a ``k``-donor optimum costs at least ``k`` iterations of a
+    ``(k, k)`` solve. The ridged programs SDID builds have optima on a dense
+    face -- around 70 percent of the pool -- which is the worst case for that
+    rule and the best case for being told the answer: on a 500-problem placebo
+    family with 99 donors the seed takes 87 iterations to 1.
+
+    Every problem runs the same number of iterations. The stopping rules are
+    therefore read across the whole batch -- the loop ends when *every* row has
+    settled -- so a batch is paced by its hardest member, as the solve it seeds
+    already is.
+
+    The seed is speed only. The active set certifies optimality whatever point
+    it starts from, so a coarse, late, or wrong seed costs iterations and cannot
+    move the answer.
+
+    Parameters
+    ----------
+    G : numpy.ndarray, shape (S, J, J)
+        Symmetric positive semi-definite Gram matrices, one per problem.
+    max_iter : int
+        Hard cap on iterations.
+    tol : float
+        Stop once no row moves more than this in the sup norm.
+    support_patience : int or None
+        Stop once no row's support has changed for this many consecutive
+        iterations, sampled every ``SUPPORT_CHECK_EVERY`` of them. ``None``
+        disables the rule.
+
+    Returns
+    -------
+    numpy.ndarray, shape (S, J)
+    """
+    if support_patience is not None and (
+            not isinstance(support_patience, numbers.Integral)
+            or support_patience < 1):
+        raise ValueError(
+            "support_patience must be a positive integer or None, got "
+            f"{support_patience!r}."
+        )
+    G = np.asarray(G, dtype=float)
+    S, J = G.shape[0], G.shape[-1]
+    if J == 1:
+        return np.ones((S, 1))
+    L = 2.0 * _spectral_bound_batch(G)
+    # A degenerate problem (a zero Gram, whose objective is flat, or a
+    # non-finite one) has no usable step; it keeps the uniform point, which is
+    # feasible and is as good as any other for a flat objective.
+    usable = np.isfinite(L) & (L > 0.0)
+    L = np.where(usable, L, 1.0)[:, None]
+
+    w = np.full((S, J), 1.0 / J)
+    y = w.copy()
+    t = 1.0
+    support = None
+    held = 0
+    holds_needed = (None if support_patience is None
+                    else max(1, -(-support_patience // SUPPORT_CHECK_EVERY)))
+    for i in range(max_iter):
+        step = np.where(usable[:, None], 2.0 * np.einsum("sjk,sk->sj", G, y) / L, 0.0)
+        w_new = simplex_project_batch(y - step)
+        t_new = 0.5 * (1.0 + np.sqrt(1.0 + 4.0 * t * t))
+        y = w_new + ((t - 1.0) / t_new) * (w_new - w)
+        if np.max(np.abs(w_new - w)) < tol:
+            w = w_new
+            break
+        if holds_needed is not None and i % SUPPORT_CHECK_EVERY == 0:
+            current = w_new > SUPPORT_TOL
+            # Armed on the same reasoning as the scalar loop: every row starts
+            # at the uniform point where all J coordinates are positive, so an
+            # unarmed counter would read that plateau as a settled support and
+            # hand back the whole pool -- the uniform start renamed, which
+            # leaves the solver its full cold iteration count. Read across the
+            # batch, so one row still moving keeps the loop running.
+            armed = bool((current.sum(axis=1) < J).all())
             held = held + 1 if (armed and support is not None
                                 and np.array_equal(current, support)) else 0
             support = current

--- a/mlsynth/utils/bilevel/minnorm.py
+++ b/mlsynth/utils/bilevel/minnorm.py
@@ -46,6 +46,8 @@ from typing import Callable, Optional
 
 import numpy as np
 
+from .accelerate import BATCH_ACCEL_MIN_DONORS, fista_warm_start_batch
+
 # Ridge on the *scale-normalised* corral system. It exists to keep the batched
 # LU factorisation defined when the donors in a support are affinely dependent
 # (duplicate or collinear donors, or fewer matching rows than donors), where the
@@ -77,7 +79,9 @@ def gram_reduction_is_safe(B: np.ndarray, tol: float = 1e-8) -> bool:
     * If the design is rank deficient and the minimiser is a face and not a
       point, both solvers are correct and they land in different places: on an
       8-row, 39-donor design whose target the donors reproduce exactly, they
-      agree on the fitted values to 1e-11 while differing by 0.19 in the weights.
+      agree on the fitted values to 1e-11 while differing in the weights -- by
+      0.015 since the Gram solver gained a first-order seed, and by 0.209 before
+      it, the seed starting it from a spread point instead of a vertex.
       Nothing is wrong, but anything reading the weights -- a donor table, a
       counterfactual built from post-period donor outcomes -- would change.
 
@@ -365,6 +369,7 @@ def solve_simplex_minnorm(
     *,
     warm_start: Optional[np.ndarray] = None,
     max_iter: Optional[int] = None,
+    accelerate: bool = True,
     return_info: bool = False,
 ):
     """Minimise ``w' G w`` over ``w >= 0, sum(w) == 1`` for one Gram matrix.
@@ -381,6 +386,11 @@ def solve_simplex_minnorm(
         Feasible starting weights.
     max_iter : int, optional
         Cap on active-set iterations.
+    accelerate : bool, default True
+        Seed the corral from a first-order pass when the pool is wide enough.
+        Speed only; see :func:`solve_simplex_minnorm_batch`. A single problem
+        still pays for itself -- measured 2.4x at 40 donors and 3.9x at 99 --
+        because the seed's cost scales with the pool and not with the batch.
     return_info : bool
         If ``True`` also return ``{"iterations", "converged"}``.
 
@@ -393,7 +403,8 @@ def solve_simplex_minnorm(
     warm = None if warm_start is None else np.asarray(
         warm_start, dtype=float).reshape(1, -1)
     out = solve_simplex_minnorm_batch(
-        G[None], warm_start=warm, max_iter=max_iter, return_info=return_info)
+        G[None], warm_start=warm, max_iter=max_iter, accelerate=accelerate,
+        return_info=return_info)
     if not return_info:
         return out[0]
     W, info = out
@@ -406,6 +417,7 @@ def solve_simplex_minnorm_batch(
     *,
     warm_start: Optional[np.ndarray] = None,
     max_iter: Optional[int] = None,
+    accelerate: bool = True,
     return_info: bool = False,
 ):
     """Minimise ``w' G_s w`` on the simplex for every ``G_s`` in a stack.
@@ -426,9 +438,16 @@ def solve_simplex_minnorm_batch(
         generation's solution, when the population moves slowly. A row that is
         not usable (negative, all-zero, non-finite), or a whole array of the
         wrong shape, is discarded in favour of the cold start; a warm start
-        changes only how much work the solve costs.
+        changes only how much work the solve costs. Supplying one turns the
+        accelerator off: a caller with a seed of its own has better information
+        than a cold first-order pass.
     max_iter : int, optional
         Cap on active-set iterations. Defaults to ``max(50, 10 * J)``.
+    accelerate : bool, default True
+        Seed the corrals from a batched FISTA pass when the pool is wide enough
+        to pay for it (``BATCH_ACCEL_MIN_DONORS``). Set ``False`` to force the
+        cold start. Speed only: the optimality test below decides the answer,
+        so this changes how much work the solve costs and nothing else.
     return_info : bool
         If ``True`` also return ``{"iterations", "converged"}``, where
         ``converged`` is a length-``S`` boolean array. A candidate that hits
@@ -448,6 +467,15 @@ def solve_simplex_minnorm_batch(
     donors than matching rows, so the optimal set is a face and not a point --
     which of them is returned depends on the starting corral, and so on the warm
     start. The objective does not. Compare losses, not weights.
+
+    The cold start is a vertex and the corral grows by one donor per iteration,
+    so an optimum supported on ``k`` donors costs at least ``k`` iterations of a
+    ``(k, k)`` solve. That is cheap when the optimum is sparse and quadratically
+    expensive when it is not, and the ridged programs SDID builds are not: their
+    optima sit on a face carrying most of the pool, because spreading the weight
+    is what the ridge is for. The accelerator exists for that case -- it names
+    the support up front so the corrals start at the answer instead of walking
+    to it (#461).
     """
     G = _validate(G, ndim=3)
     S, J = G.shape[0], G.shape[-1]
@@ -466,6 +494,8 @@ def solve_simplex_minnorm_batch(
     # optimum outright whenever the treated unit is nearest one donor.
     W = np.zeros((S, J))
     W[np.arange(S), np.argmin(gdiag, axis=1)] = 1.0
+    if warm_start is None and accelerate and J >= BATCH_ACCEL_MIN_DONORS:
+        warm_start = fista_warm_start_batch(G)
     if warm_start is not None:
         ws = np.asarray(warm_start, dtype=float)
         if ws.shape == (S, J):

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -976,7 +976,7 @@ timeout = 900.0
 [[target]]
 name = "batch-seed-gate"
 module-path = "mlsynth/utils/bilevel/minnorm.py"
-test-command = "python -m pytest mlsynth/tests/test_minnorm_support_seed.py mlsynth/tests/test_minnorm.py -q -p no:cacheprovider"
+test-command = "python -m pytest mlsynth/tests/test_minnorm_support_seed.py mlsynth/tests/test_simplex_minnorm.py mlsynth/tests/test_bilevel_simplex_batch.py -q -p no:cacheprovider"
 timeout = 900.0
 
   [[target.mutant]]

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -765,8 +765,8 @@ timeout = 600.0
 
   [[target.mutant]]
   id = "support-patience-counts-total-instead-of-consecutive-holds"
-  find = "            held = held + 1 if (armed and support is not None\n                                and np.array_equal(current, support)) else 0"
-  replace = "            held = held + 1 if (armed and support is not None\n                                and np.array_equal(current, support)) else held"
+  find = "            armed = int(current.sum()) < J\n            held = held + 1 if (armed and support is not None\n                                and np.array_equal(current, support)) else 0"
+  replace = "            armed = int(current.sum()) < J\n            held = held + 1 if (armed and support is not None\n                                and np.array_equal(current, support)) else held"
   models = "a patience counter that never resets, so a support that flickers still accumulates holds and the warm start returns while the support is moving -- the seed is then rejected coordinate by coordinate and the solve pays the cold pivot count anyway"
 
   [[target.mutant]]
@@ -930,3 +930,64 @@ timeout = 900.0
   find = "        pivot = _wide_pivot(df, index=time_period_column_name,\n                            columns=unit_id_column_name, values=cov,\n                            keys=keys)"
   replace = "        pivot = _wide_pivot(df, index=time_period_column_name,\n                            columns=unit_id_column_name, values=cov)"
   models = "one scan per covariate instead of one for the panel. A ten-covariate panel is scanned eleven times, and every covariate matrix is correct, so nothing but a pass count reports it"
+
+[[target]]
+name = "batch-support-seed"
+module-path = "mlsynth/utils/bilevel/accelerate.py"
+test-command = "python -m pytest mlsynth/tests/test_minnorm_support_seed.py mlsynth/tests/test_fista_support_patience.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "batch-projection-takes-the-first-threshold-not-the-last"
+  find = "    rho = J - 1 - np.argmax(cond[:, ::-1], axis=1)"
+  replace = "    rho = np.argmax(cond, axis=1)"
+  models = "the projection reading the first index where the threshold condition holds instead of the last. Index zero always satisfies it, so every row projects onto its own largest coordinate: the seed becomes a vertex, which is feasible, is what the cold start already was, and names a support of one"
+
+  [[target.mutant]]
+  id = "batch-seed-support-counter-never-arms"
+  find = "            armed = bool((current.sum(axis=1) < J).all())"
+  replace = "            armed = True"
+  models = "the counter armed on the uniform plateau every row starts from, where all J coordinates are positive. The stop then fires on the first sample and hands back the whole pool as the support -- the uniform start renamed, which leaves the exact solver its full cold iteration count"
+
+  [[target.mutant]]
+  id = "degenerate-problems-take-a-step-anyway"
+  find = "    usable = np.isfinite(L) & (L > 0.0)"
+  replace = "    usable = np.isfinite(L)"
+  models = "a zero Gram, whose objective is flat and whose Lipschitz constant is zero, divided through by its own zero step size. The seed comes back non-finite for that row, and a non-finite warm start is discarded, so the row silently loses its seed rather than keeping the feasible uniform point"
+
+  [[target.mutant]]
+  id = "lipschitz-estimate-not-inflated"
+  find = "    return np.where(lam > 0.0, lam * 1.1, 0.0)"
+  replace = "    return np.where(lam > 0.0, lam, 0.0)"
+  models = "the ten percent margin removed from a bound that power iteration approaches from below, so the step is too long and FISTA oscillates. The answer is unaffected -- the projection keeps every iterate feasible and the exact solver certifies whatever it is handed -- and only the seed's quality, and so the pivot count, degrades"
+
+  [[target.mutant]]
+  id = "batch-patience-counts-total-instead-of-consecutive-holds"
+  find = "            armed = bool((current.sum(axis=1) < J).all())\n            held = held + 1 if (armed and support is not None\n                                and np.array_equal(current, support)) else 0"
+  replace = "            armed = bool((current.sum(axis=1) < J).all())\n            held = held + 1 if (armed and support is not None\n                                and np.array_equal(current, support)) else held"
+  models = "the batch counter never resetting, so a support that flickers in any row still accumulates holds and the seed returns while rows are still moving. Those rows are seeded with the wrong support and the exact solver pays to fix each one"
+
+  [[target.mutant]]
+  id = "batch-stop-fires-when-any-row-settles"
+  find = "            armed = bool((current.sum(axis=1) < J).all())"
+  replace = "            armed = bool((current.sum(axis=1) < J).any())"
+  models = "the stop read across the batch with any instead of all, so one row pinning a coordinate arms the counter for every row. A batch is paced by its hardest member -- which is also true of the solve it seeds -- and this stops it at its easiest"
+
+[[target]]
+name = "batch-seed-gate"
+module-path = "mlsynth/utils/bilevel/minnorm.py"
+test-command = "python -m pytest mlsynth/tests/test_minnorm_support_seed.py mlsynth/tests/test_minnorm.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "narrow-pools-are-seeded-too"
+  find = "    if warm_start is None and accelerate and J >= BATCH_ACCEL_MIN_DONORS:"
+  replace = "    if warm_start is None and accelerate:"
+  models = "the gate dropped, so a ten-donor batch pays for a first-order pass to name a support the cold start reaches in eleven cheap iterations. Every answer is unchanged; the measured cost is 0.45x to 0.74x, and only a count of who was seeded can see it"
+
+  [[target.mutant]]
+  id = "caller-warm-start-overridden-by-the-seed"
+  find = "    if warm_start is None and accelerate and J >= BATCH_ACCEL_MIN_DONORS:\n        warm_start = fista_warm_start_batch(G)"
+  replace = "    if accelerate and J >= BATCH_ACCEL_MIN_DONORS:\n        warm_start = fista_warm_start_batch(G)"
+  models = "the accelerator overwriting a seed the caller supplied. The placebo chain hands on the previous draw's certified solution, which is strictly better information than a cold first-order pass, and both the chain's benefit and the pass's cost are invisible in the answer"
+


### PR DESCRIPTION
Closes #461.

## What was wrong

Wolfe's min-norm-point method adds one vertex per iteration and solves a corral system that grows with each addition, so an optimum supported on `k` donors costs at least `k` iterations of a `(k, k)` solve. That cost model assumes a sparse optimum. SDID's unit-weight program is ridged by `zeta`, and spreading the weight off the vertices is what the ridge is for, so the optimum sits on a face carrying most of the pool — median 67 of 99 donors on a 101-unit panel, 26 of 37 on Prop 99, synthetic and real data alike. The solver spent 87 iterations rediscovering, one element at a time, a support a first-order pass names in one go.

`solve_simplex_minnorm_batch` was 67 percent of a `vce="placebo"` SDID fit, in a single call.

The ladder, and the three hypotheses that had to be refuted first — replacing Wolfe outright, any interior warm start, padding waste at `counts.max()` — are in #461.

## What changed

`fista_warm_start_batch` is the batched counterpart of the seed #447 gave `solve_simplex_qp`, and `solve_simplex_minnorm_batch` now calls it for pools of at least `BATCH_ACCEL_MIN_DONORS`. The seed is speed only: Wolfe's optimality test still decides the answer, so a coarse, late or wrong seed costs iterations and cannot move the objective.

Two constants carry their own measurements rather than inheriting the scalar seed's:

- The seed runs 50 iterations, not 400. Its job is to name the support, not to converge; at 100 the seed cost more than the pivots it saved (6.8x against 7.3x).
- Its Lipschitz estimate takes 3 power iterations, not 50. Each one is a batched `(S, J, J)` matvec — the same price as an iteration of the seed it is sizing — and at 50 the bound was 73 percent of the seed's whole cost: 3.4x end to end against 7.3x at 3. A loose or invalid bound only degrades the seed, since the projection keeps every iterate feasible and the exact solver certifies whatever it is handed.

## Effect

A `vce="placebo"` SDID fit, single-threaded:

| panel | fit | batch solver | solver share | iterations | ATT |
|---|---|---|---|---|---|
| synthetic 101 x 70 | 3.87 → 2.32 s | 2.59 → 0.72 s | 67% → 31% | 87 → 2 | unchanged, −1.808378 |
| Prop 99 | 0.74 → 0.66 s | 0.20 → 0.12 s | 27% → 18% | 39 → 36 | unchanged, −15.60540 |

All 500 candidates still certify. Across a grid of shapes the gate sits where the seed starts paying: below 30 donors both a dense-support and a sparse-support family lose, at 40 and above both win (ridged 1.9–7.8x, sparse 0.94–1.33x). SDID's time-weight batch at J=50 pays about 0.02 s for a seed it does not need, against 1.9 s saved on the unit weights in the same fit.

## The one behaviour that moves

On a rank-deficient design the minimiser is a face, and which point on it Wolfe returns is fixed by where it starts — documented on the solver, and previously reachable only by passing a `warm_start` explicitly. Now the solver seeds itself, so a caller who passes nothing can get a different point than before.

On the 8 x 39 design in `test_simplex_minnorm`:

```
                max|w_gram - w_design|   support   fit gap    objective
cold  (before)          0.2087            9 / 39   5.2e-12   -4.30e-17
seeded (after)          0.0148           38 / 39   3.2e-13   -5.67e-17
design form                --            38 / 39
```

The fit and the objective do not move; both answers certify and both objectives are numerically zero. The move is toward agreement — the seeded answer picks the design form's own 38 donors and differs only in how much each carries — so the discrepancy `gram_reduction_is_safe` exists to prevent narrows by an order of magnitude without closing.

No production path reaches it. Checked rather than assumed: SDID takes the batch only when `ridged_gram_reduction_is_safe` passes, both leave-one-out paths verify `simplex_optimum_is_unique` and fall back per problem, and mlSC's crossval adds `_RIDGE_FLOOR` for uniqueness by construction. `gram_reduction_is_safe`'s docstring cited the 0.19 figure as its second failure mode and now carries both numbers.

## Tests

New `test_minnorm_support_seed.py`, 43 tests.

The work assertions count corral rows solved — `sum(live)` across the run — and not iterations, because iterations are the wrong metric here: on a ridged 500 x 40 family cold and seeded both run 45 iterations and the seeded one is 3.6x faster, since candidates certify early and the arrays shrink. The gate is tested from three directions: a narrow pool, a caller-supplied warm start, and `accelerate=False` must each leave the seed uncalled.

The answer tests are the acceptance bar. Six batch families (ridged-dense, sparse, narrow, square, wide-ridge, tiny-ridge) are solved both ways and compared the way the solver measures optimality — against the problem's mean diagonal, the scale its own KKT test is relative to — with the relative check applied wherever the optimum is not numerically zero, so the scaled bound cannot hide a real divergence. That distinction is itself a finding: on the near-singular family both certified answers sit 62 percent apart relatively while being the same answer by every standard the solver applies, because ratios of zeros are not the property under test.

Eight deliberately bad seeds — uniform, a wrong vertex, a random face, an unnormalised block, a wrong shape, negative, non-finite — must each leave the objective where it was. "The answer does not depend on the seed" is what the whole design rests on; if it fails, the accelerator is not an accelerator but a second estimator.

`tools/mutation/targets.toml` gains `batch-support-seed` (6 mutants) and `batch-seed-gate` (2). Three are output-invisible by construction — seeding narrow pools, overriding a caller's seed, an uninflated Lipschitz bound — so only a count can kill them. One existing mutant in `fista-support-stop` was re-anchored, since the batch loop made its `find` ambiguous; the whole catalogue is verified to match at exactly one site.

The batched seed's patience rule cannot fire at the default budget (patience 100 sampled every 10 wants 100 iterations, the budget is 50), so it is live only for a caller who raises `max_iter`, and it is covered by a test that does exactly that and counts projections. Recorded in #461 rather than tuned away.

Replications re-run and passing: `sdid_prop99`, `sdid_euets`, `mlsc_bottmer`. The solver-adjacent suites are running in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_