### PR TITLE
Give the Callaway-Sant'Anna estimate the Callaway-Sant'Anna interval

### DIFF
--- a/benchmarks/reference/ppscm_cs/LICENSE.diff-diff
+++ b/benchmarks/reference/ppscm_cs/LICENSE.diff-diff
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Isaac Gerber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/benchmarks/reference/ppscm_cs/provenance.json
+++ b/benchmarks/reference/ppscm_cs/provenance.json
@@ -1,0 +1,39 @@
+{
+  "upstream": {
+    "name": "diff-diff",
+    "version": "3.9.0",
+    "commit": "d9cd475fec8e67ceea1772896e2b29501cb90485",
+    "repository": "https://github.com/igerber/diff-diff",
+    "license": "MIT",
+    "license_file": "LICENSE.diff-diff",
+    "copyright": "Copyright (c) 2025-2026 Isaac Gerber",
+    "transcribed_from": [
+      "diff_diff/staggered.py -- per-cell ATT(g,t) and influence function",
+      "diff_diff/staggered_aggregation.py -- wif-corrected aggregation and se_from_psi"
+    ]
+  },
+  "scope": {
+    "restrictions": [
+      "balanced panel",
+      "never-treated comparison group",
+      "no covariates",
+      "no survey design",
+      "no clustering",
+      "no anticipation"
+    ],
+    "note": "Transcribed, not copied wholesale: the distribution is 95 modules and only the panel / never-treated / no-covariate path is what PPSCM's callaway_santanna mode must agree with. Outside the restrictions the vendored path raises; it does not approximate."
+  },
+  "verified": {
+    "how": "Every quantity compared against an installed diff-diff 3.9.0 over six staggered panels (278 group-time cells).",
+    "max_abs_diff_att_gt": 0.0,
+    "max_abs_diff_se_gt": 0.0,
+    "max_abs_diff_aggregated_se": 5.551115123125783e-17
+  },
+  "sha256": {
+    "reference.py": "2055668f82a181136428c42a66830d8950adb7b8936e51cf8b79d04257cd28d7",
+    "LICENSE.diff-diff": "c1d2ae2763c44346f93d73b4885a2cd1d030e5a413e243b75f128a2f222e2726"
+  },
+  "platform": "Linux-6.18.5-fc-v20-x86_64-with-glibc2.39",
+  "python": "3.11.15",
+  "numpy": "2.4.6"
+}

--- a/benchmarks/reference/ppscm_cs/reference.py
+++ b/benchmarks/reference/ppscm_cs/reference.py
@@ -1,0 +1,176 @@
+"""Callaway-Sant'Anna group-time ATT and its influence function, vendored.
+
+Transcribed from ``diff-diff`` 3.9.0 (Isaac Gerber, MIT; see
+``LICENSE.diff-diff``), commit ``d9cd475fec8e67ceea1772896e2b29501cb90485``,
+from ``diff_diff/staggered.py`` (the per-cell estimate and influence function)
+and ``diff_diff/staggered_aggregation.py`` (the weight-influence-corrected
+aggregation). ``diff-diff`` carries R-parity suites against ``did``, ``fixest``,
+``estimatr`` and Stata, which is what makes it usable as a reference here.
+
+Vendored, not depended on, and cut down instead of copied wholesale.
+The distribution is 95 modules of estimators mlsynth does not use; what PPSCM's
+Callaway-Sant'Anna mode has to agree with is the panel / never-treated /
+no-covariate path, which is small enough to read in one sitting. A reference
+nobody can read is not a reference, and 240KB of ``staggered.py`` would drift
+without anyone noticing.
+
+Restrictions, all of them deliberate and all of them checked by the caller:
+
+* balanced panel, one row per ``(unit, time)``;
+* a never-treated comparison group, coded ``first_treat = 0``;
+* no covariates, so the doubly-robust estimator collapses to the difference in
+  means that ``diff-diff`` computes inline for that case;
+* no survey design, no clustering, no anticipation.
+
+Outside those the vendored path is wrong, not approximate, so it raises.
+
+Refreshing this file is a deliberate act: bump the commit above, re-transcribe,
+and re-run the parity test. It is a characterisation of a pinned upstream, and
+an edit that brings it into agreement with mlsynth stops it being evidence of
+anything.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+#: Upstream this file is a transcription of. Recorded here as well as in
+#: ``provenance.json`` so a reader of the code sees it without leaving it.
+DIFF_DIFF_VERSION = "3.9.0"
+DIFF_DIFF_COMMIT = "d9cd475fec8e67ceea1772896e2b29501cb90485"
+
+
+def _wide(df, outcome, unit, time):
+    w = df.pivot(index=unit, columns=time, values=outcome)
+    if w.isna().to_numpy().any():
+        raise ValueError(
+            "The vendored Callaway-Sant'Anna reference needs a balanced panel: "
+            "the (unit, time) grid has holes.")
+    return w
+
+
+def group_time_att(
+    df: pd.DataFrame, outcome: str, unit: str, time: str, first_treat: str,
+) -> Tuple[Dict[Tuple[Any, Any], float], Dict[Tuple[Any, Any], float], Dict[Any, Any]]:
+    """``ATT(g, t)``, its standard error, and the per-cell influence functions.
+
+    With a never-treated comparison group and no covariates each cell is a
+    two-period, two-group difference in differences against base period
+    ``g - 1``. ``diff-diff`` computes exactly this inline
+    (``staggered.py``)::
+
+        mu_t = mean(treated_change);  mu_c = mean(control_change)
+        att  = mu_t - mu_c
+        inf_treated =  (treated_change - mu_t) / n_t
+        inf_control = -(control_change - mu_c) / n_c
+        se = sqrt(sum(inf_treated**2) + sum(inf_control**2))
+
+    The standard error is ``sqrt(sum(phi^2))`` and not a plug-in with ``ddof=1``:
+    the influence contributions are already divided by their group sizes, and
+    the DRDID convention is what R's ``reg_did_panel`` matches.
+    """
+    wide = _wide(df, outcome, unit, time)
+    cohort = df.groupby(unit)[first_treat].first().reindex(wide.index)
+    never = np.flatnonzero((cohort == 0).to_numpy())
+    if never.size == 0:
+        raise ValueError(
+            "The vendored reference uses a never-treated comparison group and "
+            "this panel has none.")
+    periods = list(wide.columns)
+    Y = wide.to_numpy(dtype=float)
+
+    effects: Dict[Tuple[Any, Any], float] = {}
+    ses: Dict[Tuple[Any, Any], float] = {}
+    inf: Dict[Tuple[Any, Any], Any] = {}
+    for g in sorted({c for c in cohort.unique() if c != 0}):
+        if (g - 1) not in periods:
+            continue
+        base = periods.index(g - 1)
+        treated = np.flatnonzero((cohort == g).to_numpy())
+        if treated.size == 0:
+            continue
+        for t in periods:
+            if t < g:
+                continue
+            col = periods.index(t)
+            d_tr = Y[treated, col] - Y[treated, base]
+            d_co = Y[never, col] - Y[never, base]
+            mu_t, mu_c = float(d_tr.mean()), float(d_co.mean())
+            att = mu_t - mu_c
+            inf_t = (d_tr - mu_t) / treated.size
+            inf_c = -(d_co - mu_c) / never.size
+            effects[(g, t)] = att
+            ses[(g, t)] = float(np.sqrt((inf_t ** 2).sum() + (inf_c ** 2).sum()))
+            inf[(g, t)] = {"treated_idx": treated, "control_idx": never,
+                           "treated_inf": inf_t, "control_inf": inf_c}
+    return effects, ses, inf
+
+
+def aggregate(
+    cells: Iterable[Tuple[Any, Any]],
+    effects: Dict[Tuple[Any, Any], float],
+    inf: Dict[Any, Any],
+    cohort_of_unit: np.ndarray,
+    weights: Optional[np.ndarray] = None,
+) -> Tuple[float, float, np.ndarray]:
+    """Aggregate selected cells, with the weight-influence correction.
+
+    The correction is the part that is easy to omit and expensive to omit: the
+    group-size weights are themselves estimated, so an aggregate's variance
+    carries their sampling error too. Dropping it leaves standard errors that
+    look entirely plausible and are too small. R's ``did::aggte`` computes
+
+        agg_inf_i = sum_k w_k * inf_i_k + wif_i
+        se        = sqrt(sum(agg_inf^2))
+
+    with ``wif`` built from the group shares ``pg`` as transcribed below.
+
+    Returns ``(estimate, standard_error, psi)``; ``psi`` is the per-unit
+    combined influence function, which is what a multiplier bootstrap resamples.
+    """
+    cells = [c for c in cells if c in effects]
+    if not cells:
+        return float("nan"), float("nan"), np.zeros(0)
+    n_units = int(cohort_of_unit.shape[0])
+    eff = np.array([effects[c] for c in cells], dtype=float)
+    w = (np.full(len(cells), 1.0 / len(cells)) if weights is None
+         else np.asarray(weights, dtype=float))
+
+    psi_standard = np.zeros(n_units)
+    for k, c in enumerate(cells):
+        info = inf[c]
+        psi_standard[info["treated_idx"]] += w[k] * info["treated_inf"]
+        psi_standard[info["control_idx"]] += w[k] * info["control_inf"]
+
+    groups_for_cell = np.array([c[0] for c in cells])
+    uniq = sorted(set(groups_for_cell))
+    pg_by_group = {g: float((cohort_of_unit == g).sum()) / n_units for g in uniq}
+    pg_keepers = np.array([pg_by_group[g] for g in groups_for_cell])
+    sum_pg = float(pg_keepers.sum())
+    if sum_pg == 0:
+        return float(eff @ w), 0.0, psi_standard
+
+    indicator = (cohort_of_unit[:, None] == groups_for_cell[None, :]).astype(float)
+    diff = indicator - pg_keepers
+    if1 = diff / sum_pg
+    if2 = np.outer(diff.sum(axis=1), pg_keepers) / (sum_pg ** 2)
+    psi_wif = ((if1 - if2) @ eff) / n_units
+
+    psi = psi_standard + psi_wif
+    return float(eff @ w), float(np.sqrt((psi ** 2).sum())), psi
+
+
+def multiplier_bootstrap(psi: np.ndarray, n_boot: int, seed: int = 0) -> np.ndarray:
+    """Mammen multiplier bootstrap draws of ``sum_i v_i psi_i``.
+
+    Mammen's two-point distribution has mean 0, variance 1 and third moment 1,
+    which is what buys the refinement over Rademacher weights here.
+    """
+    rng = np.random.default_rng(seed)
+    k = (np.sqrt(5.0) + 1.0) / 2.0
+    p = (np.sqrt(5.0) + 1.0) / (2.0 * np.sqrt(5.0))
+    draws = np.where(rng.random((n_boot, psi.shape[0])) < p, 1.0 - k, k)
+    return draws @ psi

--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -223,6 +223,77 @@ for the overall ATT and each relative-time horizon, with Wald intervals.
 ``inference_method="bootstrap"`` swaps in augsynth's default Mammen wild
 bootstrap, which reweights the single fit instead of refitting.
 
+Analytical standard errors under the Callaway-Sant'Anna conventions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``method="callaway_santanna"`` reaches their point estimate exactly, and an
+equal point estimate does not make an equal interval. The preset therefore
+also selects ``inference_method="influence_function"``, which is the standard
+error that goes with that estimate.
+
+Under those conventions each cell is a two-period, two-group difference in
+differences and its influence function is available in closed form:
+
+.. math::
+
+   \widehat{\phi}_i(g,t) =
+     \frac{\Delta_i - \bar{\Delta}_{\mathcal{G}_g}}{n_g}\ \ (i \in \mathcal{G}_g),
+   \qquad
+   \widehat{\phi}_i(g,t) =
+     -\frac{\Delta_i - \bar{\Delta}_{\mathcal{C}}}{n_{\mathcal{C}}}\ \ (i \in \mathcal{C}),
+
+with :math:`\Delta_i = Y_{it} - Y_{i,g-1}` and
+:math:`\widehat{\text{se}}(g,t) = \sqrt{\sum_i \widehat{\phi}_i(g,t)^2}`. A
+standard error then costs one pass over the panel, where the jackknife costs one
+refit per unit.
+
+PPSCM averages cohorts by size at each horizon and then averages horizons,
+:math:`\widehat{\theta} = \tfrac1H \sum_h \widehat{\theta}_h` with
+:math:`\widehat{\theta}_h = \sum_{k \in \mathcal{K}_h} p_k \widehat{\tau}_{kh} / S_h`
+and :math:`S_h = \sum_{k \in \mathcal{K}_h} p_k`. That is Callaway and
+Sant'Anna's dynamic aggregation followed by an average over event time, and it
+coincides with their simple aggregation when every cohort is the same size and
+reaches every horizon. The cohort shares :math:`p_k` are estimated from the same
+panel, so the aggregate carries their sampling error through
+:math:`\partial \theta_h / \partial p_j = (\tau_{jh} - \theta_h)/S_h` -- the term
+R's ``did::aggte`` calls ``wif``. Deleting it leaves a standard error that is
+finite, plausible and too small, so the test suite computes the aggregate both
+ways and pins the difference.
+
+``results.inference_detail`` then carries ``group_time_att`` and
+``group_time_se`` keyed by the public ``(adoption time, time)`` labels, the
+per-unit ``influence`` matrix every reported standard error is a functional of,
+and two bands on the event-time path. ``cband=True`` tabulates the second one:
+
+.. math::
+
+   c_{1-\alpha} = \text{quantile}_{1-\alpha}\ \max_h
+     \Bigl| \sum_i v_i \widehat{\psi}_{h,i} \Bigr| \big/ \widehat{\text{se}}_h ,
+
+with :math:`v_i` Mammen (1993) multipliers. One critical value covers every
+horizon at once, which is the level a reader assumes when they read the path as
+a path ("positive by horizon three and never back"); the pointwise band read
+that way covers less. No refit is involved -- the multipliers act on the
+influence functions the point estimate already produced.
+
+The derivation assumes the conventions that produce the Callaway-Sant'Anna
+estimate, so ``inference_method="influence_function"`` is available only with
+``donor_weights="uniform"``, ``base_period="pre_treatment"``,
+``donor_pool="never_treated"`` and ``fixedeff=True``. Solved SCM weights are
+estimated too and contribute a term of their own, and a not-yet-treated pool
+changes the comparison group's composition over time; outside the four the
+formula is wrong and not approximate, and the configuration raises
+``MlsynthConfigError`` naming the convention that broke it. Setting a convention
+explicitly alongside the preset is a coherent question whose answer is the
+jackknife, so the preset stands down instead of raising.
+
+Verification: the analytical standard errors are pinned cell by cell and in
+aggregate against
+`benchmarks/reference/ppscm_cs/reference.py <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/reference/ppscm_cs/reference.py>`_,
+a transcription of ``diff-diff`` 3.9.0 at commit ``d9cd475`` kept in-tree so the
+check runs without a runtime dependency. Measured agreement is 0.0 per cell and
+5.6e-17 on the aggregate.
+
 Per-unit fits alongside the pooled report
 -----------------------------------------
 

--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -28,6 +28,7 @@ from ..exceptions import (
     MlsynthEstimationError,
     MlsynthPlottingError,
 )
+from ..utils.ppscm_helpers.cs_inference import influence_function_inference
 from ..utils.ppscm_helpers.engine import Conventions, run_multisynth
 from ..utils.ppscm_helpers.inference import (
     jackknife_inference, bootstrap_inference, per_unit_intervals,
@@ -88,6 +89,7 @@ class PPSCM:
         self.base_period: str = config.base_period
         self.donor_pool: str = config.donor_pool
         self.method: Any = config.method
+        self.cband: bool = config.cband
         self.solver: Any = config.solver
         self.run_inference: bool = config.run_inference
         self.inference_method: str = config.inference_method
@@ -155,7 +157,19 @@ class PPSCM:
             per_time = fit["per_time"]
             att = fit["att"]
             replicate_paths = None
-            if self.run_inference and self.inference_method == "bootstrap":
+            cs = None
+            if self.run_inference and self.inference_method == "influence_function":
+                cs = influence_function_inference(
+                    fit, inputs.time_labels, alpha=self.alpha,
+                    att_full=att, per_time_full=per_time,
+                    n_boot=self.n_boot, seed=self.seed, cband=self.cband,
+                    want_paths=self.cumulative_band,
+                )
+                se, ci = cs.se, cs.ci
+                pt_se, pt_ci = cs.per_time_se, cs.per_time_ci
+                replicate_paths = cs.replicate_paths
+                method = "influence_function"
+            elif self.run_inference and self.inference_method == "bootstrap":
                 att, se, ci, pt_se, pt_ci, replicate_paths = bootstrap_inference(
                     fit, alpha=self.alpha, n_boot=self.n_boot, seed=self.seed,
                     per_time_full=per_time, att_full=att, return_paths=True,
@@ -191,10 +205,16 @@ class PPSCM:
                     jackknife=(method == "jackknife"), seed=self.seed,
                     method=method,
                 )
-            inference = PPSCMInference(att=float(att), se=float(se),
-                                      ci=tuple(ci), method=method,
-                                      replicate_paths=replicate_paths,
-                                      cumulative=cumulative)
+            inference = PPSCMInference(
+                att=float(att), se=float(se), ci=tuple(ci), method=method,
+                replicate_paths=replicate_paths, cumulative=cumulative,
+                group_time_att=(cs.group_time_att if cs is not None else None),
+                group_time_se=(cs.group_time_se if cs is not None else None),
+                pointwise_band=(cs.pointwise_band if cs is not None else None),
+                uniform_band=(cs.uniform_band if cs is not None else None),
+                critical_value=(cs.critical_value if cs is not None else None),
+                influence=(cs.influence if cs is not None else None),
+            )
 
             # donor weights per treated cohort (label -> {donor: weight})
             donor_weights: Dict[Any, Dict[Any, float]] = {}

--- a/mlsynth/tests/test_ppscm_callaway_santanna.py
+++ b/mlsynth/tests/test_ppscm_callaway_santanna.py
@@ -50,7 +50,7 @@ from scipy.stats import norm
 from mlsynth import PPSCM
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 from mlsynth.utils.ppscm_helpers.cs_inference import influence_function_inference
-from mlsynth.utils.ppscm_helpers.engine import run_multisynth
+from mlsynth.utils.ppscm_helpers.engine import Conventions, run_multisynth
 from mlsynth.utils.ppscm_helpers.setup import prepare_ppscm_inputs
 
 try:                                             # corroboration, not the oracle
@@ -231,8 +231,10 @@ def _refit(df):
     T, d = inputs.Xy.shape[1], inputs.n_pre
     return run_multisynth(inputs.Xy, inputs.trt, d, T - d, d,
                           fixedeff=True, time_cohort=False,
-                          donor_weights="uniform", base_period="pre_treatment",
-                          donor_pool="never_treated")
+                          conventions=Conventions(
+                              donor_weights="uniform",
+                              base_period="pre_treatment",
+                              donor_pool="never_treated"))
 
 
 # shapes where every non-focal cohort adopts inside the focal cohort's window,
@@ -493,6 +495,35 @@ class TestInference:
         agg = psi.mean(axis=1)
         assert float(res.inference.standard_error) == pytest.approx(
             float(np.sqrt((agg ** 2).sum())), rel=1e-12)
+
+    def test_the_comparison_group_enters_with_the_opposite_sign(self):
+        """What makes a cell a difference in differences and not a sum.
+
+        A never-treated unit whose outcome rose more than its group's average
+        pulls the estimate down, so its contribution to the influence function
+        is negative. No standard error can see this. The treated and control
+        blocks sit on disjoint units, each cell's control influence sums to
+        zero, and the weight-influence term is a single constant across
+        never-treated units, so flipping the entire control block changes
+        ``sum_i psi_i^2`` by ``4c * sum_i A_i = 0`` -- every reported number
+        stays bit-identical while the object they are computed from is wrong.
+        Measured: the influence matrix moves by 1.36e-01 and its norm by 0.
+
+        ``influence`` is public and documented as what a caller re-aggregates,
+        so its sign convention is part of the contract and not an internal
+        detail.
+        """
+        df = staggered((12,), k=3)          # one cohort, so the wif term is 0
+        res = fit_cs_mode(df, run_inference=True)
+        psi = res.inference_detail.influence
+        wide = df.pivot(index="id", columns="time", values="y")
+        g_of = df.groupby("id")["first_treat"].first().reindex(wide.index)
+        never = np.flatnonzero((g_of == 0).to_numpy())
+        d_co = (wide.iloc[never][12].to_numpy() - wide.iloc[never][11].to_numpy())
+        want = -(d_co - d_co.mean()) / never.size
+        assert np.allclose(psi[never, 0], want, atol=1e-12), (
+            "the comparison group's influence contributions have the wrong sign "
+            "or the wrong scale")
 
     def test_the_influence_function_is_mean_zero(self):
         """A mean-zero influence function is what makes the sum of squares a
