### PR TITLE
Expose Melnychuk's replacePreTreatData switch, and require a clean control for the waterfall

### DIFF
--- a/docs/spillsynth.rst
+++ b/docs/spillsynth.rst
@@ -1614,6 +1614,101 @@ are rich enough to bind -- with only a few weak covariates mscmt's global
 solution); with the full AG block it agrees with malo at :math:`\approx
 -0.68`. As always, read the ``pre_rmspe`` column as the referee.
 
+Method: ``method='iterative'`` -- Melnychuk (2024)
+--------------------------------------------------
+
+Melnychuk (2024), *Synthetic Controls with Spillover Effects: A Comparative
+Study*, proposes a "waterfall" alternative to the inclusive method's linear
+system. Where the inclusive method writes down every affected unit's gap at
+once and inverts the cross-weight matrix :math:`\Omega`, the iterative method
+cleans the affected donors one at a time and then refits.
+
+The idea
+^^^^^^^^
+
+Take the affected controls in order. For each one, build its own synthetic
+control from the units that carry no spillover -- the clean controls, plus any
+affected controls already cleaned in earlier passes -- with the treated unit
+held out of that donor pool. That synthetic is a spillover-free version of the
+donor, so substituting it for the donor's observed outcomes removes the
+contamination the treatment pushed into it. Once every affected donor has been
+through the mill, refit the treated unit's synthetic control on the cleaned
+pool and read the ATT off that.
+
+Nothing is trimmed: an affected donor that would be dropped by the pure-donor
+recipe stays in the pool with its spillover taken out. The waterfall ordering
+is what lets the second affected donor borrow from the first one's cleaned
+series instead of its contaminated one.
+
+How much of the donor gets replaced
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The substitution step has a switch, ``iterative_replace_pre``, and the two
+settings are different estimators.
+
+With ``False`` (the default) only the post-treatment outcomes are replaced.
+The donor keeps its observed pre-period, so the data the treated unit is fit
+on is unchanged and the refit returns the same weights as the naive fit. The
+correction reaches the estimate through one channel: the cleaned post-period
+counterfactual.
+
+With ``True`` the donor's whole series is replaced. Its pre-period is then an
+exact convex combination of the units it was built from, so the refit has no
+reason to load on it and the weights move -- a second channel. On German
+reunification with the outcome-only backend, Austria's weight in synthetic
+West Germany goes from 0.46 to 0.00 and the ATT moves by roughly 320 USD.
+
+Melnychuk's function signature defaults the switch to ``FALSE``; the call
+sites that produce the paper's tables pass ``TRUE``. Set
+``iterative_replace_pre=True`` to reproduce the published configuration, and
+read the ``replace_pre`` field on the fit to see which branch ran.
+
+The switch acts on outcomes, so in covariate mode the predictor block is
+untouched. That is why it moves the answer much less there: on the German
+covariate specification the two branches differ by tens of USD, against
+hundreds with the outcome-only backend.
+
+Example
+^^^^^^^
+
+.. code-block:: python
+
+   import pandas as pd
+   from mlsynth import SPILLSYNTH
+
+   d = pd.read_stata("basedata/repgermany.dta")[["country", "year", "gdp"]]
+   d["treat"] = ((d.country == "West Germany") & (d.year >= 1990)).astype(int)
+
+   res = SPILLSYNTH({
+       "df": d, "outcome": "gdp", "treat": "treat",
+       "unitid": "country", "time": "year",
+       "method": "iterative", "affected_units": ["Austria"],
+       "iscm_intercept": True,            # the reference's SCM backend
+       "iterative_replace_pre": True,     # the reference's call-site setting
+       "display_graphs": False,
+   }).fit()
+
+   res.att                                  # cleaned-pool ATT
+   res.att_scm                              # naive ATT, same weights
+   res.iterative.spillover_att["Austria"]   # spillover taken out of Austria
+   res.iterative.donor_weights              # weights over the cleaned pool
+
+``treated_synthetic_pre`` and ``naive_synthetic_pre`` are the treated unit's
+pre-period fits on the cleaned and original panels. They coincide exactly
+under the default and separate under ``iterative_replace_pre=True``, which is
+the observable that says whether the refit refit anything.
+
+When to use it against the inclusive method
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Melnychuk's own simulation study puts the inclusive method first for accuracy
+and the waterfall a close second, and the waterfall is the simpler object: a
+sequence of ordinary synthetic-control fits, with no matrix to invert. Reach
+for it when :math:`\Omega` is near-singular or the affected set is large
+enough that inverting it is uncomfortable, and when you would prefer an
+estimator whose every step is a fit you can inspect. The inclusive method
+remains the sharper tool when the affected set is small and well synthesized.
+
 Method: ``method='grossi'`` -- Grossi et al. (2025)
 ---------------------------------------------------
 

--- a/docs/spillsynth.rst
+++ b/docs/spillsynth.rst
@@ -1640,6 +1640,13 @@ recipe stays in the pool with its spillover taken out. The waterfall ordering
 is what lets the second affected donor borrow from the first one's cleaned
 series instead of its contaminated one.
 
