### PR TITLE
Reach the cumulative effect by inverting a test instead of counting windows

### DIFF
--- a/benchmarks/cases/conformal_inversion_prop99.py
+++ b/benchmarks/cases/conformal_inversion_prop99.py
@@ -1,0 +1,156 @@
+r"""Cross-validation: mlsynth's conformal test against Facure's chapter.
+
+The Chernozhukov-Wuthrich-Zhu test is short enough to write twice, which makes it
+a good candidate for a value-for-value cross-check. Matheus Facure's *Causal
+Inference for the Brave and True* implements it from scratch in
+``Conformal-Inference-for-Synthetic-Control.ipynb``: impose a constant null over
+the post window, refit a simplex synthetic control on the imputed series, roll
+the residual path through all ``T`` cyclic shifts, score each shift's post block
+with ``S_q = (mean |u|^q)^(1/q)``, and report the share of shifts scoring at
+least as extreme as the observed one.
+
+This case transcribes that notebook -- the cvxpy program and the p-value loop,
+not a paraphrase -- and runs it beside
+:func:`~mlsynth.utils.bilevel.ridge_inference.conformal_pvalue` on the same
+panel. The two are expected to agree exactly, not approximately. mlsynth's
+statistic is ``(sum |u|^q / sqrt(n))^(1/q)`` where the notebook's is the mean,
+and mlsynth counts ``obs <= perm`` where the notebook counts
+``stat >= stat[0]``; over a post block of fixed length both are monotone
+re-expressions of the same quantity, so any disagreement is a defect and not a
+convention.
+
+Also pinned: the cumulative band that inverts this test
+(:func:`~mlsynth.utils.conformal.cumulative_conformal_by_inversion`), by both of
+its searches, because this panel is the reason the second one exists. At
+``alpha = 0.1`` the accepted set here is two islands -- roughly ``[-122, -20]``
+and ``[-10, +5]`` -- separated by a candidate whose p-value falls to the block
+scheme's floor of ``1 / 31``. A search that brackets outward from the point
+estimate and bisects stops at the first crossing near ``-19.6`` and never sees
+the far island, so it excludes zero even though the zero-null p-value of 0.161
+accepts it. The grid search scans and returns the range of every survivor, which
+puts zero back inside and flags that the survivors had holes. Both are recorded:
+the disagreement is a property of the two searches, not a defect in either.
+
+Data: Abadie, Diamond & Hainmueller's California Proposition 99 panel,
+``basedata/smoking_data.csv``, 38 donor states over 1970-2000, on the notebook's
+own convention of a 1988 intervention and a 13-period window.
+
+Provenance: github.com/matheusfacure/python-causality-handbook, chapter
+"Conformal Inference for Synthetic Controls" (MIT licence, not vendored).
+"""
+from __future__ import annotations
+
+_INTERVENTION = 1988          # the notebook's convention, not Abadie's 1989
+_LAST_YEAR = 2000
+_NULLS = (0.0, -10.0, -20.0, -30.0)
+
+
+def _panel():
+    import numpy as np
+    import pandas as pd
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    csv = root / "basedata" / "smoking_data.csv"
+    if not csv.exists():                                   # pragma: no cover
+        from benchmarks.compare import BenchmarkSkipped
+        raise BenchmarkSkipped(f"missing {csv}")
+    d = pd.read_csv(csv)
+    wide = d.pivot(index="state", columns="year", values="cigsale").T
+    wide = wide.loc[wide.index <= _LAST_YEAR].sort_index()
+    y = wide["California"].to_numpy(dtype=float)
+    Y0 = wide.drop(columns=["California"]).to_numpy(dtype=float)
+    pre = int((wide.index < _INTERVENTION).sum())
+    return y, Y0, pre
+
+
+def _notebook_weights(X, target):
+    """The notebook's ``SyntheticControl.fit``: cvxpy, ``sum(w) == 1``, ``w >= 0``."""
+    import cvxpy as cp
+    import numpy as np
+
+    w = cp.Variable(X.shape[1])
+    cp.Problem(cp.Minimize(cp.sum_squares(X @ w - target)),
+               [cp.sum(w) == 1, w >= 0]).solve(verbose=False)
+    return np.asarray(w.value, dtype=float)
+
+
+def _notebook_pvalue(y, Y0, pre, null, q=1):
+    """The notebook's ``with_effect`` / ``residuals`` / ``p_value``, transcribed."""
+    import numpy as np
+
+    y_null = y.copy()
+    y_null[pre:] -= null
+    resid = y_null - Y0 @ _notebook_weights(Y0, y_null)
+    post = np.zeros(resid.size, dtype=bool)
+    post[pre:] = True
+    stats = np.array([(np.abs(np.roll(resid, s)[post]) ** q).mean() ** (1.0 / q)
+                      for s in range(resid.size)])
+    return float(np.mean(stats >= stats[0]))
+
+
+def run() -> dict:
+    import numpy as np
+
+    from mlsynth.utils.bilevel.ridge_inference import conformal_pvalue
+    from mlsynth.utils.conformal import cumulative_conformal_by_inversion
+
+    y, Y0, pre = _panel()
+    out = {"pre_periods": float(pre), "post_periods": float(y.size - pre),
+           "n_donors": float(Y0.shape[1])}
+
+    worst = 0.0
+    for null in _NULLS:
+        theirs = _notebook_pvalue(y, Y0, pre, null)
+        shifted = y.copy()
+        shifted[pre:] -= null
+        ours = conformal_pvalue(shifted, Y0, pre, refit="sc",
+                                conformal_type="block", q=1.0)
+        worst = max(worst, abs(theirs - ours))
+        out[f"pvalue_null_{int(abs(null))}"] = ours
+    out["max_pvalue_gap_vs_notebook"] = worst
+
+    kw = dict(alpha=0.1, refit="sc", conformal_type="block")
+    bisect = cumulative_conformal_by_inversion(y, Y0, pre, **kw)
+    out.update(bisect_point=bisect.point,
+               bisect_per_period_lower=bisect.per_period_lower,
+               bisect_per_period_upper=bisect.per_period_upper,
+               bisect_zero_inside=float(bisect.lower <= 0.0 <= bisect.upper))
+
+    grid = cumulative_conformal_by_inversion(
+        y, Y0, pre, search="grid", grid=np.arange(-160.0, 40.5, 2.5), **kw)
+    out.update(grid_lower=grid.lower, grid_upper=grid.upper,
+               grid_per_period_lower=grid.per_period_lower,
+               grid_per_period_upper=grid.per_period_upper,
+               grid_has_gaps=float(bool(grid.has_interior_gaps)),
+               grid_zero_inside=float(grid.lower <= 0.0 <= grid.upper))
+
+    # The band is the accepted set, so the search that can see the whole set must
+    # place zero on the side the zero-null p-value does.
+    out["grid_zero_agreement"] = float(
+        out["grid_zero_inside"] == float(out["pvalue_null_0"] > 0.1))
+    return out
+
+
+EXPECTED = {
+    "pre_periods": (18.0, 0.0),
+    "post_periods": (13.0, 0.0),
+    "n_donors": (38.0, 0.0),
+    # exact agreement: 1/31 granularity, so a tolerance below half a step
+    "max_pvalue_gap_vs_notebook": (0.0, 1e-12),
+    "pvalue_null_0": (0.161290, 0.0005),
+    "pvalue_null_10": (0.161290, 0.0005),
+    "pvalue_null_20": (0.129032, 0.0005),
+    "pvalue_null_30": (0.451613, 0.0005),
+    # the grid search sees both islands, so it agrees with the p-value it inverts
+    "grid_zero_agreement": (1.0, 0.0),
+    "grid_zero_inside": (1.0, 0.0),
+    "grid_has_gaps": (1.0, 0.0),
+    "grid_per_period_lower": (-122.5, 2.6),
+    "grid_per_period_upper": (5.0, 2.6),
+    # the bisecting search stops at the near crossing; recorded, not gated as a
+    # defect, because finding a narrow set at any width is what it is for
+    "bisect_zero_inside": (0.0, 0.0),
+    "bisect_per_period_upper": (-19.64, 0.5),
+    "bisect_point": (-240.48, 0.5),
+}

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -197,7 +197,8 @@ CASES = {
     "fsc_okano": "benchmarks.cases.fsc_okano",  # Path A (reference port): Okano-Kurisu 2026 functional SC -- all three applications, both fits each, and Tables 1-3 reproduced exactly from the authors' data
     "fsc_estimator": "benchmarks.cases.fsc_estimator",  # Path A: mlsynth.FSC itself on the same three applications -- fertility exact, and the mortality/service divergences measured and pinned
     "vanillasc_xval_references": "benchmarks.cases.vanillasc_xval_references",  # cross-val vs Synth (uniform V) + tidysynth (ADH spec): placebo rank/p-value agreement, plus recorded solver-quality gaps
-    "wiltshire_walmart": "benchmarks.cases.wiltshire_walmart",  # Path A (geometry, not cells): Wiltshire 2023 sec 4.2 stacked SCM on 566 Walmart counties -- the paper's prose claims (pre-fit, no effect at entry, decline from e=2, large negative at e=5) plus the base-period indexing identity; magnitudes not claimed, see docs/replications/stackedsc.rst
+    "wiltshire_walmart": "benchmarks.cases.wiltshire_walmart",
+    "conformal_inversion_prop99": "benchmarks.cases.conformal_inversion_prop99",  # cross-val vs Facure's "Conformal Inference for Synthetic Controls" notebook, transcribed: the CWZ block-permutation p-value agrees value-for-value on the Prop 99 panel, and the cumulative band that inverts it is pinned under both searches -- the accepted set is two islands, so the bisecting search excludes zero where the grid search (and the p-value itself) accepts it  # Path A (geometry, not cells): Wiltshire 2023 sec 4.2 stacked SCM on 566 Walmart counties -- the paper's prose claims (pre-fit, no effect at entry, decline from e=2, large negative at e=5) plus the base-period indexing identity; magnitudes not claimed, see docs/replications/stackedsc.rst
 }
 
 # Names whose case reads an external R/MATLAB reference *dump*. Cross-checks that

