### PR TITLE
Chain the grid search's refits, so the sweep it was built for is used

### DIFF
--- a/mlsynth/tests/test_cumulative_inversion_chained_grid.py
+++ b/mlsynth/tests/test_cumulative_inversion_chained_grid.py
@@ -1,0 +1,180 @@
+"""The grid search chains its refits, and the band it returns does not move.
+
+``cumulative_conformal_by_inversion(search="grid")`` evaluates the conformal
+p-value once per candidate effect. Each evaluation solves the same simplex
+program on a design that barely moves between neighbours -- only the post block
+shifts, by one grid step -- and solved cold, every candidate rebuilds its active
+set from nothing. ``conformal_pvalue_sweep`` exists to chain them, and this wires
+the grid route to it.
+
+There are exactly two things to assert, and the order matters. The band must be
+identical, because a seed is a starting point for the solver and never a
+parameter of the estimand: if the interval moves, the change is not an
+optimisation. And the work must actually fall, because a wiring that silently
+reverts to cold solves leaves every number right and only the saving gone --
+which no assertion on the band can see.
+
+Levels: smoke, unit invariants, edge.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.utils.bilevel.ridge_inference import conformal_pvalue
+from mlsynth.utils.conformal import cumulative_conformal_by_inversion
+from mlsynth.utils.conformal.inversion import confidence_set_bounds
+
+_KW = dict(refit="sc", conformal_type="block", alpha=0.1)
+
+
+def _panel(J=20, pre=40, horizon=8, effect=0.3, seed=0):
+    rng = np.random.default_rng(seed)
+    T = pre + horizon
+    f = np.column_stack([np.cumsum(rng.normal(0, 1, T)) for _ in range(2)])
+    lam = rng.dirichlet(np.ones(J - 1), size=2).T * 2.0
+    Y0 = f @ lam.T + 0.5 * rng.standard_normal((T, J - 1))
+    y = Y0 @ rng.dirichlet(np.ones(J - 1)) + 0.5 * rng.standard_normal(T)
+    y[pre:] += effect
+    return y, Y0, pre, horizon
+
+
+def _oracle_bounds(y, Y0, pre, horizon, grid, alpha):
+    """The interval as one cold call per candidate would give it."""
+    pvalues = []
+    for tau in grid:
+        shifted = y[:pre + horizon].copy()
+        shifted[pre:] -= tau
+        pvalues.append(conformal_pvalue(shifted, Y0[:pre + horizon], pre,
+                                        refit="sc", conformal_type="block"))
+    return confidence_set_bounds(np.asarray(grid), np.asarray(pvalues), alpha)
+
+
+def _pivots_of(call):
+    """Active-set pivots spent inside ``call``.
+
+    ``simplex_qp`` imports the solver at call time, so replacing the module
+    attribute is seen by the code under test; the replacement forwards to the
+    real solver and only records its work.
+    """
+    from mlsynth.utils.bilevel import active_set
+
+    real = active_set.solve_simplex_qp
+    spent = []
+
+    def counting(B, A, **kw):
+        want_info = kw.pop("return_info", False)
+        w, info = real(B, A, return_info=True, **kw)
+        spent.append(info["pivots"])
+        return (w, info) if want_info else w
+
+    active_set.solve_simplex_qp = counting
+    try:
+        call()
+    finally:
+        active_set.solve_simplex_qp = real
+    return sum(spent)
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_the_grid_route_still_returns_a_band():
+    y, Y0, pre, h = _panel()
+    band = cumulative_conformal_by_inversion(
+        y, Y0, pre, h, search="grid", grid=np.linspace(-1.0, 1.5, 21), **_KW)
+    assert band.search == "grid"
+    assert band.has_interior_gaps in (True, False)
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_chaining_does_not_move_the_band(seed):
+    """The claim the wiring lives or dies by, asserted exactly. A conformal
+    p-value is a rank among a finite reference set, so any discrepancy is a
+    different rank and a different interval."""
+    y, Y0, pre, h = _panel(seed=seed)
+    grid = np.linspace(-1.5, 2.0, 25)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, search="grid",
+                                             grid=grid, **_KW)
+    lo, hi = _oracle_bounds(y, Y0, pre, h, grid, 0.1)
+    assert band.per_period_lower == lo
+    assert band.per_period_upper == hi
+
+
+def test_the_grid_route_spends_far_fewer_pivots():
+    """The work assertion. Without it, a wiring that reverts to cold solves
+    leaves every number right and only the saving gone."""
+    y, Y0, pre, h = _panel(J=30, seed=4)
+    grid = np.linspace(-1.5, 2.0, 41)
+    chained = _pivots_of(lambda: cumulative_conformal_by_inversion(
+        y, Y0, pre, h, search="grid", grid=grid, **_KW))
+    cold = _pivots_of(lambda: _oracle_bounds(y, Y0, pre, h, grid, 0.1))
+    assert chained < cold / 3, f"chained {chained} pivots against cold {cold}"
+
+
+def test_a_shuffled_grid_costs_no_more_than_a_sorted_one():
+    """The saving comes from consecutive solves being neighbours, which the
+    sweep arranges by sorting internally."""
+    y, Y0, pre, h = _panel(J=30, seed=4)
+    grid = np.linspace(-1.5, 2.0, 41)
+    shuffled = grid.copy()
+    np.random.default_rng(0).shuffle(shuffled)
+    kw = dict(search="grid", **_KW)
+    a = _pivots_of(lambda: cumulative_conformal_by_inversion(
+        y, Y0, pre, h, grid=grid, **kw))
+    b = _pivots_of(lambda: cumulative_conformal_by_inversion(
+        y, Y0, pre, h, grid=shuffled, **kw))
+    assert b <= a * 1.25
+
+
+def test_the_reported_gaps_are_unchanged_by_chaining():
+    """``has_interior_gaps`` is read off the same p-values, so it cannot depend
+    on how they were computed."""
+    y, Y0, pre, h = _panel(seed=5)
+    grid = np.linspace(-2.0, 2.0, 33)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, search="grid",
+                                             grid=grid, **_KW)
+    pvalues = []
+    for tau in grid:
+        shifted = y[:pre + h].copy()
+        shifted[pre:] -= tau
+        pvalues.append(conformal_pvalue(shifted, Y0[:pre + h], pre, refit="sc",
+                                        conformal_type="block"))
+    kept = np.asarray(pvalues) > 0.1
+    if kept.any():
+        first = int(np.argmax(kept))
+        last = int(kept.size - 1 - np.argmax(kept[::-1]))
+        assert band.has_interior_gaps == bool((~kept[first:last + 1]).any())
+
+
+def test_the_bisecting_route_is_untouched():
+    """Only the grid branch is wired; bisection walks outward one candidate at a
+    time and has no sweep to chain."""
+    y, Y0, pre, h = _panel(seed=2)
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, **_KW)
+    assert band.search == "bisect"
+    assert band.has_interior_gaps is None
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_a_two_candidate_grid_still_agrees_with_cold_calls():
+    y, Y0, pre, h = _panel(seed=3)
+    grid = np.array([-0.5, 1.0])
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, search="grid",
+                                             grid=grid, **_KW)
+    lo, hi = _oracle_bounds(y, Y0, pre, h, grid, 0.1)
+    assert (band.per_period_lower, band.per_period_upper) == (lo, hi)
+
+
+def test_a_grid_no_candidate_survives_is_still_empty():
+    """An empty accepted set is a real answer, and chaining must not turn it
+    into a spurious interval."""
+    y, Y0, pre, h = _panel(seed=6)
+    grid = np.linspace(500.0, 600.0, 9)      # nowhere near any plausible effect
+    band = cumulative_conformal_by_inversion(y, Y0, pre, h, search="grid",
+                                             grid=grid, **_KW)
+    assert band.is_empty
+    assert np.isnan(band.lower) and np.isnan(band.upper)

--- a/mlsynth/utils/conformal/cumulative_inversion.py
+++ b/mlsynth/utils/conformal/cumulative_inversion.py
@@ -191,7 +191,7 @@ def _check_grid(grid):
     return np.sort(grid)
 
 
-def _grid_bounds(accepts, grid, alpha):
+def _grid_bounds(pvalues, grid, alpha):
     """Range of the surviving candidates, and whether they had holes.
 
     Delegates the accept rule and the range to
