### PR TITLE
Skip the pull-request benchmark shards when nothing could move a pinned value

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,42 +38,18 @@ on:
     # Eastern in summer (EDT). Runs every day regardless of whether code changed.
     - cron: "0 7 * * *"
   workflow_dispatch:
-  # Every pull request that could move a pinned value runs the pure-Python suite
-  # (see the pr-suite job). The daily run is the full gate; this is the one that
-  # fails a change before it lands. A regression that reaches main is otherwise
-  # invisible until 07:00 UTC.
+  # Every pull request runs the pure-Python suite (see the pr-suite job), which
+  # gates its own shards on a paths filter so a change that cannot move a pinned
+  # value does not pay for them. The daily run is the full gate; the pull-request
+  # one is what fails a change before it lands. A regression that reaches main is
+  # otherwise invisible until 07:00 UTC.
   #
-  # The paths filter exists because pr-suite runs the WHOLE registry, and most
-  # pull requests cannot move a number: a docs page, a workflow edit, a change
-  # confined to the test suite. They were paying for the slowest shard, which has
-  # run past forty minutes here.
-  #
-  # It sits on the trigger, so it gates the workflow and not one job. That is
-  # only safe because every other job in this file already excludes pull requests
-  # through its own `if`, so a filtered-out pull request loses nothing it would
-  # otherwise have run. Adding a job that should run on every pull request means
-  # moving this filter down to the jobs.
-  #
-  # Inside the filter is anything a benchmark case reads: the library, the cases
-  # and their captured references, and the dependency pins that decide which
-  # versions of each get installed. This workflow is in too, so an edit to it
-  # re-validates against the suite it drives. mlsynth/tests is out because no
-  # case imports it -- the references in case docstrings are prose -- and
-  # mlsynth/guides/llms.txt is out because it is generated agent documentation
-  # that no case reads. Which side a path is on is pinned in
-  # benchmarks/tests/test_workflow_sharding.py, so a new directory that cases
-  # read cannot be added without saying so.
+  # The filter is a step inside pr-suite and not a `paths:` here on purpose. A
+  # trigger-level filter stops the whole workflow, so the check never appears on
+  # the pull request at all; gating the step leaves the job reporting success,
+  # which is what a required check would need and what build.yml already does.
   pull_request:
     branches: [main]
-    paths:
-      - 'mlsynth/**'
-      - '!mlsynth/tests/**'
-      - '!mlsynth/guides/llms.txt'
-      - 'benchmarks/**'
-      - 'pyproject.toml'
-      - 'setup.py'
-      - 'constraints.txt'
-      - '.github/workflows/benchmarks.yml'
 
 permissions:
   contents: read
@@ -257,13 +233,43 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e '.[all]' -c benchmarks/constraints.txt
 
+      # The benchmark shards are the slow half of a pull request, and most pull
+      # requests cannot move a pinned value. This is the same dorny/paths-filter
+      # gate build.yml already uses, with the same danger recorded there: a
+      # skipped step reports success, and a skipped success is indistinguishable
+      # from a real one on the pull request page. So the list is asserted in
+      # benchmarks/tests/test_workflow_sharding.py against what a case can read.
+      #
+      # It is build.yml's list minus two trees and one file. mlsynth/tests and
+      # benchmarks/tests are out because the registry loads only benchmarks.cases,
+      # so no case imports either -- the references to test modules in case
+      # docstrings are prose. This workflow is out because its own invariants are
+      # unit tested, and build.yml runs those tests; validating a YAML edit by
+      # running the whole registry is the cost this gate exists to remove.
+      #
+      # basedata is IN and must stay in: 127 case files read fixtures from it.
+      - name: Detect changes that could move a pinned value
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            benchmarked:
+              - 'mlsynth/**'
+              - '!mlsynth/tests/**'
+              - 'benchmarks/**'
+              - '!benchmarks/tests/**'
+              - 'basedata/**'
+              - 'requirements.txt'
+              - 'pyproject.toml'
+
       - name: Run benchmark suite shard
+        if: steps.filter.outputs.benchmarked == 'true'
         run: |
           python -u benchmarks/run_benchmarks.py --all --report \
             --shard "${{ matrix.shard }}" --num-shards "${NUM_SHARDS}"
 
       - name: Upload benchmark report
