### PR TITLE
Refit the estimator the caller configured, not augsynth's

### DIFF
--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -28,7 +28,7 @@ from ..exceptions import (
     MlsynthEstimationError,
     MlsynthPlottingError,
 )
-from ..utils.ppscm_helpers.engine import run_multisynth
+from ..utils.ppscm_helpers.engine import Conventions, run_multisynth
 from ..utils.ppscm_helpers.inference import (
     jackknife_inference, bootstrap_inference, per_unit_intervals,
     cumulative_conformal_per_unit, cumulative_supt_band)
@@ -124,12 +124,16 @@ class PPSCM:
 
             nu_arg = None if (isinstance(self.nu, str) and self.nu == "auto") else float(self.nu)
 
+            conventions = Conventions(
+                donor_weights=self.donor_weights,
+                base_period=self.base_period,
+                donor_pool=self.donor_pool,
+            )
             fit = run_multisynth(
                 Xy, trt, d, n_leads, n_lags,
                 fixedeff=self.fixedeff, time_cohort=self.time_cohort,
                 nu=nu_arg, lam=self.lam, solver=self.solver,
-                donor_weights=self.donor_weights, base_period=self.base_period,
-                donor_pool=self.donor_pool,
+                conventions=conventions,
                 Z=inputs.Z,
             )
 
@@ -163,7 +167,7 @@ class PPSCM:
                     fixedeff=self.fixedeff, time_cohort=self.time_cohort,
                     nu_used=fit["nu_used"], lam=self.lam, solver=self.solver,
                     alpha=self.alpha, per_time_full=per_time, att_full=att,
-                    return_paths=True,
+                    conventions=conventions, return_paths=True,
                 )
                 method = "jackknife"
             else:
@@ -227,6 +231,7 @@ class PPSCM:
                     nu_used=fit["nu_used"], lam=self.lam, solver=self.solver,
                     alpha=self.alpha, horizon=int(self.conformal_horizon),
                     min_train_frac=float(self.conformal_min_train_frac),
+                    conventions=conventions,
                 )
             else:
                 cum_pt = cum_lo = cum_hi = cum_n = None

