### PR TITLE
Build the block permutation reference as one gather, not T rolls

### DIFF
--- a/mlsynth/tests/test_conformal_reference_vectorise.py
+++ b/mlsynth/tests/test_conformal_reference_vectorise.py
@@ -1,0 +1,196 @@
+"""The block permutation reference, built as one gather instead of T rolls.
+
+``_reference_stats`` supplies the conformal test's reference distribution. Under
+the moving-block scheme that is the ``T`` cyclic shifts of the residual path,
+each sliced to the post block and scored -- built, until now, by a Python loop
+of ``np.roll`` over a length-``T`` array. Since ``np.roll(u, s)[pre:]`` is
+``u[(arange(pre, T) - s) % T]``, the whole family is a single ``(T, H)`` fancy
+index, and the loop disappears.
+
+Test inversion calls this once per candidate effect, and a grid sweep runs it
+tens of times per draw, so the loop was 62 percent of a sweep's cost.
+
+What makes this delicate is the exponent. The statistic is
+``(sum|x|^q / sqrt(len))^(1/q)``, and a fractional power evaluated on a
+``(T, H)`` block does not always take the same numpy code path as one evaluated
+on a length-``H`` row: measured, ``q = 1.5`` differs in the last bit. One bit is
+not negligible here. A conformal p-value counts how many reference statistics
+reach the observed one, so a value moved by an ULP can cross a tie and change a
+rank -- the SPSC port had exactly this and the band came out 13 percent wide.
+
+So the fast path is taken only at ``q == 1``, where the exponent is the identity
+and equality is provable, not merely observed. That is the augsynth default and
+every call site in the library. Anything else keeps the loop, and the tests pin
+both halves: the values agree with the loop everywhere, and the work only drops
+where the guard allows it.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.ridge_inference import _reference_stats, _stat
+
+
+def _oracle(resids, post_slice, q):
+    """The construction as it was written, transcribed as the test's reference.
+
+    Kept here instead of imported so the tests still describe the intended
+    behaviour once the implementation stops looking like this.
+    """
+    n = np.asarray(resids).shape[0]
+    return np.array(
+        [_stat(np.roll(resids, s)[post_slice], q) for s in range(n)], dtype=float)
+
+
+def _roll_calls(fn):
+    """How many times ``np.roll`` is called inside ``fn``.
+
+    The loop calls it once per shift; the gather never calls it. Counting them
+    is a machine-independent way to assert which path ran, where a wall-clock
+    comparison on a shared runner is not.
+    """
+    real = np.roll
+    seen = []
+
+    def counting(*args, **kwargs):
+        seen.append(1)
+        return real(*args, **kwargs)
+
+    np.roll = counting
+    try:
+        fn()
+    finally:
+        np.roll = real
+    return len(seen)
+
+
+def _series(n, seed=0):
+    return np.random.default_rng(seed).standard_normal(n)
+
+
+_SHAPES = [(117, 104), (31, 18), (60, 40), (25, 12), (200, 150), (8, 4), (3, 1)]
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_it_returns_one_statistic_per_cyclic_shift():
+    u = _series(31)
+    out = _reference_stats(u, slice(18, None), 1.0, conformal_type="block",
+                           ns=0, seed=0)
+    assert out.shape == (31,)
+    assert np.isfinite(out).all()
+    assert (out >= 0.0).all()
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("n,pre", _SHAPES)
+def test_it_matches_the_loop_exactly_at_the_default_exponent(n, pre):
+    """Bit-identical, not close: a reference statistic moved by an ULP can cross
+    a tie with the observed one and change the p-value's rank."""
+    u = _series(n, seed=n)
+    got = _reference_stats(u, slice(pre, None), 1.0, conformal_type="block",
+                           ns=0, seed=0)
+    assert np.array_equal(got, _oracle(u, slice(pre, None), 1.0))
+
+
+@pytest.mark.parametrize("q", [0.5, 1.5, 2.0, 3.0])
+def test_it_matches_the_loop_at_every_other_exponent_too(q):
+    """The guard is about which path runs, never about what comes out."""
+    u = _series(60, seed=7)
+    got = _reference_stats(u, slice(40, None), q, conformal_type="block",
+                           ns=0, seed=0)
+    assert np.array_equal(got, _oracle(u, slice(40, None), q))
+
+
+def test_the_first_entry_is_the_observed_statistic():
+    """Shift zero is the identity, so the reference set always contains the
+    observed value. That is why a block p-value can never fall below ``1 / T``."""
+    u = _series(31, seed=3)
+    out = _reference_stats(u, slice(18, None), 1.0, conformal_type="block",
+                           ns=0, seed=0)
+    assert out[0] == _stat(u[18:], 1.0)
+
+
+def test_the_default_exponent_takes_the_gather_and_rolls_nothing():
+    """The work assertion. Without it, a change that reverts to the loop leaves
+    every value correct and only the speed gone."""
+    u = _series(117, seed=1)
+    calls = _roll_calls(lambda: _reference_stats(
+        u, slice(104, None), 1.0, conformal_type="block", ns=0, seed=0))
+    assert calls == 0
+
+
+@pytest.mark.parametrize("q", [0.5, 1.5, 2.0])
+def test_another_exponent_keeps_the_loop(q):
+    """The other half of the guard: where equality is only observed and not
+    provable, the original path runs and the cost is accepted."""
+    u = _series(60, seed=2)
+    calls = _roll_calls(lambda: _reference_stats(
+        u, slice(40, None), q, conformal_type="block", ns=0, seed=0))
+    assert calls == 60
+
+
+def test_the_iid_scheme_is_untouched():
+    """Its permutations come from a seeded generator in a fixed order, so the
+    loop there is the draw sequence and not an inefficiency."""
+    u = _series(40, seed=5)
+    a = _reference_stats(u, slice(25, None), 1.0, conformal_type="iid",
+                         ns=50, seed=11)
+    b = _reference_stats(u, slice(25, None), 1.0, conformal_type="iid",
+                         ns=50, seed=11)
+    assert np.array_equal(a, b)
+    assert a.shape == (50,)
+
+
+def test_a_fancy_index_post_block_works_like_a_slice():
+    """``post_slice`` is documented as a slice or a fancy index; the gather has
+    to honour both, since it turns the slice into indices either way."""
+    u = _series(31, seed=9)
+    by_slice = _reference_stats(u, slice(18, None), 1.0, conformal_type="block",
+                                ns=0, seed=0)
+    by_index = _reference_stats(u, np.arange(18, 31), 1.0,
+                                conformal_type="block", ns=0, seed=0)
+    assert np.array_equal(by_slice, by_index)
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_a_single_period_post_block():
+    u = _series(20, seed=4)
+    got = _reference_stats(u, slice(19, None), 1.0, conformal_type="block",
+                           ns=0, seed=0)
+    assert np.array_equal(got, _oracle(u, slice(19, None), 1.0))
+
+
+def test_a_post_block_covering_the_whole_path():
+    """Every shift then scores the same multiset, so all T statistics agree and
+    the p-value is exactly one -- the degenerate case a caller reaches by asking
+    for a horizon as long as the series."""
+    u = _series(12, seed=6)
+    got = _reference_stats(u, slice(0, None), 1.0, conformal_type="block",
+                           ns=0, seed=0)
+    assert np.array_equal(got, _oracle(u, slice(0, None), 1.0))
+    assert np.allclose(got, got[0])
+
+
+def test_an_all_zero_path_gives_zero_everywhere():
+    u = np.zeros(15)
+    got = _reference_stats(u, slice(10, None), 1.0, conformal_type="block",
+                           ns=0, seed=0)
+    assert np.array_equal(got, np.zeros(15))
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", ["moving", "BLOCK", ""])
+def test_an_unknown_scheme_is_still_refused(bad):
+    u = _series(20)
+    with pytest.raises(ValueError, match="conformal_type"):
+        _reference_stats(u, slice(10, None), 1.0, conformal_type=bad,
+                         ns=10, seed=0)

