### PR TITLE
Catalogue the resample draw's mutants, and assert what holds for every series

### DIFF
--- a/mlsynth/tests/test_conformal_resample_paths_properties.py
+++ b/mlsynth/tests/test_conformal_resample_paths_properties.py
@@ -1,0 +1,177 @@
+"""Metamorphic invariants of the block-resampled error paths.
+
+The example tests pin the draw on fixed series. These assert what has to hold
+for every calibration series, every horizon and every admissible block, and they
+are the assertions that catch a defect the examples happen not to exercise:
+
+* structure -- the output is always ``(n_sim, horizon)`` and finite, whatever
+  the block length or how the horizon divides it;
+* membership -- every drawn value is plus or minus an entry of the centred
+  series, because the draw resamples that series and does nothing else to it;
+* location invariance -- adding a constant to the whole series changes no path
+  at all, since the draw centres first. This is what makes the band a statement
+  about the fit's variability instead of its level;
+* scale equivariance -- multiplying the series by a constant multiplies every
+  path by the same constant, exactly;
+* reflection invariance -- negating the series leaves the drawn paths
+  unchanged, because each block's sign is flipped with probability one half and
+  the flip is drawn from the same generator state;
+* determinism -- the same generator state gives the same paths, which is what
+  lets a caller reproduce a band;
+* contiguity -- with one block covering the horizon, each path is a circular
+  run of the centred series up to an overall sign, so the draw carries serial
+  dependence instead of shuffling it away.
+
+Not asserted here: that the drawn spread matches the series' own. Centring the
+series constrains its circular sums, so a b-block's drawn variance falls short
+of ``b`` times the series variance by about ``(n - b) / (n - 1)`` -- measured at
+0.70 for a 13-block of 47 periods. That is a property of the draw as it stands
+and correcting it changes every band's width, so it belongs to a change of its
+own and not to a test file.
+"""
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils.conformal import block_error_paths
+
+_SETTINGS = settings(
+    max_examples=50, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+)
+
+#: Series long enough to admit a block, short enough to draw quickly.
+_SERIES = st.lists(
+    st.floats(min_value=-1e3, max_value=1e3, allow_nan=False, allow_infinity=False,
+              width=64),
+    min_size=4, max_size=60,
+)
+
+
+def _admissible(series, block):
+    """A block the draw accepts: at least 1, at most half the series."""
+    return max(1, min(block, len(series) // 2))
+
+
+@given(series=_SERIES, horizon=st.integers(min_value=1, max_value=20),
+       block=st.integers(min_value=1, max_value=30),
+       seed=st.integers(min_value=0, max_value=10_000))
+@_SETTINGS
+def test_the_shape_is_always_simulations_by_horizon(series, horizon, block, seed):
+    e = np.asarray(series, dtype=float)
+    paths = block_error_paths(e, horizon=horizon, block=_admissible(series, block),
+                              n_sim=16, rng=np.random.default_rng(seed))
+    assert paths.shape == (16, horizon)
+    assert np.isfinite(paths).all()
+
+
+@given(series=_SERIES, horizon=st.integers(min_value=1, max_value=20),
+       block=st.integers(min_value=1, max_value=30),
+       seed=st.integers(min_value=0, max_value=10_000))
+@_SETTINGS
+def test_every_drawn_value_is_a_signed_entry_of_the_centred_series(
+        series, horizon, block, seed):
+    """The draw resamples; it does not interpolate, smooth or rescale."""
+    e = np.asarray(series, dtype=float)
+    paths = block_error_paths(e, horizon=horizon, block=_admissible(series, block),
+                              n_sim=16, rng=np.random.default_rng(seed))
+    pool = np.concatenate([e - e.mean(), -(e - e.mean())])
+    for value in np.unique(paths):
+        assert np.isclose(np.abs(pool - value).min(), 0.0, atol=1e-9)
+
+
+@given(series=_SERIES, shift=st.floats(min_value=-500.0, max_value=500.0,
+                                       allow_nan=False, allow_infinity=False),
+       horizon=st.integers(min_value=1, max_value=20),
+       block=st.integers(min_value=1, max_value=30),
+       seed=st.integers(min_value=0, max_value=10_000))
+@_SETTINGS
+def test_shifting_the_whole_series_changes_no_path(series, shift, horizon, block,
+                                                   seed):
+    """A fit sitting high shifts every error by the same amount. The draw centres,
+    so the band describes how the errors move, not where they sit."""
+    e = np.asarray(series, dtype=float)
+    b = _admissible(series, block)
+    kw = dict(horizon=horizon, block=b, n_sim=16)
+    base = block_error_paths(e, rng=np.random.default_rng(seed), **kw)
+    moved = block_error_paths(e + shift, rng=np.random.default_rng(seed), **kw)
+    assert np.allclose(moved, base, rtol=1e-9, atol=1e-8)
+
+
+@given(series=_SERIES, scale=st.floats(min_value=0.01, max_value=100.0,
+                                       allow_nan=False, allow_infinity=False),
+       horizon=st.integers(min_value=1, max_value=20),
+       block=st.integers(min_value=1, max_value=30),
+       seed=st.integers(min_value=0, max_value=10_000))
+@_SETTINGS
+def test_rescaling_the_series_rescales_every_path(series, scale, horizon, block,
+                                                  seed):
+    e = np.asarray(series, dtype=float)
+    b = _admissible(series, block)
+    kw = dict(horizon=horizon, block=b, n_sim=16)
+    base = block_error_paths(e, rng=np.random.default_rng(seed), **kw)
+    scaled = block_error_paths(e * scale, rng=np.random.default_rng(seed), **kw)
+    assert np.allclose(scaled, base * scale, rtol=1e-9, atol=1e-8)
+
+
+@given(series=_SERIES, horizon=st.integers(min_value=1, max_value=20),
+       block=st.integers(min_value=1, max_value=30),
+       seed=st.integers(min_value=0, max_value=10_000))
+@_SETTINGS
+def test_negating_the_series_leaves_the_paths_alone(series, horizon, block, seed):
+    """Each block's sign is flipped with probability one half from the same
+    generator state, so the sign of the series itself carries no information."""
+    e = np.asarray(series, dtype=float)
+    b = _admissible(series, block)
+    kw = dict(horizon=horizon, block=b, n_sim=16)
+    base = block_error_paths(e, rng=np.random.default_rng(seed), **kw)
+    flipped = block_error_paths(-e, rng=np.random.default_rng(seed), **kw)
+    assert np.allclose(flipped, -base, rtol=1e-9, atol=1e-8)
+
+
+@given(series=_SERIES, horizon=st.integers(min_value=1, max_value=20),
+       block=st.integers(min_value=1, max_value=30),
+       seed=st.integers(min_value=0, max_value=10_000))
+@_SETTINGS
+def test_the_same_generator_state_gives_the_same_paths(series, horizon, block, seed):
+    e = np.asarray(series, dtype=float)
+    b = _admissible(series, block)
+    kw = dict(horizon=horizon, block=b, n_sim=16)
+    a = block_error_paths(e, rng=np.random.default_rng(seed), **kw)
+    c = block_error_paths(e, rng=np.random.default_rng(seed), **kw)
+    assert np.array_equal(a, c)
+
+
+@given(series=_SERIES, horizon=st.integers(min_value=2, max_value=12),
+       seed=st.integers(min_value=0, max_value=10_000))
+@_SETTINGS
+def test_a_whole_horizon_block_draws_a_contiguous_run(series, horizon, seed):
+    """The reason a block exists. With one block spanning the horizon, each path
+    is a circular run of the centred series up to an overall sign, so whatever
+    serial dependence the series carries survives into the total. Skipped where
+    the horizon exceeds half the series, which the draw refuses."""
+    e = np.asarray(series, dtype=float)
+    if 2 * horizon > e.size:
+        pytest.skip("a whole-horizon block past n/2 is refused by design")
+    centred = e - e.mean()
+    paths = block_error_paths(e, horizon=horizon, block=horizon, n_sim=12,
+                              rng=np.random.default_rng(seed))
+    for row in paths:
+        runs = [np.concatenate([centred, centred])[s:s + horizon]
+                for s in range(e.size)]
+        assert any(np.allclose(row, r, atol=1e-8) or np.allclose(row, -r, atol=1e-8)
+                   for r in runs)
+
+
+@given(series=_SERIES, horizon=st.integers(min_value=1, max_value=20),
+       seed=st.integers(min_value=0, max_value=10_000))
+@_SETTINGS
+def test_single_period_blocks_stay_within_the_pool(series, horizon, seed):
+    """At block one the draw is Wheeler's symmetrised pool, one element per
+    period, so a path cannot contain a value the pool does not."""
+    e = np.asarray(series, dtype=float)
+    paths = block_error_paths(e, horizon=horizon, block=1, n_sim=16,
+                              rng=np.random.default_rng(seed))
+    pool = np.concatenate([e - e.mean(), -(e - e.mean())])
+    assert paths.min() >= pool.min() - 1e-9
+    assert paths.max() <= pool.max() + 1e-9

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1495,3 +1495,45 @@ timeout = 300.0
   find = "        lo, hi, gaps = _grid_bounds(pvalues, grid, alpha)"
   replace = "        lo, hi, gaps = _grid_bounds(pvalues, grid, alpha / 2.0)"
   models = "the accepted set read off at half the requested level, so fewer candidates are rejected and the band is wider than the caller asked for. A wider band still covers, so no coverage check catches it; only comparing the endpoints against the p-values they are supposed to invert does"
+
+[[target]]
+name = "conformal-resample-draw"
+module-path = "mlsynth/utils/conformal/resample.py"
+test-command = "python -m pytest mlsynth/tests/test_conformal_resample_paths.py mlsynth/tests/test_conformal_resample_paths_properties.py mlsynth/tests/test_pda_resample_band.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "series-not-centred"
+  find = "    e = e - e.mean()"
+  replace = "    e = e * 1.0"
+  models = "the centring dropped. A fit sitting a little high shifts every one of its errors by the same amount, and an uncentred draw charges the band for that shift once per period it accumulates, so a biased fit buys itself a wider band. The paths stay finite and the right shape, and on a well-centred calibration series nothing shows at all"
+
+  [[target.mutant]]
+  id = "blocks-never-sign-flipped"
+  find = "    signs = rng.choice(np.array([-1.0, 1.0]), size=(n_sim, n_blocks, 1))"
+  replace = "    signs = np.ones((n_sim, n_blocks, 1))"
+  models = "Wheeler's symmetrisation removed. The pool is then the series itself instead of the series and its reflection, so a calibration series that happens to lean one way draws paths that lean the same way, and the band is displaced instead of symmetric about zero"
+
+  [[target.mutant]]
+  id = "sign-flipped-per-period-not-per-block"
+  find = "    signs = rng.choice(np.array([-1.0, 1.0]), size=(n_sim, n_blocks, 1))"
+  replace = "    signs = rng.choice(np.array([-1.0, 1.0]), size=(n_sim, n_blocks, b))"
+  models = "the sign drawn per period rather than per block, which destroys the very correlation the blocks were drawn to keep. A total accumulated from positively autocorrelated periods is more variable than independent draws imply, and this makes every block behave as if its periods were independent -- the defect the block length exists to prevent, invisible in the shape and the finiteness of the output"
+
+  [[target.mutant]]
+  id = "blocks-drawn-non-circularly"
+  find = "    idx = (starts[:, :, None] + np.arange(b)[None, None, :]) % e.size"
+  replace = "    idx = np.minimum(starts[:, :, None] + np.arange(b)[None, None, :], e.size - 1)"
+  models = "the circular wrap replaced by clamping at the last period. Blocks that would have wrapped instead repeat the final error b times, so the last period of the calibration series is over-represented and a large final error is duplicated into many paths. Every value drawn is still a real entry of the series, so a membership check passes"
+
+  [[target.mutant]]
+  id = "failed-refit-zeroed-not-dropped"
+  find = "    e = e[np.isfinite(e)]"
+  replace = "    e = np.nan_to_num(e, nan=0.0, posinf=0.0, neginf=0.0)"
+  models = "an origin whose refit failed contributed as a zero instead of being dropped. A zero is the smallest error the series could hold, so every failure drags the drawn spread down and the band narrows in proportion to how often the estimator could not fit -- the band is most confident exactly where the fit was least able. The series stays finite and the right length, and nothing about the paths shows it"
+
+  [[target.mutant]]
+  id = "block-count-rounds-down"
+  find = "    n_blocks = int(np.ceil(h / b))"
+  replace = "    n_blocks = max(1, int(h // b))"
+  models = "the block count floored, so a horizon that is not a multiple of the block assembles too few periods and the reshape yields a path shorter than the horizon. The failure is a shape error at the caller rather than a wrong number, which is the best case, but only because the truncation would otherwise be silent"


### PR DESCRIPTION
## Related Links

- Mutation target `conformal-resample-draw` in `tools/mutation/targets.toml` (6 mutants).
- The module this covers, `mlsynth/utils/conformal/resample.py`, arrived on main via #501.

## What

- Added `mlsynth/tests/test_conformal_resample_paths_properties.py`, 8 hypothesis properties.
- Added a six-mutant target for `conformal/resample.py`.

No source changes.

## Why

`conformal/resample.py` is 347 lines of live code with no mutation target — the catalogue entry written for it did not survive the squash merge that brought the module to main. It also had only example tests on fixed series, no properties.

## How

Four of the six mutants stand for defects that leave the output finite, the right shape and the right sign, so nothing about the paths' appearance can see them:

- `series-not-centred` — a fit sitting high buys itself a wider band, since an uncentred draw charges for that shift once per period it accumulates.
- `blocks-never-sign-flipped` — Wheeler's symmetrisation removed, so a series that leans one way draws paths that lean the same way.
- `sign-flipped-per-period-not-per-block` — the sign drawn per period, destroying the very correlation the block length exists to carry.
- `failed-refit-zeroed-not-dropped` — an origin whose refit failed contributes a zero instead of being dropped, so the band narrows in proportion to how often the estimator could not fit. The band is then most confident exactly where the fit was least able.

The eight properties assert what must hold for every series, horizon and admissible block: shape; that every drawn value is a signed entry of the centred series; that shifting the whole series changes no path; that rescaling rescales every path exactly; that negating negates them; determinism; that a whole-horizon block draws a contiguous circular run; and that single-period blocks stay inside the symmetrised pool.

## Verification

- 6 mutants, all killed. 8 properties + the existing 20 example tests pass (76 passed, 1 skipped).

**One mutant was removed as equivalent, recorded here so nobody re-derives it.** Truncating the assembled path from the end (`[:, -h:]`) instead of the start (`[:, :h]`) is not a defect. Each block is a circular run at a uniform offset, so a partial suffix has the same law as a partial prefix. Two-sample KS across four `(h, b)` pairs where the truncation actually bites:

```
h=10 b=4   var 7.2145 vs 7.1667   KS p = 0.287
h=13 b=5   var 9.8571 vs 9.7635   KS p = 0.477
h= 7 b=3   var 4.8849 vs 4.8732   KS p = 0.036
h= 9 b=2   var 6.1819 vs 6.2314   KS p = 0.996
```

Same distribution, differing only in which values a given seed yields. It survived my first run and I checked whether the assertion was weak before concluding it was equivalent; it was replaced by `failed-refit-zeroed-not-dropped`, which is real.

## A defect found while writing this, not fixed here

The draw does not reproduce the spread of the series it resamples. Centring constrains the circular sums, so a `b`-block's drawn variance falls short of `b` times the series variance:

```
    n   b   drawn var       b*v   ratio   predicted (n-b)/(n-1)
   47  13      9.0849   13.0000  0.6988      0.7391
   47   1      0.9844    1.0000  0.9844      1.0000   <- exact at b=1, as the theory says
  100  25     18.0539   25.0000  0.7222      0.7576
   60   5      4.6542    5.0000  0.9308      0.9322
```

At PDA and VanillaSC's operating point (`n = 47`, `b = 13`) that is a band about 16% too narrow — a live under-coverage defect on `main`, affecting both shipped cumulative bands.

The correction exists: commit `a53f07b` on `claude/conformal-resample-calibration`, which #501 did not include. I have deliberately not folded it in here. It changes every band's width and moves pinned benchmark values, so it wants its own branch, its own red-to-green, and a decision about the benchmark deltas. No property in this PR asserts the spread, for the same reason — a test that fails on `main` cannot land.

## Scope checks

None of the four blocks fits — test and catalogue coverage for an existing module, no source change. The branch carries only this.

## Designs

No visual output.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_conformal_resample_paths_properties.py mlsynth/tests/test_conformal_resample_paths.py mlsynth/tests/test_pda_resample_band.py -q` — 76 passed, 1 skipped
- [x] `pytest mlsynth/tests/test_mutation_harness.py -q` — the catalogue's own contract test
- [ ] `pytest mlsynth/tests/` — full suite, running here in CI
- [x] All six mutants run serially and killed

## Other Notes

- The skipped property is the contiguity one, which skips where a whole-horizon block would exceed half the series — a configuration the draw refuses by design.
- The spread defect above is the item I would take next, if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx)_