### PR TITLE
Calibrate PPSCM's per-unit cumulative band by resampling the rolling pass

### DIFF
--- a/docs/ppscm.rst
+++ b/docs/ppscm.rst
@@ -713,17 +713,53 @@ band assumes only that the calibration windows are exchangeable with the
 post-period window, and reports the accumulated effect directly, so it makes no
 claim about the effect's shape.
 
-The two report the same estimand, so ``conformal_method`` selects between them
-the way ``inference_method`` selects the bootstrap or the jackknife behind the
-ATT, and there is one set of bounds either way. Their diagnostics differ and so
-occupy separate fields: ``cumulative_windows`` counts the split band's calibration
-windows, ``cumulative_p_value`` is the cyclic band's permutation p-value of the
-no-effect null, and the other is ``None``. ``cumulative_method`` says which one
-produced the bounds.
+``conformal_method="resample"`` attacks the same shortage from a third
+direction, and it is the cheapest of the three. The split band runs a rolling
+pass over the pre-period and reduces each window to its total, so :math:`m`
+windows give :math:`m` numbers. The same pass computes an :math:`L`-period path
+on the way to each of those totals, and the resample band keeps them: its
+reference set is the :math:`m \times L` per-period errors rather than the
+:math:`m` totals. Each draw assembles a post-period path from circular blocks of
+a unit's own errors, flipping each block's sign with probability one half, and
+the band is the :math:`1-\alpha` quantile of the absolute accumulated draw::
 
-Their parameters differ too, and a parameter belonging to the method not chosen
-is refused by name at config time: ``conformal_min_train_frac`` is the split
-band's, ``conformal_n_nulls`` and ``conformal_grid_scale`` are the cyclic band's.
+   res = PPSCM({..., "conformal_horizon": 8,
+                     "conformal_method": "resample"}).fit()
+
+Because the reference set counts periods, the window floor does not apply, and a
+panel with seven windows against a required rank of eight -- infinite under the
+split band -- returns a finite one. It buys that without the cyclic band's shape
+assumption: nothing is subtracted, no null family is posited, and an effect that
+ramps is as admissible as a flat one. It also refits nothing beyond the rolling
+pass the split band already pays for, where the cyclic band pays a refit per
+candidate in its grid.
+
+What it does assume is that ``conformal_block`` is long enough to carry the
+serial correlation of the period errors. The variance of an :math:`H`-period
+total is :math:`H\gamma_0 + 2\sum_k (H-k)\gamma_k`, so drawing periods
+independently -- ``conformal_block=1``, Wheeler's original construction -- keeps
+only the first term and reports a band too narrow whenever the errors are
+positively autocorrelated. The default, ``0``, means the whole horizon, the
+longest block the accumulated total is sensitive to. A block longer than the
+horizon is clamped to it.
+
+The three report the same estimand, so ``conformal_method`` selects between them
+the way ``inference_method`` selects the bootstrap or the jackknife behind the
+ATT, and there is one set of bounds whichever is chosen. Their diagnostics
+differ and so occupy separate fields: ``cumulative_windows`` counts calibration
+windows and is filled by the split and resample bands, ``cumulative_p_value`` is
+the cyclic band's permutation p-value of the no-effect null, and the unused one
+is ``None``. ``cumulative_method`` says which produced the bounds. A window count
+means different things to the two bands that report it -- the split band's order
+statistic is taken over exactly those windows, while the resample band draws from
+the :math:`L` periods inside each -- which is what ``cumulative_method`` is there
+to disambiguate.
+
+Their parameters differ too, and a parameter belonging to a method not chosen is
+refused by name at config time: ``conformal_n_nulls`` and ``conformal_grid_scale``
+are the cyclic band's, ``conformal_block`` and ``conformal_n_sim`` are the
+resample band's, and ``conformal_min_train_frac`` is shared by the split and
+resample bands, which run the same pass and differ only in how they read it.
 The grid is an approximation and it errs in one direction: the band is the range
 of accepted candidates, so a coarse grid samples fewer of them and reports a band
 too narrow, converging upward as ``conformal_n_nulls`` rises -- measured on a

