### PR TITLE
Chain the conformal grid sweep's refits instead of solving each one cold

### DIFF
--- a/mlsynth/tests/test_conformal_sweep_warm_start.py
+++ b/mlsynth/tests/test_conformal_sweep_warm_start.py
@@ -1,0 +1,244 @@
+"""Chaining the conformal grid sweep's refits, and proving it changes only cost.
+
+Inverting a conformal test means solving the same simplex program once per
+candidate effect, on a design that barely moves between neighbours: only the
+post block of the treated series shifts, by one grid step. Solved cold, each
+candidate rebuilds its active set from scratch. Seeded with the previous
+candidate's solution it starts from the right support and certifies in a
+handful of pivots.
+
+``conformal_refit_gaps`` has taken a ``warm_start`` and offered ``return_base``
+from the beginning, and ``conformal_att_interval``'s docstring already says a
+grid sweep can chain them, but nothing between them exposed the seam:
+``conformal_pvalue`` neither accepted a seed nor handed one back, so every
+caller sweeping a grid solved cold. These tests pin the seam and, more
+importantly, pin that using it is free of consequence.
+
+The test this rests on is not the speed one. An optimisation that changes an
+answer is not an optimisation, and a warm-started active set could in principle
+certify at a different optimum where the program is degenerate -- equally
+optimal weights, different residuals, a different p-value. So the sweep is
+required to reproduce the unchained p-values exactly, not nearly.
+
+Work is asserted in pivots, not seconds. ``solve_simplex_qp`` returns them for
+this purpose and they are machine independent, where wall-clock on a shared
+runner is not.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.bilevel.ridge_inference import (conformal_pvalue,
+                                                   conformal_pvalue_sweep)
+
+
+def _panel(J=20, pre=40, horizon=8, effect=0.3, seed=0):
+    """A donor pool the treated unit sits inside, with a constant post effect."""
+    rng = np.random.default_rng(seed)
+    T = pre + horizon
+    f = np.column_stack([np.cumsum(rng.normal(0, 1, T)) for _ in range(2)])
+    lam = rng.dirichlet(np.ones(J - 1), size=2).T * 2.0
+    Y0 = f @ lam.T + 0.5 * rng.standard_normal((T, J - 1))
+    y = Y0 @ rng.dirichlet(np.ones(J - 1)) + 0.5 * rng.standard_normal(T)
+    y[pre:] += effect
+    return y, Y0, pre
+
+
+def _unchained(y, Y0, pre, grid, **kw):
+    """One cold call per candidate: what the sweep has to reproduce."""
+    out = np.empty(len(grid))
+    for i, tau in enumerate(grid):
+        shifted = y.copy()
+        shifted[pre:] -= tau
+        out[i] = conformal_pvalue(shifted, Y0, pre, **kw)
+    return out
+
+
+_KW = dict(refit="sc", conformal_type="block", q=1.0)
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_it_returns_one_p_value_per_candidate():
+    y, Y0, pre = _panel()
+    grid = np.linspace(-1.0, 1.5, 11)
+    p = conformal_pvalue_sweep(y, Y0, pre, grid, **_KW)
+    assert p.shape == grid.shape
+    assert np.isfinite(p).all()
+    assert ((p > 0.0) & (p <= 1.0)).all()
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_the_sweep_reproduces_the_unchained_p_values_exactly(seed):
+    """The test the optimisation lives or dies by. Not ``allclose``: a conformal
+    p-value is a rank among a finite reference set, so a discrepancy of any size
+    means a different rank, and the interval that inverts it moves."""
+    y, Y0, pre = _panel(seed=seed)
+    grid = np.linspace(-1.5, 2.0, 25)
+    assert np.array_equal(conformal_pvalue_sweep(y, Y0, pre, grid, **_KW),
+                          _unchained(y, Y0, pre, grid, **_KW))
+
+
+def test_an_unsorted_grid_returns_values_aligned_to_the_input():
+    """The chain only saves anything if it walks the grid in order, but the
+    caller's ordering is what the result must line up with."""
+    y, Y0, pre = _panel()
+    grid = np.array([0.6, -0.9, 1.4, 0.0, -0.3])
+    swept = conformal_pvalue_sweep(y, Y0, pre, grid, **_KW)
+    assert np.array_equal(swept, _unchained(y, Y0, pre, grid, **_KW))
+
+
+def test_a_repeated_candidate_gets_the_same_p_value_twice():
+    y, Y0, pre = _panel()
+    grid = np.array([0.3, -0.2, 0.3])
+    p = conformal_pvalue_sweep(y, Y0, pre, grid, **_KW)
+    assert p[0] == p[2]
+
+
+def test_seeding_a_single_call_does_not_move_its_p_value():
+    """``warm_start`` on ``conformal_pvalue`` is a seed for the solver, not a
+    parameter of the estimand."""
+    y, Y0, pre = _panel()
+    cold = conformal_pvalue(y, Y0, pre, **_KW)
+    seed_w = np.full(Y0.shape[1], 1.0 / Y0.shape[1])
+    assert conformal_pvalue(y, Y0, pre, warm_start=seed_w, **_KW) == cold
+
+
+def test_asking_for_the_base_returns_simplex_weights_and_the_same_p_value():
+    y, Y0, pre = _panel()
+    plain = conformal_pvalue(y, Y0, pre, **_KW)
+    p, base = conformal_pvalue(y, Y0, pre, return_base=True, **_KW)
+    assert p == plain
+    assert base.shape == (Y0.shape[1],)
+    assert (base >= -1e-9).all()
+    assert base.sum() == pytest.approx(1.0)
+
+
+def _pivots_of(call):
+    """Total active-set pivots spent inside ``call``.
+
+    ``simplex_qp`` imports ``solve_simplex_qp`` from :mod:`active_set` at call
+    time, so replacing the module attribute is seen by the code under test. The
+    replacement forwards to the real solver and only records its work, which is
+    what makes this a measurement of the path actually taken, not of a
+    reimplementation of it.
+    """
+    from mlsynth.utils.bilevel import active_set
+
+    real = active_set.solve_simplex_qp
+    spent = []
+
+    def counting(B, A, **kw):
+        want_info = kw.pop("return_info", False)
+        w, info = real(B, A, return_info=True, **kw)
+        spent.append(info["pivots"])
+        return (w, info) if want_info else w
+
+    active_set.solve_simplex_qp = counting
+    try:
+        call()
+    finally:
+        active_set.solve_simplex_qp = real
+    return sum(spent)
+
+
+def test_the_sweep_itself_spends_far_fewer_pivots_than_cold_calls():
+    """Work, in the unit the solver reports it, measured through the sweep.
+
+    Asserting on the solver directly would pass even if the sweep never chained,
+    which is exactly what two catalogued mutants do: walking the caller's order
+    instead of the grid's, and passing no seed at all. Both leave every p-value
+    correct and only the saving disappears, so nothing but a work assertion
+    through this entry point can see them.
+
+    The bound is loose on purpose -- the measured saving is about 95 percent and
+    this asserts only that most of it survives a slower machine or a different
+    BLAS, neither of which changes a pivot count.
+    """
+    y, Y0, pre = _panel(J=30, seed=4)
+    grid = np.linspace(-1.5, 2.0, 41)
+    chained = _pivots_of(
+        lambda: conformal_pvalue_sweep(y, Y0, pre, grid, **_KW))
+    cold = _pivots_of(lambda: _unchained(y, Y0, pre, grid, **_KW))
+    assert chained < cold / 3, f"chained {chained} pivots against cold {cold}"
+
+
+def test_the_sweep_walks_the_grid_in_order():
+    """The saving comes from consecutive solves being neighbouring problems, so
+    a shuffled grid must cost no more than a sorted one -- which it can only
+    manage by sorting internally."""
+    y, Y0, pre = _panel(J=30, seed=4)
+    grid = np.linspace(-1.5, 2.0, 41)
+    rng = np.random.default_rng(0)
+    shuffled = grid.copy()
+    rng.shuffle(shuffled)
+    sorted_cost = _pivots_of(
+        lambda: conformal_pvalue_sweep(y, Y0, pre, grid, **_KW))
+    shuffled_cost = _pivots_of(
+        lambda: conformal_pvalue_sweep(y, Y0, pre, shuffled, **_KW))
+    assert shuffled_cost <= sorted_cost * 1.25
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_a_single_candidate_sweep_matches_a_single_call():
+    y, Y0, pre = _panel()
+    swept = conformal_pvalue_sweep(y, Y0, pre, np.array([0.25]), **_KW)
+    shifted = y.copy()
+    shifted[pre:] -= 0.25
+    assert swept[0] == conformal_pvalue(shifted, Y0, pre, **_KW)
+
+
+def test_an_infeasible_seed_is_ignored_rather_than_used():
+    """A seed off the simplex is not a feasible starting point. The solver drops
+    it, so the answer is the cold one and no exception is owed to the caller."""
+    y, Y0, pre = _panel()
+    cold = conformal_pvalue(y, Y0, pre, **_KW)
+    bad = np.full(Y0.shape[1], -3.0)
+    assert conformal_pvalue(y, Y0, pre, warm_start=bad, **_KW) == cold
+
+
+def test_the_iid_scheme_sweeps_too_and_still_matches():
+    """Chaining is a property of the refit, not of the permutation set."""
+    y, Y0, pre = _panel()
+    grid = np.linspace(-0.5, 1.0, 9)
+    kw = dict(refit="sc", conformal_type="iid", q=1.0, ns=200, seed=3)
+    assert np.array_equal(conformal_pvalue_sweep(y, Y0, pre, grid, **kw),
+                          _unchained(y, Y0, pre, grid, **kw))
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", [[], "0,1", 0.5])
+def test_a_bad_grid_is_refused(bad):
+    y, Y0, pre = _panel()
+    with pytest.raises((MlsynthConfigError, MlsynthDataError), match="grid"):
+        conformal_pvalue_sweep(y, Y0, pre, bad, **_KW)
+
+
+def test_a_non_finite_grid_is_refused():
+    y, Y0, pre = _panel()
+    with pytest.raises(MlsynthDataError, match="finite"):
+        conformal_pvalue_sweep(y, Y0, pre, [0.0, np.inf], **_KW)
+
+
+def test_a_seed_of_the_wrong_length_is_refused():
+    """A seed sized for a different donor pool is a caller bug, and silently
+    ignoring it would hide the mix-up behind a correct-looking answer."""
+    y, Y0, pre = _panel()
+    with pytest.raises(MlsynthDataError, match="warm_start"):
+        conformal_pvalue(y, Y0, pre, warm_start=np.ones(3) / 3.0, **_KW)
+
+
+def test_an_unknown_refit_rule_is_still_refused_by_the_sweep():
+    y, Y0, pre = _panel()
+    with pytest.raises(MlsynthConfigError, match="refit"):
+        conformal_pvalue_sweep(y, Y0, pre, np.array([0.0, 0.5]), refit="lasso")

