### PR TITLE
Reach the Callaway-Sant'Anna estimator from PPSCM (estimation)

### DIFF
--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -84,6 +84,10 @@ class PPSCM:
         self.n_lags = config.n_lags
         self.time_cohort: bool = config.time_cohort
         self.lam: float = config.lam
+        self.donor_weights: str = config.donor_weights
+        self.base_period: str = config.base_period
+        self.donor_pool: str = config.donor_pool
+        self.method: Any = config.method
         self.solver: Any = config.solver
         self.run_inference: bool = config.run_inference
         self.inference_method: str = config.inference_method
@@ -124,6 +128,8 @@ class PPSCM:
                 Xy, trt, d, n_leads, n_lags,
                 fixedeff=self.fixedeff, time_cohort=self.time_cohort,
                 nu=nu_arg, lam=self.lam, solver=self.solver,
+                donor_weights=self.donor_weights, base_period=self.base_period,
+                donor_pool=self.donor_pool,
                 Z=inputs.Z,
             )
 
@@ -133,6 +139,13 @@ class PPSCM:
                 global_l2=fit["global_l2"], ind_l2=fit["ind_l2"],
                 scaled_global_l2=fit["scaled_global_l2"],
                 scaled_ind_l2=fit["scaled_ind_l2"],
+                conventions={
+                    "donor_weights": self.donor_weights,
+                    "base_period": self.base_period,
+                    "donor_pool": self.donor_pool,
+                    "inference_method": (
+                        self.inference_method if self.run_inference else None),
+                },
             )
 
             per_time = fit["per_time"]

--- a/mlsynth/tests/test_ppscm_callaway_santanna.py
+++ b/mlsynth/tests/test_ppscm_callaway_santanna.py
@@ -45,8 +45,52 @@ import pytest
 from mlsynth import PPSCM
 from mlsynth.exceptions import MlsynthConfigError
 
-dd = pytest.importorskip("diff_diff", reason="CS reference implementation")
-from diff_diff import CallawaySantAnna, SunAbraham  # noqa: E402
+try:                                             # corroboration, not the oracle
+    from diff_diff import CallawaySantAnna, SunAbraham
+    HAVE_DIFF_DIFF = True
+except ImportError:                              # pragma: no cover - CI without it
+    HAVE_DIFF_DIFF = False
+
+needs_diff_diff = pytest.mark.skipif(
+    not HAVE_DIFF_DIFF, reason="diff-diff not installed")
+
+
+# --------------------------------------------------------------------------- #
+# the oracle: Callaway-Sant'Anna's group-time ATT, transcribed
+# --------------------------------------------------------------------------- #
+def cs_group_time(df, outcome="y", unit="id", time="time", first_treat="first_treat"):
+    """``ATT(g, t)`` with a never-treated comparison group and no covariates.
+
+    With those two restrictions the estimator is a two-period, two-group DiD per
+    cell, against the base period ``g - 1``::
+
+        ATT(g,t) = mean_{i in G_g}(Y_it - Y_{i,g-1})
+                 - mean_{i in C} (Y_it - Y_{i,g-1})
+
+    Transcribed rather than imported so the identity this module exists to prove
+    is enforced wherever the suite runs, and not only where ``diff-diff`` is
+    installed. The imported package is compared against separately, which is
+    what keeps this transcription honest.
+    """
+    wide = df.pivot(index=unit, columns=time, values=outcome)
+    g_of = df.groupby(unit)[first_treat].first()
+    never = g_of.index[g_of == 0]
+    out = {}
+    for g in sorted(x for x in g_of.unique() if x != 0):
+        treated = g_of.index[g_of == g]
+        for t in wide.columns:
+            if t < g or (g - 1) not in wide.columns:
+                continue
+            d_tr = (wide.loc[treated, t] - wide.loc[treated, g - 1]).mean()
+            d_co = (wide.loc[never, t] - wide.loc[never, g - 1]).mean()
+            out[(g, t)] = float(d_tr - d_co)
+    return out
+
+
+def oracle_att(df, L):
+    """The oracle's ATT over leads ``0 .. L-1``, aggregated as PPSCM aggregates."""
+    gt = cs_group_time(df)
+    return float(np.mean([v for (g, t), v in gt.items() if 0 <= t - g < L]))
 
 
 # --------------------------------------------------------------------------- #
@@ -174,12 +218,31 @@ class TestConfigSurface:
 # =========================================================================== #
 class TestIdentityWithCallawaySantAnna:
     @pytest.mark.parametrize("name,onsets,k", ALIGNED)
+    def test_matches_the_callaway_santanna_oracle(self, name, onsets, k):
+        df = staggered(onsets, k=k)
+        res = fit_cs_mode(df)
+        assert float(res.att) == pytest.approx(oracle_att(df, leads_of(res)),
+                                               abs=1e-12), name
+
+    @needs_diff_diff
+    @pytest.mark.parametrize("name,onsets,k", ALIGNED)
     def test_matches_callaway_santanna(self, name, onsets, k):
+        """Corroboration against an independent implementation."""
         df = staggered(onsets, k=k)
         res = fit_cs_mode(df)
         ref, _ = reference_cs(df, leads_of(res))
         assert float(res.att) == pytest.approx(ref, abs=1e-12), name
 