--- a/mlsynth/tests/test_conformal_cumulative_inversion.py
+++ b/mlsynth/tests/test_conformal_cumulative_inversion.py
@@ -1,0 +1,388 @@
+"""A band for the cumulative effect, obtained by inverting a joint conformal test.
+
+The other route to a cumulative band calibrates on out-of-sample errors: split a
+withheld stretch into horizon-length windows and resample them. Its accuracy is
+bounded by how many such windows exist, which on a design with a 47-period blank
+window and a 13-period horizon is three, and three windows do not reach nominal
+coverage even when every distributional assumption holds.
+
+Test inversion has no such ceiling. Under a sharp null the whole post block is
+imputed, the control is refit on every period, and the post-block residual is
+compared with permutations of the residual path -- so the reference set is the
+``T0 + H`` periods themselves, not a count of windows carved out of them.
+
+The price is the shape of the null. A one-dimensional interval needs a
+one-dimensional null, so the effect is taken to be constant across the post
+block; the interval covers the total under that restriction and says nothing
+about an arbitrary effect path. A constant null also has two honest failure
+states this band must preserve: no constant effect conforms at all (an empty
+set), and nothing is excluded in a direction (an unbounded side).
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.conformal import (CumulativeInversionBand,
+                                     cumulative_conformal_by_inversion)
+
+
+def _panel(J=8, pre=30, horizon=6, effect=0.0, seed=0, trend=0.0):
+    """A donor pool the treated unit sits inside, plus a constant post effect."""
+    rng = np.random.default_rng(seed)
+    T = pre + horizon
+    f = np.cumsum(rng.normal(0, 1.0, T)) + 20.0
+    Y0 = np.column_stack([f * (0.9 + 0.05 * j) + rng.normal(0, 0.3, T)
+                          for j in range(J)])
+    w = rng.dirichlet(np.ones(J))
+    y = Y0 @ w + rng.normal(0, 0.3, T)
+    y[pre:] += effect
+    if trend:
+        y[pre:] += trend * np.arange(1, horizon + 1)
+    return y, Y0, pre, horizon
+
+
+_KW = dict(refit="sc", conformal_type="block", alpha=0.1)
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_it_produces_a_band_around_the_total():
+    y, Y0, pre, h = _panel(effect=4.0)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, **_KW)
+    assert isinstance(band, CumulativeInversionBand)
+    assert band.horizon == h
+    assert np.isfinite(band.lower) and np.isfinite(band.upper)
+    assert band.lower < band.upper
+    assert band.lower <= 4.0 * h <= band.upper
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+def test_the_cumulative_band_is_the_constant_effect_band_times_the_horizon():
+    """The arithmetic that turns a per-period null into a total, pinned against
+    the search it delegates to. A total over ``H`` periods of a constant effect
+    is ``H`` times that effect, so nothing else may enter."""
+    from mlsynth.utils.bilevel.ridge_inference import conformal_att_interval
+
+    y, Y0, pre, h = _panel(effect=3.0)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, **_KW)
+    lo, hi = conformal_att_interval(y[:pre + h], Y0[:pre + h], pre,
+                                    alpha=0.1, refit="sc",
+                                    conformal_type="block")
+    assert band.per_period_lower == pytest.approx(lo)
+    assert band.per_period_upper == pytest.approx(hi)
+    assert band.lower == pytest.approx(lo * h)
+    assert band.upper == pytest.approx(hi * h)
+
+
+def test_shifting_the_post_block_shifts_the_band_by_the_same_total():
+    """Equivariance. Adding a constant ``c`` to every post period adds exactly
+    ``c`` to the effect being tested, so the interval must translate by ``c * H``
+    and keep its width -- the test is about the effect, not about the level."""
+    y, Y0, pre, h = _panel(effect=2.0)
+    base = cumulative_conformal_by_inversion(y, Y0, pre, h, **_KW)
+    shifted_y = y.copy()
+    shifted_y[pre:] += 5.0
+    moved = cumulative_conformal_by_inversion(shifted_y, Y0, pre, h, **_KW)
+    assert moved.lower == pytest.approx(base.lower + 5.0 * h, rel=2e-2)
+    assert moved.upper == pytest.approx(base.upper + 5.0 * h, rel=2e-2)
+    assert (moved.upper - moved.lower) == pytest.approx(base.upper - base.lower,
+                                                        rel=2e-2)
+
+
+def test_a_tighter_level_does_not_narrow_the_band():
+    """Fewer candidates are rejected at a smaller alpha, so the accepted set can
+    only grow. The comparison is one-sided because the p-value is discrete: two
+    levels between the same pair of attainable values give the identical set."""
+    y, Y0, pre, h = _panel(effect=3.0)
+    kw = dict(refit="sc", conformal_type="block")
+    loose = cumulative_conformal_by_inversion(y, Y0, pre, h, alpha=0.2, **kw)
+    tight = cumulative_conformal_by_inversion(y, Y0, pre, h, alpha=0.05, **kw)
+    assert (tight.upper - tight.lower) >= (loose.upper - loose.lower) - 1e-9
+
+
+def test_the_point_is_the_horizon_times_the_average_gap():
+    """The point comes from a fit on the pre-period alone, not from a null refit.
+
+    A refit that treats the post block as matching periods pulls its own
+    post-period gaps toward zero, so a point taken from it would sit nearer zero
+    than the estimator's own effect and the band would be centred away from what
+    it is meant to describe.
+    """
+    from mlsynth.utils.bilevel.simplex import simplex_lstsq
+
+    y, Y0, pre, h = _panel(effect=4.0)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, **_KW)
+    w = simplex_lstsq(Y0[:pre], y[:pre])
+    expected = h * float(np.mean(y[pre:pre + h] - Y0[pre:pre + h] @ w))
+    assert band.point == pytest.approx(expected, rel=1e-4)
+
+
+def test_the_horizon_bounds_the_reference_set():
+    """Only ``pre + horizon`` periods enter, so a longer series does not lend the
+    test extra permutations."""
+    y, Y0, pre, h = _panel(pre=30, horizon=10, effect=3.0)
+    short = cumulative_conformal_by_inversion(y, Y0, pre, 4, **_KW)
+    assert short.horizon == 4
+    assert short.n_reference == pre + 4
+
+
+def test_an_unstated_horizon_takes_every_post_period():
+    """``None`` is the documented default, not a rejected value: a caller who
+    wants the whole post block should not have to count it."""
+    y, Y0, pre, h = _panel(pre=30, horizon=6, effect=3.0)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, None, **_KW)
+    assert band.horizon == 6
+    assert band.n_reference == y.size
+
+
+def test_the_two_permutation_schemes_are_both_available_and_differ():
+    """``block`` uses the ``T`` cyclic shifts and preserves serial dependence;
+    ``iid`` draws permutations and gives a finer p-value grid. They are different
+    reference sets and need not agree."""
+    y, Y0, pre, h = _panel(effect=3.0)
+    blk = cumulative_conformal_by_inversion(y, Y0, pre, h, refit="sc",
+                                            conformal_type="block", alpha=0.1)
+    iid = cumulative_conformal_by_inversion(y, Y0, pre, h, refit="sc",
+                                            conformal_type="iid", alpha=0.1,
+                                            ns=400, seed=0)
+    assert np.isfinite(blk.lower) and np.isfinite(iid.lower)
+    assert not np.isclose(blk.lower, iid.lower, rtol=1e-9)
+
+
+def test_the_band_and_the_zero_null_p_value_agree_about_zero():
+    """The band is the set the test accepts, so the two must not disagree about
+    the one candidate anybody checks. Zero belongs inside exactly when the
+    zero-null p-value clears the level, and the same statement has to hold at a
+    level on the other side of that p-value."""
+    from mlsynth.utils.bilevel.ridge_inference import conformal_pvalue
+
+    y, Y0, pre, h = _panel(effect=2.5, pre=24, horizon=6, seed=3)
+    kw = dict(refit="sc", conformal_type="block")
+    p0 = conformal_pvalue(y[:pre + h], Y0[:pre + h], pre, q=1.0, **kw)
+    for alpha in (p0 / 2.0, min(0.999, p0 * 2.0)):
+        band = cumulative_conformal_by_inversion(y, Y0, pre, h, alpha=alpha, **kw)
+        if band.is_empty:
+            continue
+        contains_zero = band.lower <= 0.0 <= band.upper
+        assert contains_zero == (p0 > alpha)
+
+
+def test_it_records_what_produced_it():
+    y, Y0, pre, h = _panel(effect=3.0)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, **_KW)
+    assert band.alpha == pytest.approx(0.1)
+    assert band.refit == "sc"
+    assert band.conformal_type == "block"
+    assert band.n_reference == pre + h
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_a_level_finer_than_the_reference_set_leaves_the_band_unbounded():
+    """The block scheme's reference set is the ``T`` cyclic shifts, one of which
+    is the observed path, so no p-value falls below ``1 / T``. Below that level
+    nothing is rejected, and an infinite endpoint is the honest report -- a
+    finite one would invent a rejection that never happened."""
+    y, Y0, pre, h = _panel(effect=3.0, pre=12, horizon=4)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, refit="sc",
+                                             conformal_type="block",
+                                             alpha=1.0 / (pre + h) / 2.0)
+    assert band.is_unbounded
+    assert band.lower == -np.inf and band.upper == np.inf
+
+
+def test_an_effect_no_constant_explains_returns_an_empty_set():
+    """The null being inverted is a constant effect. A steeply growing one is not
+    constant, and when no candidate conforms the band says so instead of
+    returning the least-rejected value as though it had been accepted."""
+    y, Y0, pre, h = _panel(effect=0.0, trend=14.0, pre=30, horizon=8, seed=5)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, refit="sc",
+                                             conformal_type="iid", alpha=0.5,
+                                             ns=400, seed=0)
+    if band.is_empty:
+        assert np.isnan(band.lower) and np.isnan(band.upper)
+    else:                       # the panel did not defeat the constant null
+        assert band.lower < band.upper
+
+
+def test_a_single_post_period_is_a_per_period_interval():
+    y, Y0, pre, h = _panel(effect=4.0, horizon=6)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, 1, **_KW)
+    assert band.horizon == 1
+    assert band.lower == pytest.approx(band.per_period_lower)
+    assert band.upper == pytest.approx(band.per_period_upper)
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1, 1.5, "0.05", None, True])
+def test_a_bad_level_is_refused(bad):
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthConfigError, match="alpha"):
+        cumulative_conformal_by_inversion(y, Y0, pre, h, refit="sc", alpha=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -2, 2.5, "6", True])
+def test_a_bad_horizon_is_refused(bad):
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthConfigError, match="horizon"):
+        cumulative_conformal_by_inversion(y, Y0, pre, bad, **_KW)
+
+
+def test_a_horizon_past_the_series_is_refused():
+    y, Y0, pre, h = _panel(pre=30, horizon=6)
+    with pytest.raises(MlsynthConfigError, match="horizon"):
+        cumulative_conformal_by_inversion(y, Y0, pre, 7, **_KW)
+
+
+@pytest.mark.parametrize("bad", [0, -1, 40])
+def test_a_bad_pre_period_count_is_refused(bad):
+    y, Y0, pre, h = _panel(pre=30, horizon=6)
+    with pytest.raises(MlsynthConfigError, match="pre"):
+        cumulative_conformal_by_inversion(y, Y0, bad, 3, **_KW)
+
+
+@pytest.mark.parametrize("bad", ["lasso", "SC", "", None])
+def test_an_unknown_refit_rule_is_refused(bad):
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthConfigError, match="refit"):
+        cumulative_conformal_by_inversion(y, Y0, pre, h, refit=bad,
+                                          conformal_type="block", alpha=0.1)
+
+
+@pytest.mark.parametrize("bad", ["moving", "BLOCK", "", None])
+def test_an_unknown_permutation_scheme_is_refused(bad):
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthConfigError, match="conformal_type"):
+        cumulative_conformal_by_inversion(y, Y0, pre, h, refit="sc",
+                                          conformal_type=bad, alpha=0.1)
+
+
+def test_a_donor_block_of_the_wrong_length_is_refused():
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthDataError, match="periods"):
+        cumulative_conformal_by_inversion(y, Y0[:-3], pre, h, **_KW)
+
+
+def test_a_two_dimensional_treated_series_is_refused():
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthDataError, match="one-dimensional"):
+        cumulative_conformal_by_inversion(np.tile(y, (2, 1)), Y0, pre, h, **_KW)
+
+
+@pytest.mark.parametrize("spoil", ["nan", "inf"])
+def test_a_non_finite_series_is_refused(spoil):
+    y, Y0, pre, h = _panel()
+    y = y.copy()
+    y[2] = np.nan if spoil == "nan" else np.inf
+    with pytest.raises(MlsynthDataError, match="finite"):
+        cumulative_conformal_by_inversion(y, Y0, pre, h, **_KW)
+
+
+def test_a_one_dimensional_donor_block_is_refused():
+    """A single donor passed as a flat series is the common shape slip, and the
+    failure names the argument instead of broadcasting into a wrong fit."""
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthDataError, match="two-dimensional"):
+        cumulative_conformal_by_inversion(y, Y0[:, 0], pre, h, **_KW)
+
+
+@pytest.mark.parametrize("bad", [2.5, "30", None, True])
+def test_a_non_integer_pre_period_count_is_refused(bad):
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthConfigError, match="pre"):
+        cumulative_conformal_by_inversion(y, Y0, bad, 3, **_KW)
+
+
+# --------------------------------------------------------------------------- #
+# the accepted set need not be an interval
+# --------------------------------------------------------------------------- #
+def test_a_grid_search_is_offered_and_reports_gaps():
+    """A conformal p-value is not unimodal in the candidate.
+
+    On the Proposition 99 panel the accepted set at ``alpha = 0.1`` is two
+    islands, ``[-120, -20]`` and ``[-10, +5]``, separated by a candidate whose
+    p-value falls to the block scheme's floor of ``1 / T``. A search that
+    brackets outward from the point estimate and bisects stops at the first
+    crossing and never sees the far island -- so it can exclude a candidate the
+    test accepts, including zero. The grid route scans instead and reports the
+    range of everything that survived, plus whether the survivors had holes.
+    """
+    y, Y0, pre, h = _panel(effect=3.0)
+    grid = np.linspace(-20.0, 20.0, 41)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, search="grid",
+                                             grid=grid, **_KW)
+    assert band.search == "grid"
+    assert band.has_interior_gaps in (True, False)
+    assert band.lower <= band.upper or band.is_empty
+
+
+def test_the_bisecting_search_does_not_claim_to_know_about_gaps():
+    """It cannot: it only ever evaluates candidates along one outward walk, so
+    ``None`` is the honest report and ``False`` would be a claim it has not
+    earned."""
+    y, Y0, pre, h = _panel(effect=3.0)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, **_KW)
+    assert band.search == "bisect"
+    assert band.has_interior_gaps is None
+
+
+def test_the_grid_route_keeps_every_accepted_candidate_inside_the_band():
+    """The defining property. Whatever the survivors look like, the reported
+    range must contain all of them -- that is what makes it a confidence set."""
+    from mlsynth.utils.bilevel.ridge_inference import conformal_pvalue
+
+    y, Y0, pre, h = _panel(effect=2.0, pre=24, horizon=6, seed=8)
+    grid = np.linspace(-12.0, 12.0, 25)
+    kw = dict(refit="sc", conformal_type="block")
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, alpha=0.1,
+                                             search="grid", grid=grid, **kw)
+    accepted = []
+    for tau in grid:
+        shifted = y[:pre + h].copy()
+        shifted[pre:] -= tau
+        if conformal_pvalue(shifted, Y0[:pre + h], pre, q=1.0, **kw) > 0.1:
+            accepted.append(tau)
+    if not accepted:
+        assert band.is_empty
+    else:
+        assert band.per_period_lower <= min(accepted) + 1e-9
+        assert band.per_period_upper >= max(accepted) - 1e-9
+
+
+def test_a_grid_search_without_a_grid_is_refused():
+    """There is no safe default grid: its width has to be scaled to the panel's
+    own dispersion, and one guessed here would step over a narrow set and report
+    it empty."""
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthConfigError, match="grid"):
+        cumulative_conformal_by_inversion(y, Y0, pre, h, search="grid", **_KW)
+
+
+@pytest.mark.parametrize("bad", [[], [1.0], "0,1", 5.0])
+def test_a_bad_grid_is_refused(bad):
+    y, Y0, pre, h = _panel()
+    with pytest.raises((MlsynthConfigError, MlsynthDataError), match="grid"):
+        cumulative_conformal_by_inversion(y, Y0, pre, h, search="grid",
+                                          grid=bad, **_KW)
+
+
+def test_a_non_finite_grid_is_refused():
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthDataError, match="finite"):
+        cumulative_conformal_by_inversion(y, Y0, pre, h, search="grid",
+                                          grid=[0.0, np.nan, 1.0], **_KW)
+
+
+@pytest.mark.parametrize("bad", ["bisection", "GRID", "", None])
+def test_an_unknown_search_is_refused(bad):
+    y, Y0, pre, h = _panel()
+    with pytest.raises(MlsynthConfigError, match="search"):
+        cumulative_conformal_by_inversion(y, Y0, pre, h, search=bad, **_KW)

--- a/mlsynth/utils/conformal/__init__.py
+++ b/mlsynth/utils/conformal/__init__.py
@@ -23,6 +23,11 @@ Contents:
 * :mod:`.cumulative` -- the band for a cumulative (total) effect:
   :func:`cumulative_conformal_interval` (pure combiner) and
   :func:`cumulative_conformal_from_refit` (single-treated-unit convenience).
+* :mod:`.cumulative_inversion` -- the same total by the other route:
+  :func:`cumulative_conformal_by_inversion` inverts a constant-effect null over
+  the whole post block, so its reference set is the ``T0 + H`` periods and not a
+  count of calibration windows. It restricts the effect's shape where
+  :mod:`.cumulative` restricts the window count.
 * :mod:`.refit` -- :func:`conformal_refit_gaps`, the refit a test-inversion
   procedure performs under a candidate null, and the one place the choice
   between a simplex and a ridge-augmented control is made.
@@ -46,6 +51,9 @@ American Statistical Association, 116(536), 1849-1864.
 from __future__ import annotations
 
 from .cumulative import cumulative_conformal_from_refit, cumulative_conformal_interval
+from .cumulative_inversion import (CONFORMAL_PERMUTATIONS,
+                                   CumulativeInversionBand,
+                                   cumulative_conformal_by_inversion)
 from .ensemble import (AGGREGATIONS, DEFAULT_MEMBERS, EnsembleErrors,
                        bootstrap_loo_errors)
 from .inversion import confidence_set_bounds
@@ -65,7 +73,9 @@ from .structure import CumulativeConformalBand
 __all__ = [
     "AGGREGATIONS",
     "BLOCK_STATISTICS",
+    "CONFORMAL_PERMUTATIONS",
     "CONFORMAL_REFIT_RULES",
+    "CumulativeInversionBand",
     "DEFAULT_MEMBERS",
     "EnsembleErrors",
     "MIN_TRAIN_PERIODS",
@@ -73,6 +83,7 @@ __all__ = [
     "confidence_set_bounds",
     "bootstrap_loo_errors",
     "conformal_refit_gaps",
+    "cumulative_conformal_by_inversion",
     "cumulative_conformal_from_refit",
     "cumulative_conformal_interval",
     "moving_block_pvalue",

--- a/mlsynth/utils/conformal/cumulative_inversion.py
+++ b/mlsynth/utils/conformal/cumulative_inversion.py
@@ -1,0 +1,342 @@
+"""A band for the cumulative effect, obtained by inverting a joint conformal test.
+
+:mod:`.cumulative` calibrates a total on out-of-sample errors: a withheld stretch
+is split into horizon-length windows and their summed errors become the
+conformity scores. A total over ``H`` periods is ``H`` times the mean error over
+them, so the term that sizes it is a level observed once per window, and the
+calibration set for that term has size ``m`` -- the number of windows -- not
+``m * H``. Coverage is then bounded by ``m``: 0.86 at three windows and 0.94 at
+twenty-six, even with every distributional assumption granted (see
+``benchmarks/cases/conformal_window_count.py``). A design whose withheld stretch
+supports three windows cannot reach nominal by any resampling of them.
+
+Test inversion has no such ceiling. Under a sharp null the whole post block is
+imputed, the control is refit on every period, and the post-block statistic is
+compared against permutations of the residual path, so the reference set is the
+``T0 + H`` periods themselves. Chernozhukov, Wuthrich and Zhu give a
+nonasymptotic size bound whose leading term is ``(H / T0) ** 0.25 * log T`` with
+``H`` fixed: the rate is in the length of the pre-period, and no window count
+enters it.
+
+What that costs is the shape of the null. A one-dimensional interval requires a
+one-dimensional null, so the effect is taken to be constant across the post
+block and the total is ``H`` times it. The band therefore covers the total under
+a constant effect and says nothing about an arbitrary path -- CWZ's Remark 1
+statistic (the signed sum) targets the same average deviation, and neither
+recovers a path from one number. Where the effect plainly grows or decays,
+``.cumulative`` or ``.resample`` make no such restriction and pay for it in
+``m`` instead.
+
+Two answers here are not numbers, and both are real answers, not failures to
+compute. An empty set means no constant effect conforms, which a multiplicative
+lift on a trending panel produces. An infinite endpoint means nothing is excluded
+in that direction: the block scheme's reference set is the ``T`` cyclic shifts,
+one of which is the observed path, so no p-value falls below ``1 / T`` and at
+``alpha < 1 / T`` no candidate is ever rejected. Returning a finite bound in
+either case would report a rejection that never happened.
+
+The search, the refit rules and the permutation schemes are
+:func:`~mlsynth.utils.bilevel.ridge_inference.conformal_att_interval`'s; this
+module supplies the validation, the cumulative reading and the container, so an
+estimator can ask for a band for the total without reaching into the ridge
+machinery.
+
+References
+----------
+Chernozhukov, V., Wuthrich, K., & Zhu, Y. (2021). An Exact and Robust Conformal
+Inference Method for Counterfactual and Synthetic Controls. Journal of the
+American Statistical Association, 116(536), 1849-1864. Remark 1 and Assumption 2.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+from .refit import CONFORMAL_REFIT_RULES
+
+#: Permutation sets, CWZ's ``Pi_all`` and ``Pi_->``. ``block`` uses the ``T``
+#: cyclic shifts and preserves serial dependence, which Assumption 2.2 requires
+#: of a stationary strongly-mixing shock process; ``iid`` draws permutations and
+#: is valid under Assumption 2.1, giving a finer p-value grid.
+CONFORMAL_PERMUTATIONS = ("block", "iid")
+
+#: How the accepted set is located. ``bisect`` brackets outward from the point
+#: estimate and bisects each crossing, which finds a narrow set at any width but
+#: assumes the survivors form one interval. ``grid`` evaluates the candidates it
+#: is given and returns the range of everything that survived, which tolerates
+#: gaps but only sees what the grid covers.
+CONFORMAL_SEARCHES = ("bisect", "grid")
+
+
+@dataclass(frozen=True)
+class CumulativeInversionBand:
+    """Interval for the total effect, from inverting a constant-effect null.
+
+    Parameters
+    ----------
+    point : float
+        ``horizon`` times the mean post-period gap of a fit on the pre-period
+        alone -- the estimator's own effect, not the null refit's.
+    lower, upper : float
+        Endpoints for the total. ``nan`` on both when the accepted set is empty;
+        ``-inf`` / ``+inf`` on a side nothing excludes. The two need not be
+        equidistant from ``point``: the test's asymmetry is preserved.
+    per_period_lower, per_period_upper : float
+        The same interval before multiplying by the horizon, i.e. for the
+        constant per-period effect that was actually tested.
+    horizon : int
+        Post periods accumulated.
+    alpha : float
+        Level; the band is the candidates with ``p > alpha``.
+    refit : str
+        Which control the null refit used, from
+        :data:`~mlsynth.utils.conformal.refit.CONFORMAL_REFIT_RULES`.
+    conformal_type : str
+        Permutation set, from :data:`CONFORMAL_PERMUTATIONS`.
+    n_reference : int
+        Periods entering the test, ``pre + horizon``. Under the block scheme this
+        is also the size of the reference set, so ``1 / n_reference`` is the
+        smallest attainable p-value.
+    search : str
+        How the set was located, from :data:`CONFORMAL_SEARCHES`.
+    has_interior_gaps : bool or None
+        Whether accepted candidates were separated by rejected ones. ``None``
+        under ``bisect``, which evaluates only one outward walk per side and so
+        cannot know; reporting ``False`` there would claim more than it has
+        seen.
+    is_empty : bool
+        No constant effect conformed.
+    is_unbounded : bool
+        At least one endpoint is infinite.
+    """
+
+    point: float
+    lower: float
+    upper: float
+    per_period_lower: float
+    per_period_upper: float
+    horizon: int
+    alpha: float
+    refit: str
+    conformal_type: str
+    n_reference: int
+    is_empty: bool
+    is_unbounded: bool
+    search: str
+    has_interior_gaps: Optional[bool]
+
+
+def _check_alpha(alpha) -> float:
+    if isinstance(alpha, bool) or not isinstance(alpha, (int, float, np.floating,
+                                                         np.integer)):
+        raise MlsynthConfigError(f"alpha must be a number in (0, 1); got {alpha!r}.")
+    if not 0.0 < float(alpha) < 1.0:
+        raise MlsynthConfigError(
+            f"alpha must lie in the open interval (0, 1); got {alpha!r}.")
+    return float(alpha)
+
+
+def _check_series(y, Y0):
+    y = np.asarray(y, dtype=float)
+    Y0 = np.asarray(Y0, dtype=float)
+    if y.ndim != 1:
+        raise MlsynthDataError(
+            f"y must be one-dimensional; got shape {y.shape}.")
+    if Y0.ndim != 2:
+        raise MlsynthDataError(
+            f"Y0 must be two-dimensional (n_periods, n_donors); got shape "
+            f"{Y0.shape}.")
+    if Y0.shape[0] != y.size:
+        raise MlsynthDataError(
+            f"y and Y0 must cover the same periods; y has {y.size} periods and "
+            f"Y0 has {Y0.shape[0]}.")
+    if not np.isfinite(y).all() or not np.isfinite(Y0).all():
+        raise MlsynthDataError("y and Y0 must be finite; they contain nan or inf.")
+    return y, Y0
+
+
+def _check_counts(pre, horizon, n_periods):
+    if isinstance(pre, bool) or not isinstance(pre, (int, np.integer)):
+        raise MlsynthConfigError(f"pre must be a positive int; got {pre!r}.")
+    if not 1 <= pre < n_periods:
+        raise MlsynthConfigError(
+            f"pre must be between 1 and {n_periods - 1}; got {pre}.")
+    if horizon is None:
+        horizon = n_periods - int(pre)
+    if isinstance(horizon, bool) or not isinstance(horizon, (int, np.integer)):
+        raise MlsynthConfigError(
+            f"horizon must be a positive int; got {horizon!r}.")
+    if not 1 <= horizon <= n_periods - int(pre):
+        raise MlsynthConfigError(
+            f"horizon must be between 1 and the {n_periods - int(pre)} post "
+            f"periods available; got {horizon}.")
+    return int(pre), int(horizon)
+
+
+def _check_grid(grid):
+    grid = np.asarray(grid, dtype=float).ravel() if not isinstance(grid, str) \
+        else None
+    if grid is None:
+        raise MlsynthConfigError(
+            "grid must be an array of candidate per-period effects.")
+    if grid.size < 2:
+        raise MlsynthConfigError(
+            f"grid must hold at least two candidates; got {grid.size}.")
+    if not np.isfinite(grid).all():
+        raise MlsynthDataError("grid must be finite; it contains nan or inf.")
+    return np.sort(grid)
+
+
+def _grid_bounds(accepts, grid, alpha):
+    """Range of the surviving candidates, and whether they had holes.
+
+    Delegates the accept rule and the range to
+    :func:`~mlsynth.utils.conformal.inversion.confidence_set_bounds`, which owns
+    the strict ``p > alpha`` convention and the decision to take the range of the
+    whole surviving set instead of its largest contiguous run.
+    """
+    from .inversion import confidence_set_bounds
+
+    pvalues = np.array([accepts(float(t)) for t in grid], dtype=float)
+    lo, hi = confidence_set_bounds(grid, pvalues, alpha)
+    kept = pvalues > alpha
+    if not kept.any():
+        return float("nan"), float("nan"), False
+    first, last = int(np.argmax(kept)), int(kept.size - 1 - np.argmax(kept[::-1]))
+    gaps = bool((~kept[first:last + 1]).any())
+    return float(lo), float(hi), gaps
+
+
+def cumulative_conformal_by_inversion(
+    y,
+    Y0,
+    pre: int,
+    horizon: Optional[int] = None,
+    *,
+    alpha: float = 0.1,
+    refit: str = "sc",
+    conformal_type: str = "block",
+    search: str = "bisect",
+    grid=None,
+    **kwargs: Any,
+) -> CumulativeInversionBand:
+    """Band for the total effect over ``horizon`` periods, by test inversion.
+
+    Parameters
+    ----------
+    y : array-like, shape ``(T,)``
+        Treated outcomes over the full sample.
+    Y0 : array-like, shape ``(T, J)``
+        Donor outcomes aligned to ``y``.
+    pre : int
+        Number of pre-treatment periods.
+    horizon : int, optional
+        Post periods to accumulate. Defaults to every post period. Only
+        ``pre + horizon`` periods enter the test, so a longer series does not
+        lend it extra permutations.
+    alpha : float
+        Level. The band is the candidates a level-``alpha`` test does not reject,
+        i.e. ``p > alpha``.
+    refit : {"sc", "ridge"}
+        Which control the null refit uses; see
+        :mod:`~mlsynth.utils.conformal.refit`. It should match the estimator
+        whose effect is being tested. ``"sc"`` is the procedure as published.
+    conformal_type : {"block", "iid"}
+        Permutation set. See :data:`CONFORMAL_PERMUTATIONS`.
+    search : {"bisect", "grid"}
+        How to locate the accepted set. See :data:`CONFORMAL_SEARCHES`. A
+        conformal p-value is not unimodal in the candidate, so the survivors can
+        form more than one island; ``bisect`` walks outward from the point
+        estimate and stops at the first crossing, which is fast and finds a
+        narrow set, but can exclude an accepted candidate beyond a hole.
+        ``grid`` sees whatever the grid covers and says whether there were holes.
+    grid : array-like, optional
+        Candidate per-period effects, required by ``search="grid"``. There is no
+        default: a grid has to be scaled to the panel's own dispersion, and one
+        guessed here would step over a narrow set and report it empty.
+    **kwargs
+        Forwarded to
+        :func:`~mlsynth.utils.bilevel.ridge_inference.conformal_att_interval`
+        (``q``, ``ns``, ``seed``, ``lambda_``, ``fixed_effects``, the search
+        controls).
+
+    Returns
+    -------
+    CumulativeInversionBand
+
+    Raises
+    ------
+    MlsynthConfigError
+        On a bad ``alpha``, ``pre``, ``horizon``, ``refit`` or
+        ``conformal_type``.
+    MlsynthDataError
+        On mismatched, misshapen or non-finite series.
+    """
+    y, Y0 = _check_series(y, Y0)
+    pre, horizon = _check_counts(pre, horizon, y.size)
+    alpha = _check_alpha(alpha)
+    if refit not in CONFORMAL_REFIT_RULES:
+        raise MlsynthConfigError(
+            f"refit must be one of {CONFORMAL_REFIT_RULES}; got {refit!r}.")
+    if conformal_type not in CONFORMAL_PERMUTATIONS:
+        raise MlsynthConfigError(
+            f"conformal_type must be one of {CONFORMAL_PERMUTATIONS}; got "
+            f"{conformal_type!r}.")
+    if search not in CONFORMAL_SEARCHES:
+        raise MlsynthConfigError(
+            f"search must be one of {CONFORMAL_SEARCHES}; got {search!r}.")
+    if search == "grid":
+        if grid is None:
+            raise MlsynthConfigError(
+                'search="grid" needs a grid of candidate per-period effects.')
+        grid = _check_grid(grid)
+
+    from ..bilevel.ridge_inference import conformal_att_interval
+    from ..bilevel.simplex import simplex_lstsq
+
+    n_reference = pre + horizon
+    y_w, Y0_w = y[:n_reference], Y0[:n_reference]
+
+    if search == "bisect":
+        lo, hi = conformal_att_interval(y_w, Y0_w, pre, alpha=alpha, refit=refit,
+                                        conformal_type=conformal_type, **kwargs)
+        gaps = None
+    else:
+        from ..bilevel.ridge_inference import conformal_pvalue
+
+        def pvalue_at(tau0: float) -> float:
+            shifted = y_w.copy()
+            shifted[pre:] -= tau0
+            return conformal_pvalue(shifted, Y0_w, pre, refit=refit,
+                                    conformal_type=conformal_type, **kwargs)
+
+        lo, hi, gaps = _grid_bounds(pvalue_at, grid, alpha)
+
+    # The point is the estimator's own effect: weights fitted on the pre-period
+    # alone, so the post gaps are the ones the band is meant to describe.
+    w = simplex_lstsq(Y0[:pre], y[:pre])
+    point = horizon * float(np.mean(y[pre:n_reference]
+                                    - Y0[pre:n_reference] @ w))
+
+    is_empty = bool(np.isnan(lo) or np.isnan(hi))
+    is_unbounded = bool(np.isinf(lo) or np.isinf(hi))
+    return CumulativeInversionBand(
+        point=point,
+        lower=lo * horizon,
+        upper=hi * horizon,
+        per_period_lower=float(lo),
+        per_period_upper=float(hi),
+        horizon=horizon,
+        alpha=alpha,
+        refit=refit,
+        conformal_type=conformal_type,
+        n_reference=n_reference,
+        is_empty=is_empty,
+        is_unbounded=is_unbounded,
+        search=search,
+        has_interior_gaps=gaps,
+    )


