### PR TITLE
Let MC-NNM's regularisation be pinned, and refuse zero

### DIFF
--- a/docs/mcnnm.rst
+++ b/docs/mcnnm.rst
@@ -120,7 +120,38 @@ The problem is solved by singular-value soft-thresholding [Mazumder2010]_
 re-fitting the fixed effects from their first-order conditions after each step
 until convergence. The regularization strength :math:`\lambda` is chosen by
 cross-validation over the observed cells (an ``n_lambda``-point grid,
-``n_folds`` folds).
+``n_folds`` folds), on a geometric grid running from the spectral norm of the
+demeaned observed matrix down to a thousandth of it.
+
+Pass ``lam`` to fix :math:`\lambda` instead. That is what reproduces a
+published fit, and what lets a comparison against another implementation say
+whether a disagreement is the estimator or the tuning: hold the threshold and
+the two either agree or they do not. The result reports which happened, as
+``lambda_source``, alongside the value in ``best_lambda`` --- so a
+cross-validated fit can be read off and replayed exactly.
+
+The scale is the outcome's. ``lam`` is an absolute threshold on the singular
+values of the demeaned outcome matrix, so a value another package reports on
+its own normalized grid does not transfer. ``gsynth``'s matrix-completion mode
+reports ``lambda.cv`` on a normalized scale of its own, and setting mlsynth's
+``lam`` to that number would regularize by an unrelated amount.
+
+Zero is refused. With no shrinkage the soft-threshold operator is the identity,
+so :math:`\mathbf{L}` is fit on the observed cells and never propagates to the
+unobserved ones, and the imputed counterfactual collapses to the fixed effects
+alone --- while :math:`\mathbf{L}` still reports a high rank. The
+cross-validation grid never reaches zero, so this is only reachable by asking
+for it, and asking for it is an error.
+
+.. code-block:: python
+
+   cv = MCNNM({"df": df, "outcome": "y", "treat": "d",
+               "unitid": "unit", "time": "period"}).fit()
+   cv.lambda_source        # "cv"
+
+   # the same fit, pinned
+   MCNNM({"df": df, "outcome": "y", "treat": "d", "unitid": "unit",
+          "time": "period", "lam": cv.best_lambda}).fit()
 
 Assumptions and remarks
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mlsynth/estimators/mcnnm.py
+++ b/mlsynth/estimators/mcnnm.py
@@ -82,6 +82,7 @@ class MCNNM:
         self.time: str = config.time
         self.estimate_unit_fe: bool = config.estimate_unit_fe
         self.estimate_time_fe: bool = config.estimate_time_fe
+        self.lam = config.lam
         self.n_lambda: int = config.n_lambda
         self.n_folds: int = config.n_folds
         self.inference: bool = config.inference
@@ -103,6 +104,7 @@ class MCNNM:
                 inputs=inputs,
                 est_u=self.estimate_unit_fe,
                 est_v=self.estimate_time_fe,
+                lam=self.lam,
                 n_lam=self.n_lambda,
                 n_folds=self.n_folds,
                 inference=self.inference,