+    @needs_diff_diff
+    @pytest.mark.parametrize("name,onsets,k", ALIGNED)
+    def test_the_oracle_agrees_with_the_package(self, name, onsets, k):
+        """If these ever disagree, the transcription is what to distrust."""
+        df = staggered(onsets, k=k)
+        L = leads_of(fit_cs_mode(df))
+        ref, _ = reference_cs(df, L)
+        assert oracle_att(df, L) == pytest.approx(ref, abs=1e-12), name
+
+    @needs_diff_diff
     @pytest.mark.parametrize("name,onsets,k", ALIGNED)
     def test_matches_sun_abraham(self, name, onsets, k):
         df = staggered(onsets, k=k)
@@ -192,23 +255,22 @@ class TestIdentityWithCallawaySantAnna:
         """A DGP-specific identity would be worthless; vary the effect."""
         df = staggered((10, 14, 18), effect=effect)
         res = fit_cs_mode(df)
-        ref, _ = reference_cs(df, leads_of(res))
-        assert float(res.att) == pytest.approx(ref, abs=1e-12), effect
+        assert float(res.att) == pytest.approx(oracle_att(df, leads_of(res)),
+                                               abs=1e-12), effect
 
     @pytest.mark.parametrize("seed", range(4))
     def test_identity_holds_across_seeds(self, seed):
         df = staggered((10, 14, 18), seed=seed)
         res = fit_cs_mode(df)
-        ref, _ = reference_cs(df, leads_of(res))
-        assert float(res.att) == pytest.approx(ref, abs=1e-12)
+        assert float(res.att) == pytest.approx(oracle_att(df, leads_of(res)),
+                                               abs=1e-12)
 
     def test_event_study_path_matches_lead_for_lead(self):
         """The ATT is one number; the path is where an estimator can hide."""
         df = staggered((10, 14, 18))
         res = fit_cs_mode(df)
         L = leads_of(res)
-        _, ref = reference_cs(df, L)
-        gt = {(g, t): v["effect"] for (g, t), v in ref.group_time_effects.items()}
+        gt = cs_group_time(df)
         for l in range(L):
             ours = float(np.nanmean([f.tau[l] for f in res.per_unit.values()]))
             theirs = float(np.mean([v for (g, t), v in gt.items() if t - g == l]))
@@ -257,7 +319,7 @@ class TestDocumentedDivergence:
         cs_mode = float(fit_cs_mode(df).att)
         window = float(fit_cs_mode(df, donor_pool="window").att)
         res = fit_cs_mode(df)
