### PR TITLE
Let PPSCM choose which cumulative conformal band it reports

### DIFF
--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -663,6 +663,81 @@ leaving eight windows, which no longer supports a 90% band. Read
   120          0.5    8          below the 90% threshold
   ===========  =====  =========  ===============================================
 
+Which calibration set: ``conformal_method``
+-------------------------------------------
+
+The band above calibrates on non-overlapping windows of the pre-period, and that
+reference set is small. With :math:`m \approx 0.7\,T_0/L` windows, a finite
+:math:`1-\alpha` band needs :math:`\lceil (m+1)(1-\alpha) \rceil \le m`, which
+puts a floor of about :math:`12.8\,L` pre-periods under it. Past the floor, at
+whatever level a given :math:`m` just supports, the required rank equals
+:math:`m` itself, so the order statistic never trims anything and the half-width
+is simply the largest calibration score:
+
+  ===========  =====  =========  ================  ===================
+  :math:`T_0`  L      windows    tightest level    rank
+  ===========  =====  =========  ================  ===================
+  120          8      10         90%               10 of 10
+  120          4      21         95%               21 of 21
+  104          13     5          80%               5 of 5
+  156          8      13         90%               13 of 13
+  ===========  =====  =========  ================  ===================
+
+On a thirty-market weekly panel with 120 pre-weeks, an eight-week horizon and
+:math:`\alpha = 0.05`, that leaves ten windows against a rank of eleven, and
+every treated unit's band is infinite. Marketing geo-lift panels sit here
+routinely: the horizon is a campaign flight and the pre-period is however much
+history the advertiser has.
+
+``conformal_method="cyclic"`` calibrates instead against the :math:`T` cyclic
+shifts of the residual path, a reference set whose size is the length of the
+panel and not a count of windows. Neither the floor nor the rank-never-trims
+regime applies to it. On the same panel, 118 of 120 unit-fits return a finite
+band and 114 of those 118 cover, against 0 of 120 finite for the split band::
+
+   res = PPSCM({..., "conformal_horizon": 8,
+                     "conformal_method": "cyclic"}).fit()
+   for label, uf in res.per_unit.items():
+       print(label, uf.cumulative_effect,
+             (uf.cumulative_lower, uf.cumulative_upper), uf.cumulative_p_value)
+
+The price is a shape assumption. Inverting a test needs a null to subtract, and
+the null here is a constant per-period effect: a candidate :math:`\theta` is
+subtracted from the treated unit's post-period, the panel is refitted, and the
+adjusted residual path is compared against its own cyclic shifts by a
+moving-block statistic. The reported band is :math:`L` times the range of the
+candidates the test accepts. An effect that ramps is outside that null family,
+and the honest outcome is an empty accepted set, reported as ``nan`` bounds --
+distinct from ``None``, which means no band was asked for at all. The split
+band assumes only that the calibration windows are exchangeable with the
+post-period window, and reports the accumulated effect directly, so it makes no
+claim about the effect's shape.
+
+The two report the same estimand, so ``conformal_method`` selects between them
+the way ``inference_method`` selects the bootstrap or the jackknife behind the
+ATT, and there is one set of bounds either way. Their diagnostics differ and so
+occupy separate fields: ``cumulative_windows`` counts the split band's calibration
+windows, ``cumulative_p_value`` is the cyclic band's permutation p-value of the
+no-effect null, and the other is ``None``. ``cumulative_method`` says which one
+produced the bounds.
+
+Their parameters differ too, and a parameter belonging to the method not chosen
+is refused by name at config time: ``conformal_min_train_frac`` is the split
+band's, ``conformal_n_nulls`` and ``conformal_grid_scale`` are the cyclic band's.
+The grid is an approximation and it errs in one direction: the band is the range
+of accepted candidates, so a coarse grid samples fewer of them and reports a band
+too narrow, converging upward as ``conformal_n_nulls`` rises -- measured on a
+two-unit panel, a width of 3.14 at five candidates against 5.86 at thirty-one.
+Coarse is anti-conservative here, the opposite of the usual intuition about
+discretisation. An accepted set reaching an end of the grid is bounded by
+``conformal_grid_scale`` and not by the data, and that end is reported as
+infinite.
+
+Every candidate is a refit, so the cyclic band costs about fourteen times the
+split one -- 9.6s against 0.7s per fit at the geometry above. Reach for it when
+the split band comes back infinite, or when the pre-period is too short for the
+floor.
+
 The cumulative effect overall
 -----------------------------
 

--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -32,7 +32,7 @@ from ..utils.ppscm_helpers.cs_inference import influence_function_inference
 from ..utils.ppscm_helpers.engine import Conventions, run_multisynth
 from ..utils.ppscm_helpers.inference import (
     jackknife_inference, bootstrap_inference, per_unit_intervals,
-    cumulative_conformal_per_unit, cumulative_supt_band)
+    cumulative_conformal_per_unit, cumulative_supt_band, cwz_cumulative_per_unit)
 from ..utils.ppscm_helpers.plotter import plot_ppscm
 from ..utils.ppscm_helpers.setup import prepare_ppscm_inputs
 from ..utils.ppscm_helpers.structures import (
@@ -97,7 +97,10 @@ class PPSCM:
         self.seed: int = config.seed
         self.alpha: float = config.alpha
         self.conformal_horizon = config.conformal_horizon
+        self.conformal_method = config.conformal_method
         self.conformal_min_train_frac = config.conformal_min_train_frac
+        self.conformal_n_nulls = config.conformal_n_nulls
+        self.conformal_grid_scale = config.conformal_grid_scale
         self.cumulative_band: bool = config.cumulative_band
         self.covariates = config.covariates
 
@@ -256,17 +259,30 @@ class PPSCM:
             # Per-unit band on the CUMULATIVE effect -- the total each unit gained.
             # Additional to the pooled inference above, not a replacement for it, so
             # it is off unless a horizon is asked for.
+            # ``conformal_method`` picks the calibration set: non-overlapping
+            # pre-period windows, or the cyclic shifts of the residual path. Same
+            # estimand either way, so one set of bounds; the diagnostic differs,
+            # which is why the window count and the p-value are separate fields
+            # and only one of them is filled.
+            cum_pt = cum_lo = cum_hi = cum_n = cum_p = None
             if self.conformal_horizon is not None:
-                cum_pt, cum_lo, cum_hi, cum_n = cumulative_conformal_per_unit(
-                    Xy, trt, d, n_leads, n_lags,
+                common = dict(
                     fixedeff=self.fixedeff, time_cohort=self.time_cohort,
                     nu_used=fit["nu_used"], lam=self.lam, solver=self.solver,
                     alpha=self.alpha, horizon=int(self.conformal_horizon),
-                    min_train_frac=float(self.conformal_min_train_frac),
                     conventions=conventions,
                 )
-            else:
-                cum_pt = cum_lo = cum_hi = cum_n = None
+                if self.conformal_method == "cyclic":
+                    cum_pt, cum_lo, cum_hi, cum_p = cwz_cumulative_per_unit(
+                        Xy, trt, d, n_leads, n_lags, **common,
+                        n_nulls=int(self.conformal_n_nulls),
+                        grid_scale=float(self.conformal_grid_scale),
+                    )
+                else:
+                    cum_pt, cum_lo, cum_hi, cum_n = cumulative_conformal_per_unit(
+                        Xy, trt, d, n_leads, n_lags, **common,
+                        min_train_frac=float(self.conformal_min_train_frac),
+                    )
             per_unit: Dict[Any, PPSCMUnitFit] = {}
             for k, g in enumerate(fit["groups"]):
                 key = (str(inputs.time_labels[fit["adopt_of"][g]]) if self.time_cohort
@@ -293,6 +309,11 @@ class PPSCM:
                     cumulative_lower=(float(cum_lo[k]) if cum_lo is not None else None),
                     cumulative_upper=(float(cum_hi[k]) if cum_hi is not None else None),
                     cumulative_windows=(int(cum_n[k]) if cum_n is not None else None),
+                    # nan bounds mean the cyclic band's accepted set was empty;
+                    # None means no band was asked for. Kept apart on purpose.
+                    cumulative_p_value=(float(cum_p[k]) if cum_p is not None else None),
+                    cumulative_method=(self.conformal_method
+                                       if self.conformal_horizon is not None else None),
                 )
 
             results = PPSCMResults(

--- a/mlsynth/tests/test_ppscm_conformal_method.py
+++ b/mlsynth/tests/test_ppscm_conformal_method.py
@@ -1,0 +1,356 @@
+"""Choosing which cumulative conformal band PPSCM reports.
+
+``cwz_cumulative_per_unit`` calibrates against the cyclic shifts of the residual
+path; ``cumulative_conformal_per_unit`` calibrates against a disjoint split of
+the pre-period. They report the same estimand -- the total a treated unit gained
+over ``conformal_horizon`` periods -- from different reference sets, so
+``conformal_method`` selects between them the way ``inference_method`` selects
+the bootstrap or the jackknife behind the ATT.
+
+The split band's reference set is the number of non-overlapping calibration
+windows, so a finite ``1 - alpha`` band needs ``ceil((m+1)(1-alpha)) <= m`` and
+there is a floor of roughly ``12.8 * L`` pre-periods before one exists. The
+cyclic reference set does not depend on the horizon, so neither the floor nor
+the regime past it applies. The price is a shape assumption: the cyclic band
+inverts a test against a constant per-period effect, and an effect that ramps is
+outside that null family, which comes back as an empty accepted set.
+
+The two carry different diagnostics -- a window count for the split, a
+permutation p-value for the cyclic -- so each fills its own field and
+``cumulative_method`` says which one produced the band.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.utils.ppscm_helpers.engine import Conventions
+from mlsynth.utils.ppscm_helpers.inference import cwz_cumulative_per_unit
+
+
+def _staggered_df(seed=0, adoption=(14, 18), n_donors=8, T=34, effect=-3.0, noise=0.4):
+    """Staggered panel with enough pre-period for several calibration windows."""
+    rng = np.random.default_rng(seed)
+    factors = rng.standard_normal((T, 2))
+    load_d = rng.standard_normal((n_donors, 2)) * 0.5
+    load_t = load_d.mean(axis=0)
+    rec = []
+    for j, Tj in enumerate(adoption):
+        series = (factors @ (load_t + 0.1 * rng.standard_normal(2))
+                  + rng.standard_normal(T) * noise)
+        series[Tj:] += effect
+        rec += [{"unit": f"treated_{j}", "year": 2000 + t, "y": float(series[t]),
+                 "tr": int(t >= Tj)} for t in range(T)]
+    for dd in range(n_donors):
+        series = factors @ load_d[dd] + rng.standard_normal(T) * noise
+        rec += [{"unit": f"d_{dd}", "year": 2000 + t, "y": float(series[t]), "tr": 0}
+                for t in range(T)]
+    return pd.DataFrame(rec)
+
+
+def _cfg(**kw):
+    cfg = dict(df=_staggered_df(), outcome="y", treat="tr", unitid="unit",
+               time="year", display_graphs=False, run_inference=False)
+    cfg.update(kw)
+    return cfg
+
+
+def _fit(**kw):
+    import warnings as _w
+    from mlsynth import PPSCM
+    with _w.catch_warnings():
+        _w.simplefilter("ignore")
+        return PPSCM(_cfg(**kw)).fit()
+
+
+def _build(**kw):
+    from mlsynth import PPSCM
+    return PPSCM(_cfg(**kw))
+
+
+# --------------------------------------------------------------------------- #
+# the config field                                                             #
+# --------------------------------------------------------------------------- #
+
+def test_the_default_is_the_split_band():
+    from mlsynth.config_models import PPSCMConfig
+    assert PPSCMConfig.model_fields["conformal_method"].default == "split"
+
+
+@pytest.mark.parametrize("bad", ["cwz", "Split", "", None, 3])
+def test_an_unknown_method_is_refused_by_name(bad):
+    with pytest.raises(MlsynthConfigError, match="conformal_method"):
+        _build(conformal_horizon=3, conformal_method=bad)
+
+
+def test_choosing_a_method_without_a_horizon_is_refused():
+    """The horizon is what turns the band on; a method with no band is a typo."""
+    with pytest.raises(MlsynthConfigError) as exc:
+        _build(conformal_method="cyclic")
+    assert "conformal_horizon" in str(exc.value)
+    assert "conformal_method" in str(exc.value)
+
+
+@pytest.mark.parametrize("field,value", [("conformal_n_nulls", 9),
+                                         ("conformal_grid_scale", 2.0)])
+def test_a_cyclic_parameter_set_on_the_split_band_is_refused(field, value):
+    with pytest.raises(MlsynthConfigError) as exc:
+        _build(conformal_horizon=3, **{field: value})
+    assert field in str(exc.value)
+    assert "cyclic" in str(exc.value)
+
+
+def test_the_split_parameter_set_on_the_cyclic_band_is_refused():
+    with pytest.raises(MlsynthConfigError) as exc:
+        _build(conformal_horizon=3, conformal_method="cyclic",
+               conformal_min_train_frac=0.4)
+    assert "conformal_min_train_frac" in str(exc.value)
+    assert "split" in str(exc.value)
+
+
+def test_leaving_a_parameter_at_its_default_is_not_setting_it():
+    """The refusal is about what the caller asked for, not what the field holds."""
+    _build(conformal_horizon=3)                                    # split defaults
+    _build(conformal_horizon=3, conformal_method="cyclic")         # cyclic defaults
+
+
+@pytest.mark.parametrize("bad", [2, 0, -1, True, 5.0, "9"])
+def test_an_unusable_null_grid_size_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="conformal_n_nulls"):
+        _build(conformal_horizon=3, conformal_method="cyclic", conformal_n_nulls=bad)
+
+
+@pytest.mark.parametrize("bad", [0.0, -1.0, True, "3"])
+def test_an_unusable_grid_scale_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="conformal_grid_scale"):
+        _build(conformal_horizon=3, conformal_method="cyclic", conformal_grid_scale=bad)
+
+
+# --------------------------------------------------------------------------- #
+# routing                                                                      #
+# --------------------------------------------------------------------------- #
+
+def test_no_horizon_leaves_every_cumulative_field_empty():
+    res = _fit()
+    assert res.per_unit
+    for unit in res.per_unit.values():
+        assert unit.cumulative_effect is None
+        assert unit.cumulative_lower is None
+        assert unit.cumulative_upper is None
+        assert unit.cumulative_windows is None
+        assert unit.cumulative_p_value is None
+        assert unit.cumulative_method is None
+
+
+def test_the_split_band_reports_its_window_count_and_no_p_value():
+    res = _fit(conformal_horizon=3, alpha=0.2)
+    assert res.per_unit
+    for unit in res.per_unit.values():
+        assert unit.cumulative_method == "split"
+        assert unit.cumulative_windows is not None and unit.cumulative_windows >= 1
+        assert unit.cumulative_p_value is None
+        assert unit.cumulative_lower <= unit.cumulative_effect <= unit.cumulative_upper
+
+
+def test_the_cyclic_band_reports_its_p_value_and_no_window_count():
+    res = _fit(conformal_horizon=3, alpha=0.2, conformal_method="cyclic",
+               conformal_n_nulls=5)
+    assert res.per_unit
+    for unit in res.per_unit.values():
+        assert unit.cumulative_method == "cyclic"
+        assert unit.cumulative_windows is None
+        assert 0.0 <= unit.cumulative_p_value <= 1.0
+        assert unit.cumulative_effect is not None
+
+
+def test_naming_the_default_method_changes_nothing():
+    """The pin on existing behaviour: ``split`` is what a caller already got."""
+    implicit = _fit(conformal_horizon=3, alpha=0.2)
+    explicit = _fit(conformal_horizon=3, alpha=0.2, conformal_method="split")
+    for key, unit in implicit.per_unit.items():
+        other = explicit.per_unit[key]
+        assert other.cumulative_effect == pytest.approx(unit.cumulative_effect)
+        assert other.cumulative_lower == pytest.approx(unit.cumulative_lower)
+        assert other.cumulative_upper == pytest.approx(unit.cumulative_upper)
+        assert other.cumulative_windows == unit.cumulative_windows
+
+
+def test_the_two_methods_agree_on_the_point_and_differ_on_the_band():
+    """Same estimand, different reference set."""
+    split = _fit(conformal_horizon=3, alpha=0.2)
+    cyclic = _fit(conformal_horizon=3, alpha=0.2, conformal_method="cyclic",
+                  conformal_n_nulls=5)
+    widths = []
+    for key, unit in split.per_unit.items():
+        other = cyclic.per_unit[key]
+        assert other.cumulative_effect == pytest.approx(unit.cumulative_effect)
+        widths.append((unit.cumulative_upper - unit.cumulative_lower,
+                       other.cumulative_upper - other.cumulative_lower))
+    assert any(a != b for a, b in widths)
+
+
+def test_the_band_is_additional_and_does_not_disturb_the_att():
+    base = _fit(run_inference=True, alpha=0.2)
+    with_band = _fit(run_inference=True, alpha=0.2, conformal_horizon=3,
+                     conformal_method="cyclic", conformal_n_nulls=5)
+    for key, unit in base.per_unit.items():
+        other = with_band.per_unit[key]
+        assert other.att == pytest.approx(unit.att)
+        np.testing.assert_allclose(other.tau, unit.tau, equal_nan=True)
+
+
+# --------------------------------------------------------------------------- #
+# edges                                                                        #
+# --------------------------------------------------------------------------- #
+
+def _single_treated_df(seed=0, Tj=18, n_donors=8, T=34, effect=-3.0, noise=0.4):
+    rng = np.random.default_rng(seed)
+    factors = rng.standard_normal((T, 2))
+    load_d = rng.standard_normal((n_donors, 2)) * 0.5
+    series = factors @ load_d.mean(axis=0) + rng.standard_normal(T) * noise
+    series[Tj:] += effect
+    rec = [{"unit": "treated_0", "year": 2000 + t, "y": float(series[t]),
+            "tr": int(t >= Tj)} for t in range(T)]
+    for dd in range(n_donors):
+        z = factors @ load_d[dd] + rng.standard_normal(T) * noise
+        rec += [{"unit": f"d_{dd}", "year": 2000 + t, "y": float(z[t]), "tr": 0}
+                for t in range(T)]
+    return pd.DataFrame(rec)
+
+
+def test_a_single_treated_unit_gets_a_cyclic_band():
+    """The automatic pooling rule sits on the program's boundary at one treated
+    unit, so the null refits are given the fit's own ``nu`` instead of asking
+    for it again. Without that they would be infeasible and the band would
+    never be computed."""
+    res = _fit(df=_single_treated_df(), conformal_horizon=3, alpha=0.2,
+               conformal_method="cyclic", conformal_n_nulls=5)
+    assert len(res.per_unit) == 1
+    unit = next(iter(res.per_unit.values()))
+    assert unit.cumulative_method == "cyclic"
+    assert np.isfinite(unit.cumulative_effect)
+    assert 0.0 <= unit.cumulative_p_value <= 1.0
+
+
+def test_the_null_refits_are_given_the_fits_own_pooling_level():
+    from mlsynth.estimators import ppscm as mod
+    seen = {}
+    original = mod.cwz_cumulative_per_unit
+
+    def spy(*args, **kwargs):
+        seen.update(kwargs)
+        return original(*args, **kwargs)
+
+    mod.cwz_cumulative_per_unit = spy
+    try:
+        _fit(conformal_horizon=3, alpha=0.2, conformal_method="cyclic",
+             conformal_n_nulls=5)
+    finally:
+        mod.cwz_cumulative_per_unit = original
+    assert np.isfinite(seen["nu_used"])
+    assert seen["n_nulls"] == 5
+    assert seen["conventions"] is not None
+
+
+@pytest.mark.parametrize("method", ["split", "cyclic"])
+def test_a_horizon_past_the_post_period_is_reported_and_not_swallowed(method):
+    from mlsynth.exceptions import MlsynthDataError
+    kw = {"conformal_n_nulls": 5} if method == "cyclic" else {}
+    with pytest.raises(MlsynthDataError):
+        _fit(conformal_horizon=99, alpha=0.2, conformal_method=method, **kw)
+
+
+# --------------------------------------------------------------------------- #
+# what the cyclic band reports when it has nothing to report                   #
+# --------------------------------------------------------------------------- #
+
+def test_an_empty_accepted_set_is_carried_as_nan_and_not_as_absent():
+    """``None`` means no band was asked for; ``nan`` means none was accepted.
+
+    Collapsing the two would make an effect outside the constant null family
+    indistinguishable from a fit that never computed a band.
+    """
+    from mlsynth.estimators import ppscm as mod
+    nan = np.array([np.nan, np.nan])
+    stub = (np.array([1.0, 2.0]), nan, nan, np.array([0.5, 0.5]))
+    original = mod.cwz_cumulative_per_unit
+    mod.cwz_cumulative_per_unit = lambda *a, **k: stub
+    try:
+        res = _fit(conformal_horizon=3, alpha=0.2, conformal_method="cyclic",
+                   conformal_n_nulls=5)
+    finally:
+        mod.cwz_cumulative_per_unit = original
+    for unit in res.per_unit.values():
+        assert unit.cumulative_method == "cyclic"
+        assert unit.cumulative_effect is not None
+        assert np.isnan(unit.cumulative_lower)
+        assert np.isnan(unit.cumulative_upper)
+
+
+# --------------------------------------------------------------------------- #
+# the conventions the wiring forces through the helper                         #
+# --------------------------------------------------------------------------- #
+
+def _panel(n_ctrl=10, n_trt=2, t0=24, horizon=4, seed=3):
+    rng = np.random.default_rng(seed)
+    n, T = n_ctrl + n_trt, t0 + horizon
+    f = rng.normal(size=(T, 2))
+    load = rng.uniform(0.3, 1.3, size=(n, 2))
+    Xy = load @ f.T + rng.normal(scale=0.3, size=(n, T))
+    Xy = Xy - Xy.min() + 1.0
+    trt = np.full(n, np.inf)
+    # Two cohorts far enough apart that the later one is inside the earlier
+    # one's estimation window: "window" admits it as a donor, "never_treated"
+    # does not, so the two conventions are different estimators here.
+    trt[0] = t0 - 8
+    trt[1] = t0
+    return Xy, trt, t0, horizon
+
+
+def _cwz(**kw):
+    Xy, trt, t0, L = _panel()
+    base = dict(d=t0, n_leads=L, n_lags=t0, fixedeff=True, time_cohort=False,
+                nu_used=0.5, lam=0.0, solver=None, alpha=0.10, horizon=L,
+                n_nulls=5)
+    base.update(kw)
+    return cwz_cumulative_per_unit(Xy, trt, **base)
+
+
+def test_the_default_conventions_reproduce_the_call_without_them():
+    """#511's behaviour is the ``Conventions()`` default, unchanged."""
+    a = _cwz()
+    b = _cwz(conventions=Conventions())
+    for x, y in zip(a, b):
+        np.testing.assert_allclose(x, y, equal_nan=True)
+
+
+def test_a_different_estimator_moves_what_the_cyclic_band_reports():
+    """Without this the band would answer for augsynth's estimator, not the fit's."""
+    a = _cwz()
+    b = _cwz(conventions=Conventions(donor_weights="uniform"))
+    assert not np.allclose(a[0], b[0], equal_nan=True)
+
+
+def test_every_refit_the_cyclic_band_makes_uses_the_configured_estimator():
+    """The observed fit and each null refit alike.
+
+    A null refit left on the defaults would calibrate the band against an
+    estimator the caller did not configure, and the point estimate would still
+    look right, so the point alone cannot pin this.
+    """
+    import mlsynth.utils.ppscm_helpers.inference as inf
+    conv = Conventions(donor_weights="uniform")
+    seen, original = [], inf.run_multisynth
+
+    def spy(*args, **kwargs):
+        seen.append(kwargs.get("conventions"))
+        return original(*args, **kwargs)
+
+    inf.run_multisynth = spy
+    try:
+        _cwz(conventions=conv, n_nulls=3)
+    finally:
+        inf.run_multisynth = original
+    assert len(seen) > 1                       # the observed fit, then the nulls
+    assert all(c == conv for c in seen)

--- a/mlsynth/utils/ppscm_helpers/config.py
+++ b/mlsynth/utils/ppscm_helpers/config.py
@@ -231,6 +231,94 @@ class PPSCMConfig(BaseEstimatorConfig):
             )
         return float(v)
 
+    conformal_method: Literal["split", "cyclic"] = Field(
+        default="split",
+        description=(
+            "Which reference set calibrates the cumulative band, once "
+            "``conformal_horizon`` has asked for one. Both report the same "
+            "estimand from different calibration sets, so this selects between "
+            "them the way ``inference_method`` selects the bootstrap or the "
+            "jackknife behind the ATT. ``'split'`` (default) calibrates on "
+            "non-overlapping windows of the pre-period and assumes only that "
+            "they are exchangeable with the post-period window; its reference "
+            "set is ``m ~ 0.7 * T0 / horizon``, and a finite ``1 - alpha`` band "
+            "needs ``ceil((m+1)(1-alpha)) <= m``, which puts a floor of roughly "
+            "``12.8 * horizon`` pre-periods under it. Past that floor every "
+            "feasible design sits where the rank equals ``m``, so the half-width "
+            "is simply the largest calibration score. ``'cyclic'`` calibrates on "
+            "the cyclic shifts of the residual path, a reference set that does "
+            "not depend on the horizon, so neither the floor nor that regime "
+            "applies -- reach for it on a panel where the split band comes back "
+            "infinite. The price is a shape assumption: it inverts a test "
+            "against a constant per-period effect and reports ``horizon`` times "
+            "the accepted range, so an effect that ramps is outside the null "
+            "family and the accepted set is empty, reported as ``nan`` bounds. "
+            "It also costs about fourteen times as much, since every candidate "
+            "in the grid is a refit."
+        ),
+    )
+
+    conformal_n_nulls: int = Field(
+        default=25,
+        description=(
+            "Candidate constant per-period effects the cyclic band tests, spread "
+            "evenly across the grid. Only meaningful with "
+            "``conformal_method='cyclic'``. The band is the range of the "
+            "candidates the test accepts, so a coarse grid samples fewer of them "
+            "and reports a band too narrow, converging upward as this rises -- on "
+            "a two-unit panel, a width of 3.14 at five candidates against 5.86 at "
+            "thirty-one. Coarse is anti-conservative here, the opposite of the "
+            "usual intuition about discretisation. Every candidate is a refit, so "
+            "this is also what the method costs."
+        ),
+    )
+
+    conformal_grid_scale: float = Field(
+        default=3.0,
+        description=(
+            "How wide the cyclic band's candidate grid reaches, in pre-period "
+            "residual standard deviations either side of the observed "
+            "per-period effect. Only meaningful with "
+            "``conformal_method='cyclic'``. An accepted set that reaches an end "
+            "of the grid is bounded by this number and not by the data, and that "
+            "end is reported as infinite; widening the grid at a fixed "
+            "``conformal_n_nulls`` coarsens it, so the two move together."
+        ),
+    )
+
+    @field_validator("conformal_n_nulls", mode="before")
+    @classmethod
+    def _validate_conformal_n_nulls(cls, v):
+        """Read before coercion: ``True`` and ``"9"`` both become integers if
+        pydantic sees them first, and neither is a grid size anyone meant."""
+        if isinstance(v, bool) or not isinstance(v, int):
+            raise ValueError(
+                f"conformal_n_nulls must be an integer of at least 3; got {v!r}.")
+        if v < 3:
+            raise ValueError(
+                f"conformal_n_nulls must be an integer of at least 3; got {v!r}. A "
+                "two-point grid cannot express an interval -- it can only return "
+                "its own endpoints, which would read as a band and be an artifact "
+                "of the grid."
+            )
+        return v
+
+    @field_validator("conformal_grid_scale", mode="before")
+    @classmethod
+    def _validate_conformal_grid_scale(cls, v):
+        """Read before coercion, for the reason given on
+        :meth:`_validate_conformal_n_nulls`."""
+        if isinstance(v, bool) or not isinstance(v, (int, float)):
+            raise ValueError(
+                f"conformal_grid_scale must be a positive number; got {v!r}.")
+        if not float(v) > 0.0:
+            raise ValueError(
+                f"conformal_grid_scale must be a positive number; got {v!r}. A "
+                "grid of zero width has one candidate in it and reports the "
+                "observed effect back as its own band."
+            )
+        return float(v)
+
     covariates: Optional[List[str]] = Field(
         default=None,
         description=(
@@ -290,6 +378,36 @@ class PPSCMConfig(BaseEstimatorConfig):
                     and self.donor_pool == "never_treated"
                     and self.fixedeff):
                 object.__setattr__(self, "inference_method", "influence_function")
+        return self
+
+    @model_validator(mode="after")
+    def _check_conformal_method(self):
+        """Refuse a conformal parameter that the chosen band never reads.
+
+        The two bands take different parameters, so a caller who sets
+        ``conformal_n_nulls`` and gets the split band has stated a preference
+        the fit will not honour. Asked against ``model_fields_set``, so the
+        refusal is about what the caller wrote and not about what the field
+        holds -- the defaults of both methods are always present.
+        """
+        fields = self.model_fields_set
+        if "conformal_method" in fields and self.conformal_horizon is None:
+            raise MlsynthConfigError(
+                f"conformal_method={self.conformal_method!r} selects which "
+                "cumulative band to report, and conformal_horizon is None, so "
+                "no band is computed. Set conformal_horizon to the number of "
+                "post-periods to accumulate.")
+        by_method = {"cyclic": ("conformal_n_nulls", "conformal_grid_scale"),
+                     "split": ("conformal_min_train_frac",)}
+        other = "split" if self.conformal_method == "cyclic" else "cyclic"
+        stray = [f for f in by_method[other] if f in fields]
+        if stray:
+            raise MlsynthConfigError(
+                f"{', '.join(stray)} configures the {other!r} cumulative band, "
+                f"and conformal_method is {self.conformal_method!r}, which does "
+                f"not read it. Set conformal_method={other!r} to use it, or drop "
+                "it to take the "
+                f"{self.conformal_method!r} band's own parameters.")
         return self
 
     @model_validator(mode="after")

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -494,7 +494,7 @@ def cwz_cumulative_per_unit(
     Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
     *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
     solver: Any, alpha: float, horizon: int, n_nulls: int = 25,
-    grid_scale: float = 3.0,
+    grid_scale: float = 3.0, conventions: Conventions = Conventions(),
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Per-unit cumulative band by inverting a moving-block conformal test.
 
@@ -542,6 +542,10 @@ def cwz_cumulative_per_unit(
     at thirty-one. Coarse is anti-conservative here, not conservative, which is
     the opposite of the usual intuition about discretisation.
 
+    ``conventions`` reaches both refits, the observed fit and each null one, so
+    the band is calibrated on the estimator the caller configured. The default
+    is augsynth's, so a call that says nothing gets what it always got.
+
     An accepted set that reaches an end of the grid is bounded by ``grid_scale``
     and not by the data, and that end is returned as infinite. Reporting the
     endpoint instead would understate the band silently, since it looks like any
@@ -587,7 +591,7 @@ def cwz_cumulative_per_unit(
 
     full = run_multisynth(Xy, trt, d, n_leads, n_lags, fixedeff=fixedeff,
                           time_cohort=time_cohort, nu=nu_used, lam=lam,
-                          solver=solver)
+                          solver=solver, conventions=conventions)
     tau = np.asarray(full["tau_rel"], dtype=float)
     groups = full["groups"]
     t0 = int(np.min(trt[adopted]))
@@ -608,7 +612,7 @@ def cwz_cumulative_per_unit(
         adj[row, t0:t0 + horizon] -= theta
         f = run_multisynth(adj, trt_null, T, 1, T, fixedeff=fixedeff,
                            time_cohort=time_cohort, nu=nu_used, lam=lam,
-                           solver=solver)
+                           solver=solver, conventions=conventions)
         return moving_block_pvalue(_resid(f, k)[:t0 + horizon], block=horizon,
                                    statistic="mean_abs")
 

--- a/mlsynth/utils/ppscm_helpers/structures.py
+++ b/mlsynth/utils/ppscm_helpers/structures.py
@@ -282,13 +282,22 @@ class PPSCMUnitFit:
     tau_lower: Optional[np.ndarray] = None
     tau_upper: Optional[np.ndarray] = None
     # Conformal band on this unit's CUMULATIVE effect over ``conformal_horizon``
-    # periods -- the total it gained, calibrated on out-of-sample windows of the
-    # same length. None unless ``conformal_horizon`` is set. See
-    # ``cumulative_conformal_per_unit`` in ``inference.py``.
+    # periods -- the total it gained. None unless ``conformal_horizon`` is set.
+    # ``cumulative_method`` names the calibration set that produced the bounds,
+    # and the two diagnostics below it belong one to each: a window count for
+    # ``"split"`` (``cumulative_conformal_per_unit``), a permutation p-value of
+    # the no-effect null for ``"cyclic"`` (``cwz_cumulative_per_unit``). The
+    # other is None, which is why they are separate fields.
+    #
+    # The bounds are ``nan`` when the cyclic band's accepted set is empty -- the
+    # effect is outside its constant-per-period null family. That is distinct
+    # from None, which means no band was asked for.
     cumulative_effect: Optional[float] = None
     cumulative_lower: Optional[float] = None
     cumulative_upper: Optional[float] = None
     cumulative_windows: Optional[int] = None
+    cumulative_p_value: Optional[float] = None
+    cumulative_method: Optional[str] = None
 
 
 class PPSCMResults(_BaseEstimatorResults):

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1268,6 +1268,55 @@ timeout = 900.0
   models = "norms read off the unscaled imbalance matrix but applied to scaled residuals, so the pooled objective shrinks by the fourth power of the scale and terminates at the first iterate the tolerance accepts"
 
 [[target]]
+name = "ppscm-conformal-method"
+module-path = "mlsynth/estimators/ppscm.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_conformal_method.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "the-method-field-ignored-at-the-branch"
+  find = "                if self.conformal_method == \"cyclic\":"
+  replace = "                if False:"
+  models = "a config field the fit reads and then does not act on. Every refusal still fires and every result field is still populated, so only a test that compares the two bands notices the caller was given the one they did not ask for"
+
+  [[target.mutant]]
+  id = "the-reported-method-taken-from-the-field-alone"
+  find = """                    cumulative_method=(self.conformal_method
+                                       if self.conformal_horizon is not None else None),"""
+  replace = "                    cumulative_method=self.conformal_method,"
+  models = "a fit with no horizon reporting 'split' as the method that produced its bounds, when it produced none. The label would then read as a band that was computed and came back empty"
+
+[[target]]
+name = "ppscm-conformal-method-config"
+module-path = "mlsynth/utils/ppscm_helpers/config.py"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_conformal_method.py -q -p no:cacheprovider"
+timeout = 900.0
+
+  [[target.mutant]]
+  id = "the-stray-parameter-check-reads-the-chosen-method"
+  find = '        other = "split" if self.conformal_method == "cyclic" else "cyclic"'
+  replace = '        other = self.conformal_method'
+  models = "the refusal firing on the parameters the chosen band does read and passing the ones it ignores, so every correct configuration is rejected and every mistaken one accepted"
+
+  [[target.mutant]]
+  id = "the-refusal-asked-of-the-field-instead-of-the-caller"
+  find = "        stray = [f for f in by_method[other] if f in fields]"
+  replace = "        stray = [f for f in by_method[other]]"
+  models = "a refusal that fires on the other method's parameters whether or not the caller set them. Both methods' defaults are always present on the model, so this rejects every fit that asks for a band at all"
+
+  [[target.mutant]]
+  id = "a-method-named-without-a-horizon-accepted"
+  find = '        if "conformal_method" in fields and self.conformal_horizon is None:'
+  replace = '        if False:'
+  models = "a caller who names a method and forgets the horizon getting a fit with no band and no complaint, which reads as the method having been applied"
+
+  [[target.mutant]]
+  id = "the-null-grid-read-after-coercion"
+  find = '    @field_validator("conformal_n_nulls", mode="before")'
+  replace = '    @field_validator("conformal_n_nulls")'
+  models = "the grid size checked after pydantic has coerced it, so True and \"9\" arrive as integers and the bool check they exist for never fires"
+
+[[target]]
 name = "weights-container-contract"
 module-path = "mlsynth/config_models.py"
 test-command = "python -m pytest mlsynth/tests/test_weights_container.py mlsynth/tests/test_result_contract.py -q -p no:cacheprovider"


### PR DESCRIPTION
Closes #512.

## Related Links

- Issue: #512, follow-up to #511
- Source: `mlsynth/estimators/ppscm.py`, `mlsynth/utils/ppscm_helpers/config.py`
- Mutation targets `ppscm-conformal-method` (2) and `ppscm-conformal-method-config` (4)
- Docs: the new "Which calibration set: `conformal_method`" section in `docs/ppscm.rst`

## What

- `conformal_method: Literal["split", "cyclic"] = "split"`, plus `conformal_n_nulls` and `conformal_grid_scale`.
- `estimators/ppscm.py` routes to `cwz_cumulative_per_unit` when asked.
- `PPSCMUnitFit` gains `cumulative_p_value` and `cumulative_method`.
- `cwz_cumulative_per_unit` gains a `conventions` parameter.
- `mlsynth/tests/test_ppscm_conformal_method.py`, 35 tests.

## The design call

The issue framed this as a decision, not a wiring job. The two bands report the same estimand from different calibration sets, so `conformal_method` selects between them the way `inference_method` selects the bootstrap or the jackknife behind the ATT, and `conformal_horizon` still decides whether any band is computed. That is the issue's option 1.

Option 2 was rejected on the ground the issue itself named: reporting both hands the reader two numbers for one estimand, and costs the extra solve whenever both are on.

The `conformal_horizon` precedent — an additional object, not a mode — does not extend here. It was chosen because the cumulative band and the pooled ATT are different estimands. Split and cyclic are the same one.

## Why the choice matters

The split band's reference set is the number of non-overlapping calibration windows, `m ~ 0.7 * T0 / L`, and a finite `1 - alpha` band needs `ceil((m+1)(1-alpha)) <= m`. That puts a floor of about `12.8 * L` pre-periods under it, and past the floor every feasible design sits where the required rank equals `m`, so the order statistic never trims and the half-width is simply the largest calibration score:

```
T0=120 L= 8: m=10  tightest level 90%  rank 10 of 10
T0=120 L= 4: m=21  tightest level 95%  rank 21 of 21
T0=104 L=13: m= 5  tightest level 80%  rank  5 of  5
T0=156 L= 8: m=13  tightest level 90%  rank 13 of 13
```

On a thirty-market weekly panel with 120 pre-weeks, an eight-week horizon and `alpha = 0.05` that is ten windows against a rank of eleven, and every treated unit's band is infinite. The cyclic reference set is the `T` cyclic shifts of the residual path, so neither the floor nor that regime applies.

The price is a shape assumption. Test inversion needs a null to subtract, and the null is a constant per-period effect. An effect that ramps is outside the family and the accepted set is empty, which arrives as `nan` bounds. `None` means no band was asked for; the two are kept apart on purpose, and a test pins the distinction.

## Result fields and refusals

The diagnostics differ, so they occupy separate fields: `cumulative_windows` for the split band, `cumulative_p_value` for the cyclic one, the other `None`, and `cumulative_method` naming which produced the bounds.

The parameters differ too, and one belonging to the method not chosen is refused by name at config time. The check is asked against `model_fields_set`, so it is about what the caller wrote and not what the field holds — both methods' defaults are always present on the model. Naming a method with no `conformal_horizon` is refused for the same reason.

`conformal_n_nulls` and `conformal_grid_scale` validate in `mode="before"`, so `True` and `"9"` are rejected instead of arriving as the integers pydantic would coerce them into.

## The one helper change

`cwz_cumulative_per_unit` called `run_multisynth` without `conventions`, so with a non-default `donor_pool` or `base_period` the band would have been calibrated against a different estimator than the fit it describes. The issue put the helper out of scope, but the wiring forces this: the point estimate would still look right, which is exactly why it needed catching. The default is `Conventions()`, so #511's behaviour, its 25 tests and its six mutants are untouched, and a spy test pins that both the observed fit and every null refit receive it.

## Verification

- Red to green: 15 of the 35 tests fail without the change.
- Mutation: 6/6 killed across two targets, including the branch reading the field and doing nothing with it, the stray-parameter check reading the chosen method instead of the other one, and the grid size validated after coercion.
- 1341 tests pass across the PPSCM, result-contract and config suites.
- Coverage: every new line in `estimators/ppscm.py` and `ppscm_helpers/config.py` is exercised; the modules' remaining gaps are pre-existing and outside this diff.
- `ppscm_paglayan` and `ppscm_paglayan_covs` pin unchanged. No pinned value moves — the default path is byte-for-byte the split branch it always was.
- A single-treated-unit panel gets a cyclic band: the automatic pooling rule sits on the program's boundary there, and the null refits take the fit's own `nu` instead of asking for it again.

## Test Steps

- [x] `pytest mlsynth/tests/test_ppscm_conformal_method.py -q` — 35 passed
- [x] `pytest mlsynth/tests/ -k "ppscm or result_contract or config"` — 1341 passed, 33 skipped
- [x] `python tools/mutation/run_mutants.py --target ppscm-conformal-method` — 2/2 killed
- [x] `python tools/mutation/run_mutants.py --target ppscm-conformal-method-config` — 4/4 killed
- [x] `python benchmarks/run_benchmarks.py --case ppscm_paglayan` and `--case ppscm_paglayan_covs`
- [x] `python tools/gen_llms_txt.py` — no change; the index does not enumerate config fields
- [x] RST underlines and a docutils parse — no new warnings
- [ ] `pytest mlsynth/tests/` — full suite, running here in CI

## Other Notes

`docs/choose.rst` is unchanged. This selects a calibration set inside PPSCM and moves nobody between estimators; the page's PPSCM passage does not mention the cumulative band, so there is nothing there to correct.

The cyclic band costs about fourteen times the split one, since every candidate in the grid is a refit. That is in the field description and the docs, not enforced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY6aV1skYFnj1awnwUBjDx)_