### PR TITLE
Index NSC's penalties on the spectrum the reference indexes

### DIFF
--- a/benchmarks/cases/nsc_prop99.py
+++ b/benchmarks/cases/nsc_prop99.py
@@ -21,8 +21,18 @@ fix those and match:
 
 mlsynth's NSC is a faithful port of the reference QP (eigenvalue-scaled penalty,
 the ``rbind(Z, -Z)`` negativity trick, distance-weighted L1), so the weights
-match to a correlation of ~0.99; residual per-weight differences (<~0.025) come
-from the standardisation convention and the author's 3-decimal weight rounding.
+match to a correlation of 1.000 and the effect path to ~1e-6 packs. What remains
+is the author's 3-decimal rounding of the returned weights, which bounds any
+single weight's deviation at 5e-4.
+
+Until #463 this case carried tolerances an order of magnitude wider (ATT within
+1.7 packs, correlation 0.989) and attributed them to "the standardisation
+convention and the author's 3-decimal weight rounding". Both were wrong: the
+standardisation already agreed, and the rounding accounted for 2 percent of the
+observed gap. The cause was that mlsynth indexed its penalties on the spectrum
+of ``Z_0 Z_0'`` where the reference indexes the stacked ``Z* Z*'``, so the
+paper's ``(a*, b*)`` bought half the penalty they name. The tolerances here are
+now what a faithful port reaches, so they fail if that regresses.
 
 The reference side is a live captured run of Tian's own ``NSC()`` (vendored at
 ``benchmarks/R/nsc_tian2023_reference.R``, executed at ``a = 0.3, b = 0.7``),
@@ -133,19 +143,21 @@ def comparison() -> dict:
 
 # Deterministic (penalty fixed at the Table-2 values; no stochastic CV) => exact
 # re-runs. The reference values are pinned from the live captured NSC.R run
-# (benchmarks/reference/nsc_prop99/) via reference_value; tolerances absorb the
-# standardisation convention and the author's 3-decimal weight rounding while
-# pinning the cross-validation: mlsynth's NSC weights track the author's code to
-# correlation ~0.99 with no per-weight gap above ~0.025, recover the same
-# (signed) donor pool, and reproduce its effect path.
+# (benchmarks/reference/nsc_prop99/) via reference_value. The tolerances are set
+# to what a faithful port reaches and not to what mlsynth happened to produce:
+# the only irreducible difference is NSC.R rounding its returned weights to three
+# decimals, which bounds a single weight at 5e-4 and leaves the effect path,
+# computed from unrounded weights on both sides, agreeing to ~1e-6 packs. The
+# effect-path bands are 0.02 packs -- 0.1 percent of the estimate -- which is
+# headroom for BLAS and solver-version drift, not for a methodological gap.
 _ns = lambda k: reference_value("nsc_prop99", k)
 EXPECTED = {
     "n_donors": (_ns("n_donors"), 0.0),
-    "weight_max_abs_dev": (0.024, 0.020),     # largest single-donor gap < ~0.044
-    "weight_mean_abs_dev": (0.006, 0.008),
-    "weight_correlation": (0.989, 0.02),      # fails below ~0.97
-    "att_mean_post": (_ns("att_mean_post"), 1.7),   # mlsynth -19.13 vs NSC.R -20.59
-    "ite_1990": (_ns("ite_1990"), 0.8),       # mlsynth -9.05 vs NSC.R -9.51
-    "ite_1995": (_ns("ite_1995"), 2.2),       # mlsynth -22.62 vs NSC.R -24.50
-    "ite_2000": (_ns("ite_2000"), 2.0),       # mlsynth -27.01 vs NSC.R -28.70
+    "weight_max_abs_dev": (0.0, 1.5e-3),      # 3-decimal rounding floor: 5e-4
+    "weight_mean_abs_dev": (0.0, 5.0e-4),
+    "weight_correlation": (1.0, 1.0e-4),
+    "att_mean_post": (_ns("att_mean_post"), 0.02),
+    "ite_1990": (_ns("ite_1990"), 0.02),
+    "ite_1995": (_ns("ite_1995"), 0.02),
+    "ite_2000": (_ns("ite_2000"), 0.02),
 }

--- a/docs/nsc.rst
+++ b/docs/nsc.rst
@@ -454,9 +454,11 @@ linear one.
 
    Verification. NSC is validated two ways: a cross-validation
    against Tian's own R implementation on Proposition 99 (weights match
-   to correlation 0.989; effect path :math:`-9.1/-22.6/-27.0` vs the
-   paper's :math:`-9.5/-24.5/-28.7`) and the Path-B nonlinear Monte
-   Carlo (near-nominal coverage; error shrinking with the donor pool).
+   to correlation 1.000, with the largest single weight differing by
+   5e-4 -- the author's 3-decimal rounding of its own output -- and the
+   effect path :math:`-9.51/-24.50/-28.70` reproducing the paper's to
+   1e-6 packs) and the Path-B nonlinear Monte Carlo (near-nominal
+   coverage; error shrinking with the donor pool).
    See the dedicated page :doc:`replications/nsc`; durable checks
    ``nsc_prop99`` and ``nsc_mc``.
 
@@ -581,12 +583,10 @@ a pack or two of the paper's reported numbers.
 Output::
 
    selected (a*, b*) = (0.3, 0.7)        # matches the paper exactly