--- a/mlsynth/tests/test_mcnnm_lambda.py
+++ b/mlsynth/tests/test_mcnnm_lambda.py
@@ -1,0 +1,169 @@
+"""The regularisation can be fixed, so a fit can be reproduced and compared.
+
+MC-NNM's answer is a function of one number: the singular-value threshold that
+SOFT-IMPUTE shrinks against. mlsynth chose it by cross-validation and offered no
+way to say otherwise, which costs two things (#484).
+
+A published fit cannot be reproduced. Papers report the threshold they used, and
+without a way to set it the estimator can only be run at whatever its own
+cross-validation picks.
+
+And a disagreement cannot be attributed. Against ``gsynth(estimator = "mc")`` on
+the Ronczewski (2026) cannabis panel, mlsynth reports 0.01254 where gsynth
+reports 0.00775. Two explanations fit -- a different threshold, or a different
+estimator -- and with the threshold unpinnable neither can be ruled out. Fixing
+the factor number is exactly what let GSYNTH's estimator be validated against
+``gsynth`` to 4e-17 while its selection rule was set aside as its own question
+(#483); MC-NNM had no equivalent handle.
+
+The tuning is doing real work here, which is why this matters and not merely
+tidies the interface. Refining the CV grid fivefold moves the estimate by 1e-05,
+but changing the fold count moves it by 3e-04 and drops the recovered rank from
+15 to 13.
+
+``lam`` is an absolute threshold on the singular values of the demeaned outcome
+matrix, so its scale is the outcome's. It is not comparable to a value reported
+by another implementation on its own normalised grid, and the tests below fix
+the scale by construction -- a threshold above the largest singular value must
+annihilate the low-rank term -- instead of by comparison with a number from
+somewhere else.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import MCNNM
+from mlsynth.exceptions import MlsynthConfigError
+
+
+def panel(n_units=25, n_per=18, r_true=2, t0=12, n_treated=3, noise=0.05, seed=0):
+    rng = np.random.default_rng(seed)
+    F = rng.normal(size=(n_per, r_true))
+    L = rng.normal(size=(n_units, r_true))
+    rows = []
+    for u in range(n_units):
+        for t in range(n_per):
+            on = u < n_treated and t >= t0
+            rows.append((u, t, float(F[t] @ L[u] + noise * rng.normal() + 2.0 * on),
+                         int(on)))
+    return pd.DataFrame(rows, columns=["id", "time", "y", "d"])
+
+
+def fit(df, **over):
+    return MCNNM({"df": df, "outcome": "y", "treat": "d", "unitid": "id",
+                  "time": "time", "display_graphs": False, "inference": False,
+                  **over}).fit()
+
+
+class TestTheThresholdCanBeFixed:
+    def test_a_given_lam_is_the_one_used(self):
+        res = fit(panel(), lam=0.5)
+        assert res.best_lambda == pytest.approx(0.5)
+
+    def test_it_is_reported_as_the_callers_choice(self):
+        assert fit(panel(), lam=0.5).lambda_source == "user"
+
+    def test_cross_validation_stays_the_default(self):
+        res = fit(panel())
+        assert res.lambda_source == "cv"
+        assert res.best_lambda > 0
+
+    def test_two_fits_at_the_same_lam_agree_exactly(self):
+        """No fold draw enters a fixed-threshold fit, so it is deterministic
+        without reference to ``random_state``."""
+        a = fit(panel(), lam=0.5, random_state=0)
+        b = fit(panel(), lam=0.5, random_state=99)
+        np.testing.assert_array_equal(a.counterfactual_matrix,
+                                      b.counterfactual_matrix)
+        assert float(a.effects.att) == float(b.effects.att)
+
+
+class TestTheThresholdMeansWhatItSays:
+    def test_a_larger_threshold_gives_a_lower_rank(self):
+        """Monotone in the sense the estimator is defined by: shrinking harder
+        keeps fewer singular values. Asserted as an ordering, not as counts,
+        since the counts are a property of this panel."""
+        ranks = [fit(panel(), lam=lam).rank for lam in (0.05, 0.5, 2.0)]
+        assert ranks[0] >= ranks[1] >= ranks[2]
+
+    def test_a_threshold_above_the_spectrum_annihilates_the_low_rank_term(self):
+        """The scale is the outcome's, fixed here by construction and not by
+        comparison with another implementation's normalised grid."""
+        df = panel()
+        wide = df.pivot(index="id", columns="time", values="y").to_numpy()
+        smax = float(np.linalg.svd(wide - wide.mean(), compute_uv=False)[0])
+        res = fit(df, lam=10.0 * smax)
+        assert res.rank == 0
+        assert np.allclose(res.L, 0.0, atol=1e-8)
+
+    def test_a_threshold_of_zero_is_refused(self):
+        """Zero is not "no regularisation" here, it is a degenerate fit.
+
+        With no shrinkage SOFT-IMPUTE's threshold operator is the identity, so
+        the low-rank term is fit on the observed cells and never propagates to
+        the unobserved ones. The imputation is then the fixed effects alone.
+        Measured on a panel whose true effect is 2.0::
+
+            lam=0     rank=17  |L|max=3.465  att=1.797264522
+            lam=0.01  rank=17  |L|max=3.469  att=1.997495412
+            lam=50    rank= 0  |L|max=0.000  att=1.797264520
+
+        Zero returns what annihilating the low-rank term returns, while
+        reporting a rank-17 L. The CV grid runs from the spectral norm down to
+        a thousandth of it and never reaches zero, so nothing could ask for
+        this before ``lam`` existed.
+        """
+        with pytest.raises(MlsynthConfigError, match="greater than 0"):
+            fit(panel(), lam=0.0)
+
+    def test_the_cv_choice_can_be_replayed_by_fixing_it(self):
+        """The point of the option: read the selected threshold off one fit and
+        reproduce that fit exactly."""
+        chosen = fit(panel())
+        replayed = fit(panel(), lam=chosen.best_lambda)
+        np.testing.assert_allclose(replayed.counterfactual_matrix,
+                                   chosen.counterfactual_matrix,
+                                   rtol=0, atol=1e-10)
+        assert float(replayed.effects.att) == pytest.approx(
+            float(chosen.effects.att), abs=1e-12)
+
+
+class TestTheTuningIsRefusedOrHonouredExplicitly:
+    """Every refusal here matches on its own message.
+
+    ``extra="forbid"`` rejects an unknown ``lam`` with ``MlsynthConfigError``
+    too, so a bare ``pytest.raises`` passes before the field exists and reports
+    a missing feature as a working validator.
+    """
+
+    def test_a_negative_lam_is_refused(self):
+        with pytest.raises(MlsynthConfigError, match="greater than 0"):
+            fit(panel(), lam=-1.0)
+
+    def test_giving_lam_and_a_grid_size_together_is_refused(self):
+        """``n_lambda`` sizes a search that a fixed threshold does not run, so
+        passing both states two incompatible intentions."""
+        with pytest.raises(MlsynthConfigError, match="n_lambda"):
+            fit(panel(), lam=0.5, n_lambda=80)
+
+    def test_giving_lam_and_a_fold_count_together_is_refused(self):
+        with pytest.raises(MlsynthConfigError, match="n_folds"):
+            fit(panel(), lam=0.5, n_folds=10)
+
+    def test_the_grid_size_is_still_free_when_lam_is_not_given(self):
+        assert fit(panel(), n_lambda=20).lambda_source == "cv"
+
+
+class TestInferenceFollowsTheFixedThreshold:
+    def test_the_jackknife_refits_at_the_given_lam(self):
+        """The jackknife holds the threshold fixed across its refits, and the
+        threshold it holds must be the caller's when one was given."""
+        res = MCNNM({"df": panel(), "outcome": "y", "treat": "d",
+                     "unitid": "id", "time": "time", "display_graphs": False,
+                     "inference": True, "lam": 0.5}).fit()
+        assert res.best_lambda == pytest.approx(0.5)
+        assert res.lambda_source == "user"
+        assert np.isfinite(res.inference.standard_error)

