### PR TITLE
Derive the Callaway-Sant'Anna equivalence, and correct what it replaces

### DIFF
--- a/benchmarks/cases/ppscm_cs_real_panels.py
+++ b/benchmarks/cases/ppscm_cs_real_panels.py
@@ -28,6 +28,22 @@ synthetic fallback -- a network failure during a benchmark run -- would
 otherwise let this case report real-data agreement against generated data,
 which is the failure mode #473 was about.
 
+Which estimator these panels justify
+------------------------------------
+This case validates PPSCM's ``callaway_santanna`` mode, and only that mode, on
+these panels. Difference in differences is a large-N, short-T estimator, and
+``mpdta`` is exactly that shape: 4 pre-periods against 309 never-treated
+donors, N0/T0 = 77, with 480 donors carrying weight in the window pool. The
+partially-pooled program there fits 480 free parameters to 4 balance
+constraints and reaches a global imbalance of 3.4e-06, which is interpolation
+and not fit. ``castle_doctrine`` at N0/T0 = 3.2 cannot drive its imbalance to
+zero (2.1e-02), which is what a determined problem looks like.
+
+So the agreement recorded below says the Callaway-Sant'Anna estimand is
+reachable from PPSCM and reached exactly, on the data the reference is
+validated against. It is not a comparison of PPSCM's default against
+Callaway-Sant'Anna, and a panel this short does not support one.
+
 The reference is ``diff_diff.CallawaySantAnna(control_group="never_treated",
 estimation_method="dr", n_bootstrap=0)`` run live on the same frame, so the
 target is the package's number and not a transcription of it.

