### PR TITLE
Keep the moving-block permutation p-value in one place

### DIFF
--- a/mlsynth/tests/test_conformal_moving_block.py
+++ b/mlsynth/tests/test_conformal_moving_block.py
@@ -176,3 +176,81 @@ def test_an_empty_path_is_refused():
 def test_an_unknown_statistic_is_refused_by_name():
     with pytest.raises(MlsynthConfigError, match="statistic"):
         moving_block_pvalue(np.zeros(20), block=4, statistic="median_abs")
+
+
+# --------------------------------------------------------------------------- #
+# the precondition: exchangeability must hold for the statistic being used     #
+# --------------------------------------------------------------------------- #
+def _position_coherent_path(T=66, block=6, seed=0):
+    """A path with flat magnitudes and sign coherence that grows toward the end.
+
+    This is what a fitted synthetic-control residual looks like. The QP makes the
+    residual orthogonal to the donor space over the window it balances, and the
+    residual that leaves behind is not position-homogeneous: measured on a fitted
+    PPSCM path, the standardized absolute block sum runs 0.733 in the interior,
+    0.956 near the end, and 1.114 at the final position, while the per-period
+    magnitude profile stays flat at 0.99 to 1.04. The coherence is in the signs.
+    """
+    rng = np.random.default_rng(seed)
+    mag = np.abs(rng.normal(size=T))                  # flat magnitudes
+    sign = rng.choice([-1.0, 1.0], size=T)
+    # progressively align the signs toward the end of the path
+    ramp = np.linspace(0.0, 1.0, T) ** 3
+    aligned = rng.random(T) < ramp
+    sign[aligned] = 1.0
+    return mag * sign
+
+
+def test_a_sum_statistic_needs_position_exchangeable_signs():
+    """The precondition a magnitude statistic does not have, stated as a test.
+
+    ``abs_sum`` reads sign coherence as signal. On a path whose signs align
+    toward the end -- flat magnitudes throughout -- the trailing block is not
+    exchangeable with its own rotations, and the p-value is anti-conservative.
+    ``mean_abs`` cannot see the coherence and stays calibrated on the same paths.
+
+    This is why a running-total band cannot simply swap the statistic underneath
+    a moving-block permutation: the reference set has to be exchangeable in the
+    thing the statistic measures, not merely in magnitude.
+    """
+    p_sum = np.array([moving_block_pvalue(_position_coherent_path(seed=s), block=6,
+                                          statistic="abs_sum") for s in range(400)])
+    p_abs = np.array([moving_block_pvalue(_position_coherent_path(seed=s), block=6,
+                                          statistic="mean_abs") for s in range(400)])
+    assert np.mean(p_sum <= 0.10) > 0.15, "the sum statistic should over-reject here"
+    assert np.mean(p_abs <= 0.10) < 0.14, "the magnitude statistic should not"
+
+
+def test_both_statistics_are_calibrated_when_the_path_is_exchangeable():
+    """The control for the test above: remove the position effect and the sum
+    statistic is fine. The fault is the interaction, not the statistic."""
+    rng = np.random.default_rng(5)
+    p_sum, p_abs = [], []
+    for _ in range(400):
+        u = rng.normal(size=66)
+        p_sum.append(moving_block_pvalue(u, block=6, statistic="abs_sum"))
+        p_abs.append(moving_block_pvalue(u, block=6, statistic="mean_abs"))
+    for p in (np.array(p_sum), np.array(p_abs)):
+        assert 0.05 < np.mean(p <= 0.10) < 0.15
+
+
+def test_the_sum_statistic_is_two_sided():
+    """A large negative block is as much evidence as a large positive one.
+
+    Without the absolute value the score is signed, so a negative block ranks at
+    the bottom of the reference set rather than the top and is never rejected --
+    the band would cover only one tail while appearing to be two-sided. A
+    cumulative effect is as likely to be a loss as a gain, so this is the more
+    consequential direction, not the symmetric afterthought.
+    """
+    quiet = np.random.default_rng(2).normal(scale=0.1, size=114)
+    for sign in (+1.0, -1.0):
+        u = np.concatenate([quiet, np.full(6, sign * 9.0)])
+        assert moving_block_pvalue(u, block=6, statistic="abs_sum") < 0.05
+
+
+def test_the_sum_statistic_scores_a_block_and_its_negation_alike():
+    u = np.concatenate([np.random.default_rng(8).normal(size=40), np.full(5, 2.5)])
+    v = np.concatenate([u[:40], -u[40:]])
+    assert moving_block_pvalue(u, block=5, statistic="abs_sum") == \
+           pytest.approx(moving_block_pvalue(v, block=5, statistic="abs_sum"))

--- a/mlsynth/tests/test_conformal_moving_block.py
+++ b/mlsynth/tests/test_conformal_moving_block.py
@@ -1,0 +1,178 @@
+"""The moving-block permutation p-value, in one place.
+
+:mod:`mlsynth.utils.conformal` exists so that "bands cannot drift apart between
+estimators", and :func:`confidence_set_bounds` was centralised for exactly that
+reason -- the library had the inclusion rule both ways and the two disagreed by
+15 to 40 percent on the authors' own panel. The statistic that rule consumes is
+still written out per estimator: ``cscipca_helpers``, ``bilevel``,
+``syndes_helpers``, ``shc_helpers`` and ``rrsc_helpers`` each roll their own,
+two of them in the opposite direction. They happen to enumerate the same block
+set today, which is luck rather than design.
+
+This pins the shared definition. Chernozhukov, Wuthrich and Zhu calibrate a
+post-treatment block against the ``T`` cyclic shifts of the residual path: every
+position in the series contributes a block, so a panel with ``T0`` pre-periods
+supplies ``T`` reference blocks rather than the ``T0 / block`` a disjoint split
+would give. That is what makes the p-value fine-grained enough to invert at a
+tight level, and it is the whole reason to prefer moving blocks when the
+pre-period is short relative to the horizon.
+
+The statistic is a parameter because the estimand decides it. A per-period band
+wants mean absolute residual; a band on a running total wants the absolute block
+sum, because a block that is uniformly positive and one that oscillates around
+zero have the same mean absolute residual and very different totals.
+
+Levels: smoke, unit invariants, property, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.conformal import moving_block_pvalue
+
+
+# --------------------------------------------------------------------------- #
+# smoke                                                                        #
+# --------------------------------------------------------------------------- #
+def test_smoke_returns_a_probability():
+    p = moving_block_pvalue(np.arange(20.0), block=4)
+    assert isinstance(p, float) and 0.0 < p <= 1.0
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants                                                              #
+# --------------------------------------------------------------------------- #
+def test_every_cyclic_position_contributes_a_block():
+    """The property the whole method rests on: ``T`` reference blocks, not
+    ``T0 / block`` of them. It shows up as the granularity of the p-value."""
+    for T in (17, 40, 113):
+        p = moving_block_pvalue(np.random.default_rng(T).normal(size=T), block=5)
+        assert abs(p * T - round(p * T)) < 1e-9, "p is not a multiple of 1/T"
+
+
+def test_the_post_block_is_always_counted():
+    """It is one of the shifts, so the p-value can never be zero -- the smallest
+    attainable value is ``1 / T``. A p-value of exactly zero would claim more
+    evidence than a permutation test can produce."""
+    u = np.concatenate([np.zeros(30), np.full(4, 1e6)])
+    assert moving_block_pvalue(u, block=4) == pytest.approx(1 / u.size)
+
+
+def test_a_typical_block_is_not_rejected():
+    p = moving_block_pvalue(np.random.default_rng(0).normal(size=120), block=6)
+    assert p > 0.10
+
+
+def test_an_extreme_block_is_rejected():
+    u = np.concatenate([np.random.default_rng(1).normal(scale=0.1, size=114),
+                        np.full(6, 9.0)])
+    assert moving_block_pvalue(u, block=6) < 0.05
+
+
+def test_the_two_statistics_answer_different_questions():
+    """A block that is uniformly positive and one that oscillates have the same
+    mean absolute residual and very different sums, which is why a band on a
+    running total cannot use the per-period statistic."""
+    osc = np.tile([2.0, -2.0], 57)
+    u = np.concatenate([osc, np.full(6, 2.0)])
+    assert moving_block_pvalue(u, block=6, statistic="abs_sum") < \
+           moving_block_pvalue(u, block=6, statistic="mean_abs")
+
+
+def test_the_default_statistic_is_the_per_period_one():
+    """Matching the existing call sites, so adopting this function anywhere
+    changes nothing unless the caller asks for the other statistic."""
+    u = np.random.default_rng(3).normal(size=50)
+    assert moving_block_pvalue(u, block=5) == \
+           moving_block_pvalue(u, block=5, statistic="mean_abs")
+
+
+def test_it_reproduces_the_per_estimator_implementations():
+    """The five hand-rolled copies enumerate the same block set, in two roll
+    directions. Both must agree with this one, or adopting it would move a
+    published number."""
+    u = np.random.default_rng(4).normal(size=31)
+    T, blk = u.size, 5
+    forward = np.array([np.abs(np.roll(u, s)[-blk:]).mean() for s in range(T)])
+    backward = np.array([np.abs(np.roll(u, -j)[T - blk:]).mean() for j in range(T)])
+    want_f = float(np.mean(forward >= forward[0]))
+    assert moving_block_pvalue(u, block=blk) == pytest.approx(want_f)
+    assert sorted(np.round(forward, 12)) == sorted(np.round(backward, 12))
+
+
+# --------------------------------------------------------------------------- #
+# property                                                                     #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("block", [1, 2, 5, 13])
+@pytest.mark.parametrize("seed", range(5))
+def test_it_is_always_a_probability_at_the_right_granularity(block, seed):
+    u = np.random.default_rng(seed).normal(size=40)
+    p = moving_block_pvalue(u, block=block)
+    assert 1 / 40 - 1e-12 <= p <= 1.0
+
+
+def test_a_whole_block_shift_of_the_path_leaves_it_unchanged():
+    """The reference set is the cyclic orbit, so rotating the input permutes the
+    blocks among themselves. Only which block is 'the post block' can change."""
+    u = np.random.default_rng(6).normal(size=24)
+    stats = [moving_block_pvalue(np.roll(u, s), block=4) for s in range(24)]
+    assert len(set(np.round(stats, 12))) <= 24        # values come from one orbit
+    assert all(abs(p * 24 - round(p * 24)) < 1e-9 for p in stats)
+
+
+def test_scaling_the_residuals_does_not_move_it():
+    """Both statistics are positively homogeneous, so the p-value is scale free
+    -- which matters because the caller's outcome units are arbitrary."""
+    u = np.random.default_rng(7).normal(size=60)
+    for stat in ("mean_abs", "abs_sum"):
+        a = moving_block_pvalue(u, block=6, statistic=stat)
+        b = moving_block_pvalue(u * 1e5, block=6, statistic=stat)
+        assert a == pytest.approx(b)
+
+
+# --------------------------------------------------------------------------- #
+# edge                                                                         #
+# --------------------------------------------------------------------------- #
+def test_a_block_as_long_as_the_path_is_one_block():
+    """Every cyclic shift is then the same multiset, so nothing is more extreme
+    than anything else and the p-value is one."""
+    assert moving_block_pvalue(np.arange(8.0), block=8, statistic="abs_sum") == 1.0
+
+
+def test_a_constant_path_is_never_significant():
+    assert moving_block_pvalue(np.full(20, 3.0), block=4) == 1.0
+
+
+def test_a_list_is_accepted():
+    assert moving_block_pvalue([1.0, 2.0, 3.0, 4.0, 5.0], block=2) > 0.0
+
+
+# --------------------------------------------------------------------------- #
+# failure -- reported, not swallowed                                           #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", [0, -1, 21])
+def test_an_impossible_block_length_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="block"):
+        moving_block_pvalue(np.zeros(20), block=bad)
+
+
+def test_a_fractional_block_is_refused_rather_than_truncated():
+    with pytest.raises(MlsynthConfigError):
+        moving_block_pvalue(np.zeros(20), block=2.5)
+
+
+def test_a_non_finite_residual_is_refused():
+    """Silently dropping one would change the block count and therefore the
+    p-value's denominator, which is the guarantee's reference set."""
+    with pytest.raises(MlsynthDataError):
+        moving_block_pvalue(np.array([1.0, np.nan, 2.0, 3.0]), block=2)
+
+
+def test_an_empty_path_is_refused():
+    with pytest.raises(MlsynthDataError):
+        moving_block_pvalue(np.array([]), block=1)
+
+
+def test_an_unknown_statistic_is_refused_by_name():
+    with pytest.raises(MlsynthConfigError, match="statistic"):
+        moving_block_pvalue(np.zeros(20), block=4, statistic="median_abs")

