### PR TITLE
Raise the CI cap over the slowest shard, not the average

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,10 +35,22 @@ jobs:
     # It was raised 40 -> 55 once and was reached again: the suite grows, a slow
     # runner lands within a few minutes of the cap, and a healthy run is killed
     # at 99%, which GitHub reports as 'cancelled' -- neither a pass nor a
-    # failure, and a full re-run to tell them apart. Sharding is the fix; each
-    # shard now runs a quarter of the modules, so 30 is generous and the guard
-    # bites long before a whole afternoon is spent on a hang.
-    timeout-minutes: 30
+    # failure, and a full re-run to tell them apart.
+    #
+    # Sharding reduced the work per job but not evenly. The split is round-robin
+    # over sorted module names, which is blind to how long a module takes, and
+    # shard 0 measures about twice shard 1 on every interpreter (#479): on
+    # 2026-08-16 across one matrix, shard 0 ran 22:22 / >30 / >30 against shard
+    # 1's 7:06 / 15:11 / 17:16. 30 was set on the reasoning that a quarter of
+    # the modules is a quarter of the work, and it is not; it killed a green
+    # shard on three PRs, once after the suite had already printed
+    # '2561 passed'.
+    #
+    # The cap has to clear the SLOWEST shard on the slowest interpreter, not the
+    # average, so 50 leaves headroom over today's 30 while still bounding a
+    # hang. Balancing the shards by duration is the actual fix and is tracked
+    # separately; this stops healthy runs being reported as cancelled meanwhile.
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:
@@ -151,7 +163,9 @@ jobs:
     # Same reasoning as `build` above. These are the jobs that reached the old
     # cap first: 3.12 and 3.13 run slower than the 3.11 `build` job on identical
     # work, so they were the ones killed at 99%.
-    timeout-minutes: 30
+    # Same cap and the same measurement as `build` above (#479); these are the
+    # jobs that lost shards.
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Refs #479. Part one of two: stops healthy runs being reported as `cancelled`. The balance fix follows.

## What happened

Three PRs lost a shard to `timeout-minutes: 30`:

| PR | shard lost |
| --- | --- |
| #466 | `pyversions (3.12, 1)` |
| #468 | `pyversions (3.13, 1)` |
| #478 | `pyversions (3.12, 0)` and `(3.13, 0)` |

None was a failure. From #478's log:

```
14:49:49  ================= 2561 passed, 9 skipped in 1750.10s (0:29:10) =================
14:49:49  ##[error]The operation was canceled.
```

The suite finished green. The job started 14:19:43, the cap expired 14:49:43, the cancel landed at 14:49:49 during cleanup. GitHub renders that with a red mark, so it reads as a failure and costs a re-run to tell apart — which is what happened here.

## Why the cap was wrong

The comment it was set under:

> Sharding is the fix; each shard now runs a quarter of the modules, so 30 is generous

A quarter of the *modules* is what the splitter guarantees. A quarter of the *time* is what the cap assumed. The split is `sorted(set(modules))[shard::num_shards]` — round-robin over sorted names, blind to duration. Measured across one matrix on #478:

| shard | 3.10 | 3.12 | 3.13 |
| --- | --- | --- | --- |
| **0** | **22:22** | **>30, cancelled** | **>30, cancelled** |
| 1 | 7:06 | 15:11 | 17:16 |
| 2 | 12:14 | 12:00 | 13:54 |
| 3 | 14:57 | 13:00 | 13:22 |

Shard 0 is roughly twice shard 1 everywhere. Three runners finish and idle while one sits against the cap, so wall clock is set by the worst shard and the average is not the quantity the cap should clear.

## This change

`timeout-minutes: 30` → `50` on both jobs, and the comment now states the measurement rather than the assumption that produced the wrong number. 50 clears today's 30 with room for a slow runner and for the suite to grow, and still bounds a hang.

Also deletes `claude/ci-raise-job-timeout`: 62 commits behind `main`, raising 55 → 75 with measurements from before the suite was sharded, so its numbers describe a job that no longer exists. Superseded rather than merged.

## Not this change

Balancing the shards by measured duration. That is what removes the failure mode instead of moving the cap in front of it — with even shards the wall clock roughly halves and the cap stops being near-binding. I am collecting per-module durations now and it lands separately, so this one is a two-line config change that can go in immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_