--- a/mlsynth/utils/mcnnm_helpers/config.py
+++ b/mlsynth/utils/mcnnm_helpers/config.py
@@ -6,8 +6,11 @@ Co-located with the helper package; re-exported from
 
 from __future__ import annotations
 
-from pydantic import Field
+from typing import Any, Optional
+
+from pydantic import Field, model_validator
 from ...config_models import BaseEstimatorConfig
+from ...exceptions import MlsynthConfigError
 
 
 class MCNNMConfig(BaseEstimatorConfig):
@@ -27,10 +30,22 @@ class MCNNMConfig(BaseEstimatorConfig):
         Estimate (unregularised) unit fixed effects. Default True.
     estimate_time_fe : bool
         Estimate (unregularised) time fixed effects. Default True.
+    lam : float or None
+        The singular-value threshold SOFT-IMPUTE shrinks against. ``None``
+        (default) selects it by cross-validation over the observed cells.
+        Giving it fixes the fit, which is what reproduces a published one and
+        what lets a comparison against another implementation separate the
+        estimator from its tuning. The scale is the outcome's: ``lam`` is an
+        absolute threshold on the singular values of the demeaned outcome
+        matrix, so a value another package reports on its own normalised grid
+        does not transfer. Read ``result.best_lambda`` off a
+        cross-validated fit to replay it.
     n_lambda : int
-        Number of candidate singular-value thresholds in the CV grid.
+        Number of candidate singular-value thresholds in the CV grid. Applies
+        only when ``lam`` is None.
     n_folds : int
-        Cross-validation folds over the observed cells.
+        Cross-validation folds over the observed cells. Applies only when
+        ``lam`` is None.
     inference : bool
         Run a leave-one-control jackknife for the ATT SE / CI. Default
         False (it refits the model once per control unit).
@@ -44,6 +59,17 @@ class MCNNMConfig(BaseEstimatorConfig):
         default=True, description="Estimate unregularised unit fixed effects.")
     estimate_time_fe: bool = Field(
         default=True, description="Estimate unregularised time fixed effects.")
