### PR TITLE
docs: executable example gallery (Basque MSCMT + Bayesian RSC)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ benchmarks/report.json
 
 # Hypothesis example database (local, machine-specific)
 .hypothesis/
+
+# Sphinx-Gallery generated output
+docs/auto_examples/
+docs/sg_execution_times.rst

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,11 @@ sphinx:
   # citations). Turning this on before then will fail the RTD build.
   # fail_on_warning: true
 
-# Install dependencies listed in docs/requirements.txt
+# Install dependencies listed in docs/requirements.txt, then mlsynth itself so
+# the executable Sphinx-Gallery examples can ``import mlsynth`` with its full
+# runtime dependency set (pulled from pyproject.toml, the authoritative list).
 python:
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,8 +24,29 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
-    "sphinx_copybutton"
+    "sphinx_copybutton",
+    "sphinx_gallery.gen_gallery",
 ]
+
+# -- Sphinx-Gallery -----------------------------------------------------------
+#
+# Executable example gallery. Source scripts live in ``docs/gallery/`` (one
+# ``plot_*.py`` per example, plus a ``README.rst`` header); the rendered gallery
+# is generated into ``docs/auto_examples/`` at build time and is git-ignored.
+# Scripts matching ``filename_pattern`` are executed and their stdout + figures
+# captured; ``abort_on_example_error`` makes a broken example fail the build,
+# so the examples stay validated the way the estimator pages' Verification
+# numbers do. Each example is offered as a downloadable notebook and script.
+sphinx_gallery_conf = {
+    "examples_dirs": "gallery",
+    "gallery_dirs": "auto_examples",
+    "filename_pattern": r"/plot_",
+    "abort_on_example_error": True,
+    "remove_config_comments": True,
+    "download_all_examples": False,
+    "matplotlib_animations": False,
+    "image_scrapers": ("matplotlib",),
+}
 
 # Napoleon settings.
 #
