### PR TITLE
Make the Wied independent port runnable

### DIFF
--- a/benchmarks/reference/wied_nj_minwage/independent_port.py
+++ b/benchmarks/reference/wied_nj_minwage/independent_port.py
@@ -8,12 +8,19 @@ using statsmodels' Probit for the DR step -- NOT the author's probit_fit.
   eq (2) : f_t(x) = mean_l [ Lambda(x'th1) - Lambda(x'th0) ]^2
 """
 import json, time, numpy as np, pandas as pd
+from pathlib import Path
 from scipy.stats import norm
 import statsmodels.api as sm
 
-d = pd.read_parquet("nj64.parquet")
+# The estimation sample and its standardisation constants sit beside this script,
+# so it runs from any working directory. Both are the float64 files
+# ``provenance.txt`` describes; the Gram matrix has kappa ~ 9.6e4 and a float32
+# round-trip moves the donor weights by 40x the tolerance they reproduce at.
+_DIR = Path(__file__).resolve().parent
+
+d = pd.read_parquet(_DIR / "nj_estimation_sample.parquet")
 d["STATEFIP"] = d["STATEFIP"].astype(int); d["t"] = d["t"].astype(int)
-meta = json.load(open("/root/.claude/uploads/a068a0ba-90d2-58b5-8873-c6320eda4fd6/5c1a37ef-nj_meta.json"))
+meta = json.loads((_DIR / "nj_meta.json").read_text())
 SP = {k: meta[k] for k in ("me","se","mx","sx")}
 NJ, PRE, POST = 34, [1, 2, 3], 4
 states = [NJ] + sorted(s for s in d.STATEFIP.unique() if s != NJ)
@@ -61,7 +68,6 @@ def eval_point(ed, ex):
     es = (ed - SP["me"]) / SP["se"]; xs = (ex - SP["mx"]) / SP["sx"]
     return np.array([1.0, es, xs, xs**2])
 
-w_auth = np.load("w_sc.npy")   # from the float32 run; recompute for f64 below
 print(f"kappa(G) = {np.linalg.cond(G):.5g}   (paper 9.6e4)")
 print(f"sum(w)   = {w.sum():.9f}")
 FIPS = {12:"Florida",36:"New York",46:"South Dakota",32:"Nevada",29:"Missouri"}
@@ -78,4 +84,3 @@ for nm, ed, ex in EVAL:
     x = eval_point(ed, ex)
     dd = norm.cdf(theta[(0, POST)] @ x) - norm.cdf(th0 @ x)
     print(f"  {nm:5s}{np.mean(dd**2)*1e3:8.3f}   paper {PAPER_F[nm]:6.2f}")
-np.save("w_independent.npy", w)


### PR DESCRIPTION
## Related Links

- Reference port: [`benchmarks/reference/wied_nj_minwage/independent_port.py`](https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/reference/wied_nj_minwage/independent_port.py)
- The provenance it reproduces: `benchmarks/reference/wied_nj_minwage/provenance.txt`
- The benchmark case that reads the same two data files correctly: `benchmarks/cases/wied_nj_minwage.py`
- Source paper: Wied, Dominik (2026), "A Synthetic Control Approach to Conditional Distributional Treatment Effects", arXiv:2606.09625v1

## What

- Fixed the two input paths in the archived independent port of Wied's DR-SC so it resolves them from `Path(__file__).parent`.
- Removed a `np.load("w_sc.npy")` of a file that is not in the repo, into a variable nothing reads.
- Removed a `np.save("w_independent.npy", w)` that wrote into the caller's working directory and that nothing reads.

## Why

The port could not run for anyone. It read the estimation sample from a relative
`nj64.parquet` that is not in the repo under that name, and the standardisation
constants from an absolute upload path that existed only on the machine that
wrote the script. Its role -- showing that the paper's Table 1 and Table 2 come
back from an implementation written independently of the author's code, from the
paper's equations, using `statsmodels.Probit` -- could not be checked by a reader.

Both files are checked in beside the script: `nj_estimation_sample.parquet` and
`nj_meta.json`.

## How

`benchmarks/cases/wied_nj_minwage.py` already reads those same two files by
resolving a `_DIR` from `__file__`. The port now uses the same idiom against its
own parent, so the two agree on where the reference data lives. The added comment
records why both must stay float64: the Gram matrix has kappa ~ 9.6e4, and per
`provenance.txt` a float32 round-trip moves the donor weights by 40x the tolerance
they otherwise reproduce at.

## Verification

- Path: cross-validation. The script is itself the independent implementation the
  case is checked against; this change only makes it executable.
- Run from `/tmp`, so the fix is demonstrated and not asserted, it reproduces
  every figure recorded in `provenance.txt`:

```
DR via statsmodels: 20s, m=32
kappa(G) = 96424   (paper 9.6e4)
sum(w)   = 1.000000000

=== Table 1: independent port vs paper ===
  Florida          0.5155   paper   0.515
  New York         0.4789   paper   0.479
  South Dakota    -0.2554   paper  -0.255
  Nevada           0.1989   paper   0.199
  Missouri        -0.1963   paper  -0.196

=== Table 2 f-hat: independent port vs paper ===
  x0      0.582   paper   0.58
  x10     1.714   paper   1.71
  xhl     1.551   paper   1.55
  xlh     0.607   paper   0.61
  x90     0.205   paper   0.21
```

- Twenty-five seconds, no network, no R, no artifacts left in the working directory.
- Durable pinning is unchanged and lives where it already did, in
  `benchmarks/cases/wied_nj_minwage.py`.

## Scope checks

None of the four blocks fits: this touches no estimator code, no config, no result
contract, and no pinned value. It is a repair to a reference script's file paths.

## Designs

No visual output; the script prints two tables, both quoted above.

## Test Steps

- [x] `python benchmarks/reference/wied_nj_minwage/independent_port.py` run from a
      different working directory, output as above
- [x] No estimator code touched, so no suite is implicated by this diff

## Other Notes

`git grep claude` is now empty under `benchmarks/`. The remaining repo-wide hits
are `CLAUDE.md` references in four test docstrings, which name the file itself and
would only go away with a rename; left alone deliberately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx)_