### PR TITLE
Refuse a jackknife that never deletes a treated unit

### DIFF
--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -408,6 +408,31 @@ for the overall ATT and each relative-time horizon, with Wald intervals.
 ``inference_method="bootstrap"`` swaps in augsynth's default Mammen wild
 bootstrap, which reweights the single fit instead of refitting.
 
+What the jackknife varies, and what it therefore prices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Dropping a control and dropping a treated unit are not the same experiment.
+Removing a control moves the synthetic counterfactual a little. Removing a
+treated unit removes one of the few draws the effect is averaged over, and that
+is the sampling variability of the pooled estimand. A jackknife ensemble made
+entirely of control deletions measures donor substitution.
+
+That distinction bites with a single treated unit. Deleting it leaves no treated
+unit, so the estimator cannot be refit and the replicate is skipped: every
+survivor is a control deletion, and the reported standard error cannot be moved
+by the treated unit's own outcomes at all. Raising a planted effect from 2.0 to
+52.0 on such a panel moves the ATT by 50 and leaves the standard error
+bit-identical.
+
+``PPSCM`` therefore refuses instead of reporting that number. The refusal names
+how many replicates were admitted and how many removed a treated unit, so the
+distinction is visible in the message. Two treated units give one treated
+deletion, which is a thin ensemble but not a vacuous one, and it is allowed.
+
+With one treated unit, reach for an inference method that does not rest on
+deleting treated units --- ``inference_method="bootstrap"`` reweights a single
+fit --- or report the point estimate without an interval.
+
 Analytical standard errors under the Callaway-Sant'Anna conventions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mlsynth/tests/test_ppscm_jackknife_treated_deletions.py