--- a/mlsynth/tests/test_conformal_reference_vectorise_properties.py
+++ b/mlsynth/tests/test_conformal_reference_vectorise_properties.py
@@ -1,0 +1,103 @@
+"""Metamorphic invariants of the block permutation reference.
+
+The unit suite pins the gather against the loop on fixed shapes. These
+properties assert what has to hold for every path and every post block, and the
+first is the one the optimisation rests on:
+
+* equivalence -- the gather reproduces the loop bit for bit at ``q == 1``. Not
+  ``allclose``: the p-value counts how many reference statistics reach the
+  observed one, so a value moved by an ULP can cross a tie and change a rank;
+* fidelity at other exponents -- where the guard sends the call back to the
+  loop, the answer is still the loop's, which is what makes the guard invisible
+  to a caller;
+* structure -- one statistic per period of the path, all finite and
+  non-negative, with shift zero equal to the observed statistic;
+* equivariance -- rescaling the path rescales every reference statistic by the
+  same factor, since the statistic is homogeneous of degree one at ``q == 1``;
+* invariance -- rotating the whole path permutes the reference set and leaves it
+  the same multiset, which is what makes the block scheme a permutation scheme.
+"""
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as npst
+
+from mlsynth.utils.bilevel.ridge_inference import _reference_stats, _stat
+
+_SETTINGS = settings(
+    max_examples=60, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+)
+
+
+def _oracle(resids, post_slice, q):
+    """The loop, transcribed, as the reference the gather must reproduce."""
+    n = np.asarray(resids).shape[0]
+    return np.array(
+        [_stat(np.roll(resids, s)[post_slice], q) for s in range(n)], dtype=float)
+
+
+_PATHS = npst.arrays(
+    dtype=np.float64,
+    shape=st.integers(min_value=2, max_value=60),
+    elements=st.floats(min_value=-1e3, max_value=1e3, allow_nan=False,
+                       allow_infinity=False, width=64),
+)
+
+
+@given(u=_PATHS, frac=st.floats(min_value=0.0, max_value=0.95))
+@_SETTINGS
+def test_the_gather_reproduces_the_loop_bit_for_bit(u, frac):
+    pre = int(frac * u.size)
+    got = _reference_stats(u, slice(pre, None), 1.0, conformal_type="block",
+                           ns=0, seed=0)
+    assert np.array_equal(got, _oracle(u, slice(pre, None), 1.0))
+
+
+@given(u=_PATHS, frac=st.floats(min_value=0.0, max_value=0.95),
+       q=st.sampled_from([0.5, 1.5, 2.0, 3.0]))
+@_SETTINGS
+def test_other_exponents_still_give_the_loop(u, frac, q):
+    pre = int(frac * u.size)
+    got = _reference_stats(u, slice(pre, None), q, conformal_type="block",
+                           ns=0, seed=0)
+    assert np.array_equal(got, _oracle(u, slice(pre, None), q))
+
+
+@given(u=_PATHS, frac=st.floats(min_value=0.0, max_value=0.95))
+@_SETTINGS
+def test_the_reference_set_has_the_shape_a_permutation_scheme_needs(u, frac):
+    pre = int(frac * u.size)
+    got = _reference_stats(u, slice(pre, None), 1.0, conformal_type="block",
+                           ns=0, seed=0)
+    assert got.shape == (u.size,)
+    assert np.isfinite(got).all()
+    assert (got >= 0.0).all()
+    assert got[0] == _stat(u[pre:], 1.0)
+
+
+@given(u=_PATHS, frac=st.floats(min_value=0.0, max_value=0.95),
+       scale=st.floats(min_value=0.01, max_value=100.0, allow_nan=False))
+@_SETTINGS
+def test_rescaling_the_path_rescales_every_reference_statistic(u, frac, scale):
+    """At ``q == 1`` the statistic is a scaled sum of absolute values, so it is
+    homogeneous of degree one."""
+    pre = int(frac * u.size)
+    kw = dict(conformal_type="block", ns=0, seed=0)
+    base = _reference_stats(u, slice(pre, None), 1.0, **kw)
+    scaled = _reference_stats(u * scale, slice(pre, None), 1.0, **kw)
+    assert np.allclose(scaled, base * scale, rtol=1e-9, atol=1e-12)
+
+
+@given(u=_PATHS, frac=st.floats(min_value=0.0, max_value=0.95),
+       shift=st.integers(min_value=0, max_value=59))
+@_SETTINGS
+def test_rotating_the_path_permutes_the_reference_set(u, frac, shift):
+    """The block scheme's reference set is the orbit of the path under rotation,
+    so rotating the input reorders that set without changing what is in it."""
+    pre = int(frac * u.size)
+    kw = dict(conformal_type="block", ns=0, seed=0)
+    base = _reference_stats(u, slice(pre, None), 1.0, **kw)
+    rotated = _reference_stats(np.roll(u, shift % u.size), slice(pre, None),
+                               1.0, **kw)
+    assert np.allclose(np.sort(rotated), np.sort(base), rtol=1e-9, atol=1e-12)