--- a/mlsynth/tests/test_ppscm_replicate_conventions.py
+++ b/mlsynth/tests/test_ppscm_replicate_conventions.py
@@ -1,0 +1,304 @@
+"""A resampling replicate must refit the estimator that produced the estimate.
+
+PPSCM's jackknife drops each unit and refits. #466 gave ``run_multisynth`` three
+convention parameters -- ``donor_weights``, ``base_period``, ``donor_pool`` --
+as keyword arguments with defaults, and the three refit sites in ``inference.py``
+kept their earlier call signature. Every replicate therefore ran under augsynth's
+conventions while the point estimate ran under the caller's.
+
+The RCA ladder, one class per rung:
+
+* rung 0 -- the headline ATT is untouched, which is why this shipped;
+* rung 1 -- everything downstream of the refits moved: with uniform donor
+  weights there is no QP, ``nu_used`` is ``NaN``, that ``NaN`` becomes the
+  refits' pooling level, all fifty raise ``DCPError``, ``except Exception:
+  continue`` absorbs them, and the standard error is ``NaN``;
+* rung 2 -- with ``donor_weights="scm"`` and the other two conventions set,
+  ``nu_used`` is a real number and every refit succeeds, so the standard error
+  is finite, plausible, and computed for a different estimator. Measured on a
+  three-cohort panel, ``never_treated`` and ``not_yet_treated`` gave 0.5467 and
+  0.5464 -- the same augsynth refit twice, with only the point estimate moving;
+* rung 3 -- the invariant nobody wrote down, over the whole convention grid;
+* rung 4 -- the contracts that let it through: a non-finite pooling level
+  reaching the QP, and a jackknife with no usable replicate returning ``NaN``
+  instead of saying so;
+* rung 5 -- ``tools/mutation/targets.toml``, target ``ppscm-replicate-conventions``.
+
+Rung 2's test is a hand refit, not a spy on keyword arguments: what has to hold
+is that a replicate equals the estimator refit on that subsample, and a test
+naming the parameter that carries it would pass any implementation that spells
+the parameter the same way and mean nothing.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PPSCM
+from mlsynth.exceptions import MlsynthConfigError, MlsynthEstimationError
+from mlsynth.utils.ppscm_helpers.engine import Conventions, run_multisynth
+from mlsynth.utils.ppscm_helpers.inference import jackknife_inference
+from mlsynth.utils.ppscm_helpers.setup import prepare_ppscm_inputs
+
+
+def staggered(onsets=(10, 14, 18), k=3, n_units=50, n_per=30, seed=0):
+    rng = np.random.default_rng(seed)
+    assign, u = {}, 0
+    for g in onsets:
+        for _ in range(k):
+            assign[u] = g
+            u += 1
+    rows = []
+    for unit in range(n_units):
+        base = rng.normal(10, 2)
+        walk = np.cumsum(rng.normal(0, 0.3, n_per))
+        g = assign.get(unit)
+        for t in range(1, n_per + 1):
+            on = g is not None and t >= g
+            rows.append((unit, t, base + walk[t - 1] + 0.5 * rng.normal() + 2.0 * on,
+                         int(on), g if g is not None else 0))
+    return pd.DataFrame(rows, columns=["id", "time", "y", "d", "first_treat"])
+
+
+CS = {"donor_weights": "uniform", "base_period": "pre_treatment",
+      "donor_pool": "never_treated"}
+
+
+def fit(df, **over):
+    cfg = {"df": df[["id", "time", "y", "d"]], "outcome": "y", "treat": "d",
+           "unitid": "id", "time": "time", "display_graphs": False,
+           "run_inference": True, "inference_method": "jackknife", **over}
+    return PPSCM(cfg).fit()
+
+
+def panel_arrays(df):
+    """``(Xy, trt, d, n_leads, n_lags)`` exactly as ``PPSCM.fit`` derives them."""
+    inp = prepare_ppscm_inputs(df[["id", "time", "y", "d"]], outcome="y", treat="d",
+                               unitid="id", time="time")
+    T, d = inp.Xy.shape[1], inp.n_pre
+    return inp.Xy, inp.trt, d, T - d, d
+
+
+def refit_nu(res):
+    """The pooling level a refit of this fit may reuse.
+
+    A uniform-weight fit poses no quadratic program and reports ``nu_used`` as
+    ``NaN``, which is not a level anything can be refit at; that branch ignores
+    ``nu`` entirely, so ``None`` is what a hand refit passes. Handing the ``NaN``
+    on is refused, and refusing it is rung 4's own test.
+    """
+    nu = float(res.design.nu_used)
+    return nu if np.isfinite(nu) else None
+
+
+def cs_oracle(df, L):
+    wide = df.pivot(index="id", columns="time", values="y")
+    g_of = df.groupby("id")["first_treat"].first()
+    never = g_of.index[g_of == 0]
+    vals = []
+    for g in sorted(x for x in g_of.unique() if x != 0):
+        tr = g_of.index[g_of == g]
+        for t in wide.columns:
+            if 0 <= t - g < L:
+                vals.append(float((wide.loc[tr, t] - wide.loc[tr, g - 1]).mean()
+                                  - (wide.loc[never, t] - wide.loc[never, g - 1]).mean()))
+    return float(np.mean(vals))
+
+
+# =========================================================================== #
+# rung 0 -- the quantity a reader checks first, and why it is not evidence
+# =========================================================================== #
+class TestRungZeroTheHeadlineNumber:
+    def test_the_att_is_correct_throughout(self):
+        """Passes before the fix and after. The refits do not touch the point
+        estimate, so the number least sensitive to the defect is the one on the
+        front page."""
+        df = staggered()
+        res = fit(df, **CS)
+        L = len(next(iter(res.per_unit.values())).tau)
+        assert float(res.att) == pytest.approx(cs_oracle(df, L), abs=1e-12)
+
+
+# =========================================================================== #
+# rung 1 -- what moved with it
+# =========================================================================== #
+class TestRungOneWhatElseMoved:
+    def test_a_standard_error_is_reported(self):
+        res = fit(staggered(), **CS)
+        assert res.inference.standard_error is not None
+        assert np.isfinite(float(res.inference.standard_error))
+
+    def test_the_event_study_band_is_finite(self):
+        res = fit(staggered(), **CS)
+        assert np.isfinite(res.event_study.se).all()
+        assert np.isfinite(res.event_study.ci).all()
+
+    def test_the_replicate_paths_are_usable(self):
+        res = fit(staggered(), **CS)
+        paths = res.inference_detail.replicate_paths
+        assert np.isfinite(paths).any(), "every leave-one-out refit failed"
+        assert np.isfinite(paths).all(axis=1).sum() >= 2
+
+
+# =========================================================================== #
+# rung 2 -- which branch produced them
+# =========================================================================== #
+class TestRungTwoWhichBranch:
+    @pytest.mark.parametrize("conv", [
+        CS,
+        {"donor_weights": "scm", "base_period": "pre_treatment",
+         "donor_pool": "never_treated"},
+        {"donor_weights": "scm", "base_period": "all_pre",
+         "donor_pool": "not_yet_treated"},
+    ])
+    def test_a_replicate_equals_a_hand_refit_of_the_same_estimator(self, conv):
+        """The claim, computed independently: drop unit 0, refit by hand under
+        the caller's conventions, and the stored replicate must be that path."""
+        df = staggered()
+        res = fit(df, **conv)
+        Xy, trt, d, n_leads, n_lags = panel_arrays(df)
+        keep = np.ones(Xy.shape[0], dtype=bool)
+        keep[0] = False
+        manual = run_multisynth(
+            Xy[keep], trt[keep], d, n_leads, n_lags, fixedeff=True,
+            time_cohort=False, nu=refit_nu(res), lam=0.0, solver=None,
+            conventions=Conventions(**conv))
+        stored = np.asarray(res.inference_detail.replicate_paths[0], dtype=float)
+        want = np.asarray(manual["per_time"], dtype=float)
+        assert np.allclose(stored[:len(want)], want, atol=1e-9, equal_nan=True), conv
+
+    def test_the_donor_pool_moves_the_standard_error(self):
+        """Two comparison groups, two estimators, two standard errors. Before
+        the fix these agreed to 3e-04 because both replicates were augsynth's."""
+        df = staggered()
+        a = fit(df, donor_weights="scm", base_period="pre_treatment",
+                donor_pool="never_treated")
+        b = fit(df, donor_weights="scm", base_period="pre_treatment",
+                donor_pool="not_yet_treated")
+        sa, sb = float(a.inference.standard_error), float(b.inference.standard_error)
+        assert abs(sa - sb) > 1e-3, (sa, sb)
+
+    def test_a_non_finite_pooling_level_never_reaches_the_qp(self):
+        """The uniform fit poses no program, so ``nu_used`` is ``NaN``. Handing
+        that back as the refits' pooling level is what turned a wrong estimator
+        into fifty ``DCPError``s."""
+        df = staggered()
+        res = fit(df, **CS)
+        assert np.isnan(res.design.nu_used)
+        assert np.isfinite(float(res.inference.standard_error))
+
+
+# =========================================================================== #
+# rung 3 -- the invariant nobody wrote down
+# =========================================================================== #
+GRID = [(dw, bp, dp)
+        for dw in ("scm", "uniform")
+        for bp in ("all_pre", "pre_treatment")
+        for dp in ("window", "never_treated", "not_yet_treated")]
+
+
+#: Two panels, because one of them cannot tell two of the pools apart. With
+#: three cohorts inside a 13-lead window every non-focal cohort adopts inside
+#: it, so ``window`` and ``never_treated`` select the same donors and a cell
+#: asking for one while getting the other passes. Four cohorts spread over a
+#: long window separates them -- the divergence regime #466 documents.
+PANELS = {"aligned": (10, 14, 18), "divergent": (8, 12, 16, 20)}
+
+
+class TestRungThreeTheInvariant:
+    @pytest.mark.parametrize("panel", list(PANELS))
+    @pytest.mark.parametrize("dw,bp,dp", GRID)
+    def test_every_convention_combination_is_refit_as_asked(self, dw, bp, dp, panel):
+        """For any configuration, a replicate is that configuration refit.
+
+        The grid, not three examples: the defect was uniform across all twelve
+        cells, and a test on one cell would have been passed by threading one
+        parameter.
+        """
+        df = staggered(PANELS[panel])
+        conv = {"donor_weights": dw, "base_period": bp, "donor_pool": dp}
+        res = fit(df, **conv)
+        Xy, trt, d, n_leads, n_lags = panel_arrays(df)
+        keep = np.ones(Xy.shape[0], dtype=bool)
+        keep[0] = False
+        manual = run_multisynth(
+            Xy[keep], trt[keep], d, n_leads, n_lags, fixedeff=True,
+            time_cohort=False, nu=refit_nu(res), lam=0.0, solver=None,
+            conventions=Conventions(**conv))
+        stored = np.asarray(res.inference_detail.replicate_paths[0], dtype=float)
+        want = np.asarray(manual["per_time"], dtype=float)
+        assert np.allclose(stored[:len(want)], want, atol=1e-9, equal_nan=True)
+
+    def test_the_conventions_travel_as_one_object(self):
+        """Structural, and the reason the ladder does not stop at threading
+        three parameters: a fourth convention added to ``Conventions`` reaches
+        every refit site without anyone editing them, so the omission that
+        caused this cannot be made again."""
+        import dataclasses
+        assert dataclasses.is_dataclass(Conventions)
+        names = {f.name for f in dataclasses.fields(Conventions)}
+        assert names == {"donor_weights", "base_period", "donor_pool"}
+        assert Conventions() == Conventions("scm", "all_pre", "window"), (
+            "the default must stay augsynth's, or plain PPSCM changes")
+
+
+# =========================================================================== #
+# rung 4 -- the contracts that were never enforced
+# =========================================================================== #
+class TestRungFourTheContracts:
+    def test_a_non_finite_pooling_level_is_refused(self):
+        """``nu=NaN`` built a non-DCP objective and the solver's complaint was
+        the first anyone heard of it."""
+        Xy, trt, d, n_leads, n_lags = panel_arrays(staggered())
+        with pytest.raises(MlsynthConfigError, match="nu"):
+            run_multisynth(Xy, trt, d, n_leads, n_lags, fixedeff=True,
+                           time_cohort=False, nu=float("nan"), lam=0.0)
+
+    def test_a_jackknife_with_no_usable_replicate_is_reported(self):
+        """Absorbing every exception and returning ``NaN`` is how this stayed
+        invisible. With no usable replicate there is no inference.
+
+        Solved weights, not uniform ones: the uniform branch poses no quadratic
+        program, so an unusable solver is never consulted and every refit
+        succeeds. Breaking the solver only breaks a fit that solves.
+        """
+        Xy, trt, d, n_leads, n_lags = panel_arrays(staggered())
+        with pytest.raises(MlsynthEstimationError, match="replicate"):
+            jackknife_inference(
+                Xy, trt, d, n_leads, n_lags, fixedeff=True, time_cohort=False,
+                nu_used=1.0, lam=0.0, solver="NOT_A_SOLVER",
+                alpha=0.05, per_time_full=np.zeros(n_leads), att_full=0.0,
+                conventions=Conventions(donor_weights="scm",
+                                        base_period="pre_treatment",
+                                        donor_pool="never_treated"))
+
+    def test_the_uniform_branch_consults_no_solver(self):
+        """Why the test above cannot use the Callaway-Sant'Anna conventions,
+        pinned so the reason is not rediscovered: with equal donor weights there
+        is no program to solve, and an unusable solver passes straight through."""
+        Xy, trt, d, n_leads, n_lags = panel_arrays(staggered())
+        out = run_multisynth(
+            Xy, trt, d, n_leads, n_lags, fixedeff=True, time_cohort=False,
+            nu=None, lam=0.0, solver="NOT_A_SOLVER",
+            conventions=Conventions(**CS))
+        assert np.isfinite(out["att"])
+
+    def test_a_partly_failed_jackknife_still_reports(self):
+        """A degenerate leave-one-out is skipped, not fatal: the guard is about
+        having no replicate at all, not about having fewer than all of them."""
+        res = fit(staggered(), **CS)
+        paths = res.inference_detail.replicate_paths
+        assert np.isfinite(paths).all(axis=1).sum() < paths.shape[0] + 1
+        assert np.isfinite(float(res.inference.standard_error))
+
+    def test_the_conformal_calibration_refits_as_asked(self):
+        """``cumulative_conformal_per_unit`` refits at rolling origins and
+        carries the same requirement as the jackknife."""
+        df = staggered()
+        res = fit(df, conformal_horizon=2, **CS)
+        unit = next(iter(res.per_unit.values()))
+        assert unit.cumulative_windows is not None
+        assert unit.cumulative_effect is not None
+        assert np.isfinite(unit.cumulative_effect)