-        ref, _ = reference_cs(df, leads_of(res))
+        ref = oracle_att(df, leads_of(res))
         assert cs_mode == pytest.approx(ref, abs=1e-12), (
             "never_treated must still match CS exactly")
         assert abs(window - ref) > 1e-4, (
@@ -267,6 +329,12 @@ class TestDocumentedDivergence:
 # =========================================================================== #
 # 5. inference -- separate from estimation on purpose
 # =========================================================================== #
+@pytest.mark.xfail(strict=True, reason=(
+    "Influence-function inference is the second half of #465 and is not built "
+    "yet. These are written first and left strict on purpose: they fail now, "
+    "and the moment the inference lands they flip to unexpected passes, which "
+    "is what removes this marker. PPSCM's jackknife is still what runs, and "
+    "``parameters_used['inference_method']`` says so."))
 class TestInference:
     @pytest.mark.parametrize("name,onsets,k", ALIGNED[:3])
     def test_per_cell_standard_errors_match(self, name, onsets, k):

--- a/mlsynth/tests/test_ppscm_callaway_santanna.py
+++ b/mlsynth/tests/test_ppscm_callaway_santanna.py
@@ -1,0 +1,315 @@
+"""PPSCM reaches the Callaway-Sant'Anna estimator exactly, and says so honestly.
+
+Ben-Michael, Feller & Rothstein (2022) p.369 note that with uniform donor
+weights their intercept-shifted partially-pooled SCM "is equivalent to recent
+proposals for DiD estimators that allow for treatment effect heterogeneity with
+a fixed donor set per treatment time cohort (see Callaway & Sant'Anna, 2020; Sun
+& Abraham, 2020)". Measured, that is not an approximation: three independent
+implementations agree to 1e-14 once three conventions are aligned (#465).
+
+The three, each separable and each isolated by measurement:
+
+* donor weights -- CS/SA weight donors uniformly, PPSCM solves the SCM QP.
+  Uniform is not reachable by sending ``lam`` up: the weights saturate at
+  ``max|w - 1/J| = 3.47e-03`` and do not move between ``lam = 1e9`` and ``1e18``
+  at any ``nu``, so it has to be imposed.
+* base period -- ``fit_feff`` subtracts each unit's mean over its whole
+  pre-adoption window (augsynth's convention); CS baselines on ``g-1``. The
+  difference is a per-cohort level shift.
+* donor eligibility -- augsynth admits units untreated through the cohort's
+  estimation window, which is neither ``never_treated`` nor CS's
+  ``not_yet_treated``. It coincides with ``never_treated`` only when every other
+  cohort adopts inside the window, and that is exactly when the identity holds.
+
+The identity tests pin the estimate at 1e-12, which needs no tolerance
+negotiation because the true agreement is two orders tighter. The isolation
+tests pin what each convention does on its own, so a regression names the
+convention. The divergence test pins the regime where the three legitimately
+disagree, as a documented difference and not a bug -- a benchmark panel with
+adoptions spread across a long window lands there, so it must not be read as
+breakage.
+
+Inference is tested separately from estimation on purpose. Equal point
+estimates do not make equal intervals: CS reports influence-function analytical
+standard errors with an optional multiplier bootstrap, PPSCM reports jackknife,
+and reporting one while naming the other is the failure #459 and #463 both
+bottomed out at.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PPSCM
+from mlsynth.exceptions import MlsynthConfigError
+
+dd = pytest.importorskip("diff_diff", reason="CS reference implementation")
+from diff_diff import CallawaySantAnna, SunAbraham  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# panels
+# --------------------------------------------------------------------------- #
+def staggered(onsets, k=3, n_units=50, n_per=30, seed=0, effect="const"):
+    """Never-treated donors plus cohorts adopting at ``onsets``.
+
+    ``effect`` selects the treatment-effect structure, since an identity that
+    only holds for a constant effect would be an artefact of the DGP.
+    """
+    rng = np.random.default_rng(seed)
+    assign, u = {}, 0
+    for g in onsets:
+        for _ in range(k):
+            assign[u] = g
+            u += 1
+    rows = []
+    for unit in range(n_units):
+        base = rng.normal(10, 2)
+        walk = np.cumsum(rng.normal(0, 0.3, n_per))
+        g = assign.get(unit)
+        u_eff = rng.normal()
+        for t in range(1, n_per + 1):
+            on = g is not None and t >= g
+            if not on:
+                eff = 0.0
+            elif effect == "const":
+                eff = 2.0
+            elif effect == "cohort":
+                eff = 1.0 + onsets.index(g)
+            elif effect == "dynamic":
+                eff = 0.3 * (t - g + 1)
+            elif effect == "unit":
+                eff = 2.0 + u_eff
+            else:                                    # pragma: no cover - typo guard
+                raise ValueError(effect)
+            rows.append((unit, t, base + walk[t - 1] + 0.5 * rng.normal() + eff,
+                         int(on), g if g is not None else 0))
+    return pd.DataFrame(rows, columns=["id", "time", "y", "d", "first_treat"])
+
+
+CS_CFG = {"method": "callaway_santanna"}
+
+
+def fit_cs_mode(df, **over):
+    cfg = {"df": df[["id", "time", "y", "d"]], "outcome": "y", "treat": "d",
+           "unitid": "id", "time": "time", "display_graphs": False,
+           "run_inference": False, **CS_CFG, **over}
+    return PPSCM(cfg).fit()
+
+
+def reference_cs(df, L, control_group="never_treated"):
+    r = CallawaySantAnna(control_group=control_group, estimation_method="dr",
+                         n_bootstrap=0).fit(df, outcome="y", unit="id",
+                                            time="time", first_treat="first_treat")
+    gt = {(g, t): v["effect"] for (g, t), v in r.group_time_effects.items()}
+    return float(np.mean([v for (g, t), v in gt.items() if 0 <= t - g < L])), r
+
+
+def reference_sa(df, L):
+    r = SunAbraham(control_group="never_treated").fit(
+        df, outcome="y", unit="id", time="time", first_treat="first_treat")
+    es = r.event_study_effects
+    return float(np.mean([(v["effect"] if isinstance(v, dict) else v)
+                          for l, v in sorted(es.items()) if 0 <= l < L])), r
+
+
+def leads_of(res):
+    return len(next(iter(res.per_unit.values())).tau)
+
+
+# shapes where every non-focal cohort adopts inside the focal cohort's window,
+# so the donor pools coincide and the identity is exact
+ALIGNED = [("one-cohort", (12,), 3), ("two-cohort", (10, 14), 3),
+           ("three-cohort", (10, 14, 18), 3), ("three-cohort-small", (10, 14, 18), 2),
+           ("three-cohort-large", (10, 14, 18), 4)]
+EFFECTS = ["const", "cohort", "dynamic", "unit"]
+
+
+# =========================================================================== #
+# 1. the configuration surface -- starts red
+# =========================================================================== #
+class TestConfigSurface:
+    def test_preset_sets_all_three_conventions(self):
+        df = staggered((10, 14))
+        res = fit_cs_mode(df)
+        d = res.method_details.parameters_used
+        assert d.get("donor_weights") == "uniform"
+        assert d.get("base_period") == "pre_treatment"
+        assert d.get("donor_pool") == "never_treated"
+
+    @pytest.mark.parametrize("field,value", [
+        ("donor_weights", "uniform"), ("donor_weights", "scm"),
+        ("base_period", "all_pre"), ("base_period", "pre_treatment"),
+        ("donor_pool", "window"), ("donor_pool", "never_treated"),
+        ("donor_pool", "not_yet_treated")])
+    def test_each_convention_is_settable(self, field, value):
+        df = staggered((10, 14))
+        res = fit_cs_mode(df, **{field: value})
+        assert res.method_details.parameters_used[field] == value
+
+    @pytest.mark.parametrize("field,bad", [
+        ("donor_weights", "equal"), ("base_period", "g-1"),
+        ("donor_pool", "not_yet"), ("method", "callaway")])
+    def test_an_unknown_convention_is_refused(self, field, bad):
+        df = staggered((10, 14))
+        with pytest.raises((MlsynthConfigError, ValueError)):
+            fit_cs_mode(df, **{field: bad})
+
+    def test_the_defaults_are_augsynth(self):
+        """The preset is opt-in; plain PPSCM keeps multisynth's conventions."""
+        df = staggered((10, 14))
+        cfg = {"df": df[["id", "time", "y", "d"]], "outcome": "y", "treat": "d",
+               "unitid": "id", "time": "time", "display_graphs": False,
+               "run_inference": False}
+        d = PPSCM(cfg).fit().method_details.parameters_used
+        assert d.get("donor_weights") == "scm"
+        assert d.get("base_period") == "all_pre"
+        assert d.get("donor_pool") == "window"
+
+
+# =========================================================================== #
+# 2. the identity -- the whole point
+# =========================================================================== #
+class TestIdentityWithCallawaySantAnna:
+    @pytest.mark.parametrize("name,onsets,k", ALIGNED)
+    def test_matches_callaway_santanna(self, name, onsets, k):
+        df = staggered(onsets, k=k)
+        res = fit_cs_mode(df)
+        ref, _ = reference_cs(df, leads_of(res))
+        assert float(res.att) == pytest.approx(ref, abs=1e-12), name
+
+    @pytest.mark.parametrize("name,onsets,k", ALIGNED)
+    def test_matches_sun_abraham(self, name, onsets, k):
+        df = staggered(onsets, k=k)
+        res = fit_cs_mode(df)
+        ref, _ = reference_sa(df, leads_of(res))
+        assert float(res.att) == pytest.approx(ref, abs=1e-11), name
+
+    @pytest.mark.parametrize("effect", EFFECTS)
+    def test_identity_survives_effect_heterogeneity(self, effect):
+        """A DGP-specific identity would be worthless; vary the effect."""
+        df = staggered((10, 14, 18), effect=effect)
+        res = fit_cs_mode(df)
+        ref, _ = reference_cs(df, leads_of(res))
+        assert float(res.att) == pytest.approx(ref, abs=1e-12), effect
+
+    @pytest.mark.parametrize("seed", range(4))
+    def test_identity_holds_across_seeds(self, seed):
+        df = staggered((10, 14, 18), seed=seed)
+        res = fit_cs_mode(df)
+        ref, _ = reference_cs(df, leads_of(res))
+        assert float(res.att) == pytest.approx(ref, abs=1e-12)
+
+    def test_event_study_path_matches_lead_for_lead(self):
+        """The ATT is one number; the path is where an estimator can hide."""
+        df = staggered((10, 14, 18))
+        res = fit_cs_mode(df)
+        L = leads_of(res)
+        _, ref = reference_cs(df, L)
+        gt = {(g, t): v["effect"] for (g, t), v in ref.group_time_effects.items()}
+        for l in range(L):
+            ours = float(np.nanmean([f.tau[l] for f in res.per_unit.values()]))
+            theirs = float(np.mean([v for (g, t), v in gt.items() if t - g == l]))
+            assert ours == pytest.approx(theirs, abs=1e-12), f"lead {l}"
+
+
+# =========================================================================== #
+# 3. each convention, isolated
+# =========================================================================== #
+class TestConventionsIsolated:
+    def test_scm_weights_move_the_answer(self):
+        df = staggered((10, 14, 18))
+        cs = float(fit_cs_mode(df).att)
+        scm = float(fit_cs_mode(df, donor_weights="scm").att)
+        assert abs(scm - cs) > 1e-6, "SCM weights should not reproduce uniform"
+
+    def test_the_baseline_is_a_per_cohort_level_shift(self):
+        """all-pre-lags vs g-1: the event-study *shape* must not move."""
+        df = staggered((10, 14, 18))
+        a = fit_cs_mode(df)
+        b = fit_cs_mode(df, base_period="all_pre")
+        L = leads_of(a)
+        diffs = [float(np.nanmean([f.tau[l] for f in b.per_unit.values()])
+                       - np.nanmean([f.tau[l] for f in a.per_unit.values()]))
+                 for l in range(L)]
+        assert max(diffs) - min(diffs) < 1e-9, f"not a level shift: {diffs}"
+        assert abs(diffs[0]) > 1e-6, "expected a non-zero shift"
+
+    def test_donor_pool_only_matters_when_a_cohort_survives_the_window(self):
+        df_aligned = staggered((10, 14, 18))
+        a1 = float(fit_cs_mode(df_aligned).att)
+        a2 = float(fit_cs_mode(df_aligned, donor_pool="window").att)
+        assert a1 == pytest.approx(a2, abs=1e-12), (
+            "pools coincide here, so the setting must not matter")
+
+
+# =========================================================================== #
+# 4. the regime where they legitimately diverge
+# =========================================================================== #
+class TestDocumentedDivergence:
+    def test_window_pool_differs_when_a_later_cohort_survives(self):
+        """Four cohorts over a long window: augsynth admits the last cohort as a
+        donor for the first, CS does not. Measured at ~1.2e-02 -- pinned as a
+        documented difference so it is not read as breakage."""
+        df = staggered((8, 12, 16, 20))
+        cs_mode = float(fit_cs_mode(df).att)
+        window = float(fit_cs_mode(df, donor_pool="window").att)
+        res = fit_cs_mode(df)
+        ref, _ = reference_cs(df, leads_of(res))
+        assert cs_mode == pytest.approx(ref, abs=1e-12), (
+            "never_treated must still match CS exactly")
+        assert abs(window - ref) > 1e-4, (
+            "augsynth's window pool is expected to differ here")
+
+
+# =========================================================================== #
+# 5. inference -- separate from estimation on purpose
+# =========================================================================== #
+class TestInference:
+    @pytest.mark.parametrize("name,onsets,k", ALIGNED[:3])
+    def test_per_cell_standard_errors_match(self, name, onsets, k):
+        df = staggered(onsets, k=k)
+        res = fit_cs_mode(df, run_inference=True)
+        _, ref = reference_cs(df, leads_of(res))
+        ours = res.inference_detail.group_time_se
+        for (g, t), v in ref.group_time_effects.items():
+            if (g, t) in ours and np.isfinite(v["se"]):
+                assert ours[(g, t)] == pytest.approx(v["se"], rel=1e-9), (g, t)
+
+    def test_aggregated_standard_error_matches(self):
+        """Includes the weight-influence term; without it the SE is wrong by
+        the amount R's did::aggte corrects for."""
+        df = staggered((10, 14, 18))
+        res = fit_cs_mode(df, run_inference=True)
+        _, ref = reference_cs(df, leads_of(res))
+        assert float(res.inference.standard_error) == pytest.approx(
+            float(ref.se), rel=1e-8)
+
+    def test_confidence_interval_matches(self):
+        df = staggered((10, 14, 18))
+        res = fit_cs_mode(df, run_inference=True)
+        _, ref = reference_cs(df, leads_of(res))
+        lo, hi = ref.conf_int
+        assert float(res.inference.ci_lower) == pytest.approx(lo, rel=1e-8)
+        assert float(res.inference.ci_upper) == pytest.approx(hi, rel=1e-8)
+
+    def test_multiplier_bootstrap_bands_are_wider_than_pointwise(self):
+        """Uniform bands cover the whole path simultaneously, so they cannot be
+        narrower than the pointwise interval."""
+        df = staggered((10, 14, 18))
+        res = fit_cs_mode(df, run_inference=True, n_bootstrap=200, cband=True)
+        assert (res.inference.ci_upper - res.inference.ci_lower) > 0
+        band = res.inference_detail.uniform_band
+        point = res.inference_detail.pointwise_band
+        assert all(b[1] - b[0] >= p[1] - p[0] - 1e-12
+                   for b, p in zip(band, point))
+
+    def test_inference_is_not_silently_jackknife(self):
+        """The preset must report which inference it ran; naming CS while
+        reporting PPSCM's jackknife is the failure #459/#463 bottomed out at."""
+        df = staggered((10, 14))
+        res = fit_cs_mode(df, run_inference=True)
+        assert res.method_details.parameters_used.get("inference_method") == \
+            "influence_function"

--- a/mlsynth/utils/ppscm_helpers/config.py
+++ b/mlsynth/utils/ppscm_helpers/config.py
@@ -64,6 +64,46 @@ class PPSCMConfig(BaseEstimatorConfig):
             "fully-pooled cohort (one synthetic control per cohort)."
         ),
     )