--- a/mlsynth/utils/conformal/__init__.py
+++ b/mlsynth/utils/conformal/__init__.py
@@ -35,12 +35,14 @@ from __future__ import annotations
 
 from .cumulative import cumulative_conformal_from_refit, cumulative_conformal_interval
 from .inversion import confidence_set_bounds
+from .permutation import BLOCK_STATISTICS, moving_block_pvalue
 from .quantile import split_conformal_quantile
 from .refit import CONFORMAL_REFIT_RULES, conformal_refit_gaps
 from .scores import MIN_TRAIN_PERIODS, rolling_origin_block_sums
 from .structure import CumulativeConformalBand
 
 __all__ = [
+    "BLOCK_STATISTICS",
     "CONFORMAL_REFIT_RULES",
     "MIN_TRAIN_PERIODS",
     "CumulativeConformalBand",
@@ -48,6 +50,7 @@ __all__ = [
     "conformal_refit_gaps",
     "cumulative_conformal_from_refit",
     "cumulative_conformal_interval",
+    "moving_block_pvalue",
     "rolling_origin_block_sums",
     "split_conformal_quantile",
 ]

--- a/mlsynth/utils/conformal/permutation.py
+++ b/mlsynth/utils/conformal/permutation.py
@@ -1,0 +1,131 @@
+"""The moving-block permutation p-value, in one place.
+
+A split-conformal band carves the pre-period into disjoint calibration windows
+and asks where the post-treatment window falls among them. That is simple, and it
+is wasteful when the pre-period is short relative to the horizon: an eight-period
+horizon over a hundred pre-periods yields around ten windows, and a p-value built
+from ten reference values takes only the multiples of one tenth. A band inverted
+at ``alpha = 0.1`` from such a p-value has no resolution left at the level it is
+trying to hit.
+
+Chernozhukov, Wuthrich and Zhu calibrate against the ``T`` cyclic shifts of the
+residual path instead. Every position in the series supplies a reference block,
+so the same panel gives a hundred-odd blocks rather than ten, and the p-value
+takes the multiples of ``1 / T``. The blocks overlap and are therefore dependent,
+which is the price; the permutation argument runs on exchangeability of the
+residual sequence under cyclic rotation rather than on independence between
+blocks.
+
+The statistic is a parameter because the estimand chooses it. For a per-period
+band the natural score is mean absolute residual, which is what the existing call
+sites use and what stays the default here. For a band on a running total it is
+the absolute block sum: a block that is uniformly positive and one that
+oscillates around zero share a mean absolute residual and have entirely different
+totals, so the per-period statistic cannot see the thing a cumulative band is
+about.
+
+This function is the single definition. The statistic is currently written out
+again in :mod:`mlsynth.utils.cscipca_helpers.inference`,
+:mod:`mlsynth.utils.bilevel.ridge_inference`,
+:mod:`mlsynth.utils.syndes_helpers.inference`,
+:mod:`mlsynth.utils.shc_helpers.inference` and
+:mod:`mlsynth.utils.rrsc_helpers.inference`, two of them rolling in the opposite
+direction. Those five enumerate the same block set today, so they agree; they
+agree by coincidence rather than by construction, which is the same situation
+:func:`~mlsynth.utils.conformal.inversion.confidence_set_bounds` was centralised
+to end. Migrating them is deliberately not bundled here -- each is pinned by its
+own golden benchmark and moves on its own PR.
+
+References
+----------
+Chernozhukov, V., Wuthrich, K., & Zhu, Y. (2021). An Exact and Robust Conformal
+Inference Method for Counterfactual and Synthetic Controls. Journal of the
+American Statistical Association, 116(536), 1849-1864.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+
+#: Statistics a block may be scored by. ``mean_abs`` is the per-period score of
+#: the reference implementation; ``abs_sum`` is its counterpart for a running
+#: total, which needs the signed sum before the absolute value is taken.
+BLOCK_STATISTICS = ("mean_abs", "abs_sum")
+
+
+def _score(window: np.ndarray, statistic: str) -> float:
+    if statistic == "mean_abs":
+        return float(np.mean(np.abs(window)))
+    return abs(float(np.sum(window)))
+
+
+def moving_block_pvalue(residuals, *, block: int,
+                        statistic: str = "mean_abs") -> float:
+    r"""Permutation p-value of the trailing block against every cyclic shift.
+
+    The post-treatment block is the last ``block`` entries of ``residuals``. The
+    ``T`` cyclic rotations of the path each supply a block of the same length,
+    every one is scored, and the p-value is the share scoring at least as extreme
+    as the post block:
+
+    .. math::
+
+        p = \frac{1}{T} \sum_{s=0}^{T-1}
+            \mathbb{1}\{ S(\text{roll}(u, s)) \ge S(u) \}
+
+    The post block is itself one of the rotations, so ``p`` is never zero: the
+    smallest attainable value is ``1 / T``, which is the most evidence a
+    permutation test over ``T`` reference values can produce.
+
+    Parameters
+    ----------
+    residuals : array-like, shape (T,)
+        The residual path, pre-period first, with the block being tested last.
+        Must be finite throughout -- dropping an entry would change ``T`` and so
+        change the reference set the guarantee is stated over.
+    block : int
+        Length of the trailing block, in ``[1, T]``. Keyword-only.
+    statistic : {"mean_abs", "abs_sum"}, default "mean_abs"
+        How a block is scored. ``mean_abs`` matches the reference implementation
+        and suits a per-period band; ``abs_sum`` suits a band on a running total.
+        Keyword-only.
+
+    Returns
+    -------
+    float
+        A p-value in ``[1 / T, 1]``, always a multiple of ``1 / T``.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``block`` is not an integer in ``[1, T]``, or ``statistic`` is not one
+        of :data:`BLOCK_STATISTICS`.
+    MlsynthDataError
+        If ``residuals`` is empty or holds a non-finite entry.
+    """
+    if statistic not in BLOCK_STATISTICS:
+        raise MlsynthConfigError(
+            f"statistic must be one of {BLOCK_STATISTICS}; got {statistic!r}.")
+    u = np.asarray(residuals, dtype=float).ravel()
+    if u.size == 0:
+        raise MlsynthDataError("residuals is empty; there is nothing to permute.")
+    if not np.isfinite(u).all():
+        raise MlsynthDataError(
+            "residuals must be finite. A non-finite entry cannot be scored, and "
+            "dropping it would shrink the cyclic reference set the p-value's "
+            "denominator is defined over.")
+    if isinstance(block, bool) or not isinstance(block, (int, np.integer)):
+        raise MlsynthConfigError(
+            f"block must be an integer; got {block!r}. A fractional block would "
+            "be truncated, silently scoring a shorter window than requested.")
+    block = int(block)
+    if not 1 <= block <= u.size:
+        raise MlsynthConfigError(
+            f"block must lie in [1, {u.size}]; got {block}.")
+
+    observed = _score(u[-block:], statistic)
+    stats = np.array([_score(np.roll(u, s)[-block:], statistic)
+                      for s in range(u.size)], dtype=float)
+    return float(np.mean(stats >= observed))

--- a/mlsynth/utils/conformal/permutation.py
+++ b/mlsynth/utils/conformal/permutation.py
@@ -24,6 +24,35 @@ oscillates around zero share a mean absolute residual and have entirely differen
 totals, so the per-period statistic cannot see the thing a cumulative band is
 about.
 
+The precondition the two statistics do not share
+------------------------------------------------
+
+The permutation argument needs the trailing block to be exchangeable with its own
+rotations *in whatever the statistic measures*, and a fitted synthetic-control
+residual satisfies that for magnitude but not for sign.
+
+Measured on a fitted PPSCM residual path, the per-period magnitude profile is
+flat -- 0.99 to 1.04 of the path mean at every position -- while the standardized
+absolute block sum ramps from 0.733 in the interior to 0.956 near the end of the
+balanced window and 1.114 at the final position. The quadratic program leaves
+end-of-window residuals positively correlated, so their signs stop cancelling and
+their sums grow, without their magnitudes growing at all. Wrapping blocks, which
+splice the end of the path to its start, show the same inflation (0.874 against
+0.757 for contiguous ones) because they join two edge regions.
+
+The trailing block always occupies the most inflated position, so a sum statistic
+reads that coherence as evidence: on a null panel, ``abs_sum`` rejects at 0.225
+against a nominal 0.10, while ``mean_abs`` on the identical paths sits at 0.092.
+Placing the block at a random position instead restores calibration (0.108), which
+is what identifies the position -- not the path, and not the statistic -- as the
+fault.
+
+So ``abs_sum`` is valid on an exchangeable path (0.091 to 0.096 on iid and AR
+draws, constrained and unconstrained) and invalid on a fitted residual path
+without first removing the position effect. A cumulative band cannot be obtained
+merely by swapping the statistic underneath this function. ``test_conformal_
+moving_block.py`` pins both halves of that.
+
 This function is the single definition. The statistic is currently written out
 again in :mod:`mlsynth.utils.cscipca_helpers.inference`,
 :mod:`mlsynth.utils.bilevel.ridge_inference`,

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1303,3 +1303,33 @@ timeout = 300.0
   find = "        if exclude_idx_list is not None and exclude_idx_list[k] is not None:\n            excluded |= {int(j) for j in exclude_idx_list[k]}"
   replace = "        pass"
   models = "the exclusion restriction dropped for the batch path, letting a treated unit's conflict neighbours serve as its own controls"
+
+[[target]]
+name = "moving-block-pvalue"
+module-path = "mlsynth/utils/conformal/permutation.py"
+test-command = "python -m pytest mlsynth/tests/test_conformal_moving_block.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "exclude-the-observed-block-from-its-own-reference-set"
+  find = "    stats = np.array([_score(np.roll(u, s)[-block:], statistic)\n                      for s in range(u.size)], dtype=float)"
+  replace = "    stats = np.array([_score(np.roll(u, s)[-block:], statistic)\n                      for s in range(1, u.size)], dtype=float)"
+  models = "dropping the shift that reproduces the observed block, so the p-value can reach zero. A permutation test over T reference values cannot produce more evidence than 1/T, and a zero p-value claims certainty the reference set does not contain"
+
+  [[target.mutant]]
+  id = "strict-instead-of-weak-comparison"
+  find = "    return float(np.mean(stats >= observed))"
+  replace = "    return float(np.mean(stats > observed))"
+  models = "excluding ties from the count. On a continuous statistic this changes nothing; on a discrete reference set it drops the observed block itself and every block equal to it, which is the same anti-conservative error as excluding the observed shift, arrived at through the comparison instead of the range"
+
+  [[target.mutant]]
+  id = "sum-without-the-absolute-value"
+  find = "    return abs(float(np.sum(window)))"
+  replace = "    return float(np.sum(window))"
+  models = "scoring a signed rather than a two-sided statistic. A band inverted from it covers only one tail, so a negative effect of any size is never detected while a positive one is over-detected"
+
+  [[target.mutant]]
+  id = "disjoint-blocks-instead-of-every-rotation"
+  find = "                      for s in range(u.size)], dtype=float)"
+  replace = "                      for s in range(0, u.size, block)], dtype=float)"
+  models = "reverting to a disjoint reference set, which is the split-conformal block count this function exists to improve on. The p-value's granularity falls from 1/T to block/T, which at an eight-period horizon over a hundred pre-periods is coarser than the level being inverted at"


### PR DESCRIPTION
## Related Links

- Issue: #492 (this is part 1 of two; the band itself follows separately)
- Source paper: Chernozhukov, Wüthrich & Zhu (2021), JASA 116(536) — the moving-block conformal procedure
- The sibling centralisation this follows: `confidence_set_bounds` in `mlsynth/utils/conformal/inversion.py`, and its account of what happens when a conformal decision lives at each call site instead
- The five call sites that will migrate later, each on its own PR: `cscipca_helpers/inference.py`, `bilevel/ridge_inference.py`, `syndes_helpers/inference.py`, `shc_helpers/inference.py`, `rrsc_helpers/inference.py`

## What

- Added `moving_block_pvalue` in a new `mlsynth/utils/conformal/permutation.py`, exported from the package alongside `BLOCK_STATISTICS`.
- Documented a precondition the function's two statistics do not share, with the measurements behind it.
- Added the `moving-block-pvalue` mutation target, four mutants.

Nothing migrates to the new function and no existing behaviour changes.

## Why

`mlsynth/utils/conformal/` says in its own docstring that it keeps score constructions in one place "so bands cannot drift apart between estimators", and `confidence_set_bounds` was centralised after the library held the inclusion rule two ways and the two disagreed by 15 to 40 percent on the authors' panel. The statistic that rule consumes is still written out five times, two of them rolling in the opposite direction. They enumerate the same block set today — I checked — so they agree by coincidence rather than by construction, which is the situation that was worth ending once already.

The immediate consumer is a per-unit cumulative band for PPSCM, where split conformal runs out of calibration windows: the count is roughly `0.7 * T0 / L`, a finite 90% band needs at least 9 of them, and that puts a floor of about `12.8 * L` pre-periods on reporting one at all. Moving blocks replace `T0 / L` windows with `T` cyclic positions.

## How

The function scores the trailing block against the `T` cyclic rotations of the residual path. Two details are load-bearing and both are pinned: the observed block is itself one of the rotations, so `p` is never zero and its floor is `1/T`; and the comparison is weak (`>=`), so ties count, which on a discrete reference set is the difference between a valid p-value and an anti-conservative one.

The statistic is a parameter because the estimand chooses it. `mean_abs` is the reference implementation's per-period score and stays the default, so adopting this anywhere changes nothing unless a caller asks otherwise. `abs_sum` is its counterpart for a running total.

Then a root-cause analysis, which is the substance of the second commit. A prototype band using `abs_sum` under-covered at 0.189 against a nominal 0.10. The ladder ran: the residual path is scale-exchangeable (post/pre rms 0.95, eliminated); the null p-value is non-uniform for `abs_sum` at 0.225 while `mean_abs` gives 0.092 on identical paths; the primitive itself is sound (0.089–0.096 on iid and AR paths, mean-removed or not); the fit's zero-sum constraint contributes but does not explain it (0.225 → 0.188 without fixed effects).

The cause is the block's position. Scoring a randomly placed block on the same paths gives 0.108 with a mean p-value of 0.505 — only the trailing position fails. The per-period magnitude profile is flat at 0.99 to 1.04 across the window, while the standardized absolute block sum ramps from 0.733 in the interior to 0.956 near the end and 1.114 at the final position. The quadratic program leaves end-of-window residuals positively correlated, so their signs stop cancelling while their magnitudes do not grow. Wrapping blocks show the same inflation (0.874 against 0.757) because they splice two edge regions together. The trailing block always occupies the most inflated position, so a sum statistic reads that coherence as evidence and a magnitude statistic cannot see it.

So the precondition is that the block must be exchangeable with its rotations in whatever the statistic measures, not merely in magnitude — and that is what the docstring now says and two tests pin.

## Verification

- Path: not applicable as a paper replication. This adds a primitive and changes no estimator's output; no pinned value moves.
- Correctness against the existing implementations is asserted directly: one test reproduces both roll directions of the five hand-rolled copies and requires this function to match, so adopting it later cannot move a published number.
- Validity is measured rather than assumed: on exchangeable paths (iid and AR(0.4), constrained and unconstrained) both statistics reject at 0.089 to 0.096 against a nominal 0.10, over 3000 draws each.
- The precondition is pinned in both directions — a path with flat magnitudes and end-loaded sign coherence, where `abs_sum` over-rejects and `mean_abs` does not, plus its control where both are calibrated.
- Durably pinned by `mlsynth/tests/test_conformal_moving_block.py` (44 tests) and the `moving-block-pvalue` mutation target (4/4 killed).
- Nothing fails to match.

## Scope checks

None of the four blocks fits: this adds a shared helper and migrates no caller, so it is neither a new estimator, a feature on one, a bug fix, nor benchmark authoring.

## Designs

No visual output. The function returns a scalar p-value.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_conformal_moving_block.py -q` — 44 passed
- [x] `pytest mlsynth/tests/ -k "conformal or ppscm or cscipca or bilevel or shc or rrsc or syndes"` — 1737 passed, 35 skipped
- [x] `python tools/mutation/run_mutants.py --target moving-block-pvalue` — 4/4 killed
- [ ] Full `pytest mlsynth/tests/` — not run end to end here; the selection above covers every module that touches this code or could adopt it. Worth letting CI carry it.

## Other Notes

- One mutant survived the first run. `sum-without-the-absolute-value` makes the statistic one-sided, and it passed the whole suite because every `abs_sum` test used a positive block. The assertion was too weak, not the mutant equivalent, and the two tests added for it say why: a cumulative effect is as likely to be a loss as a gain, so the negative direction is the consequential one.
- Migrating the five call sites is deliberately out of scope. Each is pinned by its own golden benchmark and should move separately so any change is attributable.
- The band that motivated this needs a different construction, not a fix. A sum statistic cannot be swapped underneath a moving-block permutation on fitted residuals without first removing the position effect — by studentizing block sums per position, or by scoring something sign-invariant. That is a design question and #492 stays open for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKrMz8fQvjDNM1eur5kQ2V)_