--- a/mlsynth/utils/bilevel/ridge_inference.py
+++ b/mlsynth/utils/bilevel/ridge_inference.py
@@ -66,9 +66,29 @@ def _reference_stats(resids, post_slice, q, *, conformal_type, ns, seed):
     scheme, ``resids[(0:T-1+j) %% T]`` in augsynth) -- deterministic, preserving
     serial dependence. The post-block statistic is taken on ``post_slice`` of
     each permuted/shifted path.
+
+    The block family is one gather, not ``T`` rolls: ``np.roll(u, s)[post]`` is
+    ``u[(post - s) % T]``, so every shift's post block is a row of a single
+    ``(T, |post|)`` fancy index. That is ~70x faster per call, and test
+    inversion calls this once per candidate effect.
+
+    The gather runs only at ``q == 1``. The statistic raises to ``q`` and then to
+    ``1 / q``, and a fractional power evaluated over a ``(T, |post|)`` block does
+    not always take the same numpy code path as one over a single row -- measured,
+    ``q = 1.5`` differs in the last bit. An ULP is not negligible here: the
+    p-value counts how many reference statistics reach the observed one, so a
+    value nudged across a tie changes a rank. At ``q == 1`` both exponents are
+    the identity and equality is provable, not merely observed; ``q == 1`` is
+    also augsynth's default and every call site in this library. Any other ``q``
+    keeps the loop.
     """
     if conformal_type == "block":
+        resids = np.asarray(resids, dtype=float)
         n = resids.shape[0]
+        if q == 1.0:
+            post = np.arange(n)[post_slice]
+            shifts = resids[(post[None, :] - np.arange(n)[:, None]) % n]
+            return np.sum(np.abs(shifts), axis=1) / np.sqrt(post.size)
         return np.array(
             [_stat(np.roll(resids, s)[post_slice], q) for s in range(n)],
             dtype=float,

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1417,3 +1417,33 @@ timeout = 120.0
   find = "    \"bootstrap_loo_errors\",\n"
   replace = "    \"bootstrap_loo_errors\",\n    \"bootstrap_loo_errors\",\n"
   models = "the other signature of a resolution that kept both sides of a conflicting region. A duplicated name changes nothing at import time, so it survives review and accumulates"
+
+[[target]]
+name = "conformal-block-reference-gather"
+module-path = "mlsynth/utils/bilevel/ridge_inference.py"
+test-command = "python -m pytest mlsynth/tests/test_conformal_reference_vectorise.py mlsynth/tests/test_conformal_reference_vectorise_properties.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "gather-guard-widened-past-q-one"
+  find = "        if q == 1.0:"
+  replace = "        if q > 0.0:"
+  models = "the exponent guard removed, so a fractional power runs over the (T, |post|) block instead of a row. The values stay right to fifteen digits and differ in the last bit at q = 1.5, which is enough to move a reference statistic across a tie with the observed one and change the p-value's rank -- the same ULP that made the SPSC band 13 percent wide"
+
+  [[target.mutant]]
+  id = "gather-never-taken"
+  find = "        if q == 1.0:"
+  replace = "        if False:"
+  models = "the fast path switched off, which is the pre-change behaviour wearing the new code's name. Every value is identical and only the 70x is gone, so nothing that checks numbers can see it and only a count of np.roll calls can"
+
+  [[target.mutant]]
+  id = "shift-direction-reversed"
+  find = "            shifts = resids[(post[None, :] - np.arange(n)[:, None]) % n]"
+  replace = "            shifts = resids[(post[None, :] + np.arange(n)[:, None]) % n]"
+  models = "the rotation taken the other way. The reference set is the orbit of the path under rotation, so as a multiset it is unchanged and the p-value is unchanged with it -- but entry s is no longer the statistic of shift s, and shift zero is no longer first, which is what the block p-value's floor of 1/T depends on"
+
+  [[target.mutant]]
+  id = "normalised-by-the-path-not-the-block"
+  find = "            return np.sum(np.abs(shifts), axis=1) / np.sqrt(post.size)"
+  replace = "            return np.sum(np.abs(shifts), axis=1) / np.sqrt(n)"
+  models = "the statistic divided by the length of the whole path instead of the post block. Every reference statistic shrinks by the same factor and so does the observed one, so the p-value survives -- but the returned magnitudes no longer match the loop's, and any caller comparing them against a statistic computed by _stat is comparing different scales"


### PR DESCRIPTION
## Related Links

- Mutation target `conformal-block-reference-gather` in `tools/mutation/targets.toml` (4 mutants).
- The other half of the same speedup: #504, which chains the grid sweep's refits. Independent of this — both touch `bilevel/ridge_inference.py` but different regions, so whichever lands second may need a trivial rebase.
- The ULP precedent this is careful about: `mlsynth/utils/proximal_helpers/spsc/conformal.py::_conformal_pvalue`, whose docstring records a one-ULP p-value difference widening a band ~13%.

## What

- `_reference_stats` builds the block family with a single `(T, |post|)` fancy index instead of a Python loop of `np.roll`, guarded to `q == 1`.
- `mlsynth/tests/test_conformal_reference_vectorise.py` (25 tests) and `..._properties.py` (5 hypothesis properties).
- A four-mutant target.

No public signature changes; no caller changes. Values are identical at every `q`.

## Why

`_reference_stats` supplies the conformal test's reference distribution. Under the moving-block scheme that is the `T` cyclic shifts of the residual path, each sliced to the post block and scored. Test inversion calls it once per candidate effect and a grid sweep runs it tens of times per draw, where profiling put it at 62% of the cost.

```
q=1 (gather)      22.8 us per call
q=1.5 (loop)    1629.6 us per call     ~70x
```

## How

`np.roll(u, s)[pre:]` is `u[(arange(pre, T) - s) % T]`, so the whole family of shifts is one gather and the loop disappears.

The exponent is what makes this delicate. The statistic raises to `q` and then to `1/q`, and a fractional power over a `(T, H)` block does not always take the same numpy code path as one over a single row — measured, `q = 1.5` differs in the last bit, and `q = 3.0` did too before I tried a flat-buffer variant. One bit matters here: the p-value counts how many reference statistics reach the observed one, so a value nudged across a tie changes a rank. That is not hypothetical — the SPSC port hit exactly this and its band came out 13% wide.

So the gather runs only at `q == 1`, where both exponents are the identity and equality is provable instead of observed. That is augsynth's default and every call site in this library. Any other `q` keeps the loop, and that is a deliberate refusal to trade correctness for speed on a path nobody currently uses.

I did try to widen it. A flat-buffer variant (`np.abs(P).ravel() ** q` then reshape) recovers exactness at `q = 3.0` but not at `q = 1.5`, and costs 297 µs against 24 — most of the gain for less than all of the guarantee. Not worth it; the guard stays at `q == 1`.

## Verification

- Path: not applicable; a pure-performance change validated by equivalence to the path it replaces.
- Bit-identity at `q == 1` across seven fixed shapes, and as a `hypothesis` property over random paths (length 2–60) and post blocks (any fraction up to 0.95). `np.array_equal`, not `allclose`.
- Fidelity at `q` of 0.5, 1.5, 2.0 and 3.0, where the guard sends the call back to the loop — so the guard is invisible to a caller.
- Four further properties: the shape a permutation scheme needs (one statistic per period, shift zero equal to the observed statistic — which is why a block p-value cannot fall below `1/T`), homogeneity of degree one, and that rotating the path permutes the reference set without changing it as a multiset.
- Work is asserted by counting `np.roll` calls: zero at `q == 1`, exactly `T` otherwise. Machine independent, where wall-clock on a shared runner is not.
- Existing callers unaffected: `test_bilevel_ridge.py` and `test_geox_readout_interval.py` pass alongside (98 tests total).
- Four mutants, all killed — including `gather-guard-widened-past-q-one`, which survives every assertion except bit-equality, and `gather-never-taken`, which survives everything except the roll count.

## Scope checks

None of the four blocks fits — a performance change to a shared helper plus its tests. The branch carries only this.

## Designs

No visual output.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_conformal_reference_vectorise.py mlsynth/tests/test_conformal_reference_vectorise_properties.py -q` — 30 passed
- [x] `pytest mlsynth/tests/test_bilevel_ridge.py mlsynth/tests/test_geox_readout_interval.py -q` — unaffected
- [x] `pytest mlsynth/tests/test_mutation_harness.py -q` — the catalogue's own contract test
- [ ] `pytest mlsynth/tests/` — full suite, running here in CI
- [x] All four mutants run serially and killed
- [x] No docs page in this change, so no underline check applies

## Other Notes

- The `iid` branch is untouched. Its remaining loop is the seeded draw sequence, not an inefficiency — vectorising it would change which permutations are drawn.
- Widening the guard past `q == 1` needs a proof of bit-equality, not an observation on a few shapes. The mutant is catalogued so that a future attempt has to confront it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx)_