+    donor_weights: Literal["scm", "uniform"] = Field(
+        default="scm",
+        description=(
+            "How donors are weighted. 'scm' solves the partially-pooled QP. "
+            "'uniform' puts equal weight on every admissible donor, which is "
+            "the comparison Callaway-Sant'Anna and Sun-Abraham make; it is "
+            "imposed rather than approached, since driving 'lam' up saturates "
+            "at max|w - 1/J| = 3.5e-03 and never reaches it."
+        ),
+    )
+    base_period: Literal["all_pre", "pre_treatment"] = Field(
+        default="all_pre",
+        description=(
+            "Baseline for the unit fixed effect. 'all_pre' is each unit's mean "
+            "over its whole pre-adoption window, which is augsynth's. "
+            "'pre_treatment' is the single period before adoption, which is "
+            "what Callaway-Sant'Anna normalises against. The choice shifts each "
+            "cohort's level without moving the event-study shape."
+        ),
+    )
+    donor_pool: Literal["window", "never_treated", "not_yet_treated"] = Field(
+        default="window",
+        description=(
+            "Which units may serve as donors. 'window' admits any unit "
+            "untreated through the cohort's estimation window (augsynth). "
+            "'never_treated' and 'not_yet_treated' are the Callaway-Sant'Anna "
+            "comparison groups. 'window' and 'never_treated' coincide exactly "
+            "when every other cohort adopts inside the window."
+        ),
+    )
+    method: Optional[Literal["callaway_santanna"]] = Field(
+        default=None,
+        description=(
+            "Convenience preset. 'callaway_santanna' sets donor_weights="
+            "'uniform', base_period='pre_treatment' and donor_pool="
+            "'never_treated', which together reproduce the Callaway-Sant'Anna "
+            "and Sun-Abraham estimator to machine precision wherever the donor "
+            "pools coincide. Explicitly-set conventions are not overridden."
+        ),
+    )
     lam: float = Field(
         default=0.0,
         ge=0.0,
@@ -194,6 +234,25 @@ class PPSCMConfig(BaseEstimatorConfig):
             "latter. Needs ``run_inference``. Off by default."
         ),
     )
