### PR TITLE
Guard GSYNTH's rank selection instead of taking a bare argmin

### DIFF
--- a/docs/gsynth.rst
+++ b/docs/gsynth.rst
@@ -258,13 +258,30 @@ the loadings on the rest,
       \mathbf{F}^{0\top}_{-s}
       (\mathbf{Y}^0_{i,-s} - \mathbf{X}^{0}_{i,-s}\widehat{\boldsymbol{\beta}}),
 
-predict the held-out cell and save the error. The rank minimizing the mean
-squared prediction error wins. The procedure draws no random numbers, so the
-selected rank is a property of the panel and not of a seed.
+predict the held-out cell and save the error.
 
-Two consequences follow from that, and both are checked in the test suite.
-The set of scored cells is the same at every rank, so the criterion is
-comparable across :math:`r`; and repeated calls return the same rank.
+The scores are then walked upward from the smallest rank, and a larger rank is
+taken only when it beats the running minimum by more than 1 percent of it. The
+guard is what makes this a selection rule instead of a minimization. Prediction
+error is not convex in :math:`r` and its minimum is often a near-tie, so
+without it the criterion spends a degree of freedom to buy an improvement
+indistinguishable from noise. Both R references guard the step the same way.
+
+The procedure draws no random numbers, so the selected rank is a property of
+the panel and not of a seed. Two consequences follow, and both are checked in
+the test suite. The set of scored cells is the same at every rank, so the
+criterion is comparable across :math:`r`; and repeated calls return the same
+rank.
+
+Which reference this is. Algorithm 1 above is what ``gsynth`` implements
+through version 1.3.x. From 1.4.0 the R package is a wrapper that forwards to
+``fect``, whose cross-validation is a different scheme: it masks a random share
+of observed cells over :math:`k` rounds and weights the error across relative
+periods, dropping periods with too few treated observations. On a panel where
+the criterion is flat the two can land on different ranks --- on the Ronczewski
+(2026) cannabis application they choose 4 and 1, and the estimate differs by a
+factor of 2.6. Fix ``r`` when the comparison is meant to be about the
+estimators, which agree to 4e-17 at a common rank.
 
 Pass ``r`` to fix the count instead, and ``r_max`` to bound the search. The
 estimator lowers ``r_max`` further when the shortest treated pre-period