+    lam: Optional[float] = Field(
+        default=None, gt=0.0,
+        description=(
+            "Singular-value threshold for SOFT-IMPUTE. None cross-validates "
+            "it. The scale is the outcome's, so a value another package "
+            "reports on its own normalised grid does not transfer; read "
+            "result.best_lambda off a cross-validated fit to replay it. Must "
+            "be strictly positive: at zero SOFT-IMPUTE's shrinkage is the "
+            "identity and the low-rank term never propagates to the "
+            "unobserved cells, so the fit collapses to the fixed effects "
+            "alone."))
     n_lambda: int = Field(
         default=40, ge=2,
         description="Number of candidate thresholds in the CV grid.")
@@ -57,3 +83,17 @@ class MCNNMConfig(BaseEstimatorConfig):
         description="Two-sided level for the jackknife confidence interval.")
     random_state: int = Field(
         default=0, description="Seed for the CV fold assignment.")
+
+    @model_validator(mode="after")
+    def check_tuning(cls, values: Any) -> Any:
+        if values.lam is None:
+            return values
+        given = [f for f in ("n_lambda", "n_folds") if f in values.model_fields_set]
+        if given:
+            raise MlsynthConfigError(
+                f"lam fixes the threshold, so the cross-validation that "
+                f"{' and '.join(given)} configures never runs; pass lam alone, "
+                f"or drop it to search over a grid of {values.n_lambda} "
+                f"thresholds in {values.n_folds} folds."
+            )
+        return values

