### PR TITLE
Solve the LEXSCM control QP for the whole shortlist at once

### DIFF
--- a/mlsynth/tests/test_control_qp_batch.py
+++ b/mlsynth/tests/test_control_qp_batch.py
@@ -1,0 +1,245 @@
+"""The control QP, solved for a whole shortlist at once.
+
+LEXSCM solves the same donor program once per shortlisted design. Each solve
+was a fresh cvxpy problem -- graph construction, canonicalisation, an OSQP
+setup -- and on a 211-market panel with twenty designs that was 39% of the fit's
+wall clock at 0.217s a call, almost none of it arithmetic.
+
+The program is Abadie and L'Hour's penalised synthetic control,
+
+    min_v  ||A v - y||^2 + lam * sum_j v_j ||A[:, j] - y||^2,   v in simplex
+
+and it reduces to the homogeneous form the batched Wolfe active set already
+solves. Writing ``Q = A'A``, ``b = A'y``, ``c_j = ||A[:,j] - y||^2`` and
+``d = lam c - 2b``, the objective is ``v'Qv + d'v + y'y``; and since ``1'v = 1``
+on the simplex, ``d'v = v'(d 1')v``, so with
+
+    S = Q + (d 1' + 1 d') / 2
+
+the whole thing is ``v'Sv`` plus a constant. That is one Gram per design, and a
+stack of them is one batched active set: iterations set by the hardest design in
+the shortlist, not by their number.
+
+What the tests check, and why in this order:
+
+* the reduction is exact -- asserted as a KKT certificate on the *original*
+  penalised objective, computed from ``A``, ``y`` and ``v`` alone, so it holds
+  whatever produced ``v`` and does not stand one solver in for another;
+* the batch agrees with the single solve it replaces, at the objective value
+  (the meaningful quantity when the minimiser is a face);
+* exclusions are exact zeros, since a treated unit weighted 1e-7 into its own
+  control is a contamination the downstream assertion is there to catch;
+* ragged shortlists -- spillover neighbourhoods differ in size, so donor pools
+  do too -- still batch, by grouping on pool size;
+* the degenerate pools: one donor, no donors, ``lam = 0``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.fast_scm_helpers.fast_scm_control_helpers import (
+    solve_control_qp,
+    solve_control_qps,
+)
+
+
+# --------------------------------------------------------------- fixtures
+
+
+def _panel(T=30, J=24, seed=0, factor=0.9):
+    """A panel shaped like a geo panel: one dominant factor, near-collinear."""
+    rng = np.random.default_rng(seed)
+    f = np.cumsum(rng.standard_normal(T))
+    load = rng.uniform(0.6, 1.6, J)
+    X = factor * np.outer(f, load) + (1.0 - factor) * rng.standard_normal((T, J))
+    X = X - X.mean(1, keepdims=True)
+    sd = np.std(X, 1, keepdims=True)
+    return X / np.where(sd < 1e-8, 1.0, sd)
+
+
+def _objective(A, y, v, lam):
+    """The penalised objective, evaluated on the donor submatrix."""
+    c = ((A - y[:, None]) ** 2).sum(0)
+    return float(((A @ v - y) ** 2).sum() + lam * (c @ v))
+
+
+def _kkt_residual(A, y, v, lam):
+    """Distance from the KKT conditions of the penalised program.
+
+    With gradient ``g = 2 A'(A v - y) + lam c`` the simplex conditions are
+    ``g_j >= mu`` everywhere and ``g_j == mu`` wherever ``v_j > 0``, for the
+    multiplier ``mu = g'v``. Computed from the data and the point, so it
+    certifies optimality without reference to a solver.
+    """
+    c = ((A - y[:, None]) ** 2).sum(0)
+    g = 2.0 * (A.T @ (A @ v - y)) + lam * c
+    mu = float(g @ v)
+    scale = max(abs(mu), float(np.abs(g).max()), 1e-12)
+    support = v > 1e-9
+    slack = float(np.max(np.maximum(mu - g, 0.0))) / scale
+    tight = (float(np.max(np.abs(g[support] - mu))) / scale
+             if support.any() else 0.0)
+    return max(slack, tight)
+
+
+def _designs(X_E, n, m, seed=1):
+    """``n`` treated tuples of size ``m`` with their synthetic-treated series."""
+    rng = np.random.default_rng(seed)
+    J = X_E.shape[1]
+    out = []
+    for _ in range(n):
+        S = np.sort(rng.choice(J, size=m, replace=False))
+        w = rng.dirichlet(np.ones(m))
+        out.append((S, X_E[:, S] @ w))
+    return out
+
+
+# ------------------------------------------------- the answers are optima
+
+
+@pytest.mark.parametrize("lam", [0.0, 0.1, 2.0])
+def test_batched_weights_certify_against_the_penalised_program(lam):
+    """Feasible, and satisfying the KKT conditions of the original objective."""
+    X_E = _panel()
+    designs = _designs(X_E, 8, 4)
+    V = solve_control_qps(X_E, [y for _, y in designs],
+                          [S for S, _ in designs], lambda_penalty=lam)
+
+    for (S, y), v in zip(designs, V):
+        assert v is not None
+        assert v.min() >= -1e-12
+        assert v.sum() == pytest.approx(1.0, abs=1e-9)
+        assert np.all(v[S] == 0.0)                     # exactly, not to 1e-8
+        ctrl = np.setdiff1d(np.arange(X_E.shape[1]), S)
+        assert _kkt_residual(X_E[:, ctrl], y, v[ctrl], lam) < 1e-6
+
+
+def test_the_batch_matches_the_single_solve_it_replaces():
+    """Same program, so the same objective value -- to well inside cvxpy's own
+    tolerance. The weights themselves are compared loosely: with more donors
+    than estimation periods the minimiser can be a face, and two correct solvers
+    land in different places on it."""
+    X_E = _panel()
+    designs = _designs(X_E, 6, 3, seed=4)
+    lam = 0.1
+    V = solve_control_qps(X_E, [y for _, y in designs],
+                          [S for S, _ in designs], lambda_penalty=lam)
+
+    for (S, y), v in zip(designs, V):
+        ref = solve_control_qp(X_E, y, list(S), lambda_penalty=lam)
+        ctrl = np.setdiff1d(np.arange(X_E.shape[1]), S)
+        A = X_E[:, ctrl]
+        assert _objective(A, y, v[ctrl], lam) <= _objective(A, y, ref[ctrl], lam) + 1e-7
+
+
+# ------------------------------------------------------- exclusions hold
+
+
+def test_spillover_neighbours_get_exact_zeros():
+    """The exclusion restriction is enforced by dropping columns, so the
+    excluded weights are zero by construction and not to a solver tolerance."""
+    X_E = _panel()
+    designs = _designs(X_E, 4, 3, seed=7)
+    spills = [[10, 11], [12], [], [13, 14, 15]]
+    V = solve_control_qps(X_E, [y for _, y in designs],
+                          [S for S, _ in designs], lambda_penalty=0.1,
+                          exclude_idx_list=spills)
+    for (S, _), sp, v in zip(designs, spills, V):
+        dropped = np.concatenate([S, np.asarray(sp, dtype=int)]).astype(int)
+        assert np.all(v[np.unique(dropped)] == 0.0)
+        assert v.sum() == pytest.approx(1.0, abs=1e-9)
+
+
+def test_pools_of_different_widths_still_batch():
+    """Spillover neighbourhoods differ in size, so the donor pools do too. The
+    grouping must not silently drop, reorder or mismatch a design: each returned
+    vector has to belong to the design at its own position."""
+    X_E = _panel()
+    designs = _designs(X_E, 5, 3, seed=9)
+    spills = [[], [10], [10, 11], [], [12, 13, 14]]
+    V = solve_control_qps(X_E, [y for _, y in designs],
+                          [S for S, _ in designs], lambda_penalty=0.1,
+                          exclude_idx_list=spills)
+    assert len(V) == len(designs)
+    for (S, y), sp, v in zip(designs, spills, V):
+        ctrl = np.setdiff1d(np.arange(X_E.shape[1]),
+                            np.concatenate([S, np.asarray(sp, dtype=int)]))
+        assert _kkt_residual(X_E[:, ctrl], y, v[ctrl], 0.1) < 1e-6
+
+
+# ------------------------------------------------------------ degenerate
+
+
+def test_a_single_surviving_donor_takes_all_the_weight():
+    X_E = _panel(J=6)
+    S = np.array([0, 1])
+    y = X_E[:, S] @ np.array([0.5, 0.5])
+    V = solve_control_qps(X_E, [y], [S], lambda_penalty=0.1,
+                          exclude_idx_list=[[2, 3, 4]])
+    assert V[0][5] == pytest.approx(1.0, abs=1e-12)
+    assert V[0].sum() == pytest.approx(1.0, abs=1e-12)
+
+
+def test_an_emptied_donor_pool_reports_none_in_place():
+    """A design whose exclusions leave no donors is skipped downstream, so it
+    must come back as ``None`` at its own index and not shift the others."""
+    X_E = _panel(J=6)
+    designs = _designs(X_E, 2, 2, seed=11)
+    ok, dead = designs[0], designs[1]
+    V = solve_control_qps(X_E, [ok[1], dead[1]], [ok[0], dead[0]],
+                          lambda_penalty=0.1,
+                          exclude_idx_list=[[], list(range(6))])
+    assert V[1] is None
+    assert V[0] is not None and V[0].sum() == pytest.approx(1.0, abs=1e-9)
+
+
+def test_an_empty_shortlist_returns_an_empty_list():
+    X_E = _panel(J=6)
+    assert solve_control_qps(X_E, [], [], lambda_penalty=0.1) == []
+
+
+# ------------------------------------------------------- the work contract
+
+
+def test_the_shortlist_costs_one_solve_not_one_per_design(monkeypatch):
+    """The point of the reduction: designs sharing a pool width go through the
+    active set together, so the solver is entered once per width and not once
+    per design. Asserted on the call count, which is machine-independent."""
+    from mlsynth.utils.fast_scm_helpers import fast_scm_control_helpers as h
+
+    calls = {"n": 0}
+    real = h.solve_simplex_minnorm_batch
+
+    def spy(G, **kw):
+        calls["n"] += 1
+        return real(G, **kw)
+
+    monkeypatch.setattr(h, "solve_simplex_minnorm_batch", spy)
+    X_E = _panel(J=30)
+    designs = _designs(X_E, 20, 4, seed=13)
+    solve_control_qps(X_E, [y for _, y in designs], [S for S, _ in designs],
+                      lambda_penalty=0.1)
+    assert calls["n"] == 1, (
+        f"{calls['n']} solver entries for 20 designs of equal pool width -- "
+        "the batch is being run one design at a time"
+    )
+
+
+def test_cvxpy_is_not_entered_at_all(monkeypatch):
+    """cvxpy's per-problem overhead is the cost being removed; a fallback that
+    quietly re-enters it would restore the cost while the tests still passed."""
+    import cvxpy as cp
+    from mlsynth.utils.fast_scm_helpers import fast_scm_control_helpers as h
+
+    def explode(*a, **kw):
+        raise AssertionError("the batched control QP entered cvxpy")
+
+    monkeypatch.setattr(cp.Problem, "solve", explode)
+    monkeypatch.setattr(h, "_solve_qp_problem", explode)
+    X_E = _panel()
+    designs = _designs(X_E, 5, 3, seed=15)
+    V = solve_control_qps(X_E, [y for _, y in designs],
+                          [S for S, _ in designs], lambda_penalty=0.1)
+    assert all(v is not None for v in V)

--- a/mlsynth/utils/fast_scm_helpers/fast_scm_control.py
+++ b/mlsynth/utils/fast_scm_helpers/fast_scm_control.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from .fast_scm_bb_helpers import Solution
 from .structure import SEDCandidate, WeightVectors, PredictionVectors, Losses, Identification
-from .fast_scm_control_helpers import solve_control_qp
+from .fast_scm_control_helpers import solve_control_qp, solve_control_qps
 from .fast_scm_setup import IndexSet
 from .conflict import neighbours
 from ...exceptions import MlsynthConfigError
@@ -113,20 +113,33 @@ def evaluate_candidates(
     J = Y.shape[1] if Y.ndim > 1 else 1
     target = X[:, :J] @ f[:J]
 
+    # Every shortlisted design solves the same donor program against a different
+    # synthetic treated series, so they go through the active set as one batch:
+    # the cost is set by the hardest design, not by how many were shortlisted.
+    treated_idx_all: List[np.ndarray] = []
+    treated_w_all: List[np.ndarray] = []
+    spill_all: List[Optional[np.ndarray]] = []
+    treated_vecs: List[np.ndarray] = []
     for sol in candidates:
         treated_idx = np.asarray(sol.indices, dtype=int)
         m = len(treated_idx)
-
         w = sol.weights[treated_idx] if len(sol.weights) != m else sol.weights
-
         # Spillover "exclusion restriction": drop the treated units' conflict
         # neighbours N(S) from the donor pool so the treatment cannot contaminate
         # the synthetic control.
         spill = neighbours(conflict, treated_idx) if conflict is not None else None
+        treated_idx_all.append(treated_idx)
+        treated_w_all.append(w)
+        spill_all.append(spill)
+        treated_vecs.append(X_E[:, treated_idx] @ w)
 
-        treated_vec_E = X_E[:, treated_idx] @ w
-        v = solve_control_qp(X_E, treated_vec_E, treated_idx, lambda_penalty,
-                             exclude_idx=spill)
+    control_weights_all = solve_control_qps(
+        X_E, treated_vecs, treated_idx_all, lambda_penalty,
+        exclude_idx_list=spill_all)
+
+    for sol, treated_idx, w, spill, v in zip(
+            candidates, treated_idx_all, treated_w_all, spill_all,
+            control_weights_all):
         if v is None:
             # The exclusions (treated + N(S)) emptied / over-constrained the donor
             # pool for this candidate; skip it rather than crash.

--- a/mlsynth/utils/fast_scm_helpers/fast_scm_control_helpers.py
+++ b/mlsynth/utils/fast_scm_helpers/fast_scm_control_helpers.py
@@ -1,6 +1,8 @@
 import cvxpy as cp
 import numpy as np
-from typing import List, Optional
+from typing import List, Optional, Sequence
+
+from ..bilevel.minnorm import solve_simplex_minnorm_batch
 
 def _build_objective(
     X_E: np.ndarray,
@@ -185,6 +187,142 @@ def solve_control_qp(
     v[control_idx] = solution_control
     return v
 
+
+
+def _homogeneous_gram(Q: np.ndarray, b: np.ndarray, yy: np.ndarray,
+                      lambda_penalty: float) -> np.ndarray:
+    """The penalised control objective as a homogeneous form on the simplex.
+
+    With ``Q = A'A``, ``b = A'y`` and ``c_j = ||A[:, j] - y||^2`` the objective is
+
+        ||A v - y||^2 + lam * sum_j v_j c_j  =  v'Q v + d'v + y'y,
+        d = lam c - 2 b,   c_j = Q_jj - 2 b_j + y'y
+
+    and the equality constraint absorbs the linear part: ``1'v = 1`` gives
+    ``d'v = d'v (1'v) = v'(d 1')v``, so symmetrising,
+
+        S = Q + (d 1' + 1 d') / 2
+
+    leaves ``v'S v`` equal to the objective up to the constant ``y'y``. The
+    minimiser is therefore unchanged and the program is the one Wolfe's active
+    set solves.
+
+    ``S`` is not itself positive semi-definite -- the rank-one correction sees to
+    that, and no shift repairs it, since ``1 1'`` has rank one while ``Q`` is
+    singular in every direction the donors do not span. What the active set
+    needs is convexity on the *feasible* set, and that holds exactly: for any
+    ``z`` with ``1'z = 0``, ``z'S z = z'Q z >= 0``. Every step the method takes
+    -- corral solves and line searches alike -- stays on ``{1'v = 1}``, so it
+    only ever sees the restriction.
+
+    Parameters
+    ----------
+    Q : np.ndarray, shape (..., J, J)
+        Donor Gram matrices, batched over any leading axes.
+    b : np.ndarray, shape (..., J)
+        ``A'y`` for each problem.
+    yy : np.ndarray, shape (...,)
+        ``y'y`` for each problem.
+    lambda_penalty : float
+        Weight on the Abadie-L'Hour discrepancy penalty.
+
+    Returns
+    -------
+    np.ndarray, shape (..., J, J)
+        The homogeneous forms ``S``.
+    """
+    diag = np.einsum('...jj->...j', Q)
+    c = diag - 2.0 * b + yy[..., None]
+    d = lambda_penalty * c - 2.0 * b
+    return Q + 0.5 * (d[..., :, None] + d[..., None, :])
+
+
+def solve_control_qps(
+    X_E: np.ndarray,
+    treated_vecs: Sequence[np.ndarray],
+    treated_idx_list: Sequence[Sequence[int]],
+    lambda_penalty: float = 0.1,
+    exclude_idx_list: Optional[Sequence[Optional[Sequence[int]]]] = None,
+) -> List[Optional[np.ndarray]]:
+    """Solve the control QP for a whole shortlist of designs at once.
+
+    Same program as :func:`solve_control_qp`, once per design, but reduced to
+    the homogeneous form (see :func:`_homogeneous_gram`) and handed to the
+    batched Wolfe active set, which runs the stack in lockstep: iterations are
+    set by the hardest design in the shortlist and not by their number.
+
+    Designs are grouped by donor-pool width, since a stack has to be
+    rectangular and the spillover exclusions ``N(S)`` differ in size between
+    designs. With no conflict graph every pool is ``N - m`` wide and there is
+    one group.
+
+    Parameters
+    ----------
+    X_E : np.ndarray, shape (T_E, N)
+        Standardized feature matrix over the estimation period.
+    treated_vecs : sequence of np.ndarray, each shape (T_E,)
+        Synthetic treated series, one per design.
+    treated_idx_list : sequence of sequences of int
+        Treated units to exclude from the donor pool, one per design.
+    lambda_penalty : float, default=0.1
+        Regularization strength for mismatch penalties.
+    exclude_idx_list : sequence of (sequence of int or None), optional
+        Additional indices to drop per design -- the spillover neighbours
+        ``N(S)``. ``None`` or an empty sequence means no extra exclusions.
+
+    Returns
+    -------
+    list of (np.ndarray, shape (N,) or None)
+        Control weights per design, aligned with the input order. Entries at
+        treated and excluded indices are exactly zero. A design whose exclusions
+        empty the donor pool comes back as ``None`` at its own position, so the
+        caller can skip it without the list shifting under the others.
+    """
+    n = len(treated_vecs)
+    if n != len(treated_idx_list):
+        raise ValueError(
+            f"{n} treated series for {len(treated_idx_list)} designs; "
+            "the two must align.")
+    if n == 0:
+        return []
+
+    _, N = X_E.shape
+    out: List[Optional[np.ndarray]] = [None] * n
+
+    # Donor pools, one per design. Exclusion is by construction -- the columns
+    # leave the problem -- so the excluded weights are exactly zero and not zero
+    # to a solver tolerance.
+    pools: List[np.ndarray] = []
+    for k in range(n):
+        excluded = {int(j) for j in treated_idx_list[k]}
+        if exclude_idx_list is not None and exclude_idx_list[k] is not None:
+            excluded |= {int(j) for j in exclude_idx_list[k]}
+        pools.append(np.array([i for i in range(N) if i not in excluded],
+                              dtype=int))
+
+    widths: dict = {}
+    for k, ctrl in enumerate(pools):
+        if ctrl.size:
+            widths.setdefault(ctrl.size, []).append(k)
+
+    G_full = X_E.T @ X_E
+    XT = X_E.T
+
+    for width, members in widths.items():
+        C = np.stack([pools[k] for k in members])                # (S, width)
+        Ys = np.stack([np.asarray(treated_vecs[k], dtype=float)
+                       for k in members])                        # (S, T_E)
+        Q = G_full[C[:, :, None], C[:, None, :]]                 # (S, w, w)
+        b = np.einsum('sjt,st->sj', XT[C], Ys)
+        yy = np.einsum('st,st->s', Ys, Ys)
+        W = solve_simplex_minnorm_batch(
+            _homogeneous_gram(Q, b, yy, lambda_penalty))
+        for row, k in enumerate(members):
+            v = np.zeros(N)
+            v[C[row]] = W[row]
+            out[k] = v
+
+    return out
 
 
 def compute_nmse(X: np.ndarray, w: np.ndarray, target: np.ndarray, idx: np.ndarray, treated_idx: list) -> float:

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1267,3 +1267,39 @@ timeout = 300.0
   find = "    ranked = sorted(pool.items(), key=lambda kv: kv[1])[:top_K]"
   replace = "    ranked = sorted(pool.items(), key=lambda kv: -kv[1])[:top_K]"
   models = "the top-K taken from the wrong end of the pool, returning the worst-balanced designs the search found rather than the best"
+
+[[target]]
+name = "control_qp"
+module-path = "mlsynth/utils/fast_scm_helpers/fast_scm_control_helpers.py"
+test-command = "python -m pytest mlsynth/tests/test_control_qp_batch.py mlsynth/tests/test_lexscm_spillover.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "penalty-dropped-from-the-homogeneous-form"
+  find = "    d = lambda_penalty * c - 2.0 * b"
+  replace = "    d = -2.0 * b"
+  models = "the Abadie-L'Hour discrepancy penalty silently absent from the reduction, so the batch solves plain simplex least squares and the donor pool spreads over units that individually track the treated series badly"
+
+  [[target.mutant]]
+  id = "homogeneous-form-not-symmetrised"
+  find = "    return Q + 0.5 * (d[..., :, None] + d[..., None, :])"
+  replace = "    return Q + d[..., None, :]"
+  models = "the rank-one lift written one-sided, which still reproduces the linear term on the simplex but hands the active set an asymmetric matrix, so its corral solves and its optimality test disagree about the gradient"
+
+  [[target.mutant]]
+  id = "batch-scattered-into-the-wrong-donor-pool"
+  find = "            v[C[row]] = W[row]"
+  replace = "            v[C[0]] = W[row]"
+  models = "every design in a width group scattered through the first design's pool, so weights land on units the design excluded and the treated units come back with nonzero control weight"
+
+  [[target.mutant]]
+  id = "one-treated-series-used-for-the-whole-group"
+  find = "        b = np.einsum('sjt,st->sj', XT[C], Ys)"
+  replace = "        b = np.einsum('sjt,t->sj', XT[C], Ys[0])"
+  models = "the batch fitted against the first design's synthetic treated series throughout, which is the failure a rectangular stack invites and which leaves every weight vector feasible and plausible"
+
+  [[target.mutant]]
+  id = "spillover-neighbours-left-in-the-donor-pool"
+  find = "        if exclude_idx_list is not None and exclude_idx_list[k] is not None:\n            excluded |= {int(j) for j in exclude_idx_list[k]}"
+  replace = "        pass"
+  models = "the exclusion restriction dropped for the batch path, letting a treated unit's conflict neighbours serve as its own controls"


### PR DESCRIPTION
## Related Links

- `mlsynth/utils/fast_scm_helpers/fast_scm_control_helpers.py` — the control QP
- `mlsynth/utils/fast_scm_helpers/fast_scm_control.py` — the shortlist loop that calls it
- `mlsynth/utils/bilevel/minnorm.py` — the batched Wolfe active set it now calls
- `mlsynth/tests/test_control_qp_batch.py` — 11 tests
- `tools/mutation/targets.toml` — 5 catalogued mutants for `control_qp`
- Follows #490, which left this as the named remaining cost
- Abadie, A. and L'Hour, J. (2021), *A Penalized Synthetic Control Estimator for
  Disaggregated Data*, JASA 116(536) — the program being solved

## What

- `solve_control_qps` solves the whole shortlist's donor programs in one batched
  active set
- `evaluate_candidates` calls it once instead of calling `solve_control_qp` per
  candidate
- `solve_control_qp` is unchanged and still exported, so existing callers and
  tests are untouched

## Why

#490 measured the control QP at 38.8% of the fit's wall clock — 20 cvxpy solves
at 0.217s each — and recorded that the obvious substitution did not help, so it
needed a different idea. This is the different idea.

The program is Abadie and L'Hour's penalised synthetic control,

```
min_v  ||A v - y||^2 + lam * sum_j v_j ||A[:, j] - y||^2,   v in the simplex
```

and the equality constraint removes its linear part. With `Q = A'A`, `b = A'y`,
`c_j = ||A[:,j] - y||^2` and `d = lam c - 2b` the objective is
`v'Qv + d'v + y'y`; since `1'v = 1` on the simplex, `d'v = d'v (1'v) = v'(d 1')v`,
so symmetrising,

```
S = Q + (d 1' + 1 d') / 2
```

leaves `v'Sv` equal to the objective up to the constant `y'y`. That is the
homogeneous form `minnorm` already solves for a whole stack in lockstep, so a
shortlist costs what its hardest member costs and not what all of them cost.

## How

`S` is not positive semi-definite, and no shift repairs it: `1 1'` has rank one
while `Q` is singular in every direction the donors do not span — with `J = 206`
donors and `T_E = 89` estimation rows, `null(Q)` is 117-dimensional. What the
active set needs is convexity on the *feasible* set, and that holds exactly: for
any `z` with `1'z = 0`, `z'S z = z'Q z >= 0`. Every step the method takes —
corral solves and line searches alike — stays on `{1'v = 1}`, so it only ever
sees the restriction. The KKT tests coincide too: with `g = Sv` and `nu = v'Sv`,
`g_j >= nu` is `[grad f]_j >= 2 nu - d'v`, the same condition against the same
constant. The precondition is stated where the reduction is built rather than
left for a reader to rediscover.

Designs are grouped by donor-pool width, since a stack has to be rectangular and
the spillover exclusions `N(S)` differ in size between designs. With no conflict
graph every pool is `N - m` wide and there is one group. Exclusion stays by
construction — the columns leave the problem — so treated and excluded weights
are exactly zero and not zero to a solver tolerance, which is what the
downstream assertion in `evaluate_candidates` is checking.

One mutation is equivalent and is left out of the catalogue rather than recorded
as a coverage gap: dropping `y'y` from `c` shifts every `c_j` by the same
constant, so `d'v` shifts by a constant on the simplex and the minimiser cannot
move.

## Verification

Path: cross-validation against the implementation being replaced. It is the same
program, so the contract is that no reported number moves.

On the DMA panel, 20 designs, `T_E = 89`, `N = 211`, `lam = 0.1`:

| quantity | agreement |
|---|---|
| objective, new minus old | `+1.3e-14` (worst of 20) |
| fitted control series `X v` | max abs diff `4.5e-11` |
| weights `v` | max abs diff `9.6e-10` |

Timings on the same problem:

| | |
|---|---|
| cvxpy sequential | 3.605s |
| batched Wolfe | 0.235s |
| | 15.4x |

End to end on the 211-market panel the fit goes 8.5s to 6.0s, and the control QP
falls from 38.8% of wall clock to 4.8%. Stage attribution after this change:

| stage | time | share |
|---|---|---|
| treated-design search | 5.69s | 87.5% |
| control QP | 0.31s | 4.8% |
| power / resampling | 0.24s | 3.6% |

Pinned durably by `test_control_qp_batch.py`, whose agreement test asserts the
batch's objective is no worse than the single solve's on every design. The
weights themselves are compared loosely on purpose: with more donors than
estimation periods the minimiser can be a face, and two correct solvers land in
different places on it — the objective is the quantity that is well defined.

## Scope checks

Not one of the four blocks — this replaces a solver call on an existing
estimator, with its tests.

- Tests certify against the *original* penalised objective, computed from `A`,
  `y` and `v` alone, so they hold whatever produced `v`
- 5 of 5 catalogued mutants killed
- No docstring still describes the control QP as a per-candidate cvxpy solve

## Designs

No figures. The fitted control series agree to 4.5e-11, so any overlay would be
one line.

## Test Steps

- [x] `pytest mlsynth/tests/test_control_qp_batch.py -q` — 11 passed
- [x] `pytest mlsynth/tests/ -k "lex or fastsc or control"` — 790 passed, 8 skipped
- [x] `python tools/mutation/run_mutants.py --target control_qp` — 5/5 killed
- [x] Re-profiled end to end on the 211-market panel; stage table above

## Other Notes

The remaining cost is now the treated-design search, at 87.5% of a 6s fit. That
is a different problem from this one and it does not have a clean answer: the
search's inner objective is exact and fast, so what is left is the combinatorics.
Measured on this panel, the separating-direction bound — which the minimax
identity `sqrt(L(S)) = max_u min_j <u, x_j>` shows is not one bound family but
the whole of them — prunes at most 49.6% of `C(211, 10)`, because the largest set
of markets whose hull stays further than `sqrt(L*)` from the origin has 197 of
211 members and a direction can only prune tuples drawn entirely from that set.
Pools of directions saturate almost immediately. So the enumeration branch cannot
be replaced by an exact branch-and-bound at that size, and the search stays a
heuristic. Recorded here so the next attempt starts from the measurement.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nd9F9eUaGjqcgTAPqrKxsZ)_