@@ -805,117 +836,3 @@ class TestInfluenceModuleEdges:
         keys = res.inference_detail.group_time_se.keys()
         assert (2010, 2010) in keys and (2014, 2014) in keys
         assert all(g >= 2010 and t >= g for g, t in keys)
-
-
-# =========================================================================== #
-# 9. the replicates are the same estimator as the point estimate
-# =========================================================================== #
-class TestReplicatesAreTheSameEstimator:
-    """A jackknife replicate must refit the estimator that produced the ATT.
-
-    ``jackknife_inference`` refits the panel unit by unit, and the conventions
-    that decide *which* estimator is being refit have to travel with it.
-    Without them the delete-one fits run under augsynth's donor weighting,
-    baseline and donor pool while the point estimate is Callaway-Sant'Anna's,
-    and the two failure modes are different sizes of the same defect:
-
-    * with ``donor_weights="uniform"`` there is no QP, so ``nu_used`` is ``NaN``;
-      that ``NaN`` is handed back as the refits' pooling level, every refit
-      raises a ``DCPError``, ``except Exception: continue`` absorbs all of them,
-      and the standard error comes back ``NaN``;
-    * with ``donor_weights="scm"`` and the other two conventions set,
-      ``nu_used`` is a real number, every refit succeeds, and the standard
-      error is finite, plausible, and computed for a different estimator.
-
-    The second is why this is tested and not left to the ``NaN``: a missing
-    number announces itself and a wrong one does not.
-    """
-
-    def test_the_jackknife_reports_a_standard_error_at_all(self):
-        df = staggered((10, 14, 18))
-        res = fit_cs_mode(df, run_inference=True,
-                          inference_method="jackknife")
-        assert res.inference.method == "jackknife"
-        assert res.inference.standard_error is not None
-        assert np.isfinite(float(res.inference.standard_error))
-        assert np.isfinite(res.inference_detail.replicate_paths).any()
-
-    def test_every_refit_carries_the_callers_conventions(self, monkeypatch):
-        """The direct claim, read off the calls themselves."""
-        import mlsynth.utils.ppscm_helpers.inference as inf_mod
-        seen = []
-        real = inf_mod.run_multisynth
-
-        def spy(*args, **kwargs):
-            seen.append(kwargs)
-            return real(*args, **kwargs)
-
-        monkeypatch.setattr(inf_mod, "run_multisynth", spy)
-        fit_cs_mode(staggered((10, 14)), run_inference=True,
-                    inference_method="jackknife")
-        assert seen, "the jackknife did not refit anything"
-        for kw in seen:
-            assert kw.get("donor_weights") == "uniform"
-            assert kw.get("base_period") == "pre_treatment"
-            assert kw.get("donor_pool") == "never_treated"
-
-    def test_the_jackknife_agrees_with_the_bootstrap_on_the_same_fit(self):
-        """The bootstrap reweights the fitted weights and cannot drift; the
-        jackknife refits and can. They need not be equal, but a jackknife
-        running a different estimator is not within a factor of two."""
-        df = staggered((10, 14, 18))
-        j = fit_cs_mode(df, run_inference=True, inference_method="jackknife")
-        b = fit_cs_mode(df, run_inference=True, inference_method="bootstrap",
-                        n_boot=400)
-        sj, sb = float(j.inference.standard_error), float(b.inference.standard_error)
-        assert 0.5 < sj / sb < 2.0, (sj, sb)
-
-    def test_scm_weights_with_the_cs_baseline_and_pool_are_refit_as_such(
-            self, monkeypatch):
-        """The variant that returns a plausible wrong number instead of NaN."""
-        import mlsynth.utils.ppscm_helpers.inference as inf_mod
-        seen = []
-        real = inf_mod.run_multisynth
-        monkeypatch.setattr(inf_mod, "run_multisynth",
-                            lambda *a, **k: (seen.append(k), real(*a, **k))[1])
-        fit_cs_mode(staggered((10, 14)), run_inference=True,
-                    inference_method="jackknife", donor_weights="scm",
-                    base_period="pre_treatment", donor_pool="never_treated")
-        assert seen
-        for kw in seen:
-            assert kw.get("donor_weights") == "scm"
-            assert kw.get("base_period") == "pre_treatment"
-            assert kw.get("donor_pool") == "never_treated"
-
-    def test_a_jackknife_whose_every_refit_failed_is_reported(self):
-        """Absorbing every exception and returning NaN is how the defect above
-        stayed invisible; with no usable replicate there is no inference, and
-        saying so is the only honest report."""
-        from mlsynth.utils.ppscm_helpers.inference import jackknife_inference
-        from mlsynth.exceptions import MlsynthEstimationError
-        df = staggered((10, 14))
-        inputs = prepare_ppscm_inputs(df[["id", "time", "y", "d"]], outcome="y",
-                                      treat="d", unitid="id", time="time")
-        T, d = inputs.Xy.shape[1], inputs.n_pre
-        with pytest.raises(MlsynthEstimationError, match="replicate"):
-            jackknife_inference(
-                inputs.Xy, inputs.trt, d, T - d, d, fixedeff=True,
-                time_cohort=False, nu_used=float("nan"), lam=0.0, solver=None,
-                alpha=0.05, per_time_full=np.zeros(T - d), att_full=0.0)
-
-    def test_the_conformal_calibration_refits_the_same_estimator(self,
-                                                                 monkeypatch):
-        """``cumulative_conformal_per_unit`` refits at rolling origins, so it
-        carries the same requirement as the jackknife."""
-        import mlsynth.utils.ppscm_helpers.inference as inf_mod
-        seen = []
-        real = inf_mod.run_multisynth
-        monkeypatch.setattr(inf_mod, "run_multisynth",
-                            lambda *a, **k: (seen.append(k), real(*a, **k))[1])
-        fit_cs_mode(staggered((10, 14)), run_inference=True,
-                    conformal_horizon=2)
-        assert seen, "the conformal calibration did not refit anything"
-        for kw in seen:
-            assert kw.get("donor_weights") == "uniform"
-            assert kw.get("base_period") == "pre_treatment"
-            assert kw.get("donor_pool") == "never_treated"

--- a/mlsynth/tests/test_ppscm_callaway_santanna.py
+++ b/mlsynth/tests/test_ppscm_callaway_santanna.py
@@ -38,12 +38,20 @@ bottomed out at.
 
 from __future__ import annotations
 
+import importlib.util
+import pathlib
+
 import numpy as np
 import pandas as pd
 import pytest
+from hypothesis import HealthCheck, given, settings, strategies as st
+from scipy.stats import norm
 
 from mlsynth import PPSCM
-from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.ppscm_helpers.cs_inference import influence_function_inference
+from mlsynth.utils.ppscm_helpers.engine import run_multisynth
+from mlsynth.utils.ppscm_helpers.setup import prepare_ppscm_inputs
 
 try:                                             # corroboration, not the oracle
     from diff_diff import CallawaySantAnna, SunAbraham
@@ -53,6 +61,14 @@ except ImportError:                              # pragma: no cover - CI without
 
 needs_diff_diff = pytest.mark.skipif(
     not HAVE_DIFF_DIFF, reason="diff-diff not installed")
+
+# The vendored transcription of ``diff-diff`` 3.9.0 at ``d9cd475``, which is the
+# oracle for inference. Loaded by path because ``benchmarks/`` is not a package.
+_REF_PATH = (pathlib.Path(__file__).resolve().parents[2]
+             / "benchmarks" / "reference" / "ppscm_cs" / "reference.py")
+_spec = importlib.util.spec_from_file_location("_ppscm_cs_reference", _REF_PATH)
+REF = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(REF)
 
 
 # --------------------------------------------------------------------------- #