@@ -201,7 +201,7 @@ def _grid_bounds(accepts, grid, alpha):
     """
     from .inversion import confidence_set_bounds
 
-    pvalues = np.array([accepts(float(t)) for t in grid], dtype=float)
+    pvalues = np.asarray(pvalues, dtype=float)
     lo, hi = confidence_set_bounds(grid, pvalues, alpha)
     kept = pvalues > alpha
     if not kept.any():
@@ -253,7 +253,10 @@ def cumulative_conformal_by_inversion(
         form more than one island; ``bisect`` walks outward from the point
         estimate and stops at the first crossing, which is fast and finds a
         narrow set, but can exclude an accepted candidate beyond a hole.
-        ``grid`` sees whatever the grid covers and says whether there were holes.
+        ``grid`` sees whatever the grid covers and says whether there were holes,
+        and chains its refits through
+        :func:`~mlsynth.utils.bilevel.ridge_inference.conformal_pvalue_sweep`,
+        so its cost is far below one cold solve per candidate.
     grid : array-like, optional
         Candidate per-period effects, required by ``search="grid"``. There is no
         default: a grid has to be scaled to the panel's own dispersion, and one
@@ -306,15 +309,16 @@ def cumulative_conformal_by_inversion(
                                         conformal_type=conformal_type, **kwargs)
         gaps = None
     else:
-        from ..bilevel.ridge_inference import conformal_pvalue
+        # One sweep, not one call per candidate. The sweep walks the grid sorted
+        # so consecutive solves are neighbouring problems and each seeds the next
+        # from its own solution; the p-values come back in the caller's order and
+        # are identical to solving every candidate cold, since a seed moves how
+        # many pivots the active set takes and never where it certifies.
+        from ..bilevel.ridge_inference import conformal_pvalue_sweep
 
-        def pvalue_at(tau0: float) -> float:
-            shifted = y_w.copy()
-            shifted[pre:] -= tau0
-            return conformal_pvalue(shifted, Y0_w, pre, refit=refit,
-                                    conformal_type=conformal_type, **kwargs)
-
-        lo, hi, gaps = _grid_bounds(pvalue_at, grid, alpha)
+        pvalues = conformal_pvalue_sweep(y_w, Y0_w, pre, grid, refit=refit,
+                                         conformal_type=conformal_type, **kwargs)
+        lo, hi, gaps = _grid_bounds(pvalues, grid, alpha)
 
     # The point is the estimator's own effect: weights fitted on the pre-period
     # alone, so the post gaps are the ones the band is meant to describe.

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1477,3 +1477,21 @@ timeout = 300.0
   find = "        if warm_start.size != Y0.shape[1]:"
   replace = "        if False:"
   models = "a seed sized for a different donor pool passed through to the solver, which drops it as infeasible and solves cold. The answer stays correct, so the caller's mix-up -- weights from another panel -- is hidden behind a right-looking number instead of being named"
+
+[[target]]
+name = "conformal-grid-chains-refits"
+module-path = "mlsynth/utils/conformal/cumulative_inversion.py"
+test-command = "python -m pytest mlsynth/tests/test_cumulative_inversion_chained_grid.py mlsynth/tests/test_conformal_cumulative_inversion.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "grid-route-solves-each-candidate-cold"
+  find = "        pvalues = conformal_pvalue_sweep(y_w, Y0_w, pre, grid, refit=refit,"
+  replace = "        pvalues = [conformal_pvalue_sweep(y_w, Y0_w, pre, [t], refit=refit,"
+  models = "the sweep called once per candidate instead of once for the grid, which is the pre-wiring behaviour wearing the new call's name. Each single-candidate sweep starts with no seed, so every solve is cold again and the whole saving disappears while every p-value, every endpoint and every reported gap stays exactly right"
+
+  [[target.mutant]]
+  id = "grid-bounds-read-the-wrong-level"
+  find = "        lo, hi, gaps = _grid_bounds(pvalues, grid, alpha)"
+  replace = "        lo, hi, gaps = _grid_bounds(pvalues, grid, alpha / 2.0)"
+  models = "the accepted set read off at half the requested level, so fewer candidates are rejected and the band is wider than the caller asked for. A wider band still covers, so no coverage check catches it; only comparing the endpoints against the p-values they are supposed to invert does"


### PR DESCRIPTION
## Related Links

- **Stacked on #504**, which adds `conformal_pvalue_sweep`. That function is not on `main` yet, so this targets `claude/conformal-sweep-warm-start` rather than `main`. Retarget to `main` once #504 lands.
- Mutation target `conformal-grid-chains-refits` in `tools/mutation/targets.toml` (2 mutants).

## What

- `cumulative_conformal_by_inversion(search="grid")` now calls `conformal_pvalue_sweep` once for the grid instead of `conformal_pvalue` once per candidate.
- `_grid_bounds` takes the p-values directly instead of a callable.
- `mlsynth/tests/test_cumulative_inversion_chained_grid.py`, 10 tests.
- A two-mutant target.

## Why

#504 added `conformal_pvalue_sweep` to chain a grid sweep's simplex solves, and nothing called it — the grid route still solved every candidate cold. That was the follow-up #504's description named, and this is it. Until now #504 delivered no end-to-end gain, which I had to correct in its description.

Measured on a 41-point grid at `T0 = 104`, `H = 13`, warm on both sides:

```
20 donors   pivots  401 -> 19   (95.3% fewer)   1.36x
60 donors   pivots 1703 -> 69   (95.9% fewer)   7.21x
```

The wall-clock gain grows with the donor pool, because the solve is what scales with it — at twenty donors the solve is already cheap and #505's block reference gather dominates what remains. The pivot counts are the durable measurement: direct counts from the solver's own `info`, which do not move with the runner.

## How

The sweep walks the grid sorted so consecutive solves are neighbouring problems and each seeds the next, then returns p-values in the caller's order.

Two things needed asserting and only one is about numbers:

- The band must be identical. A seed is a starting point for the active set, never a parameter of the estimand. The tests compare endpoints against an oracle built from one cold `conformal_pvalue` per candidate and require **exact** equality — a conformal p-value is a rank among a finite reference set, so any discrepancy is a different rank and a different interval.
- The work must actually fall. A wiring that reverts to cold solves leaves every number right and only the saving gone. That is exactly what `grid-route-solves-each-candidate-cold` does — calling the sweep once per candidate, which reseeds nothing — and only a pivot count through the public entry point can see it.

`has_interior_gaps` is read off the same p-values, so it cannot depend on how they were computed; a test pins that. The bisecting route is untouched — it walks outward one candidate at a time and has no sweep to chain.

## Verification

- Path: not applicable; a pure-performance change validated by exact equivalence to the path it replaces.
- Exact endpoint equality against the cold oracle on three panels, plus a two-candidate grid and an empty-accepted-set case (an empty set is a real answer and chaining must not turn it into a spurious interval).
- Work asserted in pivots through `cumulative_conformal_by_inversion` itself.
- Both mutants killed.
- `benchmarks/run_benchmarks.py --case conformal_inversion_prop99` still passes, so the Prop 99 cross-validation against Facure's notebook is unmoved.
- 92 tests pass across this suite, the inversion suite and #504's two suites.

## Scope checks

None of the four blocks fits — wiring one shared helper to another, plus its tests. The branch carries only this.

## Designs

No visual output.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_cumulative_inversion_chained_grid.py -q` — 10 passed
- [x] `pytest mlsynth/tests/test_conformal_cumulative_inversion.py mlsynth/tests/test_conformal_sweep_warm_start*.py -q` — 92 passed together
- [x] `pytest mlsynth/tests/test_mutation_harness.py -q`
- [ ] `pytest mlsynth/tests/` — full suite, running here in CI
- [x] `python benchmarks/run_benchmarks.py --case conformal_inversion_prop99`
- [x] Both mutants run serially and killed

## Other Notes

- Retarget this to `main` after #504 merges; the diff is one file plus its tests and should rebase cleanly.
- The bisecting route could in principle chain too, but its candidates are chosen adaptively rather than known in advance, so it would need a different mechanism than a sweep over a fixed grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx)_