+
+    @model_validator(mode="after")
+    def _apply_method_preset(self):
+        """Expand ``method`` into the three conventions it names.
+
+        Only fields the caller left at their default are set, so an explicit
+        convention alongside the preset is honoured and not silently reversed --
+        someone asking for the CS estimator with augsynth's donor pool is asking
+        a coherent question, and the answer is not the preset's.
+        """
+        if self.method == "callaway_santanna":
+            fields = self.model_fields_set
+            if "donor_weights" not in fields:
+                object.__setattr__(self, "donor_weights", "uniform")
+            if "base_period" not in fields:
+                object.__setattr__(self, "base_period", "pre_treatment")
+            if "donor_pool" not in fields:
+                object.__setattr__(self, "donor_pool", "never_treated")
+        return self
 
     @model_validator(mode="after")
     def _check_inference_method(self):

--- a/mlsynth/utils/ppscm_helpers/engine.py
+++ b/mlsynth/utils/ppscm_helpers/engine.py
@@ -25,25 +25,87 @@ import numpy as np
 _EPS = 1e-12
 
 
-def fit_feff(Xy: np.ndarray, trt: np.ndarray, adopt_indices, fixedeff: bool) -> Dict[int, np.ndarray]:
+def fit_feff(Xy: np.ndarray, trt: np.ndarray, adopt_indices, fixedeff: bool,
+             base_period: str = "all_pre") -> Dict[int, np.ndarray]:
     """Residualize ``Xy`` per cohort.
 
     Returns ``{adoption_index: residual_matrix (n, T)}``. With ``fixedeff`` the
-    time effect is the never-treated column mean and the unit effect is each
-    unit's mean residual over its pre-adoption window ``[:tj]``; without it,
-    only the time effect (control averages) is removed.
+    time effect is the never-treated column mean and the unit effect is a
+    pre-adoption baseline; without it, only the time effect (control averages)
+    is removed.
+
+    ``base_period`` selects the baseline, and the two are different estimators:
+
+    * ``"all_pre"`` -- each unit's mean over its whole pre-adoption window
+      ``[:tj]``. This is augsynth's ``fit_feff`` (``rowMeans(residuals[, 1:tj])``)
+      and the default, verified against it to 0.0 over 300 random panels.
+    * ``"pre_treatment"`` -- the single period ``tj - 1``, which is the base
+      period Callaway-Sant'Anna and Sun-Abraham normalise against. Choosing it
+      is one of the three conventions that make this estimator theirs (#465);
+      on its own it shifts each cohort's level without moving the event-study
+      shape.
     """
