### PR TITLE
Make an empty weights container a contract violation

### DIFF
--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -305,13 +305,39 @@ class WeightsResults(BaseModel):
       period weights);
     * ``unit_weights``  -- a weight matrix / array (e.g. MCNNM / ISCM unit
       factors, per-unit weight matrices).
+
+    Some estimators hold weights that fit none of these: one mapping per cohort
+    (PPSCM), unit and time weights per cohort (SequentialSDID), factor matrices
+    per treated unit (SPILLSYNTH). Collapsing those to a single vector would
+    produce an object no cohort used, so they leave the faces empty and set
+    ``weights_at`` to name where the weights actually are. ``is_empty`` is what
+    separates that from an estimator with no weights at all.
     """
     donor_weights: Optional[Dict[str, float]] = Field(default=None, description="Dictionary mapping donor unit names/IDs to their weights.")
     time_weights: Optional[Dict[Any, float]] = Field(default=None, description="Dictionary mapping time periods to weights (e.g. SDID lambda, DSC period weights).")
     unit_weights: Optional[np.ndarray] = Field(default=None, description="Unit weight matrix/array for estimators whose weights are not a donor mapping (e.g. MCNNM/ISCM).")
     summary_stats: Optional[Dict[str, Any]] = Field(default=None, description="Summary statistics about weights (e.g., cardinality).")
+    weights_at: Optional[List[str]] = Field(default=None, description=(
+        "Attribute names on the result where this estimator's weights live, for "
+        "estimators whose weights fit none of the faces above -- per cohort, per "
+        "treated unit, or as factor matrices. Names a location; it does not hold "
+        "weights."))
     # For estimators returning multiple sets of weights (e.g. TSSC sub-methods), this might be part of a list or dict structure.
     # donor_names is removed as it's incorporated into donor_weights dict keys
+
+    @property
+    def is_empty(self) -> bool:
+        """No face populated and no pointer: the container says nothing.
+
+        The four faces are optional because weights are not one thing across
+        synthetic-control methods, and that permissiveness has a failure mode:
+        every face ``None`` reads as "this estimator has no weights" whether or
+        not it has them. An estimator whose weights fit no face sets
+        ``weights_at`` and stops being indistinguishable from one that has none
+        (#475). Pinned for every estimator in ``tests/test_result_contract.py``.
+        """
+        return not any((self.donor_weights, self.time_weights, self.summary_stats,
+                        self.weights_at)) and self.unit_weights is None
 
     @property
     def weight_vector(self) -> Optional[np.ndarray]:

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -335,8 +335,13 @@ class WeightsResults(BaseModel):
         not it has them. An estimator whose weights fit no face sets
         ``weights_at`` and stops being indistinguishable from one that has none
         (#475). Pinned for every estimator in ``tests/test_result_contract.py``.
+
+        ``summary_stats`` does not count. It holds descriptive statistics about
+        the weights -- cardinality, a constraint label -- in prose no caller can
+        resolve to a location, which is the state #475 was filed about. A
+        sentence saying the weights are per cohort is not a way to reach them.
         """
-        return not any((self.donor_weights, self.time_weights, self.summary_stats,
+        return not any((self.donor_weights, self.time_weights,
                         self.weights_at)) and self.unit_weights is None
 
     @property

--- a/mlsynth/config_models.py
+++ b/mlsynth/config_models.py
@@ -336,13 +336,18 @@ class WeightsResults(BaseModel):
         ``weights_at`` and stops being indistinguishable from one that has none
         (#475). Pinned for every estimator in ``tests/test_result_contract.py``.
 
+        The test is ``is None``, not emptiness. An empty ``donor_weights`` is a
+        statement -- the factor-model estimators set ``{}`` and mean "checked,
+        this method has no donor weights", which is exactly what a caller needs
+        to know. ``None`` is the absence of a statement.
+
         ``summary_stats`` does not count. It holds descriptive statistics about
         the weights -- cardinality, a constraint label -- in prose no caller can
         resolve to a location, which is the state #475 was filed about. A
         sentence saying the weights are per cohort is not a way to reach them.
         """
-        return not any((self.donor_weights, self.time_weights,
-                        self.weights_at)) and self.unit_weights is None
+        return (self.donor_weights is None and self.time_weights is None
+                and self.unit_weights is None and self.weights_at is None)
 
     @property
     def weight_vector(self) -> Optional[np.ndarray]:

--- a/mlsynth/estimators/seq_sdid.py
+++ b/mlsynth/estimators/seq_sdid.py
@@ -245,6 +245,7 @@ class SequentialSDID:
                     intervention_time=0,
                 ),
                 weights=WeightsResults(
+                    weights_at=["cohort_effects"],
                     summary_stats={"constraint": "SSDiD unit + time weights "
                                    "(per cohort x horizon)"}),
                 fit_diagnostics=FitDiagnosticsResults(),

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -276,6 +276,40 @@ def test_flat_accessor_contract(Est, extra, fitted):
 
 
 @pytest.mark.parametrize("Est, extra", OBSERVATIONAL)
+def test_weights_container_says_something(Est, extra, fitted):
+    """An estimator that computed weights must not hand back an empty container.
+
+    ``WeightsResults`` offers four optional faces, and every one being ``None``
+    is indistinguishable from "this estimator has no weights". Several
+    estimators hold real weights on bespoke fields -- per cohort, per treated
+    unit, as factor matrices -- for which no single face is the right shape.
+    Those name where the weights are, in ``weights_at``. What is not allowed is
+    saying nothing: a caller reaching for ``res.weights.donor_weights`` and
+    getting ``None`` cannot tell which case they are in (#475).
+    """
+    res = fitted[Est.__name__]
+    w = res.weights
+    assert not w.is_empty, (
+        f"{Est.__name__} returns a WeightsResults with no face populated and no "
+        "weights_at pointer, so a caller cannot tell whether it has weights")
+
+
+@pytest.mark.parametrize("Est, extra", OBSERVATIONAL)
+def test_weights_pointer_resolves(Est, extra, fitted):
+    """``weights_at`` names attributes that exist and are populated.
+
+    A pointer to nothing is worse than no pointer, so each name is resolved
+    against the result it came from.
+    """
+    res = fitted[Est.__name__]
+    for name in (res.weights.weights_at or []):
+        assert hasattr(res, name), (
+            f"{Est.__name__} weights_at names {name!r}, absent from the result")
+        assert getattr(res, name) is not None, (
+            f"{Est.__name__} weights_at names {name!r}, which is None")
+
+
+@pytest.mark.parametrize("Est, extra", OBSERVATIONAL)
 def test_serializable(Est, extra, fitted):
     """A standardized result serializes through pydantic (reproducibility)."""
     res = fitted[Est.__name__]

--- a/mlsynth/tests/test_result_contract.py
+++ b/mlsynth/tests/test_result_contract.py
@@ -32,7 +32,8 @@ from mlsynth import (
     BFSC, BPSCS, BSCM, BVSS, CAST, CFM, CLUSTERSC, CSCIPCA, CSCM, DPSC, DSCAR, ESC, GSYNTH, ISCM, FDID, FMA, FSCM, HSC, LEXSCM, MAREX, MASC, MEDSC,
     COMPSC,
     LPCA, MCNNM, MSQRT, MTGP, MVBBSC, NSC, PDA, PROPSC, PROXIMAL, RESCM, RMSI, RRSC, SBC, SCMO, SCUL, SDID,
-    SequentialSDID, SHC, SNN, SparseSC, SPILLSYNTH, SPOTSYNTH, SSC, TASC, TSSC,
+    PPSCM, SequentialSDID, SHC, SNN, SparseSC, SPILLSYNTH, SPOTSYNTH, SSC, TASC,
+    TSSC,
     VanillaSC,
 )
 from mlsynth.config_models import (
@@ -181,6 +182,7 @@ OBSERVATIONAL = [
                          "inference": False}, id="MEDSC"),
     pytest.param(SDID, {}, id="SDID"),
     pytest.param(SequentialSDID, {"n_bootstrap": 20, "seed": 0}, id="SequentialSDID"),
+    pytest.param(PPSCM, {"run_inference": False}, id="PPSCM"),
     pytest.param(SSC, {}, id="SSC"),
     pytest.param(BVSS, {"n_iter": 30, "burn_in": 10, "seed": 0}, id="BVSS"),
     pytest.param(BSCM, {"n_iter": 60, "burn_in": 30, "chains": 2, "seed": 0}, id="BSCM"),

--- a/mlsynth/tests/test_weights_container.py
+++ b/mlsynth/tests/test_weights_container.py
@@ -1,0 +1,99 @@
+"""``WeightsResults.is_empty`` separates three states that look alike.
+
+An estimator's weights container can be in one of three conditions, and a
+caller needs to tell them apart:
+
+* it has weights, on one of the four faces;
+* it has weights that fit no face -- one mapping per cohort, factor matrices
+  per treated unit -- and names where they are in ``weights_at``;
+* it has no weights, and says so.
+
+Only the fourth state is a defect: silence, where every face is ``None`` and
+nothing points anywhere, so a caller reaching for ``donor_weights`` cannot tell
+whether the estimator has none or simply did not say (#475).
+
+The two distinctions below are the ones that were got wrong while building
+this, and each was got wrong in a way that a conformance sweep reported as
+good news:
+
+* ``{}`` is a statement and ``None`` is not. The factor-model estimators set
+  ``donor_weights={}`` to mean "checked, this method has none". A truthiness
+  test reads that as silence and fails six correct estimators.
+* ``summary_stats`` is not a statement. It carries prose -- "partially-pooled
+  SC donor weights (per cohort)" -- that no caller can resolve to a location.
+  Counting it lets exactly the estimators #475 was about pass unchanged.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.config_models import WeightsResults
+
+
+class TestSilenceIsTheOnlyFailure:
+    def test_a_bare_container_is_empty(self):
+        assert WeightsResults().is_empty is True
+
+    @pytest.mark.parametrize("kwargs", [
+        {"donor_weights": {"a": 1.0}},
+        {"time_weights": {0: 0.5}},
+        {"unit_weights": np.zeros(3)},
+        {"weights_at": ["donor_weights_by_cohort"]},
+    ])
+    def test_any_face_or_a_pointer_is_not_empty(self, kwargs):
+        assert WeightsResults(**kwargs).is_empty is False
+
+
+class TestAnExplicitNoneIsAStatement:
+    """``{}`` means checked-and-none; ``None`` means nothing was said."""
+
+    @pytest.mark.parametrize("kwargs", [
+        {"donor_weights": {}},
+        {"time_weights": {}},
+        {"unit_weights": np.array([])},
+        {"weights_at": []},
+    ])
+    def test_an_empty_face_is_not_silence(self, kwargs):
+        assert WeightsResults(**kwargs).is_empty is False
+
+    def test_the_distinction_is_none_and_not_truthiness(self):
+        """The pair that a truthiness test collapses.
+
+        Six factor-model estimators report ``donor_weights={}``. Reading that
+        as silence fails all of them while changing nothing about the ones the
+        contract is aimed at.
+        """
+        assert WeightsResults(donor_weights={}).is_empty is False
+        assert WeightsResults(donor_weights=None).is_empty is True
+
+
+class TestProseIsNotALocation:
+    def test_summary_stats_alone_does_not_satisfy_the_contract(self):
+        """The permissive reading that let #475's own estimators pass.
+
+        ``summary_stats`` holds cardinality and a constraint label. A sentence
+        saying the weights are per cohort is not a way to reach them, so it
+        cannot stand in for a face or a pointer.
+        """
+        w = WeightsResults(summary_stats={
+            "constraint": "partially-pooled SC donor weights (per cohort)"})
+        assert w.is_empty is True
+
+    def test_summary_stats_alongside_a_pointer_is_fine(self):
+        w = WeightsResults(weights_at=["donor_weights_by_cohort"],
+                           summary_stats={"constraint": "per cohort"})
+        assert w.is_empty is False
+
+
+class TestTheFaceStillWorks:
+    def test_weight_vector_is_unaffected(self):
+        w = WeightsResults(donor_weights={"a": 0.25, "b": 0.75})
+        assert np.allclose(w.weight_vector, [0.25, 0.75])
+
+    def test_weight_vector_of_an_explicit_none_is_an_empty_array(self):
+        assert WeightsResults(donor_weights={}).weight_vector.size == 0
+
+    def test_weight_vector_of_silence_is_none(self):
+        assert WeightsResults().weight_vector is None

--- a/mlsynth/utils/ppscm_helpers/structures.py
+++ b/mlsynth/utils/ppscm_helpers/structures.py
@@ -334,8 +334,10 @@ class PPSCMResults(_BaseEstimatorResults):
             observed_outcome=tau, counterfactual_outcome=_np.zeros_like(tau),
             estimated_gap=tau, time_periods=_np.asarray(es.horizons),
             intervention_time=0))
-        set_("weights", _WeightsResults(summary_stats={
-            "constraint": "partially-pooled SC donor weights (per cohort)"}))
+        set_("weights", _WeightsResults(
+            weights_at=["donor_weights_by_cohort", "per_unit"],
+            summary_stats={
+                "constraint": "partially-pooled SC donor weights (per cohort)"}))
         set_("inference", _InferenceResults(
             method=inf.method, standard_error=se,
             ci_lower=(ci_lo if finite_ci else None),

--- a/mlsynth/utils/rmsi_helpers/pipeline.py
+++ b/mlsynth/utils/rmsi_helpers/pipeline.py
@@ -64,7 +64,7 @@ def run_rmsi(inputs: RMSIInputs, *, J: int = 2, rank: Optional[int] = None,
         n_pre_periods=int(T0),
         n_post_periods=int(T - T0),
         time_periods=np.asarray(inputs.time_labels),
-        weights=WeightsResults(summary_stats={
+        weights=WeightsResults(donor_weights={}, summary_stats={
             "constraint": "matrix completion (no donor weights)",
             "rank": int(used_rank),
         }),

--- a/mlsynth/utils/spillsynth_helpers/structures.py
+++ b/mlsynth/utils/spillsynth_helpers/structures.py
@@ -664,7 +664,14 @@ class SpillSynthResults(BaseEstimatorResults):
                 rmse_pre=float(np.sqrt(np.mean(resid ** 2))),
             )
         if self.weights is None:
-            self.weights = WeightsResults()
+            # SPILLSYNTH's weights are the active sub-fit's spillover and SCM
+            # matrices -- alpha is (n, T0) and gamma (n_treated, T0) -- so no
+            # single face is the right shape. Name the sub-result instead of
+            # flattening them into a vector no unit used (#475).
+            self.weights = WeightsResults(
+                weights_at=[self.method],
+                summary_stats={"constraint":
+                               f"SPILLSYNTH/{self.method} spillover + SCM weights"})
         if self.method_details is None:
             self.method_details = MethodDetailsResults(
                 method_name=f"SPILLSYNTH/{self.method}",

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1176,3 +1176,21 @@ timeout = 900.0
   find = "    widest = max(int(len(donors[g])) for g in groups)"
   replace = "    widest = min(int(len(donors[g])) for g in groups)"
   models = "the pool measured at its narrowest, so one late cohort with few admissible donors masks an early one with hundreds. Whether the program could interpolate is decided by the widest pool any cohort was given, not the tightest"
+
+[[target]]
+name = "weights-container-contract"
+module-path = "mlsynth/config_models.py"
+test-command = "python -m pytest mlsynth/tests/test_weights_container.py mlsynth/tests/test_result_contract.py -q -p no:cacheprovider"
+timeout = 1800.0
+
+  [[target.mutant]]
+  id = "emptiness-tested-by-truthiness"
+  find = "        return (self.donor_weights is None and self.time_weights is None\n                and self.unit_weights is None and self.weights_at is None)"
+  replace = "        return not any((self.donor_weights, self.time_weights,\n                        self.weights_at)) and self.unit_weights is None"
+  models = "an empty face read as silence. Six factor-model estimators report donor_weights={} to mean 'checked, this method has none', and truthiness collapses that into the same state as never having said anything -- failing the estimators that are already correct while leaving the ones the contract is aimed at untouched"
+
+  [[target.mutant]]
+  id = "prose-counted-as-a-location"
+  find = "        return (self.donor_weights is None and self.time_weights is None\n                and self.unit_weights is None and self.weights_at is None)"
+  replace = "        return (self.donor_weights is None and self.time_weights is None\n                and self.unit_weights is None and self.weights_at is None\n                and self.summary_stats is None)"
+  models = "summary_stats accepted in place of a face or a pointer. It carries a constraint label in prose no caller can resolve to an attribute, so counting it lets an estimator hold real weights, say nothing machine-readable about where, and pass -- which is the exact state #475 was filed about"


### PR DESCRIPTION
Closes #475.

`WeightsResults` offers four optional faces, and every one being `None` is indistinguishable from "this estimator has no weights". `test_result_contract` asserted `res.weights is not None` and `dw is None or isinstance(dw, dict)` — both pass on a container with nothing in it.

The concrete failure (the sweep behind #473): `res.weights.donor_weights` → `TypeError: 'NoneType' object is not iterable`. The silent version: `sum((res.weights.donor_weights or {}).values())` → a plausible `0`.

## The three-way distinction

This is the whole content of the change, and it took two wrong attempts to see:

| state | meaning | verdict |
| --- | --- | --- |
| `None` | nothing was said | **the only failure** |
| `{}` | checked, this method has none | fine — what the factor models mean |
| a face, or `weights_at` | here they are | fine |

`weights_at: Optional[List[str]]` names attributes on the result where weights live. A typed field rather than a `summary_stats` key, so it is in the schema and cannot collide with an estimator's own summary keys. It holds no weights.

## What was found

Once the discriminator was right, four:

| Estimator | before | after |
| --- | --- | --- |
| `RMSI` | `donor_weights=None` + prose | `donor_weights={}`, as its five factor-model siblings already say |
| `PPSCM` | `summary_stats` prose only | `weights_at=["donor_weights_by_cohort", "per_unit"]` |
| `SequentialSDID` | `summary_stats` prose only | `weights_at=["cohort_effects"]` |
| `SPILLSYNTH` | `WeightsResults()`, nothing | `weights_at=[self.method]` |

None collapses per-cohort weights into a single vector. Averaging PPSCM's cohorts would produce weights no cohort used — the class of plausible-but-wrong object this repository has spent the week removing.

**`PPSCM` was not in the conformance roster at all** — zero mentions in `test_result_contract.py`. The estimator this RCA started from was never checked against the contract. It is added, and fits the contract panel as a single cohort.

## Two wrong discriminators, both reported as good news

Worth stating plainly, because each was a green-looking result on the defect it existed to catch:

1. **Truthiness instead of `is None`.** `donor_weights={}` is falsy, so "checked, none" read as silence and **six correct factor models failed** while the real targets were untouched.
2. **Excluding `summary_stats` without fixing (1).** Reported exactly **one** violation — SPILLSYNTH. That looks like a tidy one-line fix, and would have shipped with PPSCM and SequentialSDID still handing back the unparseable prose #475 is about.

Both are now mutants, both killed:

- `emptiness-tested-by-truthiness`
- `prose-counted-as-a-location`

`is_empty` gets 15 unit tests of its own (`test_weights_container.py`), because the reasoning lives in the discriminator, not in the estimators.

## Conformance

Two tests over every observational estimator: the container must not be empty, and every name in `weights_at` must resolve to a populated attribute on the result — a pointer to nothing being worse than no pointer.

**994 passed, 5 skipped** across the contract, the four touched estimators, and the mutation harness.

## Not in scope

The conformance roster is maintained by hand, so an estimator can exist without ever being checked against the contract — which is how PPSCM went uncovered. Same species as #475; not filed, and not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_