-   pre-RMSE          = 1.2450
-   ATT (1989-2000)   = -19.1313  packs/capita
-   ATT 95% CI        = (-25.51, -12.75)
-     1990: gap =  -9.05  CI=(-26.38, +8.27)        # paper: -9.5
-     1995: gap = -22.62  CI=(-46.03, +0.78)        # paper: -24.5
-     2000: gap = -27.01  CI=(-54.31, +0.29)        # paper: -28.7
+   ATT (1989-2000)   = -20.5897  packs/capita
+     1990: gap =  -9.51        # paper: -9.5
+     1995: gap = -24.50        # paper: -24.5
+     2000: gap = -28.70        # paper: -28.7
 
 Two things about this replication:
 

--- a/docs/replications.rst
+++ b/docs/replications.rst
@@ -383,10 +383,11 @@ Convex-hull relaxation
 * :doc:`nsc` -- Nonlinear SC. Cross-validation: matched to
   Tian's (2023) own R implementation on the Proposition 99 panel
   (Table 2) -- per-donor NSC weights track the author's to
-  correlation 0.989 (max :math:`|\Delta| = 0.024`), recovering the
-  same signed donor pool, with an average effect :math:`-19.1` and
-  an effect path (:math:`-9.1/-22.6/-27.0` in 1990/1995/2000)
-  matching the paper's :math:`-9.5/-24.5/-28.7`. Path B: the
+  correlation 1.000 (max :math:`|\Delta| = 0.0005`, the author's own
+  3-decimal rounding), recovering the same signed donor pool, with an
+  average effect :math:`-20.59` and an effect path
+  (:math:`-9.51/-24.50/-28.70` in 1990/1995/2000) reproducing the
+  paper's :math:`-9.5/-24.5/-28.7`. Path B: the
   nonlinear-outcome Monte Carlo (Section 4, Table 1) -- on the
   :math:`r = 2` panel NSC's 95% CI covers near nominal
   (:math:`0.93/0.97` at :math:`J = 25/50`, paper

--- a/docs/replications/nsc.rst
+++ b/docs/replications/nsc.rst
@@ -35,28 +35,39 @@ reported in Table 2, so we fix those and match the per-donor weights:
      - mlsynth NSC
      - Tian Table 2 / paper
    * - weight correlation (38 donors)
-     - 0.989
+     - 1.000
      - —
    * - max per-donor :math:`|\Delta|`
-     - 0.024
+     - 0.0005
      - (Table 2 rounded to 3 dp)
    * - mean per-donor :math:`|\Delta|`
-     - 0.006
+     - 0.0001
      - —
    * - average post-period effect
-     - :math:`-19.1`
-     - :math:`\approx -19`
+     - :math:`-20.59`
+     - :math:`-20.59`
    * - effect in 1990 / 1995 / 2000
-     - :math:`-9.1 / -22.6 / -27.0`
+     - :math:`-9.51 / -24.50 / -28.70`
      - :math:`-9.5 / -24.5 / -28.7`
 
 mlsynth's NSC is a faithful port of the reference QP — eigenvalue-scaled penalty,
 the ``rbind(Z, -Z)`` negativity trick, distance-weighted L1 — so it recovers the
 same signed donor pool (positive weights concentrated on Idaho, Montana,
 Colorado, Connecticut; small negative weights on Alabama, Arkansas, Tennessee)
-and the paper's growing effect path. The residual per-weight differences
-(:math:`<0.025`) come from the standardisation convention and Table 2's
-three-decimal rounding.
+and the paper's growing effect path. The one remaining difference is Table 2's
+three-decimal rounding, which bounds any single weight at :math:`5 \times
+10^{-4}`; the effect path, computed from unrounded weights on both sides, agrees
+to :math:`10^{-6}` packs.
+
+Earlier versions of this page reported a correlation of 0.989 and an average
+effect of :math:`-19.1`, attributing the gap to the standardisation convention.
+That attribution was wrong -- the standardisation already agreed -- and the cause
+was the penalty scaling: ``NSC.R`` writes the :math:`\ell_1` term by splitting
+each weight into a non-negative pair, which stacks the design as :math:`Z^* =
+[Z; -Z]`, and indexes the eigenvalues of :math:`Z^* Z^{*\prime}`. mlsynth wrote
+the same term with auxiliary variables and indexed :math:`Z Z'`, whose non-zero
+eigenvalues are exactly half of the stacked ones, so :math:`(a^*, b^*)` bought
+half the penalty they name. Fixed in #463.
 
 The durable check lives in ``benchmarks/cases/nsc_prop99.py``::
 

--- a/mlsynth/tests/test_nsc.py
+++ b/mlsynth/tests/test_nsc.py
@@ -107,11 +107,27 @@ class TestOptimization:
             assert b > 0.0
 
     def test_scale_a_uses_combined_design(self):
+        """``b`` enters ``a``'s spectrum, and not only by shifting it.
+
+        This asserted ``a`` rises with ``b`` at every ``a*``, which was a
+        property of the old scaling and is not one of the method (#463). Adding
+        the ridge lifts ``2J - rank`` zero eigenvalues above the reference's
+        ``1e-7`` filter, so the spectrum this indexes grows -- on a 5 x 4 design
+        from 4 entries to 10 -- and ``ceil(a* n)`` can land on the ridge value
+        where it used to land on a data eigenvalue. Tian's own code does the
+        same: at ``a* = 0.5`` it returns 1.636, 0.500 and 5.000 for ``b`` of 0,
+        1 and 10.
+
+        What does hold at every ``b`` is the anchor the docstring claims: at
+        ``a* = 1`` the largest eigenvalue is taken, which is ``max(2 lambda) +
+        b`` and therefore increasing in ``b``.
+        """
         rng = np.random.default_rng(0)
         Z0 = rng.standard_normal((5, 4))
-        a_no_b = scale_a(0.5, Z0, 0.0)
-        a_with_b = scale_a(0.5, Z0, 1.0)
-        assert a_with_b >= a_no_b
+        assert scale_a(1.0, Z0, 1.0) > scale_a(1.0, Z0, 0.0)
+        assert scale_a(0.5, Z0, 10.0) > scale_a(0.5, Z0, 1.0)
+        # the non-monotone step, pinned so it is a decision and not a surprise
+        assert scale_a(0.5, Z0, 1.0) < scale_a(0.5, Z0, 0.0)
 
     def test_solve_nsc_weights_sum_to_one(self):
         rng = np.random.default_rng(0)

--- a/mlsynth/tests/test_nsc_penalty_scaling.py
+++ b/mlsynth/tests/test_nsc_penalty_scaling.py
@@ -1,0 +1,311 @@
+"""NSC's dimensionless penalties mean what Tian (2023) means by them.
+
+``a`` and ``b`` enter NSC as dimensionless numbers in ``[0, 1]``, and what they
+buy is fixed by a spectrum: ``b`` indexes the eigenvalues of the donor Gram and
+``a`` those of the same Gram once ``b`` has been added to its diagonal. Which
+Gram, exactly, is the whole question. Tian's ``NSC.R`` poses the program on the
+stacked design ``rbind(ZJ, -ZJ)`` -- the split-variable encoding of the L1 term
+-- and takes eigenvalues of ``ZJstar ZJstar'``, a ``(2J, 2J)`` matrix. mlsynth
+encodes the same L1 term with auxiliary variables ``u >= |w|`` and took them
+from ``ZJ ZJ'``, ``(J, J)``.
+
+Both encodings have the same feasible set and the same optimum for a *given*
+``(a, b)``, which is why the QP was never the problem. They do not have the same
+spectrum, and the spectrum is what defines ``(a, b)``. Reading Table 2 and
+passing ``a=0.3, b=0.7`` therefore solved a different program: on Proposition 99
+that is an ATT of -19.13 against the author's -20.59 (#463).
+
+The scaling tests start red and are the assertion the analysis found missing:
+they pin the map from ``(a*, b*)`` to raw multipliers directly, against a
+transcription of ``NSC.R``, instead of inferring it from an ATT with a wide
+tolerance around it. They are checked across ranks on purpose. On Proposition 99
+the error is exactly a factor of two in both multipliers, so a fix that doubled
+them would pass there and stay wrong: the doubling is a coincidence of the
+low-rank regime (19 of 38), and once the rank approaches ``J`` the ``a``
+multiplier is out by 1.36 to 1.63 instead.
+
+The QP tests pass before the change and must pass after it. Nothing about the
+solver moves; only what it is asked to solve.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.nsc_helpers.optimization import (
+    design_eigenvalues,
+    scale_a,
+    scale_b,
+    solve_nsc_weights,
+)
+
+_REF_DIR = (pathlib.Path(__file__).resolve().parents[2]
+            / "benchmarks" / "reference" / "nsc_prop99")
+_BASEDATA = pathlib.Path(__file__).resolve().parents[2] / "basedata"
+
+
+# --------------------------------------------------------------------------- #
+# the oracle: NSC.R's scaling, transcribed
+# --------------------------------------------------------------------------- #
+def nsc_r_scaling(ZJ: np.ndarray, a_star: float, b_star: float):
+    """``fn_weights``'s penalty scaling from ``NSC.R``, line for line.
+
+    R, with ``Negativity = TRUE``::
+
+        ZJstar = rbind(ZJ,-ZJ)
+        Dmat0  = ZJstar %*% t(ZJstar)
+        eg0    = eigen(Dmat0)$values; eg0 = eg0[eg0>10^-7]
+        if (b>0) {b = sort(eg0)[ceiling(b*length(eg0))]*b}
+        Dmat   = Dmat0 + (b+10^-8)*diag(2*J)
+        eg1    = eigen(Dmat)$values;  eg1 = eg1[eg1>10^-7]
+        if (a>0) {a = sort(eg1)[ceiling(a*length(eg1))]*a}
+
+    ``sort`` is ascending and R indexes from one.
+    """
+    J = ZJ.shape[0]
+    ZJstar = np.vstack([ZJ, -ZJ])
+    Dmat0 = ZJstar @ ZJstar.T
+    eg0 = np.linalg.eigvalsh(0.5 * (Dmat0 + Dmat0.T))
+    eg0 = np.sort(eg0[eg0 > 1e-7])
+    b = 0.0
+    if b_star > 0 and eg0.size:
+        b = float(eg0[int(np.ceil(b_star * eg0.size)) - 1] * b_star)
+    Dmat = Dmat0 + (b + 1e-8) * np.eye(2 * J)
+    eg1 = np.linalg.eigvalsh(0.5 * (Dmat + Dmat.T))
+    eg1 = np.sort(eg1[eg1 > 1e-7])
+    a = 0.0
+    if a_star > 0 and eg1.size:
+        a = float(eg1[int(np.ceil(a_star * eg1.size)) - 1] * a_star)
+    return a, b
+
+
+def donor_design(J, p, seed=0, rank=None):
+    """A standardised donor block, as ``NSC.R`` standardises ``Z``."""
+    rng = np.random.default_rng(seed)
+    Z = rng.standard_normal((J, p))
+    if rank is not None:
+        U = rng.standard_normal((J, rank))
+        V = rng.standard_normal((rank, p))
+        Z = U @ V
+    Z = Z - Z.mean(axis=0)
+    sd = Z.std(axis=0, ddof=1)
+    sd[sd == 0] = 1.0
+    return Z / sd
+
+
+def treated_row(Z, seed=0, noise=0.1):
+    """A treated unit shaped like one of the donors.
+
+    Standardisation is across units, so a treated row is on the donors' scale
+    and near their span -- not an independent draw. (Standardising a single row
+    by its own column SDs divides by zero, which is how this helper first went
+    wrong: the QP was handed NaN and raised, correctly.)
+    """
+    rng = np.random.default_rng(seed)
+    k = max(1, min(3, Z.shape[0]))
+    return Z[:k].mean(axis=0) + noise * rng.standard_normal(Z.shape[1])
+
+
+# shapes chosen to straddle the rank regimes, since the size of the error
+# depends on the rank and not only on J
+SHAPES = [
+    ("prop99-like", 38, 19),
+    ("wide-pool-short-pre", 100, 12),
+    ("square", 60, 60),
+    ("more-pre-than-donors", 20, 50),
+    ("near-full-rank", 38, 40),
+    ("tiny", 10, 3),
+    ("two-donors", 2, 5),
+]
+STARS = [0.0, 0.1, 0.2, 0.3, 0.5, 0.7, 0.9, 1.0]
+
+
+# =========================================================================== #
+# the scaling contract -- these start red
+# =========================================================================== #
+class TestScalingMatchesTheReference:
+    @pytest.mark.parametrize("name,J,p", SHAPES)
+    @pytest.mark.parametrize("b_star", STARS)
+    def test_b_matches(self, name, J, p, b_star):
+        Z = donor_design(J, p, seed=hash(name) % 1000)
+        _, b_ref = nsc_r_scaling(Z, 0.3, b_star)
+        b_got = scale_b(b_star, design_eigenvalues(Z))
+        assert b_got == pytest.approx(b_ref, rel=1e-9, abs=1e-12), (
+            f"{name}: b*={b_star} -> {b_got}, reference {b_ref}")
+
+    @pytest.mark.parametrize("name,J,p", SHAPES)
+    @pytest.mark.parametrize("a_star", STARS)
+    def test_a_matches(self, name, J, p, a_star):
+        Z = donor_design(J, p, seed=hash(name) % 1000)
+        a_ref, b_ref = nsc_r_scaling(Z, a_star, 0.7)
+        b_got = scale_b(0.7, design_eigenvalues(Z))
+        a_got = scale_a(a_star, Z, b_got)
+        assert a_got == pytest.approx(a_ref, rel=1e-9, abs=1e-12), (
+            f"{name}: a*={a_star} -> {a_got}, reference {a_ref}")
+
+    @pytest.mark.parametrize("name,J,p", SHAPES)
+    def test_rank_deficient_designs_agree_too(self, name, J, p):
+        """The regime where the error is not a constant.
+
+        On a low-rank design both spectra put the selected element on the ridge
+        value and the old scaling was out by exactly two; as the rank approaches
+        ``J`` they select structurally different elements and it is out by less.
+        A fix that doubles the multipliers passes the first and fails this.
+        """
+        r = max(1, min(J, p) // 3)
+        Z = donor_design(J, p, seed=7, rank=r)
+        for a_star, b_star in ((0.3, 0.7), (0.5, 0.5), (0.9, 0.2)):
+            a_ref, b_ref = nsc_r_scaling(Z, a_star, b_star)
+            b_got = scale_b(b_star, design_eigenvalues(Z))
+            a_got = scale_a(a_star, Z, b_got)
+            assert b_got == pytest.approx(b_ref, rel=1e-9, abs=1e-12)
+            assert a_got == pytest.approx(a_ref, rel=1e-9, abs=1e-12)
+
+
+class TestScalingBoundaries:
+    def test_zero_stars_give_no_penalty(self):
+        Z = donor_design(20, 8)
+        assert scale_b(0.0, design_eigenvalues(Z)) == 0.0
+        assert scale_a(0.0, Z, 1.0) == 0.0
+
+    def test_negative_stars_give_no_penalty(self):
+        Z = donor_design(20, 8)
+        assert scale_b(-0.5, design_eigenvalues(Z)) == 0.0
+        assert scale_a(-0.5, Z, 1.0) == 0.0
+
+    def test_star_of_one_takes_the_largest_eigenvalue(self):
+        Z = donor_design(20, 8)
+        a_ref, b_ref = nsc_r_scaling(Z, 1.0, 1.0)
+        b_got = scale_b(1.0, design_eigenvalues(Z))
+        assert b_got == pytest.approx(b_ref, rel=1e-9)
+        assert scale_a(1.0, Z, b_got) == pytest.approx(a_ref, rel=1e-9)
+
+    def test_an_empty_donor_block_is_unpenalised(self):
+        assert scale_b(0.5, np.asarray([])) == 0.0
+        assert design_eigenvalues(np.zeros((0, 4))).size == 0
+        assert scale_b(0.5, design_eigenvalues(np.zeros((0, 4)))) == 0.0
+
+    def test_no_donors_leaves_a_unpenalised(self):
+        """No donor pool is no spectrum to index, and no penalty to scale."""
+        assert scale_a(0.5, np.zeros((0, 4)), 1.0) == 0.0
+
+    def test_a_zero_design_is_unpenalised(self):
+        Z = np.zeros((6, 4))
+        assert scale_b(0.5, design_eigenvalues(Z)) == 0.0
+        assert scale_a(0.5, Z, 0.0) == 0.0
+
+    def test_scaling_is_monotone_in_the_star(self):
+        """More penalty asked for is never less penalty delivered."""
+        Z = donor_design(30, 15)
+        eig = design_eigenvalues(Z)
+        vals = [scale_b(s, eig) for s in (0.0, 0.2, 0.4, 0.6, 0.8, 1.0)]
+        assert all(x <= y + 1e-12 for x, y in zip(vals, vals[1:])), vals
+
+
+# =========================================================================== #
+# what the solver does with it -- green before and after
+# =========================================================================== #
+def scaled(Z, a_star, b_star):
+    """The penalties as the estimator forms them, on the design's own scale.
+
+    The solver is only ever called with eigenvalue-scaled multipliers. Handing
+    it an arbitrary raw pair leaves the Hessian off the design's scale and it
+    raises ``MlsynthEstimationError`` -- correctly, since a QP it cannot solve
+    is not a weight vector -- so the tests below scale first, as the caller
+    does.
+    """
+    b = scale_b(b_star, design_eigenvalues(Z))
+    return scale_a(a_star, Z, b), b
+
+
+class TestQpUnchanged:
+    """The QP solves what it is handed; only what it is handed moves."""
+
+    @pytest.mark.parametrize("name,J,p", [s for s in SHAPES if s[1] > 2])
+    def test_weights_are_feasible_and_sum_to_one(self, name, J, p):
+        Z = donor_design(J, p, seed=3)
+        Z1 = treated_row(Z, seed=99)
+        a, b = scaled(Z, 0.3, 0.7)
+        w = solve_nsc_weights(Z1, Z, a, b)
+        assert w.shape == (J,)
+        assert float(w.sum()) == pytest.approx(1.0, abs=1e-6)
+
+    def test_negative_weights_are_permitted(self):
+        """NSC drops non-negativity; that is the method, not a bug."""
+        Z = donor_design(12, 6, seed=5)
+        Z1 = -3.0 * Z[0] + 2.0 * Z[1]
+        a, b = scaled(Z, 0.0, 0.05)
+        w = solve_nsc_weights(Z1, Z, a, b)
+        assert (w < -1e-6).any()
+
+    def test_a_given_penalty_pair_is_deterministic(self):
+        Z = donor_design(15, 7, seed=8)
+        Z1 = treated_row(Z, seed=4)
+        a, b = scaled(Z, 0.3, 0.7)
+        np.testing.assert_allclose(solve_nsc_weights(Z1, Z, a, b),
+                                   solve_nsc_weights(Z1, Z, a, b), atol=0)
+
+    def test_a_larger_l2_shrinks_the_spread_of_the_weights(self):
+        Z = donor_design(20, 9, seed=2)
+        Z1 = treated_row(Z, seed=11)
+        eig = design_eigenvalues(Z)
+        spreads = [solve_nsc_weights(Z1, Z, 0.0, scale_b(s, eig)).std()
+                   for s in (0.05, 0.5, 1.0)]
+        assert spreads[0] > spreads[-1], spreads
+
+
+# =========================================================================== #
+# Proposition 99 against the author's captured run
+# =========================================================================== #
+def _prop99_blocks():
+    import pandas as pd
+    d = pd.read_csv(_BASEDATA / "smoking_data.csv").sort_values(["state", "year"])
+    states = list(dict.fromkeys(d["state"]))
+    years = sorted(d["year"].unique())
+    Y = d["cigsale"].to_numpy().reshape(len(states), len(years))
+    treat_year = int(d.loc[d["Proposition 99"] == 1, "year"].min())
+    T0 = years.index(treat_year)
+    ti = states.index(d.loc[d["Proposition 99"] == 1, "state"].iloc[0])
+    Z = Y[:, :T0]
+    Z = (Z - Z.mean(axis=0)) / Z.std(axis=0, ddof=1)
+    return states, years, Y, T0, ti, Z
+
+
+@pytest.mark.skipif(not (_REF_DIR / "reference.json").is_file(),
+                    reason="captured NSC.R reference not present")
+class TestProp99:
+    def test_weights_match_the_authors_run(self):
+        states, years, Y, T0, ti, Z = _prop99_blocks()
+        ref = json.loads((_REF_DIR / "reference.json").read_text())
+        rw = ref.get("weights") or ref["values"]["weights"]
+        donors = [s for s in states if s != states[ti]]
+        ref_w = np.array([rw[s] for s in donors])
+
+        ZJ = np.delete(Z, ti, axis=0)
+        b = scale_b(0.7, design_eigenvalues(ZJ))
+        a = scale_a(0.3, ZJ, b)
+        w = solve_nsc_weights(Z[ti], ZJ, a, b)
+
+        # The reference is rounded to three decimals by NSC.R's own return, so
+        # 5e-4 per weight is the floor a faithful port can reach.
+        assert np.max(np.abs(w - ref_w)) < 1e-3
+        assert np.corrcoef(w, ref_w)[0, 1] > 0.9999
+
+    def test_effect_path_matches_the_authors_run(self):
+        states, years, Y, T0, ti, Z = _prop99_blocks()
+        ref = json.loads((_REF_DIR / "reference.json").read_text())
+        vals = ref.get("values", ref)
+        ZJ = np.delete(Z, ti, axis=0)
+        b = scale_b(0.7, design_eigenvalues(ZJ))
+        a = scale_a(0.3, ZJ, b)
+        w = solve_nsc_weights(Z[ti], ZJ, a, b)
+        ite = Y[ti] - w @ np.delete(Y, ti, axis=0)
+        for yr in (1990, 1995, 2000):
+            got = float(ite[years.index(yr)])
+            exp = float(vals[f"ite_{yr}"])
+            assert abs(got - exp) < 0.02, f"{yr}: {got} vs {exp}"
+        assert abs(float(ite[T0:].mean()) - float(vals["att_mean_post"])) < 0.02

--- a/mlsynth/utils/nsc_helpers/optimization.py
+++ b/mlsynth/utils/nsc_helpers/optimization.py
@@ -43,8 +43,38 @@ from ...exceptions import MlsynthEstimationError
 # Eigenvalue-based (a, b) scaling
 # ---------------------------------------------------------------------------
 
+# NSC.R filters both spectra at this level before indexing them, so the same
+# threshold decides how many eigenvalues ``a`` and ``b`` are chosen from.
+_EIG_TOL = 1e-7
+
+
 def design_eigenvalues(Z0: np.ndarray) -> np.ndarray:
-    """Return ascending non-zero eigenvalues of ``Z_0 Z_0'``.
+    """Ascending non-zero eigenvalues of the *stacked* donor Gram.
+
+    The matrix is the one the reference program is posed on. ``NSC.R`` writes
+    the L1 term by splitting each weight into a non-negative pair, which stacks
+    the design as ``Z* = [Z_0; -Z_0]`` and makes the quadratic form
+    ``Z* Z*'`` -- a ``(2J, 2J)`` matrix -- and it is that spectrum the
+    dimensionless ``b`` indexes.
+
+    It is not built here. Writing ``A = Z_0 Z_0'``,
+
+    .. math::
+
+       Z^* Z^{*\prime} = \begin{pmatrix} A & -A \\ -A & A \end{pmatrix}
+                        = \begin{pmatrix} 1 & -1 \\ -1 & 1 \end{pmatrix}
+                          \otimes A,
+
+    and the left factor has eigenvalues ``{0, 2}``, so the Kronecker product's
+    spectrum is ``{0}`` together with ``{2 lambda_i(A)}``. The non-zero part is
+    therefore twice the non-zero spectrum of ``A``, available from one ``(J, J)``
+    decomposition instead of a ``(2J, 2J)`` one. Equality with the literal
+    construction is asserted in ``test_nsc_penalty_scaling``.
+
+    Taking the spectrum of ``A`` itself -- which the auxiliary-variable encoding
+    of the same L1 term suggests, since it never forms ``Z*`` -- halves every
+    ``b``, and through ``b`` every ``a``, so the paper's tuning parameters buy
+    half the penalty they name (#463).
 
     Parameters
     ----------
@@ -55,8 +85,8 @@ def design_eigenvalues(Z0: np.ndarray) -> np.ndarray:
         return np.asarray([], dtype=float)
     M = Z0 @ Z0.T
     M = 0.5 * (M + M.T)
-    vals = np.linalg.eigvalsh(M)
-    vals = vals[vals > 1e-12]
+    vals = 2.0 * np.linalg.eigvalsh(M)
+    vals = vals[vals > _EIG_TOL]
     return np.sort(vals)
 
 
@@ -83,23 +113,44 @@ def scale_b(b_star: float, eigvals: np.ndarray) -> float:
 def scale_a(a_star: float, Z0: np.ndarray, b_raw: float) -> float:
     """Eigenvalue-scaled L1-discrepancy multiplier.
 
-    Uses the eigenvalues of ``Z_0 Z_0' + b * I`` (where ``b`` is the
-    *already-scaled* raw L2 multiplier) so the L1 anchor maxes out at
-    the nearest-neighbour solution when ``a_star = 1`` regardless of
-    the L2 penalty.
+    Indexes the spectrum of the ridged stacked Gram ``Z* Z*' + b I`` -- the
+    matrix ``NSC.R`` forms once ``b`` is fixed -- so the L1 anchor maxes out at
+    the nearest-neighbour solution when ``a_star = 1`` whatever the L2 penalty.
+
+    Adding ``b`` to the diagonal makes it full rank, so the spectrum has ``2J``
+    entries and not ``rank(Z_0)`` of them: the ``2J - rank`` zero eigenvalues of
+    ``Z* Z*'`` become ``b``, and the rest become ``2 lambda_i + b``. That
+    multiplicity is why the error this corrects was not a constant. Indexing the
+    ``(J, J)`` spectrum instead leaves ``J - rank`` copies of ``b`` where there
+    should be ``2J - rank``, so ``ceil(a^* n)`` lands on the ridge value in both
+    when the rank is low -- and on structurally different elements once the rank
+    approaches ``J``, where the multipliers differ by 1.36 to 1.63 and not by
+    two (#463).
+
+    The tiny ``1e-8`` is the reference's, added so the quadratic form is
+    positive definite for its solver; it is kept so the filtering threshold
+    below decides the same way.
     """
     if a_star <= 0.0:
         return 0.0
-    M = Z0 @ Z0.T + float(b_raw) * np.eye(Z0.shape[0])
+    J = Z0.shape[0]
+    if J == 0:
+        return 0.0
+    M = Z0 @ Z0.T
     M = 0.5 * (M + M.T)
-    vals = np.linalg.eigvalsh(M)
-    vals = vals[vals > 1e-12]
+    lam = 2.0 * np.linalg.eigvalsh(M)
+    ridge = float(b_raw) + 1e-8
+    nonzero = lam[lam > _EIG_TOL]
+    # The (2J, 2J) ridged spectrum, assembled from the (J, J) one: the stacked
+    # Gram's non-zero eigenvalues shifted, and one copy of the ridge for each of
+    # its 2J - rank zeros.
+    vals = np.concatenate([nonzero + ridge,
+                           np.full(2 * J - nonzero.size, ridge)])
+    vals = np.sort(vals[vals > _EIG_TOL])
     if vals.size == 0:
         return 0.0
-    vals = np.sort(vals)
-    n = vals.size
-    idx = int(np.ceil(n * float(a_star))) - 1
-    idx = max(0, min(idx, n - 1))
+    idx = int(np.ceil(vals.size * float(a_star))) - 1
+    idx = max(0, min(idx, vals.size - 1))
     return float(a_star) * float(vals[idx])
 
 

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -930,3 +930,39 @@ timeout = 900.0
   find = "        pivot = _wide_pivot(df, index=time_period_column_name,\n                            columns=unit_id_column_name, values=cov,\n                            keys=keys)"
   replace = "        pivot = _wide_pivot(df, index=time_period_column_name,\n                            columns=unit_id_column_name, values=cov)"
   models = "one scan per covariate instead of one for the panel. A ten-covariate panel is scanned eleven times, and every covariate matrix is correct, so nothing but a pass count reports it"
+
+[[target]]
+name = "nsc-penalty-scaling"
+module-path = "mlsynth/utils/nsc_helpers/optimization.py"
+test-command = "python -m pytest mlsynth/tests/test_nsc_penalty_scaling.py mlsynth/tests/test_nsc.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "b-indexes-the-unstacked-gram"
+  find = "    vals = 2.0 * np.linalg.eigvalsh(M)"
+  replace = "    vals = np.linalg.eigvalsh(M)"
+  models = "the defect this target exists for, restored: the spectrum of Z0 Z0' where the reference indexes the stacked Z* Z*', whose non-zero eigenvalues are twice as large. Every b is halved and, through b, every a, so the paper's tuning parameters buy half the penalty they name -- on Prop 99 an ATT of -19.13 against -20.59, which the previous tolerances were wide enough to admit"
+
+  [[target.mutant]]
+  id = "a-indexes-a-spectrum-of-length-J"
+  find = "    vals = np.concatenate([nonzero + ridge,\n                           np.full(2 * J - nonzero.size, ridge)])"
+  replace = "    vals = np.concatenate([nonzero + ridge,\n                           np.full(J - nonzero.size, ridge)])"
+  models = "the ridge counted once per donor instead of once per stacked variable. The spectrum is then J long where the reference's is 2J, so ceil(a* n) selects a different element -- identical on a low-rank design, where both land on the ridge value, and wrong once the rank approaches J. This is the half of the fault that a blanket doubling would not have caught"
+
+  [[target.mutant]]
+  id = "eigenvalue-filter-loosened-to-machine-zero"
+  find = "_EIG_TOL = 1e-7"
+  replace = "_EIG_TOL = 1e-12"
+  models = "the threshold that decides how many eigenvalues are indexed, moved off the reference's. At b = 0 the ridge is 1e-8, which the reference filters out and this keeps, so the a spectrum grows from rank(Z0) entries to 2J and the selected element changes"
+
+  [[target.mutant]]
+  id = "reference-ridge-dropped-from-the-a-spectrum"
+  find = "    ridge = float(b_raw) + 1e-8"
+  replace = "    ridge = float(b_raw)"
+  models = "the reference's positive-definiteness nudge removed. At b = 0 the ridge entries become exactly zero instead of 1e-8, which changes nothing downstream because both are filtered -- but at any b it shifts every entry of the spectrum a and b are read from"
+
+  [[target.mutant]]
+  id = "scaling-index-off-by-one"
+  find = "    idx = int(np.ceil(vals.size * float(a_star))) - 1"
+  replace = "    idx = int(np.ceil(vals.size * float(a_star)))"
+  models = "R's one-based sort() index used directly on a zero-based array, so every a takes the next eigenvalue up. At a* = 1 it clamps and is invisible; below that it silently over-penalises"


### PR DESCRIPTION
Closes #463.

## What was wrong

NSC's `a` and `b` are dimensionless dials in `[0, 1]`. What enters the QP is an eigenvalue times the dial, and which matrix supplies that eigenvalue was a free choice made differently on each side.

`Σ|w_j|` is not a quadratic-program term, so both implementations rewrite it. Tian's `NSC.R` splits each weight into a non-negative pair, which stacks the design as `Z* = [Z; -Z]`, makes the quadratic form `Z* Z*'`, and indexes that spectrum. mlsynth writes the same term with auxiliary variables `u >= |w|`, never forms `Z*`, and indexed `Z Z'`.

Both rewrites give the same feasible set and the same optimum *for a given* `(a, b)` — which is why the QP was never at fault; handed `NSC.R`'s raw pair it reproduces the reference exactly. But `Z* Z*'` is `[[1,-1],[-1,1]] ⊗ Z Z'`, and the left factor's eigenvalues are `{0, 2}`, so the stacked spectrum is the zeros together with `2λ_i`. Indexing the same position returns half the value:

```
a* = 0.3, b* = 0.7   ->   NSC.R:    a = 0.3170,  b = 1.0566
                     ->   mlsynth:  a = 0.1585,  b = 0.5283
```

The paper's own Table 2 penalty therefore bought half the penalty it names.

## What changed

`design_eigenvalues` returns the stacked spectrum, built from one `(J, J)` decomposition through the Kronecker identity above instead of a `(2J, 2J)` one; equality with the literal construction is asserted, not assumed. `scale_a` assembles the ridged `2J` spectrum the same way.

The second half matters independently. Adding the ridge lifts `2J - rank` zero eigenvalues above the reference's `1e-7` filter, so the spectrum `a` indexes is `2J` long and not `J`, and `ceil(a* n)` lands on the ridge value in both only while the rank stays low:

| J | pre-periods | rank | b ratio | a ratio |
|---:|---:|---:|---:|---:|
| 38 | 19 | 19 | 2.000 | 2.000 |
| 38 | 40 | 37 | 2.000 | 1.554 |
| 20 | 50 | 19 | 2.000 | 1.359 |
| 60 | 60 | 59 | 2.000 | 1.631 |
| 100 | 12 | 12 | 2.000 | 2.000 |

Doubling the multipliers would have passed Proposition 99 — rank 19 of 38 — and stayed wrong wherever the rank approaches `J`.

## Effect

Against the author's captured `NSC.R` run at the Table-2 penalty:

| quantity | before | after | reference |
|---|---:|---:|---:|
| weight correlation | 0.989 | 1.000 | — |
| max per-donor \|Δ\| | 0.0239 | 0.00047 | — |
| mean per-donor \|Δ\| | 0.0056 | 0.00011 | — |
| ATT (post) | −19.13 | −20.59 | −20.59 |
| ITE 1990 | −9.05 | −9.51 | −9.51 |
| ITE 1995 | −22.62 | −24.50 | −24.50 |
| ITE 2000 | −27.01 | −28.70 | −28.70 |

What remains is `NSC.R` rounding its own returned weights to three decimals, which bounds a single weight at 5e-4; the effect path, computed from unrounded weights on both sides, agrees to ~1e-6 packs.

Every NSC estimate moves, tuned as well as fixed — self-tuned Prop 99 was −23.34 before. This is a correctness change, not a refactor.

## Tests

New `test_nsc_penalty_scaling.py`, 138 tests, built around a line-for-line transcription of `NSC.R`'s scaling as the differential oracle. The scaling is asserted directly — seven shapes chosen to straddle the rank regimes, eight dial values each, plus a rank-deficient family — so the map from `(a*, b*)` to `(a, b)` is pinned on its own rather than inferred from an ATT with a wide band around it. That is the assertion rung 5 of the analysis found missing. Boundaries (`0`, `1`, negative dials, empty pool, zero design, monotonicity in the dial) and the Prop 99 weights and effect path against the captured run are pinned alongside.

The benchmark's tolerances were the reason this went unexamined for as long as it did: they were built around the gap — the ATT band was 1.7 against an observed 1.46, with `# mlsynth -19.13 vs NSC.R -20.59` written into the comment — and the case docstring attributed the residual to "the standardisation convention and the author's 3-decimal weight rounding". Both were wrong: the standardisation already agreed (`ddof=1` on both sides) and the rounding accounts for 2 percent of what was observed. `nsc_prop99` now carries tolerances a faithful port reaches (1.5e-3 on the largest weight, 0.02 packs on the effect path) and the docstring says what the cause actually was.

One existing test, `test_scale_a_uses_combined_design`, asserted that `a` rises with `b` at every `a*`. That was a property of the old spectrum and not of the method: the reference returns 1.636, 0.500 and 5.000 at `a* = 0.5` for `b` of 0, 1 and 10, because the ridge changes how many eigenvalues clear the filter. It now pins what `NSC.R` does, including the non-monotone step, with the reason recorded.

`tools/mutation/targets.toml` gains `nsc-penalty-scaling` with five mutants, the first of which restores the exact defect and the second of which is the half a blanket doubling would not have caught.

Green locally: 196 NSC tests, `nsc_prop99` and `nsc_mc` both passing, the changed module at 91 percent with only pre-existing defensive branches uncovered. `docs/nsc.rst`, `docs/replications/nsc.rst` and `docs/replications.rst` carry the corrected figures, and the replication page records what the old ones were and why they were wrong.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_