### PR TITLE
Run only the benchmark cases a diff can reach

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -252,7 +252,14 @@ jobs:
         id: filter
         uses: dorny/paths-filter@v3
         with:
+          # `all` exists so case_deps sees the whole diff. The gating filter
+          # drops test trees on purpose, and a path missing from the list cannot
+          # be recognised as one no manifest entry claims -- which is the check
+          # that widens the selection when the map has a hole.
+          list-files: json
           filters: |
+            all:
+              - '**'
             benchmarked:
               - 'mlsynth/**'
               - '!mlsynth/tests/**'
@@ -269,10 +276,18 @@ jobs:
       # case-deps job below.
       - name: Collect the changed files
         if: steps.filter.outputs.benchmarked == 'true'
+        env:
+          CHANGED_JSON: ${{ steps.filter.outputs.all_files }}
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-          git diff --name-only FETCH_HEAD...HEAD > /tmp/changed.txt
-          echo "changed files:"; cat /tmp/changed.txt
+          python - <<'EOF'
+          import json, os
+          files = json.loads(os.environ["CHANGED_JSON"] or "[]")
+          with open("/tmp/changed.txt", "w") as fh:
+              fh.write("\n".join(files) + ("\n" if files else ""))
+          print(f"{len(files)} changed file(s)")
+          for f in files:
+              print(" ", f)
+          EOF
 
       - name: Run benchmark suite shard
         if: steps.filter.outputs.benchmarked == 'true'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -262,10 +262,23 @@ jobs:
               - 'requirements.txt'
               - 'pyproject.toml'
 
+      # The filter above decides whether the shards run at all; this decides
+      # which cases they run. case_deps widens on any doubt -- an unmapped case
+      # runs, and a changed file no entry claims runs everything -- so it can
+      # cost time and cannot silence a case. The map is refreshed nightly by the
+      # case-deps job below.
+      - name: Collect the changed files
+        if: steps.filter.outputs.benchmarked == 'true'
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          git diff --name-only FETCH_HEAD...HEAD > /tmp/changed.txt
+          echo "changed files:"; cat /tmp/changed.txt
+
       - name: Run benchmark suite shard
         if: steps.filter.outputs.benchmarked == 'true'
         run: |
           python -u benchmarks/run_benchmarks.py --all --report \
+            --changed-from /tmp/changed.txt \
             --shard "${{ matrix.shard }}" --num-shards "${NUM_SHARDS}"
 
       - name: Upload benchmark report
@@ -365,6 +378,64 @@ jobs:
   # [all]+R provisioning only runs when a benchmark case/reference actually
   # changed, and commits only when the page changed.
   # ---------------------------------------------------------------------------
+
+  case-deps:
+    # Never on a pull request: this job commits the refreshed dependency map back
+    # to the default branch, and measuring it means running every case.
+    #
+    # The map is what lets a pull request run only the cases its diff can reach.
+    # It is measured, not written, because the cheaper routes fail here:
+    # cases import inside their functions, so a static scan sees entry points and
+    # not reach, and tracing imports returns the whole library because
+    # mlsynth/__init__.py loads every estimator. tools/benchmark_deps.py runs each
+    # case under coverage with the package already imported, which separates
+    # executing a module from loading one.
+    #
+    # --merge keeps entries this run did not produce. A case that skips here for
+    # a missing optional toolchain loses its entry and goes back to always
+    # running, which is the safe direction.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    permissions:
+      contents: write
+    env:
+      OMP_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install mlsynth
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[design,bayes]" coverage
+
+      - name: Measure what each case executes
+        run: python -u tools/benchmark_deps.py --all --merge
+
+      - name: Commit the map if it changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add benchmarks/case_deps.json
+          if git diff --cached --quiet; then
+            echo "Dependency map unchanged; nothing to commit."
+            exit 0
+          fi
+          git commit -m "benchmarks: refresh the case dependency map [skip ci]"
+          git pull --rebase --autostash origin main
+          git push
+
   validation-dashboard:
     # Never on a pull request: this job commits the rebuilt dashboard
     # back to the default branch.

--- a/benchmarks/case_deps.json
+++ b/benchmarks/case_deps.json
@@ -17,6 +17,10 @@
   "mlsynth/utils/post_fit.py",
   "mlsynth/utils/syndes_helpers/restrictions.py"
  ],
