### PR TITLE
Solve PPSCM's program at the scale its tolerances assume

### DIFF
--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -127,6 +127,22 @@ pooled SCM.
    :math:`\nu = \text{global\_l2}\cdot\sqrt{T_0}/\text{avg\_l2}`
    from the separate fit; a float fixes it.
 
+The program is posed on residuals divided by a power of two that brings them to
+unit magnitude, and the answer is read back in the caller's units. Synthetic
+control is scale-equivariant, so this leaves the estimand alone: multiplying
+every series by a constant leaves the weights where they were and scales the
+effect with them. What it changes is what the solver is asked for. The separate
+fit normalizes by one, because it is the fit that produces
+:math:`\text{norm}_{\text{pool}}` and :math:`\text{norm}_{\text{sep}}`, so its
+objective carries the square of whatever units the outcome happens to be in,
+while the solver's convergence test is an absolute tolerance. On a panel running
+at :math:`10^5` that fit takes twenty times as long as the identical problem at
+unit scale, and past about :math:`10^3` it stops converging at all and a fallback
+solver answers to a looser standard. The divisor is the median absolute
+residual: stage 1 has already removed the level, and a panel of markets spans an
+order of magnitude in size, so the typical residual and not the largest sets the
+scale. Residuals already within :math:`2^3` of unit magnitude are left alone.
+
 Assumptions / Remarks.
 
 *Assumption 1 (no anticipation, parallel residual trends).* After removing the