-        if: always()
+        if: always() && steps.filter.outputs.benchmarked == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: pr-benchmark-report-shard-${{ matrix.shard }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,11 +38,42 @@ on:
     # Eastern in summer (EDT). Runs every day regardless of whether code changed.
     - cron: "0 7 * * *"
   workflow_dispatch:
-  # Every pull request runs the pure-Python suite (see the pr-suite job). The
-  # daily run is the full gate; this is the one that fails a change before it
-  # lands. A regression that reaches main is otherwise invisible until 07:00 UTC.
+  # Every pull request that could move a pinned value runs the pure-Python suite
+  # (see the pr-suite job). The daily run is the full gate; this is the one that
+  # fails a change before it lands. A regression that reaches main is otherwise
+  # invisible until 07:00 UTC.
+  #
+  # The paths filter exists because pr-suite runs the WHOLE registry, and most
+  # pull requests cannot move a number: a docs page, a workflow edit, a change
+  # confined to the test suite. They were paying for the slowest shard, which has
+  # run past forty minutes here.
+  #
+  # It sits on the trigger, so it gates the workflow and not one job. That is
+  # only safe because every other job in this file already excludes pull requests
+  # through its own `if`, so a filtered-out pull request loses nothing it would
+  # otherwise have run. Adding a job that should run on every pull request means
+  # moving this filter down to the jobs.
+  #
+  # Inside the filter is anything a benchmark case reads: the library, the cases
+  # and their captured references, and the dependency pins that decide which
+  # versions of each get installed. This workflow is in too, so an edit to it
+  # re-validates against the suite it drives. mlsynth/tests is out because no
+  # case imports it -- the references in case docstrings are prose -- and
+  # mlsynth/guides/llms.txt is out because it is generated agent documentation
+  # that no case reads. Which side a path is on is pinned in
+  # benchmarks/tests/test_workflow_sharding.py, so a new directory that cases
+  # read cannot be added without saying so.
   pull_request:
     branches: [main]
+    paths:
+      - 'mlsynth/**'
+      - '!mlsynth/tests/**'
+      - '!mlsynth/guides/llms.txt'
+      - 'benchmarks/**'
+      - 'pyproject.toml'
+      - 'setup.py'
+      - 'constraints.txt'
+      - '.github/workflows/benchmarks.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,7 @@ jobs:
               - 'requirements.txt'
               - 'pyproject.toml'
               - '.github/workflows/build.yml'
+              - '.github/workflows/benchmarks.yml'
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -190,6 +191,7 @@ jobs:
               - 'requirements.txt'
               - 'pyproject.toml'
               - '.github/workflows/build.yml'
+              - '.github/workflows/benchmarks.yml'
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/benchmarks/tests/test_workflow_sharding.py
+++ b/benchmarks/tests/test_workflow_sharding.py
@@ -151,85 +151,79 @@ class TestTheTimeoutFitsTheSlowestShard:
         assert jobs["pr-suite"]["timeout-minutes"] >= jobs["suite"]["timeout-minutes"]
 
 
-class TestThePullRequestRunIsScopedToWhatCanMoveANumber:
-    """A path filter, and the reason each entry is on the right side of it.
+class TestTheShardsAreSkippedWhenNothingCouldMoveANumber:
+    """The paths filter on ``pr-suite``, and why each entry is where it is.
 
-    ``pr-suite`` runs the whole case registry on every pull request. Most pull
-    requests cannot move a pinned value: a docs page, a workflow edit, a change
-    confined to the test suite. They still paid for the slowest shard, which has
-    run past forty minutes on this repository.
+    The shards are the slow half of a pull request and most pull requests cannot
+    move a pinned value, so they are gated on a ``dorny/paths-filter`` step --
+    the same mechanism ``build.yml`` uses, asserted here for the same reason
+    ``mlsynth/tests/test_benchmark_reference.py`` gives for that one: a skipped
+    step reports success, and a skipped success is indistinguishable from a real
+    one on the pull request page. Narrowing this list without deleting the
+    dependency it covers is how a case stops being checked without anyone seeing
+    it happen.
 
-    The filter is on the ``pull_request`` trigger, so it gates the workflow and
-    not one job. That is safe here only because every other job in the file is
-    already excluded from pull requests by its own ``if``, so a filtered-out pull
-    request loses nothing that would otherwise have run.
-
-    What has to be inside the filter is anything a benchmark case reads: the
-    library, the cases and their captured references, and the dependency pins
-    that decide which versions of both get installed. The workflow itself is in
-    too, so a change to this file re-validates against the suite it drives.
+    The gate is a step and not a ``paths:`` on the trigger. A trigger-level
+    filter stops the workflow, so the check never appears on the pull request;
+    gating the step leaves the job reporting success.
     """
 
     @staticmethod
     @pytest.fixture(scope="class")
-    def paths(workflow):
-        return workflow["on"]["pull_request"]["paths"]
+    def gate(jobs):
+        steps = jobs["pr-suite"]["steps"]
+        return next(s for s in steps if s.get("id") == "filter")
 
-    def test_the_pull_request_trigger_is_filtered(self, paths):
-        assert paths, "pr-suite runs the full registry; scope it to what can move it"
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def patterns(gate):
+        body = gate["with"]["filters"]
+        return [line.strip().lstrip("- ").strip("'")
+                for line in body.splitlines() if line.strip().startswith("-")]
 
-    @pytest.mark.parametrize("changed", [
-        "mlsynth/utils/conformal/resample.py",   # a shared helper a band is drawn from
-        "mlsynth/estimators/ppscm.py",           # an estimator a case fits
-        "mlsynth/config_models.py",              # a config a case constructs
-        "benchmarks/cases/pda_wheeler_lassosynth.py",   # a case and its pinned values
-        "benchmarks/reference/ascm_mixtape/reference.json",  # a captured reference
-        "benchmarks/run_benchmarks.py",          # the driver
-        "pyproject.toml",                        # the dependency pins
-        ".github/workflows/benchmarks.yml",      # this workflow
-    ])
-    def test_a_change_that_could_move_a_pinned_value_still_runs(self, paths, changed):
-        assert _matches(paths, changed), changed
+    def test_the_gate_uses_the_same_action_build_yml_does(self, gate):
+        assert gate["uses"].startswith("dorny/paths-filter@")
 
-    @pytest.mark.parametrize("changed", [
-        "docs/ppscm.rst",                        # prose
-        "docs/index.rst",
-        "README.md",
-        "CLAUDE.md",
-        "agents/agents_tests.md",
-        "mlsynth/tests/test_ppscm.py",           # nothing imports the test suite
-        "mlsynth/guides/llms.txt",               # generated agent docs, read by no case
-        ".github/workflows/build.yml",           # a different workflow
-    ])
-    def test_a_change_that_cannot_move_one_does_not(self, paths, changed):
-        assert not _matches(paths, changed), changed
+    def test_the_expensive_step_is_the_one_gated(self, jobs):
+        run = next(s for s in jobs["pr-suite"]["steps"]
+                   if s["name"] == "Run benchmark suite shard")
+        assert run["if"] == "steps.filter.outputs.benchmarked == 'true'"
 
-    def test_a_mixed_change_still_runs(self, paths):
-        """One qualifying file is enough; the filter is any-match, not all-match."""
-        assert _matches(paths, "mlsynth/utils/datautils.py")
-        assert not _matches(paths, "docs/choose.rst")
+    def test_the_trigger_itself_is_not_filtered(self, workflow):
+        """A trigger-level filter would remove the check instead of passing it."""
+        assert "paths" not in workflow["on"]["pull_request"]
 
-    def test_the_daily_run_is_not_filtered(self, workflow):
-        """The schedule is the full gate and must not inherit the PR's scope."""
-        schedule = workflow["on"]["schedule"]
-        assert schedule and all("paths" not in entry for entry in schedule)
+    @pytest.mark.parametrize("directory", ["mlsynth/**", "benchmarks/**",
+                                           "basedata/**"])
+    def test_a_directory_a_case_reads_is_covered(self, patterns, directory):
+        assert directory in patterns
 
+    def test_basedata_is_covered_because_the_cases_read_it(self, patterns):
+        """127 case files load fixtures from it; omitting it was the first bug here."""
+        from pathlib import Path
+        cases = Path(__file__).resolve().parents[1] / "cases"
+        readers = sum("basedata" in f.read_text() for f in cases.glob("*.py"))
+        assert readers > 50, readers
+        assert "basedata/**" in patterns
 
-def _matches(patterns, path: str) -> bool:
-    """GitHub's path filter: later negations override earlier matches.
+    @pytest.mark.parametrize("excluded", ["!mlsynth/tests/**",
+                                          "!benchmarks/tests/**"])
+    def test_a_test_tree_no_case_imports_is_excluded(self, patterns, excluded):
+        assert excluded in patterns
 
-    A leading ``!`` excludes. Patterns are evaluated in order and the last one to
-    match decides, so ``mlsynth/**`` followed by ``!mlsynth/tests/**`` includes
-    the library and excludes its test suite.
-    """
-    import fnmatch
+    def test_the_registry_really_loads_only_cases(self):
+        """The claim the two exclusions rest on, checked and not assumed."""
+        from benchmarks import registry
+        assert {m.split(".")[1] for m in registry.CASES.values()} == {"cases"}
 
-    verdict = False
-    for pattern in patterns:
-        negated = pattern.startswith("!")
-        glob = pattern[1:] if negated else pattern
-        # GitHub's ** spans separators; fnmatch's * does not, so translate.
-        if fnmatch.fnmatch(path, glob) or (
-                glob.endswith("/**") and path.startswith(glob[:-2])):
-            verdict = not negated
-    return verdict
+    def test_the_dependency_pins_are_covered(self, patterns):
+        """They decide which versions a case gets installed against."""
+        assert "requirements.txt" in patterns and "pyproject.toml" in patterns
+
+    def test_every_listed_path_exists(self, patterns):
+        """A pattern naming nothing is a filter entry that can never fire."""
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[2]
+        for pattern in patterns:
+            head = pattern.lstrip("!").split("*")[0].rstrip("/")
+            assert (root / head).exists(), pattern

--- a/benchmarks/tests/test_workflow_sharding.py
+++ b/benchmarks/tests/test_workflow_sharding.py
@@ -149,3 +149,87 @@ class TestTheTimeoutFitsTheSlowestShard:
         per-shard work is lower -- never give it a tighter cap than the run
         that is known to complete."""
         assert jobs["pr-suite"]["timeout-minutes"] >= jobs["suite"]["timeout-minutes"]
+
+
+class TestThePullRequestRunIsScopedToWhatCanMoveANumber:
+    """A path filter, and the reason each entry is on the right side of it.
+
+    ``pr-suite`` runs the whole case registry on every pull request. Most pull
+    requests cannot move a pinned value: a docs page, a workflow edit, a change
+    confined to the test suite. They still paid for the slowest shard, which has
+    run past forty minutes on this repository.
+
+    The filter is on the ``pull_request`` trigger, so it gates the workflow and
+    not one job. That is safe here only because every other job in the file is
+    already excluded from pull requests by its own ``if``, so a filtered-out pull
+    request loses nothing that would otherwise have run.
+
+    What has to be inside the filter is anything a benchmark case reads: the
+    library, the cases and their captured references, and the dependency pins
+    that decide which versions of both get installed. The workflow itself is in
+    too, so a change to this file re-validates against the suite it drives.
+    """
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def paths(workflow):
+        return workflow["on"]["pull_request"]["paths"]
+
+    def test_the_pull_request_trigger_is_filtered(self, paths):
+        assert paths, "pr-suite runs the full registry; scope it to what can move it"
+
+    @pytest.mark.parametrize("changed", [
+        "mlsynth/utils/conformal/resample.py",   # a shared helper a band is drawn from
+        "mlsynth/estimators/ppscm.py",           # an estimator a case fits
+        "mlsynth/config_models.py",              # a config a case constructs
+        "benchmarks/cases/pda_wheeler_lassosynth.py",   # a case and its pinned values
+        "benchmarks/reference/ascm_mixtape/reference.json",  # a captured reference
+        "benchmarks/run_benchmarks.py",          # the driver
+        "pyproject.toml",                        # the dependency pins
+        ".github/workflows/benchmarks.yml",      # this workflow
+    ])
+    def test_a_change_that_could_move_a_pinned_value_still_runs(self, paths, changed):
+        assert _matches(paths, changed), changed
+
+    @pytest.mark.parametrize("changed", [
+        "docs/ppscm.rst",                        # prose
+        "docs/index.rst",
+        "README.md",
+        "CLAUDE.md",
+        "agents/agents_tests.md",
+        "mlsynth/tests/test_ppscm.py",           # nothing imports the test suite
+        "mlsynth/guides/llms.txt",               # generated agent docs, read by no case
+        ".github/workflows/build.yml",           # a different workflow
+    ])
+    def test_a_change_that_cannot_move_one_does_not(self, paths, changed):
+        assert not _matches(paths, changed), changed
+
+    def test_a_mixed_change_still_runs(self, paths):
+        """One qualifying file is enough; the filter is any-match, not all-match."""
+        assert _matches(paths, "mlsynth/utils/datautils.py")
+        assert not _matches(paths, "docs/choose.rst")
+
+    def test_the_daily_run_is_not_filtered(self, workflow):
+        """The schedule is the full gate and must not inherit the PR's scope."""
+        schedule = workflow["on"]["schedule"]
+        assert schedule and all("paths" not in entry for entry in schedule)
+
+
+def _matches(patterns, path: str) -> bool:
+    """GitHub's path filter: later negations override earlier matches.
+
+    A leading ``!`` excludes. Patterns are evaluated in order and the last one to
+    match decides, so ``mlsynth/**`` followed by ``!mlsynth/tests/**`` includes
+    the library and excludes its test suite.
+    """
+    import fnmatch
+
+    verdict = False
+    for pattern in patterns:
+        negated = pattern.startswith("!")
+        glob = pattern[1:] if negated else pattern
+        # GitHub's ** spans separators; fnmatch's * does not, so translate.
+        if fnmatch.fnmatch(path, glob) or (
+                glob.endswith("/**") and path.startswith(glob[:-2])):
+            verdict = not negated
+    return verdict

--- a/mlsynth/tests/test_benchmark_reference.py
+++ b/mlsynth/tests/test_benchmark_reference.py
@@ -61,6 +61,16 @@ class TestCIRunsWhenTheSuiteCanBreak:
         assert blocks, "could not locate any paths-filter block in build.yml"
         return [set(re.findall(r"-\s*'([^']+)'", b)) for b in blocks]
 
+    def test_a_benchmarks_workflow_edit_still_runs_the_unit_tests(self):
+        """benchmarks.yml gates its shards on its own filter, so a change to it
+        skips them. The invariants that gate rests on -- the shard count, which
+        jobs a pull request may run -- are asserted in
+        benchmarks/tests/test_workflow_sharding.py, which runs here. Without this
+        entry a pull request touching only benchmarks.yml would skip both, and
+        nothing would check it at all."""
+        for block in self._filter_blocks():
+            assert ".github/workflows/benchmarks.yml" in block
+
     def test_the_workflow_still_has_the_two_filter_copies(self):
         """If a copy is added or removed, re-read the test below before trusting it."""
         assert len(self._filter_blocks()) == 2


### PR DESCRIPTION
## Related Links

- The workflow: `.github/workflows/benchmarks.yml`
- The pattern this copies: the `dorny/paths-filter` gate in `.github/workflows/build.yml`
- The test that guards that gate, and now guards this one too: `mlsynth/tests/test_benchmark_reference.py`
- This workflow's other invariants: `benchmarks/tests/test_workflow_sharding.py`

## What

- A `dorny/paths-filter` step in `pr-suite`, gating the benchmark shard and its report upload.
- `.github/workflows/benchmarks.yml` added to `build.yml`'s existing filter.
- 12 tests on the new gate, and 1 on the coupling between the two workflows.

No job logic changes and the daily run is untouched.

## Why

`pr-suite` runs the whole case registry on every pull request. Most pull requests cannot move a pinned value — a docs page, a workflow edit, a change confined to the test suite — and they still paid for the slowest shard, which has run past forty minutes here.

A naming point, since it is what made this hard to see. The workflow is called "Daily benchmark validation" and every check run it produces is labelled with that name, so a pull request looks like it is running the daily benchmark. It is not: the four daily jobs each carry `if: github.event_name != 'pull_request'` and report as `skipped`. What runs is `pr-suite`, a separate job sharing the file. But that distinction does not matter to someone watching the benchmark cases execute on their pull request, which is exactly what was happening.

## How

The gate is a step, not a `paths:` on the trigger. A trigger-level filter stops the whole workflow, so the check disappears from the pull request instead of passing; gating the step leaves the job reporting success, which is what a required check would need. This is the mechanism `build.yml` already uses, and copying it was the right move over inventing one.

```yaml
benchmarked:
  - 'mlsynth/**'
  - '!mlsynth/tests/**'
  - 'benchmarks/**'
  - '!benchmarks/tests/**'
  - 'basedata/**'
  - 'requirements.txt'
  - 'pyproject.toml'
```

That is `build.yml`'s list minus two test trees. The exclusions rest on a claim that is checked rather than assumed: `registry.CASES` resolves entirely under `benchmarks.cases`, so no case imports either tree — the references to test modules in case docstrings are prose. A test asserts it, so if the registry ever loads from elsewhere the exclusion fails rather than going stale.

`.github/workflows/benchmarks.yml` is deliberately not in its own filter, and is added to `build.yml`'s instead. The invariants a shard-count edit needs checked — that the matrix and `NUM_SHARDS` agree, that the shards partition the registry — are unit tested in `test_workflow_sharding.py`, which `build.yml` runs in seconds. Validating a YAML edit by running the whole registry is the cost this gate exists to remove. Without the `build.yml` entry, a pull request touching only this file would have skipped both and been checked by nothing, so a test pins the coupling.

## Verification

- Path: not applicable, no numerical code changes.

Replayed against the last thirteen merges to `main`, using the files each actually changed: 12 would run, 1 would skip (#506, a test file and a mutation target). The saving is small, and that is the honest headline — most work here does touch `mlsynth` or `benchmarks`. What it removes is the case this pull request is itself an instance of: a change to CI configuration and its tests, which under the first version of this branch still fanned out across eight shards.

- Pinned durably: 12 tests in `benchmarks/tests/test_workflow_sharding.py` covering the action used, which step is gated, that the trigger is not filtered, that each directory a case reads is present, that each excluded tree is excluded, that the registry really loads only cases, and that no listed path names something that does not exist. Plus 1 in `mlsynth/tests/test_benchmark_reference.py` for the `build.yml` coupling.
- 131 tests pass across both suites on current `main`.

## Scope checks

None of the four blocks fits — CI configuration and its tests, no source change. The branch carries only this.

## Designs

No visual output.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest benchmarks/tests/ mlsynth/tests/test_benchmark_reference.py -q` — 131 passed
- [x] The workflow parses; `on.schedule` and `on.pull_request` are unchanged
- [x] The filter replayed over the last thirteen merges
- [x] The filter replayed over this pull request's own file set — all four files skip

## Other Notes

**The first version of this branch was wrong three ways, and the second commit replaces it.** Recording them because two are the kind of mistake that would otherwise be repeated:

It omitted `basedata/**`, which 127 case files read fixtures from. A change to a data file would have skipped the suite that validates it — which is the failure `test_benchmark_reference.py` already records happening once, to the pull request that added the Song benchmark. Writing a filter with the same hole the repository already has a test guarding against is the substantive error here.

It listed `setup.py` and `constraints.txt`, neither of which exists in this repository.

And it filtered the trigger rather than the step, which removes the check from the pull request instead of passing it, and diverges from the pattern already in the tree.

**No status check is required on `main`.** I checked before touching this, because a required check that never runs leaves a pull request waiting forever. The evidence is that #508 reported `mergeable_state: "unstable"` while `pr-suite (1)` was still in flight; a pending required check reports `blocked`. The step-level gate makes this moot going forward — the job reports success either way — which is one more reason it is the better mechanism.

**This pull request will not run the benchmark shards**, by its own filter. So the evidence that the filter is correct is the 131 unit tests and the thirteen-merge replay, not a green benchmark run on this branch.

Selecting cases from the diff instead of running `--all` would save the most and is deliberately not here. A case whose dependency you failed to map stops being checked without saying so, which is the same failure mode as the `basedata` omission above, at a larger scale.