--- a/benchmarks/cases/ppscm_cs_real_panels.py
+++ b/benchmarks/cases/ppscm_cs_real_panels.py
@@ -1,0 +1,240 @@
+"""Cross-validation: PPSCM's Callaway-Sant'Anna mode on ``diff-diff``'s own panels.
+
+The equivalence #465 established was measured on panels this repository
+generated. Agreement on synthetic data is agreement on a data-generating
+process someone here chose; this case runs it on the datasets the reference
+implementation validates against, including Callaway and Sant'Anna's own paper
+data.
+
+Provenance
+----------
+Datasets ship with ``diff-diff`` (Isaac Gerber, MIT) and are loaded from the
+installed package, so nothing is vendored and nothing can drift out of step
+with the reference:
+
+* ``mpdta`` -- the county teen-employment panel from Callaway & Sant'Anna
+  (2021), and the example dataset of R's ``did``. 500 counties x 5 years,
+  cohorts 2004/2006/2007, 309 never-treated.
+* ``castle_doctrine`` -- castle-doctrine laws, 50 states x 11 years, five
+  cohorts, 29 never-treated.
+* ``walmart`` -- fourteen cohorts, which is what exercises the cohort-share
+  weighting that a three- or five-cohort panel cannot. ``diff-diff`` sources it
+  by download and substitutes a synthetic panel of the same schema when the
+  host is unreachable, so it is a structural check and not a replication. Its
+  metrics carry that in their names.
+
+Every panel's ``attrs["source"]`` is pinned. A silent substitution of the
+synthetic fallback -- a network failure during a benchmark run -- would
+otherwise let this case report real-data agreement against generated data,
+which is the failure mode #473 was about.
+
+The reference is ``diff_diff.CallawaySantAnna(control_group="never_treated",
+estimation_method="dr", n_bootstrap=0)`` run live on the same frame, so the
+target is the package's number and not a transcription of it.
+
+What is compared, and on which cells
+------------------------------------
+PPSCM inherits augsynth's rule that the event study runs to the *last* cohort's
+horizon, ``n_leads = T - T_0``. On real staggered panels the last cohort tends
+to adopt at or near the final period, so that window is short: one lead on
+``mpdta`` and ``walmart``, two on ``castle_doctrine``. The comparison is
+therefore over the cells PPSCM estimates -- 3 of the 7 post-treatment cells
+Callaway-Sant'Anna report for ``mpdta``, 10 of 20 for ``castle_doctrine``,
+14 of 105 for ``walmart`` -- and the coverage fraction is reported as a metric
+so a change in the windowing rule shows up here.
+
+``mpdta`` also appears with its 2007 cohort dropped. That cohort adopts in the
+final period, so removing it moves the last adoption back to 2006 and widens
+the window to two leads; it is a subsample of the real panel, not a synthetic
+variant, and it exercises the multi-lead path on real data.
+
+The castle_doctrine residual
+----------------------------
+Its ``homicide_rate`` ships as ``float32`` while the other two panels are
+``float64``. As shipped, the two implementations promote to double at different
+points and agree to 4.5e-08 -- float32 epsilon against an ATT of 0.62 is
+7.4e-08, so that residual is the storage type and not a disagreement. Cast the
+column to ``float64`` and the same comparison closes to 1.1e-16. Both are
+measured below: ``castle_att_diff`` keeps the shipped dtype, and
+``castle_att_diff_float64`` pins the diagnosis.
+"""
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+
+from benchmarks.compare import BenchmarkSkipped
+
+_SPECS = {
+    "mpdta": ("load_mpdta", "countyreal", "year", "lemp", "first_treat"),
+    "castle": ("load_castle_doctrine", "state", "year", "homicide_rate", "first_treat"),
+    "walmart": ("load_walmart", "cid", "year", "log_retail_emp", "first_year"),
+}
+
+
+def _load(key: str) -> pd.DataFrame:
+    try:
+        import diff_diff
+    except ImportError as exc:                   # pragma: no cover - CI without it
+        raise BenchmarkSkipped(
+            "diff-diff is not installed; it supplies both the reference "
+            "implementation and the datasets for this case.") from exc
+    return getattr(diff_diff, _SPECS[key][0])()
+
+
+def _cs_cells(df, unit, time, y, ft):
+    """``diff-diff``'s per-cell estimates and standard errors, from a live fit."""
+    from diff_diff import CallawaySantAnna
+
+    fit = CallawaySantAnna(control_group="never_treated", estimation_method="dr",
+                           n_bootstrap=0).fit(df, outcome=y, unit=unit,
+                                              time=time, first_treat=ft)
+    eff = {c: float(v["effect"]) for c, v in fit.group_time_effects.items()}
+    ses = {c: float(v["se"]) for c, v in fit.group_time_effects.items()}
+    return eff, ses
+
+
+def _one(key: str, df: pd.DataFrame = None) -> Dict[str, Any]:
+    from mlsynth import PPSCM
+
+    _, unit, time, y, ft = _SPECS[key]
+    src = df.attrs.get("source") if df is not None else None
+    df = (_load(key) if df is None else df).copy()
+    if src is not None:
+        df.attrs["source"] = src
+    df["_d"] = ((df[ft] > 0) & (df[time] >= df[ft])).astype(int)
+
+    eff, ses = _cs_cells(df, unit, time, y, ft)
+    per = df.groupby(unit)[ft].first()
+    size = {g: int((per == g).sum()) for g in sorted(c for c in per.unique() if c > 0)}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = PPSCM({"df": df[[unit, time, y, "_d"]], "outcome": y, "treat": "_d",
+                     "unitid": unit, "time": time, "display_graphs": False,
+                     "method": "callaway_santanna", "run_inference": True}).fit()
+
+    leads = len(next(iter(res.per_unit.values())).tau)
+    cells = [(g, g + h) for g in size for h in range(leads) if (g, g + h) in eff]
+    w = np.array([size[g] for g, _ in cells], dtype=float)
+    w /= w.sum()
+    target = float(np.array([eff[c] for c in cells]) @ w)
+
+    gta, gse = res.inference_detail.group_time_att, res.inference_detail.group_time_se
+    return {
+        "source": str(df.attrs.get("source", "unknown")),
+        "att_diff": abs(float(res.att) - target),
+        "cell_att_diff": max(abs(gta[c] - eff[c]) for c in cells),
+        "cell_se_diff": max(abs(gse[c] - ses[c]) for c in cells
+                            if np.isfinite(ses[c])),
+        "leads": leads,
+        "cells": len(cells),
+        "post_cells": sum(1 for (g, t) in eff if t >= g),
+        "cohorts": len(size),
+    }
+
+
+def run() -> dict:
+    mpdta = _one("mpdta")
+    full = _load("mpdta")
+    trimmed = _one("mpdta", full[full.first_treat != 2007])
+    castle = _one("castle")
+    c64 = _load("castle")
+    c64["homicide_rate"] = c64["homicide_rate"].astype(np.float64)
+    castle64 = _one("castle", c64)
+    walmart = _one("walmart")
+
+    return {
+        "mpdta_att_diff": mpdta["att_diff"],
+        "mpdta_cell_att_diff": mpdta["cell_att_diff"],
+        "mpdta_cell_se_diff": mpdta["cell_se_diff"],
+        "mpdta_cells_covered": mpdta["cells"],
+        "mpdta_post_cells": mpdta["post_cells"],
+        "mpdta_trimmed_att_diff": trimmed["att_diff"],
+        "mpdta_trimmed_leads": trimmed["leads"],
+        "castle_att_diff": castle["att_diff"],
+        "castle_att_diff_float64": castle64["att_diff"],
+        "castle_cell_se_diff_float64": castle64["cell_se_diff"],
+        "many_cohort_att_diff": walmart["att_diff"],
+        "many_cohort_cell_se_diff": walmart["cell_se_diff"],
+        "many_cohort_cohorts": walmart["cohorts"],
+        "mpdta_is_authentic": int(mpdta["source"] == "callaway_santanna_mpdta"),
+        "castle_is_authentic": int(castle["source"] == "cheng_hoekstra_castle_data"),
+    }
+
+
+def comparison() -> dict:
+    """PPSCM's Callaway-Sant'Anna mode against ``diff-diff``, panel by panel.
+
+    Each row is a live ``CallawaySantAnna`` fit on the same frame, aggregated
+    over the cells PPSCM's event-study window covers with the cohort-share
+    weights PPSCM uses, against PPSCM's own aggregate. Raises
+    ``BenchmarkSkipped`` when ``diff-diff`` is absent, since it supplies the
+    reference and the data alike.
+    """
+    from mlsynth import PPSCM
+
+    rows: List[Dict[str, Any]] = []
+    jobs: List[Tuple[str, str, pd.DataFrame]] = []
+    full = _load("mpdta")
+    jobs.append(("mpdta", "mpdta", None))
+    jobs.append(("mpdta (2007 cohort dropped)", "mpdta",
+                 full[full.first_treat != 2007]))
+    jobs.append(("castle_doctrine (float32, as shipped)", "castle", None))
+    c64 = _load("castle")
+    c64["homicide_rate"] = c64["homicide_rate"].astype(np.float64)
+    jobs.append(("castle_doctrine (cast to float64)", "castle", c64))
+    jobs.append(("walmart (synthetic fallback here; structural check of 14-cohort weighting)", "walmart", None))
+
+    for label, key, frame in jobs:
+        m = _one(key, frame)
+        rows.append({"quantity": f"{label}/ATT abs diff",
+                     "mlsynth": float(f"{m['att_diff']:.3g}"), "reference": 0.0})
+        rows.append({"quantity": f"{label}/per-cell ATT abs diff",
+                     "mlsynth": float(f"{m['cell_att_diff']:.3g}"), "reference": 0.0})
+        rows.append({"quantity": f"{label}/per-cell SE abs diff",
+                     "mlsynth": float(f"{m['cell_se_diff']:.3g}"), "reference": 0.0})
+        rows.append({"quantity": f"{label}/cells covered",
+                     "mlsynth": m["cells"], "reference": m["post_cells"]})
+
+    return {
+        "rows": rows,
+        "mlsynth_call": {"estimator": "PPSCM",
+                         "config": {"method": "callaway_santanna",
+                                    "run_inference": True}},
+        "reference": {"impl": "diff_diff.CallawaySantAnna (live run)",
+                      "version": "diff-diff 3.9.0"},
+    }
+
+
+# Agreement is exact wherever both sides read float64: the estimators are the
+# same object on these conventions, so the only residual is arithmetic. The
+# castle_doctrine tolerance as shipped brackets float32 epsilon against an ATT
+# of 0.62 (7.4e-08), and the float64 row beside it shows that is the whole of
+# it. "cells covered" is a structural count, pinned exactly so a change to
+# augsynth's n_leads rule surfaces here instead of silently widening or
+# narrowing what was compared.
+EXPECTED = {
+    "mpdta_att_diff": (0.0, 1e-14),
+    "mpdta_cell_att_diff": (0.0, 1e-14),
+    "mpdta_cell_se_diff": (0.0, 1e-14),
+    "mpdta_cells_covered": (3, 0),
+    "mpdta_post_cells": (7, 0),
+    "mpdta_trimmed_att_diff": (0.0, 1e-14),
+    "mpdta_trimmed_leads": (2, 0),
+    "castle_att_diff": (0.0, 1e-06),          # float32 as shipped
+    "castle_att_diff_float64": (0.0, 1e-14),
+    "castle_cell_se_diff_float64": (0.0, 1e-14),
+    "many_cohort_att_diff": (0.0, 1e-14),
+    "many_cohort_cell_se_diff": (0.0, 1e-14),
+    "many_cohort_cohorts": (14, 0),
+    # Provenance, pinned. These are the assertions that keep the case honest:
+    # diff-diff falls back to a synthetic panel of the same schema when a
+    # dataset host is unreachable, and without these a network failure would
+    # turn a real-data replication into a generated-data one with no sign.
+    "mpdta_is_authentic": (1, 0),
+    "castle_is_authentic": (1, 0),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -12,6 +12,7 @@ CASES = {
     "snn_prop99": "benchmarks.cases.snn_prop99",        # cross-val vs deshen24/syntheticNN (Prop 99)
     "ppscm_paglayan": "benchmarks.cases.ppscm_paglayan",  # cross-val vs augsynth::multisynth (jackknife + bootstrap SEs)
     "ppscm_paglayan_covs": "benchmarks.cases.ppscm_paglayan_covs",  # cross-val vs augsynth::multisynth Sec 5.2 (auxiliary covariates)
+    "ppscm_cs_real_panels": "benchmarks.cases.ppscm_cs_real_panels",  # cross-val vs diff-diff CallawaySantAnna on mpdta / castle_doctrine / walmart
     "ppscm_bfr_mc": "benchmarks.cases.ppscm_bfr_mc",  # Path B: BFR sharp-null designs (ATT coverage both methods + cumulative band)
     "rolldid_lw": "benchmarks.cases.rolldid_lw",        # Path A: Lee-Wooldridge Prop99 + castle
     "fdid_table5": "benchmarks.cases.fdid_table5",      # Path B: simulation

--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -179,10 +179,8 @@ The three are separate settings, because each is independently meaningful:
 ``donor_weights``
    ``"scm"`` (default) solves the partially-pooled QP; ``"uniform"`` puts equal
    weight on every admissible donor, which is the comparison Callaway-Sant'Anna
-   and Sun-Abraham make. Uniform weights have to be imposed, not approached:
-   driving ``lam`` up saturates the weights at :math:`\max_j |w_j - 1/J| =
-   3.5 \times 10^{-3}`, unmoved between :math:`\lambda = 10^9` and
-   :math:`10^{18}` at any :math:`\nu`.
+   and Sun-Abraham make. It is the :math:`\lambda \to \infty` limit of the
+   same program, written in closed form; the derivation is below.
 
 ``base_period``
    ``"all_pre"`` (default) is augsynth's: each unit's mean over its whole
@@ -212,6 +210,155 @@ On four cohorts spread over a long window the gap is about 1.2e-02. A panel with
 adoptions spread widely lands there, so a difference of that size between
 ``donor_pool="window"`` and ``donor_pool="never_treated"`` is the conventions
 disagreeing, not a bug.
+
+Why the two estimators meet: the ridge path
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The equivalence is not a coincidence of two formulas. Callaway-Sant'Anna sits at
+the end of a path the partially-pooled program already contains, and the
+conventions above are the coordinates of that endpoint. Ben-Michael, Feller and
+Rothstein introduce the :math:`\lambda` term (their Section 3) as
+
+   a term that penalizes the weights towards uniformity, with hyperparameter
+   :math:`\lambda`. While we penalize the sum of the squared weights, there are
+   many options, for example, an entropy or elastic net penalty
+
+so uniformity is what the penalty is for. Following it to its limit is what
+produces the other estimator.
+
+Step 1: the barycenter is what any such penalty selects. Let
+:math:`\Omega : \Delta^{N_0} \to \mathbb{R}` be strictly convex and
+permutation-symmetric, so :math:`\Omega(\mathbf{P}\mathbf{w}) =
+\Omega(\mathbf{w})` for every permutation matrix :math:`\mathbf{P}`. Strict
+convexity gives a unique minimiser :math:`\mathbf{w}^\star`; symmetry makes
+:math:`\mathbf{P}\mathbf{w}^\star` a minimiser too, so
+:math:`\mathbf{P}\mathbf{w}^\star = \mathbf{w}^\star` for all :math:`\mathbf{P}`,
+and the only permutation-invariant point of the simplex is its barycenter:
+
+.. math::
+
+   \operatorname*{arg\,min}_{\mathbf{w} \in \Delta^{N_0}} \Omega(\mathbf{w})
+     = \bar{\mathbf{w}} \coloneqq \tfrac{1}{N_0}\mathbf{1}.
+
+The squared norm :math:`\sum_i w_i^2` and the negative entropy
+:math:`\sum_i w_i \log w_i` are both of this form, so the alternatives BFR list
+have the same endpoint. Geometrically :math:`\bar{\mathbf{w}}` is the point of
+the simplex nearest the origin, which is why the ridge sends the weights there.
+
+Step 2: the program converges to it, and forgets :math:`\nu`. Write the
+partially-pooled objective as :math:`f_\nu(\mathbf{w}) + \lambda
+\Omega(\mathbf{w})`, equivalently :math:`\lambda^{-1} f_\nu(\mathbf{w}) +
+\Omega(\mathbf{w})`. Since :math:`\Delta^{N_0}` is compact and :math:`f_\nu`
+continuous, :math:`\lambda^{-1} f_\nu \to 0` uniformly, so
+:math:`\mathbf{w}_\lambda \to \bar{\mathbf{w}}` for every :math:`\nu`. The
+pooling dial is inert in the limit: it weights a term that has been scaled away.
+
+Step 3: the rate, and what :math:`\nu` does instead. The barycenter has every
+coordinate :math:`1/N_0 > 0`, so it lies in the relative interior and no
+non-negativity constraint is active near it. For large :math:`\lambda` the
+program is therefore smooth on the affine hull :math:`\{\mathbf{1}'\mathbf{w} =
+1\}`, and stationarity :math:`\nabla f_\nu(\mathbf{w}_\lambda) + 2\lambda
+\mathbf{w}_\lambda + \mu\mathbf{1} = \mathbf{0}` linearised at
+:math:`\bar{\mathbf{w}}` gives
+
+.. math::
+
+   \mathbf{w}_\lambda = \bar{\mathbf{w}}
+     - \frac{1}{2\lambda}\,\mathbf{P}\,\nabla f_\nu(\bar{\mathbf{w}})
+     + O(\lambda^{-2}),
+   \qquad
+   \mathbf{P} \coloneqq \mathbf{I} - \tfrac{1}{N_0}\mathbf{1}\mathbf{1}' ,
+
+with :math:`\mathbf{P}` the projection onto the simplex's tangent space. So the
+approach is first order in :math:`\lambda^{-1}` -- not the :math:`\lambda^{-1/2}`
+a boundary solution would give -- along a fixed direction that is tangent to the
+simplex. That direction is where :math:`\nu` survives: it sets the direction in
+which partially pooled SCM departs from Callaway-Sant'Anna, having no say in
+where the path ends.
+
+Measured on a three-cohort panel with 41 never-treated donors, against the
+Callaway-Sant'Anna estimate:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40 40
+
+   * - :math:`\lambda`
+     - :math:`|\widehat{\tau} - \widehat{\tau}_{\mathrm{CS}}|`
+     - :math:`\max_i |w_i - 1/N_0|`
+   * - 0
+     - 1.0e-01
+     - 2.6e-01
+   * - 1e6
+     - 7.7e-07
+     - 1.4e-07
+   * - 1e12
+     - 7.7e-13
+     - 1.4e-13
+
+A decade of :math:`\lambda` buys a decade of accuracy, in the weights and in the
+estimate alike, down to machine precision. The scaled departure
+:math:`\lambda(\mathbf{w}_\lambda - \bar{\mathbf{w}})` settles to a fixed vector
+(norms 0.410880, 0.411064, 0.411066 at :math:`\lambda = 10^4, 10^6, 10^8`;
+direction cosine 1.000000 to eight decimals), and its size moves with
+:math:`\nu` alone -- 0.2846, 0.6152, 0.9541 at :math:`\nu = 0, 0.5, 1` -- while
+the limit does not move at all.
+
+Step 4: the endpoint is the estimator. At :math:`\bar{\mathbf{w}}`, with
+``base_period="pre_treatment"`` subtracting :math:`Y_{i,g-1}` and
+``donor_pool="never_treated"`` supplying the comparison group
+:math:`\mathcal{C}`, cohort :math:`g`'s horizon-:math:`k` effect is
+
+.. math::
+
+   \widehat{\tau}_{g,g+k}
+     = \frac{1}{n_g}\sum_{i \in \mathcal{G}_g}\bigl(Y_{i,g+k} - Y_{i,g-1}\bigr)
+     - \frac{1}{n_{\mathcal{C}}}\sum_{i \in \mathcal{C}}
+         \bigl(Y_{i,g+k} - Y_{i,g-1}\bigr)
+     = \widehat{ATT}(g, g+k),
+
+the two-period, two-group difference in differences Callaway and Sant'Anna
+identify under their Assumptions 1-4 with a never-treated comparison group. The
+common time effect cancels between the two group means, so removing it changes
+nothing. This is BFR's own reading of their Equation (9): with uniform weights
+it "is the simple average over all two-period, two-group DiD estimates", which
+they call "equivalent to recent proposals ... (see Callaway & Sant'Anna, 2020;
+Sun & Abraham, 2020)".
+
+One difference hides in that sentence. BFR average over all pre-treatment lags,
+where Callaway-Sant'Anna normalise on :math:`g-1` alone -- which is exactly the
+``base_period`` setting, and why the equivalence needs all three conventions and
+not just uniform weights.
+
+Aggregation closes it. PPSCM averages cohorts by size at each horizon and then
+averages horizons,
+
+.. math::
+
+   \widehat{\theta} = \frac{1}{H}\sum_{h} \widehat{\theta}_h ,
+   \qquad
+   \widehat{\theta}_h = \sum_{k \in \mathcal{K}_h}
+     \frac{p_k}{S_h}\,\widehat{\tau}_{g_k, g_k + h} ,
+   \quad S_h = \sum_{k \in \mathcal{K}_h} p_k ,
+
+which is Callaway-Sant'Anna's dynamic aggregation followed by an average over
+event time. It coincides with their simple aggregation when every cohort is the
+same size and reaches every horizon, and not otherwise -- so equal-sized cohorts
+hide the distinction instead of establishing it.
+
+What this does not close is the donor pool. Uniform weights and the :math:`g-1`
+baseline are choices inside the program; :math:`\mathcal{C}` is the set the
+program ranges over. When a later cohort outlives an earlier cohort's estimation
+window the two sets genuinely differ, and no :math:`\lambda` reconciles them --
+which is the regime described above.
+
+In practice ``donor_weights="uniform"`` is the limit written down instead of
+approached: exact, with no quadratic program to solve and no :math:`\lambda` for
+the caller to guess. The path matters because it explains why the two estimators
+are the same object, and it is verified in
+`test_ppscm_cs_ridge_limit.py <https://github.com/jgreathouse9/mlsynth/blob/main/mlsynth/tests/test_ppscm_cs_ridge_limit.py>`_,
+which pins every number quoted above and checks the limit against ``diff-diff``
+itself where it is installed.
 
 Inference
 ---------

--- a/mlsynth/tests/test_ppscm_cs_ridge_limit.py
+++ b/mlsynth/tests/test_ppscm_cs_ridge_limit.py
@@ -192,6 +192,46 @@ class TestTheEstimateConverges:
             assert gaps[a] / gaps[b] == pytest.approx(1000.0, rel=0.05), (a, b)
         assert gaps[1e12] < 1e-11
 
+    def test_the_weights_reach_uniform_even_where_the_estimate_does_not(self):
+        """Two columns of one table, and the fault #473 records is reading them
+        as one.
+
+        Convergence of the weights is a property of the penalty, so it happens
+        under any conventions. Convergence of the *estimate* to
+        Callaway-Sant'Anna needs the other two conventions as well. The sweep
+        that produced the retracted claim tabulated both columns side by side,
+        saw the estimate's residual hold flat, and attributed it to weights that
+        had in fact converged to 1.8e-10 in the next column along.
+        """
+        df = panel()
+        L = len(next(iter(fit(df, donor_weights="uniform").per_unit.values())).tau)
+        target = cs_oracle(df, L)
+        augsynth = dict(base_period="all_pre", donor_pool="window")
+
+        # The weights converge under both sets of conventions.
+        assert deviation_from_uniform(
+            fit(df, donor_weights="scm", lam=1e12)) < 1e-12
+        assert deviation_from_uniform(
+            fit(df, donor_weights="scm", lam=1e12, **augsynth)) < 1e-12
+
+        # The estimate converges under only one of them.
+        cs_gap = abs(float(fit(df, donor_weights="scm", lam=1e12).att) - target)
+        aug_gap = abs(float(fit(df, donor_weights="scm", lam=1e12,
+                                **augsynth).att) - target)
+        assert cs_gap < 1e-11, cs_gap
+        assert aug_gap > 1e-2, aug_gap
+
+        # And the residual is flat in lam, which is what "saturation" described.
+        # Flat to five significant figures, not exactly constant: the weights
+        # are still making their last decades, so the estimate they produce
+        # drifts by about 1e-06 over the same range the weights cross six
+        # orders of magnitude. Reporting it as motionless was fair; reading the
+        # motionlessness as a property of the weights was not.
+        aug_gap_6 = abs(float(fit(df, donor_weights="scm", lam=1e6,
+                                  **augsynth).att) - target)
+        assert aug_gap == pytest.approx(aug_gap_6, rel=1e-4)
+        assert abs(aug_gap - aug_gap_6) < 1e-5
+
     def test_uniform_weights_are_that_limit_reached_exactly(self):
         """The setting is the limit in closed form: no quadratic program, and
         agreement with the oracle at machine precision instead of at whatever

--- a/mlsynth/tests/test_ppscm_cs_ridge_limit.py
+++ b/mlsynth/tests/test_ppscm_cs_ridge_limit.py
@@ -1,0 +1,319 @@
+"""The Callaway-Sant'Anna estimator is the infinite-ridge limit of PPSCM.
+
+``docs/ppscm.rst`` states this as mathematics, so it is asserted here as
+mathematics. Every number the page quotes has a test in this file; #473 exists
+because a measured claim reached a doc page, an issue and a field description
+with nothing asserting it, and was wrong.
+
+The claims, in the order the page makes them:
+
+1. The barycenter of the simplex minimises any strictly convex,
+   permutation-symmetric penalty over it -- so the limit is the same whether
+   the penalty is ridge, entropy or elastic net.
+2. Partially pooled SCM's weights converge to that barycenter as ``lam``
+   grows, at rate ``O(1/lam)``, for every ``nu``.
+3. So does the estimate, to the Callaway-Sant'Anna estimate.
+4. The departure from the barycenter is first order in ``1/lam`` along a fixed
+   direction, tangent to the simplex, and ``nu`` sets that direction without
+   moving the limit.
+5. ``donor_weights="uniform"`` is that limit reached exactly, in one step and
+   with no quadratic program.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PPSCM
+
+try:                                             # the authority, where installed
+    from diff_diff import CallawaySantAnna
+    HAVE_DIFF_DIFF = True
+except ImportError:                              # pragma: no cover - CI without it
+    HAVE_DIFF_DIFF = False
+
+needs_diff_diff = pytest.mark.skipif(
+    not HAVE_DIFF_DIFF, reason="diff-diff not installed")
+
+_REF_PATH = (pathlib.Path(__file__).resolve().parents[2]
+             / "benchmarks" / "reference" / "ppscm_cs" / "reference.py")
+_spec = importlib.util.spec_from_file_location("_ppscm_cs_reference", _REF_PATH)
+REF = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(REF)
+
+
+def panel(onsets=(10, 14, 18), k=3, n_units=50, n_per=30, seed=0, scale=1.0):
+    rng = np.random.default_rng(seed)
+    assign = {u: g for i, g in enumerate(onsets) for u in range(i * k, (i + 1) * k)}
+    rows = []
+    for u in range(n_units):
+        base, walk = rng.normal(10, 2), np.cumsum(rng.normal(0, 0.3, n_per))
+        g = assign.get(u)
+        for t in range(1, n_per + 1):
+            on = g is not None and t >= g
+            rows.append((u, t, scale * (base + walk[t - 1] + 0.5 * rng.normal()
+                                        + 2.0 * on), int(on), g if g else 0))
+    return pd.DataFrame(rows, columns=["id", "time", "y", "d", "first_treat"])
+
+
+def fit(df, **over):
+    cfg = {"df": df[["id", "time", "y", "d"]], "outcome": "y", "treat": "d",
+           "unitid": "id", "time": "time", "display_graphs": False,
+           "run_inference": False, "base_period": "pre_treatment",
+           "donor_pool": "never_treated", **over}
+    return PPSCM(cfg).fit()
+
+
+def deviation_from_uniform(res):
+    """``max_i |w_i - 1/N0|`` over the *full* donor set.
+
+    ``donor_weights_by_cohort`` omits weights below 1e-8, so at small ``lam``,
+    where the SCM solution is sparse, the stored vector is shorter than the
+    donor pool. Dividing by its length would measure the deviation from a
+    uniform distribution over the support that happened to survive, which is a
+    different quantity and is small exactly when the weights are least uniform.
+    Every omitted donor sits at zero and so contributes ``1/N0``.
+    """
+    stored = np.array(list(next(iter(res.donor_weights_by_cohort.values())).values()))
+    n0 = int(res.metadata["n_control"])          # donor_pool="never_treated"
+    dev = float(np.max(np.abs(stored - 1.0 / n0))) if stored.size else 1.0 / n0
+    if stored.size < n0:
+        dev = max(dev, 1.0 / n0)
+    return dev
+
+
+def dense_weights(res):
+    """The stored weights, usable only where every donor is above the 1e-8 cut."""
+    return np.array(list(next(iter(res.donor_weights_by_cohort.values())).values()))
+
+
+def cs_oracle(df, L):
+    """Callaway-Sant'Anna's estimate over PPSCM's cells, cohort-share weighted."""
+    eff, _, inf = REF.group_time_att(df, "y", "id", "time", "first_treat")
+    cohort = df.groupby("id")["first_treat"].first().to_numpy()
+    cells = [(g, t) for (g, t) in eff if 0 <= t - g < L]
+    pg = np.array([(cohort == g).sum() / cohort.shape[0] for g, _ in cells])
+    est, _, _ = REF.aggregate(cells, eff, inf, cohort, weights=pg / pg.sum())
+    return est
+
+
+# =========================================================================== #
+# 1. the barycenter is what the penalty selects
+# =========================================================================== #
+class TestTheBarycenter:
+    """No estimator involved: a fact about the simplex."""
+
+    @pytest.mark.parametrize("n", [2, 3, 5, 16, 41, 91])
+    def test_uniform_minimises_the_squared_norm_over_the_simplex(self, n):
+        bary = np.full(n, 1.0 / n)
+        rng = np.random.default_rng(0)
+        for _ in range(200):
+            w = rng.dirichlet(np.full(n, 0.7))
+            assert (w ** 2).sum() >= (bary ** 2).sum() - 1e-15
+
+    @pytest.mark.parametrize("n", [3, 16, 41])
+    def test_uniform_also_minimises_the_entropy_penalty(self, n):
+        """BFR name entropy as an alternative penalty. Any strictly convex
+        permutation-symmetric penalty has the same minimiser, so naming a
+        different one does not move the limit."""
+        neg_entropy = lambda w: float((w * np.log(np.where(w > 0, w, 1.0))).sum())
+        bary = np.full(n, 1.0 / n)
+        rng = np.random.default_rng(1)
+        for _ in range(200):
+            w = rng.dirichlet(np.full(n, 0.7))
+            assert neg_entropy(w) >= neg_entropy(bary) - 1e-12
+
+    def test_the_barycenter_is_interior_so_no_constraint_binds_there(self):
+        """The rate is O(1/lam) and not O(1/sqrt(lam)) because the limit is in
+        the relative interior: for large lam the non-negativity constraints are
+        inactive and the path is smooth."""
+        for n in (2, 5, 41):
+            assert np.all(np.full(n, 1.0 / n) > 0)
+
+
+# =========================================================================== #
+# 2. the weights converge to it, at O(1/lam), for every nu
+# =========================================================================== #
+class TestTheRidgeLimit:
+    @pytest.mark.parametrize("nu", ["auto", 0.0, 0.5, 1.0])
+    def test_the_deviation_falls_by_a_decade_per_decade_of_lam(self, nu):
+        df = panel()
+        devs = {lam: deviation_from_uniform(
+                    fit(df, donor_weights="scm", lam=lam, nu=nu))
+                for lam in (1e6, 1e9, 1e12)}
+        # The expansion is asymptotic, so the rate is asserted where it applies.
+        # At lam = 1e3 the O(lam^-2) term is still visible (the 1e3 -> 1e6 ratio
+        # is 933 at nu = 1), which is the expansion behaving as an expansion.
+        for a, b in ((1e6, 1e9), (1e9, 1e12)):
+            assert devs[a] / devs[b] == pytest.approx(1000.0, rel=0.05), (nu, a, b)
+
+    def test_the_limit_is_reached_to_machine_precision(self):
+        """The claim #473 corrects: there is no floor."""
+        df = panel()
+        assert deviation_from_uniform(fit(df, donor_weights="scm", lam=1e18)) < 1e-14
+
+    @pytest.mark.parametrize("donor_pool", ["window", "never_treated"])
+    @pytest.mark.parametrize("base_period", ["all_pre", "pre_treatment"])
+    @pytest.mark.parametrize("scale", [1.0, 1e4])
+    def test_no_configuration_has_a_floor(self, donor_pool, base_period, scale):
+        """#473 asserted a floor at 3.5e-03 'at any nu'. It is absent from every
+        combination of the conventions and both outcome scales."""
+        df = panel(scale=scale)
+        dev = deviation_from_uniform(fit(df, donor_weights="scm", lam=1e18,
+                                        donor_pool=donor_pool,
+                                        base_period=base_period))
+        assert dev < 1e-14, f"{donor_pool}/{base_period}/{scale}: {dev:.2e}"
+
+    @pytest.mark.parametrize("n_units,n_donors", [(25, 16), (50, 41), (100, 91)])
+    def test_the_limit_holds_at_every_donor_count(self, n_units, n_donors):
+        df = panel(n_units=n_units)
+        res = fit(df, donor_weights="scm", lam=1e18)
+        assert int(res.metadata["n_control"]) == n_donors
+        assert deviation_from_uniform(res) < 1e-14
+
+
+# =========================================================================== #
+# 3. and so does the estimate, to Callaway-Sant'Anna's
+# =========================================================================== #
+class TestTheEstimateConverges:
+    def test_the_ridge_path_reaches_the_callaway_santanna_estimate(self):
+        df = panel()
+        L = len(next(iter(fit(df, donor_weights="uniform").per_unit.values())).tau)
+        oracle = cs_oracle(df, L)
+        gaps = {}
+        for lam in (1e3, 1e6, 1e9, 1e12):
+            gaps[lam] = abs(float(fit(df, donor_weights="scm", lam=lam).att) - oracle)
+        for a, b in ((1e3, 1e6), (1e6, 1e9), (1e9, 1e12)):
+            assert gaps[a] / gaps[b] == pytest.approx(1000.0, rel=0.05), (a, b)
+        assert gaps[1e12] < 1e-11
+
+    def test_uniform_weights_are_that_limit_reached_exactly(self):
+        """The setting is the limit in closed form: no quadratic program, and
+        agreement with the oracle at machine precision instead of at whatever
+        lam the caller thought to pick."""
+        df = panel()
+        res = fit(df, donor_weights="uniform")
+        L = len(next(iter(res.per_unit.values())).tau)
+        assert float(res.att) == pytest.approx(cs_oracle(df, L), abs=1e-12)
+        assert deviation_from_uniform(res) < 1e-15
+
+
+# =========================================================================== #
+# 4. how it leaves the limit: first order in 1/lam, direction set by nu
+# =========================================================================== #
+class TestTheDepartureFromTheLimit:
+    @staticmethod
+    def _direction(df, lam, nu="auto"):
+        w = dense_weights(fit(df, donor_weights="scm", lam=lam, nu=nu))
+        return lam * (w - 1.0 / w.size)
+
+    def test_the_scaled_departure_converges_to_a_fixed_vector(self):
+        """``w_lam = w_bary + d / lam + O(lam^-2)``: multiplying the deviation
+        by ``lam`` leaves something that stops moving."""
+        df = panel()
+        ds = [self._direction(df, lam) for lam in (1e4, 1e6, 1e8, 1e10)]
+        for d in ds[1:]:
+            cos = float(d @ ds[-1] / (np.linalg.norm(d) * np.linalg.norm(ds[-1])))
+            assert cos == pytest.approx(1.0, abs=1e-6)
+            assert np.linalg.norm(d) == pytest.approx(np.linalg.norm(ds[-1]), rel=1e-3)
+
+    def test_the_departure_is_tangent_to_the_simplex(self):
+        """The weights stay on the simplex, so the direction sums to zero."""
+        df = panel()
+        d = self._direction(df, 1e10)
+        assert abs(float(d.sum())) < 1e-3 * float(np.linalg.norm(d))
+
+    def test_nu_sets_the_direction_without_moving_the_limit(self):
+        """Near the Callaway-Sant'Anna end of the path, nu chooses the direction
+        in which partially pooled SCM departs from Callaway-Sant'Anna."""
+        df = panel()
+        norms = {nu: float(np.linalg.norm(self._direction(df, 1e10, nu)))
+                 for nu in (0.0, 0.5, 1.0)}
+        assert norms[0.0] < norms[0.5] < norms[1.0]
+        assert norms[1.0] / norms[0.0] > 2.0, norms
+        for nu in (0.0, 0.5, 1.0):
+            assert deviation_from_uniform(
+                fit(df, donor_weights="scm", lam=1e18, nu=nu)) < 1e-14, nu
+
+
+# =========================================================================== #
+# 5. the limit, against diff-diff itself
+# =========================================================================== #
+@needs_diff_diff
+class TestTheLimitAgainstThePackage:
+    """The vendored transcription is convenient; the package is the authority.
+
+    Sections 2-4 measure the limit against ``reference.py``, which is code this
+    repository wrote. That is enough to pin a rate, and not enough to claim the
+    limit is Callaway-Sant'Anna's estimator: a transcription that drifted would
+    still converge to itself. Here the target comes from ``diff-diff``'s own
+    ``CallawaySantAnna`` fit, aggregated the way PPSCM aggregates, so the object
+    at the end of the ridge path is the package's number.
+    """
+
+    @staticmethod
+    def _package_att(df, L):
+        r = CallawaySantAnna(control_group="never_treated", estimation_method="dr",
+                             n_bootstrap=0).fit(df, outcome="y", unit="id",
+                                                time="time", first_treat="first_treat")
+        gt = {c: v["effect"] for c, v in r.group_time_effects.items()}
+        cells = [(g, t) for (g, t) in gt if 0 <= t - g < L]
+        cohort = df.groupby("id")["first_treat"].first().to_numpy()
+        pg = np.array([(cohort == g).sum() for g, _ in cells], dtype=float)
+        return float(np.array([gt[c] for c in cells]) @ (pg / pg.sum()))
+
+    def test_the_ridge_path_reaches_the_package_estimate(self):
+        df = panel()
+        L = len(next(iter(fit(df, donor_weights="uniform").per_unit.values())).tau)
+        target = self._package_att(df, L)
+        gaps = {lam: abs(float(fit(df, donor_weights="scm", lam=lam).att) - target)
+                for lam in (1e3, 1e6, 1e9, 1e12)}
+        for a, b in ((1e3, 1e6), (1e6, 1e9), (1e9, 1e12)):
+            assert gaps[a] / gaps[b] == pytest.approx(1000.0, rel=0.05), (a, b)
+        assert gaps[1e12] < 1e-11
+
+    @pytest.mark.parametrize("onsets,k", [((12,), 3), ((10, 14), 3),
+                                          ((10, 14, 18), 3), ((10, 14, 18), 4)])
+    def test_uniform_weights_equal_the_package_exactly(self, onsets, k):
+        df = panel(onsets, k)
+        res = fit(df, donor_weights="uniform")
+        L = len(next(iter(res.per_unit.values())).tau)
+        assert float(res.att) == pytest.approx(self._package_att(df, L), abs=1e-12)
+
+    def test_the_transcription_and_the_package_agree_on_the_target(self):
+        """If these ever part, the transcription is what to distrust."""
+        df = panel()
+        L = len(next(iter(fit(df, donor_weights="uniform").per_unit.values())).tau)
+        assert cs_oracle(df, L) == pytest.approx(self._package_att(df, L), abs=1e-12)
+
+
+# =========================================================================== #
+# 6. the numbers the doc page quotes
+# =========================================================================== #
+class TestTheQuotedNumbers:
+    """Each figure in the equivalence section of ``docs/ppscm.rst``."""
+
+    def test_the_quoted_convergence_table(self):
+        df = panel()
+        L = len(next(iter(fit(df, donor_weights="uniform").per_unit.values())).tau)
+        oracle = cs_oracle(df, L)
+        quoted = {0.0: (1.0e-01, 2.6e-01), 1e6: (7.7e-07, 1.4e-07),
+                  1e12: (7.7e-13, 1.4e-13)}
+        for lam, (gap_q, dev_q) in quoted.items():
+            res = fit(df, donor_weights="scm", lam=lam)
+            gap = abs(float(res.att) - oracle)
+            dev = deviation_from_uniform(res)
+            assert gap == pytest.approx(gap_q, rel=0.1), (lam, gap)
+            assert dev == pytest.approx(dev_q, rel=0.1), (lam, dev)
+
+    def test_the_quoted_direction_norms(self):
+        df = panel()
+        for nu, quoted in ((0.0, 0.2846), (0.5, 0.6152), (1.0, 0.9541)):
+            w = dense_weights(fit(df, donor_weights="scm", lam=1e10, nu=nu))
+            d = 1e10 * (w - 1.0 / w.size)
+            assert float(np.linalg.norm(d)) == pytest.approx(quoted, rel=1e-3), nu

--- a/mlsynth/utils/ppscm_helpers/config.py
+++ b/mlsynth/utils/ppscm_helpers/config.py
@@ -69,9 +69,11 @@ class PPSCMConfig(BaseEstimatorConfig):
         description=(
             "How donors are weighted. 'scm' solves the partially-pooled QP. "
             "'uniform' puts equal weight on every admissible donor, which is "
-            "the comparison Callaway-Sant'Anna and Sun-Abraham make; it is "
-            "imposed rather than approached, since driving 'lam' up saturates "
-            "at max|w - 1/J| = 3.5e-03 and never reaches it."
+            "the comparison Callaway-Sant'Anna and Sun-Abraham make. It is the "
+            "'lam' -> infinity limit of the QP in closed form: the barycenter "
+            "minimises the ridge penalty over the simplex, so the solved "
+            "weights approach it at rate O(1/lam) for every 'nu'. Setting it "
+            "reaches the limit exactly and skips the program."
         ),
     )
     base_period: Literal["all_pre", "pre_treatment"] = Field(
@@ -164,8 +166,8 @@ class PPSCMConfig(BaseEstimatorConfig):
         default=None,
         description=(
             "Post-periods to accumulate for a per-unit conformal band on the "
-            "CUMULATIVE effect -- the total each treated unit gained, rather than "
-            "its per-period or time-averaged effect. ``None`` (default) leaves it "
+            "CUMULATIVE effect -- the total each treated unit gained, not its "
+            "per-period or time-averaged effect. ``None`` (default) leaves it "
             "off and nothing changes. Unlike VanillaSC, where "
             "``inference='conformal_cumulative'`` selects one mode, this band is "
             "an additional object: ``inference_method`` still chooses the bootstrap "

--- a/mlsynth/utils/ppscm_helpers/engine.py
+++ b/mlsynth/utils/ppscm_helpers/engine.py
@@ -119,9 +119,13 @@ def eligible_donors(trt: np.ndarray, adopt: int, n_leads: int, donor_pool: str) 
 def uniform_weights(donors, groups, n) -> Dict[Any, np.ndarray]:
     """Equal weight on every admissible donor -- the CS/Sun-Abraham comparison.
 
-    Imposed, not approximated. Driving ``lam`` up does not reach it: the QP's
-    weights saturate at ``max|w - 1/J| = 3.47e-03`` and do not move between
-    ``lam = 1e9`` and ``1e18`` at any ``nu``.
+    The ``lam -> infinity`` limit of the partially-pooled program, in closed
+    form. The barycenter minimises ``sum_i w_i^2`` over the simplex, so the
+    solved weights approach it as the ridge grows -- at ``O(1/lam)``, for every
+    ``nu``, since the barycenter is interior and no non-negativity constraint
+    binds there. Setting this reaches the limit exactly and skips the program;
+    the QP would otherwise need a ``lam`` the caller has to guess, and would
+    still return the answer to within solver tolerance instead of exactly.
     """
     W: Dict[Any, np.ndarray] = {}
     for g in groups:

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1140,3 +1140,21 @@ timeout = 1800.0
   find = "_PROB = (np.sqrt(5.0) + 1.0) / (2.0 * np.sqrt(5.0))"
   replace = "_PROB = 0.5"
   models = "Mammen's two probabilities replaced by a coin flip, keeping his two values. The law's mean goes to 0.5 and its variance to 1.25, and neither is visible downstream: the influence function sums to zero across units, so a non-zero multiplier mean contributes nothing, and the variance error only inflates the simultaneous critical value by about twelve percent -- a band that is wider than the pointwise one either way. Only the moments themselves catch it"
+
+[[target]]
+name = "cs-ridge-limit"
+module-path = "mlsynth/utils/ppscm_helpers/engine.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_cs_ridge_limit.py mlsynth/tests/test_ppscm_callaway_santanna.py -q -p no:cacheprovider"
+timeout = 1800.0
+
+  [[target.mutant]]
+  id = "uniform-weights-are-not-uniform"
+  find = "            Wg[donors[g]] = 1.0 / len(donors[g])"
+  replace = "            Wg[donors[g]] = 1.0 / len(donors[g]); Wg[donors[g][0]] *= 1.001"
+  models = "the closed-form limit missing the barycenter by a tenth of a percent on one donor. The estimate stays plausible and the weights still sum to one, so only a comparison against the Callaway-Sant'Anna target at machine precision separates the limit from something near it -- which is the whole claim the ridge path is making"
+
+  [[target.mutant]]
+  id = "the-limit-is-taken-over-the-wrong-donor-set"
+  find = "        Wg = np.zeros(n)\n        if len(donors[g]):\n            Wg[donors[g]] = 1.0 / len(donors[g])"
+  replace = "        Wg = np.zeros(n)\n        if len(donors[g]):\n            Wg[donors[g]] = 1.0 / n"
+  models = "the barycenter computed over every unit instead of the admissible donors, so the weights no longer sum to one. The donor pool is the one convention no lam reconciles, and normalising over the wrong set is how that distinction gets lost"


### PR DESCRIPTION
Closes #473.

## The correction

`docs/ppscm.rst`, the `donor_weights` field description and `uniform_weights`' docstring all said uniform donor weights were unreachable by tuning `lam`:

> saturates at `max|w - 1/J| = 3.5e-03`, unmoved between `lam = 1e9` and `1e18` at any `nu`

False. The weights converge at rate `O(1/lam)`, to machine precision:

| `lam` | \|att − CS\| | `max|w − 1/N0|` |
| --- | --- | --- |
| 0 | 1.0e-01 | 2.6e-01 |
| 1e6 | 7.7e-07 | 1.4e-07 |
| 1e12 | 7.7e-13 | 1.4e-13 |
| 1e18 | 4.4e-16 | 1.4e-17 |

A decade of `lam` buys a decade of accuracy, in the weights and the estimate alike. It does not reproduce anywhere: 4 convention combinations × outcome scales 1 and 1e4 × `nu` ∈ {auto, 0, 0.5, 1} × 16/41/91 donors all reach `1e-17`.

No test asserted the number, which is why it survived into `main`. This adds 39.

## What replaces it

BFR introduce the `lam` term (§3) as one that "penalizes the weights towards uniformity", naming entropy and elastic net as alternatives — so uniformity is what the penalty is *for*, and Callaway-Sant'Anna sits at the end of that path.

**Step 1.** The barycenter minimises *any* strictly convex permutation-symmetric penalty over the simplex: permute the minimiser, uniqueness forces invariance, and the only permutation-invariant point of `Δ` is `1/N0 · 1`. So every alternative BFR name shares the endpoint.

**Step 2.** Rescaling to `lam^-1 f_nu + Omega` on a compact set sends the first term to zero uniformly. The limit exists and is `nu`-free — `nu` weights a term that has been scaled away.

**Step 3.** The barycenter is interior, so no non-negativity constraint binds and the path is smooth. Stationarity linearises to

```
w_lam = w_bary - (1 / 2 lam) P grad f_nu(w_bary) + O(lam^-2)
```

first order in `1/lam`, not the `1/sqrt(lam)` a boundary solution would give. Measured, the scaled departure settles to a fixed tangent vector (direction cosine `1.000000` to eight decimals) whose size moves with `nu` alone: `0.2846 / 0.6152 / 0.9541` at `nu = 0 / 0.5 / 1`. So near that end of the path, `nu` chooses the *direction* in which partially pooled SCM departs from Callaway-Sant'Anna, with no say in where it ends.

**Step 4.** At the endpoint, with the `g-1` baseline and never-treated pool, the cell is `ATT(g,t)` exactly, and PPSCM's aggregation is their dynamic aggregation averaged over event time. The donor pool is the one thing no `lam` reconciles — the documented divergence regime.

One detail hides in BFR's own sentence: they average over *all* pre-treatment lags where Callaway-Sant'Anna normalise on `g-1` alone. That is the `base_period` convention, and why the equivalence needs all three settings and not just uniform weights.

## Tests

39, pinning every number the page quotes. The limit is checked against `diff-diff`'s own `CallawaySantAnna` fit and not only the vendored transcription — a transcription that drifted would still converge to itself, so parity with the package is what makes "the limit is *their* estimator" a claim rather than a tautology.

Writing them found a measurement fault: `donor_weights_by_cohort` omits weights below `1e-8`, so at small `lam` the stored vector is shorter than the donor pool, and dividing by its length measures deviation from uniformity over the surviving support. Different quantity, and smallest exactly where the weights are least uniform. The corrected helper reproduces the original `2.640e-01` at `lam = 0`.

## Scope

`donor_weights="uniform"` is unchanged. The case for it is that the limit in closed form is exact, costs no quadratic program and asks nobody to guess a `lam` — not that the limit is out of reach.

363 PPSCM tests passing, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_