--- a/mlsynth/tests/test_ppscm_solve_conditioning.py
+++ b/mlsynth/tests/test_ppscm_solve_conditioning.py
@@ -1,0 +1,214 @@
+"""The partially-pooled program is solved at the scale its tolerances assume.
+
+``solve_cohort_qp`` asks OSQP for ``eps_abs=1e-8``. That is an absolute
+demand, so what it costs depends on the units the caller's outcome happens to
+be measured in. Synthetic control is scale-equivariant -- multiplying every
+series by a constant leaves the weights alone and scales the effect with them
+-- so any dependence of the answer on the panel's magnitude is an artefact of
+the solver, and these tests pin it out.
+
+The separate fit is the one that breaks. It normalizes by ``1.0`` (it is the
+fit that produces the norms the pooled fit uses), so its objective grows with
+the square of the panel's magnitude, and past about 1e3 OSQP returns nothing
+at all and the SCS fallback answers a different question. The pooled fit
+divides by norms carrying the same units, so its objective was already
+dimensionless.
+"""
+
+import numpy as np
+import pytest
+
+from mlsynth.utils.ppscm_helpers.engine import (
+    run_multisynth,
+    solve_cohort_qp,
+    solve_scale,
+)
+
+
+def staggered_panel(seed=7, n_donor=40, n_treat=6, T0=100, H=8, effect=0.5):
+    """Factor-model panel with one adoption date: donors, then treated."""
+    rng = np.random.default_rng(seed)
+    n, T = n_donor + n_treat, T0 + H
+    F = rng.normal(size=(T, 3)).cumsum(axis=0) / np.sqrt(T)
+    L = rng.normal(size=(n, 3))
+    Y = L @ F.T + rng.normal(scale=0.3, size=(n, T)) + 5.0
+    trt = np.full(n, np.inf)
+    trt[n_donor:] = T0
+    Y[n_donor:, T0:] += effect
+    return Y, trt, H
+
+
+def fit(Y, trt, H, **kw):
+    return run_multisynth(Y, trt, d=20, n_leads=H, n_lags=20, **kw)
+
+
+# --- solve_scale: the summary itself -----------------------------------------
+
+def test_a_unit_scale_residual_is_left_alone():
+    rng = np.random.default_rng(0)
+    res = {5: rng.normal(size=(20, 30))}
+    assert solve_scale(res) == 1.0
+
+
+def test_the_scale_is_a_power_of_two():
+    rng = np.random.default_rng(0)
+    for level in (1e3, 1e5, 1e-6, 2.0 ** 40):
+        s = solve_scale({5: rng.normal(size=(20, 30)) * level})
+        assert s > 0.0
+        assert np.log2(s) == int(np.log2(s)), (level, s)
+
+
+def test_dividing_by_the_scale_and_multiplying_back_is_exact():
+    rng = np.random.default_rng(1)
+    x = rng.normal(size=(20, 30)) * 1e5
+    s = solve_scale({5: x})
+    assert s != 1.0
+    assert np.array_equal((x / s) * s, x)
+
+
+def test_the_scale_lands_within_a_factor_of_two_of_the_typical_residual():
+    rng = np.random.default_rng(2)
+    x = rng.normal(size=(20, 30)) * 2.0 ** 20
+    assert solve_scale({5: x}) == pytest.approx(float(np.median(np.abs(x))), rel=0.5)
+
+
+def test_one_very_large_market_does_not_set_the_scale():
+    """A panel of markets spans an order of magnitude in size, so the divisor
+    is the typical residual and not the biggest one: reading it off the
+    largest would push every other market's residuals far below the tolerance
+    the solver is working to."""
+    rng = np.random.default_rng(2)
+    x = rng.normal(size=(20, 30))
+    x[0, 0] = 1e6
+    assert solve_scale({5: x}) == 1.0
+
+
+def test_a_degenerate_residual_gets_unit_scale():
+    assert solve_scale({}) == 1.0
+    assert solve_scale({5: np.zeros((4, 5))}) == 1.0
+    assert solve_scale({5: np.full((4, 5), np.nan)}) == 1.0
+
+
+# --- equivariance of the fit --------------------------------------------------
+
+@pytest.mark.parametrize("level", [1e3, 1e5])
+def test_the_effect_scales_with_the_panel(level):
+    Y, trt, H = staggered_panel()
+    base = fit(Y, trt, H)["att"]
+    scaled = fit(Y * level, trt, H)["att"] / level
+    assert scaled == pytest.approx(base, rel=1e-8)
+
+
+def test_the_weights_do_not_move_with_the_panels_magnitude():
+    Y, trt, H = staggered_panel()
+    base = fit(Y, trt, H)["weights"]
+    scaled = fit(Y * 1e5, trt, H)["weights"]
+    assert set(base) == set(scaled)
+    for g in base:
+        assert np.allclose(base[g], scaled[g], atol=1e-7)
+
+
+def test_the_event_study_scales_with_the_panel():
+    Y, trt, H = staggered_panel()
+    base = np.asarray(fit(Y, trt, H)["per_time"], dtype=float)
+    scaled = np.asarray(fit(Y * 1e5, trt, H)["per_time"], dtype=float) / 1e5
+    assert np.allclose(scaled, base, rtol=1e-8, atol=1e-10)
+
+
+def _tiny_program(seed=11, n=6, T=12, tj=8):
+    """One cohort of two treated units and four donors, in residual space."""
+    rng = np.random.default_rng(seed)
+    res = {tj: rng.normal(size=(n, T))}
+    groups = [tj]
+    return dict(
+        res=res, groups=groups, adopt_of={tj: tj},
+        members={tj: [0, 1]}, donors={tj: np.array([2, 3, 4, 5])},
+        n1=np.array([2.0]), d=tj, n=n, n_lags=tj,
+    )
+
+
+def _solve(p, nu, norm_pool, norm_sep, lam, divisor=1.0):
+    res = {k: v / divisor for k, v in p["res"].items()}
+    return solve_cohort_qp(res, p["groups"], p["adopt_of"], p["members"],
+                           p["donors"], p["n1"], p["d"], p["n"], p["n_lags"],
+                           nu, norm_pool, norm_sep, lam, None)
+
+
+def test_the_separate_fits_ridge_is_divided_by_the_square_of_the_scale():
+    """Its norms are 1.0, so dividing the residuals by ``s`` divides the
+    imbalance by ``s ** 2``, and the ridge has to follow to leave the minimizer
+    where it was."""
+    p, s, lam = _tiny_program(), 16.0, 0.3
+    base = _solve(p, 0.0, 1.0, 1.0, lam)
+    rescaled = _solve(p, 0.0, 1.0, 1.0, lam / s ** 2, divisor=s)
+    for g in base:
+        assert np.allclose(base[g], rescaled[g], atol=1e-7)
+
+
+def test_the_pooled_fits_ridge_is_left_alone():
+    """Its norms carry the residuals' units, so dividing both by ``s`` leaves
+    the imbalance term exactly as it was and the ridge with it."""
+    p, s, lam = _tiny_program(), 16.0, 0.3
+    base = _solve(p, 0.4, 2.5, 1.7, lam)
+    rescaled = _solve(p, 0.4, 2.5 / s ** 2, 1.7 / s ** 2, lam, divisor=s)
+    for g in base:
+        assert np.allclose(base[g], rescaled[g], atol=1e-7)
+
+
+def test_the_pooling_level_is_read_off_the_same_separate_fit_at_any_magnitude():
+    """``nu_used`` comes entirely from the separate fit's imbalance matrix, so
+    it is the run's window onto that fit. A ridge stated in the caller's units
+    has to reach it the same way at any magnitude, which it does only because
+    the ridge is divided by the same square as the imbalance it trades
+    against."""
+    Y, trt, H = staggered_panel()
+    base = fit(Y, trt, H, lam=0.5)["nu_used"]
+    scaled = fit(Y * 1e5, trt, H, lam=0.5 * 1e5 ** 2)["nu_used"]
+    assert base == pytest.approx(0.244, abs=0.01)      # the ridge is biting
+    assert scaled == pytest.approx(base, rel=1e-6)
+
+
+def test_a_ridge_penalty_survives_the_rescale_end_to_end():
+    Y, trt, H = staggered_panel()
+    out = fit(Y * 1e5, trt, H, lam=0.05)
+    assert np.isfinite(out["att"])
+    for g in out["weights"]:
+        assert np.all(np.isfinite(out["weights"][g]))
+
+
+def test_covariates_are_carried_through_the_rescale():
+    Y, trt, H = staggered_panel()
+    rng = np.random.default_rng(3)
+    Z = rng.normal(size=(Y.shape[0], 2))
+    base = fit(Y, trt, H, Z=Z)["att"]
+    scaled = fit(Y * 1e5, trt, H, Z=Z)["att"] / 1e5
+    assert scaled == pytest.approx(base, rel=1e-7)
+
+
+# --- the untouched path -------------------------------------------------------
+
+def test_a_near_unit_panel_is_solved_without_any_rescaling():
+    """No pinned fit moves: the panels mlsynth already ships sit at unit scale.
+
+    Asserted on the residuals the program actually sees, because that is what
+    ``solve_scale`` reads -- a panel with a large mean and small variation has
+    small residuals, and dividing it by its raw level would push the objective
+    under the solver's absolute tolerance instead of onto it.
+    """
+    Y, trt, H = staggered_panel()
+    assert solve_scale(fit(Y, trt, H)["res"]) == 1.0
+
+
+def test_a_uniform_weight_fit_poses_no_program_and_is_unaffected():
+    from mlsynth.utils.ppscm_helpers.engine import Conventions
+    Y, trt, H = staggered_panel()
+    conv = Conventions(donor_weights="uniform")
+    base = fit(Y, trt, H, conventions=conv)["att"]
+    scaled = fit(Y * 1e5, trt, H, conventions=conv)["att"] / 1e5
+    assert scaled == pytest.approx(base, rel=1e-10)
+
+
+def test_a_single_donor_panel_still_solves_when_rescaled():
+    Y, trt, H = staggered_panel(n_donor=1, n_treat=2, H=4)
+    out = fit(Y * 1e5, trt, H)
+    assert np.isfinite(out["att"])