+The method therefore needs at least one control it can treat as clean --
+the first affected donor has nothing else to be built from. Declaring every
+control affected leaves the waterfall with no first step, and mlsynth raises
+``MlsynthDataError`` instead of returning an estimate. When the spillover
+really does reach every control, ``method='cd'`` is the option that still
+works: it imposes a structure on the spillover instead of needing a clean pool.
+
 How much of the donor gets replaced
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/mlsynth/estimators/spillsynth.py
+++ b/mlsynth/estimators/spillsynth.py
@@ -92,6 +92,8 @@ class SPILLSYNTH:
         self.bilevel_solver: str = getattr(config, "bilevel_solver", "malo")
         self.bias_correct: bool = getattr(config, "bias_correct", False)
         self.iscm_intercept: bool = getattr(config, "iscm_intercept", False)
+        self.iterative_replace_pre: bool = getattr(
+            config, "iterative_replace_pre", False)
         self.n_boot: int = getattr(config, "n_boot", 0)
         self.ci_level: float = getattr(config, "ci_level", 0.90)
         self.seed: int = getattr(config, "seed", 0)
@@ -182,7 +184,8 @@ class SPILLSYNTH:
             elif self.method == "iterative":
                 fit = run_iterative(inputs, bilevel_solver=self.bilevel_solver,
                                     bias_correct=self.bias_correct,
-                                    intercept=self.iscm_intercept)
+                                    intercept=self.iscm_intercept,
+                                    replace_pre=self.iterative_replace_pre)
                 results = SpillSynthResults(
                     inputs=inputs, method="iterative", iterative=fit,
                 )