### PR DESCRIPTION
## Related Links

- Chernozhukov, Wüthrich & Zhu (2021), JASA 116(536), 1849-1864 — Remark 1 (the average-effect statistic) and Assumption 2 (which permutation set is valid under which dependence).
- Reference implementation cross-checked against: Matheus Facure, *Causal Inference for the Brave and True*, "Conformal Inference for Synthetic Controls" (`matheusfacure/python-causality-handbook`, MIT, not vendored).
- Benchmark case: `benchmarks/cases/conformal_inversion_prop99.py`.
- Related but independent: #502 (`claude/conformal-ensemble`), the other route to a cumulative calibration series. Neither depends on the other.

## What

- Added `mlsynth/utils/conformal/cumulative_inversion.py`: `cumulative_conformal_by_inversion`, the frozen `CumulativeInversionBand`, and the `CONFORMAL_PERMUTATIONS` / `CONFORMAL_SEARCHES` constants.
- Added `mlsynth/tests/test_conformal_cumulative_inversion.py`, 59 tests.
- Added the cross-validation benchmark case and registered it.
- Updated `mlsynth/utils/conformal/__init__.py` to export the new names and describe the module.

No existing module changes behaviour; nothing calls this yet.

## Why

A band for a total can be calibrated two ways and they fail differently. The resampling route (`.cumulative`, `.resample`) splits a withheld stretch into horizon-length windows and scores their summed errors. A total over `H` periods is `H` times the mean error over them, so the term that sizes it is a level observed once per window: the calibration set has size `m`, not `m·H`, and coverage is bounded by `m` — 0.86 at three windows, 0.94 at twenty-six, with every distributional assumption granted.