@@ -76,6 +97,12 @@ intersphinx_mapping = {
 intersphinx_disabled_domains = ["std"]
 
 templates_path = ["_templates"]
+
+# Sphinx-Gallery reads the source scripts under ``gallery/`` directly from disk
+# and writes the rendered pages into ``auto_examples/``. Exclude the source dir
+# from Sphinx's own document scan so its ``README.rst`` is not also parsed as a
+# standalone page (which would duplicate the gallery-index label).
+exclude_patterns = ["gallery"]
 
 # -- Options for HTML output
 

--- a/docs/gallery/README.rst
+++ b/docs/gallery/README.rst
@@ -1,0 +1,11 @@
+.. _examples_gallery:
+
+Example gallery
+===============
+
+End-to-end, runnable examples of mlsynth estimators on real panel data. Each
+example executes when these docs are built, so the numbers and figures you see
+are the ones the current code produces -- not transcribed output that can drift
+out of date. Every page can be downloaded as a Jupyter notebook or a plain
+Python script from the links at its foot, and each reads its data from a public
+URL, so a downloaded example runs as-is with mlsynth installed.

--- a/docs/gallery/plot_basque_mscmt.py
+++ b/docs/gallery/plot_basque_mscmt.py
@@ -1,0 +1,170 @@
+"""
+The Basque Country: synthetic control, the MSCMT way
+====================================================
+
+This is the ground-floor example of the whole toolbox: one treated unit, a pool
+of donor units, and a single question. In 1968 the separatist group ETA began a
+campaign of terrorism concentrated in the Basque Country, one of Spain's
+seventeen regions. Abadie and Gardeazabal (2003) asked what that violence cost
+the regional economy. There is no parallel Basque Country that escaped the
+conflict to compare against, so they built one: a synthetic Basque Country,
+assembled as a weighted average of the other Spanish regions, chosen so that the
+blend tracks the real region's economy before the violence began. The gap that
+opens up afterwards is the estimated cost.
+
+We reproduce their study through :class:`~mlsynth.VanillaSC` with
+``backend="mscmt"``. The name refers to the R package MSCMT (Becker and
+Klossner, 2018), whose vignette re-runs Abadie and Gardeazabal on their
+thirteen-predictor specification; mlsynth's ``mscmt`` backend matches that
+package's donor weights to four decimals (see the :doc:`Verification section of
+the VanillaSC page </vanillasc>`). The outcome is real per-capita GDP; the donor
+pool is the remaining Spanish regions; the intervention year is 1970.
+"""
+
+# %%
+# Load the panel
+# --------------
+# The data ship with mlsynth as ``basedata/basque_mscmt.csv`` -- the MSCMT
+# transform of the classic Basque panel, one row per region-year from 1955 to
+# 1997, carrying GDP and the thirteen predictors. We read it straight from
+# GitHub so this notebook runs anywhere, then add the treatment column:
+# Basque Country from 1970 onward. Spain-as-a-whole is a row in the file and is
+# dropped from the donor pool downstream by the estimator.
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from mlsynth import VanillaSC
+
+url = (
+    "https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
+    "refs/heads/main/basedata/basque_mscmt.csv"
+)
+panel = pd.read_csv(url)
+panel["treat"] = (
+    (panel["regionname"] == "Basque Country (Pais Vasco)")
+    & (panel["year"] >= 1970)
+).astype(int)
+
+panel.head()
+
+# %%
+# Fit the synthetic control
+# -------------------------
+# The classical estimator matches on covariates as well as the outcome, and it
+# learns two sets of weights at once: donor weights ``W`` (which regions to
+# average) and predictor weights ``V`` (how much each covariate matters for the
+# match). That nested problem is what ``backend="mscmt"`` solves, by a seeded
+# differential-evolution search over ``V``.
+#
+# Three settings pin the specification to Abadie and Gardeazabal's:
+# ``covariates`` lists the thirteen predictors; ``covariate_windows`` gives each
+# one the pre-period years it is averaged over; and ``fit_window=(1960, 1969)``
+# is the decade the outcome fit is optimised on, even though the panel reaches
+# back to 1955. The ``seed`` makes the search reproducible.
+
+covariates = [
+    "school.illit", "school.prim", "school.med", "school.higher", "invest",
+    "gdpcap", "sec.agriculture", "sec.energy", "sec.industry",
+    "sec.construction", "sec.services.venta", "sec.services.nonventa",
+    "popdens",
+]
+schooling_and_investment = (1964, 1969)
+sector_shares = (1961, 1969)
+covariate_windows = {
+    "school.illit": schooling_and_investment,
+    "school.prim": schooling_and_investment,
+    "school.med": schooling_and_investment,
+    "school.higher": schooling_and_investment,
+    "invest": schooling_and_investment,
+    "gdpcap": (1960, 1969),
+    "sec.agriculture": sector_shares,
+    "sec.energy": sector_shares,
+    "sec.industry": sector_shares,
+    "sec.construction": sector_shares,
+    "sec.services.venta": sector_shares,
+    "sec.services.nonventa": sector_shares,
+    "popdens": (1969, 1969),
+}
+
+result = VanillaSC({
+    "df": panel,
+    "outcome": "gdpcap",
+    "treat": "treat",
+    "unitid": "regionname",
+    "time": "year",
+    "backend": "mscmt",
+    "canonical_v": "min.loss.w",
+    "covariates": covariates,
+    "covariate_windows": covariate_windows,
+    "fit_window": (1960, 1969),
+    "mscmt_maxiter": 400,
+    "mscmt_popsize": 20,
+    "seed": 42,
+    "display_graphs": False,
+}).fit()
+
+# %%
+# Who is in the synthetic Basque Country?
+# ---------------------------------------
+# Three regions carry essentially all the weight. Cataluna and Madrid are the
+# other industrialised regions; Baleares fills in the rest. These are the same
+# weights the MSCMT R package reports, to four decimals.
+
+weights = {
+    region: float(w)
+    for region, w in result.weights.donor_weights.items()
+    if float(w) > 1e-4
+}
+for region, w in sorted(weights.items(), key=lambda kv: -kv[1]):
+    print(f"{region:28s} {w:.4f}")
+
+# %%
+# The estimated cost
+# ------------------
+# The average treatment effect on the treated is the mean gap between the real
+# Basque Country and its synthetic twin over the post-1970 period, in the units
+# of the outcome (thousands of 1986 USD of per-capita GDP).
+
+print(f"ATT = {result.effects.att:+.3f}  (per-capita GDP, thousands of USD)")
+
+# %%
+# Treated versus synthetic
+# ------------------------
+# The picture is the whole argument. Before 1970 the synthetic Basque Country
+# tracks the real one closely -- that is the match the estimator optimised. After
+# 1970 the two diverge: the real region's GDP falls below the counterfactual, and
+# the shaded distance between the lines is the estimated economic cost of the
+# conflict.
+
+ts = result.time_series
+years = np.asarray(ts.time_periods).ravel()
+observed = np.asarray(ts.observed_outcome, dtype=float).ravel()
+synthetic = np.asarray(ts.counterfactual_outcome, dtype=float).ravel()
+
+fig, ax = plt.subplots(figsize=(7, 4.5))
+ax.plot(years, observed, color="black", lw=2, label="Basque Country (observed)")
+ax.plot(years, synthetic, color="crimson", lw=2, ls="--",
+        label="Synthetic Basque Country")
+post = years >= 1970
+ax.fill_between(years[post], observed[post], synthetic[post],
+                color="crimson", alpha=0.12)
+ax.axvline(1970, color="gray", lw=1, ls=":")
+ax.annotate("ETA campaign\nintensifies", xy=(1970, ax.get_ylim()[1]),
+            xytext=(1971, observed.max() * 0.98), fontsize=8, color="gray")
+ax.set_xlabel("Year")
+ax.set_ylabel("Real per-capita GDP (thousands of 1986 USD)")
+ax.set_title("The economic cost of conflict in the Basque Country")
+ax.legend(frameon=False, loc="lower right")
+fig.tight_layout()
+
+# %%
+# What to take away
+# -----------------
+# This is the entire synthetic-control workflow in one screen: express the panel
+# as a long DataFrame, name the outcome, treatment, unit, and time columns, pick
+# an estimator, and read the ATT and the donor weights off the result object.
+# Every other estimator in mlsynth follows the same shape; what changes between
+# them is the assumption each one is willing to make about how the donors relate
+# to the treated unit. See :doc:`/choose` to find the one your problem calls for.

--- a/docs/gallery/plot_bayesian_rsc_prop99.py
+++ b/docs/gallery/plot_bayesian_rsc_prop99.py
@@ -1,0 +1,147 @@
+"""
+Bayesian Robust Synthetic Control: uncertainty on Proposition 99
+================================================================
+
+The Basque example draws a single counterfactual line. A synthetic control is an
+estimate, though, and an estimate without a sense of its uncertainty is only half
+an answer. This example reproduces the Bayesian treatment of Robust Synthetic
+Control from Amjad, Shah and Shen (2018, *Robust Synthetic Control*, JMLR
+19(22):1-51, Sections 4.4 and 5.2), which returns not a line but a posterior: a
+predictive mean and a band around it whose width is the model's own statement of
+how much it knows.
+
+Robust Synthetic Control first de-noises the donor pool -- it keeps only the top
+few singular values of the donor matrix, on the premise that a handful of latent
+factors drive the panel and the rest is noise -- then regresses the treated unit
+on the de-noised donors. The Bayesian version puts a Gaussian prior on the donor
+weights and reads off the closed-form posterior, whose predictive variance at
+each period is
+
+.. math::
+
+   \\sigma^2_{D,t} = \\sigma^2 + \\hat{\\mathbf{M}}_{\\cdot t}^\\top\\,
+   \\Sigma_D\\,\\hat{\\mathbf{M}}_{\\cdot t}
+
+(Amjad-Shah-Shen eq. 43): the observation noise :math:`\\sigma^2` plus the
+uncertainty the posterior weight covariance :math:`\\Sigma_D` propagates through
+the donors. We plot the posterior mean with a band one standard deviation wide on
+each side, as the paper does, and reproduce its central observation for
+California: the band's width is governed by how many singular values you keep.
+
+We call the Bayesian RSC kernel that ``CLUSTERSC(estimator="bayesian")`` is built
+on -- :func:`mlsynth.utils.pcr.core.hsvt` for the de-noising and
+:func:`mlsynth.utils.clustersc_helpers.pcr.bayesian.BayesSCM` for the posterior --
+so the per-period predictive band can be drawn directly, on California
+Proposition 99 (California treated in 1989, 38 donor states, per-capita cigarette
+pack sales, 1970-2000).
+"""
+
+# sphinx_gallery_thumbnail_number = 1
+
+# %%
+# The Bayesian RSC posterior
+# --------------------------
+# Load the ADH Proposition 99 panel and cast it wide (states x years). The donor
+# pool is every state other than California; the pre-period runs 1970-1988.
+# ``sigma2`` is the observation-noise plug-in for the predictive variance -- the
+# pre-period variance of the treated series -- and the Gaussian prior precision
+# (``alpha``) is left at 1. The retained rank is the knob the paper studies.
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from mlsynth.utils.pcr.core import hsvt
+from mlsynth.utils.clustersc_helpers.pcr.bayesian import BayesSCM
+
+url = (
+    "https://raw.githubusercontent.com/jgreathouse9/mlsynth/"
+    "refs/heads/main/basedata/smoking_data.csv"
+)
+panel = pd.read_csv(url)
+wide = panel.pivot(index="state", columns="year", values="cigsale").sort_index()
+
+years = np.asarray(wide.columns, dtype=int)
+treat_year = 1989
+T0 = int((years < treat_year).sum())
+donors = [s for s in wide.index if s != "California"]
+
+observed = wide.loc["California"].to_numpy(dtype=float)
+donor_full = wide.loc[donors].to_numpy(dtype=float).T      # (T, J)
+
+
+def bayesian_rsc(rank):
+    """Rank-r HSVT de-noising + Gaussian posterior; return mean and per-period SD."""
+    sigma2 = float(np.var(observed[:T0], ddof=1))
+    denoised = hsvt(donor_full.T, rank=rank)[0]            # (J, T)
+    design_pre = denoised[:, :T0].T                        # (T0, J)
+    weights, cov, _, _ = BayesSCM(design_pre, observed[:T0], sigma2, 1.0)
+    mean = denoised.T @ weights
+    predictive_sd = np.sqrt(
+        sigma2 + np.einsum("ti,ij,tj->t", denoised.T, cov, denoised.T)
+    )
+    return mean, predictive_sd
+
+
+# %%
+# Reproducing the paper's Figure 9: one, two, and three singular values
+# ---------------------------------------------------------------------
+# Amjad, Shah and Shen plot California's synthetic control at successive
+# thresholds. Keeping a single singular value is too rigid -- the mean is biased,
+# overstating the counterfactual. Two singular values balance bias against
+# variance: the mean tracks the pre-period and the band is moderate. At three, the
+# mean still matches the classical synthetic control, but the band widens sharply
+# -- the paper's central California observation, and the reason it cautions that
+# the classical method "may have overestimated the effect of Prop. 99."
+
+fig, axes = plt.subplots(1, 3, figsize=(12, 4), sharey=True)
+for ax, rank in zip(axes, (1, 2, 3)):
+    mean, sd = bayesian_rsc(rank)
+    ax.plot(years, observed, color="black", lw=1.8, label="California")
+    ax.plot(years, mean, color="#1f5fbf", lw=1.8, ls="--", label="posterior mean")
+    ax.fill_between(years, mean - sd, mean + sd, color="#1f5fbf", alpha=0.15,
+                    label=r"$\pm 1$ SD")
+    ax.axvline(treat_year, color="gray", lw=1, ls=":")
+    ax.set_title(f"{rank} singular value" + ("s" if rank > 1 else ""))
+    ax.set_xlabel("Year")
+axes[0].set_ylabel("Per-capita cigarette sales (packs)")
+axes[0].legend(frameon=False, loc="lower left", fontsize=8)
+fig.suptitle("Bayesian Robust Synthetic Control: California Proposition 99")
+fig.tight_layout()
+
+# %%
+# The effect estimate, and how the band grows with rank
+# -----------------------------------------------------
+# At every rank the posterior mean shows the post-1989 decline -- the estimated
+# effect of the program is real. What changes is the confidence around it. The
+# post-period predictive standard deviation is flat through rank two, then jumps:
+# beyond two singular values the model lets noise directions into the posterior
+# and the band widens fast, exactly as the paper reports.
+
+ranks = [1, 2, 3, 4, 5]
+att = [float(np.mean(observed[T0:] - bayesian_rsc(r)[0][T0:])) for r in ranks]
+post_sd = [float(np.mean(bayesian_rsc(r)[1][T0:])) for r in ranks]
+for r, a, s in zip(ranks, att, post_sd):
+    print(f"rank {r}: ATT {a:+6.2f} packs/capita   mean post-period SD {s:5.1f}")
+
+fig2, ax2 = plt.subplots(figsize=(6, 4))
+ax2.plot(ranks, post_sd, "o-", color="#b3202c", lw=2)
+ax2.axvline(2, color="gray", lw=1, ls=":")
+ax2.set_xlabel("Retained singular values (rank)")
+ax2.set_ylabel("Mean post-period predictive SD (packs)")
+ax2.set_title("Uncertainty grows once the rank exceeds two")
+ax2.set_xticks(ranks)
+fig2.tight_layout()
+
+# %%
+# What to take away
+# -----------------
+# The Bayesian Robust Synthetic Control returns a distribution, not a point. Both
+# it and the classical method agree that Proposition 99 reduced cigarette
+# consumption; the Bayesian band adds a second layer of honesty on top of that
+# agreement. Read at the rank the model best supports it warns how much of the
+# apparent effect is firmly pinned down and how much is the estimator's own
+# uncertainty -- for California, enough that the classical point estimate may
+# overstate the decline. The same posterior machinery drives
+# ``CLUSTERSC(estimator="bayesian")``; see :doc:`/clustersc` for the estimator and
+# its donor-clustering options.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -223,6 +223,12 @@ headline numbers.
 
 .. toctree::
    :hidden:
+   :caption: Examples
+
+   auto_examples/index
+
+.. toctree::
+   :hidden:
    :caption: Observational: canonical workhorses
 
    vanillasc

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@
 sphinx>=7,<9
 sphinx-book-theme>=1.1
 sphinx-copybutton>=0.5
+sphinx-gallery>=0.15
 
 pandas
 numpy


### PR DESCRIPTION
## Related Links

- Gallery source: `docs/gallery/plot_basque_mscmt.py`, `docs/gallery/plot_bayesian_rsc_prop99.py` (rendered into `docs/auto_examples/`, gitignored)
- Estimator pages exercised: `docs/vanillasc.rst` (MSCMT backend), `docs/clustersc.rst` (Bayesian RSC)
- Source papers: Abadie & Gardeazabal (2003), AER 93(1); Amjad, Shah & Shen (2018), *Robust Synthetic Control*, JMLR 19(22):1-51 (§4.4, §5.2, Fig 9)
- Grew out of the discussion of adding DoWhy-style executable notebooks/galleries to the docs

## What

- Added Sphinx-Gallery (`sphinx_gallery.gen_gallery`) to the docs build: source scripts in `docs/gallery/`, rendered into `docs/auto_examples/`, each executed at build time with `abort_on_example_error=True`
- Added two executable examples: the Basque Country study via `VanillaSC(backend="mscmt")`, and the Bayesian Robust SC posterior on California Prop 99 (reproducing Amjad-Shah-Shen Fig 9)
- Updated `docs/requirements.txt` (sphinx-gallery), `.readthedocs.yaml` (pip-install mlsynth so executed examples import it with its full runtime deps), `docs/index.rst` (Examples toctree), `.gitignore` (generated output), `docs/conf.py` (gallery config + exclude source dir from the doc scan)

## Why

- The docs carried no runnable, end-to-end demonstrations of estimator syntax — the notebook/gallery format other libraries ship. Executing examples at build time keeps their numbers and figures tracking the current code instead of drifting into stale listings.

## How

- Examples authored as jupytext-style `.py` scripts (reviewable diffs, no notebook JSON); each reads data from a public raw URL so a downloaded notebook runs as-is
- Basque MSCMT lands the same donor weights as the R MSCMT package (Cataluña 0.6328, Baleares 0.2193, Madrid 0.1479), cross-checked against `benchmarks/cases/mscmt_basque.py`
- Bayesian RSC is drawn via the kernel `CLUSTERSC(estimator="bayesian")` is built on (`hsvt` + `BayesSCM`), so the per-period ±1 SD predictive band (Amjad-Shah-Shen eq. 43) can be shown directly

## Verification

- Path: not applicable — docs/tooling; no numerical estimator code changed. The examples execute at doc-build time and a broken one fails the build (`abort_on_example_error=True`).
- Basque MSCMT weights match the durable `mscmt_basque` benchmark; the Bayesian RSC example reproduces Fig 9's qualitative finding (ATT −30 / −17 / −11 at ranks 1/2/3; post-period predictive SD flat through rank 2 then jumping), the basis for the paper's caution that the classical method may overestimate the Prop 99 effect

## Scope checks

Docs/tooling change — none of the four blocks apply (no new estimator, no estimator feature, no bug fix, no benchmark case).

## Designs

- Basque: observed vs synthetic Basque Country, shaded post-1970 gap = estimated cost of conflict
- Bayesian RSC: 3-panel Fig 9 reproduction (1/2/3 singular values, observed + posterior mean + ±1 SD band) and post-period predictive SD vs rank

## Test Steps

- [x] `pip install -e .`
- [x] Docs build (`python -m sphinx -b html docs/ <out>`) succeeds; both examples execute; gallery HTML + downloadable notebook/script generated; section underlines OK
- [x] Each example runs standalone and produces its figures
- [ ] `pytest mlsynth/tests/` — not applicable, no library code changed

## Other Notes

- The public `CLUSTERSC(estimator="bayesian")` result does not surface the per-period credible band (only a scalar ATT interval), so the Bayesian example uses the documented kernel to draw it. Surfacing the per-period band on the estimator result is a sensible fast-follow on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J82EiQWA1BNatkYYhKGrw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01J82EiQWA1BNatkYYhKGrw6)_