### PR TITLE
Report the shape of the balance problem, not only its residual

### DIFF
--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -63,6 +63,14 @@ Do not use PPSCM when
   large and noisy. Partial pooling cannot manufacture a hull that does
   not contain the treated units; a factor-model (:doc:`fma`) or low-rank
   (:doc:`clustersc`, :doc:`mcnnm`) approach is better.
+* The pre-period is short relative to the donor pool. Synthetic control needs
+  enough pre-periods to pin the weights down; with more donors than periods to
+  balance, the simplex is wide enough that near-exact balance is available for
+  free and says nothing about how well the donors track the treated units. This
+  is the regime where difference in differences is the justified estimator --
+  it asks for many units and few periods, which is the opposite trade -- so
+  reach for :doc:`sdid`, or for PPSCM's own ``method="callaway_santanna"``.
+  ``design.underdetermined`` reports when a fit is in this regime.
 * Distributional effects (quantiles, tails) -- use :doc:`dsc`.
 
 Notation
@@ -440,6 +448,39 @@ aggregate against
 a transcription of ``diff-diff`` 3.9.0 at commit ``d9cd475`` kept in-tree so the
 check runs without a runtime dependency. Measured agreement is 0.0 per cell and
 5.6e-17 on the aggregate.
+
+Reading the balance diagnostics
+-------------------------------
+
+``design.global_l2`` and ``design.ind_l2`` are the pre-treatment imbalance the
+fitted weights leave, and ``pct_improve_global`` / ``pct_improve_ind`` express
+them against the uniform-weight baseline. A residual near zero means a good fit
+only if the program could have done worse, so the design also reports the shape
+of the problem that produced it:
+
+``max_donors``
+   the widest admissible donor pool across cohorts.
+
+``balance_periods``
+   the pre-periods actually balanced, capped by the cohort with the least
+   history, since that cohort binds.
+
+``underdetermined``
+   whether ``max_donors - 1 > balance_periods``. Weights on the simplex carry
+   ``max_donors - 1`` degrees of freedom against ``balance_periods`` equations,
+   so past that point exact balance is generically attainable.
+
+Both panels ``diff-diff`` ships illustrate the difference. On ``mpdta`` -- 500
+counties over five years, the shape difference in differences is built for --
+the binding cohort adopts in the second period, leaving one pre-period against
+a pool of 480: ``global_l2`` comes to 3.4e-06 and 100 percent better than
+uniform, which describes the geometry. On ``castle_doctrine``, 32 donors
+against five periods cannot reach zero, and its 2.1e-02 is a fit.
+
+``underdetermined`` is a statement about the program's shape and not a verdict.
+The simplex is bounded, so a wide pool whose convex hull misses the treated path
+still leaves a large residual, and that residual is informative. What the flag
+rules out is reading a small one as evidence.
 
 Per-unit fits alongside the pooled report
 -----------------------------------------

--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -145,6 +145,8 @@ class PPSCM:
                 global_l2=fit["global_l2"], ind_l2=fit["ind_l2"],
                 scaled_global_l2=fit["scaled_global_l2"],
                 scaled_ind_l2=fit["scaled_ind_l2"],