Test inversion has no such ceiling. The reference set is the `T0 + H` periods themselves, and CWZ's size bound has leading term `(H/T0)^{1/4} log T` with `H` fixed, so the rate is in the pre-period's length and no window count enters it. What it costs is the shape of the null: a one-dimensional interval needs a one-dimensional null, so the effect is taken constant across the post block.

## How

Most of the statistics already existed and this PR does not reimplement them. `conformal_att_interval` already inverts the constant-effect null and `conformal_pvalue` already computes the p-value under both permutation schemes, in `bilevel/ridge_inference.py`. What was missing is that they are reachable only through the ridge machinery, are called only by tests, and return a bare tuple. This adds the validation, the cumulative reading and a container.

It also adds a second search, for a measured reason. A conformal p-value is not unimodal in the candidate. On the Prop 99 panel at `alpha = 0.1` the accepted set is two islands, roughly `[-122, -20]` and `[-10, +5]`, separated by a candidate whose p-value falls to the block scheme's floor of `1/31`:

```
tau0     p       tau0     p
-125  0.0645     -20  0.1290  ACCEPT
-120  0.2258  ✓  -15  0.0323     <- hole
 ...            -10  0.1613  ✓
 -25  0.4194  ✓    0  0.1613  ✓
                  10  0.0968
```

Bracketing outward from the point estimate and bisecting stops at the first crossing near `-19.6` and never sees the far island, so it excludes zero while the zero-null p-value of 0.161 accepts it — the band disagreeing with the test it inverts about the one candidate anybody checks. `search="grid"` scans and returns the range of every survivor through `confidence_set_bounds`, which already owned that decision, and reports `has_interior_gaps`.

Neither search is wrong. Bisection finds a narrow set at any width, which is what `conformal_att_interval`'s docstring says it is for, and a grid only sees what it covers — which is why no default grid is supplied, and why `bisect` reports `has_interior_gaps` as `None` rather than `False`, since one outward walk per side cannot know.

## Verification

- Path: cross-validation. Facure's implementation is short enough to transcribe rather than paraphrase, so the case runs his cvxpy program and p-value loop beside `conformal_pvalue` on the same panel.
- Quantities: the block-permutation p-value at four nulls on the Prop 99 panel (38 donors, 1970-2000, the notebook's own 1988 intervention and 13-period window). Agreement is **exact**, pinned at `max_pvalue_gap_vs_notebook ≤ 1e-12` — mlsynth's statistic (`(Σ|u|^q/√n)^{1/q}`) and counting convention (`obs <= perm`) are monotone re-expressions of the notebook's (`(mean|u|^q)^{1/q}`, `stat >= stat[0]`) over a fixed-length post block, so anything but exact agreement would be a defect rather than a convention.
- Values: `0.161290, 0.161290, 0.129032, 0.451613` at nulls `0, -10, -20, -30`.
- Durably pinned in `benchmarks/cases/conformal_inversion_prop99.py`, registered so `--all` runs it (3s).
- Recorded, not fixed: the two searches disagree about zero on this panel. Both are pinned, because the disagreement is a property of the searches and the case exists partly to document it.

## Scope checks

None of the four blocks fits — a new shared helper plus its cross-validation, not an estimator, a feature on one, or a bug fix. The branch carries only this.

## Designs

No visual output; this returns an interval.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_conformal_cumulative_inversion.py -q` — 59 passed
- [x] `pytest mlsynth/tests/test_geox_readout_interval.py mlsynth/tests/test_bilevel_ridge.py -q` — 109 passed with the above; the existing callers of the search are unaffected
- [ ] `pytest mlsynth/tests/` — full suite, running here in CI
- [x] `coverage run --timid --source=mlsynth/utils/conformal -m pytest … && coverage report` — 105 statements, 0 missed, 100 percent, no `# pragma: no cover`
- [x] `python benchmarks/run_benchmarks.py --case conformal_inversion_prop99` — 16/16 metrics pass
- [x] No docs page in this change, so no underline check applies

## Other Notes

- No estimator calls this yet, on purpose. Wiring it to one is a separate branch, and that is where the docs page belongs.
- The constant-effect restriction is real and stated in the module docstring: where the effect plainly grows or decays, the resampling route makes no such assumption and pays for it in `m` instead. The two routes are complements.
- A mutation target for this module is not included; the branch is already carrying a helper plus a benchmark case, and the catalogue entry belongs with whichever lands first.
- The grid route costs one refit per candidate, so it is the expensive option; that is the trade for seeing the whole accepted set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx)_