### PR TITLE
Cross-validate the spillover SCM against the reference's own R output

### DIFF
--- a/benchmarks/cases/spillsynth_iscm_xval.py
+++ b/benchmarks/cases/spillsynth_iscm_xval.py
@@ -1,28 +1,41 @@
 """SPILLSYNTH (inclusive SCM) cross-validation vs Melnychuk's reference.
 
 Cross-validates mlsynth's ``SPILLSYNTH(method="iscm", iscm_intercept=True)``
-against an independent transcription of the inclusive-SCM reference
-implementation (``Melnychuk-Andrii/Spillover-SCM``, pinned commit ``282b621``)
-on German reunification. The reference's SCM backend is a **demeaned simplex SCM
-with an intercept** (``scm_weights``); with ``iscm_intercept=True`` mlsynth uses
-the same backend, so the two should agree up to the simplex solver (mlsynth's
-FISTA vs the reference's SLSQP/ipop).
+against the reference implementation shipped with Melnychuk (2024)
+(``Melnychuk-Andrii/Spillover-SCM``, pinned commit ``282b621``) on German
+reunification, outcome-only, with Austria the single affected neighbour.
 
-mlsynth reproduces the reference's German neighbourhood and inclusive ATT:
+The case pins two comparisons, because the reference has two answers.
+
+Against the reference's algorithm with its quadratic program solved to the
+simplex, mlsynth agrees:
 
   ===============  ===============  ===============
-  Quantity         mlsynth          reference port
+  quantity         mlsynth          converged
   ===============  ===============  ===============
-  Austria in WG    ~0.46            ~0.45
-  WG in Austria    ~0.35            ~0.36
+  Austria in WG    ~0.464           ~0.454
+  WG in Austria    ~0.353           ~0.355
   inclusive ATT    ~-1279           ~-1276
   ===============  ===============  ===============
 
-This is the no-covariates inclusive fit; the residual gap to Di Stefano &
-Mellace's *covariate*-based 0.42 weight is the predictor specification, not the
-inclusive machinery. Cross-validation (the data + algorithm are the reference's,
-transcribed): the case **skips gracefully** when the reference clone is
-unavailable.
+Against what the authors' code prints, it does not, and the reason is the
+solver. ``scm_weights`` hands the demeaned Gram to ``kernlab::ipop`` and reads
+its primal without checking feasibility. On this panel -- GDP in levels, so the
+Gram carries entries of order 1e9 -- ipop reports ``how = "converged"`` on a
+solution whose weights sum to 0.9666 fitting West Germany and 1.1933 fitting
+Austria. Its fit residual (23,225) sits below the constrained optimum (88,602),
+which is what solving a relaxed problem looks like. Austria's weight comes out
+0.176 instead of 0.454, and the inclusive estimate, which divides by
+:math:`1 - w_A \\lambda_{WG}`, comes out -1651.52 instead of -1275.53.
+
+The naive SCM ATT is the quantity that hides this: -1472.60 against -1474.45,
+0.1% apart, while the weights underneath disagree by a factor of two and a half.
+That is why this case pins the weights and the inclusive estimate, not the
+headline gap.
+
+Cross-validation (the data and the algorithm are the reference's). The captured
+R run lives in ``benchmarks/reference/spillsynth_iscm_german/`` with its
+provenance; the converged comparison runs live and needs no R.
 """
 from __future__ import annotations
 
@@ -52,9 +65,11 @@ def _fit():
 
 
 def run() -> dict:
-    from benchmarks.reference.clone_iscm import reference_inclusive_german
+    from benchmarks.reference.clone_iscm import (
+        converged_reference_german, shipped_reference_german)
 
-    ref = reference_inclusive_german()            # skips if reference unavailable
+    conv = converged_reference_german()
+    ship = shipped_reference_german()
     res = _fit()
     cw = res.iscm.cross_weights
     w_A = float(cw["Austria in West Germany"])
@@ -64,20 +79,32 @@ def run() -> dict:
         "l_WG": l_WG,
         "inclusive_att": float(res.att),
         "naive_att": float(res.att_scm),
-        "w_A_vs_ref": abs(w_A - ref["w_A"]),
-        "l_WG_vs_ref": abs(l_WG - ref["l_WG"]),
-        "inclusive_vs_ref": abs(float(res.att) - ref["inclusive_att"]),
-        "naive_vs_ref": abs(float(res.att_scm) - ref["naive_att"]),
+        # mlsynth reproduces the reference's algorithm, solved to the simplex
+        "w_A_vs_converged": abs(w_A - conv["w_A"]),
+        "l_WG_vs_converged": abs(l_WG - conv["l_WG"]),
+        "inclusive_vs_converged": abs(float(res.att) - conv["inclusive_att"]),
+        "naive_vs_converged": abs(float(res.att_scm) - conv["naive_att"]),
+        # and it does not reproduce what the shipped code prints, because that
+        # code's weights are not on the simplex
+        "shipped_weight_sum_west_germany": ship["nocov_weight_sum_west_germany"],
+        "shipped_weight_sum_austria": ship["nocov_weight_sum_austria"],
+        "shipped_w_A": ship["nocov_w_austria_in_west_germany"],
+        "shipped_inclusive_att": ship["nocov_inclusive_att"],
+        "inclusive_vs_shipped": abs(float(res.att) - ship["nocov_inclusive_att"]),
+        "naive_vs_shipped": abs(float(res.att_scm) - ship["nocov_regular_att"]),
     }
 
 
 def comparison() -> dict:
-    """mlsynth's inclusive SCM vs the ported Melnychuk reference, quantity by
-    quantity: the two cross-weights (Austria in West Germany, West Germany in
-    Austria) and the naive / inclusive ATT, side by side."""
-    from benchmarks.reference.clone_iscm import _COMMIT, reference_inclusive_german
+    """mlsynth's inclusive SCM against both reference points, quantity by
+    quantity: the two cross-weights and the naive / inclusive ATT, as the
+    authors' code prints them and as their algorithm reads once its quadratic
+    program is solved to the simplex."""
+    from benchmarks.reference.clone_iscm import (
+        _COMMIT, converged_reference_german, shipped_reference_german)
 
-    ref = reference_inclusive_german()            # load first: skips if unavailable
+    conv = converged_reference_german()
+    ship = shipped_reference_german()
     res = _fit()
     cw = res.iscm.cross_weights
     w_A = float(cw["Austria in West Germany"])
