### PR TITLE
Keep PPSCM's automatic pooling parameter inside the unit interval

### DIFF
--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -125,7 +125,20 @@ pooled SCM.
 3. Choosing :math:`\nu`. With ``nu="auto"`` (default) PPSCM uses augsynth's
    triangle-inequality ratio
    :math:`\nu = \text{global\_l2}\cdot\sqrt{T_0}/\text{avg\_l2}`
-   from the separate fit; a float fixes it.
+   from the separate fit; a float in :math:`[0,1]` fixes it, and anything
+   outside that interval is refused, since one of the two weights would be
+   negative and the program no longer convex.
+
+   The ratio is :math:`\lVert\bar m\rVert / \overline{\lVert m_k\rVert}` over
+   the treated units' separate-fit imbalance vectors :math:`m_k`, so it is at
+   most one and equals one exactly when those vectors are parallel. A single
+   treated unit gives that by definition, and a small pool of similar units comes
+   close. On the bound the separate term drops out, which is the right fit: with
+   one treated unit there is nothing to pool against. The library computes the
+   ratio in floating point and holds it inside :math:`[0,1]`, because a value a
+   unit in the last place above one is not a pooling choice -- it is a negative
+   weight on a squared norm, and the same panel measured in dollars and in
+   thousands of dollars can land on opposite sides of the boundary.
 
 Assumptions / Remarks.
 