--- a/mlsynth/estimators/ppscm.py
+++ b/mlsynth/estimators/ppscm.py
@@ -32,7 +32,8 @@ from ..utils.ppscm_helpers.cs_inference import influence_function_inference
 from ..utils.ppscm_helpers.engine import Conventions, run_multisynth
 from ..utils.ppscm_helpers.inference import (
     jackknife_inference, bootstrap_inference, per_unit_intervals,
-    cumulative_conformal_per_unit, cumulative_supt_band, cwz_cumulative_per_unit)
+    cumulative_conformal_per_unit, cumulative_supt_band, cwz_cumulative_per_unit,
+    resample_cumulative_per_unit)
 from ..utils.ppscm_helpers.plotter import plot_ppscm
 from ..utils.ppscm_helpers.setup import prepare_ppscm_inputs
 from ..utils.ppscm_helpers.structures import (
@@ -101,6 +102,8 @@ class PPSCM:
         self.conformal_min_train_frac = config.conformal_min_train_frac
         self.conformal_n_nulls = config.conformal_n_nulls
         self.conformal_grid_scale = config.conformal_grid_scale
+        self.conformal_block = config.conformal_block
+        self.conformal_n_sim = config.conformal_n_sim
         self.cumulative_band: bool = config.cumulative_band
         self.covariates = config.covariates
 
@@ -277,6 +280,19 @@ class PPSCM:
                         Xy, trt, d, n_leads, n_lags, **common,
                         n_nulls=int(self.conformal_n_nulls),
                         grid_scale=float(self.conformal_grid_scale),
+                    )
+                elif self.conformal_method == "resample":
+                    # Same rolling pass as the split branch, read at period
+                    # resolution instead of window totals, so the window floor
+                    # that leaves the split band infinite does not apply. It
+                    # reports a window count and no p-value: the diagnostic
+                    # belongs to the calibration set, and this one's is the pass.
+                    cum_pt, cum_lo, cum_hi, cum_n = resample_cumulative_per_unit(
+                        Xy, trt, d, n_leads, n_lags, **common,
+                        min_train_frac=float(self.conformal_min_train_frac),
+                        block=int(self.conformal_block),
+                        n_sim=int(self.conformal_n_sim),
+                        seed=int(self.seed),
                     )
                 else:
                     cum_pt, cum_lo, cum_hi, cum_n = cumulative_conformal_per_unit(

--- a/mlsynth/tests/test_ppscm_resample_cumulative.py
+++ b/mlsynth/tests/test_ppscm_resample_cumulative.py
@@ -1,0 +1,351 @@
+"""Calibrating PPSCM's per-unit cumulative band by resampling the rolling pass.
+
+``cumulative_conformal_per_unit`` reduces each calibration window to one number,
+its total, and reads an order statistic off the ``m`` totals. That is what puts
+a floor under the split band: a finite ``1 - alpha`` interval needs
+``ceil((m+1)(1-alpha)) <= m``, so at the 90 percent level it needs nine windows,
+about ``12.8 * L`` pre-periods.
+
+The same pass produces ``m * L`` per-period errors on the way to those totals.
+Resampling draws whole paths from them -- circular blocks, each sign-flipped
+with probability one half -- and reads the band off the accumulated draws. The
+reference set is periods instead of windows, so the window floor does not apply
+and a panel that leaves the split band infinite still gets a finite one.
+
+It is the third value of ``conformal_method``, on the same axis as the other
+two: all three report the same estimand, the total a treated unit gained over
+``conformal_horizon`` periods, from different reference sets. Unlike the cyclic
+band it assumes no shape for the effect and refits nothing beyond the rolling
+pass the split band already pays for.
+
+The aggregate band is untouched. Its jackknife resamples units, the dimension
+along which a pooled total has exchangeable replicates; this resamples time,
+which is the only dimension a single unit has.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.ppscm_helpers.engine import Conventions
+
+
+# A panel wide enough in the pre-period to schedule several calibration windows,
+# and deliberately short of the split band's floor at alpha=0.10: earliest
+# adoption 40, horizon 4, min_train_frac 0.3 puts origins at 12..36 step 4, so
+# m = 7 and the split band needs ceil(8*0.9) = 8. Seven windows, rank eight.
+def _staggered_df(seed=0, adoption=(40, 44), n_donors=8, T=60, effect=-3.0,
+                  noise=0.4):
+    rng = np.random.default_rng(seed)
+    factors = rng.standard_normal((T, 2))
+    load_d = rng.standard_normal((n_donors, 2)) * 0.5
+    load_t = load_d.mean(axis=0)
+    rec = []
+    for j, Tj in enumerate(adoption):
+        series = (factors @ (load_t + 0.1 * rng.standard_normal(2))
+                  + rng.standard_normal(T) * noise)
+        series[Tj:] += effect
+        rec += [{"unit": f"treated_{j}", "year": 2000 + t, "y": float(series[t]),
+                 "tr": int(t >= Tj)} for t in range(T)]
+    for dd in range(n_donors):
+        series = factors @ load_d[dd] + rng.standard_normal(T) * noise
+        rec += [{"unit": f"d_{dd}", "year": 2000 + t, "y": float(series[t]), "tr": 0}
+                for t in range(T)]
+    return pd.DataFrame(rec)
+
+
+def _cfg(**kw):
+    cfg = dict(df=_staggered_df(), outcome="y", treat="tr", unitid="unit",
+               time="year", display_graphs=False, run_inference=False)
+    cfg.update(kw)
+    return cfg
+
+
+def _build(**kw):
+    from mlsynth import PPSCM
+    return PPSCM(_cfg(**kw))
+
+
+def _fit(**kw):
+    import warnings as _w
+    from mlsynth import PPSCM
+    with _w.catch_warnings():
+        _w.simplefilter("ignore")
+        return PPSCM(_cfg(**kw)).fit()
+
+
+def _panel():
+    """``(Xy, trt, d, n_leads, n_lags)`` as the estimator assembles them."""
+    import numpy as _np
+    from mlsynth.utils.ppscm_helpers.setup import prepare_ppscm_inputs
+    inp = prepare_ppscm_inputs(_staggered_df(), outcome="y", treat="tr",
+                               unitid="unit", time="year")
+    Xy, trt, d = inp.Xy, inp.trt, inp.n_pre
+    T = Xy.shape[1]
+    n_leads = min(T - d, T - int(_np.min(trt[_np.isfinite(trt)])))
+    return Xy, trt, d, n_leads, d
+
+
+HORIZON = 4
+COMMON = dict(fixedeff=True, time_cohort=False, nu_used=float("nan"), lam=0.0,
+              solver=None, conventions=Conventions())
+
+
+# --------------------------------------------------------------------------- #
+# the config field                                                             #
+# --------------------------------------------------------------------------- #
+
+def test_resample_is_an_accepted_method():
+    _build(conformal_horizon=4, conformal_method="resample")
+
+
+def test_the_default_is_still_the_split_band():
+    from mlsynth.config_models import PPSCMConfig
+    assert PPSCMConfig.model_fields["conformal_method"].default == "split"
+
+
+def test_choosing_resample_without_a_horizon_is_refused():
+    with pytest.raises(MlsynthConfigError) as exc:
+        _build(conformal_method="resample")
+    assert "conformal_horizon" in str(exc.value)
+
+
+@pytest.mark.parametrize("bad", [-1, True, 2.5, "4"])
+def test_an_unusable_block_length_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="conformal_block"):
+        _build(conformal_horizon=4, conformal_method="resample",
+               conformal_block=bad)
+
+
+@pytest.mark.parametrize("bad", [1, 0, -5, True, 500.0, "2000"])
+def test_an_unusable_draw_count_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="conformal_n_sim"):
+        _build(conformal_horizon=4, conformal_method="resample",
+               conformal_n_sim=bad)
+
+
+def test_a_block_of_zero_is_accepted_and_means_the_whole_horizon():
+    """Zero is the documented default, not a missing value."""
+    from mlsynth.config_models import PPSCMConfig
+    assert PPSCMConfig.model_fields["conformal_block"].default == 0
+    _build(conformal_horizon=4, conformal_method="resample", conformal_block=0)
+
+
+@pytest.mark.parametrize("field,value", [("conformal_block", 2),
+                                         ("conformal_n_sim", 500)])
+def test_a_resample_parameter_set_on_another_band_is_refused(field, value):
+    for method in ("split", "cyclic"):
+        with pytest.raises(MlsynthConfigError) as exc:
+            _build(conformal_horizon=4, conformal_method=method, **{field: value})
+        assert field in str(exc.value)
+        assert "resample" in str(exc.value)
+
+
+@pytest.mark.parametrize("field,value", [("conformal_n_nulls", 9),
+                                         ("conformal_grid_scale", 2.0)])
+def test_a_cyclic_parameter_set_on_the_resample_band_is_refused(field, value):
+    with pytest.raises(MlsynthConfigError) as exc:
+        _build(conformal_horizon=4, conformal_method="resample", **{field: value})
+    assert field in str(exc.value)
+    assert "cyclic" in str(exc.value)
+
+
+def test_the_training_fraction_is_shared_with_the_split_band():
+    """Both run the same rolling pass, so both read where it starts."""
+    _build(conformal_horizon=4, conformal_method="resample",
+           conformal_min_train_frac=0.4)
+
+
+def test_leaving_the_resample_parameters_at_their_defaults_is_not_setting_them():
+    _build(conformal_horizon=4, conformal_method="resample")
+
+
+# --------------------------------------------------------------------------- #
+# the rolling pass returns the per-period errors it already computed            #
+# --------------------------------------------------------------------------- #
+
+def test_the_pass_returns_one_window_by_horizon_matrix_per_treated_unit():
+    from mlsynth.utils.ppscm_helpers.inference import rolling_pooled_period_errors
+    Xy, trt, d, n_leads, n_lags = _panel()
+    out = rolling_pooled_period_errors(
+        Xy, trt, d, n_leads, n_lags, horizon=HORIZON, **COMMON)
+    assert len(out) >= 1
+    for arr in out:
+        assert arr.ndim == 2
+        assert arr.shape[1] == HORIZON
+
+
+def test_the_period_errors_sum_to_the_block_sums_the_split_band_reads():
+    """One pass, two readings of it. If these diverge the two bands are no
+    longer describing the same calibration set."""
+    from mlsynth.utils.ppscm_helpers.inference import (
+        rolling_pooled_block_sums, rolling_pooled_period_errors)
+    Xy, trt, d, n_leads, n_lags = _panel()
+    sums = rolling_pooled_block_sums(
+        Xy, trt, d, n_leads, n_lags, horizon=HORIZON, **COMMON)
+    errs = rolling_pooled_period_errors(
+        Xy, trt, d, n_leads, n_lags, horizon=HORIZON, **COMMON)
+    assert len(sums) == len(errs)
+    for s, e in zip(sums, errs):
+        assert e.shape[0] == s.size
+        np.testing.assert_allclose(e.sum(axis=1), s, rtol=0, atol=1e-12)
+
+
+def test_the_pass_refuses_a_panel_with_no_treated_unit():
+    from mlsynth.utils.ppscm_helpers.inference import rolling_pooled_period_errors
+    Xy, trt, d, n_leads, n_lags = _panel()
+    with pytest.raises(MlsynthDataError):
+        rolling_pooled_period_errors(
+            Xy, np.full_like(trt, np.nan, dtype=float), d, n_leads, n_lags,
+            horizon=HORIZON, **COMMON)
+
+
+# --------------------------------------------------------------------------- #
+# the band                                                                     #
+# --------------------------------------------------------------------------- #
+
+def _band(**kw):
+    from mlsynth.utils.ppscm_helpers.inference import resample_cumulative_per_unit
+    Xy, trt, d, n_leads, n_lags = _panel()
+    opts = dict(alpha=0.10, horizon=HORIZON, **COMMON)
+    opts.update(kw)
+    return resample_cumulative_per_unit(Xy, trt, d, n_leads, n_lags, **opts)
+
+
+def test_the_band_brackets_its_point_estimate():
+    pt, lo, hi, n = _band()
+    assert np.all(lo <= pt) and np.all(pt <= hi)
+
+
+def test_the_band_is_symmetric_about_the_point():
+    """The draw is symmetric by construction -- every block's sign is flipped
+    with probability one half -- so an asymmetric band would mean the
+    accumulation, not the calibration, moved it."""
+    pt, lo, hi, _ = _band()
+    np.testing.assert_allclose(pt - lo, hi - pt, rtol=1e-9)
+
+
+def test_it_is_finite_where_the_split_band_is_infinite():
+    """The reason this construction exists. Seven windows against a rank of
+    eight leaves the split band with no order statistic; the same seven windows
+    hold twenty-eight periods."""
+    from mlsynth.utils.ppscm_helpers.inference import cumulative_conformal_per_unit
+    Xy, trt, d, n_leads, n_lags = _panel()
+    _, s_lo, s_hi, s_n = cumulative_conformal_per_unit(
+        Xy, trt, d, n_leads, n_lags, alpha=0.10, horizon=HORIZON, **COMMON)
+    assert np.all(np.isinf(s_hi)), f"panel was meant to starve the split band: {s_n}"
+    _, r_lo, r_hi, _ = _band()
+    assert np.all(np.isfinite(r_lo)) and np.all(np.isfinite(r_hi))
+
+
+def test_the_reported_window_count_is_the_passes_own():
+    from mlsynth.utils.ppscm_helpers.inference import rolling_pooled_period_errors
+    Xy, trt, d, n_leads, n_lags = _panel()
+    errs = rolling_pooled_period_errors(
+        Xy, trt, d, n_leads, n_lags, horizon=HORIZON, **COMMON)
+    _, _, _, n = _band()
+    np.testing.assert_array_equal(n, [e.shape[0] for e in errs])
+
+
+def test_the_draw_is_reproducible_under_a_seed():
+    a = _band(seed=7)
+    b = _band(seed=7)
+    for x, y in zip(a, b):
+        np.testing.assert_array_equal(x, y)
+
+
+def test_a_different_seed_moves_the_band_but_not_the_point():
+    a_pt, a_lo, _, _ = _band(seed=1)
+    b_pt, b_lo, _, _ = _band(seed=2)
+    np.testing.assert_array_equal(a_pt, b_pt)
+    assert not np.allclose(a_lo, b_lo)
+
+
+def test_a_tighter_level_gives_a_wider_band():
+    _, lo10, hi10, _ = _band(alpha=0.10)
+    _, lo01, hi01, _ = _band(alpha=0.01)
+    assert np.all((hi01 - lo01) >= (hi10 - lo10))
+
+
+def test_drawing_periods_independently_gives_a_different_band_than_whole_blocks():
+    """block=1 is Wheeler's original and discards the serial correlation the
+    accumulated total is driven by; if these agreed the block length would not
+    be doing anything."""
+    _, lo1, hi1, _ = _band(block=1)
+    _, lo0, hi0, _ = _band(block=0)
+    assert not np.allclose(hi1 - lo1, hi0 - lo0)
+
+
+def test_a_block_longer_than_the_horizon_is_clamped_to_it():
+    a = _band(block=HORIZON)
+    b = _band(block=HORIZON + 50)
+    np.testing.assert_allclose(a[1], b[1])
+
+
+def test_a_unit_with_no_calibration_windows_gets_an_infinite_band():
+    """A refusal to report, not a narrow band that does not cover."""
+    from mlsynth.utils.ppscm_helpers.inference import resample_cumulative_per_unit
+    Xy, trt, d, n_leads, n_lags = _panel()
+    pt, lo, hi, n = resample_cumulative_per_unit(
+        Xy, trt, d, n_leads, n_lags, alpha=0.10, horizon=39, **COMMON)
+    assert np.all(np.isneginf(lo)) and np.all(np.isposinf(hi))
+    assert np.all(n == 0)
+
+
+@pytest.mark.parametrize("bad", [0.0, 1.0, -0.1, True, "0.1"])
+def test_an_unusable_level_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="alpha"):
+        _band(alpha=bad)
+
+
+def test_the_band_refuses_a_panel_with_no_treated_unit():
+    """Checked here as well as in the pass: this function reads ``trt`` for its
+    point estimates before the pass is ever called, so the pass's refusal would
+    arrive too late to be the one the caller sees."""
+    from mlsynth.utils.ppscm_helpers.inference import resample_cumulative_per_unit
+    Xy, trt, d, n_leads, n_lags = _panel()
+    with pytest.raises(MlsynthDataError):
+        resample_cumulative_per_unit(
+            Xy, np.full_like(trt, np.nan, dtype=float), d, n_leads, n_lags,
+            alpha=0.10, horizon=HORIZON, **COMMON)
+
+
+# --------------------------------------------------------------------------- #
+# end to end                                                                   #
+# --------------------------------------------------------------------------- #
+
+def test_asking_for_the_resample_band_fills_the_cumulative_fields():
+    res = _fit(conformal_horizon=4, conformal_method="resample",
+               run_inference=True)
+    units = list(res.per_unit.values())
+    assert units
+    for u in units:
+        assert u.cumulative_method == "resample"
+        assert u.cumulative_effect is not None
+        assert np.isfinite(u.cumulative_lower) and np.isfinite(u.cumulative_upper)
+
+
+def test_the_resample_band_reports_a_window_count_and_no_p_value():
+    """The diagnostics belong one to each method; only the chosen one is filled."""
+    res = _fit(conformal_horizon=4, conformal_method="resample",
+               run_inference=True)
+    for u in res.per_unit.values():
+        assert u.cumulative_windows is not None
+        assert u.cumulative_p_value is None
+
+
+def test_no_horizon_leaves_every_cumulative_field_empty():
+    res = _fit(run_inference=True)
+    for u in res.per_unit.values():
+        assert u.cumulative_method is None
+        assert u.cumulative_effect is None
+        assert u.cumulative_windows is None
+
+
+def test_the_split_path_is_untouched_by_the_new_method():
+    """The default is byte-for-byte the band it always was."""
+    a = _fit(conformal_horizon=4, run_inference=True)
+    for u in a.per_unit.values():
+        assert u.cumulative_method == "split"
+        assert u.cumulative_p_value is None

--- a/mlsynth/utils/ppscm_helpers/config.py
+++ b/mlsynth/utils/ppscm_helpers/config.py
@@ -231,7 +231,7 @@ class PPSCMConfig(BaseEstimatorConfig):
             )
         return float(v)
 
-    conformal_method: Literal["split", "cyclic"] = Field(
+    conformal_method: Literal["split", "cyclic", "resample"] = Field(
         default="split",
         description=(
             "Which reference set calibrates the cumulative band, once "
@@ -254,9 +254,72 @@ class PPSCMConfig(BaseEstimatorConfig):
             "the accepted range, so an effect that ramps is outside the null "
             "family and the accepted set is empty, reported as ``nan`` bounds. "
             "It also costs about fourteen times as much, since every candidate "
-            "in the grid is a refit."
+            "in the grid is a refit. ``'resample'`` runs the same rolling pass "
+            "as ``'split'`` and reads the ``m * horizon`` per-period errors "
+            "inside those windows instead of the ``m`` totals, drawing whole "
+            "post-period paths from them as sign-flipped circular blocks. Its "
+            "reference set is periods, so the window floor does not apply and a "
+            "panel that leaves the split band infinite still gets a finite one; "
+            "unlike ``'cyclic'`` it assumes no shape for the effect and refits "
+            "nothing beyond the pass ``'split'`` already pays for. What it adds "
+            "is an assumption that ``conformal_block`` is long enough to carry "
+            "the serial correlation of the period errors."
         ),
     )
+
+    conformal_block: int = Field(
+        default=0,
+        description=(
+            "Block length in periods for the resample band's circular block "
+            "bootstrap. Only meaningful with ``conformal_method='resample'``. "
+            "``0`` (the default) means the whole horizon, the longest block the "
+            "accumulated total is sensitive to; a block longer than the horizon "
+            "is clamped to it. ``1`` draws periods independently, which is "
+            "Wheeler's original construction and is too narrow whenever the "
+            "period errors are positively autocorrelated -- the variance of an "
+            "``H``-period total is ``H * gamma_0 + 2 * sum_k (H - k) * gamma_k``, "
+            "and independent draws keep only the first term."
+        ),
+    )
+
+    conformal_n_sim: int = Field(
+        default=2000,
+        description=(
+            "Paths the resample band draws per treated unit. Only meaningful "
+            "with ``conformal_method='resample'``. Unlike the cyclic band's "
+            "``conformal_n_nulls`` these cost no refits -- the rolling pass is "
+            "the cost -- so quantile precision here is cheap."
+        ),
+    )
+
+    @field_validator("conformal_block", mode="before")
+    @classmethod
+    def _validate_conformal_block(cls, v):
+        """Read before coercion, for the reason given on
+        :meth:`_validate_conformal_n_nulls`."""
+        if isinstance(v, bool) or not isinstance(v, int):
+            raise ValueError(
+                f"conformal_block must be a non-negative integer; got {v!r}. "
+                "Zero means the whole horizon.")
+        if v < 0:
+            raise ValueError(
+                f"conformal_block must be a non-negative integer; got {v!r}. "
+                "Zero means the whole horizon.")
+        return v
+
+    @field_validator("conformal_n_sim", mode="before")
+    @classmethod
+    def _validate_conformal_n_sim(cls, v):
+        """Read before coercion, for the reason given on
+        :meth:`_validate_conformal_n_nulls`."""
+        if isinstance(v, bool) or not isinstance(v, int):
+            raise ValueError(
+                f"conformal_n_sim must be an integer of at least 2; got {v!r}.")
+        if v < 2:
+            raise ValueError(
+                f"conformal_n_sim must be an integer of at least 2; got {v!r}. "
+                "A quantile needs at least two draws to sit between.")
+        return v
 
     conformal_n_nulls: int = Field(
         default=25,
@@ -397,17 +460,27 @@ class PPSCMConfig(BaseEstimatorConfig):
                 "cumulative band to report, and conformal_horizon is None, so "
                 "no band is computed. Set conformal_horizon to the number of "
                 "post-periods to accumulate.")
-        by_method = {"cyclic": ("conformal_n_nulls", "conformal_grid_scale"),
-                     "split": ("conformal_min_train_frac",)}
-        other = "split" if self.conformal_method == "cyclic" else "cyclic"
-        stray = [f for f in by_method[other] if f in fields]
+        # Which methods read each parameter. The training fraction is shared:
+        # 'split' and 'resample' run the same rolling pass and differ only in how
+        # they reduce it, so where that pass starts belongs to both.
+        readers = {
+            "conformal_min_train_frac": ("split", "resample"),
+            "conformal_n_nulls": ("cyclic",),
+            "conformal_grid_scale": ("cyclic",),
+            "conformal_block": ("resample",),
+            "conformal_n_sim": ("resample",),
+        }
+        stray = [f for f, m in readers.items()
+                 if f in fields and self.conformal_method not in m]
         if stray:
+            owners = sorted({m for f in stray for m in readers[f]})
+            named = " or ".join(repr(m) for m in owners)
             raise MlsynthConfigError(
-                f"{', '.join(stray)} configures the {other!r} cumulative band, "
+                f"{', '.join(stray)} configures the {named} cumulative band, "
                 f"and conformal_method is {self.conformal_method!r}, which does "
-                f"not read it. Set conformal_method={other!r} to use it, or drop "
-                "it to take the "
-                f"{self.conformal_method!r} band's own parameters.")
+                f"not read it. Set conformal_method to {named} to use it, or "
+                f"drop it to take the {self.conformal_method!r} band's own "
+                "parameters.")
         return self
 
     @model_validator(mode="after")

--- a/mlsynth/utils/ppscm_helpers/inference.py
+++ b/mlsynth/utils/ppscm_helpers/inference.py
@@ -344,27 +344,34 @@ def jackknife_inference(
     return float(att_full), se, ci, per_time_se, per_time_ci
 
 
-def rolling_pooled_block_sums(
+def _rolling_pooled_paths(
     Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
     *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
     solver: Any, horizon: int, min_train_frac: float = 0.3,
     conventions: Conventions = Conventions(),
 ) -> List[np.ndarray]:
-    """Per-unit cumulative out-of-sample errors, one pooled solve per origin.
+    """Per-unit out-of-sample effect paths, one pooled solve per origin.
 
     Slides an origin across the pre-period and, at each one, pretends every treated
     unit adopted there: a single partially-pooled fit on the data before the origin
-    yields *every* unit's weights at once, and each unit's summed effect over the next
-    ``horizon`` periods is one conformity score for it. So a pass costs one solve per
-    origin, not one per unit per origin.
+    yields *every* unit's weights at once, and each unit's effect over the next
+    ``horizon`` periods is one calibration window for it. So a pass costs one solve
+    per origin, not one per unit per origin.
 
-    Origins step by ``horizon``, so the windows do not overlap and the scores stay
+    Origins step by ``horizon``, so the windows do not overlap and their totals stay
     exchangeable, and each fit sees only data strictly before the window it scores.
+
+    The two public readings of this pass -- :func:`rolling_pooled_block_sums` for the
+    split band's window totals, :func:`rolling_pooled_period_errors` for the resample
+    band's per-period errors -- differ only in how they reduce these paths. Keeping
+    the pass itself in one place means the origin schedule, which decides how much
+    calibration a panel affords, has a single definition.
 
     Returns
     -------
     list of numpy.ndarray
-        One array of finite scores per treated cohort, in ``groups`` order.
+        One ``(m, horizon)`` array per treated cohort, in ``groups`` order, holding
+        the ``m`` windows whose fit converged with a finite path.
     """
     from ..conformal import MIN_TRAIN_PERIODS
 
@@ -386,7 +393,7 @@ def rolling_pooled_block_sums(
     earliest = int(np.min(trt[adopted]))
     start = max(MIN_TRAIN_PERIODS, int(earliest * float(min_train_frac)))
 
-    scores: Dict[int, List[float]] = {}
+    paths: Dict[int, List[np.ndarray]] = {}
     n_groups = 0
     for origin in range(start, earliest - horizon + 1, horizon):
         trt_o = trt.copy()
@@ -404,8 +411,67 @@ def rolling_pooled_block_sums(
         for k in range(len(fo["groups"])):
             path = np.asarray(fo["tau_rel"][k], dtype=float)[:horizon]
             if path.size == horizon and np.isfinite(path).all():
-                scores.setdefault(k, []).append(float(path.sum()))
-    return [np.asarray(scores.get(k, []), dtype=float) for k in range(n_groups)]
+                paths.setdefault(k, []).append(path)
+    return [
+        (np.vstack(paths[k]) if k in paths
+         else np.empty((0, horizon), dtype=float))
+        for k in range(n_groups)
+    ]
+
+
+def rolling_pooled_block_sums(
+    Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
+    *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
+    solver: Any, horizon: int, min_train_frac: float = 0.3,
+    conventions: Conventions = Conventions(),
+) -> List[np.ndarray]:
+    """Each calibration window reduced to its total -- the split band's scores.
+
+    One number per window, which is the estimand's own scale, so the order
+    statistic in :func:`mlsynth.utils.conformal.cumulative_conformal_interval` is
+    taken over quantities directly comparable with the reported cumulative effect.
+
+    Returns
+    -------
+    list of numpy.ndarray
+        One array of ``m`` finite window totals per treated cohort, in ``groups``
+        order.
+    """
+    return [p.sum(axis=1) for p in _rolling_pooled_paths(
+        Xy, trt, d, n_leads, n_lags, fixedeff=fixedeff, time_cohort=time_cohort,
+        nu_used=nu_used, lam=lam, solver=solver, horizon=horizon,
+        min_train_frac=min_train_frac, conventions=conventions)]
+
+
+def rolling_pooled_period_errors(
+    Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
+    *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
+    solver: Any, horizon: int, min_train_frac: float = 0.3,
+    conventions: Conventions = Conventions(),
+) -> List[np.ndarray]:
+    """The same windows left unreduced -- the resample band's calibration series.
+
+    :func:`rolling_pooled_block_sums` throws away the cross-period structure inside
+    each window on its way to the total. A band for a running total needs it: the
+    spread of an ``H``-period sum depends on how the period errors move together,
+    and the totals alone cannot say. So this returns the paths, and the caller
+    block-resamples them.
+
+    The reference set is the ``m * horizon`` periods instead of the ``m`` totals,
+    which is why this construction stays finite on a pre-period that leaves the
+    split band's order statistic undefined.
+
+    Returns
+    -------
+    list of numpy.ndarray
+        One ``(m, horizon)`` array per treated cohort, in ``groups`` order. Row
+        ``i`` is the effect path over window ``i``; ``arr.sum(axis=1)`` is exactly
+        what :func:`rolling_pooled_block_sums` returns for the same panel.
+    """
+    return _rolling_pooled_paths(
+        Xy, trt, d, n_leads, n_lags, fixedeff=fixedeff, time_cohort=time_cohort,
+        nu_used=nu_used, lam=lam, solver=solver, horizon=horizon,
+        min_train_frac=min_train_frac, conventions=conventions)
 
 
 def cumulative_conformal_per_unit(
@@ -488,6 +554,124 @@ def cumulative_conformal_per_unit(
             point[k], s, alpha=float(alpha), horizon=horizon)
         lower[k], upper[k] = band.lower, band.upper
     return point, lower, upper, n_scores
+
+
+def resample_cumulative_per_unit(
+    Xy: np.ndarray, trt: np.ndarray, d: int, n_leads: int, n_lags: int,
+    *, fixedeff: bool, time_cohort: bool, nu_used: float, lam: float,
+    solver: Any, alpha: float, horizon: int, min_train_frac: float = 0.3,
+    block: int = 0, n_sim: int = 2000, seed: int = 0,
+    conventions: Conventions = Conventions(),
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Per-unit cumulative band from block-resampled rolling-origin errors.
+
+    The third calibration set behind PPSCM's per-unit cumulative band, alongside
+    :func:`cumulative_conformal_per_unit` (a disjoint split of the pre-period) and
+    :func:`cwz_cumulative_per_unit` (the cyclic shifts of the residual path). All
+    three report the same estimand -- the total a treated unit gained over
+    ``horizon`` periods -- so ``conformal_method`` chooses between them.
+
+    It runs the rolling pass the split band already pays for and reads the
+    ``m * horizon`` per-period errors inside those windows instead of the ``m``
+    totals. Each draw assembles a post-period path from circular blocks of a
+    unit's own errors, flipping each block's sign with probability one half, and
+    the band is the ``1 - alpha`` quantile of the absolute accumulated draw.
+
+    Two things follow, and they are the reason to reach for it. The split band
+    needs ``ceil((m+1)(1-alpha)) <= m`` before its order statistic exists, a floor
+    of roughly ``12.8 * horizon`` pre-periods; drawing from periods rather than
+    totals has no such floor, so a panel that leaves the split band infinite still
+    gets a finite one. And unlike the cyclic band it assumes no shape for the
+    effect and refits nothing beyond the pass itself, where cyclic pays a refit
+    per candidate in its grid.
+
+    What it does assume is that a unit's pre-period errors are exchangeable with
+    its post-period ones, which is the same assumption the split band makes, and
+    that ``block`` is long enough to carry their serial correlation. Drawing
+    periods independently (``block = 1``) is Wheeler's original construction and
+    understates the spread of the total whenever the period errors are positively
+    autocorrelated -- the variance of an ``H``-period total is
+    ``H * gamma_0 + 2 * sum_k (H - k) * gamma_k``, and independent draws keep only
+    the first term.
+
+    Parameters
+    ----------
+    block : int, optional
+        Block length in periods. ``0`` (default) means the whole horizon, the
+        longest block the accumulated total is sensitive to. Clamped to the
+        horizon; see :func:`mlsynth.utils.conformal.resolve_block`.
+    n_sim : int, optional
+        Paths drawn per unit (default 2000). These cost no refits -- the pass is
+        the cost -- so precision here is cheap.
+    seed : int, optional
+        Base seed. Each unit draws from ``seed + k`` so a unit's band does not
+        depend on how many other units the panel happens to carry.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        ``(point, lower, upper, n_windows)``, each of shape ``(J,)`` in ``groups``
+        order. ``n_windows`` counts the calibration windows the pass realised, the
+        same number :func:`cumulative_conformal_per_unit` reports; the draw itself
+        uses the ``n_windows * horizon`` periods inside them. A unit whose pass
+        realised no window gets an infinite band, not a narrow one that does not
+        cover.
+    """
+    from ..conformal import block_error_paths, resolve_block
+
+    if isinstance(alpha, bool) or not isinstance(alpha, (int, float, np.floating)):
+        raise MlsynthConfigError(f"alpha must be a number in (0, 1); got {alpha!r}.")
+    if not 0.0 < float(alpha) < 1.0:
+        raise MlsynthConfigError(
+            f"alpha must lie in the open interval (0, 1); got {alpha!r}.")
+    horizon = int(horizon)
+    if not np.isfinite(np.asarray(trt, dtype=float)).any():
+        raise MlsynthDataError(
+            "cumulative conformal inference needs at least one treated unit; "
+            "no unit has a finite adoption time."
+        )
+
+    full = run_multisynth(
+        Xy, trt, d, n_leads, n_lags, fixedeff=fixedeff, time_cohort=time_cohort,
+        nu=(float(nu_used) if np.isfinite(nu_used) else None),
+        lam=lam, solver=solver, conventions=conventions,
+    )
+    n_units = len(full["groups"])
+    point = np.array(
+        [float(np.sum(np.asarray(full["tau_rel"][k], dtype=float)[:horizon]))
+         for k in range(n_units)], dtype=float,
+    )
+
+    per_unit_paths = rolling_pooled_period_errors(
+        Xy, trt, d, n_leads, n_lags, fixedeff=fixedeff, time_cohort=time_cohort,
+        nu_used=nu_used, lam=lam, solver=solver, horizon=horizon,
+        min_train_frac=min_train_frac, conventions=conventions,
+    )
+
+    b = resolve_block(block, horizon)
+    lower = np.full(n_units, np.nan)
+    upper = np.full(n_units, np.nan)
+    n_windows = np.zeros(n_units, dtype=int)
+    for k in range(n_units):
+        w = (per_unit_paths[k] if k < len(per_unit_paths)
+             else np.empty((0, horizon), dtype=float))
+        n_windows[k] = int(w.shape[0])
+        if w.shape[0] == 0:
+            lower[k], upper[k] = -np.inf, np.inf
+            continue
+        # The windows are handed over as one series with their count alongside, so
+        # the draw can take a window's own level and block within it. A horizon
+        # total is driven by the level, and a block drawn across a boundary
+        # averages two of them.
+        draws = block_error_paths(
+            w.ravel(), horizon=horizon, block=b, n_sim=int(n_sim),
+            rng=np.random.default_rng(int(seed) + k),
+            n_windows=int(w.shape[0]),
+        )
+        total = draws.sum(axis=1)
+        half = float(np.quantile(np.abs(total - total.mean()), 1.0 - float(alpha)))
+        lower[k], upper[k] = point[k] - half, point[k] + half
+    return point, lower, upper, n_windows
 
 
 def cwz_cumulative_per_unit(

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -650,9 +650,9 @@ timeout = 600.0
 
   [[target.mutant]]
   id = "cumulative-scores-average-instead-of-accumulate"
-  find = "scores.setdefault(k, []).append(float(path.sum()))"
-  replace = "scores.setdefault(k, []).append(float(path.mean()))"
-  models = "calibrating on each unit's average post-period error rather than its accumulated error, so the band is sized for the wrong estimand and comes out roughly a factor of the horizon too narrow"
+  find = "    return [p.sum(axis=1) for p in _rolling_pooled_paths("
+  replace = "    return [p.mean(axis=1) for p in _rolling_pooled_paths("
+  models = "calibrating on each unit's average post-period error instead of its accumulated error, so the band is sized for the wrong estimand and comes out roughly a factor of the horizon too narrow"
 
   [[target.mutant]]
   id = "cumulative-calibration-origins-overlap"

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -1270,7 +1270,7 @@ timeout = 900.0
 [[target]]
 name = "ppscm-conformal-method"
 module-path = "mlsynth/estimators/ppscm.py"
-test-command = "python -m pytest mlsynth/tests/test_ppscm_conformal_method.py -q -p no:cacheprovider"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_conformal_method.py mlsynth/tests/test_ppscm_resample_cumulative.py -q -p no:cacheprovider"
 timeout = 900.0
 
   [[target.mutant]]
@@ -1278,6 +1278,12 @@ timeout = 900.0
   find = "                if self.conformal_method == \"cyclic\":"
   replace = "                if False:"
   models = "a config field the fit reads and then does not act on. Every refusal still fires and every result field is still populated, so only a test that compares the two bands notices the caller was given the one they did not ask for"
+
+  [[target.mutant]]
+  id = "the-resample-branch-falls-through-to-split"
+  find = '                elif self.conformal_method == "resample":'
+  replace = '                elif False:'
+  models = "a caller asking for the resample band and silently getting the split one. Every field is still populated and cumulative_method still reads 'resample', so only a test that asserts the band is finite where split is infinite catches it"
 
   [[target.mutant]]
   id = "the-reported-method-taken-from-the-field-alone"
@@ -1289,20 +1295,42 @@ timeout = 900.0
 [[target]]
 name = "ppscm-conformal-method-config"
 module-path = "mlsynth/utils/ppscm_helpers/config.py"
-test-command = "python -m pytest mlsynth/tests/test_ppscm_conformal_method.py -q -p no:cacheprovider"
+test-command = "python -m pytest mlsynth/tests/test_ppscm_conformal_method.py mlsynth/tests/test_ppscm_resample_cumulative.py -q -p no:cacheprovider"
 timeout = 900.0
 
   [[target.mutant]]
   id = "the-stray-parameter-check-reads-the-chosen-method"
-  find = '        other = "split" if self.conformal_method == "cyclic" else "cyclic"'
-  replace = '        other = self.conformal_method'
+  find = """        stray = [f for f, m in readers.items()
+                 if f in fields and self.conformal_method not in m]"""
+  replace = """        stray = [f for f, m in readers.items()
+                 if f in fields and self.conformal_method in m]"""
   models = "the refusal firing on the parameters the chosen band does read and passing the ones it ignores, so every correct configuration is rejected and every mistaken one accepted"
 
   [[target.mutant]]
   id = "the-refusal-asked-of-the-field-instead-of-the-caller"
-  find = "        stray = [f for f in by_method[other] if f in fields]"
-  replace = "        stray = [f for f in by_method[other]]"
-  models = "a refusal that fires on the other method's parameters whether or not the caller set them. Both methods' defaults are always present on the model, so this rejects every fit that asks for a band at all"
+  find = """        stray = [f for f, m in readers.items()
+                 if f in fields and self.conformal_method not in m]"""
+  replace = """        stray = [f for f, m in readers.items()
+                 if self.conformal_method not in m]"""
+  models = "a refusal that fires on the other methods' parameters whether or not the caller set them. Every method's defaults are always present on the model, so this rejects every fit that asks for a band at all"
+
+  [[target.mutant]]
+  id = "the-training-fraction-owned-by-the-split-band-alone"
+  find = '            "conformal_min_train_frac": ("split", "resample"),'
+  replace = '            "conformal_min_train_frac": ("split",),'
+  models = "the shared parameter treated as the split band's private one, so a resample fit that sets where its own rolling pass starts is refused. The two bands run the same pass; only a test that sets the fraction under resample notices"
+
+  [[target.mutant]]
+  id = "the-block-length-read-after-coercion"
+  find = '    @field_validator("conformal_block", mode="before")'
+  replace = '    @field_validator("conformal_block")'
+  models = "the block length checked after pydantic has coerced it, so True arrives as 1 -- Wheeler's independent-period draw -- and reports a band too narrow under exactly the serial correlation the block exists to carry"
+
+  [[target.mutant]]
+  id = "the-draw-count-read-after-coercion"
+  find = '    @field_validator("conformal_n_sim", mode="before")'
+  replace = '    @field_validator("conformal_n_sim")'
+  models = "the draw count checked after coercion, so True arrives as 1 and the quantile is taken over a single path"
 
   [[target.mutant]]
   id = "a-method-named-without-a-horizon-accepted"


### PR DESCRIPTION
Closes #522.

## Related Links

- Issue: #522, follow-up to #512 and #511
- Source: `mlsynth/utils/ppscm_helpers/inference.py`, `ppscm_helpers/config.py`, `mlsynth/estimators/ppscm.py`
- Mutation targets `ppscm-conformal-method` (3) and `ppscm-conformal-method-config` (7)
- Docs: the extended "Which calibration set: `conformal_method`" section in `docs/ppscm.rst`

## What

- `conformal_method` gains a third value, `"resample"`, plus `conformal_block` and `conformal_n_sim`.
- `resample_cumulative_per_unit` in `ppscm_helpers/inference.py`.
- The rolling pass moves into one private `_rolling_pooled_paths`, with `rolling_pooled_block_sums` and a new `rolling_pooled_period_errors` as its two readings.
- `mlsynth/tests/test_ppscm_resample_cumulative.py`, 43 tests.

## The design call

The issue asked which band the resample construction belongs on before any wiring, since PDA and VanillaSC have one treated unit and PPSCM does not. It goes on the per-unit band.

`conformal_method` already means "which reference set calibrates the per-unit band", and that is exactly what this changes: split reads the `m` window totals, cyclic reads the `T` cyclic shifts of the residual path, resample reads the `m * L` per-period errors. Same estimand, three reference sets, one set of bounds whichever is chosen.

The aggregate band keeps its jackknife, and that is the substantive half of the answer. Its jackknife resamples units, which is the dimension along which a pooled total has exchangeable replicates. A rolling-origin resample calibrates on time. Substituting one for the other there would report a different quantity in the units of the one that was asked for, so the aggregate band is untouched by this diff.

## Why the construction earns its place

The split band reduces each calibration window to its total, so `m` windows give `m` numbers and a finite `1 - alpha` band needs `ceil((m+1)(1-alpha)) <= m` — a floor of roughly `12.8 * L` pre-periods. A weekly geo panel with an eight-week horizon sits under it routinely.

The cyclic band (#512) answers that by changing the reference set, at the price of a constant-per-period null the effect has to belong to, and a refit per candidate in its grid — about fourteen times the split band's cost.

This answers it without either price. The rolling pass already computes an `L`-period path on its way to each window total; keeping it gives `m * L` per-period errors instead of `m` totals. Whole post-period paths are drawn from them as sign-flipped circular blocks, and the band is the `1 - alpha` quantile of the absolute accumulated draw. The reference set counts periods, so the window floor does not apply; nothing is subtracted, so an effect that ramps is as admissible as a flat one; and nothing is refit beyond the pass the split band already pays for.

The test panel is built to make that concrete: seven windows against a required rank of eight. `test_it_is_finite_where_the_split_band_is_infinite` asserts the split band is `inf` on it before asserting this one is finite, so the motivating case is pinned rather than described.

## What it does assume

`conformal_block`. The variance of an `H`-period total is `H*gamma_0 + 2*sum_k (H-k)*gamma_k`, so drawing periods independently — `conformal_block=1`, Wheeler's original — keeps only the first term and reports a band too narrow under the positive autocorrelation a fitted residual path usually carries. The default `0` means the whole horizon; a longer block is clamped to it. `test_drawing_periods_independently_gives_a_different_band_than_whole_blocks` fails if the block length stops mattering.

The draw is handed the window count alongside the series, so each path takes one window's own level and blocks the within-window residuals on top of it. A horizon total is driven by the level, and a block drawn flat across `m` concatenated windows usually straddles a boundary and averages two of them.

## One pass, two readings

`rolling_pooled_block_sums` keeps its contract exactly — `test_the_period_errors_sum_to_the_block_sums_the_split_band_reads` asserts the new per-window paths sum to what it returned before, elementwise. The refactor exists so the origin schedule, which decides how much calibration a panel affords, has one definition; two copies of it would let the split and resample bands drift onto different calibration sets while both looked correct.

## Config surface

The stray-parameter check was binary and is now a map from parameter to the methods that read it, because `conformal_min_train_frac` is genuinely shared: split and resample run the same pass and differ only in how they read it. `conformal_n_nulls` and `conformal_grid_scale` stay cyclic's; `conformal_block` and `conformal_n_sim` are resample's. Both new fields validate in `mode="before"`, so `True` and `"2000"` are refused instead of arriving as the integers pydantic would coerce them into — `conformal_block=True` would otherwise become `1` and silently select the independent-period draw.

## Result fields

`cumulative_windows` is now filled by two methods, and it means something different to each: the split band's order statistic is taken over exactly those windows, while the resample band draws from the `L` periods inside each. `cumulative_method` is what disambiguates them, which is what it is there for. `cumulative_p_value` stays cyclic's alone.

## Verification

- Red to green: 29 of the 43 tests fail without the change, and the panel geometry was checked to starve the split band (7 windows, `[-inf, inf]` for both units) before any of it was written.
- Mutation: 10/10 killed across the two targets, including the resample branch falling through to split, the shared training fraction treated as split's alone, and both new validators moved after coercion.
- Coverage: every line this diff adds to `estimators/ppscm.py` (17), `ppscm_helpers/config.py` (83) and `ppscm_helpers/inference.py` (194) is exercised. No `pragma` added.
- `ppscm_paglayan` pins unchanged, all six checks pass. The default path is untouched.
- `python tools/gen_llms_txt.py` — no change.
- RST parse — no new warnings.

## Test Steps

- [x] `pytest mlsynth/tests/test_ppscm_resample_cumulative.py -q` — 43 passed
- [x] `pytest mlsynth/tests/test_ppscm_conformal_method.py -q` — 35 passed, unchanged
- [x] `python tools/mutation/run_mutants.py --target ppscm-conformal-method` — 3/3 killed
- [x] `python tools/mutation/run_mutants.py --target ppscm-conformal-method-config` — 7/7 killed
- [x] `python benchmarks/run_benchmarks.py --case ppscm_paglayan`
- [x] `pytest mlsynth/tests/ -k "ppscm or result_contract or conformal"` — 1381 passed, 36 skipped
- [ ] `pytest mlsynth/tests/` — full suite, running here in CI

## Other Notes

`docs/choose.rst` is unchanged. This selects a calibration set inside PPSCM and moves nobody between estimators.

The two existing entry points in `utils/conformal/resample.py` are untouched. Both take a single-treated-unit callable, and PPSCM's rolling pass gets every unit's weights from one pooled solve per origin; routing through either would have paid that cost per unit. This composes `block_error_paths` and `resolve_block` directly instead, which are already public and exported.