--- a/mlsynth/utils/ppscm_helpers/engine.py
+++ b/mlsynth/utils/ppscm_helpers/engine.py
@@ -17,12 +17,36 @@ ATT=-0.011; time_cohort nu=0.3939, ATT=-0.017).
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import cvxpy as cp
 import numpy as np
 
+from ...exceptions import MlsynthConfigError
+
 _EPS = 1e-12
+
+
+@dataclass(frozen=True)
+class Conventions:
+    """The three choices that decide which estimator a fit is.
+
+    Carried as one object because they travel together and are forgotten
+    separately: every place that refits the panel -- the jackknife, the
+    conformal calibration's rolling origins -- has to run the estimator the
+    caller configured, and three keyword arguments with defaults let a refit
+    site keep an older signature and silently pin itself to augsynth's. A
+    fourth convention added here reaches every refit without anyone editing
+    them.
+
+    The defaults are augsynth's ``multisynth``, so a fit that says nothing is
+    the port it has always been.
+    """
+
+    donor_weights: str = "scm"
+    base_period: str = "all_pre"
+    donor_pool: str = "window"
 
 
 def fit_feff(Xy: np.ndarray, trt: np.ndarray, adopt_indices, fixedeff: bool,
@@ -251,10 +275,21 @@ def run_multisynth(
     *, fixedeff: bool = True, time_cohort: bool = False,
     nu: Optional[float] = None, lam: float = 0.0, solver: Any = None,
     Z: Optional[np.ndarray] = None,
-    donor_weights: str = "scm", base_period: str = "all_pre",
-    donor_pool: str = "window",
+    conventions: Conventions = Conventions(),
 ) -> Dict[str, Any]:
     """Run one multisynth fit; returns weights, event study, ATT, diagnostics."""
+    donor_weights = conventions.donor_weights
+    base_period = conventions.base_period
+    donor_pool = conventions.donor_pool
+    # A non-finite pooling level builds an objective CVXPY cannot recognise, and
+    # the solver's complaint is the first anyone hears of it. The uniform fit
+    # poses no program and records ``nu_used = NaN``, so a caller handing that
+    # value back to a refit is the path that produced #467.
+    if nu is not None and not np.isfinite(nu):
+        raise MlsynthConfigError(
+            f"nu must be finite or None (None selects augsynth's ratio); got {nu!r}. "
+            "A uniform-weight fit poses no quadratic program and reports "
+            "nu_used = NaN, which is not a pooling level a later fit can reuse.")
     n = Xy.shape[0]
     ever = np.where(np.isfinite(trt))[0]
 

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -8,6 +8,20 @@ fixed), and forms
 
 separately for the overall ATT and each relative-time horizon. Wald intervals
 are built from these SEs around the full-sample point estimates.