--- a/mlsynth/tests/test_ppscm_auto_nu.py
+++ b/mlsynth/tests/test_ppscm_auto_nu.py
@@ -1,0 +1,209 @@
+"""The automatic pooling parameter sits on a boundary, and rounding decides it.
+
+``run_multisynth`` picks ``nu`` when the caller says ``"auto"``. The rule follows
+augsynth: fit every treated unit separately, then take the ratio of the norm of
+the average imbalance to the average of the norms,
+
+    nu = ||mean_k m_k|| / mean_k ||m_k||,
+
+a triangle inequality that is at most one and is tight exactly when the treated
+units share a single imbalance vector. One treated unit does that by definition,
+so on a single-treated-unit panel ``nu`` is analytically one.
+
+The second solve then minimises
+
+    nu / (norm_pool J^2) q_pool + (1 - nu) / (norm_sep J) q_sep,
+
+so at ``nu = 1`` the separate term carries a weight of exactly zero. It is
+computed in floating point from two square roots and a division, and there is
+nothing keeping the result on the correct side of one. Land it a single unit in
+the last place above -- 1.0000000000000002 -- and the weight becomes a small
+negative number, the objective picks up a negative multiple of a convex
+quadratic, and cvxpy refuses the whole problem as non-convex with a ``DCPError``
+before the solver ever runs.
+
+The failure needs no unusual input. It is one treated unit and an arithmetic
+coin flip, and the same coin is in play whenever the treated units' imbalance
+vectors are close to parallel, which is the ordinary case for a small pool of
+similar units. Rescaling the panel is enough to flip it: the fit is
+scale-equivariant in exact arithmetic but not in the last bit, so the same panel
+measured in dollars and in thousands of dollars can land on opposite sides.
+
+Levels: smoke, unit invariants, property, edge, failure.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PPSCM
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.ppscm_helpers.engine import run_multisynth
+
+
+def _panel(n=10, T=24, t0=18, n_trt=1, seed=0, scale=1.0):
+    """A one-factor panel with ``n_trt`` units adopting at ``t0``.
+
+    The draw order is fixed: the factor, then the loadings, then the noise. It
+    reproduces the panel the failure was first seen on, and reordering the draws
+    gives a different panel that happens not to round over the boundary.
+    """
+    rng = np.random.default_rng(seed)
+    factor = rng.normal(size=T)
+    load = rng.uniform(0.5, 1.5, size=n)
+    Xy = load[:, None] * factor[None, :] + rng.normal(scale=0.3, size=(n, T))
+    trt = np.full(n, np.inf)
+    trt[:n_trt] = t0
+    return Xy * scale, trt, t0
+
+
+def _long(Xy, trt, t0):
+    """The same panel in the long form ``PPSCM`` ingests."""
+    n, T = Xy.shape
+    return pd.DataFrame([
+        {"unit": f"u{i}", "time": t, "y": Xy[i, t],
+         "treat": int(np.isfinite(trt[i]) and t >= t0)}
+        for i in range(n) for t in range(T)
+    ])
+
+
+# --------------------------------------------------------------------------- #
+# smoke                                                                       #
+# --------------------------------------------------------------------------- #
+def test_a_single_treated_unit_fits():
+    Xy, trt, t0 = _panel()
+    fit = run_multisynth(Xy, trt, t0, 5, t0)
+    assert np.isfinite(fit["att"])
+    assert np.isfinite(np.asarray(fit["per_time"], dtype=float)).all()
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants                                                             #
+# --------------------------------------------------------------------------- #
+def test_the_automatic_nu_is_a_weight():
+    """It multiplies one term and its complement multiplies the other, so a
+    value outside the unit interval is not a pooling choice at all -- it is a
+    negative weight on a convex quadratic, which is a different problem."""
+    Xy, trt, t0 = _panel(n_trt=3)
+    assert 0.0 <= run_multisynth(Xy, trt, t0, 5, t0)["nu_used"] <= 1.0
+
+
+def test_one_treated_unit_puts_the_ratio_at_its_upper_bound():
+    """With a single column the norm of the average and the average of the norms
+    are the same number, so the ratio is one and the separate term drops out."""
+    Xy, trt, t0 = _panel(n_trt=1)
+    assert run_multisynth(Xy, trt, t0, 5, t0)["nu_used"] == 1.0
+
+
+def test_an_explicit_nu_is_passed_through_untouched():
+    """The clamp guards a computed ratio. A caller naming a value is naming the
+    weights they want and gets them."""
+    Xy, trt, t0 = _panel(n_trt=3)
+    for nu in (0.0, 0.25, 0.5, 1.0):
+        assert run_multisynth(Xy, trt, t0, 5, t0, nu=nu)["nu_used"] == nu
+
+
+def test_the_clamp_does_not_reach_the_caller_s_own_nu():
+    """Out of range, an explicit nu is refused, not folded to the nearest edge.
+
+    Extending the clamp to cover it would read as defensive and change nothing on
+    any valid input, which is what makes it tempting. What it costs is the only
+    signal an out-of-range value has: the fit would go through at 1.0 and nothing
+    on the result would say the substitution happened. Refusing is the honest
+    outcome, and the range belongs to the config, which refuses it by name before
+    a solver is ever built -- see the failure section below.
+    """
+    from cvxpy.error import DCPError
+
+    Xy, trt, t0 = _panel(n_trt=3)
+    for bad in (-0.5, 1.5):
+        with pytest.raises(DCPError):
+            run_multisynth(Xy, trt, t0, 5, t0, nu=bad)
+
+
+# --------------------------------------------------------------------------- #
+# property: the bound holds wherever the panel sits                            #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("scale", [1e-4, 1e-2, 0.658, 1.0, 7.3, 1e3, 1e5])
+@pytest.mark.parametrize("n_trt", [1, 2, 4])
+def test_the_ratio_stays_a_weight_across_scales_and_pool_sizes(scale, n_trt):
+    """Twenty-one panels that differ only in units and in how many units adopt.
+
+    The scales bracket the range a real outcome is measured over, and 0.658 is
+    the median absolute level of the panel this was first seen on. Nothing here
+    may produce a weight outside the unit interval, and nothing here may raise.
+    """
+    Xy, trt, t0 = _panel(n_trt=n_trt, scale=scale)
+    assert 0.0 <= run_multisynth(Xy, trt, t0, 5, t0)["nu_used"] <= 1.0
+
+
+@pytest.mark.parametrize("seed", range(12))
+def test_the_ratio_stays_a_weight_across_draws(seed):
+    Xy, trt, t0 = _panel(seed=seed)
+    assert 0.0 <= run_multisynth(Xy, trt, t0, 5, t0)["nu_used"] <= 1.0
+
+
+# --------------------------------------------------------------------------- #
+# edge: the panel that first produced the DCPError                             #
+# --------------------------------------------------------------------------- #
+def test_the_panel_that_rounded_over_one_still_fits():
+    """Recorded from the failure. The unscaled panel gives ``nu_used`` exactly
+    one and solves; dividing by its own median absolute level, 0.658233745909389,
+    gives 1.0000000000000002 and the second solve is refused. The two differ by
+    one unit in the last place and are the same panel in different units."""
+    Xy, trt, t0 = _panel()
+    scaled = Xy / 0.658233745909389
+    for panel in (Xy, scaled):
+        assert run_multisynth(panel, trt, t0, 5, t0)["nu_used"] == 1.0
+
+
+def test_the_two_scalings_agree_on_the_effect():
+    """Having both solve is not enough -- they have to solve the same problem.
+    Synthetic control is scale-equivariant, so the effect divides by the scale."""
+    Xy, trt, t0 = _panel()
+    k = 0.658233745909389
+    base = run_multisynth(Xy, trt, t0, 5, t0)
+    scaled = run_multisynth(Xy / k, trt, t0, 5, t0)
+    assert scaled["att"] * k == pytest.approx(base["att"], rel=1e-6)
+
+
+def test_the_estimator_reaches_this_through_its_own_entry_point():
+    """The clamp sits in the engine, and the config's ``nu="auto"`` is the path
+    a caller actually takes to it."""
+    Xy, trt, t0 = _panel()
+    res = PPSCM(dict(df=_long(Xy, trt, t0), unitid="unit", time="time",
+                     outcome="y", treat="treat", display_graphs=False)).fit()
+    assert np.isfinite(res.effects.att)
+
+
+# --------------------------------------------------------------------------- #
+# failure: the clamp corrects arithmetic, it does not paper over a bad panel    #
+# --------------------------------------------------------------------------- #
+def test_a_ratio_that_is_not_a_number_is_not_silently_clamped():
+    """``np.clip`` maps NaN to NaN, so a degenerate separate fit -- one whose
+    average imbalance norm is zero, making the ratio 0/0 -- still surfaces as a
+    non-finite ``nu_used`` and is not turned into a plausible-looking 1.0."""
+    assert np.isnan(np.clip(np.nan, 0.0, 1.0))
+
+
+@pytest.mark.parametrize("bad", [-0.5, 1.5, 2.0, -1e-9])
+def test_a_nu_outside_the_unit_interval_is_refused_by_name(bad):
+    """It weights one term and its complement weights the other, so outside the
+    unit interval one of them is negative and the objective is no longer convex.
+    Left to the engine it surfaces as a ``DCPError`` from cvxpy naming a
+    ``quad_over_lin`` subexpression, which does not tell a caller that ``nu`` is
+    the field they set wrong."""
+    Xy, trt, t0 = _panel()
+    with pytest.raises(MlsynthConfigError, match="nu"):
+        PPSCM(dict(df=_long(Xy, trt, t0), unitid="unit", time="time",
+                   outcome="y", treat="treat", nu=bad, display_graphs=False))
+
+
+@pytest.mark.parametrize("good", [0.0, 0.5, 1.0, "auto"])
+def test_the_endpoints_and_the_default_are_accepted(good):
+    """The interval is closed. Zero is a separate SCM per treated unit and one is
+    the fully pooled fit -- both are the fits the parameter exists to reach, and
+    one is where the automatic rule lands on a single treated unit."""
+    Xy, trt, t0 = _panel()
+    cfg = PPSCM(dict(df=_long(Xy, trt, t0), unitid="unit", time="time",
+                     outcome="y", treat="treat", nu=good, display_graphs=False))
+    assert cfg.config.nu == good

--- a/mlsynth/utils/ppscm_helpers/config.py
+++ b/mlsynth/utils/ppscm_helpers/config.py
@@ -32,6 +32,26 @@ class PPSCMConfig(BaseEstimatorConfig):
             "augsynth's heuristic."
         ),
     )
+    @field_validator("nu")
+    @classmethod
+    def _validate_nu(cls, v):
+        if isinstance(v, str):
+            return v
+        if isinstance(v, bool) or not isinstance(v, (int, float)):
+            raise ValueError(
+                f"nu must be a number in [0, 1] or 'auto'; got {v!r}."
+            )
+        if not 0.0 <= float(v) <= 1.0:
+            raise ValueError(
+                f"nu must lie in [0, 1] or be 'auto'; got {v!r}. It weights the "
+                "pooled imbalance term and 1 - nu weights the separate one, so "
+                "outside that interval one of them is negative and the objective "
+                "is no longer convex -- the solver refuses it without naming the "
+                "field responsible. Zero is a separate SCM per treated unit and "
+                "one is the fully pooled fit."
+            )
+        return float(v)
+
     fixedeff: bool = Field(
         default=True,
         description=(

--- a/mlsynth/utils/ppscm_helpers/engine.py
+++ b/mlsynth/utils/ppscm_helpers/engine.py
@@ -354,7 +354,18 @@ def run_multisynth(
     avg_l2 = float(np.mean([np.sqrt((M0[:, k] ** 2).sum()) for k in range(J)]))
     nnz = [max(int((np.abs(M0[:, k]) > 1e-12).sum()), 1) for k in range(J)]
     ind_l2 = float(np.sqrt(np.mean([(M0[:, k] ** 2).sum() / nnz[k] for k in range(J)])))
-    nu_used = float(global_l2 * np.sqrt(d) / avg_l2) if nu is None else float(nu)
+    # The ratio is ||mean_k m_k|| / mean_k ||m_k||, a triangle inequality, so it
+    # lies in [0, 1] and is tight when the treated units share one imbalance
+    # vector -- which a single treated unit does by definition, putting the ratio
+    # exactly on the bound. It is computed from two square roots and a division,
+    # and floating point can land it a unit in the last place above one. The
+    # objective below weights the separate term by 1 - nu, so that becomes a
+    # negative multiple of a convex quadratic and cvxpy refuses the problem as
+    # non-convex before the solver runs. Clamping restores the bound the formula
+    # already has. NaN survives the clamp, so a degenerate separate fit still
+    # shows up as one. An explicit nu is the caller's choice and passes through.
+    nu_used = (float(np.clip(global_l2 * np.sqrt(d) / avg_l2, 0.0, 1.0))
+               if nu is None else float(nu))
 
     W = solve_cohort_qp(res, groups, adopt_of, members, donors, n1, d, n, n_lags,
                         nu_used, global_l2 ** 2, ind_l2 ** 2, lam, solver, zt=zt, Zc=Zc)

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1333,3 +1333,28 @@ timeout = 300.0
   find = "                      for s in range(u.size)], dtype=float)"
   replace = "                      for s in range(0, u.size, block)], dtype=float)"
   models = "reverting to a disjoint reference set, which is the split-conformal block count this function exists to improve on. The p-value's granularity falls from 1/T to block/T, which at an eight-period horizon over a hundred pre-periods is coarser than the level being inverted at"
+
+[[target]]
+name = "auto-nu"
+module-path = "mlsynth/utils/ppscm_helpers/engine.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_auto_nu.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "auto-nu-unclamped"
+  find = """    nu_used = (float(np.clip(global_l2 * np.sqrt(d) / avg_l2, 0.0, 1.0))
+               if nu is None else float(nu))"""
+  replace = "    nu_used = float(global_l2 * np.sqrt(d) / avg_l2) if nu is None else float(nu)"
+  models = "the defect this clamp removes: trusting a triangle-inequality ratio to stay inside the unit interval it is bounded by in exact arithmetic. On a single-treated-unit panel the bound is tight, so rounding decides the sign of 1 - nu, and one unit in the last place above one makes the objective a negative multiple of a convex quadratic that cvxpy refuses outright. The same panel in different units lands on opposite sides"
+
+  [[target.mutant]]
+  id = "auto-nu-clamped-to-the-wrong-interval"
+  find = "    nu_used = (float(np.clip(global_l2 * np.sqrt(d) / avg_l2, 0.0, 1.0))"
+  replace = "    nu_used = (float(np.clip(global_l2 * np.sqrt(d) / avg_l2, 0.0, 0.99))"
+  models = "keeping the problem convex by holding nu off its own boundary. Every fit still solves, so the DCPError is gone and the failure that motivated the clamp is invisible -- but a single treated unit belongs at nu = 1, where the separate term drops out, and this gives it one percent of a fit it should not be blending in at all"
+
+  [[target.mutant]]
+  id = "an-explicit-nu-is-clamped-too"
+  find = "               if nu is None else float(nu))"
+  replace = "               if nu is None else float(np.clip(nu, 0.0, 1.0)))"
+  models = "extending the clamp past the computed ratio to the caller's own value. It reads as defensive and changes nothing on any valid input, but it converts an out-of-range nu from something a caller can discover into a silently substituted one"


### PR DESCRIPTION
## Related Links

- Docs page: `docs/ppscm.rst`, the "Choosing nu" step under Method
- Source: Ben-Michael, Feller & Rothstein (2022), whose `multisynth` heuristic this reproduces
- Adjacent work: `cwz_cumulative_per_unit` (on the branch for #492) balances the full window under each null, which is one of the places this defect currently bites

## What

- Clamp PPSCM's automatic pooling parameter into `[0, 1]` in `ppscm_helpers/engine.py`.
- Refuse an out-of-range explicit `nu` in `PPSCMConfig`, by name.
- Add `mlsynth/tests/test_ppscm_auto_nu.py` and the `auto-nu` mutation target.
- Document the boundary in `docs/ppscm.rst`.

## Why

With `nu="auto"` the engine follows augsynth and picks the pooling parameter as the ratio of the norm of the average imbalance to the average of the norms, over the treated units' separate-fit imbalance vectors. That is a triangle inequality: at most one, and tight exactly when the vectors are parallel, which a single treated unit gives by definition.

The second solve minimises

```
nu / (norm_pool J^2) q_pool + (1 - nu) / (norm_sep J) q_sep
```

so on the bound the separate term carries a weight of exactly zero. The ratio is computed from two square roots and a division, and nothing holds it on the correct side. One unit in the last place above one turns that weight into a small negative number, the objective becomes a negative multiple of a convex quadratic, and cvxpy raises `DCPError` before the solver runs.

It takes no unusual input. On a ten-unit one-factor panel with a single treated unit, the panel as drawn gives `nu = 1.0` exactly and fits; the same panel divided by its own median absolute level gives `1.0000000000000002` and is refused. The two are the same data in different units, and the fit is scale-equivariant in exact arithmetic but not in the last bit — so an outcome expressed in dollars and in thousands of dollars can land on opposite sides. The near-tight case is ordinary too: a small pool of similar units has near-parallel imbalance vectors.

A single treated unit is not an edge case for this estimator, and it is precisely where the ratio sits on the boundary.

## How

`np.clip` restores the bound the formula already carries. NaN passes through it unchanged, so a degenerate separate fit with zero average imbalance norm still surfaces as a non-finite `nu_used` rather than a plausible-looking 1.0 — the clamp corrects arithmetic, it does not paper over a bad panel.

An explicit `nu` is deliberately left alone. Folding 1.5 to 1.0 would fit a model the caller did not ask for and leave nothing on the result recording the substitution. So the range is enforced where it can be named: `PPSCMConfig` refuses a `nu` outside `[0, 1]` instead of letting cvxpy report a `quad_over_lin` subexpression that does not identify the field. The mutation target includes that distinction as its own mutant, since extending the clamp to the caller's value reads as defensive and changes nothing on any valid input.

## Verification

- Path: not applicable as a paper replication. This is a bug fix that makes a previously-refused fit succeed; it changes no fit that already worked.
- The augsynth `multisynth` vignette pins are unchanged and pass — `nu=0.2607` default and `nu=0.3939` for `time_cohort`, both well inside the interval, so the clamp is inert there. That is the check that matters for "does this move an existing number", and it does not.
- The defect is reproduced before it is fixed: a recorded panel and its rescaling by 0.658233745909389, one unit in the last place apart, where the second raises `DCPError` without the clamp.
- Equivariance is asserted rather than assumed: both scalings must agree on the effect after rescaling, not merely both solve.
- Durably pinned by `test_ppscm_auto_nu.py` (50 tests) and the `auto-nu` mutation target (3/3 killed).
- Nothing fails to match.

## Scope checks

BUG FIX

- [x] A test reproduces the defect and fails without the fix — `test_the_panel_that_rounded_over_one_still_fits`, plus the config refusal tests.
- [x] It asserts the correct behaviour, not merely the absence of a crash: `nu_used` must be exactly 1.0 on the tight case, and the two scalings must agree on the effect.
- [x] No docs page, docstring or comment still states the old behaviour; `docs/ppscm.rst` now says a float outside `[0,1]` is refused and why the boundary is reachable.
- [x] No pinned value moved.

## Designs

No plotter change. The fix is a scalar clamp and a config validator.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_ppscm_auto_nu.py -q` — 50 passed
- [x] `pytest mlsynth/tests/ -k "ppscm or supt or result_contract or conformal"` — 1029 passed, 35 skipped
- [x] `python tools/mutation/run_mutants.py --target auto-nu` — 3/3 killed
- [ ] Full `pytest mlsynth/tests/` — not run end to end here; the selection above covers PPSCM and everything downstream of it. Worth letting CI carry it.

## Other Notes

- This was written before #493 and has been rebased onto current main. The only conflict was `tools/mutation/targets.toml`, where both branches appended a target; resolved by keeping main's file and re-appending `auto-nu`, and the file parses with all 48 targets including `moving-block-pvalue`.
- The three mutants are worth reading as a set. The unclamped ratio is the defect itself; a clamp to `[0, 0.99]` keeps every fit solving while denying a single treated unit the boundary it belongs at, so the `DCPError` disappears and the failure becomes invisible; and a clamp extended to the caller's own `nu` converts an out-of-range value from something discoverable into something silently substituted.
- A correction to an earlier draft of this description, which said the conformal work on #492 requires an explicit `nu_used` "partly to route around this defect". That understated the reason and implied the requirement would relax once this lands. It will not. A conformal test refits under every candidate null and compares the resulting residual paths by permutation, so any tuning parameter has to be held fixed across those refits — otherwise the estimator changes from candidate to candidate and the paths are not exchangeable. The library already makes this call elsewhere: `lasso_cv_alpha` exists so the prediction-interval bootstrap can refit at a fixed penalty, since Jiang et al. reuse `lambda_{T0}` across bootstrap samples rather than re-selecting. `nu_used` stays a parameter for that reason. What this PR removes is a crash that the parameter also happens to avoid, not the reason the parameter exists.