@@ -86,33 +113,65 @@ def comparison() -> dict:
            "method": "iscm", "affected_units": ["Austria"], "iscm_intercept": True}
     rows = [
         {"quantity": "weight[Austria in West Germany]",
-         "mlsynth": round(w_A, 6), "reference": round(ref["w_A"], 6)},
+         "mlsynth": round(w_A, 6), "reference": round(conv["w_A"], 6)},
         {"quantity": "weight[West Germany in Austria]",
-         "mlsynth": round(l_WG, 6), "reference": round(ref["l_WG"], 6)},
-        {"quantity": "naive_ATT",
-         "mlsynth": round(float(res.att_scm), 6), "reference": round(ref["naive_att"], 6)},
-        {"quantity": "inclusive_ATT",
-         "mlsynth": round(float(res.att), 6), "reference": round(ref["inclusive_att"], 6)},
+         "mlsynth": round(l_WG, 6), "reference": round(conv["l_WG"], 6)},
+        {"quantity": "naive_ATT", "mlsynth": round(float(res.att_scm), 6),
+         "reference": round(conv["naive_att"], 6)},
+        {"quantity": "inclusive_ATT", "mlsynth": round(float(res.att), 6),
+         "reference": round(conv["inclusive_att"], 6)},
+        # the same four against what the authors' code prints, whose weights are
+        # not on the simplex
+        {"quantity": "weight[Austria in West Germany], reference as shipped",
+         "mlsynth": round(w_A, 6),
+         "reference": round(ship["nocov_w_austria_in_west_germany"], 6)},
+        {"quantity": "weight[West Germany in Austria], reference as shipped",
+         "mlsynth": round(l_WG, 6),
+         "reference": round(ship["nocov_w_west_germany_in_austria"], 6)},
+        {"quantity": "naive_ATT, reference as shipped",
+         "mlsynth": round(float(res.att_scm), 6),
+         "reference": round(ship["nocov_regular_att"], 6)},
+        {"quantity": "inclusive_ATT, reference as shipped",
+         "mlsynth": round(float(res.att), 6),
+         "reference": round(ship["nocov_inclusive_att"], 6)},
+        {"quantity": "sum of donor weights, West Germany fit (1 = on the simplex)",
+         "mlsynth": 1.0,
+         "reference": round(ship["nocov_weight_sum_west_germany"], 6)},
+        {"quantity": "sum of donor weights, Austria fit (1 = on the simplex)",
+         "mlsynth": 1.0,
+         "reference": round(ship["nocov_weight_sum_austria"], 6)},
     ]
     return {
         "rows": rows,
         "mlsynth_call": {"estimator": "SPILLSYNTH", "config": cfg},
         "reference": {"impl": "Melnychuk-Andrii/Spillover-SCM inclusive SCM "
-                              "(scm_weights/runInclusiveSCM), transcribed to NumPy",
+                              "(scm_weights / runInclusiveSCM). The first four rows "
+                              "solve the same program to the simplex; the rows "
+                              "marked 'reference as shipped' are the authors' ipop "
+                              "output, whose weights sum to 0.9666 and 1.1933",
                       "version": f"git {_COMMIT[:7]}"},
     }
 
 
-# Deterministic (closed-form demeaned simplex SCM + Cramer's rule). The ``*_vs_ref``
-# cells pin mlsynth to the ported Melnychuk reference; the residuals are the
-# simplex solver (FISTA here vs SLSQP/ipop in the reference), ~2%.
+# Deterministic (closed-form demeaned simplex SCM + Cramer's rule; the shipped
+# cells come from a committed capture). The ``*_vs_converged`` cells pin mlsynth
+# to the reference algorithm solved to the simplex -- residual is the solver,
+# FISTA here against OSQP there, ~2%. The ``*_vs_shipped`` cells pin the distance
+# to what the authors' code prints, so the ipop infeasibility stays on the record
+# instead of being absorbed into a tolerance.
 EXPECTED = {
-    "w_A": (0.46, 0.03),                 # Austria in synthetic West Germany
-    "l_WG": (0.35, 0.03),                # West Germany in synthetic Austria
-    "inclusive_att": (-1279.0, 20.0),
+    "w_A": (0.464, 0.03),                    # Austria in synthetic West Germany
+    "l_WG": (0.353, 0.03),                   # West Germany in synthetic Austria
+    "inclusive_att": (-1278.8, 20.0),
     "naive_att": (-1482.0, 20.0),
-    "w_A_vs_ref": (0.01, 0.03),          # reproduces the reference weight
-    "l_WG_vs_ref": (0.003, 0.03),
-    "inclusive_vs_ref": (3.0, 20.0),     # reproduces the reference inclusive ATT
-    "naive_vs_ref": (8.0, 20.0),
+    "w_A_vs_converged": (0.010, 0.03),       # reproduces the reference weight
+    "l_WG_vs_converged": (0.003, 0.03),
+    "inclusive_vs_converged": (3.3, 20.0),   # reproduces the reference estimate
+    "naive_vs_converged": (7.6, 20.0),
+    "shipped_weight_sum_west_germany": (0.9666, 0.001),   # not 1: ipop is infeasible
+    "shipped_weight_sum_austria": (1.1933, 0.001),        # not 1
+    "shipped_w_A": (0.1762, 0.001),
+    "shipped_inclusive_att": (-1651.52, 1.0),
+    "inclusive_vs_shipped": (372.7, 25.0),   # the cost of the infeasible solve
+    "naive_vs_shipped": (9.4, 25.0),         # which the headline gap hides
 }

--- a/benchmarks/cases/spillsynth_iterative_germany.py
+++ b/benchmarks/cases/spillsynth_iterative_germany.py
@@ -1,19 +1,19 @@
 """SPILLSYNTH (Iterative SCM) Path-A: German reunification (Melnychuk 2024).
 
 Reproduces the headline of Melnychuk (2024), *"Synthetic Controls with Spillover
-Effects: A Comparative Study"* (arXiv 2405.01645): the **Iterative ("waterfall")
-SCM** estimate of the 1990 German reunification's effect on West-German GDP per
+Effects: A Comparative Study"* (arXiv 2405.01645): the Iterative ("waterfall")
+SCM estimate of the 1990 German reunification's effect on West-German GDP per
 capita, cleaning the spillover that Austria (the affected neighbour) carries.
 
-mlsynth's ``SPILLSYNTH(method="iterative")`` runs the covariate backend on
-``basedata/repgermany.dta`` with Abadie et al.'s German predictor specification
-(predictors ``gdp`` / ``trade`` / ``infrate`` averaged over the
-``time.predictors.prior`` window 1981-1990; special predictors ``industry``
-[1981-1990], ``schooling`` [1980, 1985], ``invest80`` [1980]; SSR over
-1960-1989). The lagged-GDP predictor pulls Austria's weight in synthetic West
-Germany to ``~0.43`` (the paper's 0.42). It cleans Austria's post-treatment
-outcomes with Austria's own spillover-free synthetic and refits West Germany on
-the cleaned pool, yielding a **more negative** effect than the naive SCM:
+Two arms run.
+
+The first is mlsynth's own specification: Abadie's German predictor block
+(``gdp`` / ``trade`` / ``infrate`` averaged over the ``time.predictors.prior``
+window 1981-1990; special predictors ``industry`` [1981-1990], ``schooling``
+[1980, 1985], ``invest80`` [1980]; SSR over 1960-1989) with the post-period-only
+cleaning. The lagged-GDP predictor pulls Austria's weight in synthetic West
+Germany to ``~0.43`` (the paper's 0.42), and the iterative estimate is more
+negative than the naive SCM:
 
   ================  ===============  ===============
   Quantity          mlsynth          Melnychuk
@@ -22,13 +22,69 @@ the cleaned pool, yielding a **more negative** effect than the naive SCM:
   naive SCM ATT     ~ -1333          ~ -1600 (Abadie)
   ================  ===============  ===============
 
-The ~8% gap to the paper's -1970 is the V-optimisation backend: mlsynth's global
-``mscmt`` bilevel solver vs Abadie's ``Synth::synth``. The fit is **deterministic**
-(``mscmt`` is seeded). Path A (the paper's empirical result, V-solver slack):
-the case pins mlsynth's value tightly as a regression guard *and* checks it lands
-within the solver slack of the paper's -1970.
+The second arm is the reference's own configuration, so the two can be compared
+like for like. It differs from the first in two ways, both read off the
+authors' code, not the paper:
 
-Runtime: ~2-3 min (two global ``mscmt`` V-optimisations).
+* the reference's German specification is ``predictors = c("trade","infrate")``
+  -- Abadie's lagged-GDP predictor is absent from the script, though the paper
+  reports Abadie's 0.42 weight for Austria. Dropping it is worth about -54 USD.
+* ``runAllMethodsWithCov`` calls ``runIterativeSCMwithCov(dataprepDf, TRUE,
+  TRUE)``, so ``replacePreTreatData`` is TRUE and the cleaned donor's whole
+  series is replaced, not only its post-period. In covariate mode that is worth
+  about +11 USD, because the switch acts on outcomes and leaves the predictor
+  block alone. (Outcome-only it is worth ~320 USD; see
+  ``spillsynth_iscm_xval``.)
+
+In that configuration mlsynth returns ~ -1856 against the reference R's
+-1869.33, and neither is the paper's -1970: the shipped code does not reproduce
+its own headline.
+
+The comparison to the reference cannot be made tight, and that is a property of
+the reference. ``Synth::synth``'s ``V`` search on this specification selects a
+different optimum under perturbations far below any measurement precision.
+Multiplying every predictor by ``1 + eps * N(0,1)`` and refitting the reference:
+
+  ==========  ===========  =============  ================
+  eps         regular      inclusive      iterative (TRUE)
+  ==========  ===========  =============  ================
+  0           -1305.88     -1575.21       -1869.33
+  1e-12       -1308.88     -1577.55       -1721.24
+  1e-10       -1314.85     -1506.37       -1870.58
+  1e-8        -1310.07     -1533.91       -1771.01
+  1e-6        -1313.49     -1639.15       -1826.04
+  ==========  ===========  =============  ================
+
+A last-bit change moves the iterative estimate by 148 USD, and the movement is
+not monotone in ``eps`` -- the signature of a discontinuous selection, not of
+error propagation. The spread over the ladder is 149 USD, which is where the
+``vs_reference_R`` tolerance comes from. It also explains a 108 USD difference
+between two captures of the reference that differed only in reading
+``repgermany.dta`` directly against round-tripping it through a CSV.
+
+The instability belongs to the reference's solver, not to the specification.
+mlsynth's ``mscmt`` bilevel search over the same ladder, same panel, same
+configuration, moves by 0.08 USD and moves monotonically:
+
+  ==========  ================  ===========
+  eps         iterative (TRUE)  naive
+  ==========  ================  ===========
+  0           -1855.876         -1321.095
+  1e-12       -1855.875         -1321.096
+  1e-10       -1855.877         -1321.098
+  1e-8        -1855.905         -1321.126
+  1e-6        -1855.955         -1321.164
+  ==========  ================  ===========
+
+That asymmetry is why this case pins mlsynth's own cells to a few tens of USD
+and the distance to the reference to 150.
+
+Path A (the paper's empirical result) plus cross-validation against the
+reference's live R, captured under
+``benchmarks/reference/spillsynth_iscm_german/``. mlsynth's own cells are
+deterministic (``mscmt`` seeded at 0) and pinned tightly as regression guards.
+
+Runtime: ~5 min (four global ``mscmt`` V-optimisations).
 """
 from __future__ import annotations
 