--- a/mlsynth/tests/test_spillsynth_iterative_replace_pre.py
+++ b/mlsynth/tests/test_spillsynth_iterative_replace_pre.py
@@ -1,0 +1,225 @@
+"""The iterative SCM's pre-period replacement switch (Melnychuk 2024).
+
+``runIterativeSCM(dataprepDf, replacePreTreatData, waterfallMode)`` has two
+switches. The signature defaults ``replacePreTreatData`` to ``FALSE``, but every
+call site in the reference -- ``runAllMethods`` and ``runAllMethodsWithCov``,
+which are what produce the paper's tables -- passes ``TRUE``. The two branches
+are different estimators:
+
+``False``
+    A cleaned donor keeps its observed pre-period, so the treated unit's refit
+    sees bit-identical fitting data and returns the naive weights. The
+    correction reaches the estimate only through the cleaned post-period
+    counterfactual, and the "refit" is a no-op on the weights.
+
+``True``
+    The cleaned donor's whole series is replaced by its spillover-free
+    synthetic. Its pre-period is then an exact convex combination of donors
+    already in the pool, so the refit has no reason to load on it and the
+    weights move.
+
+These tests pin the distinction. Before ``iterative_replace_pre`` existed the
+suite could not tell the branches apart: substituting ``Y[i, :] = cf`` for
+``Y[i, T0:] = cf[T0:]`` left all 252 spillsynth tests green.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import SPILLSYNTH
+from mlsynth.config_models import SPILLSYNTHConfig
+from mlsynth.exceptions import MlsynthConfigError
+
+_DATA = Path(__file__).resolve().parents[2] / "basedata" / "repgermany.dta"
+
+
+@pytest.fixture(scope="module")
+def german_panel():
+    if not _DATA.exists():
+        pytest.skip("repgermany.dta not available")
+    d = pd.read_stata(_DATA)[["country", "year", "gdp"]].copy()
+    d["treat"] = ((d.country == "West Germany") & (d.year >= 1990)).astype(int)
+    return d
+
+
+def _cfg(d, **kw):
+    base = dict(df=d, outcome="gdp", treat="treat", unitid="country",
+                time="year", method="iterative", affected_units=["Austria"],
+                iscm_intercept=True, display_graphs=False)
+    base.update(kw)
+    return base
+
+
+def _synthetic_panel(seed=0, T=20, T0=14, spillover=6.0, effect=-5.0):
+    """Treated + one affected donor + two clean donors on a common factor."""
+    rng = np.random.default_rng(seed)
+    f = np.cumsum(rng.normal(0, 1, T)) + 50.0
+    series = {
+        "T": f + rng.normal(0, 0.1, T),
+        "A": f + rng.normal(0, 0.1, T),
+        "c1": f + rng.normal(0, 0.1, T),
+        "c2": 0.5 * f + rng.normal(0, 0.1, T) + 10,
+    }
+    series["T"][T0:] += effect
+    series["A"][T0:] += spillover
+    rows = [{"unit": u, "time": t, "y": s[t], "d": int(u == "T" and t >= T0)}
+            for u, s in series.items() for t in range(T)]
+    return pd.DataFrame(rows)
+
+
+def _syn_cfg(df, **kw):
+    base = dict(df=df, outcome="y", treat="d", unitid="unit", time="time",
+                method="iterative", affected_units=["A"], iscm_intercept=True,
+                display_graphs=False)
+    base.update(kw)
+    return base
+
+
+# --------------------------------------------------------------------------
+# smoke
+# --------------------------------------------------------------------------
+
+def test_replace_pre_runs_end_to_end():
+    res = SPILLSYNTH(_syn_cfg(_synthetic_panel(), iterative_replace_pre=True)).fit()
+    assert np.isfinite(res.att)
+    assert res.iterative.replace_pre is True
+    assert res.iterative.cleaned_units == ["A"]
+
+
+# --------------------------------------------------------------------------
+# the invariant that separates the branches
+# --------------------------------------------------------------------------
+
+def test_default_is_post_only_and_leaves_the_refit_weights_alone():
+    """Under the default the refit is a no-op on the weights.
+
+    The treated unit's fitting data in the pre-period is untouched, so its
+    pre-period synthetic on the cleaned pool must equal the one the naive fit
+    produces -- exactly, not approximately.
+    """
+    df = _synthetic_panel()
+    res = SPILLSYNTH(_syn_cfg(df)).fit()
+    f = res.iterative
+    assert f.replace_pre is False
+    assert np.allclose(f.treated_synthetic_pre, f.naive_synthetic_pre, atol=1e-10)
+
+
+def test_replace_pre_moves_the_refit_weights():
+    """Under the reference's branch the refit is a real refit.
+
+    Replacing the affected donor's pre-period changes the treated unit's
+    fitting data, so the pre-period synthetic separates from the naive one and
+    the donor weights are not the naive weights.
+    """
+    df = _synthetic_panel()
+    post_only = SPILLSYNTH(_syn_cfg(df)).fit().iterative
+    whole = SPILLSYNTH(_syn_cfg(df, iterative_replace_pre=True)).fit().iterative
+    assert not np.allclose(whole.treated_synthetic_pre, whole.naive_synthetic_pre)
+    assert whole.donor_weights != post_only.donor_weights
+
+
+def test_replace_pre_makes_the_cleaned_donor_redundant():
+    """The cleaned donor becomes a convex combination of the pool it was built
+    from, so the refit stops loading on it."""
+    df = _synthetic_panel()
+    post_only = SPILLSYNTH(_syn_cfg(df)).fit().iterative
+    whole = SPILLSYNTH(_syn_cfg(df, iterative_replace_pre=True)).fit().iterative
+    assert whole.donor_weights.get("A", 0.0) < post_only.donor_weights.get("A", 0.0)
+
+
+def test_replace_pre_rewrites_the_affected_donor_pre_period(german_panel):
+    """The cleaned pre-period is the affected unit's own synthetic, so it lies
+    in the convex hull of the clean donors and differs from what was observed."""
+    res = SPILLSYNTH(_cfg(german_panel, iterative_replace_pre=True)).fit()
+    f = res.iterative
+    cleaned_pre = f.spillover_panel_pre["Austria"]
+    observed_pre = res.inputs.Y[1, : res.inputs.T0]
+    assert cleaned_pre.shape == observed_pre.shape
+    assert not np.allclose(cleaned_pre, observed_pre)
+
+
+def test_post_only_leaves_no_cleaned_pre_period():
+    res = SPILLSYNTH(_syn_cfg(_synthetic_panel())).fit()
+    assert res.iterative.spillover_panel_pre == {}
+
+
+# --------------------------------------------------------------------------
+# the two branches disagree on the estimate, and by how much
+# --------------------------------------------------------------------------
+
+def test_the_two_branches_give_different_estimates(german_panel):
+    post_only = SPILLSYNTH(_cfg(german_panel)).fit()
+    whole = SPILLSYNTH(_cfg(german_panel, iterative_replace_pre=True)).fit()
+    assert abs(whole.att - post_only.att) > 100.0
+
+
+# --------------------------------------------------------------------------
+# edge cases
+# --------------------------------------------------------------------------
+
+def test_replace_pre_with_a_single_clean_donor():
+    """One clean donor: the cleaned series is that donor's level-shifted path,
+    and the estimate stays finite."""
+    rng = np.random.default_rng(3)
+    T, T0 = 16, 12
+    f = np.cumsum(rng.normal(0, 1, T)) + 40.0
+    series = {"T": f + rng.normal(0, 0.1, T),
+              "A": f + rng.normal(0, 0.1, T),
+              "c1": f + rng.normal(0, 0.1, T)}
+    series["T"][T0:] += -3.0
+    series["A"][T0:] += 4.0
+    rows = [{"unit": u, "time": t, "y": s[t], "d": int(u == "T" and t >= T0)}
+            for u, s in series.items() for t in range(T)]
+    res = SPILLSYNTH(_syn_cfg(pd.DataFrame(rows), iterative_replace_pre=True)).fit()
+    assert np.isfinite(res.att)
+    assert res.iterative.n_clean == 1
+
+
+def test_replace_pre_is_inert_without_affected_units():
+    """With nothing to clean the switch cannot change the answer."""
+    df = _synthetic_panel()
+    cfg = dict(_syn_cfg(df))
+    cfg["affected_units"] = []
+    a = SPILLSYNTH(dict(cfg)).fit()
+    b = SPILLSYNTH(dict(cfg, iterative_replace_pre=True)).fit()
+    assert a.att == pytest.approx(b.att)
+
+
+def test_replace_pre_survives_a_covariate_backend(german_panel):
+    """The switch replaces outcomes; the predictor block is untouched, so the
+    covariate backend still runs and the two branches still differ."""
+    d = pd.read_stata(_DATA)[["country", "year", "gdp", "trade", "infrate"]].copy()
+    d["treat"] = ((d.country == "West Germany") & (d.year >= 1990)).astype(int)
+    cfg = dict(df=d, outcome="gdp", treat="treat", unitid="country", time="year",
+               method="iterative", affected_units=["Austria"],
+               covariates=["trade", "infrate"], bilevel_solver="malo",
+               display_graphs=False)
+    a = SPILLSYNTH(dict(cfg)).fit()
+    b = SPILLSYNTH(dict(cfg, iterative_replace_pre=True)).fit()
+    assert np.isfinite(a.att) and np.isfinite(b.att)
+    assert a.att != b.att
+
+
+# --------------------------------------------------------------------------
+# failure / config contract
+# --------------------------------------------------------------------------
+
+def test_default_is_false():
+    assert SPILLSYNTHConfig.model_fields["iterative_replace_pre"].default is False
+
+
+def test_non_boolean_replace_pre_is_rejected():
+    df = _synthetic_panel()
+    with pytest.raises(MlsynthConfigError):
+        SPILLSYNTH(_syn_cfg(df, iterative_replace_pre="waterfall"))
+
+
+def test_dict_and_config_agree():
+    df = _synthetic_panel()
+    r1 = SPILLSYNTH(_syn_cfg(df, iterative_replace_pre=True)).fit()
+    r2 = SPILLSYNTH(SPILLSYNTHConfig(**_syn_cfg(df, iterative_replace_pre=True))).fit()
+    assert r1.att == pytest.approx(r2.att)

--- a/mlsynth/tests/test_spillsynth_iterative_replace_pre.py
+++ b/mlsynth/tests/test_spillsynth_iterative_replace_pre.py
@@ -32,7 +32,7 @@ import pytest
 
 from mlsynth import SPILLSYNTH
 from mlsynth.config_models import SPILLSYNTHConfig
-from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 
 _DATA = Path(__file__).resolve().parents[2] / "basedata" / "repgermany.dta"
 
@@ -202,6 +202,57 @@ def test_replace_pre_survives_a_covariate_backend(german_panel):
     b = SPILLSYNTH(dict(cfg, iterative_replace_pre=True)).fit()
     assert np.isfinite(a.att) and np.isfinite(b.att)
     assert a.att != b.att
+
+
+# --------------------------------------------------------------------------
+# the cleaning pool must itself be clean
+# --------------------------------------------------------------------------
+
+def _all_controls_affected_panel(seed=1, T=16, T0=12):
+    rng = np.random.default_rng(seed)
+    f = np.cumsum(rng.normal(0, 1, T)) + 40.0
+    series = {u: f + rng.normal(0, 0.1, T) for u in ("T", "A1", "A2")}
+    series["T"][T0:] += -3.0
+    series["A1"][T0:] += 4.0
+    series["A2"][T0:] += 4.0
+    rows = [{"unit": u, "time": t, "y": s[t], "d": int(u == "T" and t >= T0)}
+            for u, s in series.items() for t in range(T)]
+    return pd.DataFrame(rows)
+
+
+@pytest.mark.parametrize("replace_pre", [False, True])
+def test_no_clean_controls_is_rejected(replace_pre):
+    """Every control declared affected leaves nothing spillover-free to learn
+    from, so the waterfall has no first step and the fit must fail."""
+    df = _all_controls_affected_panel()
+    est = SPILLSYNTH(_syn_cfg(df, affected_units=["A1", "A2"],
+                              iterative_replace_pre=replace_pre))
+    with pytest.raises(MlsynthDataError, match="clean control"):
+        est.fit()
+
+
+def test_every_reported_cleaned_unit_was_actually_cleaned():
+    """``cleaned_units`` and ``spillover_att`` describe the same set.
+
+    A unit listed as cleaned but absent from the spillover ledger was passed
+    over, and any later unit that borrowed from it was fit against contaminated
+    outcomes.
+    """
+    rng = np.random.default_rng(7)
+    T, T0 = 18, 13
+    f = np.cumsum(rng.normal(0, 1, T)) + 45.0
+    series = {u: f + rng.normal(0, 0.1, T)
+              for u in ("T", "A1", "A2", "c1", "c2")}
+    series["T"][T0:] += -4.0
+    series["A1"][T0:] += 5.0
+    series["A2"][T0:] += 3.0
+    rows = [{"unit": u, "time": t, "y": s[t], "d": int(u == "T" and t >= T0)}
+            for u, s in series.items() for t in range(T)]
+    res = SPILLSYNTH(_syn_cfg(pd.DataFrame(rows),
+                              affected_units=["A1", "A2"])).fit()
+    f_ = res.iterative
+    assert set(f_.cleaned_units) == set(f_.spillover_att)
+    assert f_.n_clean == 2
 
 
 # --------------------------------------------------------------------------

--- a/mlsynth/utils/spillsynth_helpers/config.py
+++ b/mlsynth/utils/spillsynth_helpers/config.py
@@ -156,6 +156,21 @@ class SPILLSYNTHConfig(BaseEstimatorConfig):
                     "neighbour a larger weight than the plain simplex. Ignored "
                     "in covariate mode.",
     )
+    iterative_replace_pre: bool = Field(
+        default=False,
+        description="(method='iterative') Melnychuk's replacePreTreatData. "
+                    "False (the default) replaces each affected donor's "
+                    "post-treatment outcomes only and keeps its observed "
+                    "pre-period, so the treated unit's refit sees unchanged "
+                    "fitting data and returns the naive weights. True replaces "
+                    "the donor's whole series with its spillover-free "
+                    "synthetic, which makes it a convex combination of the pool "
+                    "it was built from and moves the refit weights. The "
+                    "reference's function signature defaults to False, but its "
+                    "call sites (runAllMethods / runAllMethodsWithCov, which "
+                    "produce the paper's tables) pass True -- set this to "
+                    "reproduce the published configuration.",
+    )
     n_boot: int = Field(
         default=0, ge=0,
         description="(method='grossi') Residual-resampling draws for the "

--- a/mlsynth/utils/spillsynth_helpers/iterative/pipeline.py
+++ b/mlsynth/utils/spillsynth_helpers/iterative/pipeline.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from ....exceptions import MlsynthDataError
 from ..structures import IterativeFit, SpillSynthInputs
 from ..iscm.weights import build_unit_sc
 
@@ -85,12 +86,24 @@ def run_iterative(inputs: SpillSynthInputs, *, bilevel_solver: str = "mscmt",
     spillover_panel_pre: dict = {}
     spillover_att: dict = {}
 
+    # The waterfall bootstraps off units that carry no spillover: the first
+    # affected donor can only be cleaned against the clean controls, and every
+    # later one against those plus the donors already cleaned. With no clean
+    # control there is no first step, and proceeding would fit an affected
+    # donor against another affected donor's contaminated outcomes.
+    if affected and not clean:
+        raise MlsynthDataError(
+            "SPILLSYNTH method='iterative': every control is declared "
+            f"affected ({len(affected)} of {N - 1}), so there is no clean "
+            "control to build the spillover-free synthetics from. Leave at "
+            "least one control out of affected_units, or use method='cd', "
+            "which imposes a spillover structure instead of needing a clean "
+            "pool."
+        )
+
     # --- waterfall: clean each affected control's outcomes ------------------
     for i in affected:
         donors = np.array(sorted(clean + cleaned))
-        if donors.size == 0:                          # nothing clean to learn from
-            cleaned.append(i)
-            continue
         _, cf, _, _, _ = build_unit_sc(
             i, donors, Y, T0, predictors=P, predictor_names=pnames,
             solver=bilevel_solver, bias_correct=bias_correct, intercept=intercept)

--- a/mlsynth/utils/spillsynth_helpers/iterative/pipeline.py
+++ b/mlsynth/utils/spillsynth_helpers/iterative/pipeline.py
@@ -1,19 +1,37 @@
 """Public dispatcher for the Iterative ("waterfall") SCM (Melnychuk 2024).
 
-Pipeline (a faithful port of Melnychuk's ``runIterativeSCM`` /
-``runIterativeSCMwithCov``):
+Pipeline (a port of Melnychuk's ``runIterativeSCM`` /
+``runIterativeSCMwithCov`` in waterfall mode):
 
 1. **Clean** each spillover-affected control in turn. A synthetic control is
    built for the affected unit from the *clean* controls plus any
    already-cleaned affected units (the treated unit and not-yet-cleaned affected
-   units are excluded). The affected unit's **post-treatment** outcomes are
-   replaced by this spillover-free synthetic; its pre-treatment outcomes are
-   kept (``replacePreTreatData = FALSE``). In waterfall mode each cleaning step
-   may reuse the donors cleaned before it.
+   units are excluded). The affected unit's outcomes are replaced by this
+   spillover-free synthetic. In waterfall mode each cleaning step may reuse the
+   donors cleaned before it.
 2. **Refit** the treated unit's synthetic control on the cleaned donor pool, so
-   the affected donors no longer carry the treatment's spillover. Because the
-   pre-period outcomes are untouched, the refit weights equal the naive ones --
-   the correction enters only through the cleaned post-period counterfactual.
+   the affected donors no longer carry the treatment's spillover.
+
+``replace_pre`` is Melnychuk's ``replacePreTreatData``, and it decides how much
+of the affected donor's series step 1 overwrites. The two settings are
+different estimators, so the choice is not cosmetic:
+
+``False`` (the default)
+    Only the post-treatment outcomes are replaced. The treated unit's fitting
+    data is bit-identical to the naive fit's, so the refit returns the naive
+    weights and the correction reaches the estimate only through the cleaned
+    post-period counterfactual.
+``True``
+    The whole series is replaced. The cleaned donor's pre-period is then an
+    exact convex combination of the pool it was built from, so the refit has no
+    reason to load on it and the weights move -- on German reunification
+    (outcome-only) Austria's weight goes 0.46 to 0.00 and the ATT moves by
+    ~320 USD.
+
+The reference's function signature defaults to ``FALSE``, but its call sites --
+``runAllMethods`` and ``runAllMethodsWithCov``, which produce the paper's tables
+-- pass ``TRUE``. The default here stays ``False`` for backward compatibility;
+set ``iterative_replace_pre=True`` to reproduce the published configuration.
 
 The per-unit SCM backend is the caller's choice: outcome-only (optionally
 demeaned-with-intercept) or covariate matching through the FSCM/MASC bilevel