+    if base_period not in ("all_pre", "pre_treatment"):
+        raise ValueError(
+            f"base_period must be 'all_pre' or 'pre_treatment', got {base_period!r}.")
     ever = np.isfinite(trt)
     time_eff = np.nanmean(Xy[~ever], axis=0)
     base = Xy - time_eff[None, :]
     out: Dict[int, np.ndarray] = {}
     for tj in adopt_indices:
+        tj = int(tj)
         if fixedeff:
-            unit_eff = np.nanmean(base[:, : int(tj)], axis=1)
-            out[int(tj)] = base - unit_eff[:, None]
+            unit_eff = (np.nanmean(base[:, :tj], axis=1) if base_period == "all_pre"
+                        else base[:, tj - 1])
+            out[tj] = base - unit_eff[:, None]
         else:
-            out[int(tj)] = base
+            out[tj] = base
     return out
+
+
+def eligible_donors(trt: np.ndarray, adopt: int, n_leads: int, donor_pool: str) -> np.ndarray:
+    """Indices admissible as donors for a cohort adopting at ``adopt``.
+
+    Never-treated units carry a non-finite adoption time, so they satisfy every
+    rule below. The three differ only in which *later-adopting* units they also
+    admit, and that choice is what separates this estimator from
+    Callaway-Sant'Anna when a later cohort outlives an earlier one's window:
+
+    * ``"window"`` -- untreated through this cohort's whole estimation window,
+      ``trt > adopt + n_leads``. augsynth's rule, and the default.
+    * ``"never_treated"`` -- never treated at all, which is what CS and
+      Sun-Abraham use by default.
+    * ``"not_yet_treated"`` -- untreated as of this cohort's adoption.
+
+    ``"window"`` and ``"never_treated"`` coincide exactly when every other
+    cohort adopts inside the window, which is why the three estimators agree to
+    machine precision there and diverge otherwise.
+    """
+    if donor_pool == "window":
+        return np.where(trt > adopt + n_leads)[0]
+    if donor_pool == "never_treated":
+        return np.where(~np.isfinite(trt))[0]
+    if donor_pool == "not_yet_treated":
+        return np.where(trt > adopt)[0]
+    raise ValueError(
+        f"donor_pool must be 'window', 'never_treated' or 'not_yet_treated', "
+        f"got {donor_pool!r}.")
+
+
+def uniform_weights(donors, groups, n) -> Dict[Any, np.ndarray]:
+    """Equal weight on every admissible donor -- the CS/Sun-Abraham comparison.
+
+    Imposed, not approximated. Driving ``lam`` up does not reach it: the QP's
+    weights saturate at ``max|w - 1/J| = 3.47e-03`` and do not move between
+    ``lam = 1e9`` and ``1e18`` at any ``nu``.
+    """
+    W: Dict[Any, np.ndarray] = {}
+    for g in groups:
+        Wg = np.zeros(n)
+        if len(donors[g]):
+            Wg[donors[g]] = 1.0 / len(donors[g])
+        W[g] = Wg
+    return W
 
 
 def _padded(bal: np.ndarray, members: List[int], donors: np.ndarray, tj: int, d: int):