--- a/mlsynth/tests/test_conformal_sweep_warm_start_properties.py
+++ b/mlsynth/tests/test_conformal_sweep_warm_start_properties.py
@@ -1,0 +1,110 @@
+"""Metamorphic invariants of the chained conformal sweep.
+
+The unit suite pins the sweep on fixed panels. These properties assert what has
+to hold for every panel and every grid, and the first of them is the one the
+whole optimisation rests on:
+
+* equivalence -- the chained sweep reproduces one cold call per candidate
+  exactly. A seed is a starting point for the active set, never a parameter of
+  the estimand, so a discrepancy of any size means the optimisation changed an
+  answer. Exactness is the right bar here and ``allclose`` is not: a conformal
+  p-value is a rank among a finite reference set, so the smallest difference is
+  a different rank and a moved interval;
+* order invariance -- permuting the grid permutes the results and changes
+  nothing else, since the sweep sorts internally but must report in the
+  caller's order;
+* seed irrelevance -- any feasible seed handed to a single call leaves its
+  p-value alone, which is the same statement one candidate at a time;
+* range -- every p-value is a share of a finite reference set, so it lies in
+  ``(0, 1]`` and can never be zero: the identity permutation is always in the
+  set and always ties with itself.
+"""
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils.bilevel.ridge_inference import (conformal_pvalue,
+                                                   conformal_pvalue_sweep)
+
+_SETTINGS = settings(
+    max_examples=25, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+)
+
+_KW = dict(refit="sc", conformal_type="block", q=1.0)
+
+
+def _panel(n_donors, pre, horizon, effect, seed):
+    """A donor pool the treated unit sits inside, with a constant post effect."""
+    rng = np.random.default_rng(seed)
+    T = pre + horizon
+    f = np.column_stack([np.cumsum(rng.normal(0, 1, T)) for _ in range(2)])
+    lam = rng.dirichlet(np.ones(n_donors), size=2).T * 2.0
+    Y0 = f @ lam.T + 0.5 * rng.standard_normal((T, n_donors))
+    y = Y0 @ rng.dirichlet(np.ones(n_donors)) + 0.5 * rng.standard_normal(T)
+    y[pre:] += effect
+    return y, Y0, pre
+
+
+def _unchained(y, Y0, pre, grid, **kw):
+    out = np.empty(len(grid))
+    for i, tau in enumerate(grid):
+        shifted = y.copy()
+        shifted[pre:] -= tau
+        out[i] = conformal_pvalue(shifted, Y0, pre, **kw)
+    return out
+
+
+_PANELS = st.tuples(
+    st.integers(min_value=3, max_value=12),      # donors
+    st.integers(min_value=14, max_value=40),     # pre-periods
+    st.integers(min_value=2, max_value=10),      # horizon
+    st.floats(min_value=-2.0, max_value=2.0, allow_nan=False, allow_infinity=False),
+    st.integers(min_value=0, max_value=10_000),  # panel seed
+)
+
+
+@given(spec=_PANELS,
+       n_grid=st.integers(min_value=2, max_value=9),
+       lo=st.floats(min_value=-3.0, max_value=0.0, allow_nan=False),
+       hi=st.floats(min_value=0.1, max_value=3.0, allow_nan=False))
+@_SETTINGS
+def test_the_chain_never_changes_a_p_value(spec, n_grid, lo, hi):
+    y, Y0, pre = _panel(*spec)
+    grid = np.linspace(lo, hi, n_grid)
+    assert np.array_equal(conformal_pvalue_sweep(y, Y0, pre, grid, **_KW),
+                          _unchained(y, Y0, pre, grid, **_KW))
+
+
+@given(spec=_PANELS, n_grid=st.integers(min_value=2, max_value=7),
+       shuffle_seed=st.integers(min_value=0, max_value=10_000))
+@_SETTINGS
+def test_permuting_the_grid_permutes_the_results(spec, n_grid, shuffle_seed):
+    y, Y0, pre = _panel(*spec)
+    grid = np.linspace(-1.5, 2.0, n_grid)
+    order = np.random.default_rng(shuffle_seed).permutation(n_grid)
+    straight = conformal_pvalue_sweep(y, Y0, pre, grid, **_KW)
+    permuted = conformal_pvalue_sweep(y, Y0, pre, grid[order], **_KW)
+    assert np.array_equal(permuted, straight[order])
+
+
+@given(spec=_PANELS, seed_weight=st.integers(min_value=0, max_value=10_000))
+@_SETTINGS
+def test_any_feasible_seed_leaves_the_p_value_alone(spec, seed_weight):
+    y, Y0, pre = _panel(*spec)
+    cold = conformal_pvalue(y, Y0, pre, **_KW)
+    w = np.random.default_rng(seed_weight).dirichlet(np.ones(Y0.shape[1]))
+    assert conformal_pvalue(y, Y0, pre, warm_start=w, **_KW) == cold
+
+
+@given(spec=_PANELS, n_grid=st.integers(min_value=1, max_value=7))
+@_SETTINGS
+def test_every_p_value_is_a_share_of_a_finite_reference_set(spec, n_grid):
+    """It can reach 1 but never 0: the identity permutation is always in the
+    reference set and always ties with the observed statistic."""
+    y, Y0, pre = _panel(*spec)
+    p = conformal_pvalue_sweep(y, Y0, pre, np.linspace(-1.0, 1.0, n_grid), **_KW)
+    assert np.isfinite(p).all()
+    assert (p > 0.0).all() and (p <= 1.0).all()
+    n_ref = y.size
+    assert np.allclose(p * n_ref, np.round(p * n_ref))