@@ -30,7 +48,8 @@ from ..iscm.weights import build_unit_sc
 
 
 def run_iterative(inputs: SpillSynthInputs, *, bilevel_solver: str = "mscmt",
-                  bias_correct: bool = False, intercept: bool = False) -> IterativeFit:
+                  bias_correct: bool = False, intercept: bool = False,
+                  replace_pre: bool = False) -> IterativeFit:
     """Run the Iterative ("waterfall") SCM and assemble an :class:`IterativeFit`.
 
     Parameters
@@ -45,6 +64,10 @@ def run_iterative(inputs: SpillSynthInputs, *, bilevel_solver: str = "mscmt",
         mode only).
     intercept : bool
         Use the demeaned simplex SCM with a level shift (outcome-only mode).
+    replace_pre : bool
+        Melnychuk's ``replacePreTreatData``. False replaces each affected
+        donor's post-treatment outcomes only; True replaces its whole series,
+        which is what the reference's call sites do. See the module docstring.
     """
     Y = np.array(inputs.Y, dtype=float)               # working copy (N, T)
     Y_orig = inputs.Y
@@ -59,9 +82,10 @@ def run_iterative(inputs: SpillSynthInputs, *, bilevel_solver: str = "mscmt",
     clean = list(range(p + 1, N))
     cleaned: list = []
     spillover_panel: dict = {}
+    spillover_panel_pre: dict = {}
     spillover_att: dict = {}
 
-    # --- waterfall: clean each affected control's post-treatment outcomes ----
+    # --- waterfall: clean each affected control's outcomes ------------------
     for i in affected:
         donors = np.array(sorted(clean + cleaned))
         if donors.size == 0:                          # nothing clean to learn from
@@ -72,7 +96,10 @@ def run_iterative(inputs: SpillSynthInputs, *, bilevel_solver: str = "mscmt",
             solver=bilevel_solver, bias_correct=bias_correct, intercept=intercept)
         spillover_panel[names[i]] = cf[T0:]
         spillover_att[names[i]] = float(np.mean(Y_orig[i, T0:] - cf[T0:]))
-        Y[i, T0:] = cf[T0:]                           # replace post (keep pre)
+        Y[i, T0:] = cf[T0:]
+        if replace_pre:                               # replacePreTreatData=TRUE
+            spillover_panel_pre[names[i]] = np.asarray(cf[:T0])
+            Y[i, :T0] = cf[:T0]
         cleaned.append(i)
 
     # --- refit the treated unit on the cleaned pool -------------------------
@@ -81,8 +108,10 @@ def run_iterative(inputs: SpillSynthInputs, *, bilevel_solver: str = "mscmt",
         0, donors_final, Y, T0, predictors=P, predictor_names=pnames,
         solver=bilevel_solver, bias_correct=bias_correct, intercept=intercept)
 
-    # The pre-period is untouched, so the weights equal the naive ones; the
-    # naive counterfactual reuses them on the original (contaminated) outcomes.
+    # The naive counterfactual reuses the refit weights on the original
+    # (contaminated) outcomes. Without replace_pre the treated unit's fitting
+    # data never changed, so those weights *are* the naive ones and the two
+    # pre-period fits coincide; with it they separate.
     cf_naive = Y_orig[donors_final].T @ w_f
     if intercept and P is None:                       # add back the level shift
         mu1 = Y_orig[0, :T0].mean()
@@ -101,11 +130,14 @@ def run_iterative(inputs: SpillSynthInputs, *, bilevel_solver: str = "mscmt",
         counterfactual=cf_f[T0:],
         counterfactual_scm=cf_naive[T0:],
         spillover_panel=spillover_panel,
+        spillover_panel_pre=spillover_panel_pre,
         spillover_att=spillover_att,
         donor_weights=donor_weights,
         cleaned_units=[names[i] for i in affected],
         n_clean=len(clean),
         pre_rmspe=float(pre_rmspe),
         treated_synthetic_pre=np.asarray(cf_f[:T0]),
+        naive_synthetic_pre=np.asarray(cf_naive[:T0]),
+        replace_pre=replace_pre,
         bilevel_solver=solver_label,
     )

--- a/mlsynth/utils/spillsynth_helpers/structures.py
+++ b/mlsynth/utils/spillsynth_helpers/structures.py
@@ -429,12 +429,19 @@ class IterativeFit:
 
     Each spillover-affected control is **cleaned** in turn: a synthetic control
     is built for it from the clean controls (and already-cleaned affected units,
-    excluding the treated unit), and its **post-treatment** outcomes are replaced
-    by that spillover-free synthetic (its pre-treatment outcomes are kept). The
-    treated unit's synthetic control is then refit on the cleaned donor pool, so
-    the affected donors no longer carry the treatment's spillover. Because the
-    pre-period outcomes are untouched, the refit weights equal the naive ones --
-    the correction enters only through the cleaned post-period counterfactual.
+    excluding the treated unit), and its outcomes are replaced by that
+    spillover-free synthetic. The treated unit's synthetic control is then refit
+    on the cleaned donor pool, so the affected donors no longer carry the
+    treatment's spillover.
+
+    How much of the donor's series is replaced is Melnychuk's
+    ``replacePreTreatData`` switch, carried here as ``replace_pre``. With
+    ``False`` (the default) only the post-treatment outcomes are replaced, the
+    pre-period is kept, and the treated unit's fitting data is unchanged -- so
+    the refit returns the naive weights and the correction enters only through
+    the cleaned post-period counterfactual. With ``True`` (what the reference's
+    own call sites use) the whole series is replaced, the cleaned donor becomes
+    a convex combination of the pool it was built from, and the weights move.
 
     Attributes
     ----------