--- a/mlsynth/tests/test_gsynth_cv_rule.py
+++ b/mlsynth/tests/test_gsynth_cv_rule.py
@@ -1,0 +1,199 @@
+"""Choosing the factor number needs a parsimony guard, not a bare argmin.
+
+Xu (2017) Algorithm 1 scores each candidate rank by leave-one-pre-period-out
+mean squared prediction error. What it does with those scores is the part
+mlsynth had left out. gsynth walks the ranks upward and adopts a larger one
+only when it beats the running minimum by more than ``tol``, which defaults to
+0.001 (``R/core.R:351``, ``R/default.R:52``):
+
+    if ((min(CV.out[,"MSPE"]) - MSPE) > tol * min(CV.out[,"MSPE"]))
+
+mlsynth took ``min(mspe, key=...)``, which adopts a larger rank on any
+improvement at all. The MSPE surface is not convex in ``r`` and its minimum is
+often a near-tie, so on a flat surface the bare argmin buys a factor that
+explains nothing and spends a degree of freedom on it.
+
+The constant is gsynth's because Algorithm 1 is gsynth's criterion. ``fect``,
+which ``gsynth >= 1.4`` forwards to, guards the same step at 0.01
+(``R/cv.R:614``) but over a different fold scheme, and taking its constant here
+costs five of the sixteen rank agreements in
+``benchmarks/cases/gsynth_av_laws.py``, measured against a pinned live gsynth
+1.2.1 run. That benchmark is what caught the wrong constant.
+
+Measured on the Ronczewski (2026) cannabis-alcohol panel, where the surface is
+flat and multi-modal (#483):
+
+    r        0         1         2         3         4         5
+    mspe  6.73e-4   4.14e-4   4.63e-4   4.90e-4   3.89e-4   4.17e-4
+    att   0.00435   0.01792   0.02597   0.03983   0.00694  -0.00573
+
+The guard does not change that panel's answer -- r=4 beats r=1 by 6%, which
+clears 0.1% comfortably -- and the last test here pins that, because a guard
+credited with fixing a disagreement it does not fix would be a story instead of
+a finding.
+The published gsynth number for that panel comes from fect's cross-validation,
+a different fold scheme, and that remains open in #483.
+
+The rule is tested as a function of the scores. A panel engineered to produce a
+near-tie would be testing the fold arithmetic and the rule at once, and would
+break whenever either moved.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import GSYNTH
+from mlsynth.utils.gsynth_helpers.pipeline import select_rank, CV_GUARD
+
+# The cannabis panel's measured surface (#483), to two more digits than the
+# issue table carries.
+CANNABIS = {0: 0.00067276, 1: 0.00041379, 2: 0.00046305,
+            3: 0.00048987, 4: 0.00038902, 5: 0.00041734}
+
+
+class TestTheGuard:
+    def test_a_gain_under_the_threshold_does_not_buy_a_factor(self):
+        """0.04% better at r=2. The bare argmin takes it; the reference does not."""
+        assert select_rank({0: 1.0, 1: 0.5, 2: 0.4998}) == 1
+
+    def test_a_gain_over_the_threshold_does(self):
+        assert select_rank({0: 1.0, 1: 0.5, 2: 0.49}) == 2
+
+    def test_the_threshold_is_a_tenth_of_a_percent(self):
+        """Either side of it, with the margin written out.
+
+        The constant is ``gsynth``'s ``tol`` default, 0.001. A tenth of a
+        percent of 0.5 is 5e-04, so 0.49949 clears the bar by 1e-05 and
+        0.49951 misses it by the same.
+
+        Pinned because the constant is the whole rule and it is easy to reach
+        for the wrong one: ``fect`` guards the same step at 0.01, and taking
+        that constant costs five of the sixteen rank agreements in
+        ``benchmarks/cases/gsynth_av_laws.py`` against a live gsynth 1.2.1.
+        """
+        assert CV_GUARD == pytest.approx(0.001)
+        assert select_rank({0: 1.0, 1: 0.5, 2: 0.49949}) == 2
+        assert select_rank({0: 1.0, 1: 0.5, 2: 0.49951}) == 1
+
+    def test_the_comparison_is_against_the_running_minimum(self):
+        """Not against the preceding rank, which is the easy way to write it.
+
+        Here r=2 is much worse than r=1 and r=3 recovers to just under it. A
+        rule comparing consecutive ranks sees 0.9 -> 0.499, a 45% gain, and
+        buys two factors. Against the running minimum of 0.5 the gain is
+        0.04% and buys none.
+        """
+        assert select_rank({0: 1.0, 1: 0.5, 2: 0.9, 3: 0.4998}) == 1
+
+    def test_a_later_rank_is_measured_against_the_best_so_far_even_if_it_wins(self):
+        """The running minimum keeps falling as ranks are adopted."""
+        assert select_rank({0: 1.0, 1: 0.5, 2: 0.4, 3: 0.3999}) == 2
+        assert select_rank({0: 1.0, 1: 0.5, 2: 0.4, 3: 0.39}) == 3
+
+
+class TestTheDegenerateScores:
+    def test_a_single_rank_is_that_rank(self):
+        assert select_rank({0: 1.0}) == 0
+
+    def test_a_flat_surface_keeps_the_smallest_rank(self):
+        assert select_rank({0: 0.5, 1: 0.5, 2: 0.5}) == 0
+
+    def test_a_rising_surface_keeps_the_smallest_rank(self):
+        assert select_rank({0: 0.4, 1: 0.5, 2: 0.6}) == 0
+
+    def test_the_walk_starts_from_the_smallest_rank_offered(self):
+        """The scores need not start at zero -- a rank ceiling can push the
+        floor up -- and the first one offered is adopted unconditionally.
+
+        The 0.05% gain is deliberately off the boundary. A gain of exactly
+        0.1% lands on the comparison itself, where ``1.0 - 0.999`` is
+        0.0010000000000000009 in binary and the assertion would be about
+        float representation.
+        """
+        assert select_rank({2: 1.0, 3: 0.9995}) == 2
+        assert select_rank({2: 1.0, 3: 0.9}) == 3
+
+    def test_the_ranks_are_walked_in_order_and_not_in_dict_order(self):
+        assert select_rank({3: 0.39, 0: 1.0, 2: 0.4, 1: 0.5}) == 3
+
+    def test_a_non_finite_score_is_never_adopted(self):
+        """A rank whose loading regression was singular scores ``inf``."""
+        assert select_rank({0: 1.0, 1: float("inf"), 2: 0.5}) == 2
+
+    def test_no_scores_at_all_is_refused(self):
+        with pytest.raises(ValueError):
+            select_rank({})
+
+
+class TestTheGuardDoesNotExplainTheGsynthDisagreement:
+    def test_the_cannabis_surface_still_selects_the_larger_rank(self):
+        """r=4 beats the running minimum by 6%, so the guard passes it through.
+
+        #483's disagreement with the published r=1 is therefore about the MSPE
+        values, which come from a different fold scheme in fect, and not about
+        what is done with them.
+        """
+        best = min(CANNABIS[0], CANNABIS[1])
+        gain = (best - CANNABIS[4]) / best
+        assert gain > CV_GUARD
+        assert gain == pytest.approx(0.0599, abs=1e-3)
+        assert select_rank(CANNABIS) == 4
+
+    def test_a_bare_argmin_agrees_on_this_surface(self):
+        """Which is why the panel could not have found the missing guard."""
+        assert min(CANNABIS, key=lambda r: CANNABIS[r]) == select_rank(CANNABIS)
+
+
+# --------------------------------------------------------------------------- #
+# the rule is the one the estimator uses
+# --------------------------------------------------------------------------- #
+def factor_panel(n_units=30, n_per=24, r_true=2, onsets=(18, 20), k=2,
+                 noise=0.05, seed=0):
+    """A panel whose outcome is driven by ``r_true`` factors above the noise."""
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(n_per, r_true))
+    L = rng.normal(size=(n_units, r_true))
+    assign = {u: g for i, g in enumerate(onsets) for u in range(i * k, (i + 1) * k)}
+    rows = []
+    for u in range(n_units):
+        base = rng.normal(0, 1)
+        g = assign.get(u)
+        for t in range(n_per):
+            on = g is not None and t >= g
+            y = (base + F[t] @ L[u] + noise * rng.normal() + 2.0 * on)
+            rows.append((u, t, y, int(on)))
+    return pd.DataFrame(rows, columns=["id", "time", "y", "d"])
+
+
+def fit(df, **over):
+    return GSYNTH({"df": df, "outcome": "y", "treat": "d", "unitid": "id",
+                   "time": "time", "display_graphs": False, "inference": False,
+                   "force": "two-way", **over}).fit()
+
+
+class TestTheEstimatorUsesIt:
+    def test_the_selected_rank_is_what_the_rule_returns(self):
+        """Wiring, asserted against the scores the fit itself reports, so it
+        holds whatever the fold arithmetic produces on this panel."""
+        res = fit(factor_panel(), r_max=5)
+        cv = res.design.cv
+        assert cv.r_selected == select_rank(cv.mspe)
+        assert res.method_details.parameters_used["r"] == cv.r_selected
+        assert res.method_details.parameters_used["r_source"] == "cv"
+
+    def test_a_fixed_rank_skips_the_rule_entirely(self):
+        res = fit(factor_panel(), r=3)
+        assert res.method_details.parameters_used["r"] == 3
+        assert res.method_details.parameters_used["r_source"] == "user"
+        assert res.design.cv is None
+
+    def test_the_criterion_finds_a_rank_it_can_see(self):
+        """With two factors well above the noise, the scores must fall from
+        r=0 to r=2 and stop paying for more."""
+        res = fit(factor_panel(r_true=2, noise=0.05), r_max=5)
+        mspe = res.design.cv.mspe
+        assert mspe[2] < mspe[0]
+        assert res.design.cv.r_selected >= 2

--- a/mlsynth/utils/gsynth_helpers/config.py
+++ b/mlsynth/utils/gsynth_helpers/config.py
@@ -74,11 +74,25 @@ class GSYNTHConfig(BaseEstimatorConfig):
     )
     r: Optional[int] = Field(
         default=None, ge=0,
-        description="Number of factors; None selects it by Algorithm 1.",
+        description=(
+            "Number of factors. None selects it by Xu (2017) Algorithm 1: "
+            "leave-one-pre-treatment-period-out prediction error at each "
+            "candidate rank, taking a larger rank only when it beats the "
+            "running minimum by more than 1%. That is the criterion gsynth "
+            "implements through 1.3.x. From gsynth 1.4.0 the R package "
+            "forwards to fect, whose cross-validation masks a random share of "
+            "observed cells over k rounds and weights the error across "
+            "relative periods, so it can choose a different rank on the same "
+            "panel. Fix r to compare the estimators themselves."
+        ),
     )
     r_max: int = Field(
         default=5, ge=0,
-        description="Largest rank the cross-validation considers.",
+        description=(
+            "Largest rank the cross-validation considers. Lowered further when "
+            "the shortest treated pre-period history cannot identify that many "
+            "loadings."
+        ),
     )
     force: Literal["none", "unit", "time", "two-way"] = Field(
         default="two-way",

--- a/mlsynth/utils/gsynth_helpers/pipeline.py
+++ b/mlsynth/utils/gsynth_helpers/pipeline.py
@@ -75,6 +75,51 @@ def _treated_residual(inputs: GSYNTHInputs, fit: ControlFit) -> np.ndarray:
     return U - fit.mu - fit.xi[:, None]
 
 
+CV_GUARD = 0.001
+
+
+def select_rank(mspe: Dict[int, float]) -> int:
+    """The rank the cross-validation scores select.
+
+    Walking upward from the smallest rank scored, a larger one is taken only
+    when it beats the running minimum by more than ``CV_GUARD`` of it::
+
+        gsynth 1.2.1, R/core.R:351, with tol = 0.001 from its own signature
+            if ((min(CV.out[,"MSPE"]) - MSPE) > tol * min(CV.out[,"MSPE"]))
+
+    The constant is gsynth's, because Algorithm 1 is gsynth's criterion.
+    ``fect`` -- which ``gsynth >= 1.4`` forwards to -- guards the same step at
+    1% (``R/cv.R:614``), but over a different fold scheme, so its constant does
+    not transfer. Raising this to 0.01 costs five of the sixteen rank
+    agreements in ``benchmarks/cases/gsynth_av_laws.py``, which is measured
+    against a pinned live gsynth 1.2.1 run.
+
+    The guard is what makes the criterion a model-selection rule instead of a
+    minimisation. Mean squared prediction error is not convex in the rank and
+    its minimum is often a near-tie, so a bare ``argmin`` spends a degree of
+    freedom to buy an improvement indistinguishable from noise (#483).
+
+    A rank that scores non-finitely is never adopted; one arises only if every
+    fold's loading regression was singular, which leaves it with nothing to
+    say about fit.
+    """
+    if not mspe:
+        raise ValueError(
+            "no rank was scored, so none can be selected; cross_validate "
+            "raises before this when no treated unit has enough pre-treatment "
+            "periods to hold one back.")
+    ranks = sorted(mspe)
+    best_r = ranks[0]
+    best = mspe[best_r]
+    for r in ranks[1:]:
+        value = mspe[r]
+        if not np.isfinite(value):
+            continue
+        if not np.isfinite(best) or (best - value) > CV_GUARD * best:
+            best_r, best = r, value
+    return int(best_r)
+
+
 def _rank_ceiling(inputs: GSYNTHInputs, force: str) -> int:
     """Largest rank the shortest treated pre-period history can identify.
 
@@ -240,5 +285,5 @@ def cross_validate_rank(
             "enough pre-treatment periods to hold one back. Fix the rank with "
             "the `r` option instead."
         )
-    best = min(mspe, key=lambda r: mspe[r])
-    return GSYNTHCrossValidation(r_selected=int(best), mspe=mspe, n_scored=scored)
+    return GSYNTHCrossValidation(r_selected=select_rank(mspe), mspe=mspe,
+                                 n_scored=scored)


### PR DESCRIPTION
Addresses the actionable half of #483.

## What was wrong

Xu (2017) Algorithm 1 scores each candidate rank by leave-one-pre-period-out
prediction error. What `gsynth` does with those scores is the part mlsynth had
left out — it walks the ranks upward and adopts a larger one only when it beats
the running minimum by more than `tol`, which defaults to `0.001`
(`R/core.R:351`, `R/default.R:52`):

```r
if ((min(CV.out[,"MSPE"]) - MSPE) > tol * min(CV.out[,"MSPE"]))
```

mlsynth took `min(mspe, key=...)`, adopting on any improvement at all.
Prediction error is not convex in `r` and its minimum is often a near-tie, so
the bare argmin spends a degree of freedom to buy an improvement
indistinguishable from noise.

## The benchmark caught the wrong constant

I first took fect's `0.01`, on the reasoning that `gsynth >= 1.4` forwards to
fect. That is true and it is still the wrong constant here: fect guards the same
step over a *different fold scheme*, so its threshold does not transfer to
Algorithm 1.

At `0.01`, `benchmarks/cases/gsynth_av_laws.py` dropped from 16/16 rank
agreements to 11/16 against a commit-pinned live `gsynth` 1.2.1 over 96 fits. At
`0.001` it is back to 16/16, with mlsynth's MSPE table still matching gsynth's
to 1.3e-12.

Nothing else caught it. The unit tests passed at either constant, because I had
written their margins around 1%; so did the cannabis panel that motivated #483,
where every rule agrees on r=4. Only the live reference over 96 fits
discriminated. The test that pins the constant now records that, so the next
person to reach for fect's number sees why it is not this one.

## The change

`select_rank(mspe)` is extracted so the rule can be tested on scores. Testing it
through a panel engineered to produce a near-tie would exercise the fold
arithmetic and the rule at once, and would break whenever either moved.

```python
CV_GUARD = 0.001

ranks = sorted(mspe)
best_r = ranks[0]; best = mspe[best_r]
for r in ranks[1:]:
    value = mspe[r]
    if not np.isfinite(value):
        continue
    if not np.isfinite(best) or (best - value) > CV_GUARD * best:
        best_r, best = r, value
```

## TDD

```
first red:   ImportError -- select_rank does not exist
second red:   5 failed, 12 passed  -- rule extracted as the bare argmin,
                                      so the guard tests fail on the guard
green:       17 passed
```

The intermediate step matters: extracting the rule as the *existing* behaviour
first is what makes the guard tests fail for the reason they exist, instead of
on an import.

Covered: gains either side of the threshold with the margins written out; that
the comparison is against the running minimum and not the preceding rank (a rule
comparing consecutive ranks buys two factors on `{0: 1.0, 1: 0.5, 2: 0.9,
3: 0.4998}` where the correct one buys none); the constant itself; flat, rising,
single-entry, non-finite and empty score sets; that ranks are walked in order
and not in dict order; that the scores need not start at zero; wiring, asserted
against the scores the fit itself reports; and that a fixed `r` skips the rule.

Two tests pin that the guard does *not* explain #483's disagreement with the
published r=1 — r=4 clears the threshold comfortably, and a bare argmin agrees
on that surface. A guard credited with fixing something it does not fix would be
a story instead of a finding.

## Docs

`docs/gsynth.rst` and `GSYNTHConfig.r` now say which reference the selection
follows. Algorithm 1 is what `gsynth` implements through 1.3.x; from 1.4.0 the R
package forwards to `fect`, whose cross-validation masks a random share of
observed cells over `k` rounds and weights the error across relative periods, so
it can choose a different rank on the same panel. On the Ronczewski (2026)
cannabis application they choose 4 and 1, and the estimate differs by a factor
of 2.6 — while the estimators agree to 4e-17 at a common rank. Fix `r` when the
comparison is meant to be about the estimators.

## Verification

- `pytest -k gsynth` — 231 passed, 1 skipped
- `pytest mlsynth/tests/test_gsynth_cv_rule.py` — 17 passed
- `benchmarks/run_benchmarks.py --case gsynth_av_laws` — 14/14, `cv_rank_agreement` 16/16
- `benchmarks/run_benchmarks.py --case gsynth_xu_turnout` — 18/18, `r_cv_nocov` and `r_cv_cov` both 2

## Not in scope

The rest of #483: whether fect's MSPE *values* differ enough to explain the
published r=1 on the cannabis panel. That needs fect running against that panel,
and it is a question about which reference mlsynth tracks, not a defect in the
rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_