--- a/mlsynth/utils/bilevel/ridge_inference.py
+++ b/mlsynth/utils/bilevel/ridge_inference.py
@@ -183,7 +183,9 @@ def conformal_pvalue(
     finite_sample: bool = False,
     refit: str = "ridge",
     ridge_kwargs: Optional[Dict[str, Any]] = None,
-) -> float:
+    warm_start: Optional[np.ndarray] = None,
+    return_base: bool = False,
+):
     """Conformal p-value for the joint null of no post-treatment effect.
 
     Parameters
@@ -216,6 +218,16 @@ def conformal_pvalue(
         Number of i.i.d. residual permutations (augsynth default ``1000``).
     seed : int, optional
         RNG seed for the permutations.
+    warm_start : np.ndarray, optional
+        Feasible simplex weights to seed the refit's base solve with, e.g. the
+        previous candidate's solution in a grid sweep. A seed is a starting
+        point for the solver and not a parameter of the estimand: it changes how
+        many pivots the active set takes to certify, never where it certifies.
+        An infeasible seed is dropped by the solver and the solve proceeds cold.
+    return_base : bool, default False
+        Also return the refit's base simplex weights, so a caller sweeping a
+        grid can chain them. See :func:`conformal_pvalue_sweep`, which does the
+        chaining.
     finite_sample : bool, default False
         Return ``(1 + #{stat >= obs}) / (1 + ns)`` instead of
         ``mean(obs <= perm)``. The plain mean is augsynth's convention and is
@@ -249,7 +261,8 @@ def conformal_pvalue(
     -------
     float
         The conformal p-value ``mean(stat(observed_post) <= stat(permuted_post))``,
-        or its finite-sample correction when ``finite_sample`` is set.
+        or its finite-sample correction when ``finite_sample`` is set. With
+        ``return_base``, the pair ``(p, base_weights)``.
     """
     if refit not in CONFORMAL_REFIT_RULES:
         raise MlsynthConfigError(
@@ -267,14 +280,100 @@ def conformal_pvalue(
         # full path -- so the donor pool cannot absorb a post-period level shift.
         y = y - y.mean()
         Y0 = Y0 - Y0.mean(axis=0)
-    resids = _augmented_gaps(y, Y0, Z0, z1, ridge_kwargs, refit=refit)
+    if warm_start is not None:
+        warm_start = np.asarray(warm_start, dtype=float).ravel()
+        if warm_start.size != Y0.shape[1]:
+            raise MlsynthDataError(
+                f"warm_start must hold one weight per donor, shape "
+                f"({Y0.shape[1]},); got shape {warm_start.shape}.")
+    out = _augmented_gaps(y, Y0, Z0, z1, ridge_kwargs, warm_start=warm_start,
+                          return_base=return_base, refit=refit)
+    resids, base = out if return_base else (out, None)
     obs = _stat(resids[pre:], q)
     perm = _reference_stats(
         resids, slice(pre, None), q, conformal_type=conformal_type, ns=ns, seed=seed
     )
     if finite_sample:
-        return float((1.0 + np.sum(obs <= perm)) / (1.0 + perm.size))
-    return float(np.mean(obs <= perm))
+        p = float((1.0 + np.sum(obs <= perm)) / (1.0 + perm.size))
+    else:
+        p = float(np.mean(obs <= perm))
+    return (p, base) if return_base else p
+
+
+def conformal_pvalue_sweep(
+    y: np.ndarray,
+    Y0: np.ndarray,
+    pre: int,
+    grid,
+    **kwargs: Any,
+) -> np.ndarray:
+    r"""Conformal p-value at every candidate effect, chaining the refits.
+
+    Inverting a conformal test solves the same simplex program once per
+    candidate, on a design that barely moves between neighbours: only the post
+    block of the treated series shifts, by one grid step. Solved cold, every
+    candidate rebuilds its active set from nothing. Seeded with the previous
+    candidate's solution it starts from the right support -- measured at about
+    95 percent fewer pivots over a 41-point grid, and 5x to 16x less solve time
+    as the donor pool grows from 20 to 60.
+
+    The sweep walks the grid in sorted order, so consecutive solves are
+    neighbouring problems, and returns p-values aligned to the caller's own
+    ordering.
+
+    Chaining changes cost and nothing else. An active set seeded from a
+    neighbour certifies at the same optimum, so the p-values are identical to
+    one cold call per candidate -- exactly, not nearly, which matters because a
+    conformal p-value is a rank among a finite reference set and any discrepancy
+    is a different rank.
+
+    Parameters
+    ----------
+    y : np.ndarray, shape (T,)
+        Treated outcomes over all periods, with no candidate subtracted; the
+        sweep applies each candidate itself.
+    Y0 : np.ndarray, shape (T, J)
+        Donor outcomes over the same periods.
+    pre : int
+        Number of pre-treatment periods.
+    grid : array-like
+        Candidate constant post-period effects.
+    **kwargs
+        Forwarded to :func:`conformal_pvalue` (``refit``, ``conformal_type``,
+        ``q``, ``ns``, ``seed``, ``lambda_``, ...).
+
+    Returns
+    -------
+    np.ndarray
+        One p-value per candidate, in the order ``grid`` was given.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``grid`` is not a non-empty one-dimensional array of candidates.
+    MlsynthDataError
+        If ``grid`` holds a non-finite value.
+    """
+    y = np.asarray(y, dtype=float)
+    Y0 = np.asarray(Y0, dtype=float)
+    grid_arr = np.asarray(grid, dtype=float) if not isinstance(grid, str) else None
+    if grid_arr is None or grid_arr.ndim != 1 or grid_arr.size == 0:
+        raise MlsynthConfigError(
+            f"grid must be a non-empty one-dimensional array of candidate "
+            f"effects; got {grid!r}.")
+    if not np.isfinite(grid_arr).all():
+        raise MlsynthDataError("grid must be finite; it contains nan or inf.")
+
+    kwargs.pop("warm_start", None)
+    kwargs.pop("return_base", None)
+    out = np.empty(grid_arr.size, dtype=float)
+    base = None
+    for i in np.argsort(grid_arr, kind="stable"):
+        shifted = y.copy()
+        shifted[pre:] -= grid_arr[i]
+        out[i], base = conformal_pvalue(shifted, Y0, pre, warm_start=base,
+                                        return_base=True, **kwargs)
+    return out
 
 
 

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1447,3 +1447,33 @@ timeout = 300.0
   find = "            return np.sum(np.abs(shifts), axis=1) / np.sqrt(post.size)"
   replace = "            return np.sum(np.abs(shifts), axis=1) / np.sqrt(n)"
   models = "the statistic divided by the length of the whole path instead of the post block. Every reference statistic shrinks by the same factor and so does the observed one, so the p-value survives -- but the returned magnitudes no longer match the loop's, and any caller comparing them against a statistic computed by _stat is comparing different scales"
+
+[[target]]
+name = "conformal-sweep-warm-start"
+module-path = "mlsynth/utils/bilevel/ridge_inference.py"
+test-command = "python -m pytest mlsynth/tests/test_conformal_sweep_warm_start.py mlsynth/tests/test_conformal_sweep_warm_start_properties.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "sweep-walks-the-callers-order"
+  find = "    for i in np.argsort(grid_arr, kind=\"stable\"):"
+  replace = "    for i in range(grid_arr.size):"
+  models = "the chain following the caller's ordering instead of the grid's. Consecutive solves are then no longer neighbouring problems, so the seed is a stale point from elsewhere on the grid and the active set rebuilds anyway. Every p-value is still exactly right, because a seed cannot move the optimum -- only the saving disappears, which is why nothing but a work assertion can see it"
+
+  [[target.mutant]]
+  id = "sweep-never-chains"
+  find = "        out[i], base = conformal_pvalue(shifted, Y0, pre, warm_start=base,"
+  replace = "        out[i], base = conformal_pvalue(shifted, Y0, pre, warm_start=None,"
+  models = "the seed dropped, so every candidate solves cold. This is the pre-change behaviour wearing the new entry point's name: identical answers, none of the speed, and no test that only checks values can tell the difference"
+
+  [[target.mutant]]
+  id = "sweep-misaligns-its-output"
+  find = "        out[i], base = conformal_pvalue(shifted, Y0, pre, warm_start=base,"
+  replace = "        out[int(np.argsort(grid_arr, kind=\"stable\")[0])], base = conformal_pvalue(shifted, Y0, pre, warm_start=base,"
+  models = "results written to one slot instead of the candidate's own, which is the failure mode a sorted walk invites: the sweep visits in grid order but must report in the caller's order, and getting that wrong pairs every p-value with the wrong effect"
+
+  [[target.mutant]]
+  id = "seed-of-the-wrong-size-accepted"
+  find = "        if warm_start.size != Y0.shape[1]:"
+  replace = "        if False:"
+  models = "a seed sized for a different donor pool passed through to the solver, which drops it as infeasible and solves cold. The answer stays correct, so the caller's mix-up -- weights from another panel -- is hidden behind a right-looking number instead of being named"


### PR DESCRIPTION
## Related Links

- Mutation target `conformal-sweep-warm-start` in `tools/mutation/targets.toml` (4 mutants).
- The other half of the same idea landed as #505 (the block reference gather). This branch has been rebased on top of it.
- `conformal_att_interval`'s existing docstring already noted "a grid sweep can chain them"; this makes that reachable.

## What

- `conformal_pvalue` gains `warm_start` and `return_base`, threaded to `_augmented_gaps`, which has accepted both since it was written.
- New `conformal_pvalue_sweep(y, Y0, pre, grid, **kwargs)`: the p-value at every candidate, chaining the base simplex solve along a sorted walk, returning results in the caller's order.
- `mlsynth/tests/test_conformal_sweep_warm_start.py` (19 tests) and `..._properties.py` (4 hypothesis properties).
- A four-mutant target.

Default behaviour is unchanged: no existing call site passes `warm_start` or `return_base`, and `conformal_pvalue` returns a bare float exactly as before unless `return_base` is set.

## Why

Inverting a conformal test solves the same simplex program once per candidate effect, on a design that barely moves between neighbours — only the post block shifts, by one grid step. Solved cold, each candidate rebuilds its active set from nothing.

Measured over a 41-point grid:

```
J=20 donors:  pivots  3062 ->  156  (94.9% fewer)   solve 0.190s -> 0.036s   (5.2x)
J=60 donors:  pivots 13984 ->  644  (95.4% fewer)   solve 1.701s -> 0.108s  (15.8x)
```

**Correction to an earlier version of this description.** It claimed this was "part of a 0.278 → 0.142 second halving" of the calibration study's draw. That was wrong twice over, and both errors are worth naming:

1. The attribution was wrong. Nothing calls `conformal_pvalue_sweep` yet — the grid route in `cumulative_conformal_by_inversion` still calls `conformal_pvalue` once per candidate, so it solves cold. Wiring it to the sweep is a follow-up. This PR's benefit is not realised end-to-end by anything today.
2. The measurement was wrong. It compared a first-run baseline against a same-process rerun on the same seeds, so warm caches were folded into the difference. A proper A/B of the #505 gather (warm on both sides, three repetitions) gives 0.476s → 0.283s, a 1.68x, not a 2x — and that is #505's gain, not this one's.

The pivot counts above stand: they are direct counts from `solve_simplex_qp`'s own `info`, and they do not move with the runner.

## How

The sweep walks the grid sorted so consecutive solves are neighbouring problems, then writes each result to the candidate's own slot so the output matches the caller's ordering.

A seed is a starting point for the active set, not a parameter of the estimand — it changes how many pivots the solve takes to certify, never where it certifies. That is the claim the change lives or dies by, so it is asserted exactly and not approximately: a conformal p-value is a rank among a finite reference set, so the smallest discrepancy is a different rank and a moved interval.

One behaviour change: a `warm_start` sized for a different donor pool now raises `MlsynthDataError`. Previously the solver would drop it as infeasible and solve cold, so a caller's mix-up — weights from another panel — was hidden behind a correct-looking answer.

## Verification

- Path: not applicable; a pure-performance change to an existing procedure, validated by equivalence to the unchained path.
- The equivalence is a `hypothesis` property asserting `np.array_equal` between the chained sweep and one cold `conformal_pvalue` call per candidate, over donor counts 3–12, pre-periods 14–40, horizons 2–10, effects in [−2, 2], and grids of 2–9 points. Three further properties cover order invariance under permuting the grid, seed irrelevance for a single call, and that every p-value is a share `k/T` of the reference set in `(0, 1]`.
- Work is asserted in pivots, not seconds.
- Existing callers unaffected: `test_bilevel_ridge.py` and `test_geox_readout_interval.py` pass alongside.
- Coverage of `ridge_inference.py`: the new code is fully covered (missed count went 24 → 23, so one pre-existing gap also closed).

Two of the four mutants **survived the first version of the work test** and that is why the test was rewritten. `sweep-walks-the-callers-order` and `sweep-never-chains` both leave every p-value correct and destroy only the saving; an assertion on `solve_simplex_qp` directly passes for both. The test now measures pivots *through* `conformal_pvalue_sweep` by wrapping the solver, and all four die.

Re-verified after rebasing onto #505: all four of this PR's mutants and all four of #505's still die with both changes in the tree, and 121 tests pass across both suites plus the existing callers.

## Scope checks

None of the four blocks fits — a shared-helper change plus its tests. The branch carries only this.

## Designs

No visual output.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_conformal_sweep_warm_start.py mlsynth/tests/test_conformal_sweep_warm_start_properties.py -q` — 23 passed
- [x] `pytest mlsynth/tests/test_bilevel_ridge.py mlsynth/tests/test_geox_readout_interval.py -q` — unaffected
- [x] `pytest mlsynth/tests/test_mutation_harness.py -q` — the catalogue's own contract test
- [ ] `pytest mlsynth/tests/` — full suite, re-running here in CI after the rebase
- [x] `coverage run --timid --source=mlsynth/utils/bilevel -m pytest … && coverage report`
- [x] All four mutants run serially and killed, before and after the rebase
- [x] No docs page in this change, so no underline check applies

## Other Notes

- Wiring the grid route to `conformal_pvalue_sweep` is the follow-up that makes this measurable end-to-end. It belongs with whichever caller needs it first.
- Rebased onto `main` after #502, #503 and #505 landed; the only conflict was `tools/mutation/targets.toml` appending at EOF, resolved keeping all 51 of main's targets plus this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx