### PR TITLE
Calibrate PPSCM's per-unit cumulative band on cyclic blocks

### DIFF
--- a/mlsynth/tests/test_ppscm_cwz_cumulative.py
+++ b/mlsynth/tests/test_ppscm_cwz_cumulative.py
@@ -158,9 +158,17 @@ def test_a_coarse_grid_understates_the_band():
 
 def test_a_band_reaching_the_grid_edge_is_reported_as_infinite():
     """That end is bounded by ``grid_scale``, not by the data, and a finite
-    number there would understate it without saying so."""
+    number there would understate it without saying so.
+
+    Each end is asserted on its own. An earlier version took ``any`` over the
+    union of the two, which passes on a run where only the upper end escapes and
+    so cannot see the lower guard fail -- a mutant that disabled exactly that
+    branch survived it.
+    """
     _, lo, hi, _ = _call(grid_scale=0.05, n_nulls=9)
-    assert np.any(np.isinf(np.asarray(lo)) | np.isinf(np.asarray(hi)))
+    lo, hi = np.asarray(lo, dtype=float), np.asarray(hi, dtype=float)
+    assert np.all(lo == -np.inf), lo
+    assert np.all(hi == np.inf), hi
 
 
 def test_a_wide_enough_grid_gives_a_finite_band():

--- a/mlsynth/tests/test_ppscm_cwz_cumulative.py
+++ b/mlsynth/tests/test_ppscm_cwz_cumulative.py
@@ -1,0 +1,267 @@
+"""Test-first spec for PPSCM's per-unit cumulative band by moving-block conformal.
+
+The split-conformal band (#431) calibrates on disjoint pre-period windows, and
+there are roughly ``0.7 * T0 / L`` of them. A finite ``1 - alpha`` band needs
+``ceil((m+1)(1-alpha)) <= m``, so at the 90 percent level it needs nine, which
+puts a floor of about ``12.8 * L`` pre-periods on reporting one at all and pins
+every feasible design in the regime where the rank never trims and the half-width
+is simply the largest score.
+
+This calibrates the same estimand against the ``T`` cyclic shifts of the residual
+path instead, so the block count stops depending on the horizon and the floor
+disappears.
+
+Two things are settled before this suite and are asserted here so they cannot
+drift back.
+
+The statistic is the paper's. An earlier prototype scored blocks by their
+absolute sum, on the reasoning that a running total is a signed quantity. That is
+invalid on a fitted residual path: the quadratic program leaves end-of-window
+residuals sign-coherent, so block sums ramp toward the end of the window while
+magnitudes stay flat, and the trailing block always occupies the most inflated
+position. Measured, it rejected at 0.225 against a nominal 0.10.
+``moving_block_pvalue``'s docstring carries the full measurement. The statistic
+that is valid there is ``mean_abs``, and it is not a compromise: displacing a
+mean-zero block by ``delta`` raises the mean of its absolute values, so the test
+has power against exactly the constant shift being inverted -- measured rejection
+rises 0.04, 0.36, 0.76, 1.00 as the true effect grows through 0, 0.2, 0.5, 1.0.
+
+The null refit balances the whole window. Under the null the adjusted series is
+an untreated series, so every period is fitting data, and leaving one out puts the
+trailing block partly outside the fit the reference blocks come from. Reaching
+``d = T`` needs an explicit ``nu``, because the automatic rule sits exactly on its
+boundary for a single treated unit and cvxpy refuses the program; the caller
+passes ``nu_used`` for that reason, as the split-conformal entry point already
+does.
+
+Levels: smoke, unit invariants, property, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.ppscm_helpers.inference import cwz_cumulative_per_unit
+
+
+def _panel(n_ctrl=18, n_trt=2, t0=40, horizon=5, effect=0.0, seed=0):
+    """Factor panel with a constant post-period effect on the treated units."""
+    rng = np.random.default_rng(seed)
+    n, T = n_ctrl + n_trt, t0 + horizon
+    f = rng.normal(size=(T, 2))
+    load = rng.uniform(0.3, 1.3, size=(n, 2))
+    Xy = load @ f.T + rng.normal(scale=0.3, size=(n, T))
+    Xy = Xy - Xy.min() + 1.0
+    Xy[:n_trt, t0:] += effect
+    trt = np.full(n, np.inf)
+    trt[:n_trt] = t0
+    return Xy, trt, t0, horizon
+
+
+def _call(panel=None, **kw):
+    Xy, trt, t0, L = panel or _panel()
+    base = dict(d=t0, n_leads=L, n_lags=t0, fixedeff=True, time_cohort=False,
+                nu_used=0.5, lam=0.0, solver=None, alpha=0.10, horizon=L,
+                n_nulls=9)
+    base.update(kw)
+    return cwz_cumulative_per_unit(Xy, trt, **base)
+
+
+# --------------------------------------------------------------------------- #
+# smoke                                                                        #
+# --------------------------------------------------------------------------- #
+def test_smoke_one_band_per_treated_unit():
+    point, lower, upper, p_zero = _call()
+    for arr in (point, lower, upper, p_zero):
+        assert np.asarray(arr).shape == (2,)
+    assert np.isfinite(point).all()
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants                                                              #
+# --------------------------------------------------------------------------- #
+def test_the_point_is_each_unit_summed_effect_over_the_horizon():
+    from mlsynth.utils.ppscm_helpers.engine import run_multisynth
+
+    Xy, trt, t0, L = _panel()
+    full = run_multisynth(Xy, trt, t0, L, t0, nu=0.5)
+    want = [float(np.sum(np.asarray(full["tau_rel"][k], float)[:L]))
+            for k in range(len(full["groups"]))]
+    point, *_ = _call((Xy, trt, t0, L))
+    np.testing.assert_allclose(point, want, rtol=1e-8, atol=1e-10)
+
+
+def test_the_band_is_reported_on_the_cumulative_scale():
+    """The inversion is over a constant per-period effect; what is reported is
+    the total, so the endpoints carry a factor of the horizon. Without it the
+    band would be an order of magnitude too narrow for the number beside it."""
+    _, lo5, hi5, _ = _call(horizon=5)
+    _, lo2, hi2, _ = _call(horizon=2)
+    assert np.all(np.asarray(hi5) - np.asarray(lo5) >
+                  np.asarray(hi2) - np.asarray(lo2))
+
+
+def test_the_p_value_of_no_effect_is_reported():
+    """A caller reading significance off the band alone cannot tell an interval
+    that just excludes zero from one that comfortably does."""
+    _, _, _, p_zero = _call()
+    assert np.all((p_zero > 0.0) & (p_zero <= 1.0))
+
+
+def test_the_null_refit_balances_every_period():
+    """Leaving a period out puts the trailing block partly outside the fit its
+    reference blocks come from. This pins the window, since the failure it
+    guards is silent -- the band still comes back, just miscalibrated."""
+    import mlsynth.utils.ppscm_helpers.inference as inf
+
+    Xy, trt, t0, L = _panel()
+    T = Xy.shape[1]
+    seen = []
+    real = inf.run_multisynth
+
+    def spy(Xy_, trt_, d_, n_leads_, n_lags_, **kw):
+        seen.append(int(d_))
+        return real(Xy_, trt_, d_, n_leads_, n_lags_, **kw)
+
+    inf.run_multisynth = spy
+    try:
+        _call((Xy, trt, t0, L))
+    finally:
+        inf.run_multisynth = real
+    assert T in seen, f"no refit balanced all {T} periods; saw {sorted(set(seen))}"
+
+
+def test_a_tighter_level_never_narrows_the_band():
+    _, lo_t, hi_t, _ = _call(alpha=0.02, n_nulls=15)
+    _, lo_l, hi_l, _ = _call(alpha=0.30, n_nulls=15)
+    assert np.all(np.asarray(hi_t) - np.asarray(lo_t) >=
+                  np.asarray(hi_l) - np.asarray(lo_l) - 1e-9)
+
+
+def test_a_coarse_grid_understates_the_band():
+    """Discretisation errs anti-conservatively here, which is the opposite of the
+    usual intuition, which is why it is pinned.
+
+    The band is the range of accepted candidates. A coarse grid offers fewer
+    candidates to accept, so the range of survivors is narrower and the reported
+    band too tight; refining converges upward. Measured on this panel the width
+    runs 3.14, 4.71, 5.38, 5.65, 5.86 as the grid goes 5, 9, 15, 21, 31. An
+    earlier version of this test asserted the reverse, on the reasoning that a
+    coarse grid rounds outward, and it was wrong.
+    """
+    widths = []
+    for n in (5, 9, 21):
+        _, lo, hi, _ = _call(n_nulls=n)
+        w = np.asarray(hi) - np.asarray(lo)
+        widths.append(w[np.isfinite(w)])
+    assert widths[0].sum() < widths[1].sum() <= widths[2].sum() + 1e-9
+
+
+def test_a_band_reaching_the_grid_edge_is_reported_as_infinite():
+    """That end is bounded by ``grid_scale``, not by the data, and a finite
+    number there would understate it without saying so."""
+    _, lo, hi, _ = _call(grid_scale=0.05, n_nulls=9)
+    assert np.any(np.isinf(np.asarray(lo)) | np.isinf(np.asarray(hi)))
+
+
+def test_a_wide_enough_grid_gives_a_finite_band():
+    """The control: the guard fires on a grid that is too narrow, not always."""
+    _, lo, hi, _ = _call(grid_scale=8.0, n_nulls=15)
+    assert np.isfinite(np.asarray(lo)).any() and np.isfinite(np.asarray(hi)).any()
+
+
+# --------------------------------------------------------------------------- #
+# property: validity and power                                                 #
+# --------------------------------------------------------------------------- #
+def test_it_covers_a_true_zero_effect():
+    """Validity. Test inversion inherits it from the test, and the test is the
+    paper's; this asserts the composition did not lose it."""
+    covered = 0
+    for s in range(12):
+        _, lo, hi, _ = _call(_panel(effect=0.0, seed=s), n_nulls=11)
+        covered += int(np.all((np.asarray(lo) <= 0.0) & (0.0 <= np.asarray(hi))))
+    assert covered >= 10, f"covered the truth in only {covered}/12 draws"
+
+
+def test_it_covers_a_true_constant_effect():
+    """The null the inversion actually sweeps, at a value that is not zero."""
+    eff, L = 0.6, 5
+    covered = 0
+    for s in range(12):
+        _, lo, hi, _ = _call(_panel(effect=eff, seed=s), n_nulls=11)
+        total = eff * L
+        covered += int(np.all((np.asarray(lo) <= total) & (total <= np.asarray(hi))))
+    assert covered >= 9, f"covered the truth in only {covered}/12 draws"
+
+
+def test_a_large_effect_is_detected():
+    """Power. A band that always covers is not evidence of anything."""
+    _, lo, hi, p_zero = _call(_panel(effect=2.5, seed=1), n_nulls=15)
+    assert np.all((np.asarray(lo) > 0.0) | (np.asarray(hi) < 0.0))
+    assert np.all(np.asarray(p_zero) <= 0.10)
+
+
+def test_the_block_count_does_not_depend_on_the_horizon():
+    """The reason for the method. Split conformal loses windows as the horizon
+    grows and stops producing a finite band; the cyclic reference set does not."""
+    for L in (2, 5, 8):
+        Xy, trt, t0, _ = _panel(t0=40, horizon=10)
+        _, lo, hi, _ = _call((Xy, trt, t0, 10), horizon=L, n_nulls=9)
+        assert np.isfinite(lo).all() and np.isfinite(hi).all(), \
+            f"horizon {L} produced no finite band"
+
+
+# --------------------------------------------------------------------------- #
+# edge                                                                         #
+# --------------------------------------------------------------------------- #
+def test_a_single_treated_unit_is_supported():
+    """The case with no cross-unit replication at all, and the one whose
+    automatic nu sits on its boundary -- which is why nu_used is required."""
+    point, lo, hi, _ = _call(_panel(n_trt=1))
+    assert point.shape == (1,) and np.isfinite(point).all()
+
+
+def test_an_effect_that_is_not_constant_may_leave_the_set_empty():
+    """The cost of a constant-effect null, surfaced as a refusal. An empty
+    accepted set is a real answer: no constant effect on the grid conforms."""
+    Xy, trt, t0, L = _panel(effect=0.0, seed=3)
+    Xy[0, t0:] += np.linspace(0.0, 6.0, L)        # a ramp, not a constant
+    _, lo, hi, _ = _call((Xy, trt, t0, L), n_nulls=11)
+    assert np.isnan(lo[0]) or np.isfinite(lo[0])  # either is legitimate; not a crash
+
+
+def test_a_horizon_shorter_than_the_post_window_is_allowed():
+    point, lo, hi, _ = _call(horizon=3)
+    assert np.isfinite(point).all()
+
+
+# --------------------------------------------------------------------------- #
+# failure -- reported, not swallowed                                           #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1])
+def test_an_invalid_level_is_refused(bad):
+    with pytest.raises(MlsynthConfigError):
+        _call(alpha=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -2, 2.5])
+def test_a_nonpositive_horizon_is_refused(bad):
+    with pytest.raises(MlsynthConfigError):
+        _call(horizon=bad)
+
+
+def test_a_horizon_past_the_post_window_is_refused():
+    with pytest.raises(MlsynthDataError):
+        _call(horizon=99)
+
+
+def test_too_few_grid_points_is_refused():
+    """A two-point grid cannot express an interval; it can only return its own
+    endpoints, which would look like a band and be an artifact of the grid."""
+    with pytest.raises(MlsynthConfigError):
+        _call(n_nulls=2)
+
+
+def test_no_treated_unit_is_refused():
+    Xy, trt, t0, L = _panel()
+    with pytest.raises(MlsynthDataError):
+        _call((Xy, np.full(trt.shape, np.inf), t0, L))

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -463,3 +463,153 @@ def cumulative_conformal_per_unit(
             point[k], s, alpha=float(alpha), horizon=horizon)
         lower[k], upper[k] = band.lower, band.upper
     return point, lower, upper, n_scores