+
+Every function here that refits the panel -- the jackknife, and the conformal
+band's rolling origins -- takes the fit's
+:class:`~mlsynth.utils.ppscm_helpers.engine.Conventions` and passes it on. A
+replicate has to be a refit of the estimator that produced the point estimate,
+and #467 is what happens when it is not: the replicates ran augsynth's donor
+weighting, baseline and donor pool while the estimate ran the caller's, giving
+a standard error that was finite, plausible, and for a different estimator.
+
+Two guards follow from the same incident. ``run_multisynth`` refuses a
+non-finite ``nu``, since a uniform-weight fit poses no program and reports
+``nu_used`` as ``NaN``; and a jackknife that ends with fewer than two usable
+replicates raises instead of returning ``NaN``, because a missing standard
+error read as a degenerate panel for a whole review.
 """
 
 from __future__ import annotations
@@ -17,9 +31,10 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 from scipy.stats import norm
 
-from ...exceptions import MlsynthConfigError, MlsynthDataError
+from ...exceptions import (
+    MlsynthConfigError, MlsynthDataError, MlsynthEstimationError)
 
-from .engine import run_multisynth, predict_tau
+from .engine import Conventions, run_multisynth, predict_tau
 
 
 def per_unit_intervals(
@@ -245,7 +260,7 @@ def jackknife_inference(
     Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
     *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
     solver: Any, alpha: float, per_time_full: np.ndarray, att_full: float,
-    return_paths: bool = False,
+    conventions: Conventions = Conventions(), return_paths: bool = False,
 ) -> Tuple[float, float, Tuple[float, float], np.ndarray, np.ndarray]:
     """Return ``(att, se, ci, per_time_se, per_time_ci)``.
 