@@ -67,7 +83,7 @@ def cs_group_time(df, outcome="y", unit="id", time="time", first_treat="first_tr
         ATT(g,t) = mean_{i in G_g}(Y_it - Y_{i,g-1})
                  - mean_{i in C} (Y_it - Y_{i,g-1})
 
-    Transcribed rather than imported so the identity this module exists to prove
+    Transcribed instead of imported so the identity this module exists to prove
     is enforced wherever the suite runs, and not only where ``diff-diff`` is
     installed. The imported package is compared against separately, which is
     what keeps this transcription honest.
@@ -96,16 +112,21 @@ def oracle_att(df, L):
 # --------------------------------------------------------------------------- #
 # panels
 # --------------------------------------------------------------------------- #
-def staggered(onsets, k=3, n_units=50, n_per=30, seed=0, effect="const"):
+def staggered(onsets, k=3, n_units=50, n_per=30, seed=0, effect="const",
+              sizes=None):
     """Never-treated donors plus cohorts adopting at ``onsets``.
 
     ``effect`` selects the treatment-effect structure, since an identity that
-    only holds for a constant effect would be an artefact of the DGP.
+    only holds for a constant effect would be an artefact of the DGP. ``sizes``
+    gives the cohorts different memberships, which is what separates
+    Callaway-Sant'Anna's size-weighted aggregation from their unweighted one --
+    equal cohorts make the two coincide and hide the distinction.
     """
     rng = np.random.default_rng(seed)
+    sizes = [k] * len(onsets) if sizes is None else list(sizes)
     assign, u = {}, 0
-    for g in onsets:
-        for _ in range(k):
+    for g, size in zip(onsets, sizes):
+        for _ in range(size):
             assign[u] = g
             u += 1
     rows = []
@@ -161,6 +182,57 @@ def reference_sa(df, L):
 
 def leads_of(res):
     return len(next(iter(res.per_unit.values())).tau)
+
+
+# --------------------------------------------------------------------------- #
+# the vendored reference, as an inference oracle
+# --------------------------------------------------------------------------- #
+def ref_parts(df):
+    eff, ses, inf = REF.group_time_att(df, "y", "id", "time", "first_treat")
+    return eff, ses, inf, df.groupby("id")["first_treat"].first().to_numpy()
+
+
+def cells_of(df, L):
+    """The ``(g, t)`` cells PPSCM aggregates: leads ``0 .. L-1`` of each cohort."""
+    eff, _, _, _ = ref_parts(df)
+    return [(g, t) for (g, t) in eff if 0 <= t - g < L]
+
+
+def ref_aggregate(df, L, *, size_weighted=False, wif=True):
+    """The reference's aggregate over PPSCM's cells.
+
+    ``size_weighted`` hands it the cohort-share weights PPSCM uses; its own
+    default is an unweighted mean over cells, and the two agree only when the
+    cohorts are the same size. ``wif=False`` deletes the weight-influence
+    correction, which is how its absence is measured instead of assumed.
+    """
+    eff, _, inf, cohort = ref_parts(df)
+    cells = cells_of(df, L)
+    w = None
+    if size_weighted:
+        pg = np.array([(cohort == g).sum() / cohort.shape[0] for g, _ in cells])
+        w = pg / pg.sum()
+    if wif:
+        est, se, _ = REF.aggregate(cells, eff, inf, cohort, weights=w)
+        return est, se
+    w = np.full(len(cells), 1.0 / len(cells)) if w is None else w
+    psi = np.zeros(cohort.shape[0])
+    for k, c in enumerate(cells):
+        psi[inf[c]["treated_idx"]] += w[k] * inf[c]["treated_inf"]
+        psi[inf[c]["control_idx"]] += w[k] * inf[c]["control_inf"]
+    est = float(np.array([eff[c] for c in cells]) @ w)
+    return est, float(np.sqrt((psi ** 2).sum()))
+
+
+def _refit(df):
+    """The raw ``run_multisynth`` dictionary, for testing the module directly."""
+    inputs = prepare_ppscm_inputs(df[["id", "time", "y", "d"]], outcome="y",
+                                  treat="d", unitid="id", time="time")
+    T, d = inputs.Xy.shape[1], inputs.n_pre
+    return run_multisynth(inputs.Xy, inputs.trt, d, T - d, d,
+                          fixedeff=True, time_cohort=False,
+                          donor_weights="uniform", base_period="pre_treatment",
+                          donor_pool="never_treated")
 
 
 # shapes where every non-focal cohort adopts inside the focal cohort's window,
@@ -329,50 +401,67 @@ class TestDocumentedDivergence:
 # =========================================================================== #
 # 5. inference -- separate from estimation on purpose
 # =========================================================================== #
-@pytest.mark.xfail(strict=True, reason=(
-    "Influence-function inference is the second half of #465 and is not built "
-    "yet. These are written first and left strict on purpose: they fail now, "
-    "and the moment the inference lands they flip to unexpected passes, which "
-    "is what removes this marker. PPSCM's jackknife is still what runs, and "
-    "``parameters_used['inference_method']`` says so."))
 class TestInference:
-    @pytest.mark.parametrize("name,onsets,k", ALIGNED[:3])
-    def test_per_cell_standard_errors_match(self, name, onsets, k):
-        df = staggered(onsets, k=k)
-        res = fit_cs_mode(df, run_inference=True)
-        _, ref = reference_cs(df, leads_of(res))
-        ours = res.inference_detail.group_time_se
-        for (g, t), v in ref.group_time_effects.items():
-            if (g, t) in ours and np.isfinite(v["se"]):
-                assert ours[(g, t)] == pytest.approx(v["se"], rel=1e-9), (g, t)
+    """The interval has to be theirs too.
+
+    Equal point estimates do not make equal intervals, and PPSCM's delete-one
+    jackknife is not the Callaway-Sant'Anna standard error. The oracle here is
+    the vendored transcription (``benchmarks/reference/ppscm_cs/reference.py``),
+    so the claim is enforced wherever the suite runs; ``diff-diff`` corroborates
+    it separately in ``test_ppscm_cs_reference.py``.
+    """
+
+    def test_per_cell_standard_errors_match(self):
+        for name, onsets, k in ALIGNED[:3]:
+            df = staggered(onsets, k=k)
+            res = fit_cs_mode(df, run_inference=True)
+            ours = res.inference_detail.group_time_se
+            _, ses, _, _ = ref_parts(df)
+            for cell in cells_of(df, leads_of(res)):
+                assert ours[cell] == pytest.approx(ses[cell], rel=1e-12), (name, cell)
 
     def test_aggregated_standard_error_matches(self):
         """Includes the weight-influence term; without it the SE is wrong by
         the amount R's did::aggte corrects for."""
         df = staggered((10, 14, 18))
         res = fit_cs_mode(df, run_inference=True)
-        _, ref = reference_cs(df, leads_of(res))
-        assert float(res.inference.standard_error) == pytest.approx(
-            float(ref.se), rel=1e-8)
+        _, se_ref = ref_aggregate(df, leads_of(res))
+        assert float(res.inference.standard_error) == pytest.approx(se_ref, rel=1e-10)
 
     def test_confidence_interval_matches(self):
         df = staggered((10, 14, 18))
         res = fit_cs_mode(df, run_inference=True)
-        _, ref = reference_cs(df, leads_of(res))
-        lo, hi = ref.conf_int
-        assert float(res.inference.ci_lower) == pytest.approx(lo, rel=1e-8)
-        assert float(res.inference.ci_upper) == pytest.approx(hi, rel=1e-8)
+        est, se_ref = ref_aggregate(df, leads_of(res))
+        z = float(norm.ppf(0.975))
+        assert float(res.inference.ci_lower) == pytest.approx(est - z * se_ref, rel=1e-10)
+        assert float(res.inference.ci_upper) == pytest.approx(est + z * se_ref, rel=1e-10)
+
+    @pytest.mark.parametrize("sizes", [(2, 5, 3), (1, 6, 3), (4, 1, 2)])
+    def test_unequal_cohorts_use_the_size_weighted_aggregation(self, sizes):
+        """PPSCM averages cohorts by size at each horizon, which is
+        Callaway-Sant'Anna's dynamic aggregation and not their simple one.
+
+        Equal cohorts hide the difference, so the two aggregations are separated
+        here: handed the same cell weights, the reference reproduces PPSCM's
+        estimate and standard error exactly at every cohort split.
+        """
+        df = staggered((10, 14, 18), sizes=sizes)
+        res = fit_cs_mode(df, run_inference=True)
+        est, se_ref = ref_aggregate(df, leads_of(res), size_weighted=True)
+        assert float(res.att) == pytest.approx(est, abs=1e-12), sizes
+        assert float(res.inference.standard_error) == pytest.approx(se_ref, rel=1e-10)
 
     def test_multiplier_bootstrap_bands_are_wider_than_pointwise(self):
         """Uniform bands cover the whole path simultaneously, so they cannot be
         narrower than the pointwise interval."""
         df = staggered((10, 14, 18))
-        res = fit_cs_mode(df, run_inference=True, n_bootstrap=200, cband=True)
+        res = fit_cs_mode(df, run_inference=True, n_boot=2000, cband=True)
         assert (res.inference.ci_upper - res.inference.ci_lower) > 0
         band = res.inference_detail.uniform_band
         point = res.inference_detail.pointwise_band
         assert all(b[1] - b[0] >= p[1] - p[0] - 1e-12
                    for b, p in zip(band, point))
+        assert res.inference_detail.critical_value > float(norm.ppf(0.975))
 
     def test_inference_is_not_silently_jackknife(self):
         """The preset must report which inference it ran; naming CS while
@@ -381,3 +470,452 @@ class TestInference:
         res = fit_cs_mode(df, run_inference=True)
         assert res.method_details.parameters_used.get("inference_method") == \
             "influence_function"
+        assert res.inference.method == "influence_function"
+
+    def test_the_weight_influence_term_is_carried(self):
+        """Dropping it leaves a standard error that is finite, plausible and
+        too small, so its absence is measured and not assumed."""
+        df = staggered((10, 14, 18))
+        res = fit_cs_mode(df, run_inference=True)
+        psi = res.inference_detail.influence
+        H = psi.shape[1]
+        naive = ref_aggregate(df, H, wif=False)[1]
+        assert float(res.inference.standard_error) != pytest.approx(naive, rel=1e-6)
+
+    def test_the_influence_function_reproduces_every_reported_standard_error(self):
+        """``se`` is a functional of ``influence`` and not a parallel number."""
+        df = staggered((10, 14, 18))
+        res = fit_cs_mode(df, run_inference=True)
+        psi = res.inference_detail.influence
+        assert psi.shape == (50, len(res.event_study.tau))
+        for h, s in enumerate(res.event_study.se):
+            assert s == pytest.approx(float(np.sqrt((psi[:, h] ** 2).sum())), rel=1e-12)
+        agg = psi.mean(axis=1)
+        assert float(res.inference.standard_error) == pytest.approx(
+            float(np.sqrt((agg ** 2).sum())), rel=1e-12)
+
+    def test_the_influence_function_is_mean_zero(self):
+        """A mean-zero influence function is what makes the sum of squares a
+        variance; a non-zero mean is a location error masquerading as one."""
+        df = staggered((10, 14, 18))
+        res = fit_cs_mode(df, run_inference=True)
+        psi = res.inference_detail.influence
+        for h in range(psi.shape[1]):
+            assert float(psi[:, h].sum()) == pytest.approx(0.0, abs=1e-12), h
+
+    def test_the_cells_rebuild_the_event_study(self):
+        """``group_time_att`` is the aggregate's parts, so it must recombine."""
+        df = staggered((10, 14, 18), sizes=(2, 5, 3))
+        res = fit_cs_mode(df, run_inference=True)
+        gta = res.inference_detail.group_time_att
+        n1 = {}
+        for f in res.per_unit.values():
+            n1[f.adoption_time] = n1.get(f.adoption_time, 0) + f.n_units
+        for h, tau in enumerate(res.event_study.tau):
+            cs = [(g, g + h) for g in sorted(n1) if (g, g + h) in gta]
+            S = sum(n1[g] for g, _ in cs)
+            rebuilt = sum(n1[g] * gta[(g, t)] for g, t in cs) / S
+            assert rebuilt == pytest.approx(float(tau), abs=1e-12), h
+
+    def test_the_cumulative_band_runs_off_the_influence_functions(self):
+        df = staggered((10, 14, 18))
+        res = fit_cs_mode(df, run_inference=True, cumulative_band=True, n_boot=500)
+        band = res.inference_detail.cumulative
+        assert band.method == "influence_function"
+        assert band.n_replicates == 500
+        assert np.all(band.upper > band.lower)
+
+
+# =========================================================================== #
+# 6. the influence-function mode refuses what it cannot compute
+# =========================================================================== #
+class TestInferenceRestrictions:
+    """The formula is for uniform weights, a ``g-1`` baseline and a
+    never-treated pool. Outside those it is wrong and not approximate, so the
+    configuration refuses it instead of returning a number."""
+
+    @pytest.mark.parametrize("field,value", [
+        ("donor_weights", "scm"), ("base_period", "all_pre"),
+        ("donor_pool", "window"), ("donor_pool", "not_yet_treated"),
+        ("fixedeff", False)])
+    def test_a_broken_convention_is_refused(self, field, value):
+        df = staggered((10, 14))
+        with pytest.raises(MlsynthConfigError, match="Callaway-Sant'Anna"):
+            fit_cs_mode(df, run_inference=True,
+                        inference_method="influence_function", **{field: value})
+
+    def test_the_message_names_the_convention_that_is_wrong(self):
+        df = staggered((10, 14))
+        with pytest.raises(MlsynthConfigError, match="donor_weights='scm'"):
+            fit_cs_mode(df, run_inference=True,
+                        inference_method="influence_function", donor_weights="scm")
+
+    def test_the_preset_selects_it_only_when_the_conventions_survive(self):
+        """Both halves, because either alone is satisfied by doing nothing.
+
+        Left to itself the preset must select the Callaway-Sant'Anna interval;
+        asked for alongside augsynth's donor pool it must not, since that is a
+        coherent question whose answer is the jackknife and not a configuration
+        error about a field the caller never set.
+        """
+        df = staggered((10, 14))
+        assert fit_cs_mode(df, run_inference=True).inference.method == \
+            "influence_function"
+        assert fit_cs_mode(df, run_inference=True,
+                           donor_pool="window").inference.method == "jackknife"
+
+    def test_an_unknown_inference_method_is_refused(self):
+        df = staggered((10, 14))
+        with pytest.raises(MlsynthConfigError, match="influence_function"):
+            fit_cs_mode(df, run_inference=True, inference_method="analytic")
+
+    def test_cband_needs_the_influence_function(self):
+        """Matched on ``influence_function`` and not on ``cband``: an unknown
+        field produces a pydantic message that carries the field's own name, so
+        matching that alone passes against a build where ``cband`` does not
+        exist."""
+        df = staggered((10, 14))
+        with pytest.raises(MlsynthConfigError, match="influence_function"):
+            fit_cs_mode(df, run_inference=True, inference_method="jackknife",
+                        cband=True)
+
+    def test_cband_needs_inference_on(self):
+        df = staggered((10, 14))
+        with pytest.raises(MlsynthConfigError, match="run_inference"):
+            fit_cs_mode(df, run_inference=False, cband=True)
+
+    def test_a_panel_with_no_never_treated_unit_is_caught_at_ingestion(self):
+        """The comparison group is missing before any inference is chosen.
+
+        Not a test of the influence function: ``prepare_ppscm_inputs`` refuses
+        this panel, and the layer that refuses it is the claim. The inference
+        module's own empty-pool guard is reached by calling it directly
+        (:meth:`TestInfluenceModuleEdges.test_a_cohort_with_no_donor_is_reported_not_divided_by`).
+        """
+        df = staggered((10, 14), k=25)          # 50 units, none left untreated
+        with pytest.raises(MlsynthDataError, match="never-treated"):
+            fit_cs_mode(df, run_inference=True)
+
+    def test_the_other_methods_leave_the_cell_fields_empty(self):
+        """A jackknife produces no per-cell quantities, and must not appear to."""
+        df = staggered((10, 14))
+        res = fit_cs_mode(df, run_inference=True, donor_pool="window")
+        d = res.inference_detail
+        assert d.group_time_att is None and d.group_time_se is None
+        assert d.pointwise_band is None and d.uniform_band is None
+        assert d.influence is None and d.critical_value is None
+
+
+# =========================================================================== #
+# 7. properties -- what must hold on any panel, not just the six above
+# =========================================================================== #
+@settings(deadline=None, max_examples=25,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(onsets=st.lists(st.integers(8, 20), min_size=1, max_size=3,
+                       unique=True).map(sorted),
+       sizes=st.lists(st.integers(1, 5), min_size=1, max_size=3),
+       seed=st.integers(0, 2 ** 16))
+def test_the_influence_function_matches_the_reference_on_any_panel(
+        onsets, sizes, seed):
+    """Estimate, standard error and every cell, against the transcription.
+
+    The parametrized cases above are six panels someone chose. This is the same
+    claim on panels nobody chose: cohorts of unequal size, adoptions at
+    arbitrary spacings, and as few as one treated unit.
+    """
+    sizes = (sizes * len(onsets))[:len(onsets)]
+    df = staggered(tuple(onsets), sizes=sizes, seed=seed)
+    res = fit_cs_mode(df, run_inference=True)
+    L = leads_of(res)
+    _, ses, _, _ = ref_parts(df)
+    for cell in cells_of(df, L):
+        assert res.inference_detail.group_time_se[cell] == pytest.approx(
+            ses[cell], rel=1e-10), cell
+    est, se_ref = ref_aggregate(df, L, size_weighted=True)
+    assert float(res.att) == pytest.approx(est, abs=1e-10)
+    assert float(res.inference.standard_error) == pytest.approx(se_ref, rel=1e-9)
+
+
+@settings(deadline=None, max_examples=25,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(onsets=st.lists(st.integers(8, 20), min_size=1, max_size=3,
+                       unique=True).map(sorted),
+       seed=st.integers(0, 2 ** 16))
+def test_the_standard_error_is_positive_and_the_interval_brackets_the_estimate(
+        onsets, seed):
+    df = staggered(tuple(onsets), seed=seed)
+    res = fit_cs_mode(df, run_inference=True)
+    se = float(res.inference.standard_error)
+    assert np.isfinite(se) and se > 0
+    assert res.inference.ci_lower < res.att < res.inference.ci_upper
+    assert np.all(np.isfinite(res.event_study.se))
+    assert np.all(res.event_study.se > 0)
+
+
+@settings(deadline=None, max_examples=20,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(shift=st.floats(-50.0, 50.0), scale=st.floats(0.2, 5.0))
+def test_the_standard_error_scales_with_the_outcome_and_ignores_its_level(
+        shift, scale):
+    """A standard error is in the outcome's units: rescaling the outcome
+    rescales it exactly, and shifting the outcome leaves it alone."""
+    df = staggered((10, 14, 18))
+    base = fit_cs_mode(df, run_inference=True)
+    moved = df.copy()
+    moved["y"] = shift + scale * moved["y"]
+    got = fit_cs_mode(moved, run_inference=True)
+    assert float(got.inference.standard_error) == pytest.approx(
+        scale * float(base.inference.standard_error), rel=1e-9)
+    assert float(got.att) == pytest.approx(scale * float(base.att), abs=1e-9)
+
+
+@settings(deadline=None, max_examples=15,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(alpha=st.floats(0.005, 0.5), seed=st.integers(0, 2 ** 16))
+def test_a_tighter_level_gives_a_wider_interval_around_the_same_estimate(
+        alpha, seed):
+    df = staggered((10, 14, 18), seed=seed)
+    wide = fit_cs_mode(df, run_inference=True, alpha=alpha)
+    tight = fit_cs_mode(df, run_inference=True, alpha=alpha / 2.0)
+    assert float(tight.att) == pytest.approx(float(wide.att), abs=1e-12)
+    assert (tight.inference.ci_upper - tight.inference.ci_lower) > \
+        (wide.inference.ci_upper - wide.inference.ci_lower)
+
+
+@settings(deadline=None, max_examples=15,
+          suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(seed=st.integers(0, 2 ** 16))
+def test_relabelling_the_units_does_not_move_the_answer(seed):
+    """The influence function is indexed by unit; a permutation of the unit
+    labels must permute it and change nothing else."""
+    df = staggered((10, 14, 18))
+    rng = np.random.default_rng(seed)
+    perm = rng.permutation(df["id"].nunique())
+    shuffled = df.copy()
+    shuffled["id"] = shuffled["id"].map(lambda u: int(perm[u]))
+    a = fit_cs_mode(df, run_inference=True)
+    b = fit_cs_mode(shuffled.sort_values(["id", "time"]), run_inference=True)
+    assert float(b.att) == pytest.approx(float(a.att), abs=1e-10)
+    assert float(b.inference.standard_error) == pytest.approx(
+        float(a.inference.standard_error), rel=1e-10)
+
+
+# =========================================================================== #
+# 8. the module's own edges
+# =========================================================================== #
+class TestInfluenceModuleEdges:
+    def test_a_cohort_with_no_donor_is_reported_not_divided_by(self):
+        df = staggered((10, 14))
+        res = fit_cs_mode(df, run_inference=False)
+        fit = _refit(df)
+        fit["donors"] = {g: np.asarray([], dtype=int) for g in fit["groups"]}
+        with pytest.raises(MlsynthDataError, match="comparison group"):
+            influence_function_inference(
+                fit, np.arange(1, 31), alpha=0.05, att_full=float(res.att),
+                per_time_full=res.event_study.tau)
+
+    def test_a_panel_with_no_estimable_cell_is_reported(self):
+        df = staggered((10, 14))
+        res = fit_cs_mode(df, run_inference=False)
+        fit = _refit(df)
+        # Push every adoption past the last observed column.
+        fit["adopt_of"] = {g: 10_000 for g in fit["groups"]}
+        fit["res"] = {10_000: next(iter(fit["res"].values()))}
+        with pytest.raises(MlsynthDataError, match="no estimable"):
+            influence_function_inference(
+                fit, np.arange(1, 20_001), alpha=0.05, att_full=float(res.att),
+                per_time_full=res.event_study.tau)
+
+    def test_one_treated_unit_carries_no_weight_influence_term(self):
+        """With a single cohort the group share is not estimated against
+        anything, so the correction is exactly zero and the aggregate standard
+        error is the plain weighted one."""
+        df = staggered((12,), k=1)
+        res = fit_cs_mode(df, run_inference=True)
+        psi = res.inference_detail.influence
+        _, ses, inf, _ = ref_parts(df)
+        for h in range(psi.shape[1]):
+            cell = (12, 12 + h)
+            assert res.inference_detail.group_time_se[cell] == pytest.approx(
+                ses[cell], rel=1e-12)
+            assert float(np.sqrt((psi[:, h] ** 2).sum())) == pytest.approx(
+                ses[cell], rel=1e-12)
+
+    def test_time_cohort_collapses_to_the_same_cells(self):
+        """A Callaway-Sant'Anna cell is indexed by adoption time, so pooling
+        units into cohorts up front must not change the inference."""
+        df = staggered((10, 14, 18))
+        a = fit_cs_mode(df, run_inference=True)
+        b = fit_cs_mode(df, run_inference=True, time_cohort=True)
+        assert float(b.att) == pytest.approx(float(a.att), abs=1e-12)
+        assert float(b.inference.standard_error) == pytest.approx(
+            float(a.inference.standard_error), rel=1e-12)
+        assert b.inference_detail.group_time_se.keys() == \
+            a.inference_detail.group_time_se.keys()
+
+    def test_the_multipliers_are_mammens_and_not_rademacher(self):
+        """Mammen's two-point law has mean 0, variance 1 and third moment 1.
+
+        The third moment is the whole reason ``did::mboot`` uses it over
+        Rademacher signs, and it is the only one of the three that tells them
+        apart -- so a band tabulated from signs looks entirely reasonable and
+        has lost the refinement it was drawn for.
+        """
+        from mlsynth.utils.ppscm_helpers.cs_inference import _KAPPA, _PROB
+        vals = np.array([1.0 - _KAPPA, _KAPPA])
+        probs = np.array([_PROB, 1.0 - _PROB])
+        assert float(probs @ vals) == pytest.approx(0.0, abs=1e-12)
+        assert float(probs @ vals ** 2) == pytest.approx(1.0, abs=1e-12)
+        assert float(probs @ vals ** 3) == pytest.approx(1.0, abs=1e-12)
+
+    def test_a_horizon_no_cohort_reaches_comes_back_empty(self):
+        """PPSCM clamps ``n_leads`` to what the last cohort observes, so this is
+        reachable only by asking the module directly. A horizon past the end of
+        the panel has no cell, and it reports ``NaN`` -- not a zero effect with a
+        zero standard error, which is what a silently skipped horizon looks
+        like once it reaches an event-study plot.
+
+        The arithmetic: cohorts adopt at columns 9 and 13 of a 30-column panel,
+        so the earlier one still reaches horizon 20 and only ``h >= 21`` is
+        empty. ``n_leads`` is 17, so 25 horizons leaves exactly four with no
+        cell -- ``n_leads + 4`` would leave none, and every horizon would come
+        back populated.
+        """
+        df = staggered((10, 14))
+        res = fit_cs_mode(df, run_inference=False)
+        fit = _refit(df)
+        assert fit["n_leads"] == 17
+        H = 25
+        fit["n_leads"] = H
+        pt = np.concatenate([res.event_study.tau, np.full(H - 17, np.nan)])
+        out = influence_function_inference(
+            fit, np.arange(1, 31), alpha=0.05, att_full=float(res.att),
+            per_time_full=pt)
+        assert np.all(np.isfinite(out.per_time_se[:-4]))
+        assert np.all(np.isnan(out.per_time_se[-4:]))
+        assert np.all(np.isnan(out.influence[:, -4:]))
+        assert np.isfinite(out.se) and out.se > 0
+
+    def test_the_cells_are_keyed_by_public_time_labels(self):
+        """``(2014, 2017)`` and not ``(9, 12)``: a reader must not have to know
+        the column positions the estimator works in."""
+        df = staggered((10, 14))
+        df = df.assign(time=df["time"] + 2000)
+        res = fit_cs_mode(df, run_inference=True)
+        keys = res.inference_detail.group_time_se.keys()
+        assert (2010, 2010) in keys and (2014, 2014) in keys
+        assert all(g >= 2010 and t >= g for g, t in keys)
+
+
+# =========================================================================== #
+# 9. the replicates are the same estimator as the point estimate
+# =========================================================================== #
+class TestReplicatesAreTheSameEstimator:
+    """A jackknife replicate must refit the estimator that produced the ATT.
+
+    ``jackknife_inference`` refits the panel unit by unit, and the conventions
+    that decide *which* estimator is being refit have to travel with it.
+    Without them the delete-one fits run under augsynth's donor weighting,
+    baseline and donor pool while the point estimate is Callaway-Sant'Anna's,
+    and the two failure modes are different sizes of the same defect:
+
+    * with ``donor_weights="uniform"`` there is no QP, so ``nu_used`` is ``NaN``;
+      that ``NaN`` is handed back as the refits' pooling level, every refit
+      raises a ``DCPError``, ``except Exception: continue`` absorbs all of them,
+      and the standard error comes back ``NaN``;
+    * with ``donor_weights="scm"`` and the other two conventions set,
+      ``nu_used`` is a real number, every refit succeeds, and the standard
+      error is finite, plausible, and computed for a different estimator.
+
+    The second is why this is tested and not left to the ``NaN``: a missing
+    number announces itself and a wrong one does not.
+    """
+
+    def test_the_jackknife_reports_a_standard_error_at_all(self):
+        df = staggered((10, 14, 18))
+        res = fit_cs_mode(df, run_inference=True,
+                          inference_method="jackknife")
+        assert res.inference.method == "jackknife"
+        assert res.inference.standard_error is not None
+        assert np.isfinite(float(res.inference.standard_error))
+        assert np.isfinite(res.inference_detail.replicate_paths).any()
+
+    def test_every_refit_carries_the_callers_conventions(self, monkeypatch):
+        """The direct claim, read off the calls themselves."""
+        import mlsynth.utils.ppscm_helpers.inference as inf_mod
+        seen = []
+        real = inf_mod.run_multisynth
+
+        def spy(*args, **kwargs):
+            seen.append(kwargs)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(inf_mod, "run_multisynth", spy)
+        fit_cs_mode(staggered((10, 14)), run_inference=True,
+                    inference_method="jackknife")
+        assert seen, "the jackknife did not refit anything"
+        for kw in seen:
+            assert kw.get("donor_weights") == "uniform"
+            assert kw.get("base_period") == "pre_treatment"
+            assert kw.get("donor_pool") == "never_treated"
+
+    def test_the_jackknife_agrees_with_the_bootstrap_on_the_same_fit(self):
+        """The bootstrap reweights the fitted weights and cannot drift; the
+        jackknife refits and can. They need not be equal, but a jackknife
+        running a different estimator is not within a factor of two."""
+        df = staggered((10, 14, 18))
+        j = fit_cs_mode(df, run_inference=True, inference_method="jackknife")
+        b = fit_cs_mode(df, run_inference=True, inference_method="bootstrap",
+                        n_boot=400)
+        sj, sb = float(j.inference.standard_error), float(b.inference.standard_error)
+        assert 0.5 < sj / sb < 2.0, (sj, sb)
+
+    def test_scm_weights_with_the_cs_baseline_and_pool_are_refit_as_such(
+            self, monkeypatch):
+        """The variant that returns a plausible wrong number instead of NaN."""
+        import mlsynth.utils.ppscm_helpers.inference as inf_mod
+        seen = []
+        real = inf_mod.run_multisynth
+        monkeypatch.setattr(inf_mod, "run_multisynth",
+                            lambda *a, **k: (seen.append(k), real(*a, **k))[1])
+        fit_cs_mode(staggered((10, 14)), run_inference=True,
+                    inference_method="jackknife", donor_weights="scm",
+                    base_period="pre_treatment", donor_pool="never_treated")
+        assert seen
+        for kw in seen:
+            assert kw.get("donor_weights") == "scm"
+            assert kw.get("base_period") == "pre_treatment"
+            assert kw.get("donor_pool") == "never_treated"
+
+    def test_a_jackknife_whose_every_refit_failed_is_reported(self):
+        """Absorbing every exception and returning NaN is how the defect above
+        stayed invisible; with no usable replicate there is no inference, and
+        saying so is the only honest report."""
+        from mlsynth.utils.ppscm_helpers.inference import jackknife_inference
+        from mlsynth.exceptions import MlsynthEstimationError
+        df = staggered((10, 14))
+        inputs = prepare_ppscm_inputs(df[["id", "time", "y", "d"]], outcome="y",
+                                      treat="d", unitid="id", time="time")
+        T, d = inputs.Xy.shape[1], inputs.n_pre
+        with pytest.raises(MlsynthEstimationError, match="replicate"):
+            jackknife_inference(
+                inputs.Xy, inputs.trt, d, T - d, d, fixedeff=True,
+                time_cohort=False, nu_used=float("nan"), lam=0.0, solver=None,
+                alpha=0.05, per_time_full=np.zeros(T - d), att_full=0.0)
+
+    def test_the_conformal_calibration_refits_the_same_estimator(self,
+                                                                 monkeypatch):
+        """``cumulative_conformal_per_unit`` refits at rolling origins, so it
+        carries the same requirement as the jackknife."""
+        import mlsynth.utils.ppscm_helpers.inference as inf_mod
+        seen = []
+        real = inf_mod.run_multisynth
+        monkeypatch.setattr(inf_mod, "run_multisynth",
+                            lambda *a, **k: (seen.append(k), real(*a, **k))[1])
+        fit_cs_mode(staggered((10, 14)), run_inference=True,
+                    conformal_horizon=2)
+        assert seen, "the conformal calibration did not refit anything"
+        for kw in seen:
+            assert kw.get("donor_weights") == "uniform"
+            assert kw.get("base_period") == "pre_treatment"
+            assert kw.get("donor_pool") == "never_treated"

--- a/mlsynth/tests/test_ppscm_cs_reference.py
+++ b/mlsynth/tests/test_ppscm_cs_reference.py
@@ -1,0 +1,221 @@
+"""The vendored Callaway-Sant'Anna reference is what it says it is.
+
+``benchmarks/reference/ppscm_cs/reference.py`` is a transcription of ``diff-diff``
+3.9.0 at commit ``d9cd475``, MIT, kept in-tree so PPSCM's ``callaway_santanna``
+mode can be validated without a runtime dependency. Two things have to stay true
+of it, and they are different claims:
+
+* it agrees with the upstream it was transcribed from -- checked only where
+  ``diff-diff`` is installed, since that is the whole point of vendoring;
+* it computes what its docstring says on its own terms -- checked everywhere,
+  because a reference that is only checked against the thing it copies has no
+  independent standing.
+
+The second matters more than it looks. A vendored copy is a characterisation of
+a pinned upstream, so the failure mode is not that it disagrees with the package
+today; it is that someone later edits it to agree with mlsynth, at which point
+it stops being evidence and starts being a mirror. The properties below are the
+ones that would break first: the per-cell estimate is a 2x2 DiD, the influence
+function sums to zero within each group, and the aggregated SE strictly exceeds
+the one you get by forgetting that the group weights were estimated.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+_REF_PATH = (pathlib.Path(__file__).resolve().parents[2]
+             / "benchmarks" / "reference" / "ppscm_cs" / "reference.py")
+_spec = importlib.util.spec_from_file_location("_ppscm_cs_reference", _REF_PATH)
+REF = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(REF)
+
+try:
+    from diff_diff import CallawaySantAnna
+    HAVE_DIFF_DIFF = True
+except ImportError:                              # pragma: no cover - CI without it
+    HAVE_DIFF_DIFF = False
+
+needs_diff_diff = pytest.mark.skipif(
+    not HAVE_DIFF_DIFF, reason="diff-diff not installed")
+
+
+def panel(onsets=(10, 14, 18), k=3, n_units=50, n_per=30, seed=0):
+    rng = np.random.default_rng(seed)
+    assign, u = {}, 0
+    for g in onsets:
+        for _ in range(k):
+            assign[u] = g
+            u += 1
+    rows = []
+    for unit in range(n_units):
+        base = rng.normal(10, 2)
+        walk = np.cumsum(rng.normal(0, 0.3, n_per))
+        g = assign.get(unit)
+        for t in range(1, n_per + 1):
+            on = g is not None and t >= g
+            rows.append((unit, t, base + walk[t - 1] + 0.5 * rng.normal() + 2.0 * on,
+                         int(on), g if g is not None else 0))
+    return pd.DataFrame(rows, columns=["id", "time", "y", "d", "first_treat"])
+
+
+def parts(df):
+    eff, ses, inf = REF.group_time_att(df, "y", "id", "time", "first_treat")
+    cohort = df.groupby("id")["first_treat"].first().to_numpy()
+    return eff, ses, inf, cohort
+
+
+SHAPES = [((12,), 3, 0), ((10, 14), 3, 0), ((10, 14, 18), 3, 0),
+          ((10, 14, 18), 2, 1), ((8, 12, 16, 20), 3, 2), ((10, 14, 18), 4, 3)]
+
+
+# =========================================================================== #
+# 1. what it computes, on its own terms
+# =========================================================================== #
+class TestOnItsOwnTerms:
+    @pytest.mark.parametrize("onsets,k,seed", SHAPES)
+    def test_each_cell_is_a_two_by_two_difference_in_differences(self, onsets, k, seed):
+        df = panel(onsets, k, seed=seed)
+        eff, _, _, _ = parts(df)
+        wide = df.pivot(index="id", columns="time", values="y")
+        g_of = df.groupby("id")["first_treat"].first()
+        never = g_of.index[g_of == 0]
+        for (g, t), got in eff.items():
+            tr = g_of.index[g_of == g]
+            want = ((wide.loc[tr, t] - wide.loc[tr, g - 1]).mean()
+                    - (wide.loc[never, t] - wide.loc[never, g - 1]).mean())
+            assert got == pytest.approx(float(want), abs=1e-12), (g, t)
+
+    @pytest.mark.parametrize("onsets,k,seed", SHAPES)
+    def test_influence_functions_sum_to_zero_within_each_group(self, onsets, k, seed):
+        """A mean-zero influence function is what makes the SE a variance."""
+        _, _, inf, _ = parts(panel(onsets, k, seed=seed))
+        for cell, info in inf.items():
+            assert float(info["treated_inf"].sum()) == pytest.approx(0.0, abs=1e-12)
+            assert float(info["control_inf"].sum()) == pytest.approx(0.0, abs=1e-12)
+
+    @pytest.mark.parametrize("onsets,k,seed", SHAPES)
+    def test_the_cell_standard_error_is_the_norm_of_its_influence_function(
+            self, onsets, k, seed):
+        _, ses, inf, _ = parts(panel(onsets, k, seed=seed))
+        for cell, info in inf.items():
+            want = np.sqrt((info["treated_inf"] ** 2).sum()
+                           + (info["control_inf"] ** 2).sum())
+            assert ses[cell] == pytest.approx(float(want), rel=1e-12)
+
+    def test_the_weight_influence_term_is_not_free(self):
+        """Forgetting that the group weights are estimated shrinks the SE.
+
+        This is the term that is easy to omit and expensive to omit: without it
+        the standard error is still finite, still plausible, and too small.
+        """
+        df = panel((10, 14, 18))
+        eff, _, inf, cohort = parts(df)
+        post = [c for c in eff if c[1] >= c[0]]
+        _, se_full, psi = REF.aggregate(post, eff, inf, cohort)
+        w = np.full(len(post), 1.0 / len(post))
+        psi_no_wif = np.zeros(cohort.shape[0])
+        for k_, c in enumerate(post):
+            psi_no_wif[inf[c]["treated_idx"]] += w[k_] * inf[c]["treated_inf"]
+            psi_no_wif[inf[c]["control_idx"]] += w[k_] * inf[c]["control_inf"]
+        se_naive = float(np.sqrt((psi_no_wif ** 2).sum()))
+        assert se_full != pytest.approx(se_naive, rel=1e-6), (
+            "the wif term made no difference; it is probably not being applied")
+
+    def test_aggregate_is_the_weighted_mean_of_the_cells(self):
+        df = panel((10, 14, 18))
+        eff, _, inf, cohort = parts(df)
+        post = [c for c in eff if c[1] >= c[0]]
+        est, _, _ = REF.aggregate(post, eff, inf, cohort)
+        assert est == pytest.approx(float(np.mean([eff[c] for c in post])), abs=1e-12)
+
+    def test_supplied_weights_are_the_ones_used(self):
+        """PPSCM aggregates cohorts by size, so the reference has to accept the
+        weights it is handed. Its own default is an unweighted mean over cells,
+        and the two coincide only when every cohort is the same size."""
+        df = panel((10, 14, 18))
+        eff, _, inf, cohort = parts(df)
+        post = [c for c in eff if c[1] >= c[0]]
+        w = np.linspace(1.0, 2.0, len(post))
+        w = w / w.sum()
+        est, _, _ = REF.aggregate(post, eff, inf, cohort, weights=w)
+        assert est == pytest.approx(
+            float(np.array([eff[c] for c in post]) @ w), abs=1e-12)
+
+    def test_multiplier_draws_are_mean_zero_and_unit_variance(self):
+        """Mammen weights: mean 0, variance 1, third moment 1."""
+        rng = np.random.default_rng(0)
+        psi = rng.normal(size=200) / 200
+        draws = REF.multiplier_bootstrap(psi, n_boot=20000, seed=1)
+        scale = float(np.sqrt((psi ** 2).sum()))
+        assert abs(float(draws.mean())) < 0.05 * scale
+        assert float(draws.std()) == pytest.approx(scale, rel=0.05)
+
+
+# =========================================================================== #
+# 2. its restrictions are enforced, not assumed
+# =========================================================================== #
+class TestRestrictions:
+    def test_an_unbalanced_panel_is_refused(self):
+        df = panel((10, 14)).drop(index=5)
+        with pytest.raises(ValueError, match="balanced"):
+            REF.group_time_att(df, "y", "id", "time", "first_treat")
+
+    def test_a_panel_with_no_never_treated_unit_is_refused(self):
+        df = panel((10, 14))
+        df["first_treat"] = df["first_treat"].replace(0, 14)
+        df["d"] = (df["time"] >= df["first_treat"]).astype(int)
+        with pytest.raises(ValueError, match="never-treated"):
+            REF.group_time_att(df, "y", "id", "time", "first_treat")
+
+    def test_it_records_the_upstream_it_came_from(self):
+        assert REF.DIFF_DIFF_VERSION == "3.9.0"
+        assert REF.DIFF_DIFF_COMMIT == "d9cd475fec8e67ceea1772896e2b29501cb90485"
+
+    def test_the_provenance_file_agrees_with_the_module(self):
+        """Two records of the same pin, so a half-done refresh is visible."""
+        import json
+        prov = json.loads((_REF_PATH.parent / "provenance.json").read_text())
+        assert prov["upstream"]["version"] == REF.DIFF_DIFF_VERSION
+        assert prov["upstream"]["commit"] == REF.DIFF_DIFF_COMMIT
+
+    def test_the_licence_travels_with_the_code(self):
+        licence = (_REF_PATH.parent / "LICENSE.diff-diff").read_text()
+        assert "MIT" in licence
+        assert "Permission is hereby granted" in licence
+
+
+# =========================================================================== #
+# 3. parity with the upstream it was transcribed from
+# =========================================================================== #
+@needs_diff_diff
+class TestParityWithUpstream:
+    @pytest.mark.parametrize("onsets,k,seed", SHAPES)
+    def test_group_time_effects_and_standard_errors_match(self, onsets, k, seed):
+        df = panel(onsets, k, seed=seed)
+        eff, ses, _, _ = parts(df)
+        up = CallawaySantAnna(control_group="never_treated",
+                              estimation_method="dr", n_bootstrap=0).fit(
+            df, outcome="y", unit="id", time="time", first_treat="first_treat")
+        common = [c for c in eff if c in up.group_time_effects and c[1] >= c[0]]
+        assert common
+        for c in common:
+            assert eff[c] == pytest.approx(up.group_time_effects[c]["effect"], abs=1e-12)
+            assert ses[c] == pytest.approx(up.group_time_effects[c]["se"], abs=1e-12)
+
+    @pytest.mark.parametrize("onsets,k,seed", SHAPES)
+    def test_aggregated_estimate_and_standard_error_match(self, onsets, k, seed):
+        df = panel(onsets, k, seed=seed)
+        eff, _, inf, cohort = parts(df)
+        post = [c for c in eff if c[1] >= c[0]]
+        est, se, _ = REF.aggregate(post, eff, inf, cohort)
+        up = CallawaySantAnna(control_group="never_treated",
+                              estimation_method="dr", n_bootstrap=0).fit(
+            df, outcome="y", unit="id", time="time", first_treat="first_treat")
+        assert est == pytest.approx(float(up.att), abs=1e-12)
+        assert se == pytest.approx(float(up.se), abs=1e-12)

--- a/mlsynth/utils/ppscm_helpers/config.py
+++ b/mlsynth/utils/ppscm_helpers/config.py
@@ -123,10 +123,28 @@ class PPSCMConfig(BaseEstimatorConfig):
     inference_method: str = Field(
         default="jackknife",
         description=(
-            "Inference procedure: 'jackknife' (delete-one, refit per unit) or "
+            "Inference procedure: 'jackknife' (delete-one, refit per unit), "
             "'bootstrap' (augsynth's default Mammen wild/multiplier bootstrap; "
-            "reweights the single fit, no refit). The augsynth multisynth "
-            "vignette prints the bootstrap SEs."
+            "reweights the single fit, no refit), or 'influence_function' "
+            "(Callaway-Sant'Anna's analytical standard errors, one pass over the "
+            "panel and no refit). The augsynth multisynth vignette prints the "
+            "bootstrap SEs. 'influence_function' is the interval that goes with "
+            "the Callaway-Sant'Anna point estimate, and its derivation assumes "
+            "the three conventions that produce that estimate, so it is "
+            "available only with donor_weights='uniform', "
+            "base_period='pre_treatment', donor_pool='never_treated' and "
+            "fixedeff=True; method='callaway_santanna' selects it."
+        ),
+    )
+    cband: bool = Field(
+        default=False,
+        description=(
+            "Tabulate a simultaneous (uniform) band over event-time horizons "
+            "alongside the pointwise one, by Mammen multiplier bootstrap on the "
+            "influence functions. One critical value covers every horizon at "
+            "1 - alpha, which is the level a reader assumes when they read the "
+            "path as a path; the pointwise band read that way covers less. Needs "
+            "inference_method='influence_function'. Off by default."
         ),
     )
     n_boot: int = Field(
@@ -252,14 +270,56 @@ class PPSCMConfig(BaseEstimatorConfig):
                 object.__setattr__(self, "base_period", "pre_treatment")
             if "donor_pool" not in fields:
                 object.__setattr__(self, "donor_pool", "never_treated")
+            # The preset names an estimator, and an estimator is a point
+            # estimate and an interval. It is selected only where the three
+            # conventions actually landed on Callaway-Sant'Anna, so an explicit
+            # convention alongside the preset does not turn into a
+            # configuration error about a field the caller never set.
+            if ("inference_method" not in fields
+                    and self.donor_weights == "uniform"
+                    and self.base_period == "pre_treatment"
+                    and self.donor_pool == "never_treated"
+                    and self.fixedeff):
+                object.__setattr__(self, "inference_method", "influence_function")
         return self
 
     @model_validator(mode="after")
     def _check_inference_method(self):
-        if self.inference_method not in ("jackknife", "bootstrap"):
+        if self.inference_method not in ("jackknife", "bootstrap",
+                                         "influence_function"):
             raise MlsynthConfigError(
-                "inference_method must be 'jackknife' or 'bootstrap'; got "
+                "inference_method must be 'jackknife', 'bootstrap' or "
+                f"'influence_function'; got {self.inference_method!r}.")
+        if self.inference_method == "influence_function":
+            required = {"donor_weights": "uniform",
+                        "base_period": "pre_treatment",
+                        "donor_pool": "never_treated"}
+            wrong = [f"{k}={getattr(self, k)!r} (needs {v!r})"
+                     for k, v in required.items() if getattr(self, k) != v]
+            if not self.fixedeff:
+                wrong.append("fixedeff=False (needs True)")
+            if wrong:
+                raise MlsynthConfigError(
+                    "inference_method='influence_function' is the "
+                    "Callaway-Sant'Anna standard error, and its derivation "
+                    "assumes the conventions that produce their point estimate: "
+                    "equal donor weights against a never-treated comparison "
+                    "group, normalised on the period before adoption. "
+                    + "; ".join(wrong) + ". Solved SCM weights carry an "
+                    "estimation term of their own and a not-yet-treated pool "
+                    "changes composition over time, so the formula does not "
+                    "apply; use inference_method='jackknife' or 'bootstrap' "
+                    "there.")
+        if self.cband and self.inference_method != "influence_function":
+            raise MlsynthConfigError(
+                "cband tabulates its simultaneous critical value from the "
+                "Callaway-Sant'Anna influence functions, so it needs "
+                "inference_method='influence_function'; got "
                 f"{self.inference_method!r}.")
+        if self.cband and not self.run_inference:
+            raise MlsynthConfigError(
+                "cband needs run_inference=True: with inference off there are "
+                "no influence functions to tabulate a critical value from.")
         if self.cumulative_band and not self.run_inference:
             raise MlsynthConfigError(
                 "cumulative_band needs run_inference=True: the band is built "

--- a/mlsynth/utils/ppscm_helpers/cs_inference.py
+++ b/mlsynth/utils/ppscm_helpers/cs_inference.py
@@ -1,0 +1,7 @@
+"""Skeleton for #469. The signature exists so the suite collects; nothing is
+implemented, so every claim about the interval fails on its own terms."""
+
+
+def influence_function_inference(*args, **kwargs):
+    raise NotImplementedError(
+        "Callaway-Sant'Anna influence-function inference is not built yet (#469).")

--- a/mlsynth/utils/ppscm_helpers/cs_inference.py
+++ b/mlsynth/utils/ppscm_helpers/cs_inference.py
@@ -1,7 +1,320 @@
-"""Skeleton for #469. The signature exists so the suite collects; nothing is
-implemented, so every claim about the interval fails on its own terms."""
+"""Callaway-Sant'Anna influence-function inference for PPSCM's ``callaway_santanna`` mode.
+
+PPSCM reaches the Callaway-Sant'Anna estimator exactly once three conventions
+are aligned -- uniform donor weights, a ``g-1`` baseline and a never-treated
+donor pool (#465). An equal point estimate does not make an equal interval, so
+the interval has to be theirs too, and PPSCM's delete-one jackknife is not.
+
+Under those conventions each cell is a two-period, two-group difference in
+differences, and Callaway and Sant'Anna (2021, JoE 225(2):200-230, Sec. 4) give
+its influence function in closed form::
+
+    ATT(g, t) = mean_{i in G_g}(Y_it - Y_{i,g-1}) - mean_{i in C}(Y_it - Y_{i,g-1})
+    phi_i     =  (Delta_i - mu_treated) / n_g       for i in G_g
+    phi_i     = -(Delta_i - mu_control) / n_C       for i in C
+    se        = sqrt(sum_i phi_i^2)
+
+so a standard error costs one pass over the panel instead of one refit per unit.
+
+What PPSCM aggregates
+---------------------
+
+PPSCM's event study averages cohorts by size at each horizon and then averages
+horizons::
+
+    theta_h = sum_{k in K_h} pg_k ATT(g_k, g_k + h) / S_h,   S_h = sum_{k in K_h} pg_k
+    theta   = mean_h theta_h
+
+with ``pg_k`` the share of the panel in cohort ``k`` and ``K_h`` the cohorts
+observed at horizon ``h``. That is Callaway-Sant'Anna's dynamic aggregation
+followed by an average over event time, and it coincides with their simple
+aggregation when every cohort is the same size and reaches every horizon.
+
+The group shares ``pg`` are themselves estimated, so the aggregate's variance
+carries their sampling error through the delta method::
+
+    d theta_h / d pg_j = (ATT(g_j, g_j + h) - theta_h) / S_h
+
+giving the weight-influence term ``did::aggte`` calls ``wif``::
+
+    psi_h,i = sum_{k in K_h} w_k,h phi_i^(k,h)
+            + sum_{k in K_h} (1{G_i = g_k} - pg_k) (ATT(g_k, g_k+h) - theta_h) / (S_h n)
+    psi_i   = mean_h psi_h,i
+    se      = sqrt(sum_i psi_i^2)
+
+Omitting the second term leaves a standard error that is finite, plausible and
+too small, which is why the vendored reference
+(``benchmarks/reference/ppscm_cs/reference.py``) pins it and a test compares
+against a version with the term deleted.
+
+Bands
+-----
+
+The pointwise band is ``theta_h +- z_{alpha/2} se_h``. The uniform band shares
+one critical value across horizons, tabulated by Mammen multiplier bootstrap on
+the influence functions::
+
+    B_b,h = sum_i v_b,i psi_h,i,        c = quantile_{1-alpha} max_h |B_b,h| / se_h
+
+No refit is involved: the multipliers act on the influence functions the point
+estimate already produced. Reading an event-study path ("positive by horizon
+three and never back") is a statement about every horizon at once, which the
+pointwise band does not cover at the stated level and the uniform band does.
+
+Restrictions
+------------
+
+The influence function above is the one for uniform weights against a
+never-treated comparison group with a ``g-1`` baseline. Solved SCM weights are
+estimated too and contribute their own term; a not-yet-treated pool changes the
+comparison group's composition over time. Outside the three conventions this
+mode is wrong, not approximate, so the configuration refuses it
+(:class:`mlsynth.config_models.PPSCMConfig`) and this module raises on the data
+conditions the configuration cannot see.
+
+No refit happens here, which is why #467 does not reach this path: the
+influence functions are read off the fit that produced the point estimate,
+so there is no second estimator to disagree with.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+from scipy.stats import norm
+
+from ...exceptions import MlsynthDataError
+
+#: Mammen (1993) two-point multipliers: mean 0, variance 1, third moment 1 --
+#: the same distribution ``did::mboot`` and PPSCM's wild bootstrap draw from.
+_KAPPA = (np.sqrt(5.0) + 1.0) / 2.0
+_PROB = (np.sqrt(5.0) + 1.0) / (2.0 * np.sqrt(5.0))
 
 
-def influence_function_inference(*args, **kwargs):
-    raise NotImplementedError(
-        "Callaway-Sant'Anna influence-function inference is not built yet (#469).")
+@dataclass(frozen=True)
+class CSInfluenceResult:
+    """Everything one pass over the panel produces.
+
+    Attributes
+    ----------
+    se : float
+        Standard error of the aggregate ATT, including the weight-influence term.
+    ci : tuple of float
+        Wald interval around the estimator's own point estimate at ``1 - alpha``.
+    per_time_se, per_time_ci : numpy.ndarray
+        Per-horizon standard errors, shape ``(H,)``, and the pointwise band,
+        shape ``(H, 2)``. ``NaN`` at horizons no cohort reaches.
+    group_time_att, group_time_se : dict
+        ``ATT(g, t)`` and its standard error, keyed by the public
+        ``(adoption time, time)`` labels -- the cells the aggregate is built from.
+    pointwise_band, uniform_band : numpy.ndarray or None
+        Both ``(H, 2)``. ``pointwise_band`` repeats ``per_time_ci``; placing them
+        on one object is what makes the pair comparable. ``uniform_band`` is
+        ``None`` unless a simultaneous band was asked for.
+    critical_value : float
+        The multiplier behind ``uniform_band``; the normal quantile when no
+        simultaneous band was tabulated.
+    influence : numpy.ndarray
+        Per-unit, per-horizon influence functions, shape ``(n, H)``. The object
+        every quantity above is a functional of.
+    replicate_paths : numpy.ndarray or None
+        Multiplier-bootstrap draws of the per-horizon path, shape
+        ``(n_boot, H)``, on the estimator's scale. ``None`` when no draws were
+        taken.
+    """
+
+    se: float
+    ci: Tuple[float, float]
+    per_time_se: np.ndarray
+    per_time_ci: np.ndarray
+    group_time_att: Dict[Tuple[Any, Any], float]
+    group_time_se: Dict[Tuple[Any, Any], float]
+    pointwise_band: np.ndarray
+    uniform_band: Optional[np.ndarray]
+    critical_value: float
+    influence: np.ndarray
+    replicate_paths: Optional[np.ndarray]
+
+
+def _cohort_structure(fit: Dict[str, Any]):
+    """Collapse the fit's groups to Callaway-Sant'Anna cohorts.
+
+    PPSCM groups by treated unit unless ``time_cohort`` is set, while a
+    Callaway-Sant'Anna cell is indexed by adoption time. Units sharing an
+    adoption time are one cell either way, so the regrouping here is what makes
+    the two indexings the same object; donor eligibility depends only on the
+    adoption time, so the pools merge without ambiguity.
+    """
+    adopt_of, members, donors = fit["adopt_of"], fit["members"], fit["donors"]
+    units: Dict[int, list] = {}
+    pools: Dict[int, np.ndarray] = {}
+    for g in fit["groups"]:
+        tj = int(adopt_of[g])
+        units.setdefault(tj, []).extend(int(i) for i in members[g])
+        pools.setdefault(tj, np.asarray(donors[g], dtype=int))
+    cohorts = sorted(units)
+    return (cohorts,
+            [np.asarray(sorted(units[tj]), dtype=int) for tj in cohorts],
+            [pools[tj] for tj in cohorts])
+
+
+def _cell(resid: np.ndarray, mem: np.ndarray, don: np.ndarray, col: int):
+    """One cell's estimate and its two influence-function blocks.
+
+    ``resid`` is the fixed-effect-removed matrix for this cohort, so with the
+    ``pre_treatment`` baseline ``resid[i, col]`` is ``Y_i,col - Y_i,g-1`` up to a
+    time effect common to every unit. That common term drops out of both the
+    difference in means and the deviations below, so the cell computed here is
+    the raw-outcome difference in differences.
+    """
+    d_tr = resid[mem, col]
+    d_co = resid[don, col]
+    mu_t = float(d_tr.mean())
+    mu_c = float(d_co.mean())
+    return (mu_t - mu_c,
+            (d_tr - mu_t) / mem.size,
+            -(d_co - mu_c) / don.size)
+
+
+def influence_function_inference(
+    fit: Dict[str, Any], time_labels: np.ndarray, *,
+    alpha: float, att_full: float, per_time_full: np.ndarray,
+    n_boot: int = 1000, seed: int = 0, cband: bool = False,
+    want_paths: bool = False,
+) -> CSInfluenceResult:
+    """Analytical Callaway-Sant'Anna standard errors for a fitted PPSCM CS mode.
+
+    Parameters
+    ----------
+    fit : dict
+        The dictionary :func:`mlsynth.utils.ppscm_helpers.engine.run_multisynth`
+        returns, fitted under the Callaway-Sant'Anna conventions.
+    time_labels : numpy.ndarray
+        The panel's sorted time labels; the cell dictionaries are keyed by these
+        and not by column positions, so a caller reads ``(2014, 2017)`` and not
+        ``(9, 12)``.
+    alpha : float
+        Miscoverage level. Keyword-only.
+    att_full, per_time_full : float and numpy.ndarray
+        The estimator's own point estimates. The bands are centred on these, so
+        the interval belongs to the number the estimator reports.
+    n_boot, seed : int
+        Multiplier-bootstrap draws and their seed; used only when a simultaneous
+        band or replicate paths are asked for.
+    cband : bool
+        Tabulate the simultaneous critical value and return ``uniform_band``.
+    want_paths : bool
+        Return the bootstrap draws of the per-horizon path, which a cumulative
+        band consumes.
+
+    Returns
+    -------
+    CSInfluenceResult
+
+    Raises
+    ------
+    MlsynthDataError
+        If a cohort has no admissible donor, or if no cell is estimable.
+    """
+    res = fit["res"]
+    n = int(fit["n"])
+    H = int(fit["n_leads"])
+    cohorts, members, donors = _cohort_structure(fit)
+    K = len(cohorts)
+
+    empty = [time_labels[tj] for tj, don in zip(cohorts, donors) if don.size == 0]
+    if empty:
+        raise MlsynthDataError(
+            "Callaway-Sant'Anna inference needs a non-empty comparison group for "
+            f"every cohort; cohort(s) {empty} have no admissible donor. With "
+            "donor_pool='never_treated' this means the panel has no "
+            "never-treated unit.")
+
+    cohort_of = np.full(n, -1, dtype=int)
+    for k, mem in enumerate(members):
+        cohort_of[mem] = k
+    n1 = np.array([mem.size for mem in members], dtype=float)
+    pg = n1 / float(n)
+
+    # ---- cells: ATT(g, t) and its standard error -------------------------- #
+    att_cell = np.full((K, H), np.nan)
+    se_cell = np.full((K, H), np.nan)
+    group_time_att: Dict[Tuple[Any, Any], float] = {}
+    group_time_se: Dict[Tuple[Any, Any], float] = {}
+    for k, tj in enumerate(cohorts):
+        resid = res[tj]
+        T = resid.shape[1]
+        for h in range(H):
+            col = tj + h
+            if col >= T:
+                continue
+            att, inf_t, inf_c = _cell(resid, members[k], donors[k], col)
+            att_cell[k, h] = att
+            se_cell[k, h] = float(np.sqrt((inf_t ** 2).sum() + (inf_c ** 2).sum()))
+            key = (time_labels[tj], time_labels[col])
+            group_time_att[key] = att
+            group_time_se[key] = se_cell[k, h]
+    if not group_time_att:
+        raise MlsynthDataError(
+            "Callaway-Sant'Anna inference found no estimable (g, t) cell: every "
+            "cohort adopts at or after the last observed period.")
+
+    # ---- per-horizon influence functions ---------------------------------- #
+    influence = np.full((n, H), np.nan)
+    theta = np.full(H, np.nan)
+    for h in range(H):
+        keep = np.flatnonzero(np.isfinite(att_cell[:, h]))
+        if keep.size == 0:
+            continue
+        S = float(pg[keep].sum())
+        w = pg[keep] / S
+        a = att_cell[keep, h]
+        theta[h] = float(w @ a)
+        psi = np.zeros(n)
+        for j, k in enumerate(keep):
+            _, inf_t, inf_c = _cell(res[cohorts[k]], members[k], donors[k],
+                                    cohorts[k] + h)
+            psi[members[k]] += w[j] * inf_t
+            psi[donors[k]] += w[j] * inf_c
+        # The group shares are estimated, so their sampling error enters too.
+        indicator = (cohort_of[:, None] == keep[None, :]).astype(float)
+        psi += ((indicator - pg[keep][None, :]) @ (a - theta[h])) / (S * n)
+        influence[:, h] = psi
+
+    finite = np.isfinite(theta)
+    per_time_se = np.where(
+        finite, np.sqrt((np.nan_to_num(influence) ** 2).sum(axis=0)), np.nan)
+    psi_agg = np.nanmean(influence[:, finite], axis=1)
+    se = float(np.sqrt((psi_agg ** 2).sum()))
+
+    z = float(norm.ppf(1.0 - alpha / 2.0))
+    per_time_full = np.asarray(per_time_full, dtype=float)
+    pointwise = np.column_stack([per_time_full - z * per_time_se,
+                                 per_time_full + z * per_time_se])
+    ci = (float(att_full) - z * se, float(att_full) + z * se)
+
+    # ---- multiplier bootstrap: simultaneous band and replicate paths ------ #
+    critical_value = z
+    uniform: Optional[np.ndarray] = None
+    paths: Optional[np.ndarray] = None
+    if cband or want_paths:
+        rng = np.random.default_rng(seed)
+        V = np.where(rng.random((int(n_boot), n)) < _PROB, 1.0 - _KAPPA, _KAPPA)
+        draws = V @ np.nan_to_num(influence)
+        paths = per_time_full[None, :] + draws
+        if cband:
+            scaled = np.abs(draws[:, finite]) / per_time_se[finite][None, :]
+            critical_value = float(np.quantile(np.max(scaled, axis=1), 1.0 - alpha))
+            uniform = np.column_stack([
+                per_time_full - critical_value * per_time_se,
+                per_time_full + critical_value * per_time_se])
+
+    return CSInfluenceResult(
+        se=se, ci=ci, per_time_se=per_time_se, per_time_ci=pointwise,
+        group_time_att=group_time_att, group_time_se=group_time_se,
+        pointwise_band=pointwise, uniform_band=uniform,
+        critical_value=critical_value, influence=influence,
+        replicate_paths=paths,
+    )

--- a/mlsynth/utils/ppscm_helpers/structures.py
+++ b/mlsynth/utils/ppscm_helpers/structures.py
@@ -164,6 +164,30 @@ class PPSCMInference:
     replicate_paths: Optional[np.ndarray] = None
     # Simultaneous band for the running total; ``None`` unless asked for.
     cumulative: Optional["PPSCMCumulativeBand"] = None
+    # ---- Callaway-Sant'Anna influence-function inference ------------------ #
+    # Populated only by ``method="influence_function"``; ``None`` for the
+    # jackknife and the bootstrap, which produce no per-cell quantities.
+    #
+    # ``ATT(g, t)`` and its standard error, keyed by the public
+    # ``(adoption time, time)`` labels. The aggregate is a weighted mean of
+    # these cells, so a reader who disagrees with the aggregation can rebuild it.
+    group_time_att: Optional[Dict[Tuple[Any, Any], float]] = None
+    group_time_se: Optional[Dict[Tuple[Any, Any], float]] = None
+    # Two bands on the same event-time path, ``(H, 2)`` each. ``pointwise_band``
+    # covers one horizon at the stated level; ``uniform_band`` covers all of
+    # them at once and is therefore never narrower. Reading a path -- "positive
+    # by horizon three and never back" -- is a statement about every horizon, so
+    # the pair is placed together to make the difference visible.
+    # ``uniform_band`` is ``None`` unless ``cband`` asked for it.
+    pointwise_band: Optional[np.ndarray] = None
+    uniform_band: Optional[np.ndarray] = None
+    # The multiplier behind ``uniform_band``; the normal quantile when none was
+    # tabulated.
+    critical_value: Optional[float] = None
+    # Per-unit, per-horizon influence functions, ``(n, H)`` -- the object every
+    # quantity above is a functional of, kept so an aggregation the estimator
+    # does not offer can still be given a standard error.
+    influence: Optional[np.ndarray] = None
 
 
 @dataclass(frozen=True)

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1075,3 +1075,68 @@ timeout = 2400.0
   find = "    if nu is not None and not np.isfinite(nu):"
   replace = "    if nu is not None and not np.isfinite(nu) and False:"
   models = "the finiteness guard removed, so NaN multiplies the pooled term and CVXPY reports a non-DCP objective instead of the library naming the input. The solver's message does not mention nu, which is why the original failure was read as a solver problem"
+[[target]]
+name = "cs-influence-function"
+module-path = "mlsynth/utils/ppscm_helpers/cs_inference.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_callaway_santanna.py mlsynth/tests/test_ppscm_cs_reference.py -q -p no:cacheprovider"
+timeout = 1800.0
+
+  [[target.mutant]]
+  id = "weight-influence-term-dropped"
+  find = "        psi += ((indicator - pg[keep][None, :]) @ (a - theta[h])) / (S * n)"
+  replace = "        psi += 0.0 * ((indicator - pg[keep][None, :]) @ (a - theta[h]))"
+  models = "the cohort shares treated as known when they are estimated from the same panel. The standard error that comes back is finite, is smaller than the truth, and is smaller by an amount nothing in the point estimate reveals -- which is why did::aggte carries the term and why the vendored reference computes it twice, once with and once without"
+
+  [[target.mutant]]
+  id = "weight-influence-term-not-centred-on-its-own-horizon"
+  find = "        psi += ((indicator - pg[keep][None, :]) @ (a - theta[h])) / (S * n)"
+  replace = "        psi += ((indicator - pg[keep][None, :]) @ a) / (S * n)"
+  models = "the delta-method derivative losing its centring. d(theta_h)/d(pg_j) is (ATT_jh - theta_h)/S_h, and dropping theta_h leaves a term that does not vanish when every cohort has the same effect -- the one case where the shares cannot matter"
+
+  [[target.mutant]]
+  id = "cohorts-weighted-equally-instead-of-by-size"
+  find = "        w = pg[keep] / S"
+  replace = "        w = np.full(keep.size, 1.0 / keep.size)"
+  models = "Callaway-Sant'Anna's simple aggregation substituted for their dynamic one. The two coincide exactly when every cohort is the same size, which is every hand-written panel in the identity suite, so this is invisible until a cohort split is deliberately unbalanced"
+
+  [[target.mutant]]
+  id = "group-share-taken-among-the-treated-only"
+  find = "    pg = n1 / float(n)"
+  replace = "    pg = n1 / n1.sum()"
+  models = "the cohort share measured against the treated instead of the panel. The aggregation weights are a ratio of shares and do not move, so the point estimate is untouched; only the weight-influence term's scale changes, and it changes by the square of the treated fraction"
+
+  [[target.mutant]]
+  id = "comparison-group-enters-with-the-treated-sign"
+  find = "            -(d_co - mu_c) / don.size)"
+  replace = "            (d_co - mu_c) / don.size)"
+  models = "the comparison group's influence contributions flipped, which turns each cell from a difference in differences into a sum. Nothing numeric can see it: a per-cell standard error is a sum of squares; the treated and control blocks sit on disjoint units; each cell's control influence sums to zero; and the weight-influence term is one constant across never-treated units, so the aggregate changes by 4c * sum_i A_i = 0. Measured, the influence matrix moves by 1.36e-01 and every reported number is bit-identical. It is caught only by asserting the sign convention on the exposed influence array, which is public and documented as what a caller re-aggregates"
+
+  [[target.mutant]]
+  id = "comparison-group-contributes-no-variance"
+  find = "            se_cell[k, h] = float(np.sqrt((inf_t ** 2).sum() + (inf_c ** 2).sum()))"
+  replace = "            se_cell[k, h] = float(np.sqrt((inf_t ** 2).sum()))"
+  models = "the never-treated group's sampling error omitted from the cell, as if the comparison mean were a known constant. With many controls and few treated the term is small, which is what makes it easy to leave out and hard to see"
+
+  [[target.mutant]]
+  id = "horizons-summed-instead-of-averaged"
+  find = "    psi_agg = np.nanmean(influence[:, finite], axis=1)"
+  replace = "    psi_agg = np.nansum(influence[:, finite], axis=1)"
+  models = "the aggregate influence function summed over event time while the point estimate averages. The standard error is then H times too large and the interval covers at a level nobody asked for -- conservative, so no coverage test would complain"
+
+  [[target.mutant]]
+  id = "simultaneous-critical-value-taken-on-the-raw-scale"
+  find = "            scaled = np.abs(draws[:, finite]) / per_time_se[finite][None, :]"
+  replace = "            scaled = np.abs(draws[:, finite])"
+  models = "the sup taken over unstandardised draws, so the horizon with the largest standard error sets the critical value for all of them. The multiplier is then in outcome units and the band it builds is not simultaneous at the stated level for any horizon but that one"
+
+  [[target.mutant]]
+  id = "simultaneous-band-uses-the-lower-tail"
+  find = "            critical_value = float(np.quantile(np.max(scaled, axis=1), 1.0 - alpha))"
+  replace = "            critical_value = float(np.quantile(np.max(scaled, axis=1), alpha))"
+  models = "the critical value read off the wrong tail. A uniform band narrower than the pointwise one is incoherent, and the only thing that says so is a test that compares the two widths"
+
+  [[target.mutant]]
+  id = "multiplier-law-loses-its-moments"
+  find = "_PROB = (np.sqrt(5.0) + 1.0) / (2.0 * np.sqrt(5.0))"
+  replace = "_PROB = 0.5"
+  models = "Mammen's two probabilities replaced by a coin flip, keeping his two values. The law's mean goes to 0.5 and its variance to 1.25, and neither is visible downstream: the influence function sums to zero across units, so a non-zero multiplier mean contributes nothing, and the variance error only inflates the simultaneous critical value by about twelve percent -- a band that is wider than the pointwise one either way. Only the moments themselves catch it"


### PR DESCRIPTION
Closes #469. Second half of #465; #466 delivered the point estimate.

Asking `method="callaway_santanna"` for inference gave PPSCM's delete-one jackknife — a different procedure, under a name that means something specific. This adds `inference_method="influence_function"`, which the preset now selects.

## Why not the jackknife

`diff-diff`'s `CallawaySantAnna` has no jackknife. Its inference is influence functions plus a Mammen multiplier bootstrap; the README's JK1/JKn are survey replicate weights on an unrelated path. So a CS-mode jackknife cannot be cross-validated even in principle, while the influence function pins to machine precision.

## What it computes

Under those conventions each cell is a two-period two-group DiD with a closed-form influence function, so a standard error costs one pass over the panel where the jackknife costs one refit per unit. The test file went from **2:24 to 16s**.

PPSCM averages cohorts by size at each horizon and then averages horizons — Callaway-Sant'Anna's *dynamic* aggregation followed by an average over event time, not their simple one. Those coincide when every cohort is the same size and reaches every horizon, which every hand-written test panel does, so they are separated by a test with deliberately unbalanced cohorts. Handed the same cohort-share weights, the reference reproduces the estimate and the standard error exactly at `(2,5,3)`, `(1,6,3)` and `(4,1,2)`.

The group shares are estimated from the same panel, so the aggregate carries their sampling error through `d theta_h / d pg_j = (ATT_jh - theta_h) / S_h` — the term `did::aggte` calls `wif`. The suite computes the aggregate both ways and pins the difference, because dropping it leaves a standard error that is finite, plausible and too small.

`cband=True` tabulates a simultaneous band from the influence functions with one critical value across horizons. No refit: the multipliers act on what the point estimate already produced.

Outside the four conventions the derivation assumes — uniform weights, `g-1` baseline, never-treated pool, two-way fixed effects — the formula is wrong and not approximate, so the config refuses it and names the convention that broke it. The preset stands down where a convention was set explicitly, since that is a coherent question whose answer is the jackknife.

## Verification

| | |
|---|---|
| per-cell ATT vs reference | `0.0` |
| per-cell SE vs reference | `0.0` |
| aggregate SE vs reference | `5.55e-17` |
| PPSCM suite | 342 passed, 1 skipped |
| `xfail(strict=True)` markers left | **0** |

The oracle is the vendored transcription of `diff-diff` 3.9.0 at `d9cd475`, so every claim is enforced wherever the suite runs; the installed package corroborates separately. The reference carries 39 tests holding it to its own terms — each cell a 2×2 DiD, each influence function summing to zero, the aggregate SE strictly exceeding the one that forgets the weights were estimated — because a vendored copy checked only against what it copies has no independent standing, and its realistic failure is being edited later to agree with mlsynth.

## The mutant that needed a better assertion

Five mutants. Four died immediately; one survived, and measuring it rather than assuming equivalence is what made it interesting.

Flipping the comparison group's sign turns each cell from a difference in differences into a **sum**, and no reported number moves:

```
max |psi difference|  : 1.364629e-01     the object changes
||psi|| per horizon   : 0.283303153753   bit-identical, both ways
```

Provably so: the treated and control blocks sit on disjoint units, each cell's control influence sums to zero, and the `wif` term is one constant across never-treated units, so the sum of squares changes by `4c * sum_i A_i = 0`.

That is not an equivalent mutant, because `influence` is exposed and documented as what a caller re-aggregates — a consumer building their own aggregation would get the control block backwards while every standard error looked right. So the verdict is that the assertions were too weak, and there is now a test pinning the sign against hand-computed control deviations on a single-cohort panel where `wif` is exactly zero. It kills the mutant.

## Commits

Written test-first, and the history shows it: the oracle, then the tests committed **red**, then the implementation. Two tests exist because an earlier red run caught them passing for the wrong reason — one matched pydantic's unknown-field message instead of the guard, and one asserted an empty horizon that the panel's arithmetic could never produce.

## Docs

Not here. #470 tracks the doc page, including the estimation half #466 shipped undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_