+++ b/mlsynth/tests/test_ppscm_jackknife_treated_deletions.py
@@ -1,0 +1,117 @@
+"""What the delete-one jackknife varies, and what it therefore prices.
+
+``jackknife_inference`` deletes every unit in turn and admits a replicate
+whenever the remainder still has a treated and a control unit. With one treated
+unit, deleting it leaves no treated unit, so that replicate is skipped and every
+survivor is a control deletion. The guard counts survivors, so it passes, and a
+standard error is reported that the treated unit's own data cannot move.
+
+The two deletions are not the same quantity. Removing a control moves the
+synthetic counterfactual a little. Removing a treated unit removes one of the few
+draws the effect is averaged over, and that is the sampling variability of the
+pooled estimand. An ensemble with none of the second measures donor substitution.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthEstimationError
+from mlsynth.utils.ppscm_helpers.engine import run_multisynth
+from mlsynth.utils.ppscm_helpers.inference import jackknife_inference
+
+
+def _panel(n_treated, n_control=8, T0=30, H=6, effect=2.0, seed=0):
+    """A factor panel with ``n_treated`` treated units and a planted effect."""
+    rng = np.random.default_rng(seed)
+    n, T = n_treated + n_control, T0 + H
+    factor = np.cumsum(rng.normal(0.0, 1.0, T))
+    Xy = np.array([rng.normal(5.0, 1.0) + rng.uniform(0.5, 1.5) * factor
+                   + rng.normal(0.0, 0.3, T) for _ in range(n)])
+    Xy[:n_treated, T0:] += effect
+    trt = np.full(n, np.inf)
+    trt[:n_treated] = T0
+    return Xy, trt, T0, H
+
+
+def _call(Xy, trt, T0, H, **kw):
+    full = run_multisynth(Xy, trt, T0, H, T0, fixedeff=True, time_cohort=False,
+                          nu=0.5, lam=0.0, solver=None)
+    base = dict(d=T0, n_leads=H, n_lags=T0, fixedeff=True, time_cohort=False,
+                nu_used=0.5, lam=0.0, solver=None, alpha=0.05,
+                per_time_full=np.asarray(full["per_time"], dtype=float),
+                att_full=float(full["att"]))
+    base.update(kw)
+    return jackknife_inference(Xy, trt, **base)
+
+
+# --------------------------------------------------------------------------- smoke
+def test_two_treated_units_still_report_a_standard_error():
+    """The ensemble then contains a treated deletion, which is what is needed."""
+    att, se, ci, per_se, per_ci = _call(*_panel(n_treated=2))
+    assert np.isfinite(se) and se > 0.0
+    assert ci[0] <= att <= ci[1]
+
+
+# ------------------------------------------------------------------ unit invariants
+def test_the_standard_error_moves_when_a_treated_unit_moves():
+    """The defect this file exists for, stated positively.
+
+    With a treated deletion in the ensemble, changing a treated unit's
+    post-period changes the spread of the leave-one-out effects. Without one it
+    cannot, since no replicate ever removes a treated unit.
+    """
+    Xy, trt, T0, H = _panel(n_treated=2, effect=2.0)
+    _, se_small, *_ = _call(Xy, trt, T0, H)
+    Xy2 = Xy.copy()
+    Xy2[0, T0:] += 50.0
+    _, se_large, *_ = _call(Xy2, trt, T0, H)
+    assert not np.isclose(se_small, se_large), (se_small, se_large)
+
+
+def test_deleting_a_control_and_deleting_a_treated_unit_are_different():
+    """Both admit replicates, but only one varies the estimand's own draws."""
+    Xy, trt, T0, H = _panel(n_treated=3)
+    n = Xy.shape[0]
+    treated_deletions = [i for i in range(n)
+                         if np.isfinite(np.delete(trt, i)).any()
+                         and not np.isfinite(np.delete(trt, i)).all()
+                         and np.isfinite(trt[i])]
+    assert treated_deletions, "expected the ensemble to contain treated deletions"
+
+
+# ------------------------------------------------------------------------- edge
+def test_two_treated_units_leave_exactly_one_treated_deletion():
+    """The thinnest ensemble that is not vacuous; it is allowed."""
+    Xy, trt, T0, H = _panel(n_treated=2)
+    _, se, *_ = _call(Xy, trt, T0, H)
+    assert np.isfinite(se)
+
+
+# ---------------------------------------------------------------------- failure
+def test_one_treated_unit_is_refused():
+    """No replicate removes the treated unit, so there is nothing to report."""
+    Xy, trt, T0, H = _panel(n_treated=1)
+    with pytest.raises(MlsynthEstimationError, match="treated"):
+        _call(Xy, trt, T0, H)
+
+
+def test_the_refusal_says_what_the_ensemble_was_measuring():
+    Xy, trt, T0, H = _panel(n_treated=1)
+    with pytest.raises(MlsynthEstimationError) as exc:
+        _call(Xy, trt, T0, H)
+    message = str(exc.value)
+    assert "donor substitution" in message
+    assert "1 treated unit" in message or "one treated unit" in message
+
+
+def test_the_refusal_is_not_reached_by_the_old_usable_guard():
+    """The old guard counted survivors, so it passed here with eight of them.
+
+    Asserting the count keeps the two guards distinguishable: a future change
+    that restores survivor-counting would satisfy the raise but not this.
+    """
+    Xy, trt, T0, H = _panel(n_treated=1, n_control=8)
+    with pytest.raises(MlsynthEstimationError) as exc:
+        _call(Xy, trt, T0, H)
+    assert "0 " in str(exc.value) or "no " in str(exc.value).lower()

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -277,6 +277,16 @@ def jackknife_inference(
     # NaN on would trip ``run_multisynth``'s finiteness guard on every replicate.
     nu_refit = float(nu_used) if np.isfinite(nu_used) else None
 
+    # Which replicates removed a treated unit, as opposed to a control. The two
+    # are different quantities: deleting a control moves the synthetic
+    # counterfactual a little, deleting a treated unit removes one of the few
+    # draws the effect is averaged over, and only the second is the sampling
+    # variability of the pooled estimand. This is recorded from the loop and not
+    # derived from ``trt`` afterwards, because a treated refit can also raise and
+    # be skipped -- which rows are present is not which units are treated.
+    treated_loo = np.zeros(n, dtype=bool)
+    was_treated = np.isfinite(trt)
+
     for i in range(n):
         keep = np.ones(n, dtype=bool); keep[i] = False
         trt_i = trt[keep]
@@ -291,6 +301,7 @@ def jackknife_inference(
         except Exception:
             continue
         att_loo[i] = fit_i["att"]
+        treated_loo[i] = bool(was_treated[i])
         pt = fit_i["per_time"]
         pt_loo[i, : len(pt)] = pt
 
@@ -308,6 +319,20 @@ def jackknife_inference(
             f"out of {n} units; at least 2 are needed for a standard error. Every "
             "leave-one-out refit raised, so there is no inference to report -- "
             "returning NaN here is what hid #467.")
+    n_treated_loo = int(treated_loo.sum())
+    if n_treated_loo == 0:
+        n_treated = int(was_treated.sum())
+        raise MlsynthEstimationError(
+            f"the delete-one jackknife admitted {usable} replicate(s), and none of "
+            f"them removed a treated unit; the panel has "
+            f"{n_treated} treated unit{'' if n_treated == 1 else 's'}. Every "
+            "replicate is a control deletion, so the spread being measured is "
+            "donor substitution and not the sampling variability of the effect -- "
+            "the treated unit's own outcomes cannot move the standard error at "
+            "all. With a single treated unit its deletion leaves no treated unit "
+            "and is skipped, which is why counting usable replicates does not "
+            "catch this. Use an inference method that does not rest on deleting "
+            "treated units, or report the point estimate without an interval.")
     se = _se(att_loo)
     per_time_se = np.array([_se(pt_loo[:, h]) for h in range(H)])
     z = float(norm.ppf(1.0 - alpha / 2.0))

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1693,3 +1693,27 @@ timeout = 900.0
   find = "        pre = _resid(full, k)[:t0]"
   replace = "        pre = _resid(full, k)"
   models = "the grid half-width sized from residuals that include the treated window. A real effect inflates that spread, so the grid widens exactly when there is something to detect and the band widens with the effect it is measuring -- an interval whose width reports the treatment"
+
+[[target]]
+name = "ppscm-jackknife-treated-deletions"
+module-path = "mlsynth/utils/ppscm_helpers/inference.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_jackknife_treated_deletions.py -q -p no:cacheprovider"
+timeout = 600.0
+
+  [[target.mutant]]
+  id = "treated-deletions-never-counted"
+  find = "        treated_loo[i] = bool(was_treated[i])"
+  replace = "        treated_loo[i] = True"
+  models = "every admitted replicate counted as a treated deletion, which is the pre-fix state wearing the new guard's clothes. The count is then the survivor count the old guard already used, so a single-treated panel passes again and reports a standard error its treated unit cannot move. Nothing about the number looks wrong -- it is finite, positive, and brackets the point estimate"
+
+  [[target.mutant]]
+  id = "treated-mask-read-from-trt-not-the-loop"
+  find = "        treated_loo[i] = bool(was_treated[i])"
+  replace = "        pass"
+  models = "the mask left empty in the loop, so the guard fires on every panel including ones with many treated units. A refusal that never lifts is at least visible, unlike the defect it replaces, but it removes jackknife inference from PPSCM entirely"
+
+  [[target.mutant]]
+  id = "guard-accepts-a-single-treated-deletion-as-none"
+  find = "    if n_treated_loo == 0:"
+  replace = "    if n_treated_loo < 0:"
+  models = "the guard made unreachable while still appearing to exist. Two treated units, the thinnest ensemble that is not vacuous, still work either way, so only a single-treated panel distinguishes this from the fix -- which is exactly the case the guard was written for"


### PR DESCRIPTION
Closes #517.

## Related Links

- Issue: #517
- Source: `mlsynth/utils/ppscm_helpers/inference.py::jackknife_inference`
- Mutation target `ppscm-jackknife-treated-deletions` (3 mutants)
- Docs: the new "What the jackknife varies, and what it therefore prices" section in `docs/ppscm.rst`

## What

- The jackknife records which admitted replicates removed a treated unit, and refuses when none did.
- `mlsynth/tests/test_ppscm_jackknife_treated_deletions.py`, 7 tests.
- A three-mutant target.
- `docs/ppscm.rst` says what the jackknife varies.

## Why — this reported a number that could not be moved by the data it claimed to price

`jackknife_inference` deletes every unit in turn and admits a replicate whenever the remainder still has a treated and a control unit. With one treated unit, deleting it leaves no treated unit, so that replicate is skipped and every survivor is a control deletion. The guard counted survivors, so it passed comfortably.

Measured before the fix — one treated unit, eight controls, planted effect raised from 2.0 to 52.0:

```
att  1.9793 -> 51.9793   (moves, as it must)
se   0.112034 -> 0.112034   (identical)
ci width 0.439165 -> 0.439165
```

A twenty-five-fold change in the treated unit's post-period leaves the reported uncertainty bit-identical. That is the clearest statement of what the number was measuring.

Deleting a control moves the synthetic counterfactual a little. Deleting a treated unit removes one of the few draws the effect is averaged over, and only the second is the sampling variability of the pooled estimand.

## How

The loop records which admitted replicates removed a treated unit; the guard tests that count rather than the total.

The mask is written in the loop and not derived from `trt` afterwards, because a treated refit can also raise and be skipped — which rows are present is not the same question as which units are treated. That distinction is one of the three mutants.

With no treated deletion, the fit raises `MlsynthEstimationError` naming both counts and pointing at the bootstrap, which reweights a single fit and does not rest on deleting treated units.

Two treated units give one treated deletion. Thin, but not vacuous, and allowed.

## Verification

- Path: not a paper replication. This is a bug fix that turns a reported number into a refusal; it changes no fit that already had a treated deletion in its ensemble.
- Red to green: 3 of the 7 tests fail without the change.
- The invariance above is asserted positively — with a treated deletion present, moving a treated unit's post-period must move the standard error.
- 254 tests across every PPSCM suite still pass. No existing test ran a single-treated panel through the jackknife, which is why nothing caught this.
- The public path was checked, not just the helper: `PPSCM(..., inference_method="jackknife")` on a one-treated panel raises a translated `MlsynthEstimationError`; on a two-treated panel it returns `se = 0.373893`.
- Mutation: 3/3 killed.
- No pinned benchmark value moves.

## Scope checks

BUG FIX

- [x] A test reproduces the defect and fails without the fix
- [x] It asserts the correct behaviour — that the standard error responds to the treated unit — not merely the absence of a crash
- [x] No docs page, docstring or comment still states the old behaviour; `docs/ppscm.rst` gains a section saying what the jackknife varies
- [x] No pinned value moved

## Designs

No plotter change; the output is a refusal where a standard error used to be.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_ppscm_jackknife_treated_deletions.py -q` — 7 passed
- [x] Every PPSCM suite — 254 passed, 15 skipped
- [x] `pytest mlsynth/tests/test_mutation_harness.py -q`
- [x] `python tools/mutation/run_mutants.py --target ppscm-jackknife-treated-deletions` — 3/3 killed
- [x] The public `PPSCM.fit()` path checked at one and two treated units
- [x] RST underlines checked
- [ ] `pytest mlsynth/tests/` — full suite, running here in CI

## Other Notes

**This is a behaviour change for single-treated-unit panels.** They previously received a standard error and now receive a refusal. That is the point — the number was not inference — but it will be visible to anyone fitting that shape with `inference_method="jackknife"`, which is the ordinary geo-lift and single-market case. The message names the alternative rather than leaving the caller stuck.

**Anything downstream inherits the guard**, including the per-horizon standard errors, the replicate paths, and any cumulative band built on them. That is correct: a cumulative band assembled from control deletions has the same defect at every horizon.

**Not in scope:** choosing a replacement interval for the single-treated case. Refusing is correct and sufficient; whether PPSCM should offer something else in that shape is a separate question, and the issue says so.

#518 is the other half of what was found in `ppscm_helpers` and is independent of this.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx)_