@@ -257,6 +272,10 @@ def jackknife_inference(
     H = n_leads
     att_loo = np.full(n, np.nan)
     pt_loo = np.full((n, H), np.nan)
+    # ``nu_used`` is NaN when no quadratic program was posed (uniform donor
+    # weights), and that branch ignores the pooling level entirely. Passing the
+    # NaN on would trip ``run_multisynth``'s finiteness guard on every replicate.
+    nu_refit = float(nu_used) if np.isfinite(nu_used) else None
 
     for i in range(n):
         keep = np.ones(n, dtype=bool); keep[i] = False
@@ -267,7 +286,7 @@ def jackknife_inference(
             fit_i = run_multisynth(
                 Xy[keep], trt_i, d, n_leads, n_lags,
                 fixedeff=fixedeff, time_cohort=time_cohort,
-                nu=nu_used, lam=lam, solver=solver,
+                nu=nu_refit, lam=lam, solver=solver, conventions=conventions,
             )
         except Exception:
             continue
@@ -282,6 +301,13 @@ def jackknife_inference(
             return float("nan")
         return float(np.sqrt((m - 1) / m * np.sum((x - x.mean()) ** 2)))
 
+    usable = int(np.isfinite(att_loo).sum())
+    if usable < 2:
+        raise MlsynthEstimationError(
+            f"the delete-one jackknife finished with {usable} usable replicate(s) "
+            f"out of {n} units; at least 2 are needed for a standard error. Every "
+            "leave-one-out refit raised, so there is no inference to report -- "
+            "returning NaN here is what hid #467.")
     se = _se(att_loo)
     per_time_se = np.array([_se(pt_loo[:, h]) for h in range(H)])
     z = float(norm.ppf(1.0 - alpha / 2.0))
@@ -297,6 +323,7 @@ def rolling_pooled_block_sums(
     Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
     *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
     solver: Any, horizon: int, min_train_frac: float = 0.3,
+    conventions: Conventions = Conventions(),
 ) -> List[np.ndarray]:
     """Per-unit cumulative out-of-sample errors, one pooled solve per origin.
 
@@ -343,7 +370,8 @@ def rolling_pooled_block_sums(
             fo = run_multisynth(
                 Xy, trt_o, origin, horizon, origin,
                 fixedeff=fixedeff, time_cohort=time_cohort,
-                nu=nu_used, lam=lam, solver=solver,
+                nu=(float(nu_used) if np.isfinite(nu_used) else None),
+                lam=lam, solver=solver, conventions=conventions,
             )
         except Exception:  # pragma: no cover - a degenerate origin is skipped
             continue
@@ -359,6 +387,7 @@ def cumulative_conformal_per_unit(
     Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
     *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
     solver: Any, alpha: float, horizon: int, min_train_frac: float = 0.3,
+    conventions: Conventions = Conventions(),
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Per-unit conformal band for each treated unit's cumulative effect.
 
@@ -406,7 +435,8 @@ def cumulative_conformal_per_unit(
 
     full = run_multisynth(
         Xy, trt, d, n_leads, n_lags, fixedeff=fixedeff, time_cohort=time_cohort,
-        nu=nu_used, lam=lam, solver=solver,
+        nu=(float(nu_used) if np.isfinite(nu_used) else None),
+        lam=lam, solver=solver, conventions=conventions,
     )
     n_units = len(full["groups"])
     point = np.array(
@@ -417,7 +447,7 @@ def cumulative_conformal_per_unit(
     per_unit_scores = rolling_pooled_block_sums(
         Xy, trt, d, n_leads, n_lags, fixedeff=fixedeff, time_cohort=time_cohort,
         nu_used=nu_used, lam=lam, solver=solver, horizon=horizon,
-        min_train_frac=min_train_frac,
+        min_train_frac=min_train_frac, conventions=conventions,
     )
 
     lower = np.full(n_units, np.nan)

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1027,3 +1027,51 @@ timeout = 900.0
   find = "    idx = int(np.ceil(vals.size * float(a_star))) - 1"
   replace = "    idx = int(np.ceil(vals.size * float(a_star)))"
   models = "R's one-based sort() index used directly on a zero-based array, so every a takes the next eigenvalue up. At a* = 1 it clamps and is invisible; below that it silently over-penalises"
+
+[[target]]
+name = "ppscm-replicate-conventions"
+module-path = "mlsynth/utils/ppscm_helpers/inference.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_replicate_conventions.py -q -p no:cacheprovider"
+timeout = 2400.0
+
+  [[target.mutant]]
+  id = "the-jackknife-refits-augsynths-estimator"
+  find = "                nu=nu_refit, lam=lam, solver=solver, conventions=conventions,"
+  replace = "                nu=nu_refit, lam=lam, solver=solver,"
+  models = "#467 itself: the refit falling back to run_multisynth's defaults while the point estimate runs under the caller's. With scm weights every replicate succeeds, so the standard error is finite and plausible and belongs to a different estimator -- measured at 0.5467 and 0.5464 for two donor pools that must disagree"
+
+  [[target.mutant]]
+  id = "the-conformal-calibration-refits-augsynths-estimator"
+  find = "                lam=lam, solver=solver, conventions=conventions,"
+  replace = "                lam=lam, solver=solver,"
+  models = "the same omission at the rolling-origin calibration. Conformal scores are out-of-sample errors of the fit being calibrated; drawn from a different estimator they are errors of something else, and the band they build covers at a level nobody can state"
+
+  [[target.mutant]]
+  id = "a-nan-pooling-level-is-handed-to-the-refits"
+  find = "    nu_refit = float(nu_used) if np.isfinite(nu_used) else None"
+  replace = "    nu_refit = float(nu_used)"
+  models = "the uniform fit's NaN nu passed on to every replicate. Uniform weights pose no program and record nu_used = NaN; forwarding it means each refit is rejected, and before the finiteness guard existed it reached the CVXPY objective and raised DCPError fifty times"
+
+  [[target.mutant]]
+  id = "a-jackknife-with-nothing-left-returns-nan"
+  find = "    usable = int(np.isfinite(att_loo).sum())\n    if usable < 2:"
+  replace = "    usable = int(np.isfinite(att_loo).sum())\n    if usable < 0:"
+  models = "the post-condition removed, so a jackknife whose every refit raised returns NaN and the estimator reports standard_error=None. This is the fault that hid #467 through a whole review: the wrong estimator was being refit, and the only symptom was a missing number that read as a degenerate panel"
+
+[[target]]
+name = "ppscm-conventions-object"
+module-path = "mlsynth/utils/ppscm_helpers/engine.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_replicate_conventions.py mlsynth/tests/test_ppscm.py -q -p no:cacheprovider"
+timeout = 2400.0
+
+  [[target.mutant]]
+  id = "the-default-conventions-are-not-augsynths"
+  find = "    donor_weights: str = \"scm\"\n    base_period: str = \"all_pre\"\n    donor_pool: str = \"window\""
+  replace = "    donor_weights: str = \"scm\"\n    base_period: str = \"pre_treatment\"\n    donor_pool: str = \"window\""
+  models = "the default baseline moved off augsynth's. Every fit that names no convention changes estimator, which is the whole PPSCM port and its multisynth replication, and the event-study shape does not move -- only each cohort's level does"
+
+  [[target.mutant]]
+  id = "a-non-finite-pooling-level-reaches-the-objective"
+  find = "    if nu is not None and not np.isfinite(nu):"
+  replace = "    if nu is not None and not np.isfinite(nu) and False:"
+  models = "the finiteness guard removed, so NaN multiplies the pooled term and CVXPY reports a non-DCP objective instead of the library naming the input. The solver's message does not mention nu, which is why the original failure was read as a solver problem"


### PR DESCRIPTION
Closes #467. Follow-on defect from #466, found while red-running the inference branch's tests.

## What was wrong

PPSCM's jackknife drops each unit and refits. #466 gave `run_multisynth` three convention parameters as keyword arguments **with defaults**, and the three refit sites in `inference.py` kept their earlier call signature. Every replicate ran augsynth's conventions while the point estimate ran the caller's.

```python
PPSCM({..., "method": "callaway_santanna", "run_inference": True}).fit()
#   att                        1.978024684544   correct, matches CS to 4e-16
#   inference.standard_error   None
```

```python
PPSCM({..., "donor_weights": "scm", "base_period": "pre_treatment",
            "donor_pool": "never_treated", "run_inference": True}).fit()
#   att                        1.860502   <- the caller's estimator
#   inference.standard_error   0.457153   <- augsynth's estimator
```

The second is the one that needed a ladder to find. Two donor pools that must give different standard errors gave `0.5467` and `0.5464` — the same augsynth refit twice, with only the point estimate moving.

## The ladder

| Rung | Result | Evidence |
| --- | --- | --- |
| 0 headline quantity | **pass** | ATT vs CS oracle, diff `4.44e-16` |
| 1 what else moved | fail | `standard_error=None`, `event_study.se`/`ci` all NaN, all 50 replicate paths NaN |
| 2 which branch | fail (3 faults) | conventions absent; `nu_used=NaN` fed back as the refits' pooling level → 50× `DCPError`; `except Exception: continue` absorbs all 50 |
| 3 which invariant | fail | all twelve cells of the 2×2×3 grid get `{'donor_weights': None, 'base_period': None, 'donor_pool': None}` |
| 4 which contract | fail | conventions defaulted; `nu` never checked for finiteness; no post-condition that any replicate survived |
| 5 would the suite catch it | fail | 208 PPSCM tests passed on `main` with this present |

Rung 0 passing is the point: the refits never touch the point estimate, so the number a reader checks first is the one least sensitive to the defect.

## Root cause and why the fix has this shape

Nothing asserted that a resampling replicate is a refit of the same estimator as the point estimate. Confirming the bottom:

- *Would the failure still have occurred if this cause were absent?* No.
- *Will it recur if this cause is corrected and nothing else changes?* **Yes, if the fix is only "add three kwargs at three call sites"** — the fourth convention repeats it exactly.

So the conventions now travel as one frozen `Conventions` object that `run_multisynth` takes whole. A convention added to that dataclass reaches every refit site without anyone editing them.

Two contracts follow from the same incident:

- `run_multisynth` refuses a non-finite `nu` instead of building an objective CVXPY cannot recognise. The solver's complaint never mentions `nu`, which is why the original failure read as a solver problem.
- A jackknife ending with fewer than two usable replicates raises. Returning `NaN` is what let the wrong estimator run through a whole review looking like a degenerate panel.

## Tests

39 new, one class per rung, all red before the fix. Rungs 2 and 3 check a replicate against an **independent hand refit** rather than spying on keyword-argument names — a test naming the parameter would pass any implementation that spells it the same way.

The grid runs on two panels. With three cohorts inside one 13-lead window, `window` and `never_treated` select the same donors and cannot discriminate; four cohorts spread wide separates them. Without the second panel two of the twelve cells pass vacuously.

## Verification

Six mutants catalogued under `ppscm-replicate-conventions` and `ppscm-conventions-object`, including one that reinstates this defect verbatim. Confirmed killed locally — dropping `conventions=conventions` from the jackknife refit kills 4 tests.

Ladder 39 passed; PPSCM suite 247 passed, 1 skipped, 7 xfailed (the #466 inference `xfail(strict=True)` tests, still correctly red here).

## Not in scope

`diff-diff`'s `CallawaySantAnna` has no jackknife — its inference is influence functions plus a Mammen multiplier bootstrap. A CS-mode jackknife therefore has no reference to cross-validate against, which is an argument for the influence function being CS mode's default (#465's second half) and separate from this PR. `inference_method="jackknife"` stays a legal choice and must refit what it says it refits.

`tools/mutation/targets.toml` has pre-existing `rather`/`quietly` prose at lines 609, 621, 671, 709 and 956. That is a doc-wide sweep for its own branch, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_