@@ -448,6 +455,13 @@ class IterativeFit:
         Post-period counterfactuals (cleaned / naive).
     spillover_panel : dict
         Per-affected-unit cleaned synthetic post-period trajectory ``(T1,)``.
+    spillover_panel_pre : dict
+        Per-affected-unit cleaned synthetic *pre*-period trajectory ``(T0,)``.
+        Empty unless ``replace_pre`` is set, since otherwise the pre-period is
+        the observed one.
+    replace_pre : bool
+        Whether the affected donors' pre-period outcomes were replaced too
+        (Melnychuk's ``replacePreTreatData``).
     spillover_att : dict
         Per-affected-unit post-period mean of (observed - cleaned synthetic),
         i.e. the spillover removed from that donor.
@@ -459,6 +473,11 @@ class IterativeFit:
         Number of clean (never-affected) controls.
     pre_rmspe : float
         Treated unit's pre-treatment RMSPE on the cleaned pool.
+    naive_synthetic_pre : np.ndarray
+        Treated unit's pre-treatment synthetic fit on the *original* donor
+        outcomes, shape ``(T0,)``. Equals ``treated_synthetic_pre`` exactly when
+        ``replace_pre`` is False, and separates from it when it is set --
+        the observable that says whether the refit refit anything.
     treated_synthetic_pre : np.ndarray
         Treated unit's pre-treatment synthetic fit, shape ``(T0,)`` -- the same
         series ``ISCMFit`` and ``GrossiFit`` expose, so observed-vs-fitted plots
@@ -483,6 +502,9 @@ class IterativeFit:
     n_clean: int
     pre_rmspe: float
     treated_synthetic_pre: np.ndarray
+    naive_synthetic_pre: np.ndarray
+    spillover_panel_pre: Dict[Any, np.ndarray]
+    replace_pre: bool = False
     bilevel_solver: str = "mscmt"
 
     # SP-dialect aliases for the shared accessors / plotter.

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1223,3 +1223,11 @@ timeout = 900.0
   find = "        naive_synthetic_pre=np.asarray(cf_naive[:T0]),"
   replace = "        naive_synthetic_pre=np.asarray(cf_f[:T0]),"
   models = "the naive pre-period fit read off the cleaned panel instead of the original outcomes. The two coincide exactly when replace_pre is False, so the defect is invisible in the default configuration and silently asserts that the refit changed nothing whenever it did"
+
+  [[target.mutant]]
+  id = "uncleanable-donor-passed-off-as-cleaned"
+  find = """    if affected and not clean:
+        raise MlsynthDataError("""
+  replace = """    if False:
+        raise MlsynthDataError("""
+  models = "the identification requirement dropped, so a panel with no clean control reaches the waterfall. The shape this used to take was the worst one: the first donor was skipped, appended to the cleaned list anyway, and the next donor fit against its contaminated outcomes, which returned a finite and plausible -6.93 against a true -3.0 on a three-unit panel while cleaned_units named both donors and only the one-entry spillover ledger disagreed"

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1194,3 +1194,32 @@ timeout = 1800.0
   find = "        return (self.donor_weights is None and self.time_weights is None\n                and self.unit_weights is None and self.weights_at is None)"
   replace = "        return (self.donor_weights is None and self.time_weights is None\n                and self.unit_weights is None and self.weights_at is None\n                and self.summary_stats is None)"
   models = "summary_stats accepted in place of a face or a pointer. It carries a constraint label in prose no caller can resolve to an attribute, so counting it lets an estimator hold real weights, say nothing machine-readable about where, and pass -- which is the exact state #475 was filed about"
+
+[[target]]
+name = "iterative-waterfall-branch"
+module-path = "mlsynth/utils/spillsynth_helpers/iterative/pipeline.py"
+test-command = "python -m pytest mlsynth/tests/test_spillsynth_iterative_replace_pre.py mlsynth/tests/test_spillsynth_iterative.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "waterfall-always-replaces-the-whole-series"
+  find = """        Y[i, T0:] = cf[T0:]
+        if replace_pre:                               # replacePreTreatData=TRUE"""
+  replace = """        Y[i, :] = cf
+        if replace_pre:                               # replacePreTreatData=TRUE"""
+  models = "Melnychuk's replacePreTreatData pinned to TRUE regardless of the setting. This is the branch the reference's own call sites run, so it is not an implausible reading -- which is why it went unnoticed: before the switch existed the whole spillsynth suite (252 tests) stayed green under it, while on German reunification it moves Austria's weight from 0.46 to 0.00 and the ATT by ~320 USD"
+
+  [[target.mutant]]
+  id = "waterfall-never-replaces-the-pre-period"
+  find = """        if replace_pre:                               # replacePreTreatData=TRUE
+            spillover_panel_pre[names[i]] = np.asarray(cf[:T0])
+            Y[i, :T0] = cf[:T0]"""
+  replace = """        if replace_pre:                               # replacePreTreatData=TRUE
+            spillover_panel_pre[names[i]] = np.asarray(cf[:T0])"""
+  models = "the switch recorded but not applied -- the cleaned pre-period is reported on the fit object while the donor matrix keeps the observed one, so the setting reads as honoured and the estimate is the other branch's"
+
+  [[target.mutant]]
+  id = "naive-pre-fit-taken-from-the-cleaned-panel"
+  find = "        naive_synthetic_pre=np.asarray(cf_naive[:T0]),"
+  replace = "        naive_synthetic_pre=np.asarray(cf_f[:T0]),"
+  models = "the naive pre-period fit read off the cleaned panel instead of the original outcomes. The two coincide exactly when replace_pre is False, so the defect is invisible in the default configuration and silently asserts that the refit changed nothing whenever it did"


### PR DESCRIPTION
## Related Links

- Docs page: `docs/spillsynth.rst` — new `Method: method='iterative'` section (the method had none)
- Source paper: Melnychuk (2024), *Synthetic Controls with Spillover Effects: A Comparative Study*, [arXiv 2405.01645](https://arxiv.org/abs/2405.01645)
- Reference implementation: [`Melnychuk-Andrii/Spillover-SCM`](https://github.com/Melnychuk-Andrii/Spillover-SCM) at commit `282b621` — the commit `benchmarks/reference/clone_iscm.py` already pins
- Follow-up PR on the benchmark side is next: the cross-validation case compares mlsynth against a re-implementation of the reference, not against the reference's own output

## What

- Added `SPILLSYNTHConfig.iterative_replace_pre` (default `False`), threaded through `SPILLSYNTH.fit()` to `run_iterative`.
- Added `IterativeFit.naive_synthetic_pre`, `.spillover_panel_pre`, and `.replace_pre`.
- Added a `MlsynthDataError` when every control is declared affected, replacing a silent skip.
- Added `mlsynth/tests/test_spillsynth_iterative_replace_pre.py` (15 tests) and four mutants under a new `iterative-waterfall-branch` target.
- Added the `method='iterative'` section to `docs/spillsynth.rst`.

## Why

Two defects, found by running the reference's R and by reading coverage.

The waterfall substitutes a spillover-free synthetic for each affected donor. How much of the donor's series that overwrites is Melnychuk's `replacePreTreatData`, and the two settings are different estimators. Replacing the post-period only leaves the treated unit's fitting data untouched, so the refit returns the naive weights and the correction enters through one channel. Replacing the whole series makes the cleaned donor an exact convex combination of the pool it was built from, so the refit stops loading on it and the weights move too. On German reunification with the outcome-only backend that is Austria at 0.46 against 0.00, and roughly 320 USD of ATT.

mlsynth implemented the post-period branch and its docstring described it as the reference's behaviour, which came from reading the function signature's default. The reference's call sites — `runAllMethods` and `runAllMethodsWithCov`, the functions that produce the paper's tables — pass `TRUE`. The published configuration was unreachable.

Separately, with every control declared affected the first donor cannot be cleaned. The code appended it to the cleaned list and carried on, so the next donor was fit against contaminated outcomes and the treated unit was refit on a pool cleaned in name only. On a three-unit panel with a true effect of −3.0 the fit returned −6.93, `cleaned_units` named both donors, `spillover_att` held one, and `n_clean` read 0 in a field the estimate does not consult.

## How

Provisioned R (4.3.3 + kernlab from apt, Synth from the CRAN GitHub mirror, per the recipe in `agents/agents_benchmarking.md`) and ran the reference on the German panel, both branches, both backends. The `replacePreTreatData` attribution is a controlled swap: the reference's own algorithm, its own solver, one flag changed.

The guard replaces the `donors.size == 0` skip outright, so there is no unreachable branch left behind. ISCM already handles the same degeneracy deliberately — its Ω-singular guard fires first, with a `# pragma: no cover` and a stated reason — so the defect was confined to this module.

## Verification

- Path: cross-validation against the reference implementation, live in R.
- Quantities compared, outcome-only German panel, the reference's own algorithm with a converged QP substituted for its `ipop` call: iterative `FALSE` −1295.55 (R) against −1299.12 (mlsynth), `TRUE` −1615.79 (R) against mlsynth's branch. Covariate mode, the reference's exact configuration: R (Synth) −1868.08 against mlsynth (mscmt) −1855.88, 0.65% apart.
- Pinned durably: the unit tests assert the invariants that separate the branches, not the floats. The value pins belong in the benchmark case and are in the follow-up PR.
- Not matching, and recorded as such: the reference's own shipped output uses `ipop`, which returns weights off the simplex — sum 0.9666 fitting West Germany and 1.1933 fitting Austria, while reporting `how = "converged"`. That is the subject of the follow-up PR, not this one.

## Scope checks

<!-- FEATURE ON AN EXISTING ESTIMATOR -->
- [x] The default preserves existing behaviour exactly — `iterative_replace_pre=False` is the shipped branch, and `test_default_is_false` pins it
- [x] Existing pinned benchmark values unchanged; `benchmarks/cases/spillsynth_iterative_germany.py` is untouched and still returns −1812.70
- [x] A test pins that the default is unchanged (`test_default_is_post_only_and_leaves_the_refit_weights_alone`)
- [x] New config field has a `Field(...)` description saying when to reach for it

<!-- BUG FIX (the no-clean-control guard) -->
- [x] A test reproduces the defect and fails without the fix (`test_no_clean_controls_is_rejected`, both flag settings)
- [x] It asserts the correct behaviour — the translated error and its message — not the absence of a crash
- [x] No docstring or doc page still states the old behaviour; `IterativeFit` and the pipeline module docstring were both rewritten
- [x] No pinned value moved

## Designs

No new plots. `res.iterative.treated_synthetic_pre` and `.naive_synthetic_pre` are the two pre-period fits an outcome plot would overlay; they coincide exactly under the default and separate under the switch.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_spillsynth_iterative_replace_pre.py -q` — 15 passed
- [x] `pytest mlsynth/tests/ -k "spillsynth or result_contract or config_models"` — 572 passed, 5 skipped
- [x] `coverage run --timid -m pytest …` — `iterative/pipeline.py` at 100%, no `# pragma: no cover` added
- [x] `python tools/mutation/run_mutants.py --target iterative-waterfall-branch` — 4/4 killed
- [x] Docs build clean; section underlines checked

## Other Notes

The default stays `False`, so nothing existing moves. Whether it should become `True` — matching the configuration the paper reports — is a real question and deliberately not decided here: it would change every existing `method='iterative'` fit and the pinned benchmark. Worth a follow-up once the benchmark PR makes both branches visible side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SajJs8gcNx8Dzsq2gsTFXi

---
_Generated by [Claude Code](https://claude.ai/code/session_01SajJs8gcNx8Dzsq2gsTFXi)_