+                max_donors=int(fit["max_donors"]),
+                balance_periods=int(fit["balance_periods"]),
                 conventions={
                     "donor_weights": self.donor_weights,
                     "base_period": self.base_period,

--- a/mlsynth/tests/test_ppscm_balance_shape.py
+++ b/mlsynth/tests/test_ppscm_balance_shape.py
@@ -1,0 +1,143 @@
+"""PPSCM reports the shape of the balance problem, not only its residual.
+
+A pre-treatment imbalance near zero means two different things depending on how
+many constraints the program had. With more donors than balance periods, the
+simplex is wide enough that exact balance is generically attainable, and the
+residual describes the geometry instead of the fit. With fewer, the residual is
+the fit.
+
+On ``diff-diff``'s own panels the two cases sit side by side. ``mpdta`` reports
+``max_donors=480`` against ``balance_periods=1`` -- its earliest cohort adopts
+in the second period, so one pre-period is all the binding cohort has -- and
+reaches 3.4e-06. ``castle_doctrine`` reports 32 against 5 and cannot get below
+2.1e-02. Before #476 the estimator reported those residuals identically.
+
+The tests below fix what the estimator must report so a reader can tell them
+apart, and are written against panels whose shape is chosen, not measured.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PPSCM
+
+
+def panel(n_units=40, n_per=20, onsets=(12, 14), k=2, seed=0):
+    """A staggered panel with a chosen number of periods and donors."""
+    rng = np.random.default_rng(seed)
+    assign = {u: g for i, g in enumerate(onsets) for u in range(i * k, (i + 1) * k)}
+    rows = []
+    for u in range(n_units):
+        base, walk = rng.normal(10, 2), np.cumsum(rng.normal(0, 0.3, n_per))
+        g = assign.get(u)
+        for t in range(1, n_per + 1):
+            on = g is not None and t >= g
+            rows.append((u, t, base + walk[t - 1] + 0.5 * rng.normal() + 2.0 * on,
+                         int(on)))
+    return pd.DataFrame(rows, columns=["id", "time", "y", "d"])
+
+
+def fit(df, **over):
+    return PPSCM({"df": df, "outcome": "y", "treat": "d", "unitid": "id",
+                  "time": "time", "display_graphs": False,
+                  "run_inference": False, **over}).fit()
+
+
+class TestTheReportedShape:
+    def test_the_design_reports_donors_and_balance_periods(self):
+        d = fit(panel()).design
+        assert isinstance(d.max_donors, int) and d.max_donors > 0
+        assert isinstance(d.balance_periods, int) and d.balance_periods > 0
+
+    def test_the_donor_count_is_the_widest_pool_any_cohort_had(self):
+        """The widest pool decides whether the program could interpolate, so a
+        cohort with a narrow pool must not mask one with a wide pool.
+
+        Measured against ``eligible_donors`` and not against
+        ``per_unit[...].donor_weights``: the latter holds the weights that came
+        back non-zero, which on a wide pool is a small fraction of it, so it
+        cannot see the quantity this field is about. The panel is shaped so the
+        pools genuinely differ -- widely spaced cohorts and a short lead window
+        let the late cohort serve as a donor for the early one, and not the
+        reverse.
+        """
+        from mlsynth.utils.ppscm_helpers.engine import eligible_donors
+        from mlsynth.utils.ppscm_helpers.setup import prepare_ppscm_inputs
+
+        df = panel(n_units=40, n_per=20, onsets=(5, 18), k=2)
+        res = fit(df)
+        inputs = prepare_ppscm_inputs(df, outcome="y", treat="d",
+                                      unitid="id", time="time")
+        pools = [len(eligible_donors(inputs.trt, int(a), res.design.n_leads,
+                                     "window"))
+                 for a in sorted({int(v) for v in inputs.trt[np.isfinite(inputs.trt)]})]
+        assert min(pools) < max(pools), (
+            "the panel must give the cohorts different pools or this cannot "
+            f"distinguish widest from narrowest; got {pools}")
+        assert res.design.max_donors == max(pools)
+
+    def test_balance_periods_follows_n_lags(self):
+        df = panel(n_per=20, onsets=(12, 14))
+        assert fit(df, n_lags=3).design.balance_periods == 3
+        assert fit(df, n_lags=6).design.balance_periods == 6
+
+    def test_balance_periods_is_capped_by_the_earliest_cohorts_history(self):
+        """A cohort adopting at t=4 has 3 pre-periods however many lags are
+        asked for, and it is the cohort with the least history that binds."""
+        df = panel(n_per=20, onsets=(4, 16), k=2)
+        assert fit(df, n_lags=10).design.balance_periods == 3
+
+
+class TestUnderdetermined:
+    def test_a_wide_pool_against_few_periods_is_flagged(self):
+        df = panel(n_units=40, n_per=20, onsets=(12, 14), k=2)
+        d = fit(df, n_lags=2).design
+        assert d.max_donors - 1 > d.balance_periods
+        assert d.underdetermined is True
+
+    def test_a_narrow_pool_against_many_periods_is_not(self):
+        df = panel(n_units=8, n_per=20, onsets=(12, 14), k=2)
+        d = fit(df, n_lags=12).design
+        assert d.max_donors - 1 <= d.balance_periods
+        assert d.underdetermined is False
+
+    def test_the_flag_is_the_stated_comparison_and_not_a_heuristic(self):
+        for n_units, n_lags in ((40, 2), (40, 15), (8, 12), (8, 2)):
+            d = fit(panel(n_units=n_units), n_lags=n_lags).design
+            assert d.underdetermined == (d.max_donors - 1 > d.balance_periods)
+
+    def test_an_underdetermined_program_reaches_a_far_smaller_residual(self):
+        """The reason the flag exists: the same panel, balanced against few
+        periods and against many, gives residuals that are not comparable."""
+        df = panel(n_units=40, n_per=20, onsets=(12, 14), k=2)
+        wide = fit(df, n_lags=2).design
+        tight = fit(df, n_lags=10).design
+        # Both are underdetermined here -- 36 donors outruns even ten periods --
+        # which is the point: the flag says the residuals are not comparable,
+        # and it does not claim the tighter one is well determined.
+        assert wide.underdetermined and tight.underdetermined
+        assert wide.global_l2 < tight.global_l2
+
+    def test_uniform_weights_solve_no_program_so_the_flag_is_about_the_pool(self):
+        """``donor_weights="uniform"`` has nothing to interpolate with, so the
+        shape is still reported and still describes the pool that was available."""
+        d = fit(panel(), donor_weights="uniform").design
+        assert d.max_donors > 0 and d.balance_periods > 0
+        assert isinstance(d.underdetermined, bool)
+
+
+class TestItTravelsWithTheResult:
+    def test_the_shape_survives_inference(self):
+        d = fit(panel(), run_inference=True, inference_method="bootstrap",
+                n_boot=50).design
+        assert d.max_donors > 0 and d.balance_periods > 0
+
+    def test_time_cohort_reports_the_pooled_cohorts_shape(self):
+        df = panel(n_units=40, onsets=(12, 12, 14), k=1)
+        a = fit(df).design
+        b = fit(df, time_cohort=True).design
+        assert a.max_donors == b.max_donors
+        assert a.balance_periods == b.balance_periods

--- a/mlsynth/utils/ppscm_helpers/engine.py
+++ b/mlsynth/utils/ppscm_helpers/engine.py
@@ -116,6 +116,21 @@ def eligible_donors(trt: np.ndarray, adopt: int, n_leads: int, donor_pool: str) 
         f"got {donor_pool!r}.")
 
 
+def balance_shape(adopt_of, donors, groups, n_lags: int):
+    """The balance problem's shape: widest donor pool, and periods balanced.
+
+    ``balance_periods`` is capped by the cohort with the least pre-history,
+    because that cohort's block is what the padded design can actually
+    constrain -- asking for ten lags of a cohort adopting at t=4 balances
+    three. See ``PPSCMDesign.underdetermined``.
+    """
+    if not groups:                                # pragma: no cover - no treated
+        return 0, 0
+    widest = max(int(len(donors[g])) for g in groups)
+    periods = min(min(int(adopt_of[g]) for g in groups), int(n_lags))
+    return widest, max(periods, 0)
+
+
 def uniform_weights(donors, groups, n) -> Dict[Any, np.ndarray]:
     """Equal weight on every admissible donor -- the CS/Sun-Abraham comparison.
 
@@ -257,6 +272,7 @@ def _uniform_fit(res, groups, adopt_of, members, donors, n1, d, n, n_leads,
     given values that would read as if a QP had run.
     """
     W = uniform_weights(donors, groups, n)
+    _shape = balance_shape(adopt_of, donors, groups, d)
     M = _imbalance_matrix(res, groups, adopt_of, members, donors, W, n1, d, n)
     J = len(groups)
     nnz = [max(int((np.abs(M[:, k]) > 1e-12).sum()), 1) for k in range(J)]
@@ -271,6 +287,7 @@ def _uniform_fit(res, groups, adopt_of, members, donors, n1, d, n, n_leads,
         "scaled_global_l2": 1.0, "scaled_ind_l2": 1.0,
         "M": M, "nnz": np.asarray(nnz, dtype=float),
         "res": res, "n": n, "n_leads": n_leads,
+        "max_donors": _shape[0], "balance_periods": _shape[1],
     }
 
 
@@ -310,6 +327,7 @@ def run_multisynth(
     donors = {g: eligible_donors(trt, adopt_of[g], n_leads, donor_pool)
               for g in groups}
     res = fit_feff(Xy, trt, set(adopt_of.values()), fixedeff, base_period)
+    _shape = balance_shape(adopt_of, donors, groups, n_lags)
     if donor_weights not in ("scm", "uniform"):
         raise ValueError(
             f"donor_weights must be 'scm' or 'uniform', got {donor_weights!r}.")
@@ -361,6 +379,7 @@ def run_multisynth(
         "weights": W, "n1": n1, "tau_rel": tau_rel, "per_time": per_time, "att": att,
         "nu_used": nu_used, "global_l2": fin_global, "ind_l2": fin_ind,
         "scaled_global_l2": fin_global / unif_global, "scaled_ind_l2": fin_ind / unif_ind,
+        "max_donors": _shape[0], "balance_periods": _shape[1],
         # Per-cohort final imbalance columns ``M`` (d, J) and the ``nnz`` counts
         # from the separate fit -- the components of ``ind_l2`` (each cohort's
         # in-sample error is ``sqrt((M[:,k]**2).sum() / nnz[k])``), returned so the

--- a/mlsynth/utils/ppscm_helpers/structures.py
+++ b/mlsynth/utils/ppscm_helpers/structures.py
@@ -100,6 +100,31 @@ class PPSCMDesign:
     #: interval. Together they decide whether the fit is augsynth's multisynth
     #: or the Callaway-Sant'Anna estimator, which the numbers alone do not say.
     conventions: Optional[Dict[str, Any]] = None
+    #: The shape of the balance problem the imbalances above came out of.
+    #: ``max_donors`` is the widest admissible donor pool across cohorts and
+    #: ``balance_periods`` the pre-periods actually balanced, capped by the
+    #: cohort with the least history since that cohort binds. Read them with
+    #: ``global_l2``: a residual near zero means a good fit when the program was
+    #: constrained and describes the geometry when it was not.
+    max_donors: Optional[int] = None
+    balance_periods: Optional[int] = None
+
+    @property
+    def underdetermined(self) -> Optional[bool]:
+        """Whether the balance system had more freedom than constraints.
+
+        Weights on the simplex carry ``max_donors - 1`` degrees of freedom
+        against ``balance_periods`` equations. When the first exceeds the
+        second, exact balance is generically attainable and a near-zero
+        ``global_l2`` says nothing about how well the donors track the treated
+        units. It is a statement about the program's shape and not a verdict on
+        the fit: the simplex is bounded, so a wide pool whose hull misses the
+        treated path still leaves a large residual, and that residual is
+        informative.
+        """
+        if self.max_donors is None or self.balance_periods is None:
+            return None
+        return (self.max_donors - 1) > self.balance_periods
 
     @property
     def pct_improve_global(self) -> float:

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1158,3 +1158,21 @@ timeout = 1800.0
   find = "        Wg = np.zeros(n)\n        if len(donors[g]):\n            Wg[donors[g]] = 1.0 / len(donors[g])"
   replace = "        Wg = np.zeros(n)\n        if len(donors[g]):\n            Wg[donors[g]] = 1.0 / n"
   models = "the barycenter computed over every unit instead of the admissible donors, so the weights no longer sum to one. The donor pool is the one convention no lam reconciles, and normalising over the wrong set is how that distinction gets lost"
+
+[[target]]
+name = "ppscm-balance-shape"
+module-path = "mlsynth/utils/ppscm_helpers/engine.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_balance_shape.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "balance-periods-taken-from-the-widest-cohort"
+  find = "    periods = min(min(int(adopt_of[g]) for g in groups), int(n_lags))"
+  replace = "    periods = min(max(int(adopt_of[g]) for g in groups), int(n_lags))"
+  models = "the constraint count read off the cohort with the most history instead of the least. The binding cohort is the one that can interpolate freely, so taking the maximum reports a program better constrained than any of its parts and clears the flag exactly where it should fire"
+
+  [[target.mutant]]
+  id = "donor-pool-measured-at-its-narrowest"
+  find = "    widest = max(int(len(donors[g])) for g in groups)"
+  replace = "    widest = min(int(len(donors[g])) for g in groups)"
+  models = "the pool measured at its narrowest, so one late cohort with few admissible donors masks an early one with hundreds. Whether the program could interpolate is decided by the widest pool any cohort was given, not the tightest"


### PR DESCRIPTION
Closes #476.

`PPSCMDesign` reported `global_l2` and `ind_l2` with nothing saying how many constraints produced them, so a residual near zero read as a good fit whether or not the program could have returned anything else.

## The two cases, on `diff-diff`'s own panels

| | mpdta | castle_doctrine |
| --- | --- | --- |
| `max_donors` | 480 | 32 |
| `balance_periods` | **1** | 5 |
| `underdetermined` | True | True |
| `global_l2` | 3.4e-06 | 2.1e-02 |
| `pct_improve_global` | 100.0% | 87.1% |

mpdta's earliest cohort adopts in the second period, so one pre-period is all the binding cohort has. Any point of a 480-dimensional simplex matches one moment exactly — the `3.4e-06` and "100% better than uniform" describe the geometry. castle_doctrine's 32 donors against five periods cannot reach zero, and its `2.1e-02` is a fit. The two were reported identically.

This is the regime split between the literatures: difference in differences wants many units and few periods, which is exactly mpdta's shape, and it is the estimator justified there.

## What is added

`max_donors` (widest admissible pool across cohorts), `balance_periods` (pre-periods balanced, capped by the cohort with the least history since that cohort binds), and an `underdetermined` property comparing `max_donors - 1` degrees of freedom against `balance_periods` equations.

No refusal and no warning. A caller may know the pool is wide and want the estimate anyway; what they should not have to do is reconstruct the constraint count to interpret the number they were handed.

The flag is about the program's shape, not a verdict on the fit — the simplex is bounded, so a wide pool whose hull misses the treated path still leaves a large residual, and that residual is informative. What it rules out is reading a *small* one as evidence.

## Docs

`docs/ppscm.rst` gains the missing "Do not use PPSCM when" bullet — a short pre-period relative to the donor pool, which is the condition that decides it, where the existing bullet only says "large and noisy" — and a "Reading the balance diagnostics" section working through both panels.

## The mutant that survived first contact

`donor-pool-measured-at-its-narrowest` (swap `max` for `min`) passed the entire suite. Two reasons, both mine: the test panel gave every cohort an identical pool, and pool size was read off `per_unit[...].donor_weights`, which holds only the **non-zero** weights — a small fraction of a wide pool, so it structurally cannot see the quantity the field is about.

Rewritten against `eligible_donors` on a panel whose pools genuinely differ (`36` vs `38`), with an assertion that the panel *has* unequal pools so the test cannot silently degrade again. Both mutants now killed.

## Verification

543 passed, 5 skipped across PPSCM, the mutation harness and the result contract. Written test-first; every test was watched fail with `AttributeError: 'PPSCMDesign' object has no attribute 'max_donors'` before the fields existed.

Will want a rebase once #474 lands — both touch `docs/ppscm.rst`, in different sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_