--- a/mlsynth/utils/ppscm_helpers/engine.py
+++ b/mlsynth/utils/ppscm_helpers/engine.py
@@ -172,6 +172,44 @@ def _imbalance_matrix(res, groups, adopt_of, members, donors, W, n1, d, n) -> np
     return M
 
 
+# The separate fit normalizes by 1.0, so its objective carries the square of
+# whatever units the caller's outcome is in, while OSQP is asked for an
+# absolute ``eps_abs=1e-8``. Past a residual magnitude of about 1e3 OSQP
+# returns nothing and the SCS fallback answers to a looser standard. Residuals
+# are rescaled to unit magnitude for the solve, by a power of two so the trip
+# out and back is exact in binary floating point, and left alone when they are
+# already there.
+_SCALE_EXPONENT_TOL = 3
+
+
+def solve_scale(res: Dict[Any, np.ndarray]) -> float:
+    """Power-of-two divisor bringing the residuals to unit magnitude.
+
+    The summary is the median absolute residual, not the panel's median
+    absolute level: the level is removed by ``fit_feff`` before anything
+    reaches the program, so a panel of markets with a large mean and small
+    variation would be divided by a factor its residuals never had, and the
+    objective would land under ``eps_abs`` instead of on it. The median is the
+    right summary of what is left because a panel of markets spans an order of
+    magnitude in size and one very large market should not set the scale.
+
+    Returns 1.0 when the residuals are already within ``2 ** 3`` of unit
+    magnitude, so the arithmetic of a fit that never had this problem is
+    untouched, and when there is nothing finite and non-zero to measure.
+    """
+    parts = [np.abs(np.asarray(r, dtype=float)).ravel() for r in res.values()]
+    if not parts:
+        return 1.0
+    vals = np.concatenate(parts)
+    vals = vals[np.isfinite(vals) & (vals > 0.0)]
+    if vals.size == 0:
+        return 1.0
+    exponent = int(np.round(np.log2(float(np.median(vals)))))
+    if abs(exponent) <= _SCALE_EXPONENT_TOL:
+        return 1.0
+    return float(2.0 ** exponent)
+
+
 def solve_cohort_qp(res, groups, adopt_of, members, donors, n1, d, n, n_lags,
                     nu, norm_pool, norm_sep, lam, solver,
                     zt=None, Zc=None) -> Dict[Any, np.ndarray]:
@@ -345,9 +383,26 @@ def run_multisynth(
         return _uniform_fit(res, groups, adopt_of, members, donors, n1, d, n,
                             n_leads, nu, lam)
 
+    # The program is posed on residuals brought to unit magnitude and the
+    # answer read back in the caller's units, so what ``eps_abs=1e-8`` demands
+    # does not depend on how the outcome happens to be measured. Only the
+    # separate fit's objective changes: it normalizes by 1.0, so it carried the
+    # square of the panel's magnitude, while the pooled fit's norms carry those
+    # units already and divide them out. Both the objective and the ridge are
+    # divided by ``scale ** 2`` there, which leaves the minimizer where it was
+    # and moves the numbers the solver compares against its tolerance.
+    scale = solve_scale(res)
+    res_q, zt_q, Zc_q, lam_sep = res, zt, Zc, lam
+    if scale != 1.0:
+        res_q = {k: v / scale for k, v in res.items()}
+        lam_sep = lam / scale ** 2
+        if zt is not None:
+            zt_q = [z / scale for z in zt]
+            Zc_q = [z / scale for z in Zc]
+
     # separate fit (nu = 0) -> scaling norms + auto-nu
-    W0 = solve_cohort_qp(res, groups, adopt_of, members, donors, n1, d, n, n_lags,
-                         0.0, 1.0, 1.0, lam, solver, zt=zt, Zc=Zc)
+    W0 = solve_cohort_qp(res_q, groups, adopt_of, members, donors, n1, d, n, n_lags,
+                         0.0, 1.0, 1.0, lam_sep, solver, zt=zt_q, Zc=Zc_q)
     M0 = _imbalance_matrix(res, groups, adopt_of, members, donors, W0, n1, d, n)
     avg_imbal = M0.mean(axis=1)
     global_l2 = float(np.sqrt((avg_imbal ** 2).sum()) / np.sqrt(d))
@@ -356,8 +411,12 @@ def run_multisynth(
     ind_l2 = float(np.sqrt(np.mean([(M0[:, k] ** 2).sum() / nnz[k] for k in range(J)])))
     nu_used = float(global_l2 * np.sqrt(d) / avg_l2) if nu is None else float(nu)
 
-    W = solve_cohort_qp(res, groups, adopt_of, members, donors, n1, d, n, n_lags,
-                        nu_used, global_l2 ** 2, ind_l2 ** 2, lam, solver, zt=zt, Zc=Zc)
+    # The pooled fit's norms are read off ``M0`` in the caller's units, so they
+    # are divided by the same scale as the residuals: the two ratios are then
+    # the ones the unscaled program formed, and ``lam`` needs no adjustment.
+    W = solve_cohort_qp(res_q, groups, adopt_of, members, donors, n1, d, n, n_lags,
+                        nu_used, (global_l2 / scale) ** 2, (ind_l2 / scale) ** 2,
+                        lam, solver, zt=zt_q, Zc=Zc_q)
     M = _imbalance_matrix(res, groups, adopt_of, members, donors, W, n1, d, n)
 
     # uniform-weight baseline for scaled imbalance

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1232,6 +1232,42 @@ timeout = 900.0
   models = "the pool measured at its narrowest, so one late cohort with few admissible donors masks an early one with hundreds. Whether the program could interpolate is decided by the widest pool any cohort was given, not the tightest"
 
 [[target]]
+name = "ppscm-solve-conditioning"
+module-path = "mlsynth/utils/ppscm_helpers/engine.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_solve_conditioning.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "scale-read-off-the-largest-residual"
+  find = "    exponent = int(np.round(np.log2(float(np.median(vals)))))"
+  replace = "    exponent = int(np.round(np.log2(float(np.max(vals)))))"
+  models = "the scale set by the largest residual instead of the typical one. A panel of markets spans an order of magnitude in size, so the biggest market alone would decide the divisor and push every other market's residuals below the tolerance the solver is working to"
+
+  [[target.mutant]]
+  id = "scale-rounded-off-the-power-of-two-grid"
+  find = "    return float(2.0 ** exponent)"
+  replace = "    return float(np.median(vals))"
+  models = "a divisor that is not a power of two, so dividing out and multiplying back rounds in binary floating point and the answer at one magnitude no longer agrees with the answer at another in the last digits"
+
+  [[target.mutant]]
+  id = "near-unit-panels-rescaled-anyway"
+  find = "    if abs(exponent) <= _SCALE_EXPONENT_TOL:"
+  replace = "    if abs(exponent) < 0:"
+  models = "every panel divided by something, including the ones already at unit scale. The arithmetic of every pinned fit in the library changes for no gain, since those solves were never near the tolerance"
+
+  [[target.mutant]]
+  id = "separate-fits-ridge-left-at-the-callers-scale"
+  find = "        lam_sep = lam / scale ** 2"
+  replace = "        lam_sep = lam"
+  models = "a ridge left in the caller's units while the imbalance it trades against is divided by the square of the scale, so the penalty dominates the fit it was meant to regularize and the weights collapse toward the uniform barycenter"
+
+  [[target.mutant]]
+  id = "pooled-fits-norms-left-at-the-callers-scale"
+  find = "                        nu_used, (global_l2 / scale) ** 2, (ind_l2 / scale) ** 2,"
+  replace = "                        nu_used, global_l2 ** 2, ind_l2 ** 2,"
+  models = "norms read off the unscaled imbalance matrix but applied to scaled residuals, so the pooled objective shrinks by the fourth power of the scale and terminates at the first iterate the tolerance accepts"
+
+[[target]]
 name = "weights-container-contract"
 module-path = "mlsynth/config_models.py"
 test-command = "python -m pytest mlsynth/tests/test_weights_container.py mlsynth/tests/test_result_contract.py -q -p no:cacheprovider"


### PR DESCRIPTION
Closes #518.

`solve_cohort_qp` hands the partially-pooled program to OSQP with `eps_abs=1e-8`, an absolute demand, and nothing rescales the outcome first. So how hard the program is depends on the units the caller's panel happens to be in.

## Which of the two solves breaks

The separate fit normalizes by `1.0`, because it is the fit that produces the norms the pooled fit divides by, so its objective carries the square of the panel's magnitude. The pooled fit's norms carry the residuals' units and divide them out, so its objective was already dimensionless. Timing the two separately on forty donors, six treated units and a hundred pre-periods:

```
                 separate fit    pooled fit
unit scale             0.16s         0.17s
1e5                    3.75s         0.38s
```

Past about 1e3 the separate fit stops converging at all: OSQP returns no solution, the SCS fallback answers to a looser standard, and the effect moves by 7e-4 relative.

```
     level     secs       att/scale    rel. gap vs unit scale
         1      0.3     0.565567407                         -
      1000      3.8     0.565187731                 6.713e-04
     10000      3.7     0.565350152                 3.841e-04
    100000      4.1     0.565183496                 6.788e-04
```

Synthetic control is scale-equivariant, so the same panel at a different magnitude is the same problem and every one of those differences is the solver's.

## The change

`solve_scale` returns a power-of-two divisor bringing the residuals to unit magnitude, and `run_multisynth` poses both programs on residuals divided by it. The summary is the median absolute residual, not the panel's median absolute level: `fit_feff` removes the level before anything reaches the program, so a panel with a large mean and small variation would be divided by a factor its residuals never had and the objective would land under `eps_abs` instead of on it. The median is the right summary of what is left because a panel of markets spans an order of magnitude in size and one very large market should not set the scale.

Both minimizers are preserved exactly:

- the separate fit's ridge is divided by the square of the scale, since its imbalance term is;
- the pooled fit's norms are divided by the same square, which leaves its two ratios where they were and its ridge alone.

Residuals already within `2**3` of unit magnitude are left untouched. The tolerances themselves are unchanged: rescaling makes `eps_abs` and `eps_rel` mean what they were chosen to mean.

## Verification

18 tests in `test_ppscm_solve_conditioning.py`, seven of them red before the change. They pin the effect, the event study and the weights at 1, 1e3 and 1e5; the power-of-two round trip as bit-exact; and the two ridge rules at the `solve_cohort_qp` level, where the algebra the wiring depends on is visible. Five mutants in `tools/mutation/targets.toml`, all killed, including the scale read off the largest residual instead of the typical one and each ridge rule dropped.

409 PPSCM tests pass. All four runnable benchmark cases pass: `ppscm_paglayan`, `ppscm_paglayan_covs`, `ppscm_bfr_mc` (18/18, window counts exact at 39 and 11) and `ppscm_geo_conformal_coverage` (14/14, every count and finite share exact).

Paglayan's residuals sit at `2**-4`, so its fits are rescaled and its pinned numbers move in the last few digits. The largest movement is the jackknife standard error's distance from augsynth, 4.13e-04 to 4.75e-04 against a tolerance of 1.5e-03. That movement is the old solve. Evaluated on the same panel in the same units, the separate fit's objective at each set of weights is:

```
branch                  7.426388431525817e-04
main                    7.426388789756396e-04
Clarabel at unit scale  7.426388885335307e-04
```

The branch's weights are the best of the three, below an independent conic solve of the same program. augsynth poses that program at the same magnitude with the same solver, so agreement with it in the last digits was agreement about a shared artefact.

`docs/ppscm.rst` says what the program is posed on and why, next to the objective it states.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx)_