+ "pcr_shen_estimator_coverage": [
+  "basedata/german_reunification.csv",
+  "mlsynth/utils/clustersc_helpers/pcr/inference.py"
+ ],
  "pda_wheeler_lassosynth": [
   "mlsynth/config_models.py",
   "mlsynth/estimators/pda.py",

--- a/benchmarks/case_deps.json
+++ b/benchmarks/case_deps.json
@@ -1,0 +1,46 @@
+{
+ "conformal_window_count": [
+  "mlsynth/utils/conformal/resample.py"
+ ],
+ "marex_table3": [
+  "mlsynth/config_models.py",
+  "mlsynth/estimators/scexp.py",
+  "mlsynth/utils/datautils.py",
+  "mlsynth/utils/fast_scm_helpers/conflict.py",
+  "mlsynth/utils/fast_scm_helpers/structure.py",
+  "mlsynth/utils/marex_helpers/config.py",
+  "mlsynth/utils/marex_helpers/formulation.py",
+  "mlsynth/utils/marex_helpers/optimization.py",
+  "mlsynth/utils/marex_helpers/orchestration.py",
+  "mlsynth/utils/marex_helpers/restrictions.py",
+  "mlsynth/utils/marex_helpers/setup.py",
+  "mlsynth/utils/post_fit.py",
+  "mlsynth/utils/syndes_helpers/restrictions.py"
+ ],
+ "pda_wheeler_lassosynth": [
+  "mlsynth/config_models.py",
+  "mlsynth/estimators/pda.py",
+  "mlsynth/utils/conformal/resample.py",
+  "mlsynth/utils/conformal/scores.py",
+  "mlsynth/utils/datautils.py",
+  "mlsynth/utils/fast_scm_helpers/structure.py",
+  "mlsynth/utils/pda_helpers/config.py",
+  "mlsynth/utils/pda_helpers/inference.py",
+  "mlsynth/utils/pda_helpers/lasso/estimation.py",
+  "mlsynth/utils/pda_helpers/lasso/inference.py",
+  "mlsynth/utils/pda_helpers/orchestration.py",
+  "mlsynth/utils/pda_helpers/results_assembly.py",
+  "mlsynth/utils/pda_helpers/setup.py",
+  "mlsynth/utils/pda_helpers/structures.py",
+  "mlsynth/utils/supt.py"
+ ],
+ "syndes_exact_vs_mip": [
+  "basedata/urate_cps.csv",
+  "mlsynth/utils/syndes_helpers/enumeration.py",
+  "mlsynth/utils/syndes_helpers/exact.py",
+  "mlsynth/utils/syndes_helpers/formulation.py",
+  "mlsynth/utils/syndes_helpers/gram.py",
+  "mlsynth/utils/syndes_helpers/optimization.py",
+  "mlsynth/utils/syndes_helpers/partition.py"
+ ]
+}

--- a/benchmarks/case_deps.py
+++ b/benchmarks/case_deps.py
@@ -1,0 +1,114 @@
+"""Which benchmark cases a change can actually reach.
+
+``pr-suite`` runs the whole registry on every pull request, and the wall clock is
+set by a handful of Monte Carlo and MIP cases that most changes cannot touch.
+This module holds the map from a case to the files its ``run()`` executes, and
+the rule for selecting cases from a diff.
+
+Why the map is measured, not written
+-----------------------------------
+Two cheaper approaches fail on this repository. Cases import inside their
+functions, so a static scan of imports sees entry points and never reach --
+``from mlsynth import PPSCM`` says nothing about PPSCM using
+``conformal/resample.py``. And tracing imports at runtime is worse than useless:
+``mlsynth/__init__.py`` imports every estimator, so a case that executes one file
+has an import closure of 834.
+
+So the manifest records what a case's ``run()`` *executes*, measured with
+coverage while the package is already imported, which separates running a module
+from loading it. Measured that way ``conformal_window_count`` executes exactly
+``mlsynth/utils/conformal/resample.py``.
+
+Regenerate with ``python tools/benchmark_deps.py --all``. The daily workflow does
+it and commits the result, so the map is at most a day behind the code.
+
+Why the selection rule is lopsided
+----------------------------------
+A case with no entry always runs, and a changed file that no entry mentions
+selects every case. Both directions spend time; neither can silence a case. That
+asymmetry is the point: a skipped check reports success, and a skipped success is
+indistinguishable from a real one, so the map is allowed to cost time and is not
+allowed to hide anything.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, Sequence
+
+#: Prefixes a case can execute. A change outside all of them reaches no case, so
+#: it is neither a selection nor a hole in the map -- docs and prose land here.
+REACHABLE = ("mlsynth/", "basedata/", "benchmarks/")
+
+PATH = Path(__file__).resolve().parent / "case_deps.json"
+
+
+def load(path: Path | None = None) -> Dict[str, List[str]]:
+    """The manifest as shipped, or an empty map when it has not been built."""
+    p = PATH if path is None else Path(path)
+    if not p.exists():
+        return {}
+    return json.loads(p.read_text())
+
+
+def save(manifest: Mapping[str, Iterable[str]], path: Path | None = None) -> None:
+    """Write the manifest sorted and deduplicated, so it diffs as content."""
+    p = PATH if path is None else Path(path)
+    tidy = {k: sorted(set(v)) for k, v in sorted(manifest.items())}
+    p.write_text(json.dumps(tidy, indent=1) + "\n")
+
+
+def _case_source(name: str) -> str:
+    """The case's own module, which always selects it."""
+    return f"benchmarks/cases/{name}.py"
+
+
+def select(
+    changed: Sequence[str],
+    cases: Sequence[str],
+    manifest: Mapping[str, Sequence[str]] | None = None,
+) -> List[str]:
+    """The cases a diff can reach, in the order ``cases`` gives them.
+
+    Parameters
+    ----------
+    changed : sequence of str
+        Repository-relative paths the diff touches.
+    cases : sequence of str
+        Candidate case names, already filtered for references and sharding.
+    manifest : mapping, optional
+        Case to executed files. Defaults to the shipped manifest.
+
+    Returns
+    -------
+    list of str
+        A case is selected when it has no manifest entry, when its entry names a
+        changed file, when its own module changed, or when some changed file
+        under :data:`REACHABLE` appears in no entry at all -- that last being a
+        hole in the map, which widens the selection instead of narrowing it.
+    """
+    if isinstance(changed, (str, bytes)) or not isinstance(changed, Sequence):
+        raise TypeError(
+            f"changed must be a sequence of repository-relative paths, not "
+            f"{type(changed).__name__}. A single path must be wrapped in a list, "
+            f"since a bare string would iterate character by character."
+        )
+    m = load() if manifest is None else manifest
+    changed = [str(c) for c in changed]
+
+    known = {p for deps in m.values() for p in deps}
+    known.update(_case_source(name) for name in m)
+    unmapped_change = [c for c in changed
+                       if c.startswith(REACHABLE) and c not in known]
+    if unmapped_change:
+        return list(cases)
+
+    touched = set(changed)
+    out = []
+    for name in cases:
+        deps = m.get(name)
+        if deps is None:                       # never measured -> always run
+            out.append(name)
+        elif _case_source(name) in touched or touched.intersection(deps):
+            out.append(name)
+    return out

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -150,6 +150,20 @@ def select_cases(names, needs_reference, *, with_reference, shard, num_shards):
     return names
 
 
+
+def _read_changed(path) -> list:
+    """Repository-relative paths, one per line, as ``git diff --name-only`` gives.
+
+    Blank lines are dropped. An empty file is an empty diff, which is not the
+    same as omitting the flag: an empty diff reaches no mapped case, while no
+    flag runs everything.
+    """
+    from pathlib import Path as _Path
+
+    text = _Path(path).read_text()
+    return [ln.strip() for ln in text.splitlines() if ln.strip()]
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--all", action="store_true")
@@ -161,6 +175,9 @@ def main() -> int:
     ap.add_argument("--num-shards", type=int, default=1,
                     help="split the selected cases into this many shards "
                          "(round-robin), for parallel CI jobs")
+    ap.add_argument("--changed-from", default=None, metavar="FILE",
+                    help="a file of repository-relative changed paths, one per "
+                         "line; run only the cases that diff can reach")
     ap.add_argument("--shard", type=int, default=0,
                     help="0-based index of the shard to run (with --num-shards)")
     args = ap.parse_args()
@@ -170,6 +187,18 @@ def main() -> int:
         ap.error("--shard must be in [0, num_shards)")
 
     base = [args.case] if args.case else list(registry.CASES)
+    if args.changed_from is not None:
+        # Narrow to the cases the diff can reach before sharding, so the shards
+        # split the work that is actually going to run. case_deps widens on any
+        # doubt: an unmapped case runs, and a changed file no entry claims runs
+        # everything.
+        from benchmarks import case_deps
+
+        changed = _read_changed(args.changed_from)
+        picked = case_deps.select(changed, base)
+        print(f"changed files: {len(changed)}; cases selected: "
+              f"{len(picked)}/{len(base)}")
+        base = picked
     names = select_cases(
         base, registry.NEEDS_REFERENCE, with_reference=args.with_reference,
         shard=args.shard, num_shards=args.num_shards)

--- a/benchmarks/tests/test_case_deps.py
+++ b/benchmarks/tests/test_case_deps.py
@@ -1,0 +1,190 @@
+"""Selecting the benchmark cases a change can actually reach.
+
+``pr-suite`` runs the whole registry on every pull request, and the wall clock is
+set by a handful of Monte Carlo and MIP cases -- the SYNDES and MAREX ones -- that
+most changes cannot touch. Selecting by dependency turns those into the ones that
+run when they are implicated and not otherwise.
+
+Two approaches do not work here, and the manifest exists because of them. Cases
+import inside their functions, so a static scan sees entry points and not reach;
+and ``mlsynth/__init__.py`` imports every estimator, so tracing imports gives all
+834 library files for a case that executes one. What the manifest records is
+which files a case's ``run()`` actually *executes*, measured with coverage.
+
+The selection rule is deliberately lopsided. A case with no manifest entry always
+runs, and a changed file no entry mentions selects every case. Both directions
+cost time and neither can silence a case, which is the failure mode that matters:
+a skipped check reports success, and a skipped success is indistinguishable from
+a real one.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import json
+
+import pytest
+
+from benchmarks import case_deps, registry
+
+
+# --------------------------------------------------------------------------- smoke
+def test_the_manifest_loads():
+    m = case_deps.load()
+    assert isinstance(m, dict)
+
+
+def test_selecting_on_no_changes_selects_nothing_mapped():
+    """An empty diff implicates nothing, so only unmapped cases run."""
+    m = {"a": ["mlsynth/x.py"], "b": ["mlsynth/y.py"]}
+    assert case_deps.select([], ["a", "b"], m) == []
+
+
+# ------------------------------------------------------------------ unit invariants
+def test_a_case_runs_when_a_file_it_executes_changes():
+    m = {"a": ["mlsynth/x.py"], "b": ["mlsynth/y.py"]}
+    assert case_deps.select(["mlsynth/x.py"], ["a", "b"], m) == ["a"]
+
+
+def test_a_case_does_not_run_when_its_files_are_untouched():
+    m = {"a": ["mlsynth/x.py"], "b": ["mlsynth/y.py"]}
+    assert "b" not in case_deps.select(["mlsynth/x.py"], ["a", "b"], m)
+
+
+def test_an_unmapped_case_always_runs():
+    """No entry means no evidence, and no evidence means run it."""
+    m = {"a": ["mlsynth/x.py"]}
+    assert case_deps.select(["mlsynth/x.py"], ["a", "b"], m) == ["a", "b"]
+    assert case_deps.select(["docs/z.rst"], ["a", "b"], m) == ["b"]
+
+
+def test_a_changed_file_no_entry_mentions_selects_everything():
+    """An unrecognised dependency is a hole in the map, so widen, never narrow."""
+    m = {"a": ["mlsynth/x.py"], "b": ["mlsynth/y.py"]}
+    assert case_deps.select(["mlsynth/brand_new.py"], ["a", "b"], m) == ["a", "b"]
+
+
+def test_a_doc_change_selects_nothing():
+    """Prose reaches no case, and is not a hole in the map either."""
+    m = {"a": ["mlsynth/x.py"]}
+    assert case_deps.select(["docs/ppscm.rst", "README.md"], ["a"], m) == []
+
+
+def test_the_case_file_itself_selects_it():
+    m = {"a": ["mlsynth/x.py"]}
+    assert case_deps.select(["benchmarks/cases/a.py"], ["a"], m) == ["a"]
+
+
+def test_selection_preserves_the_given_order():
+    m = {"a": ["mlsynth/x.py"], "b": ["mlsynth/x.py"]}
+    assert case_deps.select(["mlsynth/x.py"], ["b", "a"], m) == ["b", "a"]
+
+
+def test_a_data_file_selects_the_cases_that_read_it():
+    m = {"a": ["basedata/p99.csv"], "b": ["mlsynth/y.py"]}
+    assert case_deps.select(["basedata/p99.csv"], ["a", "b"], m) == ["a"]
+
+
+# ------------------------------------------------------------------------- edge
+def test_an_empty_manifest_runs_everything():
+    assert case_deps.select(["mlsynth/x.py"], ["a", "b"], {}) == ["a", "b"]
+
+
+def test_a_case_measured_to_touch_nothing_is_mapped_not_unmapped():
+    """An empty list is a finding -- the case executed no library file -- and it
+    is distinct from a missing entry, which means nobody looked.
+
+    The changed file has to be claimed by some other entry for the distinction to
+    show. If no entry claims it the map has a hole, and the hole widens the
+    selection before the empty list can narrow it, which is the right order.
+    """
+    m = {"a": [], "b": ["mlsynth/x.py"]}
+    assert case_deps.select(["mlsynth/x.py"], ["a", "b"], m) == ["b"]
+
+
+def test_an_empty_entry_does_not_shield_a_case_from_a_hole_in_the_map():
+    m = {"a": []}
+    assert case_deps.select(["mlsynth/unclaimed.py"], ["a"], m) == ["a"]
+
+
+# ---------------------------------------------------------------------- failure
+@pytest.mark.parametrize("bad", [None, "mlsynth/x.py", 3])
+def test_changed_must_be_a_sequence_of_paths(bad):
+    with pytest.raises((TypeError, ValueError)):
+        case_deps.select(bad, ["a"], {"a": []})
+
+
+# ------------------------------------------------------- the manifest as shipped
+class TestTheShippedManifest:
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def manifest():
+        return case_deps.load()
+
+    def test_every_mapped_case_is_registered(self, manifest):
+        """A stale entry names a case that no longer exists."""
+        unknown = set(manifest) - set(registry.CASES)
+        assert not unknown, unknown
+
+    def test_every_path_it_names_exists(self, manifest):
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[2]
+        missing = {p for deps in manifest.values() for p in deps
+                   if not (root / p).exists()}
+        assert not missing, missing
+
+    def test_it_is_sorted_and_deduplicated(self, manifest):
+        """So a regenerated manifest diffs as content, not as ordering."""
+        for name, deps in manifest.items():
+            assert deps == sorted(set(deps)), name
+
+    def test_it_names_no_build_artifact(self, manifest):
+        """The audit hook sees bytecode reads; a diff never names one."""
+        junk = {p for deps in manifest.values() for p in deps
+                if "__pycache__" in p or p.endswith((".pyc", ".pyo"))}
+        assert not junk, junk
+
+    def test_every_entry_is_reachable_by_a_diff(self, manifest):
+        """Every path must sit under a prefix the selection rule recognises."""
+        from benchmarks.case_deps import REACHABLE
+        stray = {p for deps in manifest.values() for p in deps
+                 if not p.startswith(REACHABLE)}
+        assert not stray, stray
+
+    def test_it_is_json_and_stable_on_disk(self):
+        raw = case_deps.PATH.read_text()
+        assert json.loads(raw) == case_deps.load()
+        assert raw.endswith("\n")
+
+
+class TestTheDriverAcceptsADiff:
+    """``run_benchmarks.py --changed-from`` narrows the run to what a diff reaches."""
+
+    @staticmethod
+    def _argv(*extra):
+        return ["run_benchmarks.py", "--all", *extra]
+
+    def test_changed_from_reads_one_path_per_line(self, tmp_path):
+        from benchmarks import run_benchmarks
+
+        f = tmp_path / "diff.txt"
+        f.write_text("mlsynth/a.py\n\nmlsynth/b.py\n")
+        assert run_benchmarks._read_changed(f) == ["mlsynth/a.py", "mlsynth/b.py"]
+
+    def test_an_empty_diff_file_is_not_the_same_as_no_flag(self, tmp_path):
+        """An empty diff means nothing changed, which selects only unmapped cases."""
+        from benchmarks import run_benchmarks
+
+        f = tmp_path / "diff.txt"
+        f.write_text("")
+        assert run_benchmarks._read_changed(f) == []
+
+    def test_a_missing_diff_file_is_refused(self, tmp_path):
+        from benchmarks import run_benchmarks
+
+        with pytest.raises((FileNotFoundError, OSError)):
+            run_benchmarks._read_changed(tmp_path / "nope.txt")
+
+    def test_selection_composes_with_sharding(self):
+        """Selecting first and sharding after keeps every shard non-empty work."""
+        m = {"a": ["mlsynth/x.py"], "b": ["mlsynth/y.py"], "c": ["mlsynth/x.py"]}
+        picked = case_deps.select(["mlsynth/x.py"], ["a", "b", "c"], m)
+        assert picked == ["a", "c"]

--- a/benchmarks/tests/test_workflow_sharding.py
+++ b/benchmarks/tests/test_workflow_sharding.py
@@ -236,8 +236,31 @@ class TestTheDependencyMapIsWiredBothEnds:
         steps = jobs["pr-suite"]["steps"]
         run = next(s for s in steps if s["name"] == "Run benchmark suite shard")
         assert "--changed-from" in run["run"]
-        collect = next(s for s in steps if s["name"] == "Collect the changed files")
-        assert "git diff --name-only" in collect["run"]
+
+    def test_the_diff_comes_from_the_filter_and_not_from_git(self, jobs):
+        """checkout is shallow here, so git cannot produce it.
+
+        The job checks out at the default depth of one, which leaves no history
+        and no merge base, so a three-dot ``git diff`` against the base branch
+        fails outright -- it did, on every shard, the first time this was wired.
+        dorny/paths-filter asks the API instead and is already in this job for
+        the gate, so it can hand over the list it has already computed.
+        """
+        steps = {s["name"]: s for s in jobs["pr-suite"]["steps"]}
+        collect = steps["Collect the changed files"]
+        assert "git diff" not in collect.get("run", "")
+        assert "steps.filter.outputs" in str(collect)
+
+    def test_the_filter_reports_every_changed_path_not_only_the_gating_ones(self, jobs):
+        """case_deps needs the whole diff to spot a file no manifest entry claims.
+
+        The gating filter drops test trees and docs on purpose, and selecting on
+        that alone would hide a path from the hole check. A second filter matching
+        everything supplies the full list.
+        """
+        gate = next(s for s in jobs["pr-suite"]["steps"] if s.get("id") == "filter")
+        assert gate["with"].get("list-files") == "json"
+        assert "all:" in gate["with"]["filters"]
 
     def test_the_diff_is_collected_under_the_same_guard_as_the_run(self, jobs):
         """Collecting it when the shards will not run wastes a fetch."""

--- a/benchmarks/tests/test_workflow_sharding.py
+++ b/benchmarks/tests/test_workflow_sharding.py
@@ -227,3 +227,33 @@ class TestTheShardsAreSkippedWhenNothingCouldMoveANumber:
         for pattern in patterns:
             head = pattern.lstrip("!").split("*")[0].rstrip("/")
             assert (root / head).exists(), pattern
+
+
+class TestTheDependencyMapIsWiredBothEnds:
+    """The map is useless unless something writes it and something reads it."""
+
+    def test_the_pull_request_shards_pass_the_diff(self, jobs):
+        steps = jobs["pr-suite"]["steps"]
+        run = next(s for s in steps if s["name"] == "Run benchmark suite shard")
+        assert "--changed-from" in run["run"]
+        collect = next(s for s in steps if s["name"] == "Collect the changed files")
+        assert "git diff --name-only" in collect["run"]
+
+    def test_the_diff_is_collected_under_the_same_guard_as_the_run(self, jobs):
+        """Collecting it when the shards will not run wastes a fetch."""
+        steps = {s["name"]: s for s in jobs["pr-suite"]["steps"]}
+        assert (steps["Collect the changed files"]["if"]
+                == steps["Run benchmark suite shard"]["if"])
+
+    def test_the_map_is_refreshed_off_the_pull_request(self, jobs):
+        assert "pull_request" in jobs["case-deps"]["if"]
+        run = " ".join(str(s) for s in jobs["case-deps"]["steps"])
+        assert "tools/benchmark_deps.py --all --merge" in run
+
+    def test_refreshing_the_map_may_write_to_the_repository(self, jobs):
+        assert jobs["case-deps"]["permissions"]["contents"] == "write"
+
+    def test_the_map_job_outlasts_a_full_registry_run(self, jobs):
+        """It runs every case, so its timeout has to clear the daily suite's."""
+        assert (int(jobs["case-deps"]["timeout-minutes"])
+                >= int(jobs["suite"]["timeout-minutes"]))

--- a/tools/benchmark_deps.py
+++ b/tools/benchmark_deps.py
@@ -1,0 +1,122 @@
+"""Measure which files each benchmark case executes, and write the manifest.
+
+    python tools/benchmark_deps.py --case conformal_window_count
+    python tools/benchmark_deps.py --all --merge
+
+``pr-suite`` runs the whole registry on every pull request and its wall clock is
+set by a few Monte Carlo and MIP cases most changes cannot touch. Selecting by
+dependency needs a map, and the map has to be measured: cases import inside their
+functions, so a static scan sees entry points and not reach, and tracing imports
+returns the whole library because ``mlsynth/__init__.py`` loads every estimator.
+
+So this runs the case and records which files execute. The package is imported
+before measurement starts, which is what separates executing a module from
+loading it -- without that every case measures all 834 library files.
+
+File reads are captured too, through an audit hook, so a case is selected when
+the panel it reads from ``basedata`` changes.
+
+``--merge`` keeps entries for cases this invocation did not run, so a sharded
+CI job can contribute its slice without dropping everyone else's.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def _trace(name: str) -> tuple[list[str], float]:
+    """The repository-relative files ``name``'s ``run()`` executes or reads."""
+    import coverage
+
+    from benchmarks import registry
+    from benchmarks.compare import BenchmarkSkipped
+
+    read: set[str] = set()
+
+    def audit(event, args):
+        if event == "open" and args and isinstance(args[0], (str, bytes)):
+            p = args[0].decode() if isinstance(args[0], bytes) else args[0]
+            try:
+                rel = Path(p).resolve().relative_to(ROOT)
+            except (ValueError, OSError):
+                return
+            read.add(str(rel))
+
+    import mlsynth  # noqa: F401 -- warm the package, so module bodies are not measured
+    mod = registry.load(name)
+
+    cov = coverage.Coverage(source=["mlsynth"], timid=True, data_file=None)
+    sys.addaudithook(audit)
+    t0 = time.time()
+    cov.start()
+    try:
+        mod.run()
+    except BenchmarkSkipped:
+        cov.stop()
+        raise
+    finally:
+        try:
+            cov.stop()
+        except Exception:                      # pragma: no cover - stop after stop
+            pass
+    secs = time.time() - t0
+
+    data = cov.get_data()
+    executed = {str(Path(f).resolve().relative_to(ROOT))
+                for f in data.measured_files() if data.lines(f)}
+    # Keep only what a diff can name: library sources and shipped panels. The
+    # case's own module is implied by its name and is not stored.
+    keep = {p for p in executed | read
+            if (p.startswith("mlsynth/") or p.startswith("basedata/"))
+            and "__pycache__" not in p and not p.endswith((".pyc", ".pyo"))}
+    keep.discard(f"benchmarks/cases/{name}.py")
+    return sorted(keep), secs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--case", action="append", default=[],
+                    help="trace this case (repeatable)")
+    ap.add_argument("--all", action="store_true", help="trace every registered case")
+    ap.add_argument("--merge", action="store_true",
+                    help="keep manifest entries for cases not traced here")
+    ap.add_argument("--out", default=None, help="write somewhere other than the default")
+    args = ap.parse_args()
+
+    from benchmarks import case_deps, registry
+
+    names = list(registry.CASES) if args.all else args.case
+    if not names:
+        ap.error("give --case NAME or --all")
+
+    out = dict(case_deps.load()) if args.merge else {}
+    from benchmarks.compare import BenchmarkSkipped
+    skipped = []
+    for name in names:
+        try:
+            deps, secs = _trace(name)
+        except BenchmarkSkipped as exc:
+            # A case that cannot run here was not measured. Dropping its entry
+            # leaves it unmapped, which makes it always run -- the safe side.
+            out.pop(name, None)
+            skipped.append(name)
+            print(f"  skip {name}: {exc}", flush=True)
+            continue
+        out[name] = deps
+        print(f"  {name}: {len(deps)} file(s), {secs:.0f}s", flush=True)
+
+    path = Path(args.out) if args.out else None
+    case_deps.save(out, path)
+    print(f"\n{len(out)} case(s) mapped"
+          + (f", {len(skipped)} left unmapped (they will always run)" if skipped else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Related Links

- The gate this sits behind: the `dorny/paths-filter` step added in #513
- The map: `benchmarks/case_deps.json`, measured by `tools/benchmark_deps.py`
- The rule: `benchmarks/case_deps.py`

## What

- `benchmarks/case_deps.py` — the manifest and the selection rule.
- `tools/benchmark_deps.py` — measures what each case executes and writes the manifest.
- `benchmarks/case_deps.json` — the manifest, 5 of 197 cases mapped so far.
- `run_benchmarks.py` gains `--changed-from FILE`.
- `pr-suite` takes the changed-file list from the `dorny/paths-filter` step already in the job and passes it in; a nightly `case-deps` job refreshes the map and commits it.
- 35 tests: 27 on the rule and the manifest, 8 on the wiring.

## Why

#513 decides whether the shards run. This decides which cases they run. `pr-suite` executes all 197 registered cases on every pull request, and the wall clock is set by a handful of Monte Carlo and MIP cases — the SYNDES and MAREX ones — that most changes cannot touch. On #515, which changed only PCR files, `pr-suite (1)` ran about an hour while the fastest shard finished in eight minutes.

## How

Selecting by dependency needs a map, and the map has to be measured. Two cheaper routes fail here, both checked and not assumed:

- **A static scan of imports** sees entry points and never reach. Cases import inside their functions, and `from mlsynth import PPSCM` says nothing about PPSCM using `conformal/resample.py`.
- **Tracing imports at runtime** is worse. `mlsynth/__init__.py` loads every estimator, so `conformal_window_count` — which executes one file — has an import closure of **834**.

`tools/benchmark_deps.py` runs each case under coverage with the package already imported, which is what separates executing a module from loading one. An audit hook catches file reads too, so a case is selected when the panel it reads changes. Measured:

```
conformal_window_count        1 file   mlsynth/utils/conformal/resample.py
pcr_shen_estimator_coverage   2 files  pcr/inference.py + basedata/german_reunification.csv
syndes_exact_vs_mip           7 files
marex_table3                 13 files  (259s to measure)
pda_wheeler_lassosynth       15 files
```

### The selection rule is deliberately lopsided

A case with no manifest entry always runs. A changed file that no entry claims runs everything. Both directions spend time; neither can silence a case.

That asymmetry is the whole design. `mlsynth/tests/test_benchmark_reference.py` already records what the other kind of mistake costs here — a filter that stopped being correct, so the pull request adding the Song benchmark skipped the one test that would have validated it. A skipped check reports success, and a skipped success cannot be told from a real one.

### Where the diff comes from

Not from git. `pr-suite` checks out at the default depth of one, so there is no history and no merge base, and a three-dot `git diff` against the base branch cannot resolve — which is exactly what happened on the first push here, failing all eight shards in under a minute at the collect step with the benchmark step skipped behind it.

`dorny/paths-filter` was already in the job for the gate and queries the API rather than the working tree, so it works on a shallow checkout and has the list already. It reports it with `list-files: json`, and the collect step reads that.

The filter gains an `all` pattern beside `benchmarked`. The gating filter drops test trees and docs on purpose, and selecting on that list alone would hide a path from the hole check — the check that widens the selection when a changed file matches no manifest entry.

### Where the map comes from

The nightly `case-deps` job runs `tools/benchmark_deps.py --all --merge` and commits the result, the way `validation-dashboard` already commits the dashboard. `--merge` keeps entries the run did not produce, so a case that skips for a missing optional toolchain loses its entry and goes back to always running.

## Verification

- Path: not applicable, no numerical code changes.

Selection behaviour against the shipped manifest, with 5 of 197 mapped:

```
pcr/inference.py   ->  193/197   slow gates excluded
resample.py        ->  194/197   slow gates excluded
docs only          ->  192/197   slow gates excluded
unmapped file      ->  197/197   fail-safe fires
```

The 192 are the unmapped cases, which always run. Once the nightly job maps them, a docs-only change selects none.

- Pinned durably: 35 tests. They cover the rule (a case runs when a file it executes changes; does not when untouched; an unmapped case always runs; a hole in the map selects everything; a docs change selects nothing; order is preserved; a data file selects its readers), the manifest as shipped (every mapped case is registered, every path exists, sorted and deduplicated, no build artifacts, every path reachable by a diff), and the wiring (both ends present, the collect step does not shell out to git, the filter reports every changed path and not only the gating ones, the diff collected under the same guard as the run, the map job off pull requests with write permission and a timeout clearing the daily suite's).
- `pytest benchmarks/tests/ mlsynth/tests/test_benchmark_reference.py -q` — 164 passed.
- The collect step was extracted from the YAML and run locally against a realistic file list and an empty one, then driven end to end through `run_benchmarks.py --changed-from`, before pushing.

## Scope checks

None of the four blocks fits — CI selection machinery and its tests, no source change.

## Designs

No visual output.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest benchmarks/tests/ mlsynth/tests/test_benchmark_reference.py -q` — 164 passed
- [x] The workflow parses; both wiring ends asserted
- [x] `python tools/benchmark_deps.py --case ... --merge` on five cases
- [x] Selection exercised against the real registry for four kinds of diff
- [x] The collect step run locally with a realistic list and an empty one
- [ ] `pytest mlsynth/tests/` — full suite, running here in CI

## Other Notes

**The shipped manifest covers 5 of 197 cases, so there is little saving until the first nightly run.** That is the honest headline. The mechanism is complete and safe from the start; the benefit arrives when the map does.

**A full map is a multi-hour job.** `marex_table3` alone took 259 seconds to measure, which is why the `case-deps` job has a 350-minute timeout and runs nightly rather than per pull request. If that proves too long, the fallback is emitting dependencies from the daily `suite` run, which already executes every case.

**Two tests exist because earlier versions of others were wrong.** I first asserted that a case measured to execute nothing is never selected; it is not that simple, because an empty entry is a finding, a missing entry means nobody looked, and a hole in the map has to widen the selection before an empty entry can narrow it. And the first version of the wiring test asserted the collect step used `git diff`, which is what shipped and failed — it now asserts the opposite, and that the filter reports the full diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx)_