@@ -156,11 +218,41 @@ def _scale_covariates(Z: np.ndarray, trt: np.ndarray, res_first: np.ndarray, d: 
     return sdx * (Z - mu) / sd
 
 
+def _uniform_fit(res, groups, adopt_of, members, donors, n1, d, n, n_leads,
+                 nu, lam) -> Dict[str, Any]:
+    """The fit with equal donor weights, where there is no QP to solve.
+
+    Every diagnostic the partially-pooled path reports is a property of the
+    solved weights relative to the uniform baseline, so with uniform weights the
+    scaled imbalances are 1 by construction and ``nu`` and ``lam`` describe a
+    program that was not posed. They are reported as such instead of being
+    given values that would read as if a QP had run.
+    """
+    W = uniform_weights(donors, groups, n)
+    M = _imbalance_matrix(res, groups, adopt_of, members, donors, W, n1, d, n)
+    J = len(groups)
+    nnz = [max(int((np.abs(M[:, k]) > 1e-12).sum()), 1) for k in range(J)]
+    fin_global = float(np.sqrt((M.mean(axis=1) ** 2).sum()) / np.sqrt(d))
+    fin_ind = float(np.sqrt(np.mean([(M[:, k] ** 2).sum() / nnz[k] for k in range(J)])))
+    tau_rel, per_time, att = predict_tau(
+        res, groups, adopt_of, members, donors, W, n1, n_leads, n)
+    return {
+        "groups": groups, "members": members, "adopt_of": adopt_of, "donors": donors,
+        "weights": W, "n1": n1, "tau_rel": tau_rel, "per_time": per_time, "att": att,
+        "nu_used": float("nan"), "global_l2": fin_global, "ind_l2": fin_ind,
+        "scaled_global_l2": 1.0, "scaled_ind_l2": 1.0,
+        "M": M, "nnz": np.asarray(nnz, dtype=float),
+        "res": res, "n": n, "n_leads": n_leads,
+    }
+
+
 def run_multisynth(
     Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
     *, fixedeff: bool = True, time_cohort: bool = False,
     nu: Optional[float] = None, lam: float = 0.0, solver: Any = None,
     Z: Optional[np.ndarray] = None,
+    donor_weights: str = "scm", base_period: str = "all_pre",
+    donor_pool: str = "window",
 ) -> Dict[str, Any]:
     """Run one multisynth fit; returns weights, event study, ATT, diagnostics."""
     n = Xy.shape[0]
@@ -176,8 +268,12 @@ def run_multisynth(
         adopt_of = {k: int(trt[ever[k]]) for k in groups}
     J = len(groups)
     n1 = np.array([len(members[g]) for g in groups], dtype=float)
-    donors = {g: np.where(trt > adopt_of[g] + n_leads)[0] for g in groups}
-    res = fit_feff(Xy, trt, set(adopt_of.values()), fixedeff)
+    donors = {g: eligible_donors(trt, adopt_of[g], n_leads, donor_pool)
+              for g in groups}
+    res = fit_feff(Xy, trt, set(adopt_of.values()), fixedeff, base_period)
+    if donor_weights not in ("scm", "uniform"):
+        raise ValueError(
+            f"donor_weights must be 'scm' or 'uniform', got {donor_weights!r}.")
 
     # scaled auxiliary-covariate target sums (zt) and donor blocks (Zc) per cohort
     zt = Zc = None
@@ -187,6 +283,10 @@ def run_multisynth(
         Zsc = _scale_covariates(Z, trt, res_first, d)
         zt = [Zsc[members[g]].sum(axis=0) for g in groups]
         Zc = [Zsc[donors[g]] for g in groups]
+
+    if donor_weights == "uniform":
+        return _uniform_fit(res, groups, adopt_of, members, donors, n1, d, n,
+                            n_leads, nu, lam)
 
     # separate fit (nu = 0) -> scaling norms + auto-nu
     W0 = solve_cohort_qp(res, groups, adopt_of, members, donors, n1, d, n, n_lags,

--- a/mlsynth/utils/ppscm_helpers/structures.py
+++ b/mlsynth/utils/ppscm_helpers/structures.py
@@ -95,6 +95,11 @@ class PPSCMDesign:
     ind_l2: float
     scaled_global_l2: float
     scaled_ind_l2: float
+    #: The three conventions this fit ran under -- donor weighting, unit-effect
+    #: baseline and donor eligibility -- plus which inference produced the
+    #: interval. Together they decide whether the fit is augsynth's multisynth
+    #: or the Callaway-Sant'Anna estimator, which the numbers alone do not say.
+    conventions: Optional[Dict[str, Any]] = None
 
     @property
     def pct_improve_global(self) -> float:
@@ -287,5 +292,14 @@ class PPSCMResults(_BaseEstimatorResults):
             ci_lower=(ci_lo if finite_ci else None),
             ci_upper=(ci_hi if finite_ci else None), details=inf))
         set_("fit_diagnostics", _FitDiagnosticsResults())
-        set_("method_details", _MethodDetailsResults(method_name="PPSCM"))
+        # The conventions this fit ran under go in the standardized
+        # ``parameters_used``, not as bespoke fields: which donor weighting,
+        # baseline and donor pool were used is what decides whether this fit is
+        # augsynth's multisynth or the Callaway-Sant'Anna estimator, and a
+        # reader of the result should not have to consult the config to find
+        # out. ``inference_method`` is here for the same reason -- an equal
+        # point estimate does not make an equal interval.
+        set_("method_details", _MethodDetailsResults(
+            method_name="PPSCM",
+            parameters_used=dict(self.design.conventions or {})))
         return self


### PR DESCRIPTION
Estimation half of #465. Inference is deliberately not in this PR.

## What

Ben-Michael, Feller & Rothstein (2022) p.369 note that with uniform donor weights their intercept-shifted partially-pooled SCM is equivalent to the DiD estimators of Callaway & Sant'Anna and Sun & Abraham. Measured, that is not an approximation — three implementations agree to 1e-14 once three conventions are aligned, and none of the three was reachable from the public config.

One is not reachable by tuning at all: driving `lam` up saturates the weights at `max|w - 1/J| = 3.5e-03`, unmoved between `lam = 1e9` and `1e18` at any `nu`. Uniform weights have to be imposed.

## API

```python
PPSCM({..., "method": "callaway_santanna"})       # preset
PPSCM({..., "donor_weights": "uniform",           # or compose
             "base_period":   "pre_treatment",
             "donor_pool":    "never_treated"})
```

| option | values | default |
|---|---|---|
| `donor_weights` | `scm`, `uniform` | `scm` |
| `base_period` | `all_pre`, `pre_treatment` | `all_pre` |
| `donor_pool` | `window`, `never_treated`, `not_yet_treated` | `window` |

Exposed separately rather than as one opaque switch, because each is independently meaningful and a caller mixing them is asking a coherent question — someone wanting the CS estimand on augsynth's donor pool should get that, not the preset's. The preset leaves anything explicitly set alone.

Defaults are unchanged, so plain PPSCM is augsynth's `multisynth` exactly as before; 162 pre-existing PPSCM tests are untouched. The conventions a fit ran under are reported in `method_details.parameters_used`, because the numbers alone do not say which estimator produced them.

## Where it legitimately diverges

augsynth admits any unit untreated through the cohort's *estimation window*, which is neither `never_treated` nor CS's `not_yet_treated`. It coincides with `never_treated` exactly when every other cohort adopts inside that window — which is why the identity is machine-exact at 1-3 cohorts and separates at 4, where a 38-never-treated panel gives the earliest cohort 41 donors and the estimators part by ~1.2e-02.

That is pinned as a documented difference, not a defect. A staggered panel with adoptions spread over a long window lands there, so it must not read as breakage.

## Tests

46 passing, 7 `xfail(strict=True)`.

The identity is checked against a **transcribed oracle** first and the `diff-diff` package second. With a never-treated comparison group and no covariates, CS is a two-period two-group DiD per cell against base `g-1`, so it transcribes in a dozen lines — which matters, because the previous revision ran the identity behind `importorskip` and would have skipped it on CI, leaving this PR's central claim unverified where it runs. A separate test asserts the transcription and the package agree, so a divergence says which one to distrust.

Around that: the identity across five panel shapes; survival under constant, cohort-varying, dynamic and unit-level effects (an identity that only held for a constant effect would be an artefact of the DGP); the event-study path matched lead-for-lead, since the ATT is one number and a path is where an estimator can hide; each convention isolated so a regression names which one moved — including that the baseline is a pure level shift and that the donor pool provably does *not* matter where the pools coincide.

The inference tests are written and `xfail(strict=True)`. They fail because the feature is not built; when it lands they become unexpected passes, and that is what removes the marker.

## Not claimed here

CS reports influence-function standard errors with an optional multiplier bootstrap; PPSCM reports jackknife. Equal point estimates do not make equal intervals, and naming one while reporting the other is the failure #459 and #463 both bottomed out at. `parameters_used['inference_method']` says which ran. Inference, and vendoring the reference so the corroboration tests are CI-enforced without a dependency, is the follow-up branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_