--- a/mlsynth/utils/mcnnm_helpers/pipeline.py
+++ b/mlsynth/utils/mcnnm_helpers/pipeline.py
@@ -131,6 +131,7 @@ def run_mcnnm(
     *,
     est_u: bool = True,
     est_v: bool = True,
+    lam: Optional[float] = None,
     n_lam: int = 40,
     n_folds: int = 5,
     max_iter: int = 400,
@@ -147,6 +148,8 @@ def run_mcnnm(
     inputs : MCNNMInputs
     est_u, est_v : bool
         Estimate unit / time fixed effects (recommended; default True).
+    lam : float or None
+        Singular-value threshold. None cross-validates it over the grid below.
     n_lam : int
         Number of candidate thresholds in the CV grid.
     n_folds : int
@@ -157,9 +160,18 @@ def run_mcnnm(
     """
     Y, mask, D, T0 = inputs.Y, inputs.mask, inputs.D, inputs.T0
 
-    fit = mcnnm_cv(Y, mask, est_u=est_u, est_v=est_v, n_lam=n_lam,
-                   n_folds=n_folds, max_iter=max_iter, tol=tol,
-                   random_state=random_state)
+    # A given threshold skips the search entirely: no folds are drawn, so the
+    # fit does not depend on random_state (#484).
+    if lam is None:
+        fit = mcnnm_cv(Y, mask, est_u=est_u, est_v=est_v, n_lam=n_lam,
+                       n_folds=n_folds, max_iter=max_iter, tol=tol,
+                       random_state=random_state)
+        lambda_source = "cv"
+    else:
+        fit = mcnnm_fit(Y, mask, float(lam), est_u=est_u, est_v=est_v,
+                        max_iter=max_iter, tol=tol)
+        fit["best_lambda"] = float(lam)
+        lambda_source = "user"
     completed = fit["completed"]
     att, effects, att_by_period = _att_from_fit(
         Y, D, completed, T0, inputs.time_labels
@@ -217,7 +229,8 @@ def run_mcnnm(
         inputs=inputs, counterfactual_matrix=completed, effects_matrix=effects,
         att_by_period=att_by_period, cohort_att=cohort_att,
         event_study=event_study, L=fit["L"], gamma=fit["gamma"],
-        delta=fit["delta"], best_lambda=float(fit["best_lambda"]), rank=rank,
+        delta=fit["delta"], best_lambda=float(fit["best_lambda"]),
+        lambda_source=lambda_source, rank=rank,
         unit_factors=unit_factors, time_factors=time_factors,
         singular_values=singular_values, inference_jackknife=inf,
         metadata=metadata,

--- a/mlsynth/utils/mcnnm_helpers/structures.py
+++ b/mlsynth/utils/mcnnm_helpers/structures.py
@@ -10,7 +10,7 @@ forms treatment effects as observed minus imputed.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import numpy as np
 from pydantic import ConfigDict, Field as PydField
@@ -97,6 +97,8 @@ class MCNNMResults(BaseEstimatorResults):
         Unit fixed effects, shape ``(N,)``.
     delta : np.ndarray
         Time fixed effects, shape ``(T,)``.
+    lambda_source : {"cv", "user"}
+        Whether ``best_lambda`` was cross-validated or supplied by the caller.
     best_lambda : float
         Cross-validation-selected singular-value threshold.
     rank : int
@@ -129,6 +131,7 @@ class MCNNMResults(BaseEstimatorResults):
     gamma: np.ndarray
     delta: np.ndarray
     best_lambda: float
+    lambda_source: Literal["cv", "user"] = "cv"
     rank: int
     unit_factors: Optional[np.ndarray] = None
     time_factors: Optional[np.ndarray] = None


### PR DESCRIPTION
Closes #484.

## What was wrong

MC-NNM's answer is a function of one number: the singular-value threshold SOFT-IMPUTE shrinks against. It was chosen by cross-validation with no way to say otherwise, which cost two things.

A published fit could not be reproduced. And a disagreement could not be attributed: against `gsynth(estimator = "mc")` on the Ronczewski (2026) cannabis panel mlsynth reports 0.01254 where gsynth reports 0.00775, and with the threshold unpinnable, "different threshold" and "different estimator" were indistinguishable.

Pinning it settles that case. Sweeping `lam` over the panel:

```
CV       lam=0.044929  rank=15  att=0.012544474
gsynth mc target                 att=0.007746570

lam=0.30  rank=2  att=0.009555827   +1.81e-03
lam=0.60  rank=1  att=0.005768071   -1.98e-03
```

The ATT crosses gsynth's number between λ=0.3 and λ=0.6, so the gap is reachable by tuning alone and is not evidence of a different estimator. This is the same handle that let GSYNTH be validated against `gsynth` to 4e-17 at a fixed rank while its selection rule was separated out as its own question (#483).

## The bug the new option exposed

Zero is refused, and the reason is measured. With no shrinkage the soft-threshold operator is the identity, so `L` is fit on the observed cells and never propagates to the unobserved ones; the imputation collapses to the fixed effects alone while `L` still reports a high rank. On a panel whose true effect is 2.0:

```
lam=0      rank=17  |L|max=3.465  att=1.797264522
lam=0.01   rank=17  |L|max=3.469  att=1.997495412
lam=0.5    rank= 2  |L|max=3.394  att=2.001278851
lam=50     rank= 0  |L|max=0.000  att=1.797264520
```

λ=0 returns what annihilating the low-rank term returns, and misses the true effect by 0.2. The CV grid runs from the spectral norm down to a thousandth of it and never reaches zero, so nothing could ask for this before `lam` existed — adding the option without the guard would have shipped a trap at its most obvious value.

Found by sweeping the new option. My first draft of the test called λ=0 "the unregularised fit" and asserted only that the value was stored, which would have passed forever.

## The change

- `lam: Optional[float] = Field(default=None, gt=0.0)`. `None` keeps cross-validation as the default; nothing existing moves.
- `MCNNMResults.lambda_source` reports `"cv"` or `"user"`, so a cross-validated fit can be read off and replayed exactly.
- Giving `lam` alongside `n_lambda` or `n_folds` is refused: they configure a search a fixed threshold never runs.
- A fixed-threshold fit draws no folds, so it does not depend on `random_state`.

## TDD

```
first red:   10 failed, 3 passed
second red:  13 failed          <- after tightening the three false passes
green:       13 passed
```

The three "passes" in the first run were false. `extra="forbid"` rejects an unknown `lam` with `MlsynthConfigError`, so a bare `pytest.raises` reported a missing feature as a working validator — the same trap as `cband` earlier in this branch's history. Each refusal test now matches on its own message.

Covered: the threshold is used and reported as the caller's; CV stays the default; two fits at the same `lam` are bit-identical across seeds; monotonicity of rank in `lam`; a threshold above the spectrum annihilates `L` (which fixes the scale by construction, not by comparison with another package's normalised grid); a CV choice replayed exactly; the three refusals; and the jackknife refitting at the given `lam`.

## Docs

`docs/mcnnm.rst` gains the CV grid's actual range, what pinning is for, the scale caveat (`gsynth`'s `lambda.cv` is on its own normalised scale and does not transfer), why zero is an error, and a read-off-and-replay example.

## Verification

- `pytest -k "mcnnm or result_contract"` — 322 passed, 5 skipped
- `pytest mlsynth/tests/test_mcnnm_lambda.py` — 13 passed

## Not in scope

Fixing the λ=0 degeneracy in SOFT-IMPUTE itself. Refusing the input is the correct boundary for this change; making no-shrinkage propagate `L` to the unobserved cells is a solver change, and the value is not one the estimator is defined at anyway.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USGBU6Q5wMxSr2feueV9sm)_