@@ -39,21 +95,23 @@ _DATA = os.path.join(os.path.dirname(__file__), "..", "..", "basedata", "repgerm
 
 # Abadie's German spec: gdp / trade / infrate averaged over time.predictors.prior
 # (1981-1990), plus the three special predictors. The lagged-GDP predictor is the
-# one the paper carries and the Melnychuk replication file silently drops.
+# one the paper carries and the Melnychuk replication file leaves out.
 _COV = ["gdp", "trade", "infrate", "industry", "schooling", "invest80"]
+_REF_COV = ["trade", "infrate", "industry", "schooling", "invest80"]
 _WIN = {"gdp": (1981, 1990), "trade": (1981, 1990), "infrate": (1981, 1990),
         "industry": (1981, 1990), "schooling": (1980, 1985), "invest80": (1980, 1980)}
 
 
-def _fit():
+def _fit(covariates, replace_pre):
     import pandas as pd
 
     from mlsynth import SPILLSYNTH
 
     d = pd.read_stata(os.path.abspath(_DATA))
-    # _COV already contains the outcome "gdp" (the lagged-GDP predictor); select
-    # each column once so the panel doesn't carry a duplicate gdp column.
-    cols = ["country", "year"] + list(dict.fromkeys(_COV))
+    # _COV may contain the outcome "gdp" (the lagged-GDP predictor); select each
+    # column once so the panel doesn't carry a duplicate gdp column.
+    cols = ["country", "year", "gdp"] + [c for c in dict.fromkeys(covariates)
+                                         if c != "gdp"]
     d = d[cols].copy()
     d["treat"] = ((d["country"] == "West Germany") & (d["year"] >= 1990)).astype(int)
     with warnings.catch_warnings():
@@ -61,14 +119,19 @@ def _fit():
         return SPILLSYNTH({
             "df": d, "outcome": "gdp", "treat": "treat",
             "unitid": "country", "time": "year", "method": "iterative",
-            "affected_units": ["Austria"], "covariates": _COV,
-            "covariate_windows": _WIN, "bilevel_solver": "mscmt",
+            "affected_units": ["Austria"], "covariates": list(covariates),
+            "covariate_windows": {k: v for k, v in _WIN.items() if k in covariates},
+            "bilevel_solver": "mscmt", "iterative_replace_pre": replace_pre,
             "display_graphs": False,
         }).fit()
 
 
 def run() -> dict:
-    res = _fit()
+    from benchmarks.reference.clone_iscm import shipped_reference_german
+
+    ref = shipped_reference_german()
+    res = _fit(_COV, False)                       # mlsynth's specification
+    ref_arm = _fit(_REF_COV, True)                # the reference's specification
     f = res.iterative
     return {
         "iterative_att": float(res.att),
@@ -77,18 +140,31 @@ def run() -> dict:
         "austria_cleaned": float(f.cleaned_units == ["Austria"]),
         "n_clean": float(f.n_clean),
         "vs_paper_1970": abs(float(res.att) - (-1970.0)),
+        # the reference's own configuration, both knobs matched
+        "reference_spec_att": float(ref_arm.att),
+        "vs_reference_R": abs(float(ref_arm.att)
+                              - ref["cov_iterative_att_replace_pre_true"]),
+        "reference_R_att": ref["cov_iterative_att_replace_pre_true"],
+        "reference_R_vs_paper_1970": abs(
+            ref["cov_iterative_att_replace_pre_true"] - (-1970.0)),
     }
 
 
-# Deterministic (mscmt seeded at 0). The ``*_att`` cells pin mlsynth's value as a
-# regression guard; ``vs_paper_1970`` checks the estimate lands within the
-# V-solver slack of Melnychuk's reported -1970 (the residual is mlsynth's mscmt
-# bilevel solver vs Abadie's Synth::synth V-optimisation).
+# Deterministic on mlsynth's side (mscmt seeded at 0); the reference cells come
+# from a committed capture. The ``*_att`` cells pin mlsynth's values as
+# regression guards. ``vs_reference_R`` carries the tolerance the reference's own
+# solver indeterminacy imposes -- 150 USD, the spread of Synth's estimate over a
+# perturbation ladder from 0 to 1e-6 (see the docstring table). Pinning it
+# tighter would report a precision the reference does not have.
 EXPECTED = {
     "iterative_att": (-1813.0, 45.0),
     "naive_att": (-1333.0, 45.0),
     "iterative_more_negative": (1.0, 0.0),
     "austria_cleaned": (1.0, 0.0),
     "n_clean": (15.0, 0.0),
-    "vs_paper_1970": (157.0, 130.0),       # |-1813 - (-1970)| ~ 157, within slack
+    "vs_paper_1970": (157.0, 130.0),       # |-1813 - (-1970)| ~ 157
+    "reference_spec_att": (-1856.0, 60.0),
+    "vs_reference_R": (13.0, 150.0),       # within the reference's own spread
+    "reference_R_att": (-1869.3, 1.0),     # what the authors' code prints
+    "reference_R_vs_paper_1970": (100.7, 1.0),  # the code misses its own headline
 }

--- a/benchmarks/cases/spillsynth_iterative_germany.py
+++ b/benchmarks/cases/spillsynth_iterative_germany.py
@@ -84,7 +84,8 @@ reference's live R, captured under
 ``benchmarks/reference/spillsynth_iscm_german/``. mlsynth's own cells are
 deterministic (``mscmt`` seeded at 0) and pinned tightly as regression guards.
 
-Runtime: ~5 min (four global ``mscmt`` V-optimisations).
+Runtime: ~5 s (four global ``mscmt`` V-optimisations; the previous
+"2-3 min" in this docstring was never measured).
 """
 from __future__ import annotations
 

--- a/benchmarks/reference/clone_iscm.py
+++ b/benchmarks/reference/clone_iscm.py
@@ -1,35 +1,47 @@
-"""On-demand clone of the inclusive-SCM reference repo + a Python port.
+"""Melnychuk's spillover-SCM reference: the shipped code, and a converged variant.
 
 Melnychuk (2024), *"Synthetic Controls with Spillover Effects: A Comparative
-Study"* (arXiv 2405.01645), ships an R implementation of Di Stefano & Mellace's
-**inclusive** SCM at https://github.com/Melnychuk-Andrii/Spillover-SCM. The
-reference's synthetic-control backend (``scm_weights``) is a **demeaned simplex
-SCM with an intercept**, and the inclusive correction
-(``runInclusiveSCM``) solves the cross-weight system by Cramer's rule.
+Study"* (arXiv 2405.01645), ships R implementations of Di Stefano & Mellace's
+inclusive SCM and of his own iterative ("waterfall") SCM at
+https://github.com/Melnychuk-Andrii/Spillover-SCM. The repo is cloned at a
+pinned commit (``_COMMIT``) and run live; the captured run is committed under
+``benchmarks/reference/spillsynth_iscm_german/``.
 
-The repo ships the R source and the raw ``repgermany.dta`` panel but no committed
-numeric output, and no R runtime is assumed here. We therefore (i) clone the repo
-at a pinned commit for provenance + the data, and (ii) transcribe the reference's
-no-covariates ``scm_weights`` / ``runInclusiveSCM`` to NumPy and run it on the
-repo's own ``repgermany.dta``. mlsynth's ``SPILLSYNTH(method='iscm',
-iscm_intercept=True)`` is cross-checked against this independent transcription.
+Two reference points are exposed, and they are different numbers:
 
-The pinned commit (``_COMMIT``) freezes the reference so the cross-check is
-reproducible; bump it deliberately, never silently.
+:func:`shipped_reference_german`
+    What the authors' code prints. The no-covariate backend's ``scm_weights``
+    reads ``kernlab::ipop``'s primal without checking feasibility, and on this
+    panel ipop reports ``how = "converged"`` on a solution whose weights sum to
+    0.9666 fitting West Germany and 1.1933 fitting Austria. The reference's
+    synthetic controls are therefore not convex combinations, and its inclusive
+    estimate (-1651.52) is downstream of that.
+
+:func:`converged_reference_german`
+    The same algorithm with the same demeaning, intercept and Cramer's-rule
+    correction, with the quadratic program solved to the simplex instead
+    (cvxpy/OSQP at 1e-9; SLSQP stalls on this Gram). This is the number the
+    reference would print if its solver landed on the constraint set, and it is
+    what mlsynth agrees with, to about 3 USD out of 1275.
+
+Keeping both is the point. Validating mlsynth only against the converged variant
+would report agreement with a re-implementation instead of with the reference,
+and the 376 USD between them would go unrecorded.
 """
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
 import numpy as np
 
 from benchmarks.compare import BenchmarkSkipped
+from benchmarks.reference import load_reference
 from benchmarks.reference._fetch import fetch_pinned_repo
 
 _REPO = "https://github.com/Melnychuk-Andrii/Spillover-SCM.git"
 _COMMIT = "282b621f73f834b0822dcca55d9894c79f335744"
 _CACHE = Path(__file__).resolve().parent / ".cache" / "Melnychuk-Andrii-Spillover-SCM"
+_BUNDLE = "spillsynth_iscm_german"
 
 
 def _ensure_clone() -> Path:
@@ -44,14 +56,33 @@ def _ensure_clone() -> Path:
     return _CACHE
 
 
+def shipped_reference_german() -> dict:
+    """The authors' own R output, from the captured run.
+
+    Returns every quantity ``reference.R`` reports: both backends, both branches
+    of ``replacePreTreatData``, the two cross-weights, and the weight sums that
+    show the no-covariate solve missing the simplex. Regenerate with
+    ``python benchmarks/reference/generate.py spillsynth_iscm_german``.
+
+    The covariate cells come from ``Synth::synth``, whose ``V`` search on this
+    specification is sensitive far below any measurement precision: perturbing
+    the predictor block by a relative 1e-6 -- the difference between reading
+    ``repgermany.dta`` directly and round-tripping it through a CSV -- moves the
+    inclusive estimate by over 100 USD. The bundle therefore reads the ``.dta``
+    the estimators read, and its provenance records that file's checksum.
+    """
+    return dict(load_reference(_BUNDLE)["values"])
+
+
 def _scm_weights(Y_pre: np.ndarray):
-    """Port of Melnychuk's ``scm_weights``: demeaned simplex SCM + intercept.
+    """The reference's ``scm_weights``, solved to the simplex.
 
     ``Y_pre`` is the pre-period outcome matrix (rows = times, cols = units, col 0
     the target). Returns ``(a, b)`` with intercept ``a`` and full weight vector
-    ``b`` (zero on the target). Solved as a simplex-constrained least squares on
-    the demeaned series (cvxpy/OSQP -- robust on the ill-conditioned outcome
-    Gram, where SLSQP stalls).
+    ``b`` (zero on the target). The demeaning, the intercept and the objective
+    are the reference's; what differs is that the constraint is enforced --
+    cvxpy/OSQP at 1e-9, which is robust on this ill-conditioned outcome Gram
+    where SLSQP stalls and where ipop returns an infeasible primal.
     """
     import cvxpy as cp
 
@@ -76,12 +107,8 @@ def _run_scm(foo: np.ndarray, pre: np.ndarray):
     return foo[:, 0] - cf, b
 
 
-def reference_inclusive_german() -> dict:
-    """Run the ported inclusive SCM on the repo's ``repgermany.dta``.
-
-    Returns the reference ``{w_A, l_WG, naive_att, inclusive_att}`` for West
-    Germany (treated) with Austria the single affected neighbour.
-    """
+def _german_panel():
+    """The repo's own ``repgermany.dta``, wide, treated first, Austria second."""
     import pandas as pd
 
     d = pd.read_stata(_ensure_clone() / "repgermany.dta")
@@ -89,9 +116,17 @@ def reference_inclusive_german() -> dict:
     cols = ["West Germany"] + [c for c in piv.columns if c != "West Germany"]
     piv = piv[cols]
     years = piv.index.to_numpy()
-    pre = years < 1990
-    post = ~pre
-    foo = piv.to_numpy()
+    return piv.to_numpy(), cols, years < 1990, years >= 1990
+
+
+def converged_reference_german() -> dict:
+    """The reference's algorithm on its own data, with the QP solved properly.
+
+    Returns ``{w_A, l_WG, naive_att, inclusive_att, iterative_att,
+    iterative_att_replace_pre}`` for West Germany treated with Austria the
+    single affected neighbour.
+    """
+    foo, cols, pre, post = _german_panel()
     aff = cols.index("Austria")
 
     theta_gap, w_main = _run_scm(foo, pre)          # treated on all donors
@@ -104,9 +139,45 @@ def reference_inclusive_german() -> dict:
 
     det = 1.0 - w_A * l_WG
     incl_gap = (theta_gap + w_A * gamma_gap) / det
+
     return {
         "w_A": w_A,
         "l_WG": l_WG,
+        "omega_det": det,
         "naive_att": float(theta_gap[post].mean()),
         "inclusive_att": float(incl_gap[post].mean()),
+        **_converged_iterative(foo, cols, pre, post, aff),
     }
+
+
+def _converged_iterative(foo, cols, pre, post, aff) -> dict:
+    """Reference ``runIterativeSCM`` (waterfall), both replacePreTreatData branches.
+
+    Austria is swapped into the target slot and the treated unit dropped from
+    its donor pool (the reference's ``removeSpUnits``), its synthetic written
+    back over the observed series, and West Germany refit on the result.
+    """
+    out = {}
+    order = list(range(foo.shape[1]))
+    order[0], order[aff] = order[aff], order[0]
+    swapped = foo[:, order]
+    keep = [j for j in range(swapped.shape[1]) if j != order.index(0)]
+    _, actual_cf, _ = _scm_actual(swapped[:, keep], pre)
+
+    for tag, replace_pre in (("iterative_att", False),
+                             ("iterative_att_replace_pre", True)):
+        final = foo.copy()
+        cleaned = actual_cf.copy()
+        if not replace_pre:
+            cleaned[pre] = final[pre, aff]          # keep the observed pre-period
+        final[:, aff] = cleaned
+        gap, _ = _run_scm(final, pre)
+        out[tag] = float(gap[post].mean())
+    return out
+
+
+def _scm_actual(foo: np.ndarray, pre: np.ndarray):
+    """``runSCM`` returning the fitted path as well as the gap and weights."""
+    a, b = _scm_weights(foo[pre])
+    cf = a + foo @ b
+    return foo[:, 0] - cf, cf, b

--- a/benchmarks/reference/spillsynth_iscm_german/manifest.json
+++ b/benchmarks/reference/spillsynth_iscm_german/manifest.json
@@ -1,0 +1,17 @@
+{
+  "case": "spillsynth_iscm_german",
+  "title": "Inclusive and iterative spillover SCM vs Melnychuk's own R (German reunification)",
+  "paper": "Melnychuk, A. (2024), \"Synthetic Controls with Spillover Effects: A Comparative Study,\" arXiv 2405.01645; the inclusive method is Di Stefano & Mellace (2024), arXiv 2403.17624",
+  "reference_impl": "Melnychuk-Andrii/Spillover-SCM at commit 282b621 (runSCM / runInclusiveSCM / runIterativeSCM on the no-covariate backend, and the *withCov variants on Synth), cloned on demand and run live",
+  "path_type": "cross-validation",
+  "command": "python benchmarks/reference/spillsynth_iscm_german/run_reference.py",
+  "data": [
+    "basedata/repgermany.dta"
+  ],
+  "notes": [
+    "Both branches of replacePreTreatData are captured. The function signature defaults it to FALSE; runAllMethods and runAllMethodsWithCov, the entry points behind the paper's tables, pass TRUE.",
+    "nocov_weight_sum_west_germany and nocov_weight_sum_austria are 0.9666 and 1.1933, not 1. kernlab::ipop returns how = 'converged' on a primal that misses the simplex constraint, so the no-covariate reference's synthetic controls are not convex combinations and its inclusive estimate inherits that. The covariate backend goes through Synth, which standardizes its predictors, and does not show the same behaviour.",
+    "Regenerating needs R with kernlab, MASS, Synth and foreign, plus network access for the pinned clone.",
+    "The covariate cells carry the reference's own solver indeterminacy. Multiplying every predictor by 1 + eps*N(0,1) and refitting Synth::synth moves the iterative estimate over -1869.33 / -1721.24 / -1870.58 / -1771.01 / -1826.04 for eps = 0, 1e-12, 1e-10, 1e-8, 1e-6 -- a 149 USD spread, non-monotone in eps, from perturbations below any measurement precision. mlsynth's mscmt search on the same ladder moves by 0.08 USD. Regenerate this bundle from basedata/repgermany.dta and nothing else: reading the same panel through a CSV round trip perturbs the predictors at 1e-6 and moved the captured inclusive value by 108 USD."
+  ]
+}

--- a/benchmarks/reference/spillsynth_iscm_german/provenance.json
+++ b/benchmarks/reference/spillsynth_iscm_german/provenance.json
@@ -1,0 +1,25 @@
+{
+  "generated_at": "2026-08-16T19:23:31Z",
+  "git_sha": "cdd35c880f5a7204a72853511285206948e19328",
+  "platform": "Linux-6.18.5-fc-v20-x86_64-with-glibc2.39",
+  "command": "python benchmarks/reference/spillsynth_iscm_german/run_reference.py",
+  "data": [
+    {
+      "path": "basedata/repgermany.dta",
+      "sha256": "afa8cbb2812c11b45243c3523c8801b4450b5c18ab2149a3fa07f4cd7005c24e"
+    }
+  ],
+  "r_version": "R version 4.3.3 (2024-02-29)",
+  "packages": {
+    "Synth": "1.1-10",
+    "kernlab": "0.9-32",
+    "MASS": "7.3-60.0.1",
+    "compiler": "4.3.3",
+    "rgenoud": "5.9-0.10",
+    "foreign": "0.8-86",
+    "nloptr": "2.0.3",
+    "optimx": "2023-10.21",
+    "numDeriv": "2016.8-1.1",
+    "pracma": "2.4.4"
+  }
+}

--- a/benchmarks/reference/spillsynth_iscm_german/reference.R
+++ b/benchmarks/reference/spillsynth_iscm_german/reference.R
@@ -1,0 +1,129 @@
+# Melnychuk (2024) spillover-SCM reference, German reunification.
+#
+# Runs the authors' own functions -- unedited, from the pinned clone -- on the
+# panel their Main scripts assemble, and reports every quantity mlsynth's
+# SPILLSYNTH cross-checks against. Two backends:
+#
+#   no covariates   "Functions no covariates.R": scm_weights (demeaned simplex
+#                   SCM with an intercept, solved by kernlab::ipop) driving
+#                   runSCM / runInclusiveSCM / runIterativeSCM.
+#   with covariates "Functions w. covariates.R": Synth::synth with Abadie's
+#                   predictor block, driving the *withCov variants.
+#
+# Both branches of replacePreTreatData are run. The function signature defaults
+# it to FALSE; runAllMethods and runAllMethodsWithCov -- the entry points behind
+# the paper's tables -- pass TRUE.
+#
+# The weight sums are reported because they are not 1. ipop returns
+# how = "converged" on a primal that misses the simplex constraint by 3.3%
+# fitting West Germany and 19.3% fitting Austria, so the reference's synthetic
+# controls are not convex combinations. Anything downstream of the weights --
+# the cross-weight system, the inclusive correction -- inherits that.
+#
+# Usage: Rscript reference.R <clone-dir> <repgermany.dta>
+# Needs: kernlab, MASS, Synth, foreign.
+
+args <- commandArgs(trailingOnly = TRUE)
+CLONE <- args[1]
+DTA <- args[2]
+
+# The reference files load future/furrr/yaml at the top for runAllMethods, which
+# uses %<-%. Nothing called here needs them, so let only the real dependencies
+# through and stub the rest instead of installing a parallel backend.
+.real_library <- base::library
+library <- function(...) {
+  nm <- tryCatch(as.character(substitute(list(...))[[2]]), error = function(e) "")
+  if (nm %in% c("MASS", "kernlab", "Synth")) .real_library(nm, character.only = TRUE)
+  invisible(NULL)
+}
+source(file.path(CLONE, "Functions no covariates.R"))
+source(file.path(CLONE, "Functions w. covariates.R"))
+library <- .real_library
+suppressMessages({.real_library("kernlab"); .real_library("Synth")})
+
+d <- foreign::read.dta(DTA)
+
+# ---------------------------------------------------------------- no covariates
+# "Main no covariates real data.R": columns are [treated, affected, controls],
+# rows 1960:2003, with 1960:1989 the pre-period.
+wide <- reshape(d[, c("country", "year", "gdp")], idvar = "year",
+                timevar = "country", direction = "wide")
+wide <- wide[order(wide$year), ]
+years <- wide$year
+colnames(wide) <- sub("^gdp\\.", "", colnames(wide))
+units <- setdiff(colnames(wide), "year")
+ordered_units <- c("West Germany", "Austria",
+                   setdiff(units, c("West Germany", "Austria")))
+Yall <- as.matrix(wide[, ordered_units])
+
+t <- sum(years <= 1989)
+T <- nrow(Yall)
+n <- ncol(Yall)
+post <- (t + 1):T
+
+dataprep <- list(
+  foo = Yall, pre.treat.period = 1:t, full.period = 1:T,
+  sp.count = 1, total.ctrl.count = n - 1,
+  Y0 = Yall[1:t, ], Y1 = Yall[(t + 1):T, ], A = diag(n)[, c(1, 2)], y0 = 0
+)
+
+att <- function(g) mean(as.vector(g)[post])
+
+main <- runSCM(dataprep)
+swapped <- replaceSpAndTreated(dataprep, 2)
+austria <- runSCM(swapped)
+
+w_A <- main$weights[2]                      # Austria in synthetic West Germany
+l_WG <- austria$weights[2]                  # West Germany in synthetic Austria
+
+vals <- list(
+  nocov_regular_att   = att(main$gap),
+  nocov_inclusive_att = att(runInclusiveSCM(dataprep)$gap),
+  nocov_iterative_att_replace_pre_false =
+    att(runIterativeSCM(dataprep, FALSE, TRUE)$gap),
+  nocov_iterative_att_replace_pre_true =
+    att(runIterativeSCM(dataprep, TRUE, TRUE)$gap),
+  nocov_w_austria_in_west_germany = w_A,
+  nocov_w_west_germany_in_austria = l_WG,
+  nocov_omega_det = 1 - w_A * l_WG,
+  # simplex feasibility of the two ipop solves
+  nocov_weight_sum_west_germany = sum(main$weights),
+  nocov_weight_sum_austria = sum(austria$weights)
+)
+
+# -------------------------------------------------------------- with covariates
+# "Main w. covariates real data.R" dataprep2. The predictor block is
+# trade + infrate: the lagged-GDP predictor of Abadie's German specification is
+# absent from the reference script, though the paper reports Abadie's 0.42
+# weight for Austria.
+dataprep2 <- list(
+  foo = d,
+  predictors = c("trade", "infrate"),
+  dependent = "gdp",
+  unit.variable = "index",
+  time.variable = "year",
+  special.predictors = list(
+    list("industry", 1981:1990, c("mean")),
+    list("schooling", c(1980, 1985), c("mean")),
+    list("invest80", 1980, c("mean"))
+  ),
+  treatment.identifier = 7,
+  controls.identifier = setdiff(unique(d$index), c(3, 7)),
+  spillover.controls.identifier = 3,
+  time.predictors.prior = 1981:1990,
+  time.optimize.ssr = 1960:1989,
+  unit.names.variable = "country",
+  time.plot = 1960:2003
+)
+
+vals$cov_regular_att <- att(runRegularSCMwithCov(dataprep2)$gap)
+vals$cov_inclusive_att <- att(runInclusiveSCMwithCov(dataprep2)$gap)
+vals$cov_iterative_att_replace_pre_false <-
+  att(runIterativeSCMwithCov(dataprep2, FALSE, TRUE)$gap)
+vals$cov_iterative_att_replace_pre_true <-
+  att(runIterativeSCMwithCov(dataprep2, TRUE, TRUE)$gap)
+
+cat("== REFERENCE VALUES ==\n")
+for (k in names(vals)) cat(sprintf("%s\t%.6f\n", k, as.numeric(vals[[k]])))
+cat("== SESSION ==\n")
+print(sessionInfo())

--- a/benchmarks/reference/spillsynth_iscm_german/reference.json
+++ b/benchmarks/reference/spillsynth_iscm_german/reference.json
@@ -1,0 +1,18 @@
+{
+  "values": {
+    "nocov_regular_att": -1472.60001,
+    "nocov_inclusive_att": -1651.522724,
+    "nocov_iterative_att_replace_pre_false": -1651.522724,
+    "nocov_iterative_att_replace_pre_true": -1651.524568,
+    "nocov_w_austria_in_west_germany": 0.176232,
+    "nocov_w_west_germany_in_austria": 0.487178,
+    "nocov_omega_det": 0.914144,
+    "nocov_weight_sum_west_germany": 0.966605,
+    "nocov_weight_sum_austria": 1.193265,
+    "cov_regular_att": -1305.879589,
+    "cov_inclusive_att": -1575.211574,
+    "cov_iterative_att_replace_pre_false": -1801.53636,
+    "cov_iterative_att_replace_pre_true": -1869.332122
+  },
+  "weights": {}
+}

--- a/benchmarks/reference/spillsynth_iscm_german/reference.out
+++ b/benchmarks/reference/spillsynth_iscm_german/reference.out
@@ -1,0 +1,57 @@
+
+ Missing data: treated unit; special predictor: special.industry.1981.1990 ; for period: 1990 
+ We ignore (na.rm = TRUE) all missing values for predictors.op.
+
+ Missing data: treated unit; special predictor: special.industry.1981.1990 ; for period: 1990 
+ We ignore (na.rm = TRUE) all missing values for predictors.op.
+
+ Missing data - control unit: 7 ; special predictor: special.industry.1981.1990 ; for period: 1990 
+ We ignore (na.rm = TRUE) all missing values for predictors.op.
+
+ Missing data: treated unit; special predictor: special.industry.1981.1990 ; for period: 1990 
+ We ignore (na.rm = TRUE) all missing values for predictors.op.
+
+ Missing data: treated unit; special predictor: special.industry.1981.1990 ; for period: 1990 
+ We ignore (na.rm = TRUE) all missing values for predictors.op.
+== REFERENCE VALUES ==
+nocov_regular_att	-1472.600010
+nocov_inclusive_att	-1651.522724
+nocov_iterative_att_replace_pre_false	-1651.522724
+nocov_iterative_att_replace_pre_true	-1651.524568
+nocov_w_austria_in_west_germany	0.176232
+nocov_w_west_germany_in_austria	0.487178
+nocov_omega_det	0.914144
+nocov_weight_sum_west_germany	0.966605
+nocov_weight_sum_austria	1.193265
+cov_regular_att	-1305.879589
+cov_inclusive_att	-1575.211574
+cov_iterative_att_replace_pre_false	-1801.536360
+cov_iterative_att_replace_pre_true	-1869.332122
+== SESSION ==
+R version 4.3.3 (2024-02-29)
+Platform: x86_64-pc-linux-gnu (64-bit)
+Running under: Ubuntu 24.04.4 LTS
+
+Matrix products: default
+BLAS:   /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.12.0 
+LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.12.0
+
+locale:
+ [1] LC_CTYPE=C.UTF-8    LC_NUMERIC=C        LC_TIME=C          
+ [4] LC_COLLATE=C        LC_MONETARY=C       LC_MESSAGES=C      
+ [7] LC_PAPER=C          LC_NAME=C           LC_ADDRESS=C       
+[10] LC_TELEPHONE=C      LC_MEASUREMENT=C    LC_IDENTIFICATION=C
+
+time zone: Etc/UTC
+tzcode source: system (glibc)
+
+attached base packages:
+[1] stats     graphics  grDevices utils     datasets  methods   base     
+
+other attached packages:
+[1] Synth_1.1-10    kernlab_0.9-32  MASS_7.3-60.0.1
+
+loaded via a namespace (and not attached):
+[1] compiler_4.3.3      rgenoud_5.9-0.10    foreign_0.8-86     
+[4] nloptr_2.0.3        optimx_2023-10.21   numDeriv_2016.8-1.1
+[7] pracma_2.4.4       

--- a/benchmarks/reference/spillsynth_iscm_german/run_reference.py
+++ b/benchmarks/reference/spillsynth_iscm_german/run_reference.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Driver for the Melnychuk spillover-SCM reference capture.
+
+``reference.R`` runs the authors' unedited functions, which live in a repo that
+is cloned on demand at a pinned commit instead of vendored. This driver ensures
+the clone is present and hands its path to Rscript, so the whole capture is one
+command for ``benchmarks/reference/generate.py``.
+
+    python benchmarks/reference/spillsynth_iscm_german/run_reference.py
+
+Needs Rscript with kernlab, MASS, Synth and foreign. Exits non-zero (and prints
+nothing parseable) when any of that is missing, which ``generate.py`` reports as
+a skip.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+
+from benchmarks.reference.clone_iscm import _ensure_clone  # noqa: E402
+
+_HERE = Path(__file__).resolve().parent
+_DTA = ROOT / "basedata" / "repgermany.dta"
+
+
+def main() -> int:
+    clone = _ensure_clone()
+    proc = subprocess.run(
+        ["Rscript", str(_HERE / "reference.R"), str(clone), str(_DTA)],
+        capture_output=True, text=True,
+    )
+    sys.stdout.write(proc.stdout)
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/reference/spillsynth_iscm_xval/comparison.csv
+++ b/benchmarks/reference/spillsynth_iscm_xval/comparison.csv
@@ -1,12 +1,18 @@
 # case: spillsynth_iscm_xval
-# generated_at: 2026-06-24T20:09:47Z
-# mlsynth_version: 1.0.0
+# generated_at: 2026-08-16T19:31:25Z
+# mlsynth_version: 2.0.0
 # estimator: SPILLSYNTH
 # config: {"affected_units": ["Austria"], "iscm_intercept": true, "method": "iscm", "outcome": "gdp", "time": "year", "treat": "treat", "unitid": "country"}
-# reference_impl: Melnychuk-Andrii/Spillover-SCM inclusive SCM (scm_weights/runInclusiveSCM), transcribed to NumPy
+# reference_impl: Melnychuk-Andrii/Spillover-SCM inclusive SCM (scm_weights / runInclusiveSCM). The first four rows solve the same program to the simplex; the rows marked 'reference as shipped' are the authors' ipop output, whose weights sum to 0.9666 and 1.1933
 # reference_version: git 282b621
 quantity,mlsynth,reference,abs_diff
 weight[Austria in West Germany],0.463661,0.454248,0.009413
 weight[West Germany in Austria],0.352566,0.355042,0.002476
 naive_ATT,-1482.011685,-1474.451116,7.560569
 inclusive_ATT,-1278.785513,-1275.530404,3.255109
+"weight[Austria in West Germany], reference as shipped",0.463661,0.176232,0.287429
+"weight[West Germany in Austria], reference as shipped",0.352566,0.487178,0.134612
+"naive_ATT, reference as shipped",-1482.011685,-1472.60001,9.411675
+"inclusive_ATT, reference as shipped",-1278.785513,-1651.522724,372.737211
+"sum of donor weights, West Germany fit (1 = on the simplex)",1.0,0.966605,0.033395
+"sum of donor weights, Austria fit (1 = on the simplex)",1.0,1.193265,0.193265

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -172,7 +172,8 @@ Path A — empirical replications
    * - ``spillsynth_iscm_germany``
      - inclusive SCM German reunification (Di Stefano-Mellace)
    * - ``spillsynth_iterative_germany``
-     - iterative waterfall SCM German reunification (Melnychuk)
+     - iterative waterfall SCM German reunification (Melnychuk), both
+       replacePreTreatData branches, cross-checked against the authors' live R
    * - ``spotsynth_real_data``
      - SPOTSYNTH donor-spillover screening: Germany/California/Basque (Fig 6) + detection (Fig 2) + debias (Fig 4)
    * - ``tssc_brooklyn``
@@ -368,7 +369,8 @@ Cross-validation against reference implementations
    * - ``snn_prop99``
      - vs deshen24/syntheticNN (Prop 99)
    * - ``spillsynth_iscm_xval``
-     - vs Melnychuk-Andrii/Spillover-SCM (inclusive SCM German)
+     - vs Melnychuk-Andrii/Spillover-SCM (inclusive SCM German), against both
+       the authors' shipped output and their algorithm solved to the simplex
    * - ``spillsynth_prop99``
      - vs jcao0/synthetic-control-spillover (Cao-Dowd Prop 99)
    * - ``spsydid_state_mc``

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -10,8 +10,8 @@ enforces. Each row links to the reference implementation, the dataset (with
 checksum), and the mlsynth case that runs the check.
 
 Coverage: **81 cross-validation checks** against original
-implementations across **44 estimators** -- 30 reproduce the reference to display precision, 30 to
-within two percent. A further 3 are captured on the next daily run (see `Pending capture`_). Per-estimator paper replications (Path A / Path B) are catalogued in :doc:`replications`.
+implementations across **44 estimators** -- 30 reproduce the reference to display precision, 29 to
+within two percent. A further 4 are captured on the next daily run (see `Pending capture`_). Per-estimator paper replications (Path A / Path B) are catalogued in :doc:`replications`.
 
 Legend: **exact** (agreement to display precision), **tight** (worst
 relative deviation :math:`\le 2\%`), **close** (:math:`\le 10\%`), and
@@ -175,8 +175,8 @@ Summary
      - 0
    * - :ref:`SPILLSYNTH <val-spillsynth>`
      - 4
-     - 1 exact · 1 tight · 1 close · 1 documented
-     - 7.6
+     - 1 exact · 1 close · 2 documented
+     - 3.7e+02
    * - :ref:`SPSC <val-spsc>`
      - 2
      - 2 exact
@@ -1097,11 +1097,11 @@ SPILLSYNTH
      - max \|Δ\|
      - Verdict
      - Case
-   * - Melnychuk-Andrii/Spillover-SCM inclusive SCM (scm_weights/runInclusiveSCM), transcribed to NumPy
+   * - Melnychuk-Andrii/Spillover-SCM inclusive SCM (scm_weights / runInclusiveSCM). The first four rows solve the same program to the simplex; the rows marked 'reference as shipped' are the authors' ipop output, whose weights sum to 0.9666 and 1.1933
      - —
-     - 4
-     - 7.6
-     - tight
+     - 10
+     - 3.7e+02
+     - documented — see notes
      - `spillsynth_iscm_xval <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/spillsynth_iscm_xval.py>`__
    * - jcao0/synthetic-control-spillover MATLAB spillover.csv (CA row)
      - —
@@ -1415,4 +1415,6 @@ action records them once its toolchain provisions.
      - independent reproduction of tsudijon/LeaveTwoOutSCI LTO pair loop (outcome-only SC via LowRankQP), all three empirical applications
    * - `marex_scdesign_sim <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/marex_scdesign_sim.py>`__
      - jinglongzhao2/SCDesign (live run: Section 5 generation block + Synthetic_Experiment_Cardinality_Constraint on the open quadprog backend)
+   * - `ppscm_cs_real_panels <https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/ppscm_cs_real_panels.py>`__
+     - —
 


### PR DESCRIPTION
## Related Links

- Follows #486 (merged), which added the `iterative_replace_pre` switch the second benchmark arm uses. Rebased onto `main` after that merge, so this diff is benchmark-only.
- Benchmark cases: `benchmarks/cases/spillsynth_iscm_xval.py`, `benchmarks/cases/spillsynth_iterative_germany.py`
- New reference bundle: `benchmarks/reference/spillsynth_iscm_german/`
- Reference implementation: [`Melnychuk-Andrii/Spillover-SCM`](https://github.com/Melnychuk-Andrii/Spillover-SCM) at `282b621`
- Papers: Melnychuk (2024) [arXiv 2405.01645](https://arxiv.org/abs/2405.01645); Di Stefano & Mellace (2024) [arXiv 2403.17624](https://arxiv.org/abs/2403.17624)

## What

- Added `benchmarks/reference/spillsynth_iscm_german/` — a captured live run of the authors' unedited R (`reference.R`, `run_reference.py`, `manifest.json`, and the generated `reference.out` / `reference.json` / `provenance.json`), covering both backends and both `replacePreTreatData` branches.
- Rewrote `benchmarks/reference/clone_iscm.py`: `shipped_reference_german()` returns what the authors' code prints; `converged_reference_german()` runs their algorithm with the quadratic program solved to the simplex, and now covers the iterative method too.
- Rewrote `spillsynth_iscm_xval` to pin against both reference points, including the weight sums.
- Added a second arm to `spillsynth_iterative_germany` running the reference's own configuration, and replaced the gap attribution with the measured decomposition.
- Regenerated `comparison.csv` and `docs/validation.rst`; updated the two `docs/benchmarks.rst` descriptions.

## Why

The inclusive cross-check compared mlsynth against a NumPy transcription of the reference and reported agreement. The transcription substitutes cvxpy/OSQP for the reference's `kernlab::ipop` call, and that substitution is the entire disagreement.

On this panel — GDP in levels, so the demeaned Gram carries entries of order 1e9 — `ipop` reports `how = "converged"` on a primal whose weights sum to 0.9666 fitting West Germany and 1.1933 fitting Austria. Its fit residual is 23,225 against a constrained optimum of 88,602, which is what solving a relaxed problem looks like. The reference's synthetic controls are not convex combinations. Austria's weight comes out 0.176 instead of 0.454, and the inclusive estimate, which divides by 1 − w_A·λ_WG, comes out −1651.52 instead of −1275.53.

The naive SCM ATT agrees to 0.1% throughout — −1472.60 against −1474.45 — which is why this stood. The case pinned the one quantity the defect does not move.

The iterative case attributed its 157 USD gap to the paper to the V-optimisation backend. Measured, that is about 12 of it.

## How

Provisioned R per `agents/agents_benchmarking.md` (4.3.3, `kernlab`/`foreign` from apt, `Synth` built from the CRAN GitHub mirror) and ran the authors' functions unedited from the pinned clone. The `library()` calls at the top of their files load `future`/`furrr`/`yaml` for `runAllMethods`, which nothing captured here needs, so the runner stubs those and lets the real dependencies through instead of installing a parallel backend.

The `replacePreTreatData` attribution is a controlled swap — the reference's own algorithm, its own solver, one flag changed. The solver attribution is the same move in the other direction: the reference's algorithm, one solver changed, run inside R. Swapping only the QP solve moves every quantity onto the Python values (w_A 0.1762 → 0.4542, inclusive −1651.52 → −1275.53), matching to 4–5 significant figures.

## Verification

- Path: cross-validation, live R captured with provenance.
- Compared, outcome-only: `w_A` 0.4637 (mlsynth) against 0.4542 (converged) and 0.1762 (shipped); `inclusive_att` −1278.79 against −1275.53 and −1651.52; the two weight sums. Tolerances: 0.03 on weights, 20 USD on ATTs against the converged reference, 25 USD on the distance to the shipped one.
- Compared, covariate: mlsynth in the reference's configuration −1855.88 against R's −1869.33.
- Pinned durably: `benchmarks/reference/spillsynth_iscm_german/reference.json` (regenerate with `python benchmarks/reference/generate.py spillsynth_iscm_german`), read through `load_reference` so the constant in `EXPECTED` and the captured run are the same object.
- Determinism: the capture is bit-identical across repeat runs (checked twice). mlsynth's cells are seeded.
- Not matching, and recorded as such: the 373 USD to the shipped output is pinned as its own cell rather than absorbed into a tolerance, with the weight sums pinned beside it as the reason. The dashboard verdict for this case moves from `tight` to `documented`, which is what the discrepancy is.

One tolerance is deliberately loose, and the reason is measured. `Synth::synth`'s V search on this specification is discontinuous — multiplying every predictor by 1 + eps·N(0,1) moves the iterative estimate over −1869.33 / −1721.24 / −1870.58 / −1771.01 / −1826.04 for eps = 0 through 1e-6, non-monotonically. A 149 USD spread from perturbations below any measurement precision, which also explains a 108 USD difference between two captures that differed only in reading `repgermany.dta` directly against round-tripping it through a CSV. The bundle therefore reads the `.dta` and records its checksum, and `vs_reference_R` carries a 150 USD tolerance. mlsynth's `mscmt` search on the same ladder moves by 0.08 USD, monotonically, which is why its own cells stay pinned to tens of USD.

## Scope checks

- [x] Replication path stated; cross-validation with the reference run live and captured, per `agents/agents_benchmarking.md`
- [x] Expected values come from the committed capture; the generator (`reference.R` + `run_reference.py`) is committed
- [x] Each tolerance justified — the loose one from the measured perturbation ladder, the tight ones from a bit-reproducible deterministic solve
- [x] Determinism checked — repeat captures are bit-identical
- [x] Pinned quantities are the ones that move: the weights and the inclusive estimate, not the naive gap that agrees to 0.1% regardless
- [x] Branch is benchmark authoring only (the estimator change it builds on is #486)

## Designs

`benchmarks/reference/spillsynth_iscm_xval/comparison.csv` is the side-by-side, now ten rows: four against the reference's algorithm solved to the simplex, four against what it prints, and the two weight sums that separate them.

## Test Steps

- [x] `python benchmarks/reference/generate.py spillsynth_iscm_german` — regenerates, bit-identical
- [x] `python benchmarks/run_benchmarks.py --case spillsynth_iscm_xval` — 14/14 cells pass
- [x] `python benchmarks/run_benchmarks.py --case spillsynth_iterative_germany` — 10/10 cells pass
- [x] `python benchmarks/reference/export_comparison.py spillsynth_iscm_xval`
- [x] `python benchmarks/reference/build_validation.py`
- [x] `pytest mlsynth/tests/ -k "spillsynth or benchmark or registry"` — 290 passed, 1 skipped (after the rebase onto merged main)
- [x] Docs build clean

## Other Notes

Two things this does not do.

The covariate-mode inclusive estimate is captured but not cross-checked against mlsynth, because the reference's own value for it carries a 133 USD spread under the perturbation ladder. A comparison at that tolerance would not discriminate.

The reference's `ipop` behaviour would be a reasonable upstream report. `scm_weights` could check `sum(w)` against 1 before returning, and the fallback path it already has for a failed solve would then catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SajJs8gcNx8Dzsq2gsTFXi