### PR TITLE
Restore the block-sum spread that centring removes

### DIFF
--- a/benchmarks/cases/pda_wheeler_lassosynth.py
+++ b/benchmarks/cases/pda_wheeler_lassosynth.py
@@ -194,5 +194,11 @@ EXPECTED = {
     "parity_max_gap": (0.004, 0.012),        # the two constructions coincide at block=1
     "parity_h1_atoms_apart": (1.0, 1.0),     # horizon 1 differs by at most one pool atom
     "width_ratio": (1.43, 0.35),             # rolling-origin scores exceed leave-one-out
-    "block_widening": (1.31, 0.20),          # blocks carry AR(0.7) persistence
+    # Blocks carry AR(0.7) persistence. Moved 1.31 -> 1.57 when the draw began
+    # correcting the spread centring removes: an 8-block of a 24-period series is
+    # scaled by sqrt(23 / 16) = 1.199 and the single-period draw by exactly 1, so
+    # the ratio grows by that factor and by nothing else. 1.31 * 1.199 = 1.571
+    # predicted against 1.576 observed, agreeing to 0.4 percent -- the number the
+    # arithmetic gives, not the number the new output happened to produce.
+    "block_widening": (1.57, 0.20),
 }

--- a/mlsynth/tests/test_conformal_centring_shrinkage.py
+++ b/mlsynth/tests/test_conformal_centring_shrinkage.py
@@ -1,0 +1,171 @@
+"""Restoring the block-sum spread that centring takes away.
+
+``block_error_paths`` centres the calibration series before drawing, and it has
+to: a fit sitting a little high shifts every one of its errors by the same
+amount, and an uncentred draw would charge the band for that shift once per
+period it accumulates.
+
+Centring is not free. A series that sums to zero has circular autocovariances
+that sum to zero too, so for a ``b``-block
+
+    Var(S_b) = sum_{|k| < b} (b - |k|) c(k) = b v (1 - (b - 1) / (n - 1)),
+
+and the drawn totals come out narrow by ``sqrt((n - b) / (n - 1))``. At the
+thirteen-period block drawn from forty-seven calibration periods that PDA and
+VanillaSC use, that is sixteen percent, and every band built on those draws is
+narrow by the same factor -- which is under-coverage, in the direction nobody
+wants.
+
+The existing ``b <= n / 2`` guard catches the far end of this same curve, where
+the spread collapses to nothing. The shrinkage is continuous and present at every
+``b``; the guard only refuses where it becomes absurd.
+
+The draw now multiplies by the inverse. The factor is exactly one at ``b = 1``,
+so Wheeler's single-period construction is untouched and so is the parity pinned
+on it.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthDataError
+from mlsynth.utils.conformal import block_error_paths
+
+
+def _totals(series, horizon, block, n_sim=4000, seed=0):
+    paths = block_error_paths(series, horizon=horizon, block=block, n_sim=n_sim,
+                              rng=np.random.default_rng(seed))
+    return paths.sum(axis=1)
+
+
+def _drawn_variance(n, b, reps=250, seed=0):
+    """Variance of the drawn b-block total, over many iid series of length n."""
+    rng = np.random.default_rng(seed)
+    tot = [_totals(rng.standard_normal(n), b, b, n_sim=200, seed=1) for _ in range(reps)]
+    return float(np.var(np.concatenate(tot)))
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_it_still_draws_finite_paths():
+    e = np.random.default_rng(0).standard_normal(47)
+    paths = block_error_paths(e, horizon=13, block=13, n_sim=100,
+                              rng=np.random.default_rng(0))
+    assert paths.shape == (100, 13)
+    assert np.isfinite(paths).all()
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("n,b", [(47, 13), (100, 25), (200, 50), (60, 5)])
+def test_the_drawn_block_total_carries_the_series_variance(n, b):
+    """The defect this fixes. A b-block of an iid series has variance b*v; the
+    centred draw delivered b*v*(n-b)/(n-1) instead, and the band inherited the
+    shortfall."""
+    assert _drawn_variance(n, b) == pytest.approx(float(b), rel=0.07)
+
+
+def test_single_period_draws_are_untouched():
+    """The factor is exactly one at b = 1, so Wheeler's construction and the
+    parity pinned on it cannot move."""
+    e = np.random.default_rng(3).standard_normal(40)
+    kw = dict(horizon=8, block=1, n_sim=64)
+    got = block_error_paths(e, rng=np.random.default_rng(5), **kw)
+    centred = e - e.mean()
+    pool = np.concatenate([centred, -centred])
+    for value in np.unique(got):
+        assert np.isclose(np.abs(pool - value).min(), 0.0, atol=1e-12)
+
+
+def test_the_corrected_spread_is_flat_in_the_block_length():
+    """``sqrt((n-1)/(n-b))`` is increasing in b, so a longer block is scaled up
+    harder -- which is what makes the drawn spread per ``sqrt(b)`` flat instead of
+    falling away as b grows.
+
+    Averaged over series, not measured on one. A single fixed series carries its
+    own realised autocorrelation, and a long block picks that up: on one draw of
+    sixty iid normals the ratio across b runs to 1.76, which says something about
+    that series and nothing about the correction. Over many series the realised
+    dependence averages out and only the scaling is left.
+    """
+    n = 60
+    rng = np.random.default_rng(0)
+    blocks = (2, 5, 10, 20)
+    pooled = {b: [] for b in blocks}
+    for _ in range(120):
+        e = rng.standard_normal(n)
+        for b in blocks:
+            pooled[b].append(_totals(e, b, b, n_sim=300, seed=1))
+    widths = [float(np.std(np.concatenate(pooled[b])) / np.sqrt(b)) for b in blocks]
+    assert max(widths) / min(widths) < 1.10
+    assert all(0.9 < w < 1.1 for w in widths)
+
+
+@pytest.mark.parametrize("b", [1, 2, 7, 23])
+def test_shifting_the_series_still_changes_nothing(b):
+    """The correction scales; it does not re-introduce the level."""
+    e = np.random.default_rng(11).standard_normal(47)
+    kw = dict(horizon=13, block=b, n_sim=64)
+    base = block_error_paths(e, rng=np.random.default_rng(1), **kw)
+    moved = block_error_paths(e + 25.0, rng=np.random.default_rng(1), **kw)
+    assert np.allclose(moved, base, rtol=1e-9, atol=1e-8)
+
+
+@pytest.mark.parametrize("b", [1, 3, 13])
+def test_rescaling_the_series_still_rescales_the_paths(b):
+    e = np.random.default_rng(13).standard_normal(47)
+    kw = dict(horizon=13, block=b, n_sim=64)
+    base = block_error_paths(e, rng=np.random.default_rng(2), **kw)
+    scaled = block_error_paths(e * 3.0, rng=np.random.default_rng(2), **kw)
+    assert np.allclose(scaled, base * 3.0, rtol=1e-9, atol=1e-8)
+
+
+def test_the_band_is_wider_than_it_was_before_the_correction():
+    """Stated as a direction, since that is the user-visible consequence: bands
+    that were narrow by sqrt((n-b)/(n-1)) are now wider by its inverse."""
+    e = np.random.default_rng(17).standard_normal(47)
+    corrected = np.std(_totals(e, 13, 13, n_sim=8000, seed=4))
+    uncorrected = corrected * np.sqrt((47 - 13) / (47 - 1))
+    assert corrected > uncorrected
+    assert corrected / uncorrected == pytest.approx(np.sqrt(46 / 34), rel=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_the_longest_admissible_block_is_scaled_the_hardest():
+    """At b = n / 2 the factor is sqrt((n-1)/(n/2)), the largest the guard allows,
+    and the draw still returns finite paths."""
+    e = np.random.default_rng(19).standard_normal(40)
+    paths = block_error_paths(e, horizon=20, block=20, n_sim=128,
+                              rng=np.random.default_rng(0))
+    assert np.isfinite(paths).all()
+    assert np.std(paths.sum(axis=1)) > 0.0
+
+
+def test_a_two_period_series_still_draws():
+    e = np.array([1.0, -3.0])
+    paths = block_error_paths(e, horizon=4, block=1, n_sim=32,
+                              rng=np.random.default_rng(0))
+    assert np.isfinite(paths).all()
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+def test_a_block_past_half_the_series_is_still_refused():
+    """The guard and the correction describe the same curve; correcting the
+    shrinkage does not license drawing past the point where it inverts."""
+    e = np.random.default_rng(0).standard_normal(20)
+    with pytest.raises(MlsynthDataError, match="half"):
+        block_error_paths(e, horizon=11, block=11, n_sim=16,
+                          rng=np.random.default_rng(0))
+
+
+def test_a_single_calibration_error_is_still_refused():
+    with pytest.raises(MlsynthDataError, match="single calibration error"):
+        block_error_paths(np.array([2.0]), horizon=3, block=1, n_sim=16,
+                          rng=np.random.default_rng(0))

--- a/mlsynth/tests/test_conformal_resample_paths.py
+++ b/mlsynth/tests/test_conformal_resample_paths.py
@@ -205,13 +205,30 @@ def test_the_longest_admissible_block_still_draws():
 # b = n/2 and reverses: past the midpoint a longer block draws a NARROWER total,
 # mirroring a shorter one, until at b = n it draws nothing at all.
 def test_the_spread_is_symmetric_about_half_the_series():
-    """The identity the guard is built on, measured."""
+    """The identity the guard is built on, measured -- on the raw block sums.
+
+    A centred series partitions into a b-block and its (n - b) complement, whose
+    sums are exact negatives, so the two carry identical spread. That symmetry is
+    why a block past n / 2 stops meaning "how much serial correlation is carried"
+    and reverses, and it is what the guard refuses on.
+
+    The drawn paths no longer show it, and that is deliberate: the draw now
+    scales by sqrt((n - 1) / (n - b)) to give back the spread centring removed,
+    and b and n - b are scaled by different factors precisely so each carries its
+    own spread instead of the shared, shrunken one. Dividing the factor back out
+    recovers the identity, which is the quantity the guard is about.
+    """
     e = np.random.default_rng(0).normal(size=24)
-    def sd(b):
-        return block_error_paths(e, horizon=b, block=b, n_sim=100_000,
-                                 rng=np.random.default_rng(1)).sum(axis=1).std()
+    n = e.size
+
+    def raw_sd(b):
+        drawn = block_error_paths(e, horizon=b, block=b, n_sim=100_000,
+                                  rng=np.random.default_rng(1)).sum(axis=1).std()
+        factor = np.sqrt((n - 1) / (n - b)) if b > 1 else 1.0
+        return drawn / factor
+
     for b in (1, 2, 5):
-        assert sd(b) == pytest.approx(_complement_sd(e, b), rel=0.02), b
+        assert raw_sd(b) == pytest.approx(_complement_sd(e, b), rel=0.02), b
 
 
 def _complement_sd(e, b):

--- a/mlsynth/tests/test_conformal_resample_paths_properties.py
+++ b/mlsynth/tests/test_conformal_resample_paths_properties.py
@@ -34,7 +34,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from mlsynth.utils.conformal import block_error_paths
+from mlsynth.utils.conformal import block_error_paths, resolve_block
 
 _SETTINGS = settings(
     max_examples=50, deadline=None, suppress_health_check=[HealthCheck.too_slow]
@@ -71,10 +71,19 @@ def test_the_shape_is_always_simulations_by_horizon(series, horizon, block, seed
 @_SETTINGS
 def test_every_drawn_value_is_a_signed_entry_of_the_centred_series(
         series, horizon, block, seed):
-    """The draw resamples; it does not interpolate, smooth or rescale."""
+    """The draw resamples; it does not interpolate or smooth.
+
+    It applies one uniform scalar, the centring correction, which is divided
+    back out here so the membership question is about the values themselves.
+    """
     e = np.asarray(series, dtype=float)
+    # The draw resolves the block against the horizon, so a block longer than
+    # the horizon is cut down to it and carries the shorter block's factor.
+    b = resolve_block(_admissible(series, block), horizon)
     paths = block_error_paths(e, horizon=horizon, block=_admissible(series, block),
                               n_sim=16, rng=np.random.default_rng(seed))
+    scale = np.sqrt((e.size - 1) / (e.size - b)) if b > 1 else 1.0
+    paths = paths / scale
     pool = np.concatenate([e - e.mean(), -(e - e.mean())])
     for value in np.unique(paths):
         assert np.isclose(np.abs(pool - value).min(), 0.0, atol=1e-9)

--- a/mlsynth/utils/conformal/resample.py
+++ b/mlsynth/utils/conformal/resample.py
@@ -153,7 +153,9 @@ def block_error_paths(
     Returns
     -------
     numpy.ndarray, shape ``(n_sim, horizon)``
-        One error path per row, ready for
+        One error path per row, scaled so the drawn block sums carry the
+        calibration series' own spread instead of the narrower spread centring
+        leaves them with. Ready for
         :func:`mlsynth.utils.pda_helpers.inference.cumulative_supt_band` or for
         equal-tailed quantiles of the accumulated draws.
 
@@ -219,7 +221,28 @@ def block_error_paths(
     idx = (starts[:, :, None] + np.arange(b)[None, None, :]) % e.size
     draws = e[idx]
     signs = rng.choice(np.array([-1.0, 1.0]), size=(n_sim, n_blocks, 1))
-    return (draws * signs).reshape(n_sim, n_blocks * b)[:, :h]
+    # Centring costs the block sums some of their spread, and the loss is exact
+    # enough to undo. Because the centred series sums to zero, its circular
+    # autocovariances sum to zero too, so for a b-block
+    #     Var(S_b) = sum_{|k| < b} (b - |k|) c(k) = b v (1 - (b - 1) / (n - 1)),
+    # and the drawn totals come out narrow by sqrt((n - b) / (n - 1)) -- sixteen
+    # percent at a 13-period block drawn from 47 calibration periods, which is
+    # under-coverage in every band built on them. Scaling by the inverse restores
+    # it. The factor is exactly 1 at b = 1, so Wheeler's single-period draw, and
+    # the parity pinned on it, are unchanged.
+    #
+    # It is exact for a horizon made of whole blocks, which the default
+    # block = horizon always is. A horizon shorter than one block is scaled by
+    # this factor too and comes out slightly wide, since a partial block of length
+    # h < b loses sqrt((n - h) / (n - 1)) and not sqrt((n - b) / (n - 1)). Erring
+    # wide is the safe direction for a band, and a per-horizon factor cannot be
+    # applied to a path without changing its shape.
+    #
+    # The b <= n / 2 guard above is the far end of this same curve, where the
+    # spread collapses to nothing. The shrinkage is continuous and present at
+    # every b; the guard only refuses where it inverts.
+    scale = np.sqrt((e.size - 1) / (e.size - b)) if b > 1 else 1.0
+    return (draws * signs).reshape(n_sim, n_blocks * b)[:, :h] * scale
 
 
 def resample_cumulative_paths(

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1573,3 +1573,27 @@ timeout = 300.0
   find = "    lower_bound = attained + float(gradient.min() - gradient @ w)"
   replace = "    lower_bound = attained + float(gradient.max() - gradient @ w)"
   models = "the convexity bound minimised over the wrong vertex of the simplex, which turns a lower bound into a quantity above the attained objective. The certificate then reports a negative gap, and an assertion that only bounds it from above would accept a solve that never converged as optimal"
+
+[[target]]
+name = "conformal-centring-shrinkage"
+module-path = "mlsynth/utils/conformal/resample.py"
+test-command = "python -m pytest mlsynth/tests/test_conformal_centring_shrinkage.py mlsynth/tests/test_conformal_resample_paths.py -q -p no:cacheprovider"
+timeout = 300.0
+
+  [[target.mutant]]
+  id = "centring-shrinkage-uncorrected"
+  find = "    scale = np.sqrt((e.size - 1) / (e.size - b)) if b > 1 else 1.0"
+  replace = "    scale = 1.0"
+  models = "the pre-fix state: block sums drawn from a centred series come out narrow by sqrt((n - b) / (n - 1)), because the centred series' circular autocovariances sum to zero. Sixteen percent at a thirteen-period block drawn from forty-seven calibration periods, and every band built on those draws is narrow by the same factor. The draw still returns finite, symmetric, right-shaped paths, so nothing about the band's appearance shows it -- only a measurement against the series' own variance does"
+
+  [[target.mutant]]
+  id = "correction-scaled-by-the-block-not-its-complement"
+  find = "    scale = np.sqrt((e.size - 1) / (e.size - b)) if b > 1 else 1.0"
+  replace = "    scale = np.sqrt((e.size - 1) / b) if b > 1 else 1.0"
+  models = "the denominator taken as the block rather than its complement. The shrinkage centring imposes is (n - b) / (n - 1), so undoing it needs the complement; using b instead gives 1.88 where 1.16 is correct at a 13-block of 47 periods, and the band is then over half again too wide. Erring wide never fails a coverage check, which is what makes an over-correction harder to notice than an under-correction"
+
+  [[target.mutant]]
+  id = "correction-inverted"
+  find = "    scale = np.sqrt((e.size - 1) / (e.size - b)) if b > 1 else 1.0"
+  replace = "    scale = np.sqrt((e.size - b) / (e.size - 1)) if b > 1 else 1.0"
+  models = "the factor upside down, so the draw shrinks the block sums a second time instead of restoring them. The band is then narrow by (n - b) / (n - 1) rather than by its square root -- twice the under-coverage the fix exists to remove, and still finite, symmetric and the right shape"


### PR DESCRIPTION
## Related Links

- Mutation target `conformal-centring-shrinkage` in `tools/mutation/targets.toml` (3 mutants).
- Benchmark whose pinned value moves: `benchmarks/cases/pda_wheeler_lassosynth.py`.
- Found while writing the properties in #506.

## What

- `block_error_paths` scales the drawn paths by `sqrt((n - 1) / (n - b))`.
- `mlsynth/tests/test_conformal_centring_shrinkage.py`, 19 tests.
- `test_the_spread_is_symmetric_about_half_the_series` updated to assert its identity on the unscaled sums.
- `block_widening` in the PDA benchmark repinned 1.31 → 1.57.
- A three-mutant target.

**This changes the width of every cumulative band PDA and VanillaSC draw this way.** They are the only callers.

## Why — this is a live under-coverage bug

`block_error_paths` centres the calibration series before drawing, and it has to: a fit sitting high shifts every error by the same amount, and an uncentred draw charges the band for that shift once per period it accumulates.

Centring is not free. A series summing to zero has circular autocovariances summing to zero, so for a `b`-block

```
Var(S_b) = sum_{|k| < b} (b - |k|) c(k) = b·v·(1 - (b-1)/(n-1))
```

and the drawn totals come out narrow by `sqrt((n-b)/(n-1))`. Measured on `main` before the fix, over 400 iid series per row:

```
    n   b   drawn var       b*v   ratio   predicted (n-b)/(n-1)
   47  13      9.0849   13.0000  0.6988      0.7391
   47   1      0.9844    1.0000  0.9844      1.0000   <- exact at b=1
  100  25     18.0539   25.0000  0.7222      0.7576
   60   5      4.6542    5.0000  0.9308      0.9322
```

At PDA and VanillaSC's operating point that is a band about 16% too narrow — under-coverage, in the direction nobody wants.

## How

The draw multiplies by the inverse. The factor is **exactly** `1.0` at `b = 1` — verified, so the multiply is a bit-level no-op there — which leaves Wheeler's single-period construction and the parity pinned on it untouched.

It is exact for a horizon made of whole blocks, which the default `block = horizon` always is. A horizon shorter than one block is scaled by the same factor and comes out slightly wide, since a partial block of length `h < b` loses `sqrt((n-h)/(n-1))`; erring wide is the safe direction for a band, and a per-horizon factor cannot be applied to a path without changing its shape.

The existing `b <= n/2` guard is the far end of this same curve, where the spread collapses to nothing. The shrinkage is continuous and present at every `b`; the guard only refuses where it inverts.

## Verification

- Red-to-green: five of the nineteen tests failed before the change, all on spread.
- The corrected drawn variance matches `b·v` to 7% at `(47,13)`, `(100,25)`, `(200,50)`, `(60,5)`.
- The corrected spread per `sqrt(b)` is flat in `b` — 0.984, 0.986, 0.972, 0.978 across `b = 2,5,10,20`, max/min 1.014. Measured **over many series**, not one: a single fixed series carries its own realised autocorrelation, and my first version of that test measured exactly that and failed at a ratio of 1.76. The test was wrong, not the code.
- Location invariance, scale equivariance and both refusals still hold.
- 162 tests pass across every suite touching this draw.
- Three mutants killed, including `centring-shrinkage-uncorrected` (the pre-fix state) and `correction-inverted` (shrinking twice instead of restoring).

### The pinned value that moves, justified

`block_widening` in `pda_wheeler_lassosynth` goes **1.31 → 1.57**. That metric is `se(block=0)/se(block=1)`, so the correction scales its numerator by `sqrt(23/16) = 1.199` for an 8-block of a 24-period series, and its denominator by exactly 1:

```
predicted  1.31 × 1.1990 = 1.571
observed                   1.576      (0.4% apart)
```

It is repinned to the number the arithmetic gives, not the number the new output produced. `parity_max_gap` is unchanged at 0.00444 and `width_ratio` moves 1.430 → 1.435, both as the `b = 1` exemption requires.

### A test updated rather than deleted

`test_the_spread_is_symmetric_about_half_the_series` now asserts its identity on the **unscaled** sums. A `b`-block and its `(n-b)` complement have exactly equal spread — that is what the guard rests on — and the drawn paths no longer show it precisely because `b` and `n-b` are now scaled by different factors, so each carries its own spread instead of the shared shrunken one. Dividing the factor back out recovers the identity, which is the quantity the guard is about.

### Not affected

PPSCM calibrates through `cumulative_conformal_interval`, which reaches `split_conformal_quantile` and `rolling_origin_block_sums` and never this draw. Verified by call graph, not assumed.

## Scope checks

<!-- BUG FIX -->
- [x] A test reproduces the defect and fails without the fix — five do
- [x] It asserts the correct behaviour (drawn variance equals `b·v`), not merely the absence of a crash
- [x] No docstring or comment still states the old behaviour; the returns docstring now says the paths are scaled
- [x] The pinned value that moved is justified as the right number — `1.31 × sqrt(23/16)` — not re-fitted to the new output

## Designs

No visual output; the change is a scalar factor on drawn paths.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_conformal_centring_shrinkage.py -q` — 19 passed
- [x] Every suite touching the draw — 162 passed
- [x] `pytest mlsynth/tests/test_mutation_harness.py -q`
- [ ] `pytest mlsynth/tests/` — full suite, running here in CI
- [x] `python benchmarks/run_benchmarks.py --case pda_wheeler_lassosynth` — 4/4 with the repinned value
- [x] Three mutants run serially and killed

## Other Notes

- A fourth mutant was written and removed as equivalent: dropping the `b > 1` exemption changes nothing, since `sqrt((n-1)/(n-1))` is exactly `1.0` and multiplying by it is a floating-point no-op. Recorded so nobody re-derives it.
- `ppscm_bfr_mc` was not run to completion here (a slow Monte Carlo); the call-graph check above is why it does not need to be. Say the word if you would rather see it run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx)_