+
+
+def cwz_cumulative_per_unit(
+    Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
+    *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
+    solver: Any, alpha: float, horizon: int, n_nulls: int = 25,
+    grid_scale: float = 3.0,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Per-unit cumulative band by inverting a moving-block conformal test.
+
+    The counterpart of :func:`cumulative_conformal_per_unit`, calibrated against
+    the ``T`` cyclic shifts of the residual path instead of a disjoint split of
+    the pre-period. The split version's window count is roughly ``0.7 * T0 / L``
+    and a finite ``1 - alpha`` band needs ``ceil((m+1)(1-alpha)) <= m``, so at the
+    90 percent level it needs nine windows -- a floor of about ``12.8 * L``
+    pre-periods before a band exists at all, and every feasible design then sits
+    in the regime where the rank never trims and the half-width is simply the
+    largest score. The cyclic reference set does not depend on the horizon, so
+    neither the floor nor that regime applies.
+
+    The price is a shape assumption. Test inversion needs a null to subtract, so
+    the null here is a constant per-period effect and the reported band is
+    ``horizon`` times the accepted range of that effect. An effect that ramps is
+    not in the null family, and the honest outcome then is an empty accepted set,
+    which :func:`~mlsynth.utils.conformal.confidence_set_bounds` returns as
+    ``(nan, nan)``.
+
+    Two construction details decide the answer, both established by measurement;
+    the full account is in
+    :func:`~mlsynth.utils.conformal.moving_block_pvalue`.
+
+    The statistic is ``mean_abs``, the reference implementation's. The absolute
+    block sum is the intuitive choice for a running total and is invalid here:
+    the quadratic program leaves end-of-window residuals sign-coherent, so block
+    sums ramp toward the end of the window while magnitudes stay flat, and the
+    trailing block always occupies the most inflated position. It is not a
+    compromise -- displacing a mean-zero block by ``delta`` raises the mean of its
+    absolute values, so the test has power against precisely the constant shift
+    being inverted.
+
+    The null refit balances every period. Under the null the adjusted series is
+    an untreated series, so all of it is fitting data, and leaving a period out
+    would put the trailing block partly outside the fit its reference blocks come
+    from. Balancing the whole window requires an explicit ``nu``: the automatic
+    rule sits exactly on its boundary when one unit is treated, and cvxpy refuses
+    the program. That is why ``nu_used`` is a parameter, not a default.
+
+    The grid is an approximation and it errs in one direction. The band is the
+    range of accepted candidates, so a coarse grid samples fewer of them and
+    reports a band that is too narrow, converging upward as ``n_nulls`` rises --
+    measured on a two-unit panel, a width of 3.14 at five candidates against 5.86
+    at thirty-one. Coarse is anti-conservative here, not conservative, which is
+    the opposite of the usual intuition about discretisation.
+
+    An accepted set that reaches an end of the grid is bounded by ``grid_scale``
+    and not by the data, and that end is returned as infinite. Reporting the
+    endpoint instead would understate the band silently, since it looks like any
+    other number.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        ``(point, lower, upper, p_zero)``, each of shape ``(J,)`` in ``groups``
+        order. ``lower`` and ``upper`` are on the cumulative scale and may be
+        infinite; ``p_zero`` is the permutation p-value of the no-effect null.
+    """
+    from ..conformal import confidence_set_bounds, moving_block_pvalue
+
+    if (isinstance(alpha, bool) or not isinstance(alpha, (int, float, np.floating))
+            or not 0.0 < float(alpha) < 1.0):
+        raise MlsynthConfigError(
+            f"alpha must be a number in the open interval (0, 1); got {alpha!r}.")
+    if (isinstance(horizon, bool) or not isinstance(horizon, (int, np.integer))
+            or int(horizon) < 1):
+        raise MlsynthConfigError(
+            f"horizon must be a positive integer; got {horizon!r}.")
+    if (isinstance(n_nulls, bool) or not isinstance(n_nulls, (int, np.integer))
+            or int(n_nulls) < 3):
+        raise MlsynthConfigError(
+            f"n_nulls must be an integer of at least 3; got {n_nulls!r}. A "
+            "two-point grid cannot express an interval -- it can only return its "
+            "own endpoints, which would read as a band and be an artifact of the "
+            "grid.")
+    horizon, n_nulls = int(horizon), int(n_nulls)
+    if horizon > int(n_leads):
+        raise MlsynthDataError(
+            f"horizon ({horizon}) exceeds the {int(n_leads)} post-period lead(s) "
+            "estimated; there is no full window to accumulate.")
+
+    Xy = np.asarray(Xy, dtype=float)
+    trt = np.asarray(trt, dtype=float)
+    adopted = np.isfinite(trt)
+    if not adopted.any():
+        raise MlsynthDataError(
+            "cumulative conformal inference needs at least one treated unit; no "
+            "unit has a finite adoption time.")
+
+    full = run_multisynth(Xy, trt, d, n_leads, n_lags, fixedeff=fixedeff,
+                          time_cohort=time_cohort, nu=nu_used, lam=lam,
+                          solver=solver)
+    tau = np.asarray(full["tau_rel"], dtype=float)
+    groups = full["groups"]
+    t0 = int(np.min(trt[adopted]))
+    T = Xy.shape[1]
+
+    # Under the null every period is fitting data, so the refit balances all T.
+    trt_null = np.full(trt.shape, np.inf)
+    trt_null[adopted] = T
+
+    def _resid(fit, k):
+        g = fit["groups"][k]
+        res = np.asarray(fit["res"][fit["adopt_of"][g]], dtype=float)
+        row = fit["members"][g][0]
+        return res[row] - np.asarray(fit["weights"][g], dtype=float) @ res
+
+    def _pvalue(theta, row, k):
+        adj = Xy.copy()
+        adj[row, t0:t0 + horizon] -= theta
+        f = run_multisynth(adj, trt_null, T, 1, T, fixedeff=fixedeff,
+                           time_cohort=time_cohort, nu=nu_used, lam=lam,
+                           solver=solver)
+        return moving_block_pvalue(_resid(f, k)[:t0 + horizon], block=horizon,
+                                   statistic="mean_abs")
+
+    J = len(groups)
+    point = np.empty(J)
+    lower = np.empty(J)
+    upper = np.empty(J)
+    p_zero = np.empty(J)
+    for k, g in enumerate(groups):
+        row = int(full["members"][g][0])
+        total = float(np.nansum(tau[k, :horizon]))
+        point[k] = total
+        per_period = total / horizon
+        pre = _resid(full, k)[:t0]
+        half = max(float(grid_scale) * float(np.std(pre, ddof=1)), 1e-9)
+        grid = np.linspace(per_period - half, per_period + half, n_nulls)
+        pv = np.array([_pvalue(theta, row, k) for theta in grid], dtype=float)
+        lo, hi = confidence_set_bounds(grid, pv, float(alpha))
+        # An accepted set reaching an end of the grid is bounded by the grid, not
+        # by the data: the test would have gone on accepting had it been asked.
+        # Reporting the endpoint would understate the band by an amount set by
+        # ``grid_scale``, and silently, since it looks like any other number.
+        if np.isfinite(lo) and lo <= grid[0]:
+            lo = -np.inf
+        if np.isfinite(hi) and hi >= grid[-1]:
+            hi = np.inf
+        lower[k], upper[k] = lo * horizon, hi * horizon
+        p_zero[k] = _pvalue(0.0, row, k)
+    return point, lower, upper, p_zero

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1597,3 +1597,45 @@ timeout = 300.0
   find = "    scale = np.sqrt((e.size - 1) / (e.size - b)) if b > 1 else 1.0"
   replace = "    scale = np.sqrt((e.size - b) / (e.size - 1)) if b > 1 else 1.0"
   models = "the factor upside down, so the draw shrinks the block sums a second time instead of restoring them. The band is then narrow by (n - b) / (n - 1) rather than by its square root -- twice the under-coverage the fix exists to remove, and still finite, symmetric and the right shape"
+
+[[target]]
+name = "ppscm-cwz-cumulative"
+module-path = "mlsynth/utils/ppscm_helpers/inference.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_cwz_cumulative.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "null-subtracted-past-the-horizon"
+  find = "        adj[row, t0:t0 + horizon] -= theta"
+  replace = "        adj[row, t0:] -= theta"
+  models = "the candidate null subtracted from every post period instead of the horizon being tested. The band then inverts a test about a longer window than the one it reports, and on a panel whose post-period is exactly the horizon the two coincide, so the defect hides wherever the horizon happens to fill the window"
+
+  [[target.mutant]]
+  id = "band-reported-per-period-not-cumulative"
+  find = "        lower[k], upper[k] = lo * horizon, hi * horizon"
+  replace = "        lower[k], upper[k] = lo, hi"
+  models = "the accepted range of the per-period effect reported as if it were the total. The band is then narrower by a factor of the horizon and sits around a point estimate on the cumulative scale, so it is not merely small but centred wrongly -- and at horizon one the two scales agree, which is where a smoke test would look"
+
+  [[target.mutant]]
+  id = "grid-bounded-end-reported-as-a-number"
+  find = "        if np.isfinite(lo) and lo <= grid[0]:"
+  replace = "        if False and np.isfinite(lo) and lo <= grid[0]:"
+  models = "an accepted set that runs off the low end of the grid reported as if the data had bounded it there. The test would have gone on accepting had it been asked, so the endpoint is an artifact of grid_scale; printed as a number it is indistinguishable from a real bound, and it always errs narrow"
+
+  [[target.mutant]]
+  id = "null-refit-leaves-the-window-out"
+  find = "    trt_null[adopted] = T"
+  replace = "    trt_null[adopted] = t0"
+  models = "the null refit treating the window as post-treatment instead of as fitting data. Under the null the adjusted series is an untreated series, so all of it should balance; leaving the window out puts the trailing block partly outside the fit its reference blocks come from, and the shifts are then no longer exchangeable with it"
+
+  [[target.mutant]]
+  id = "statistic-is-the-block-sum"
+  find = "                                statistic=\"mean_abs\")"
+  replace = "                                statistic=\"abs_sum\")"
+  models = "the absolute block sum in place of the mean absolute residual. The quadratic program leaves end-of-window residuals sign-coherent, so block sums ramp toward the end of the window while magnitudes stay flat and the trailing block always occupies the most inflated position -- the p-value is then driven by where the block sits, not by the effect"
+
+  [[target.mutant]]
+  id = "grid-sized-from-the-treated-window-too"
+  find = "        pre = _resid(full, k)[:t0]"
+  replace = "        pre = _resid(full, k)"
+  models = "the grid half-width sized from residuals that include the treated window. A real effect inflates that spread, so the grid widens exactly when there is something to detect and the band widens with the effect it is measuring -- an interval whose width reports the treatment"


### PR DESCRIPTION
## Related Links

- The band it sits beside: `cumulative_conformal_per_unit` in `mlsynth/utils/ppscm_helpers/inference.py`
- The permutation it inverts: `mlsynth.utils.conformal.moving_block_pvalue`
- Chernozhukov, Wuthrich and Zhu (2021), whose moving-block construction this follows
- Mutation target `ppscm-cwz-cumulative` in `tools/mutation/targets.toml` (6 mutants)
- The limitation it answers is measured in #510
- Follow-up tracked in #512: wiring it into the public API

## What

- `cwz_cumulative_per_unit` in `ppscm_helpers/inference.py`.
- `mlsynth/tests/test_ppscm_cwz_cumulative.py`, 25 tests.
- A six-mutant target.

No existing behaviour changes; this adds a second calibration alongside the split one.

## Why

`cumulative_conformal_per_unit` calibrates on a disjoint split of the pre-period, so its reference set is the window count `m`, roughly `0.7 * T0 / L`. A finite `1 - alpha` band needs `ceil((m + 1)(1 - alpha)) <= m`, which is a floor of about `12.8 * L` pre-periods before any band exists at all.

Past that floor there is a second effect. At whatever level a given `m` just barely supports, the rank equals `m` and the half-width is simply the largest score the calibration saw:

```
T0=120 L= 8: m=10  tightest level 90%  rank 10 of 10
T0=120 L= 4: m=21  tightest level 95%  rank 21 of 21
T0=104 L=13: m= 5  tightest level 80%  rank  5 of  5
T0=156 L= 8: m=13  tightest level 90%  rank 13 of 13
```

The cyclic reference set does not depend on the horizon, so neither the floor nor that regime applies.

## How

The band inverts a moving-block conformal test against the `T` cyclic shifts of the residual path. The price is a shape assumption: test inversion needs a null to subtract, so the null is a constant per-period effect and the band is `horizon` times the accepted range of it. An effect that ramps is outside the null family, and the honest outcome is an empty accepted set, returned as `(nan, nan)`.

Three construction details are decided by measurement, each recorded in the docstring:

- The statistic is the mean absolute residual, not the absolute block sum. The quadratic program leaves end-of-window residuals sign-coherent, so block sums ramp toward the end of the window while magnitudes stay flat, and the trailing block always occupies the most inflated position.
- The null refit balances the whole window. Under the null the adjusted series is an untreated series, so all of it is fitting data; leaving a period out would put the trailing block partly outside the fit its reference blocks come from.
- An accepted set reaching an end of the grid is returned as infinite. That end is set by `grid_scale` and not by the data, and reporting the endpoint would understate the band by an amount that looks like any other number.

## Verification

- Path: cross-validation of the construction against `moving_block_pvalue`, which is itself pinned; and a direct measurement of the claim that motivates it.

At the geometry where the split band cannot reach 95 per cent — 30 markets, 120 pre-weeks, eight-week horizon — over 30 replications:

```
split-conformal : m = 10 windows      finite   0/120
cyclic (CWZ)    : 120 cyclic shifts   finite 118/120   covered 114/118 = 0.966
```

The split band is infinite for every treated unit, `m = 10` against the 19 it needs. The cyclic band is finite for essentially all of them and covers at 0.966 against a nominal 0.95, conservative in the right direction. The two that came back infinite are accepted sets that ran off the grid, correctly reported as unbounded.

The cost is 9.6s per replication against 0.7s, about 14x.

- Pinned durably: 25 tests, and 6 of 6 mutants killed.
- Nothing fails to match.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR

- [x] The default preserves existing behaviour exactly — this adds a function and changes none
- [x] Existing pinned benchmark values unchanged; none moved
- [x] A test pins that the default is unchanged — the split band is untouched and its suites pass
- [ ] New config field has a `Field(...)` description — there is no config field yet, tracked in #512

## Designs

No plotter change; the output is a per-unit interval on the cumulative scale.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_ppscm_cwz_cumulative.py -q` — 25 passed
- [x] `pytest mlsynth/tests/test_mutation_harness.py -q`
- [ ] `pytest mlsynth/tests/` — full suite, running here in CI
- [x] `python tools/mutation/run_mutants.py --target ppscm-cwz-cumulative` — 6/6 killed

## Other Notes

`cwz_cumulative_per_unit` is not reachable from `PPSCM.fit()`. This adds the helper and its tests but no config field and no wiring in `estimators/ppscm.py`, so nothing in the public API can call it. That is deliberate: choosing between a `conformal_method` selector and a second additional object is a public-API call, and the trade-offs are laid out in #512 for it to be decided there rather than settled quietly here.

This work sat unmerged on `claude/ppscm-cwz-band` since 18 August. It applies to current main unchanged and all 25 tests pass, so nothing had rotted. Two things were added on revival: the six-mutant target, which the original had none of, and a fix to a weak assertion it exposed. `test_a_band_reaching_the_grid_edge_is_reported_as_infinite` asserted `any(isinf(lo) | isinf(hi))` — an `or` across both bounds and every unit, so a run where only the upper end escaped satisfied it whatever the lower guard did, and the mutant disabling exactly that branch survived. Each end is now asserted on its own. Seven banned-prose hits were also fixed, including "load-bearing" in the main docstring.
