### PR TITLE
Block-resampled cumulative bands for PDA and VanillaSC (needs rebase onto main)

### DIFF
--- a/benchmarks/cases/pda_wheeler_lassosynth.py
+++ b/benchmarks/cases/pda_wheeler_lassosynth.py
@@ -29,7 +29,7 @@ It is measured from horizon two, because horizon one is not yet a continuous
 distribution. With ``m`` scores the one-period band is a quantile of ``2m``
 discrete atoms, so both implementations land exactly on an atom and sampling noise
 decides which. ``parity_h1_atoms_apart`` records how far apart those atoms are, in
-atoms, and pins that the horizon-one difference is discreteness rather than
+atoms, and pins that the horizon-one difference is discreteness, not
 disagreement: adjacent atoms, not a shifted distribution. From horizon two the
 convolution smooths the pool and the gap collapses.
 
@@ -53,7 +53,7 @@ whole-horizon block must give a wider band than the independent draw, since that
 is the correlation the blocks exist to carry.
 
 Cross-validation (scenario: reference implementation available). Wheeler's
-construction is transcribed here rather than imported, since the post ships a
+construction is transcribed here instead of imported, since the post ships a
 script and not a package; the transcription is the four lines quoted above.
 """
 from __future__ import annotations

--- a/benchmarks/cases/pda_wheeler_lassosynth.py
+++ b/benchmarks/cases/pda_wheeler_lassosynth.py
@@ -1,0 +1,198 @@
+"""PDA cross-validation: the resampled cumulative band against Wheeler's LassoSynth.
+
+``cumulative_method="resample"`` builds the cumulative band by accumulating
+resampled conformity scores. That construction is Andrew Wheeler's, from his
+LassoSynth post: fit a positive lasso on the donors, take leave-one-out conformity
+scores, mirror them into a symmetric pool (``np.concatenate([cs, -cs])``), draw one
+pool element per post period, accumulate, and read equal-tailed quantiles off the
+accumulated paths.
+
+    https://github.com/apwheele/Blog_Code/tree/master/Python/LassoSynth
+
+mlsynth generalises it in one respect: it draws whole blocks and flips each block's
+sign, because a panel's period errors are serially correlated and drawing periods
+independently understates how fast a running total's variance grows. The
+generalisation has to reduce to the original, and that reduction is what this case
+pins.
+
+Three quantities, in decreasing strength of claim.
+
+``parity_max_gap`` is the exact one. Wheeler's construction and mlsynth's, given
+the *same* conformity scores and ``block=1``, are the same distribution: the
+multiset ``{+e_i, -e_i}`` is the multiset ``{+|e_i|, -|e_i|}``, so mirroring the
+pool and sign-flipping a centred score coincide. The case runs Wheeler's code path
+and mlsynth's ``block_error_paths`` on one score vector and reports the largest
+endpoint disagreement as a fraction of band width -- Monte Carlo noise and nothing
+else, at four tenths of a percent.
+
+It is measured from horizon two, because horizon one is not yet a continuous
+distribution. With ``m`` scores the one-period band is a quantile of ``2m``
+discrete atoms, so both implementations land exactly on an atom and sampling noise
+decides which. ``parity_h1_atoms_apart`` records how far apart those atoms are, in
+atoms, and pins that the horizon-one difference is discreteness rather than
+disagreement: adjacent atoms, not a shifted distribution. From horizon two the
+convolution smooths the pool and the gap collapses.
+
+``width_ratio`` is the end-to-end one and is weaker on purpose. Run whole, the two
+differ in where the scores come from -- Wheeler calibrates on leave-one-out
+residuals over the pre-period points, mlsynth on rolling-origin out-of-sample
+windows of exactly the reported horizon. Those are different calibration sets, so
+the bands are not expected to agree to Monte Carlo error, only to be of a
+comparable size.
+
+It comes out above one, and the direction is the informative part. A leave-one-out
+residual is scored by a model that saw every pre-period point but one, so it
+measures interpolation; a rolling-origin window is scored by a model trained only
+on what came before it, from as few as a third of the pre-period. The second is
+the harder question and gives the larger errors, so the mlsynth band is the wider
+of the two. The two calibration sets are not interchangeable for a cumulative
+horizon, and this records by how much.
+
+``block_widening`` is the generalisation working. On a persistent panel the
+whole-horizon block must give a wider band than the independent draw, since that
+is the correlation the blocks exist to carry.
+
+Cross-validation (scenario: reference implementation available). Wheeler's
+construction is transcribed here rather than imported, since the post ships a
+script and not a package; the transcription is the four lines quoted above.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pandas as pd
+
+_T0, _T1, _N0, _ALPHA, _NSIM = 40, 8, 10, 0.10, 200_000
+
+
+def _panel(seed=0, rho=0.0, effect=1.0):
+    """A factor panel with one treated unit adopting at ``_T0``."""
+    rng = np.random.default_rng(seed)
+    T = _T0 + _T1
+    f = rng.standard_normal((T, 2))
+    load = rng.standard_normal((_N0, 2)) * 0.5
+    e = rng.standard_normal((_N0 + 1, T)) * 0.3
+    if rho:
+        for t in range(1, T):
+            e[:, t] = rho * e[:, t - 1] + np.sqrt(1 - rho ** 2) * e[:, t]
+    y = f @ load.mean(axis=0) + e[0]
+    y[_T0:] += effect
+    rows = [{"unit": "treated", "t": t, "y": float(y[t]), "d": int(t >= _T0)}
+            for t in range(T)]
+    for j in range(_N0):
+        s = f @ load[j] + e[j + 1]
+        rows += [{"unit": f"d{j}", "t": t, "y": float(s[t]), "d": 0} for t in range(T)]
+    return pd.DataFrame(rows)
+
+
+def _wide(df):
+    w = df.pivot(index="t", columns="unit", values="y").sort_index()
+    donors = [c for c in w.columns if c != "treated"]
+    return w["treated"].to_numpy(), w[donors].to_numpy()
+
+
+def _wheeler_scores(y, X):
+    """Leave-one-out residuals, as MAPIE ``cv=-1`` supplies them to Wheeler.
+
+    Signed, not absolute. Wheeler takes ``abs`` before mirroring, which is a no-op:
+    mirroring symmetrises either way, and ``{+r, -r}`` is ``{+|r|, -|r|}`` as a
+    multiset. Keeping the sign matters for the comparison, because mlsynth centres
+    what it is given, and centring absolute values shrinks their spread where
+    centring signed residuals does not.
+    """
+    from sklearn.linear_model import Lasso, LassoCV
+
+    ypre, Xpre = y[:_T0], X[:_T0]
+    a = LassoCV(fit_intercept=True, positive=True, max_iter=5000).fit(Xpre, ypre).alpha_
+    mk = lambda: Lasso(alpha=a, fit_intercept=True, positive=True, max_iter=5000)
+    cs = np.array([
+        ypre[i] - mk().fit(np.delete(Xpre, i, 0), np.delete(ypre, i))
+        .predict(Xpre[i:i + 1])[0]
+        for i in range(_T0)
+    ])
+    full = mk().fit(Xpre, ypre)
+    return cs, y[_T0:] - full.predict(X[_T0:])
+
+
+def _wheeler_band(scores, tau, seed=0):
+    """Wheeler's cumulative band, transcribed: mirror the pool, draw, accumulate."""
+    rng = np.random.default_rng(seed)
+    pool = np.concatenate([scores, -scores])
+    L = tau.size
+    sims = np.cumsum(tau.reshape(L, 1) + rng.choice(pool, (L, _NSIM)), axis=0)
+    return np.quantile(sims, [_ALPHA / 2, 1 - _ALPHA / 2], axis=1)
+
+
+def _mlsynth_band_from_scores(scores, tau, block=1, seed=1):
+    """The same accumulation, through mlsynth's block draw."""
+    from mlsynth.utils.pda_helpers.resample import block_error_paths
+
+    paths = block_error_paths(scores - scores.mean(), horizon=tau.size, block=block,
+                              n_sim=_NSIM, rng=np.random.default_rng(seed))
+    cum = np.cumsum(tau[None, :] + paths, axis=1)
+    return np.quantile(cum, [_ALPHA / 2, 1 - _ALPHA / 2], axis=0)
+
+
+def _fitted_band(df, **kw):
+    from mlsynth import PDA
+
+    cfg = dict(df=df, outcome="y", treat="d", unitid="unit", time="t",
+               method="LASSO", display_graphs=False, cumulative_band=True,
+               cumulative_method="resample", cumulative_n_sim=20_000)
+    cfg.update(kw)
+    res = PDA(cfg).fit()
+    fit = res.fits["lasso"] if isinstance(res.fits, dict) else res.fits[0]
+    return fit.cumulative_band
+
+
+def run() -> dict:
+    warnings.filterwarnings("ignore")
+    df = _panel()
+    y, X = _wide(df)
+
+    # (1) exact construction parity, on one shared score vector at block = 1
+    scores, tau = _wheeler_scores(y, X)
+    scores = scores - scores.mean()
+    lo_w, hi_w = _wheeler_band(scores, tau)
+    lo_m, hi_m = _mlsynth_band_from_scores(scores, tau)
+    width = np.abs(hi_w - lo_w)
+    parity = float(max(
+        max(abs(lo_m[h] - lo_w[h]), abs(hi_m[h] - hi_w[h])) / width[h]
+        for h in range(1, tau.size)))                  # horizon 1 is discrete
+
+    # horizon one: both endpoints sit on an atom of the 2m-point pool, so the
+    # question is how many atoms apart, not how far apart
+    atoms = np.sort(np.unique(np.concatenate([scores, -scores]))) + tau[0]
+    h1_apart = float(abs(int(np.argmin(np.abs(atoms - lo_w[0])))
+                         - int(np.argmin(np.abs(atoms - lo_m[0])))))
+
+    # (2) end to end: different calibration sets, comparable widths
+    fitted = _fitted_band(df, cumulative_block=1)
+    mlsynth_half = float(fitted.upper[-1] - fitted.lower[-1]) / 2.0
+    wheeler_half = float(hi_w[-1] - lo_w[-1]) / 2.0
+
+    # (3) the generalisation: blocks carry persistence the iid draw discards
+    persistent = _panel(seed=3, rho=0.7)
+    iid = _fitted_band(persistent, cumulative_block=1)
+    blocked = _fitted_band(persistent, cumulative_block=0)
+
+    return {
+        "parity_max_gap": parity,
+        "parity_h1_atoms_apart": h1_apart,
+        "width_ratio": mlsynth_half / wheeler_half,
+        "block_widening": float(blocked.se[-1] / iid.se[-1]),
+    }
+
+
+# Deterministic: fixed panel seeds, fixed draw seeds, 200k paths. parity_max_gap is
+# Monte Carlo noise on a shared pool, so its tolerance is set by the draw count and
+# not by the method. width_ratio and block_widening are properties of the two
+# calibration sets and of the DGP's persistence, so theirs absorb solver and RNG
+# drift.
+EXPECTED = {
+    "parity_max_gap": (0.004, 0.012),        # the two constructions coincide at block=1
+    "parity_h1_atoms_apart": (1.0, 1.0),     # horizon 1 differs by at most one pool atom
+    "width_ratio": (1.43, 0.35),             # rolling-origin scores exceed leave-one-out
+    "block_widening": (1.31, 0.20),          # blocks carry AR(0.7) persistence
+}

--- a/benchmarks/cases/pda_wheeler_lassosynth.py
+++ b/benchmarks/cases/pda_wheeler_lassosynth.py
@@ -126,7 +126,7 @@ def _wheeler_band(scores, tau, seed=0):
 
 def _mlsynth_band_from_scores(scores, tau, block=1, seed=1):
     """The same accumulation, through mlsynth's block draw."""
-    from mlsynth.utils.pda_helpers.resample import block_error_paths
+    from mlsynth.utils.conformal import block_error_paths
 
     paths = block_error_paths(scores - scores.mean(), horizon=tau.size, block=block,
                               n_sim=_NSIM, rng=np.random.default_rng(seed))

--- a/benchmarks/registry.py
+++ b/benchmarks/registry.py
@@ -119,6 +119,7 @@ CASES = {
     "pda_ppi": "benchmarks.cases.pda_ppi",                    # Path A: Shi-Wang China PPI L2-relaxation (real-estate policy)
     "pda_brexit": "benchmarks.cases.pda_brexit",              # Path A: Shi-Wang Brexit multi-treated-units L2-relaxation
     "pda_pi_coverage": "benchmarks.cases.pda_pi_coverage",    # Path B: Jiang et al. 2025 prediction-interval coverage (Tables 2-5)
+    "pda_wheeler_lassosynth": "benchmarks.cases.pda_wheeler_lassosynth",  # cross-val vs Wheeler's LassoSynth: the resampled cumulative band reduces to his construction at block=1
     "mlsc_bottmer": "benchmarks.cases.mlsc_bottmer",          # cross-val vs Bottmer's mlSC_estimator (skips if absent)
     "proximal_panic1907": "benchmarks.cases.proximal_panic1907",  # cross-val vs freshtaste/proximal (Panic 1907 Table 3)
     "proximal_germany_oid": "benchmarks.cases.proximal_germany_oid",  # cross-val vs authors' manuscript code (Shi et al. 2026 JASA): over-identified PI (PIOID) on German reunification, ATT + GMM CI value-for-value

--- a/docs/benchmarks.rst
+++ b/docs/benchmarks.rst
@@ -249,6 +249,8 @@ Path B — Monte Carlo / simulation
      - Li-Bell Table 2 LASSO-PDA OOS prediction (N>T1)
    * - ``pda_pi_coverage``
      - Jiang et al. 2025 prediction-interval coverage (Tables 2-5)
+   * - ``pda_wheeler_lassosynth``
+     - the resampled cumulative band reduces to Wheeler's LassoSynth at ``block=1``
    * - ``fspda_table1``
      - all 108 cells of Shi-Huang Table 1, vs the paper and their own code
    * - ``pda_table1``

--- a/docs/pda.rst
+++ b/docs/pda.rst
@@ -1254,14 +1254,77 @@ its nominal level. One shared critical value
 Plagborg-Moller) restores the level for the path as a whole; on the Oregon panel
 it is 2.54 where the pointwise normal quantile would be 1.96.
 
-The band reuses the replicate paths the prediction-interval bootstrap already
-produced, so it costs no extra refits, and it therefore requires
+By default the band reuses the replicate paths the prediction-interval bootstrap
+already produced, so it costs no extra refits, and on that setting it requires
 ``prediction_intervals=True``. Asking for it without the bootstrap raises rather
 than returning an empty field, since a caller reading a missing band as an
 absent effect is the one failure worth ruling out. PPSCM's ``cumulative_band``
 is the same object built the same way, sharing
 :mod:`mlsynth.utils.supt`, so the two estimators cannot drift apart in what the
 phrase means.
+
+Resampling the calibration errors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Reusing the bootstrap's paths is free only once the bootstrap has run, and the
+bootstrap is the expensive part: ``pi_n_boot`` refits of the whole selection,
+999 at the default. ``cumulative_method="resample"`` builds the same band from a
+rolling-origin calibration pass instead -- one refit per origin, roughly ten at
+the panel lengths PDA is used on -- and needs no bootstrap at all:
+
+.. code-block:: python
+
+   res = PDA({..., "cumulative_band": True, "cumulative_method": "resample"}).fit()
+   band = res.fits["lasso"].cumulative_band
+   band.method            # "resample"
+
+The construction is Andrew Wheeler's, from his ``LassoSynth`` post: take
+out-of-sample conformity scores, draw from them, accumulate the draws, and read
+the band off the accumulated paths. mlsynth generalises it in one respect. Wheeler
+draws one score per post period independently, which assumes the period errors are
+uncorrelated. The variance of an :math:`L`-period total is
+
+.. math::
+
+   L\gamma_0 + 2\sum_{k=1}^{L-1} (L-k)\gamma_k,
+
+so positive autocorrelation makes the total more variable than :math:`L`
+independent draws imply, and an independent draw is too narrow by a factor that
+grows with the horizon. mlsynth therefore draws whole blocks of consecutive errors,
+flipping each block's sign to symmetrise -- which is Wheeler's mirrored pool
+generalised from a period to a block, and coincides with it exactly at
+``cumulative_block=1``. ``cumulative_block=0``, the default, uses the whole
+horizon; ``cumulative_n_sim`` sets how many paths are drawn, and unlike
+``pi_n_boot`` those cost no refits.
+
+Where the scores come from differs from Wheeler as well, and the difference has a
+direction. He calibrates on leave-one-out residuals: each is scored by a model
+that saw every pre-period point but one, so it measures interpolation. mlsynth
+calibrates on rolling origins, each scored by a model trained only on what came
+before it, over a window of exactly the reported horizon. That is the harder
+question and gives the larger errors, so the resampled band runs wider than his --
+about 1.4 times on the benchmark panel. The two calibration sets are not
+interchangeable for a cumulative horizon.
+
+The choice does not change what comes back. The same
+:class:`~mlsynth.utils.pda_helpers.structures.PDACumulativeBand` is returned,
+built by the same simultaneous machinery, with only its ``method`` field recording
+which construction produced it. One reader serves all four PDA variants, since it
+asks the estimator for its counterfactual instead of a weight vector, which
+LASSO's intercept and the modified-BIC path's donor scaling would otherwise
+complicate and which forward selection and HCW do not expose at all.
+
+Verification (reference implementation). The durable case
+`benchmarks/cases/pda_wheeler_lassosynth.py
+<https://github.com/jgreathouse9/mlsynth/blob/main/benchmarks/cases/pda_wheeler_lassosynth.py>`__
+runs Wheeler's construction and mlsynth's on one shared score vector and pins that
+they agree at ``block=1`` to four tenths of a percent of band width, which is
+Monte Carlo noise on 200,000 draws. It measures that from horizon two, because at
+horizon one the band is a quantile of :math:`2m` discrete atoms and both
+implementations land exactly on one; the case records that those atoms are
+adjacent, so the difference there is discreteness and not disagreement. It also
+records the 1.4 width ratio above, and that a whole-horizon block widens the band
+by 1.31 on an AR(0.7) panel, which is the generalisation doing its work.
 
 ``hcw`` produces these same intervals, with one practical caveat: the bootstrap
 refits the entire selection on every draw, and HCW's refit re-runs the

--- a/docs/pda.rst
+++ b/docs/pda.rst
@@ -1297,6 +1297,17 @@ generalised from a period to a block, and coincides with it exactly at
 horizon; ``cumulative_n_sim`` sets how many paths are drawn, and unlike
 ``pi_n_boot`` those cost no refits.
 
+How long a block the calibration series can support is settled by an identity, not
+by taste. The series is centred, so the circular sum over a :math:`b`-block is
+minus the sum over the complementary :math:`(n-b)`-block the two partition it into;
+their spreads are exactly equal, and the drawn spread is symmetric about
+:math:`b = n/2`. Past the midpoint a longer block draws a narrower total, mirroring
+a shorter one, and at :math:`b = n` every path sums to zero and the band has no
+width. The draw refuses past :math:`n/2`, since block length has stopped meaning
+how much serial correlation is carried. With :math:`m` rolling origins the series
+is :math:`m \times L` periods, so a whole-horizon block asks for :math:`m \geq 2`
+and a block of :math:`b` asks for :math:`m \geq 2L/b`.
+
 Where the scores come from differs from Wheeler as well, and the difference has a
 direction. He calibrates on leave-one-out residuals: each is scored by a model
 that saw every pre-period point but one, so it measures interpolation. mlsynth

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -840,9 +840,8 @@ distribution -- emits a warning and returns an ``InferenceResults`` whose
     instead of summing each window into a single score, so :math:`m` windows
     supply :math:`m \times L` values where the order statistic had :math:`m`. The
     half-width is then a quantile of totals accumulated from draws of those
-    values, which exists at any :math:`m \geq 1` -- the band is finite on
-    pre-periods that leave the split band at ``±inf``, which is the practical
-    reason to reach for it.
+    values, and it is finite on pre-periods that leave the split band at
+    ``±inf``, which is the practical reason to reach for it.
 
     The draw is a circular block bootstrap of the centred errors with each block's
     sign flipped at random. ``conformal_block`` sets the block length: ``0``, the
@@ -852,6 +851,17 @@ distribution -- emits a warning and returns an ``InferenceResults`` whose
     no refits, since the refits are the calibration origins -- and
     ``conformal_seed`` fixes the draw. What comes back is the same object with the
     same fields; ``res.inference.method`` records which construction produced it.
+
+    The block must be shorter than the calibration series it is drawn from, and
+    that binds exactly where the pre-period is shortest. A circular block of length
+    :math:`L` over a series of length :math:`n` wraps, so at :math:`b \geq n` every
+    block is a rotation of the whole series and every drawn path sums to the same
+    value; the series is centred, so that value is zero and the half-width
+    collapses to zero. A band asserting perfect certainty about the accumulated
+    effect is a worse answer than the infinite one it was reached for, so the draw
+    raises instead. With :math:`m` windows the series is :math:`m \times L` periods,
+    so the default whole-horizon block needs :math:`m \geq 2`; at :math:`m = 1` the
+    remedy is a shorter block, and ``conformal_block=1`` always draws.
 
     The construction is Andrew Wheeler's ``LassoSynth`` band, generalised from a
     period to a block. :doc:`pda` develops it in full, including the

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -852,16 +852,23 @@ distribution -- emits a warning and returns an ``InferenceResults`` whose
     ``conformal_seed`` fixes the draw. What comes back is the same object with the
     same fields; ``res.inference.method`` records which construction produced it.
 
-    The block must be shorter than the calibration series it is drawn from, and
-    that binds exactly where the pre-period is shortest. A circular block of length
-    :math:`L` over a series of length :math:`n` wraps, so at :math:`b \geq n` every
-    block is a rotation of the whole series and every drawn path sums to the same
-    value; the series is centred, so that value is zero and the half-width
-    collapses to zero. A band asserting perfect certainty about the accumulated
-    effect is a worse answer than the infinite one it was reached for, so the draw
-    raises instead. With :math:`m` windows the series is :math:`m \times L` periods,
-    so the default whole-horizon block needs :math:`m \geq 2`; at :math:`m = 1` the
-    remedy is a shorter block, and ``conformal_block=1`` always draws.
+    The block can be at most half the calibration series, and that binds exactly
+    where the pre-period is shortest. The series is centred, so the circular sum
+    over a :math:`b`-block is minus the sum over the complementary
+    :math:`(n-b)`-block that together with it partitions the series. The two have
+    exactly equal spread, so the drawn spread is symmetric about :math:`b = n/2`:
+    past the midpoint a longer block draws a narrower total, mirroring a shorter
+    one, and at :math:`b = n` every path sums to zero and the band has no width at
+    all. Block length has stopped meaning how much serial correlation is carried,
+    so the draw raises instead of honouring it.
+
+    With :math:`m` windows the series is :math:`m \times L` periods and the default
+    block is :math:`L`, which is half the series at :math:`m = 2` and past half at
+    :math:`m = 1`. So the whole-horizon default needs at least two windows; below
+    that, and whenever a longer horizon is wanted from a short calibration series,
+    the remedy is a shorter block, and ``conformal_block=1`` always draws. The same
+    arithmetic says what a given block costs: reading :math:`b \leq n/2` back as
+    :math:`m \geq 2L/b` windows is the pre-period a block of :math:`b` asks for.
 
     The construction is Andrew Wheeler's ``LassoSynth`` band, generalised from a
     period to a block. :doc:`pda` develops it in full, including the

--- a/docs/vanillasc.rst
+++ b/docs/vanillasc.rst
@@ -804,7 +804,7 @@ distribution -- emits a warning and returns an ``InferenceResults`` whose
 
     A confidence interval for a running total is not the running total of the
     per-period intervals. Adding the endpoints up assumes the weekly errors move
-    in lockstep, so the width grows with the number of periods rather than with
+    in lockstep, so the width grows with the number of periods, not with
     its square root; rescaling one period's interval by the horizon assumes the
     opposite. Which is right depends on how the errors accumulate, so this mode
     measures that directly: it slides an origin across the pre-period, refits the
@@ -833,9 +833,34 @@ distribution -- emits a warning and returns an ``InferenceResults`` whose
     \texttt{min\_train\_frac}))`. At :math:`\alpha = 0.1` that is about ten
     windows: 104 pre-periods support an 8-period horizon, but not a 16-period one.
     When the windows run out the band is ``±inf`` with a warning naming the
-    shortfall, rather than a narrow band that does not cover.
+    shortfall, not a narrow band that does not cover.
 
-    Reference: :func:`mlsynth.utils.conformal.cumulative_conformal_from_refit`.
+    ``conformal_method="resample"`` spends that pre-period differently. It runs
+    the same rolling-origin pass, but keeps each window's errors period by period
+    instead of summing each window into a single score, so :math:`m` windows
+    supply :math:`m \times L` values where the order statistic had :math:`m`. The
+    half-width is then a quantile of totals accumulated from draws of those
+    values, which exists at any :math:`m \geq 1` -- the band is finite on
+    pre-periods that leave the split band at ``±inf``, which is the practical
+    reason to reach for it.
+
+    The draw is a circular block bootstrap of the centred errors with each block's
+    sign flipped at random. ``conformal_block`` sets the block length: ``0``, the
+    default, is the whole horizon, and ``1`` draws periods independently, which
+    understates the spread of a total whenever the period errors are positively
+    autocorrelated. ``conformal_n_sim`` sets how many paths are drawn -- they cost
+    no refits, since the refits are the calibration origins -- and
+    ``conformal_seed`` fixes the draw. What comes back is the same object with the
+    same fields; ``res.inference.method`` records which construction produced it.
+
+    The construction is Andrew Wheeler's ``LassoSynth`` band, generalised from a
+    period to a block. :doc:`pda` develops it in full, including the
+    :math:`L\gamma_0 + 2\sum_{k} (L-k)\gamma_k` variance of an :math:`L`-period
+    total that the block length is there to carry, and the reference-implementation
+    benchmark that pins the two constructions against each other.
+
+    Reference: :func:`mlsynth.utils.conformal.cumulative_conformal_from_refit`,
+    :func:`mlsynth.utils.conformal.resample_cumulative_paths_from_weights`.
 
 ``"ttest"`` -- debiased SC t-test for the ATT (Chernozhukov, Wüthrich & Zhu 2025)
     A :math:`K`-fold cross-fitting debiasing with a self-normalized statistic

--- a/mlsynth/estimators/pda.py
+++ b/mlsynth/estimators/pda.py
@@ -111,7 +111,10 @@ class PDA:
                        cumulative_band=self.config.cumulative_band,
                        pi_n_boot=self.config.pi_n_boot,
                        pi_dependent=self.config.pi_dependent,
-                       pi_seed=self.config.pi_seed)
+                       pi_seed=self.config.pi_seed,
+                       cumulative_method=self.config.cumulative_method,
+                       cumulative_block=self.config.cumulative_block,
+                       cumulative_n_sim=self.config.cumulative_n_sim)
         results = assemble_pda_results(inputs, fits, selected_variant=methods[0])
 
         if self.display_graphs:

--- a/mlsynth/tests/test_conformal_period_errors.py
+++ b/mlsynth/tests/test_conformal_period_errors.py
@@ -1,0 +1,178 @@
+"""Per-period out-of-sample errors from the rolling-origin calibration pass.
+
+``scores.rolling_origin_block_sums`` reduces each calibration window to the sum of
+its ``L`` out-of-sample residuals, which is the conformity score the split-conformal
+band needs. A resampled band needs what that sum destroys: the ordering of the
+periods inside a window, and across consecutive windows.
+
+``rolling_origin_period_errors`` returns the blocks concatenated in origin order.
+Because origins step by a whole horizon and are visited in increasing order, the
+concatenation is a contiguous stretch of out-of-sample periods -- origin ``o``
+scores ``o .. o + L - 1`` and the next origin picks up at ``o + L`` -- so serial
+correlation in the returned series is the panel's own and a block bootstrap over it
+means something.
+
+The two readers share one origin schedule, so they cannot drift apart in which
+windows they score. That equivalence is asserted here and again as a property in
+``test_conformal_period_errors_properties.py``.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.conformal import (
+    MIN_TRAIN_PERIODS,
+    rolling_origin_block_sums,
+    rolling_origin_period_errors,
+)
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def panel(T=60, J=3, seed=0):
+    rng = np.random.default_rng(seed)
+    Y0 = rng.normal(size=(T, J))
+    y = Y0 @ np.array([0.5, 0.3, 0.2]) + rng.normal(scale=0.1, size=T)
+    return y, Y0
+
+
+def fixed_weight_fn(w):
+    """A refit that ignores its training window; makes the errors predictable."""
+    return lambda keep_idx: np.asarray(w, dtype=float)
+
+
+def ols_weight_fn(y, Y0):
+    def _fn(keep_idx):
+        idx = np.asarray(keep_idx)
+        beta, *_ = np.linalg.lstsq(Y0[idx], y[idx], rcond=None)
+        return np.asarray(beta, float)
+    return _fn
+
+
+def expected_origins(pre_periods, horizon, min_train_frac):
+    start = max(MIN_TRAIN_PERIODS, int(pre_periods * float(min_train_frac)))
+    return list(range(start, int(pre_periods) - int(horizon) + 1, int(horizon)))
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_returns_one_error_per_scored_period():
+    y, Y0 = panel()
+    origins = expected_origins(48, 6, 0.3)
+    out = rolling_origin_period_errors(y, Y0, 48, 6, ols_weight_fn(y, Y0))
+    assert out.ndim == 1
+    assert out.dtype == float
+    assert out.size == len(origins) * 6
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+def test_the_series_is_the_blocks_concatenated_in_origin_order():
+    y, Y0 = panel()
+    w = np.array([0.5, 0.3, 0.2])
+    out = rolling_origin_period_errors(y, Y0, 48, 6, fixed_weight_fn(w))
+    wanted = np.concatenate([y[o:o + 6] - Y0[o:o + 6] @ w
+                             for o in expected_origins(48, 6, 0.3)])
+    assert out == pytest.approx(wanted)
+
+
+def test_the_scored_periods_are_contiguous():
+    """Origins step by a whole horizon, so the windows abut with no gap or overlap."""
+    y, Y0 = panel()
+    origins = expected_origins(48, 6, 0.3)
+    covered = np.concatenate([np.arange(o, o + 6) for o in origins])
+    assert np.array_equal(covered, np.arange(origins[0], origins[0] + covered.size))
+
+
+def test_the_refit_is_trained_only_on_periods_strictly_before_its_origin():
+    y, Y0 = panel()
+    seen = []
+
+    def spy(keep_idx):
+        seen.append(np.asarray(keep_idx).copy())
+        return np.array([0.5, 0.3, 0.2])
+
+    rolling_origin_period_errors(y, Y0, 48, 6, spy)
+    for call, origin in zip(seen, expected_origins(48, 6, 0.3)):
+        assert np.array_equal(call, np.arange(origin))
+
+
+def test_summing_each_block_reproduces_the_split_conformal_scores():
+    """The headline equivalence: one origin schedule, two readers of it."""
+    y, Y0 = panel(T=80, seed=4)
+    wf = ols_weight_fn(y, Y0)
+    per_period = rolling_origin_period_errors(y, Y0, 64, 8, wf, min_train_frac=0.25)
+    sums = rolling_origin_block_sums(y, Y0, 64, 8, wf, min_train_frac=0.25)
+    assert per_period.size == sums.size * 8
+    assert per_period.reshape(-1, 8).sum(axis=1) == pytest.approx(sums)
+
+
+def test_an_exactly_reproducible_panel_scores_zero_error():
+    """A donor combination that reproduces the outcome leaves nothing to calibrate."""
+    rng = np.random.default_rng(2)
+    Y0 = rng.normal(size=(60, 3))
+    w = np.array([0.4, 0.4, 0.2])
+    y = Y0 @ w
+    out = rolling_origin_period_errors(y, Y0, 48, 6, fixed_weight_fn(w))
+    assert out == pytest.approx(np.zeros_like(out), abs=1e-12)
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_a_pre_period_too_short_for_one_window_returns_nothing():
+    y, Y0 = panel(T=20)
+    out = rolling_origin_period_errors(y, Y0, 12, 6, ols_weight_fn(y, Y0))
+    assert out.size == 0
+    assert out.dtype == float
+
+
+def test_the_absolute_training_floor_beats_a_tiny_fraction():
+    """A fraction below the floor cannot buy windows the floor forbids."""
+    y, Y0 = panel()
+    out = rolling_origin_period_errors(y, Y0, 48, 6, ols_weight_fn(y, Y0),
+                                       min_train_frac=0.0)
+    assert out.size == len(expected_origins(48, 6, 0.0)) * 6
+    assert expected_origins(48, 6, 0.0)[0] == MIN_TRAIN_PERIODS
+
+
+def test_exactly_one_admissible_origin_gives_exactly_one_block():
+    y, Y0 = panel(T=30)
+    out = rolling_origin_period_errors(y, Y0, 16, 6, ols_weight_fn(y, Y0),
+                                       min_train_frac=0.0)
+    assert out.size == 6
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", [0, -4, True, 2.5, "6", None])
+def test_a_horizon_that_is_not_a_positive_integer_is_refused(bad):
+    y, Y0 = panel()
+    with pytest.raises(MlsynthConfigError, match="horizon"):
+        rolling_origin_period_errors(y, Y0, 48, bad, ols_weight_fn(y, Y0))
+
+
+@pytest.mark.parametrize("bad", [-0.1, 1.5, "0.3", None])
+def test_a_min_train_frac_outside_the_unit_interval_is_refused(bad):
+    y, Y0 = panel()
+    with pytest.raises(MlsynthConfigError, match="min_train_frac"):
+        rolling_origin_period_errors(y, Y0, 48, 6, ols_weight_fn(y, Y0),
+                                     min_train_frac=bad)
+
+
+def test_a_pre_period_longer_than_the_panel_is_refused():
+    y, Y0 = panel(T=40)
+    with pytest.raises(MlsynthDataError, match="pre_periods"):
+        rolling_origin_period_errors(y, Y0, 80, 6, ols_weight_fn(y, Y0))
+
+
+def test_a_donor_block_misaligned_with_the_outcome_is_refused():
+    y, Y0 = panel(T=40)
+    with pytest.raises(MlsynthDataError, match="align"):
+        rolling_origin_period_errors(y, Y0[:30], 24, 6, ols_weight_fn(y, Y0))

--- a/mlsynth/tests/test_conformal_period_errors_properties.py
+++ b/mlsynth/tests/test_conformal_period_errors_properties.py
@@ -1,0 +1,129 @@
+"""Metamorphic invariants of the per-period rolling-origin errors.
+
+The unit suite pins the series on fixed panels. These properties assert what must
+hold for every panel, and they are the assertions that would catch a defect the
+examples happen not to exercise:
+
+* equivalence -- summing each block reproduces ``rolling_origin_block_sums``
+  exactly, so the two readers of the origin schedule cannot drift apart;
+* structure -- the series length is the origin count times the horizon, and the
+  scored periods are contiguous;
+* equivariance -- rescaling the outcome and donors rescales every error by the same
+  factor;
+* invariance -- relabelling donors changes nothing;
+* monotonicity -- training on more of the pre-period never yields more windows.
+"""
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils.conformal import (
+    MIN_TRAIN_PERIODS,
+    rolling_origin_block_sums,
+    rolling_origin_period_errors,
+)
+
+_SETTINGS = settings(
+    max_examples=40, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+)
+
+
+def _ols_weight_fn(y, Y0):
+    """Stand-in for an estimator's refit: unconstrained donor regression."""
+    def _fn(keep_idx):
+        idx = np.asarray(keep_idx)
+        beta, *_ = np.linalg.lstsq(Y0[idx], y[idx], rcond=None)
+        return np.asarray(beta, float)
+    return _fn
+
+
+@st.composite
+def panels(draw, min_pre=48, max_pre=96):
+    """A donor panel with enough pre-period to admit several calibration blocks."""
+    n_donors = draw(st.integers(2, 6))
+    horizon = draw(st.integers(1, 6))
+    pre_periods = draw(st.integers(min_pre, max_pre))
+    post_extra = draw(st.integers(0, 6))
+    seed = draw(st.integers(0, 2 ** 31 - 1))
+    rng = np.random.default_rng(seed)
+    total = pre_periods + horizon + post_extra
+    Y0 = rng.normal(size=(total, n_donors))
+    y = Y0 @ rng.dirichlet(np.ones(n_donors)) + rng.normal(scale=0.1, size=total)
+    assume(np.linalg.matrix_rank(Y0[:pre_periods]) == n_donors)
+    return y, Y0, pre_periods, horizon
+
+
+def _origin_count(pre_periods, horizon, min_train_frac):
+    start = max(MIN_TRAIN_PERIODS, int(pre_periods * float(min_train_frac)))
+    return len(range(start, int(pre_periods) - int(horizon) + 1, int(horizon)))
+
+
+class TestEquivalence:
+    @given(panels())
+    @_SETTINGS
+    def test_block_sums_are_the_per_period_errors_summed(self, panel):
+        y, Y0, pre, horizon = panel
+        wf = _ols_weight_fn(y, Y0)
+        per = rolling_origin_period_errors(y, Y0, pre, horizon, wf, min_train_frac=0.2)
+        sums = rolling_origin_block_sums(y, Y0, pre, horizon, wf, min_train_frac=0.2)
+        assert per.size == sums.size * horizon
+        if sums.size:
+            assert per.reshape(-1, horizon).sum(axis=1) == pytest.approx(sums)
+
+
+class TestStructure:
+    @given(panels())
+    @_SETTINGS
+    def test_length_is_the_origin_count_times_the_horizon(self, panel):
+        y, Y0, pre, horizon = panel
+        per = rolling_origin_period_errors(y, Y0, pre, horizon,
+                                           _ols_weight_fn(y, Y0), min_train_frac=0.2)
+        assert per.size == _origin_count(pre, horizon, 0.2) * horizon
+
+    @given(panels())
+    @_SETTINGS
+    def test_every_scored_period_lies_inside_the_pre_period(self, panel):
+        y, Y0, pre, horizon = panel
+        start = max(MIN_TRAIN_PERIODS, int(pre * 0.2))
+        n = _origin_count(pre, horizon, 0.2)
+        assert start + n * horizon <= pre
+
+
+class TestEquivariance:
+    @given(panels(), st.floats(0.25, 4.0, allow_nan=False, allow_infinity=False))
+    @_SETTINGS
+    def test_rescaling_the_panel_rescales_every_error(self, panel, c):
+        y, Y0, pre, horizon = panel
+        base = rolling_origin_period_errors(y, Y0, pre, horizon,
+                                            _ols_weight_fn(y, Y0), min_train_frac=0.2)
+        scaled = rolling_origin_period_errors(
+            c * y, c * Y0, pre, horizon, _ols_weight_fn(c * y, c * Y0),
+            min_train_frac=0.2)
+        assume(base.size)
+        assert scaled == pytest.approx(c * base, rel=1e-8, abs=1e-9)
+
+
+class TestInvariance:
+    @given(panels(), st.integers(0, 2 ** 31 - 1))
+    @_SETTINGS
+    def test_relabelling_donors_changes_nothing(self, panel, seed):
+        y, Y0, pre, horizon = panel
+        perm = np.random.default_rng(seed).permutation(Y0.shape[1])
+        base = rolling_origin_period_errors(y, Y0, pre, horizon,
+                                            _ols_weight_fn(y, Y0), min_train_frac=0.2)
+        swapped = rolling_origin_period_errors(
+            y, Y0[:, perm], pre, horizon, _ols_weight_fn(y, Y0[:, perm]),
+            min_train_frac=0.2)
+        assert swapped == pytest.approx(base, rel=1e-7, abs=1e-8)
+
+
+class TestMonotonicity:
+    @given(panels())
+    @_SETTINGS
+    def test_training_on_more_of_the_pre_period_never_adds_windows(self, panel):
+        y, Y0, pre, horizon = panel
+        wf = _ols_weight_fn(y, Y0)
+        few = rolling_origin_period_errors(y, Y0, pre, horizon, wf, min_train_frac=0.6)
+        many = rolling_origin_period_errors(y, Y0, pre, horizon, wf, min_train_frac=0.2)
+        assert few.size <= many.size

--- a/mlsynth/tests/test_conformal_resample_paths.py
+++ b/mlsynth/tests/test_conformal_resample_paths.py
@@ -204,3 +204,14 @@ def test_a_horizon_longer_than_the_series_draws_from_short_blocks():
                               rng=np.random.default_rng(0))
     assert paths.shape == (500, 12)
     assert np.quantile(np.abs(paths.sum(axis=1)), 0.95) > 0.0
+
+
+def test_a_single_calibration_error_says_what_is_wrong():
+    """One error carries no spread: centring it leaves exactly zero, and there is
+    no shorter block to fall back on. The refusal says that instead of suggesting
+    a block length below one."""
+    with pytest.raises(MlsynthDataError) as exc:
+        block_error_paths(np.array([2.0]), horizon=3, block=0, n_sim=10)
+    msg = str(exc.value)
+    assert "block <= 0" not in msg
+    assert "single" in msg or "one" in msg

--- a/mlsynth/tests/test_conformal_resample_paths.py
+++ b/mlsynth/tests/test_conformal_resample_paths.py
@@ -1,0 +1,153 @@
+"""One call from a fitted control to resampled cumulative error paths.
+
+The pieces exist separately: :func:`rolling_origin_counterfactual_errors` turns a
+refit-by-origin callable into a contiguous series of out-of-sample per-period
+errors, and :func:`block_error_paths` turns that series into an ``(n_sim, horizon)``
+matrix of accumulable paths. Every estimator wanting a resampled band composes the
+same two in the same order, so the composition is the helper.
+
+``resample_cumulative_paths`` is that composition and nothing more. This suite pins
+that it is nothing more -- the two-step form and the one-call form return the same
+numbers for the same seed -- so an estimator adopting it inherits exactly the
+construction the benchmark cross-validated against Wheeler, and a future change to
+either piece cannot reach only one of the two paths.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.conformal import (
+    block_error_paths,
+    origin_schedule,
+    resample_cumulative_paths,
+    rolling_origin_counterfactual_errors,
+)
+
+
+def panel(T=60, J=3, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(T, J))
+    y = X @ np.array([0.5, 0.3, 0.2]) + 1.5 + rng.normal(scale=0.1, size=T)
+    return y, X
+
+
+def ols_refit_at(y, X):
+    def _fn(origin):
+        A = np.column_stack([np.ones(len(X)), X])
+        beta, *_ = np.linalg.lstsq(A[:origin], y[:origin], rcond=None)
+        return A @ beta
+    return _fn
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_returns_one_row_per_simulation_and_one_column_per_horizon():
+    y, X = panel()
+    paths = resample_cumulative_paths(y, ols_refit_at(y, X), 48, 6, n_sim=500)
+    assert paths.shape == (500, 6)
+    assert np.isfinite(paths).all()
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("block", [0, 1, 3])
+def test_it_is_exactly_the_two_step_composition(block):
+    """The headline: no estimator gets a different construction by using it."""
+    y, X = panel()
+    refit_at = ols_refit_at(y, X)
+    series = rolling_origin_counterfactual_errors(y, refit_at, 48, 6)
+    stepwise = block_error_paths(series, horizon=6, block=block, n_sim=800,
+                                 rng=np.random.default_rng(11))
+    one_call = resample_cumulative_paths(y, refit_at, 48, 6, block=block,
+                                         n_sim=800, seed=11)
+    np.testing.assert_array_equal(one_call, stepwise)
+
+
+@pytest.mark.parametrize("frac", [0.2, 0.6])
+def test_the_training_fraction_reaches_the_calibration_pass(frac):
+    """It decides how many windows there are, so it must not stop at the door."""
+    y, X = panel()
+    refit_at = ols_refit_at(y, X)
+    series = rolling_origin_counterfactual_errors(y, refit_at, 48, 6,
+                                                  min_train_frac=frac)
+    stepwise = block_error_paths(series, horizon=6, block=0, n_sim=300,
+                                 rng=np.random.default_rng(2))
+    one_call = resample_cumulative_paths(y, refit_at, 48, 6, n_sim=300, seed=2,
+                                         min_train_frac=frac)
+    np.testing.assert_array_equal(one_call, stepwise)
+
+
+def test_the_same_seed_gives_the_same_paths():
+    y, X = panel()
+    refit_at = ols_refit_at(y, X)
+    a = resample_cumulative_paths(y, refit_at, 48, 6, n_sim=400, seed=3)
+    b = resample_cumulative_paths(y, refit_at, 48, 6, n_sim=400, seed=3)
+    np.testing.assert_array_equal(a, b)
+
+
+def test_different_seeds_give_different_paths():
+    y, X = panel()
+    refit_at = ols_refit_at(y, X)
+    a = resample_cumulative_paths(y, refit_at, 48, 6, n_sim=400, seed=3)
+    b = resample_cumulative_paths(y, refit_at, 48, 6, n_sim=400, seed=4)
+    assert not np.array_equal(a, b)
+
+
+def test_it_refits_once_per_origin_and_no_more():
+    """The cost claim: the calibration pass is the only place refits happen."""
+    y, X = panel()
+    base, calls = ols_refit_at(y, X), []
+
+    def spy(origin):
+        calls.append(origin)
+        return base(origin)
+
+    resample_cumulative_paths(y, spy, 48, 6, n_sim=400)
+    assert calls == list(origin_schedule(48, 6, 0.3))
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_a_block_longer_than_the_horizon_is_clamped():
+    y, X = panel()
+    refit_at = ols_refit_at(y, X)
+    long_block = resample_cumulative_paths(y, refit_at, 48, 6, block=99,
+                                           n_sim=400, seed=5)
+    whole = resample_cumulative_paths(y, refit_at, 48, 6, block=6, n_sim=400, seed=5)
+    np.testing.assert_array_equal(long_block, whole)
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+def test_a_pre_period_admitting_no_origin_is_refused():
+    """No calibration window means no band; that is reported, not returned empty."""
+    y, X = panel(T=20)
+    with pytest.raises(MlsynthDataError, match="empty"):
+        resample_cumulative_paths(y, ols_refit_at(y, X), 12, 6, n_sim=100)
+
+
+@pytest.mark.parametrize("bad", [0, -4, True, 2.5])
+def test_a_bad_horizon_is_refused(bad):
+    y, X = panel()
+    with pytest.raises(MlsynthConfigError, match="horizon"):
+        resample_cumulative_paths(y, ols_refit_at(y, X), 48, bad, n_sim=100)
+
+
+@pytest.mark.parametrize("bad", [-1, 2.5, "3"])
+def test_a_bad_block_is_refused(bad):
+    y, X = panel()
+    with pytest.raises(MlsynthConfigError, match="block"):
+        resample_cumulative_paths(y, ols_refit_at(y, X), 48, 6, block=bad, n_sim=100)
+
+
+def test_a_failed_refit_is_refused_rather_than_resampled():
+    y, X = panel()
+    with pytest.raises(MlsynthDataError, match="finite"):
+        resample_cumulative_paths(y, lambda o: np.full_like(y, np.nan), 48, 6,
+                                  n_sim=100)

--- a/mlsynth/tests/test_conformal_resample_paths.py
+++ b/mlsynth/tests/test_conformal_resample_paths.py
@@ -151,3 +151,56 @@ def test_a_failed_refit_is_refused_rather_than_resampled():
     with pytest.raises(MlsynthDataError, match="finite"):
         resample_cumulative_paths(y, lambda o: np.full_like(y, np.nan), 48, 6,
                                   n_sim=100)
+
+
+# --------------------------------------------------------------------------- #
+# A block as long as the series it is drawn from
+# --------------------------------------------------------------------------- #
+# A circular block of length b over an n-period series wraps, so at b == n every
+# block is a rotation of the whole series and every path sums to the series total.
+# The series is centred first, so that total is exactly zero: every path sums to
+# zero, and the quantile of their magnitudes is zero. A zero-width band asserts
+# perfect certainty about the accumulated effect, which is a worse answer than the
+# infinite one it was reached for, so the draw refuses instead.
+def test_a_block_as_long_as_the_series_is_refused():
+    e = np.random.default_rng(0).normal(size=6)
+    with pytest.raises(MlsynthDataError, match="block"):
+        block_error_paths(e, horizon=6, block=6, n_sim=100,
+                          rng=np.random.default_rng(0))
+
+
+def test_a_block_longer_than_the_series_is_refused():
+    """``resolve_block`` clamps the request to the horizon, so a long horizon is
+    the way to reach this: the clamped block still exceeds the series."""
+    e = np.random.default_rng(0).normal(size=4)
+    with pytest.raises(MlsynthDataError, match="block"):
+        block_error_paths(e, horizon=10, block=0, n_sim=100,
+                          rng=np.random.default_rng(0))
+
+
+def test_the_refusal_names_both_lengths():
+    e = np.random.default_rng(0).normal(size=6)
+    with pytest.raises(MlsynthDataError) as exc:
+        block_error_paths(e, horizon=6, block=6, n_sim=100)
+    msg = str(exc.value)
+    assert "6" in msg and ("shorter block" in msg or "block" in msg)
+
+
+def test_the_longest_admissible_block_still_draws():
+    """One short of the series length is the boundary, and it must work: the
+    guard is against degeneracy, not against long blocks."""
+    e = np.random.default_rng(0).normal(size=6)
+    paths = block_error_paths(e, horizon=6, block=5, n_sim=500,
+                              rng=np.random.default_rng(0))
+    assert paths.shape == (500, 6)
+    assert np.abs(paths.sum(axis=1)).max() > 0.0
+
+
+def test_a_horizon_longer_than_the_series_draws_from_short_blocks():
+    """H > n is fine as long as the BLOCK fits: blocks are drawn and concatenated,
+    so a twelve-period path can come from a six-period calibration series."""
+    e = np.random.default_rng(0).normal(size=6)
+    paths = block_error_paths(e, horizon=12, block=2, n_sim=500,
+                              rng=np.random.default_rng(0))
+    assert paths.shape == (500, 12)
+    assert np.quantile(np.abs(paths.sum(axis=1)), 0.95) > 0.0

--- a/mlsynth/tests/test_conformal_resample_paths.py
+++ b/mlsynth/tests/test_conformal_resample_paths.py
@@ -187,13 +187,57 @@ def test_the_refusal_names_both_lengths():
 
 
 def test_the_longest_admissible_block_still_draws():
-    """One short of the series length is the boundary, and it must work: the
-    guard is against degeneracy, not against long blocks."""
-    e = np.random.default_rng(0).normal(size=6)
-    paths = block_error_paths(e, horizon=6, block=5, n_sim=500,
+    """Half the series is the boundary, and it must work: the guard is against a
+    block whose length has stopped meaning what it says, not against long blocks."""
+    e = np.random.default_rng(0).normal(size=12)
+    paths = block_error_paths(e, horizon=12, block=6, n_sim=500,
                               rng=np.random.default_rng(0))
-    assert paths.shape == (500, 6)
+    assert paths.shape == (500, 12)
     assert np.abs(paths.sum(axis=1)).max() > 0.0
+
+
+# --------------------------------------------------------------------------- #
+# A block past half the series
+# --------------------------------------------------------------------------- #
+# Over a centred series the circular sum of a b-block is minus the circular sum of
+# the complementary (n - b)-block, so the two have exactly equal spread. Block
+# length therefore stops meaning "how much serial correlation is carried" at
+# b = n/2 and reverses: past the midpoint a longer block draws a NARROWER total,
+# mirroring a shorter one, until at b = n it draws nothing at all.
+def test_the_spread_is_symmetric_about_half_the_series():
+    """The identity the guard is built on, measured."""
+    e = np.random.default_rng(0).normal(size=24)
+    def sd(b):
+        return block_error_paths(e, horizon=b, block=b, n_sim=100_000,
+                                 rng=np.random.default_rng(1)).sum(axis=1).std()
+    for b in (1, 2, 5):
+        assert sd(b) == pytest.approx(_complement_sd(e, b), rel=0.02), b
+
+
+def _complement_sd(e, b):
+    """The (n - b)-block spread, computed without the guard in the way."""
+    e = np.asarray(e, dtype=float)
+    e = e - e.mean()
+    n, k = e.size, e.size - b
+    rng = np.random.default_rng(1)
+    s = rng.integers(0, n, size=100_000)
+    idx = (s[:, None] + np.arange(k)[None, :]) % n
+    return e[idx].sum(axis=1).std()
+
+
+@pytest.mark.parametrize("block", [7, 9, 11])
+def test_a_block_past_half_the_series_is_refused(block):
+    e = np.random.default_rng(0).normal(size=12)
+    with pytest.raises(MlsynthDataError, match="half"):
+        block_error_paths(e, horizon=12, block=block, n_sim=100,
+                          rng=np.random.default_rng(0))
+
+
+def test_the_refusal_names_the_admissible_block():
+    e = np.random.default_rng(0).normal(size=12)
+    with pytest.raises(MlsynthDataError) as exc:
+        block_error_paths(e, horizon=12, block=9, n_sim=100)
+    assert "6" in str(exc.value)
 
 
 def test_a_horizon_longer_than_the_series_draws_from_short_blocks():

--- a/mlsynth/tests/test_conformal_resample_paths_weights.py
+++ b/mlsynth/tests/test_conformal_resample_paths_weights.py
@@ -1,0 +1,141 @@
+"""The weight-form composer: donor weights in, resampled paths out.
+
+Two calibration readers exist because two kinds of estimator exist.
+:func:`rolling_origin_counterfactual_errors` serves a fit that returns a
+counterfactual -- an intercept, standardized donors, or a selection with no single
+weight vector to multiply. :func:`rolling_origin_period_errors` serves a fit that
+does return donor weights, which is the classical synthetic control and what
+VanillaSC's refit hands back.
+
+Each needs the same second step, so each gets a composer.
+``resample_cumulative_paths_from_weights`` is the weight-form sibling of
+``resample_cumulative_paths``, and this suite pins that the two agree whenever the
+fit is a bare linear combination -- the case where either reader applies.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.conformal import (
+    block_error_paths,
+    resample_cumulative_paths,
+    resample_cumulative_paths_from_weights,
+    rolling_origin_period_errors,
+)
+
+
+def panel(T=60, J=3, seed=0):
+    rng = np.random.default_rng(seed)
+    Y0 = rng.normal(size=(T, J))
+    y = Y0 @ np.array([0.5, 0.3, 0.2]) + rng.normal(scale=0.1, size=T)
+    return y, Y0
+
+
+def ols_weight_fn(y, Y0):
+    def _fn(keep_idx):
+        idx = np.asarray(keep_idx)
+        beta, *_ = np.linalg.lstsq(Y0[idx], y[idx], rcond=None)
+        return np.asarray(beta, float)
+    return _fn
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_returns_one_row_per_simulation_and_one_column_per_horizon():
+    y, Y0 = panel()
+    paths = resample_cumulative_paths_from_weights(
+        y, Y0, 48, 6, ols_weight_fn(y, Y0), n_sim=500)
+    assert paths.shape == (500, 6)
+    assert np.isfinite(paths).all()
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("block", [0, 1, 3])
+def test_it_is_exactly_the_two_step_composition(block):
+    y, Y0 = panel()
+    wf = ols_weight_fn(y, Y0)
+    series = rolling_origin_period_errors(y, Y0, 48, 6, wf)
+    stepwise = block_error_paths(series, horizon=6, block=block, n_sim=800,
+                                 rng=np.random.default_rng(9))
+    one_call = resample_cumulative_paths_from_weights(
+        y, Y0, 48, 6, wf, block=block, n_sim=800, seed=9)
+    np.testing.assert_array_equal(one_call, stepwise)
+
+
+def test_the_two_composers_agree_on_a_bare_linear_fit():
+    """Where either reader applies, they must not disagree."""
+    y, Y0 = panel()
+    wf = ols_weight_fn(y, Y0)
+    from_w = resample_cumulative_paths_from_weights(y, Y0, 48, 6, wf,
+                                                    n_sim=600, seed=4)
+    from_cf = resample_cumulative_paths(
+        y, lambda o: Y0 @ wf(np.arange(o)), 48, 6, n_sim=600, seed=4)
+    np.testing.assert_allclose(from_w, from_cf, rtol=1e-9, atol=1e-11)
+
+
+def test_the_training_fraction_reaches_the_calibration_pass():
+    y, Y0 = panel()
+    wf = ols_weight_fn(y, Y0)
+    series = rolling_origin_period_errors(y, Y0, 48, 6, wf, min_train_frac=0.6)
+    stepwise = block_error_paths(series, horizon=6, block=0, n_sim=300,
+                                 rng=np.random.default_rng(2))
+    one_call = resample_cumulative_paths_from_weights(
+        y, Y0, 48, 6, wf, n_sim=300, seed=2, min_train_frac=0.6)
+    np.testing.assert_array_equal(one_call, stepwise)
+
+
+def test_the_same_seed_gives_the_same_paths():
+    y, Y0 = panel()
+    wf = ols_weight_fn(y, Y0)
+    a = resample_cumulative_paths_from_weights(y, Y0, 48, 6, wf, n_sim=400, seed=3)
+    b = resample_cumulative_paths_from_weights(y, Y0, 48, 6, wf, n_sim=400, seed=3)
+    np.testing.assert_array_equal(a, b)
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_it_needs_far_fewer_windows_than_a_split_band_does():
+    """The practical gain: m windows give m*L per-period errors to draw from.
+
+    A split band at alpha needs ceil(1/alpha) - 1 windows before its order
+    statistic exists at all. The resampled band draws from the periods inside
+    those windows, so two windows already supply twelve values at this horizon.
+    """
+    y, Y0 = panel()
+    series = rolling_origin_period_errors(y, Y0, 24, 6, ols_weight_fn(y, Y0),
+                                          min_train_frac=0.0)
+    assert series.size // 6 < 9                      # too few windows for alpha=0.10
+    paths = resample_cumulative_paths_from_weights(
+        y, Y0, 24, 6, ols_weight_fn(y, Y0), n_sim=200, min_train_frac=0.0)
+    assert np.isfinite(paths).all()                  # and yet a finite draw
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+def test_a_pre_period_admitting_no_window_is_refused():
+    y, Y0 = panel(T=20)
+    with pytest.raises(MlsynthDataError, match="empty"):
+        resample_cumulative_paths_from_weights(y, Y0, 12, 6, ols_weight_fn(y, Y0),
+                                               n_sim=100)
+
+
+@pytest.mark.parametrize("bad", [0, -4, True, 2.5])
+def test_a_bad_horizon_is_refused(bad):
+    y, Y0 = panel()
+    with pytest.raises(MlsynthConfigError, match="horizon"):
+        resample_cumulative_paths_from_weights(y, Y0, 48, bad,
+                                               ols_weight_fn(y, Y0), n_sim=100)
+
+
+def test_a_misaligned_donor_block_is_refused():
+    y, Y0 = panel()
+    with pytest.raises(MlsynthDataError, match="align"):
+        resample_cumulative_paths_from_weights(y, Y0[:30], 24, 6,
+                                               ols_weight_fn(y, Y0), n_sim=100)

--- a/mlsynth/tests/test_pda_cumulative_resample.py
+++ b/mlsynth/tests/test_pda_cumulative_resample.py
@@ -1,0 +1,204 @@
+"""The resampled cumulative band for PDA: Wheeler's construction, wired in.
+
+``cumulative_band`` today reuses the paths ``pda_prediction_intervals`` produced,
+so it needs ``prediction_intervals=True`` and costs ``pi_n_boot`` refits -- 999 at
+the default. ``cumulative_method="resample"`` builds the same object from a
+rolling-origin calibration pass instead: one refit per origin, roughly ten, and no
+bootstrap at all.
+
+Two things follow from that and are pinned here. The band no longer depends on the
+prediction intervals, so the config's ``cumulative_band needs prediction_intervals``
+rule must not apply to it. And the object handed back is the same
+``PDACumulativeBand`` the bootstrap path returns, so every reader downstream is
+untouched -- only ``method`` records which construction produced it.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import PDA
+from pydantic import ValidationError
+
+from mlsynth.exceptions import MlsynthConfigError
+
+
+def _panel(n_donors=8, T0=40, T1=6, effect=1.0, seed=0, rho=0.0):
+    rng = np.random.default_rng(seed)
+    T = T0 + T1
+    f = rng.standard_normal((T, 2))
+    load_d = rng.standard_normal((n_donors, 2)) * 0.5
+    e = rng.standard_normal((n_donors + 1, T)) * 0.3
+    if rho:
+        for t in range(1, T):
+            e[:, t] = rho * e[:, t - 1] + np.sqrt(1 - rho ** 2) * e[:, t]
+    rec = []
+    y = f @ load_d.mean(axis=0) + e[0]
+    y[T0:] += effect
+    rec += [{"unit": "treated", "t": t, "y": float(y[t]), "d": int(t >= T0)}
+            for t in range(T)]
+    for j in range(n_donors):
+        s = f @ load_d[j] + e[j + 1]
+        rec += [{"unit": f"d{j}", "t": t, "y": float(s[t]), "d": 0} for t in range(T)]
+    return pd.DataFrame(rec)
+
+
+def _fit(df=None, **kw):
+    cfg = dict(df=_panel() if df is None else df, outcome="y", treat="d",
+               unitid="unit", time="t", method="LASSO", display_graphs=False)
+    cfg.update(kw)
+    return PDA(cfg).fit()
+
+
+def _fit_obj(res, method="lasso"):
+    return res.fits[method] if isinstance(res.fits, dict) else res.fits[0]
+
+
+def _resampled(**kw):
+    base = dict(cumulative_band=True, cumulative_method="resample",
+                cumulative_n_sim=400)
+    base.update(kw)
+    return _fit(**base)
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_it_attaches_a_band_without_any_bootstrap():
+    res = _resampled()
+    fit = _fit_obj(res)
+    assert fit.prediction_intervals is None
+    b = fit.cumulative_band
+    assert b is not None
+    for arr in (b.horizons, b.point, b.lower, b.upper, b.se):
+        assert np.asarray(arr).shape == (6,)
+    assert np.isfinite(np.asarray(b.point)).all()
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+def test_the_construction_is_recorded_on_the_band():
+    assert _fit_obj(_resampled()).cumulative_band.method == "resample"
+    boot = _fit(prediction_intervals=True, cumulative_band=True, pi_n_boot=200)
+    assert _fit_obj(boot).cumulative_band.method == "bootstrap"
+
+
+def test_it_draws_the_number_of_paths_it_was_asked_for():
+    assert _fit_obj(_resampled(cumulative_n_sim=250)).cumulative_band.n_replicates == 250
+
+
+def test_the_point_is_the_running_total_of_the_period_effects():
+    res = _resampled()
+    gap = np.asarray(_fit_obj(res).gap, dtype=float)[-6:]
+    np.testing.assert_allclose(_fit_obj(res).cumulative_band.point, np.cumsum(gap),
+                               rtol=1e-10)
+
+
+def test_the_band_brackets_its_point_at_every_horizon():
+    b = _fit_obj(_resampled()).cumulative_band
+    assert (np.asarray(b.lower) <= np.asarray(b.point)).all()
+    assert (np.asarray(b.point) <= np.asarray(b.upper)).all()
+
+
+def test_the_same_seed_gives_the_same_band():
+    a = _fit_obj(_resampled(pi_seed=7)).cumulative_band
+    b = _fit_obj(_resampled(pi_seed=7)).cumulative_band
+    np.testing.assert_allclose(a.lower, b.lower)
+    np.testing.assert_allclose(a.upper, b.upper)
+
+
+def test_a_longer_block_widens_the_band_on_a_persistent_panel():
+    """Blocks carry serial correlation an independent draw discards."""
+    df = _panel(rho=0.7, seed=3)
+    one = _fit_obj(_resampled(df=df, cumulative_block=1)).cumulative_band
+    full = _fit_obj(_resampled(df=df, cumulative_block=0)).cumulative_band
+    assert full.se[-1] > one.se[-1]
+
+
+def test_the_width_does_not_depend_on_the_size_of_the_effect():
+    """Calibration is pre-period only, so the treatment cannot widen the band.
+
+    A schedule that ran past T0 would score windows containing the effect, and the
+    band would grow with it -- calibrating on the thing being measured.
+    """
+    quiet = _fit_obj(_resampled(df=_panel(effect=0.0, seed=5))).cumulative_band
+    loud = _fit_obj(_resampled(df=_panel(effect=50.0, seed=5))).cumulative_band
+    assert loud.se[-1] == pytest.approx(quiet.se[-1], rel=0.02)
+
+
+def test_the_lasso_penalty_is_pinned_before_the_origins_are_refit():
+    """Every calibration window must be the same estimator as the reported fit.
+
+    With no penalty pinned, fit_lasso re-tunes by cross-validation at each origin,
+    so the windows calibrate a different estimator at each one. The penalty
+    actually used is recorded, which is what this asserts.
+    """
+    fit = _fit_obj(_resampled())
+    assert fit.metadata.get("alpha") is not None
+    assert np.isfinite(float(fit.metadata["alpha"]))
+
+
+def test_asking_for_prediction_intervals_as_well_still_gives_both():
+    res = _resampled(prediction_intervals=True, pi_n_boot=200)
+    fit = _fit_obj(res)
+    assert fit.prediction_intervals is not None
+    assert fit.cumulative_band.method == "resample"
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_it_is_off_unless_asked_for():
+    assert _fit_obj(_fit(cumulative_method="resample")).cumulative_band is None
+
+
+def test_every_pda_variant_can_produce_one():
+    """The reader asks for a counterfactual, which all four variants return."""
+    for m in ("LASSO", "l2", "fs", "hcw"):
+        b = _fit_obj(_resampled(method=m), method=m.lower()).cumulative_band
+        assert b is not None and b.method == "resample"
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+def test_the_bootstrap_band_still_needs_prediction_intervals():
+    with pytest.raises(MlsynthConfigError, match="prediction_intervals"):
+        _fit(cumulative_band=True)
+
+
+def test_the_resampled_band_does_not_need_them():
+    assert _fit_obj(_resampled()).cumulative_band is not None
+
+
+@pytest.mark.parametrize("bad", ["wheeler", "", "Resample", None, 1])
+def test_an_unknown_construction_is_refused(bad):
+    with pytest.raises(MlsynthConfigError):
+        _fit(cumulative_band=True, cumulative_method=bad)
+
+
+@pytest.mark.parametrize("bad", [2.5, "3", True, None])
+def test_a_non_integer_block_is_refused(bad):
+    """A rounded block length is a silent change to how much correlation is kept."""
+    with pytest.raises(MlsynthConfigError, match="cumulative_block"):
+        _resampled(cumulative_block=bad)
+
+
+@pytest.mark.parametrize("bad", [-1, -8])
+def test_a_negative_block_is_refused(bad):
+    with pytest.raises(ValidationError):
+        _resampled(cumulative_block=bad)
+
+
+@pytest.mark.parametrize("bad", [2.5, "400", True, None])
+def test_a_non_integer_simulation_count_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="cumulative_n_sim"):
+        _resampled(cumulative_n_sim=bad)
+
+
+@pytest.mark.parametrize("bad", [0, 1, -5])
+def test_too_few_simulations_to_take_a_quantile_is_refused(bad):
+    with pytest.raises(ValidationError):
+        _resampled(cumulative_n_sim=bad)

--- a/mlsynth/tests/test_pda_resample_band.py
+++ b/mlsynth/tests/test_pda_resample_band.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
-from mlsynth.utils.pda_helpers.resample import block_error_paths, resolve_block
+from mlsynth.utils.conformal import block_error_paths, resolve_block
 
 ALPHA = 0.10
 

--- a/mlsynth/tests/test_pda_resample_band.py
+++ b/mlsynth/tests/test_pda_resample_band.py
@@ -162,9 +162,21 @@ def test_a_block_longer_than_the_horizon_is_clamped_to_it():
     assert resolve_block(20, 6) == 6
 
 
-def test_a_series_shorter_than_the_block_still_draws_by_wrapping():
-    """Blocks are circular, so a short series wraps instead of running out."""
-    paths = block_error_paths(np.array([1.0, -1.0, 2.0]), horizon=8, block=5,
+def test_a_series_shorter_than_the_block_is_refused():
+    """Blocks are circular, so a block at least as long as the series wraps
+    through whole cycles of it. A whole cycle of a centred series contributes
+    exactly zero, so the effective block is ``b % n``, not the ``b`` that was
+    asked for -- and at ``b % n == 0`` every path sums to zero and the band has
+    no width. Neither is silently delivered."""
+    with pytest.raises(MlsynthDataError, match="shorter block|zero width"):
+        block_error_paths(np.array([1.0, -1.0, 2.0]), horizon=8, block=5,
+                          n_sim=100, rng=np.random.default_rng(0))
+
+
+def test_a_horizon_longer_than_the_series_draws_from_admissible_blocks():
+    """The horizon is free to exceed the series; only the BLOCK is constrained,
+    since a path is assembled from several blocks."""
+    paths = block_error_paths(np.array([1.0, -1.0, 2.0]), horizon=8, block=2,
                               n_sim=100, rng=np.random.default_rng(0))
     assert paths.shape == (100, 8)
     assert np.isfinite(paths).all()

--- a/mlsynth/tests/test_pda_resample_band.py
+++ b/mlsynth/tests/test_pda_resample_band.py
@@ -162,21 +162,21 @@ def test_a_block_longer_than_the_horizon_is_clamped_to_it():
     assert resolve_block(20, 6) == 6
 
 
-def test_a_series_shorter_than_the_block_is_refused():
-    """Blocks are circular, so a block at least as long as the series wraps
-    through whole cycles of it. A whole cycle of a centred series contributes
-    exactly zero, so the effective block is ``b % n``, not the ``b`` that was
-    asked for -- and at ``b % n == 0`` every path sums to zero and the band has
-    no width. Neither is silently delivered."""
-    with pytest.raises(MlsynthDataError, match="shorter block|zero width"):
-        block_error_paths(np.array([1.0, -1.0, 2.0]), horizon=8, block=5,
-                          n_sim=100, rng=np.random.default_rng(0))
+def test_a_block_past_half_the_series_is_refused():
+    """Over a centred series the circular sum of a ``b``-block is minus the sum of
+    the complementary ``(n - b)``-block, so the two have equal spread. Past
+    ``b = n / 2`` a longer block draws a narrower total, mirroring a shorter one,
+    and at ``b = n`` every path sums to zero. The block length has stopped meaning
+    what it says, so it is refused instead of honoured."""
+    with pytest.raises(MlsynthDataError, match="half"):
+        block_error_paths(np.random.default_rng(0).normal(size=6), horizon=8,
+                          block=5, n_sim=100, rng=np.random.default_rng(0))
 
 
 def test_a_horizon_longer_than_the_series_draws_from_admissible_blocks():
     """The horizon is free to exceed the series; only the BLOCK is constrained,
     since a path is assembled from several blocks."""
-    paths = block_error_paths(np.array([1.0, -1.0, 2.0]), horizon=8, block=2,
+    paths = block_error_paths(np.array([1.0, -1.0, 2.0, 0.5]), horizon=8, block=2,
                               n_sim=100, rng=np.random.default_rng(0))
     assert paths.shape == (100, 8)
     assert np.isfinite(paths).all()

--- a/mlsynth/tests/test_pda_resample_band.py
+++ b/mlsynth/tests/test_pda_resample_band.py
@@ -1,0 +1,211 @@
+"""Block-resampled error paths for a PDA cumulative band (Wheeler's construction).
+
+``cumulative_supt_band`` already accepts an ``(B, H)`` matrix of post-period error
+paths and builds the band from it; today those paths come from
+``inferutils.pda_prediction_intervals``, which spends ``n_boot`` refits (999 by
+default). This suite pins a second producer of that matrix, costing one refit per
+rolling origin instead.
+
+The construction is the one Andrew Wheeler uses in LassoSynth: conformity scores
+resampled and accumulated into a cumulative path. Wheeler symmetrises by mirroring
+the pool, ``np.concatenate([cs, -cs])``, and draws periods independently. Drawing
+whole blocks generalises that to a panel whose period errors are serially
+correlated, and flipping each block's sign is the same symmetrisation applied to a
+block instead of a period.
+
+The two coincide exactly at ``block = 1``: the multiset ``{+e_i, -e_i}`` is the
+multiset ``{+|e_i|, -|e_i|}``, so drawing a centred score and flipping its sign and
+drawing from Wheeler's mirrored pool are the same distribution. That is the parity
+test below, and it is the reason the generalisation is safe to make.
+
+Levels: smoke, unit invariants (including reference parity), edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.pda_helpers.resample import block_error_paths, resolve_block
+
+ALPHA = 0.10
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def ar1(n, rho, *, sd=1.0, seed=0):
+    """An AR(1) series, started from its stationary distribution."""
+    rng = np.random.default_rng(seed)
+    e = np.zeros(n)
+    e[0] = rng.normal(0.0, sd / np.sqrt(1.0 - rho ** 2))
+    for t in range(1, n):
+        e[t] = rho * e[t - 1] + rng.normal(0.0, sd)
+    return e
+
+
+def ar1_sum_inflation(rho, H):
+    """Var(sum of H AR(1) terms) / (H * gamma_0) -- the closed form to match."""
+    k = np.arange(1, H)
+    return float((H + 2.0 * np.sum((H - k) * rho ** k)) / H)
+
+
+def wheeler_band(scores, tau, *, alpha=ALPHA, n_sim=200_000, seed=0):
+    """Wheeler's LassoSynth cumulative band, transcribed.
+
+    ``pool = concatenate([cs, -cs])``; draw one pool element per post period,
+    independently; accumulate; take equal-tailed empirical quantiles of the
+    accumulated paths. The reference this suite is written against.
+    """
+    rng = np.random.default_rng(seed)
+    cs = np.abs(np.asarray(scores, dtype=float).ravel())
+    pool = np.concatenate([cs, -cs])
+    L = np.asarray(tau, dtype=float).size
+    sims = np.cumsum(np.asarray(tau, float).reshape(L, 1)
+                     + rng.choice(pool, (L, n_sim)), axis=0)
+    lo, hi = np.quantile(sims, [alpha / 2, 1 - alpha / 2], axis=1)
+    return lo, hi
+
+
+def band_from_paths(paths, tau, *, alpha=ALPHA):
+    """The same equal-tailed band, read off an ``(n_sim, H)`` error-path matrix."""
+    cum = np.cumsum(np.asarray(tau, float)[None, :] + paths, axis=1)
+    lo, hi = np.quantile(cum, [alpha / 2, 1 - alpha / 2], axis=0)
+    return lo, hi
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_returns_one_row_per_simulation_and_one_column_per_horizon():
+    rng = np.random.default_rng(0)
+    paths = block_error_paths(ar1(80, 0.3), horizon=6, block=3, n_sim=500, rng=rng)
+    assert paths.shape == (500, 6)
+    assert np.isfinite(paths).all()
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+def test_block_one_reproduces_wheelers_band():
+    """The parity claim: at block 1 this is Wheeler's construction exactly."""
+    scores = ar1(60, 0.0, seed=3)
+    scores = scores - scores.mean()          # the pools coincide on centred scores
+    tau = np.linspace(2.0, 5.0, 8)
+
+    lo_w, hi_w = wheeler_band(scores, tau, n_sim=200_000, seed=0)
+    paths = block_error_paths(scores, horizon=8, block=1, n_sim=200_000,
+                              rng=np.random.default_rng(1))
+    lo_m, hi_m = band_from_paths(paths, tau)
+
+    scale = np.abs(hi_w - lo_w)
+    assert np.max(np.abs(lo_m - lo_w) / scale) < 0.02
+    assert np.max(np.abs(hi_m - hi_w) / scale) < 0.02
+
+
+def test_at_one_horizon_the_draws_are_the_symmetrised_score_pool():
+    """With a single period there is no accumulation, so the draw is the pool."""
+    scores = np.array([-3.0, -1.0, 2.0, 2.0])   # already centred
+    paths = block_error_paths(scores, horizon=1, block=1, n_sim=200_000,
+                              rng=np.random.default_rng(0))
+    drawn = np.sort(np.unique(np.round(paths.ravel(), 12)))
+    expected = np.sort(np.unique(np.round(np.concatenate([scores, -scores]), 12)))
+    assert np.array_equal(drawn, expected)
+
+
+def test_independent_draws_are_too_narrow_under_positive_autocorrelation():
+    """Blocks keep the serial correlation an independent draw throws away."""
+    rho, H = 0.7, 6
+    e = ar1(4000, rho, seed=11)
+    iid = block_error_paths(e, horizon=H, block=1, n_sim=40_000,
+                            rng=np.random.default_rng(0))
+    blocked = block_error_paths(e, horizon=H, block=H, n_sim=40_000,
+                                rng=np.random.default_rng(0))
+    # the inflation lives in the accumulated total, which is what the band
+    # covers; the final period's marginal is the same draw either way
+    ratio = blocked.sum(axis=1).std() / iid.sum(axis=1).std()
+    assert ratio > 1.4
+    assert abs(ratio - np.sqrt(ar1_sum_inflation(rho, H))) < 0.15 * ratio
+
+
+def test_the_two_agree_when_the_errors_are_white():
+    """With nothing to preserve, blocking changes nothing."""
+    e = ar1(4000, 0.0, seed=5)
+    iid = block_error_paths(e, horizon=6, block=1, n_sim=40_000,
+                            rng=np.random.default_rng(0))
+    blocked = block_error_paths(e, horizon=6, block=6, n_sim=40_000,
+                                rng=np.random.default_rng(0))
+    assert abs(blocked.sum(axis=1).std() / iid.sum(axis=1).std() - 1.0) < 0.08
+
+
+def test_the_draws_take_their_scale_from_the_centred_series():
+    """A fit sitting high shifts every error alike; the band is not charged for it.
+
+    The assertion is on spread and not on mean: the sign flips zero the mean of
+    the draws whether or not the series was centred, so a mean-zero check would
+    pass on an uncentred series too. What an uncentred draw inflates is the
+    scale -- a shift of 10 on a unit-variance series would carry a standard
+    deviation of about 10 into every period the band accumulates.
+    """
+    noise = ar1(2000, 0.2, seed=7)
+    paths = block_error_paths(noise + 10.0, horizon=5, block=2, n_sim=40_000,
+                              rng=np.random.default_rng(0))
+    assert abs(paths.std() / noise.std() - 1.0) < 0.05
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_block_zero_means_the_whole_horizon():
+    assert resolve_block(0, 8) == 8
+
+
+def test_a_block_longer_than_the_horizon_is_clamped_to_it():
+    assert resolve_block(20, 6) == 6
+
+
+def test_a_series_shorter_than_the_block_still_draws_by_wrapping():
+    """Blocks are circular, so a short series wraps instead of running out."""
+    paths = block_error_paths(np.array([1.0, -1.0, 2.0]), horizon=8, block=5,
+                              n_sim=100, rng=np.random.default_rng(0))
+    assert paths.shape == (100, 8)
+    assert np.isfinite(paths).all()
+
+
+def test_non_finite_entries_are_dropped_before_drawing():
+    e = np.array([1.0, np.nan, -1.0, np.inf, 2.0, -2.0])
+    paths = block_error_paths(e, horizon=3, block=1, n_sim=1000,
+                              rng=np.random.default_rng(0))
+    assert np.isfinite(paths).all()
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+def test_an_empty_series_is_refused():
+    with pytest.raises(MlsynthDataError, match="empty"):
+        block_error_paths(np.array([]), horizon=4, block=1, n_sim=10,
+                          rng=np.random.default_rng(0))
+
+
+def test_a_series_of_only_non_finite_values_is_refused():
+    with pytest.raises(MlsynthDataError, match="empty"):
+        block_error_paths(np.array([np.nan, np.inf]), horizon=4, block=1, n_sim=10,
+                          rng=np.random.default_rng(0))
+
+
+@pytest.mark.parametrize("bad", [-1, -8])
+def test_a_negative_block_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="block"):
+        resolve_block(bad, 8)
+
+
+@pytest.mark.parametrize("bad", [True, 2.5, "4", None])
+def test_a_non_integer_block_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="block"):
+        resolve_block(bad, 8)
+
+
+@pytest.mark.parametrize("bad", [0, -3])
+def test_a_non_positive_horizon_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="horizon"):
+        block_error_paths(np.array([1.0, -1.0]), horizon=bad, block=1, n_sim=10,
+                          rng=np.random.default_rng(0))

--- a/mlsynth/tests/test_pda_rolling_origin_errors.py
+++ b/mlsynth/tests/test_pda_rolling_origin_errors.py
@@ -22,8 +22,8 @@ import numpy as np
 import pytest
 
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
-from mlsynth.utils.conformal import origin_schedule
-from mlsynth.utils.pda_helpers.resample import rolling_origin_counterfactual_errors
+from mlsynth.utils.conformal import (origin_schedule,
+                                     rolling_origin_counterfactual_errors)
 
 
 # --------------------------------------------------------------------------- #

--- a/mlsynth/tests/test_pda_rolling_origin_errors.py
+++ b/mlsynth/tests/test_pda_rolling_origin_errors.py
@@ -1,0 +1,155 @@
+"""Rolling-origin per-period errors for a PDA fit, from its own refit.
+
+``mlsynth.utils.conformal.rolling_origin_period_errors`` reads the errors as
+``y[block] - Y0[block] @ w``, which needs the fit to be a bare linear combination
+of the donors. A PDA fit is not: LASSO carries an intercept, the modified-BIC path
+standardizes the donors the way ``glmnet`` does, and forward selection and HCW
+return a counterfactual with no single weight vector to multiply. So the PDA reader
+asks the estimator for its counterfactual instead.
+
+``refit_at(origin) -> counterfactual`` is the seam, and ``orchestration._build_refit``
+already builds one per method: it closes over the pre-period length, so pointing it
+at an origin gives a fit trained strictly before that origin. One reader covers all
+four PDA variants.
+
+The origin schedule is shared with the conformal readers
+(``conformal.scores.origin_schedule``), so a PDA band and a split-conformal band
+calibrate on the same windows.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
+from mlsynth.utils.conformal import origin_schedule
+from mlsynth.utils.pda_helpers.resample import rolling_origin_counterfactual_errors
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def panel(T=60, J=3, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(T, J))
+    y = X @ np.array([0.5, 0.3, 0.2]) + 1.5 + rng.normal(scale=0.1, size=T)
+    return y, X
+
+
+def ols_refit_at(y, X, *, intercept=True):
+    """A stand-in estimator: OLS on the periods before the origin, with intercept."""
+    def _fn(origin):
+        A = np.column_stack([np.ones(len(X)), X]) if intercept else X
+        beta, *_ = np.linalg.lstsq(A[:origin], y[:origin], rcond=None)
+        return A @ beta
+    return _fn
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_returns_one_error_per_scored_period():
+    y, X = panel()
+    out = rolling_origin_counterfactual_errors(y, ols_refit_at(y, X), 48, 6)
+    assert out.ndim == 1 and out.dtype == float
+    assert out.size == len(list(origin_schedule(48, 6, 0.3))) * 6
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+def test_the_series_is_each_window_of_the_gap_concatenated():
+    y, X = panel()
+    refit_at = ols_refit_at(y, X)
+    out = rolling_origin_counterfactual_errors(y, refit_at, 48, 6)
+    wanted = np.concatenate([(y - refit_at(o))[o:o + 6]
+                             for o in origin_schedule(48, 6, 0.3)])
+    assert out == pytest.approx(wanted)
+
+
+def test_the_estimator_is_refit_once_per_origin_in_increasing_order():
+    y, X = panel()
+    base, seen = ols_refit_at(y, X), []
+
+    def spy(origin):
+        seen.append(origin)
+        return base(origin)
+
+    rolling_origin_counterfactual_errors(y, spy, 48, 6)
+    assert seen == list(origin_schedule(48, 6, 0.3))
+
+
+def test_it_scores_the_same_windows_as_the_conformal_readers():
+    """One schedule, so a resampled band and a split band calibrate alike."""
+    y, X = panel(T=80, seed=4)
+    out = rolling_origin_counterfactual_errors(y, ols_refit_at(y, X), 64, 8,
+                                               min_train_frac=0.25)
+    assert out.size == len(list(origin_schedule(64, 8, 0.25))) * 8
+
+
+def test_an_estimator_that_reproduces_the_outcome_scores_zero_error():
+    y, X = panel()
+    out = rolling_origin_counterfactual_errors(y, lambda o: y.copy(), 48, 6)
+    assert out == pytest.approx(np.zeros_like(out), abs=1e-12)
+
+
+def test_a_constant_shift_in_the_counterfactual_shifts_every_error():
+    y, X = panel()
+    base = ols_refit_at(y, X)
+    out = rolling_origin_counterfactual_errors(y, base, 48, 6)
+    shifted = rolling_origin_counterfactual_errors(y, lambda o: base(o) + 3.0, 48, 6)
+    assert shifted == pytest.approx(out - 3.0)
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_a_pre_period_too_short_for_one_window_returns_nothing():
+    y, X = panel(T=20)
+    out = rolling_origin_counterfactual_errors(y, ols_refit_at(y, X), 12, 6)
+    assert out.size == 0 and out.dtype == float
+
+
+def test_a_horizon_equal_to_the_admissible_span_gives_one_block():
+    y, X = panel(T=30)
+    out = rolling_origin_counterfactual_errors(y, ols_refit_at(y, X), 16, 6,
+                                               min_train_frac=0.0)
+    assert out.size == 6
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", [0, -4, True, 2.5, "6", None])
+def test_a_horizon_that_is_not_a_positive_integer_is_refused(bad):
+    y, X = panel()
+    with pytest.raises(MlsynthConfigError, match="horizon"):
+        rolling_origin_counterfactual_errors(y, ols_refit_at(y, X), 48, bad)
+
+
+@pytest.mark.parametrize("bad", [-0.1, 1.5, "0.3", None])
+def test_a_min_train_frac_outside_the_unit_interval_is_refused(bad):
+    y, X = panel()
+    with pytest.raises(MlsynthConfigError, match="min_train_frac"):
+        rolling_origin_counterfactual_errors(y, ols_refit_at(y, X), 48, 6,
+                                             min_train_frac=bad)
+
+
+def test_a_pre_period_longer_than_the_sample_is_refused():
+    y, X = panel(T=40)
+    with pytest.raises(MlsynthDataError, match="pre_periods"):
+        rolling_origin_counterfactual_errors(y, ols_refit_at(y, X), 80, 6)
+
+
+def test_a_counterfactual_that_does_not_span_the_sample_is_refused():
+    """A refit returning only its training window cannot score the next one."""
+    y, X = panel()
+    with pytest.raises(MlsynthDataError, match="counterfactual"):
+        rolling_origin_counterfactual_errors(y, lambda o: y[:o], 48, 6)
+
+
+def test_a_non_finite_counterfactual_is_refused():
+    y, X = panel()
+    bad = y.copy(); bad[50] = np.nan
+    with pytest.raises(MlsynthDataError, match="finite"):
+        rolling_origin_counterfactual_errors(y, lambda o: bad, 48, 6)

--- a/mlsynth/tests/test_pda_rolling_origin_errors_properties.py
+++ b/mlsynth/tests/test_pda_rolling_origin_errors_properties.py
@@ -18,8 +18,9 @@ import pytest
 from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 
-from mlsynth.utils.conformal import origin_schedule, rolling_origin_period_errors
-from mlsynth.utils.pda_helpers.resample import rolling_origin_counterfactual_errors
+from mlsynth.utils.conformal import (origin_schedule,
+                                     rolling_origin_counterfactual_errors,
+                                     rolling_origin_period_errors)
 
 _SETTINGS = settings(
     max_examples=40, deadline=None, suppress_health_check=[HealthCheck.too_slow]

--- a/mlsynth/tests/test_pda_rolling_origin_errors_properties.py
+++ b/mlsynth/tests/test_pda_rolling_origin_errors_properties.py
@@ -1,0 +1,119 @@
+"""Metamorphic invariants of the PDA rolling-origin errors.
+
+The unit suite pins the series on fixed panels. These assert what must hold for
+every panel:
+
+* agreement -- when the estimator is a bare linear combination of the donors, this
+  reader and ``conformal.rolling_origin_period_errors`` return the same numbers, so
+  the two cannot disagree about the schedule or the sign of an error;
+* structure -- the length is the origin count times the horizon;
+* equivariance -- rescaling the outcome and the counterfactual rescales every error
+  by the same factor;
+* invariance -- shifting the counterfactual shifts every error by the negative of
+  the shift, and nothing else;
+* monotonicity -- training on more of the pre-period never yields more windows.
+"""
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from mlsynth.utils.conformal import origin_schedule, rolling_origin_period_errors
+from mlsynth.utils.pda_helpers.resample import rolling_origin_counterfactual_errors
+
+_SETTINGS = settings(
+    max_examples=40, deadline=None, suppress_health_check=[HealthCheck.too_slow]
+)
+
+
+def _ols_weight_fn(y, Y0):
+    def _fn(keep_idx):
+        idx = np.asarray(keep_idx)
+        beta, *_ = np.linalg.lstsq(Y0[idx], y[idx], rcond=None)
+        return np.asarray(beta, float)
+    return _fn
+
+
+def _ols_refit_at(y, Y0):
+    """The same fit, expressed as a counterfactual over the whole sample."""
+    wf = _ols_weight_fn(y, Y0)
+    return lambda origin: Y0 @ wf(np.arange(origin))
+
+
+@st.composite
+def panels(draw, min_pre=48, max_pre=96):
+    n_donors = draw(st.integers(2, 6))
+    horizon = draw(st.integers(1, 6))
+    pre_periods = draw(st.integers(min_pre, max_pre))
+    post_extra = draw(st.integers(0, 6))
+    seed = draw(st.integers(0, 2 ** 31 - 1))
+    rng = np.random.default_rng(seed)
+    total = pre_periods + horizon + post_extra
+    Y0 = rng.normal(size=(total, n_donors))
+    y = Y0 @ rng.dirichlet(np.ones(n_donors)) + rng.normal(scale=0.1, size=total)
+    assume(np.linalg.matrix_rank(Y0[:pre_periods]) == n_donors)
+    return y, Y0, pre_periods, horizon
+
+
+class TestAgreement:
+    @given(panels())
+    @_SETTINGS
+    def test_a_linear_fit_reads_the_same_either_way(self, panel):
+        y, Y0, pre, horizon = panel
+        via_cf = rolling_origin_counterfactual_errors(
+            y, _ols_refit_at(y, Y0), pre, horizon, min_train_frac=0.2)
+        via_w = rolling_origin_period_errors(
+            y, Y0, pre, horizon, _ols_weight_fn(y, Y0), min_train_frac=0.2)
+        assert via_cf.size == via_w.size
+        if via_w.size:
+            assert via_cf == pytest.approx(via_w, rel=1e-7, abs=1e-9)
+
+
+class TestStructure:
+    @given(panels())
+    @_SETTINGS
+    def test_length_is_the_origin_count_times_the_horizon(self, panel):
+        y, Y0, pre, horizon = panel
+        out = rolling_origin_counterfactual_errors(
+            y, _ols_refit_at(y, Y0), pre, horizon, min_train_frac=0.2)
+        assert out.size == len(list(origin_schedule(pre, horizon, 0.2))) * horizon
+
+
+class TestEquivariance:
+    @given(panels(), st.floats(0.25, 4.0, allow_nan=False, allow_infinity=False))
+    @_SETTINGS
+    def test_rescaling_rescales_every_error(self, panel, c):
+        y, Y0, pre, horizon = panel
+        base = rolling_origin_counterfactual_errors(
+            y, _ols_refit_at(y, Y0), pre, horizon, min_train_frac=0.2)
+        assume(base.size)
+        scaled = rolling_origin_counterfactual_errors(
+            c * y, _ols_refit_at(c * y, c * Y0), pre, horizon, min_train_frac=0.2)
+        assert scaled == pytest.approx(c * base, rel=1e-8, abs=1e-9)
+
+
+class TestInvariance:
+    @given(panels(), st.floats(-5.0, 5.0, allow_nan=False, allow_infinity=False))
+    @_SETTINGS
+    def test_shifting_the_counterfactual_shifts_every_error(self, panel, shift):
+        y, Y0, pre, horizon = panel
+        refit_at = _ols_refit_at(y, Y0)
+        base = rolling_origin_counterfactual_errors(
+            y, refit_at, pre, horizon, min_train_frac=0.2)
+        assume(base.size)
+        moved = rolling_origin_counterfactual_errors(
+            y, lambda o: refit_at(o) + shift, pre, horizon, min_train_frac=0.2)
+        assert moved == pytest.approx(base - shift, rel=1e-8, abs=1e-9)
+
+
+class TestMonotonicity:
+    @given(panels())
+    @_SETTINGS
+    def test_training_on_more_of_the_pre_period_never_adds_windows(self, panel):
+        y, Y0, pre, horizon = panel
+        refit_at = _ols_refit_at(y, Y0)
+        few = rolling_origin_counterfactual_errors(y, refit_at, pre, horizon,
+                                                   min_train_frac=0.6)
+        many = rolling_origin_counterfactual_errors(y, refit_at, pre, horizon,
+                                                    min_train_frac=0.2)
+        assert few.size <= many.size

--- a/mlsynth/tests/test_supt.py
+++ b/mlsynth/tests/test_supt.py
@@ -29,6 +29,8 @@ What the tests pin:
 """
 import numpy as np
 import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 from scipy.stats import norm
 
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
@@ -479,3 +481,63 @@ def test_the_two_methods_converge_as_the_calibration_support_grows():
             ratios.append(supt_critical_value(d, alpha=0.10, method="empirical") / g)
         spread[m] = float(np.std(ratios))
     assert spread[1100] < 0.5 * spread[77], spread
+
+
+# ---------------------------------------------------------------------------
+# Rung 3, as a property rather than one worked case.
+# ---------------------------------------------------------------------------
+
+@given(
+    n_h=st.integers(min_value=2, max_value=8),
+    rho=st.floats(min_value=-0.4, max_value=0.95, allow_nan=False),
+    seed=st.integers(min_value=0, max_value=2**32 - 1),
+)
+@settings(max_examples=25, deadline=None,
+          suppress_health_check=[HealthCheck.too_slow])
+def test_the_simulation_depends_on_the_draws_only_through_their_correlation(
+        n_h, rho, seed):
+    """``method="gaussian"`` is a functional of ``R``.
+
+    Replace an ensemble with normals carrying the same correlation and the
+    simulated multiplier does not move. This is the root cause stated as an
+    invariant: whatever else the draws contain, the estimator cannot see it.
+    """
+    rng = np.random.default_rng(seed)
+    H, N = n_h, 20_000
+    base = np.full((H, H), rho)
+    np.fill_diagonal(base, 1.0)
+    w, V = np.linalg.eigh(base)
+    L = V * np.sqrt(np.clip(w, 0.0, None))
+
+    # An ensemble that is emphatically not normal: a two-component mixture.
+    heavy = rng.standard_normal((N, H)) @ L.T
+    heavy *= np.where(rng.random((N, 1)) < 0.1, 6.0, 1.0)
+
+    R = np.corrcoef(heavy, rowvar=False)
+    w2, V2 = np.linalg.eigh(R)
+    twin = rng.standard_normal((N, H)) @ (V2 * np.sqrt(np.clip(w2, 0.0, None))).T
+
+    a = supt_critical_value(heavy, alpha=0.10, n_sims=20_000, seed=0)
+    b = supt_critical_value(twin, alpha=0.10, n_sims=20_000, seed=0)
+    assert a == pytest.approx(b, abs=0.06), (a, b, rho, H)
+
+
+@given(
+    method=st.sampled_from(["gaussian", "empirical"]),
+    seed=st.integers(min_value=0, max_value=2**32 - 1),
+    n_h=st.integers(min_value=2, max_value=8),
+)
+@settings(max_examples=25, deadline=None,
+          suppress_health_check=[HealthCheck.too_slow])
+def test_both_methods_are_invariant_to_rescaling_a_horizon(method, seed, n_h):
+    """Neither route may read the units. The multiplier applies to ``se_h``,
+    which carries the scale, so a horizon measured in thousands must not buy a
+    different band from the same horizon measured in millions."""
+    rng = np.random.default_rng(seed)
+    draws = rng.standard_normal((4000, n_h))
+    factors = np.exp(rng.uniform(-6.0, 6.0, size=n_h))
+    plain = supt_critical_value(draws, alpha=0.10, method=method,
+                                n_sims=20_000, seed=0)
+    scaled = supt_critical_value(draws * factors, alpha=0.10, method=method,
+                                 n_sims=20_000, seed=0)
+    assert plain == pytest.approx(scaled, rel=1e-9)

--- a/mlsynth/tests/test_supt.py
+++ b/mlsynth/tests/test_supt.py
@@ -302,3 +302,180 @@ def test_too_few_draws_to_estimate_a_correlation_is_reported():
 def test_a_nonpositive_simulation_count_is_rejected():
     with pytest.raises(MlsynthConfigError, match="n_sims"):
         supt_critical_value(_draws(20, 3), alpha=0.05, n_sims=0)
+
+
+# ---------------------------------------------------------------------------
+# Choosing the estimator: simulated (default) or read off the draws
+#
+# The Gaussian tabulation above is the right instrument for a delete-one
+# jackknife -- few draws, and on a different scale from the sampling
+# distribution. It is a poorer one for a large bootstrap ensemble, where the
+# draws are numerous and already on the estimator's scale, and where reducing
+# them to a correlation matrix discards the thing that drives ``max_h``: draws
+# that are large at every horizon at once. ``method="empirical"`` reads the
+# quantile off the draws instead, which is free when they are already in hand.
+# ---------------------------------------------------------------------------
+
+def _short_support_blocks(e, H, n, rng):
+    """Circular blocks of length ``H`` from a short fixed series, accumulated.
+
+    What a block bootstrap over a rolling calibration pass produces. The support
+    is the series, not the draw count: ``e.size`` distinct blocks times a sign, so
+    a large ``n`` resamples a small set rather than exploring a continuum. That is
+    the regime where the two estimators part company.
+    """
+    m = e.size
+    starts = rng.integers(0, m, size=n)
+    idx = (starts[:, None] + np.arange(H)[None, :]) % m
+    signs = rng.choice(np.array([-1.0, 1.0]), size=(n, 1))
+    return np.cumsum(e[idx] * signs, axis=1)
+
+
+def test_empirical_returns_a_finite_positive_scalar():
+    rng = np.random.default_rng(0)
+    c = supt_critical_value(rng.standard_normal((5000, 6)), alpha=0.10,
+                            method="empirical")
+    assert np.isfinite(c) and c > 0.0
+
+
+def test_empirical_ignores_n_sims_and_seed():
+    """No RNG is consulted, so the two knobs that steer the simulation cannot
+    move it. That is the point: the answer is a statistic of the draws."""
+    rng = np.random.default_rng(1)
+    draws = rng.standard_normal((4000, 5))
+    a = supt_critical_value(draws, alpha=0.10, method="empirical", n_sims=10, seed=0)
+    b = supt_critical_value(draws, alpha=0.10, method="empirical", n_sims=999_999, seed=7)
+    assert a == b
+
+
+def test_empirical_one_horizon_is_the_pointwise_critical_value():
+    rng = np.random.default_rng(2)
+    c = supt_critical_value(rng.standard_normal((200_000, 1)), alpha=0.10,
+                            method="empirical")
+    from scipy.stats import norm
+    assert c == pytest.approx(norm.ppf(0.95), abs=0.02)
+
+
+def test_empirical_ignores_the_scale_of_the_draws():
+    """Same invariance the simulated route has: only the standardized path
+    matters, so rescaling a horizon leaves the multiplier alone."""
+    rng = np.random.default_rng(3)
+    draws = rng.standard_normal((5000, 4))
+    scaled = draws * np.array([1.0, 100.0, 0.01, 7.0])
+    assert supt_critical_value(draws, alpha=0.10, method="empirical") == pytest.approx(
+        supt_critical_value(scaled, alpha=0.10, method="empirical"), rel=1e-12)
+
+
+def test_empirical_agrees_with_the_simulation_on_gaussian_draws():
+    """Where the Gaussian assumption holds, the two routes answer the same."""
+    rng = np.random.default_rng(4)
+    draws = rng.standard_normal((200_000, 8))
+    g = supt_critical_value(draws, alpha=0.10, n_sims=200_000, seed=0)
+    e = supt_critical_value(draws, alpha=0.10, method="empirical")
+    assert e == pytest.approx(g, rel=0.03)
+
+
+def test_the_two_methods_part_company_on_a_short_support_ensemble():
+    """The case the choice exists for.
+
+    A calibration series with one atypical stretch gives an ensemble whose
+    extreme draws are the ones that catch it. The empirical quantile sees them;
+    the simulated route cannot, because a correlation matrix does not record
+    which blocks the series happens to contain. Neither answer is wrong -- the
+    simulation trades that idiosyncrasy for stability -- but they differ enough
+    that the caller should get to pick.
+    """
+    for seed in range(4):
+        rng = np.random.default_rng(seed)
+        e = np.concatenate([rng.standard_normal(11) * (6.0 if i == 0 else 1.0)
+                            for i in range(7)])
+        e = e - e.mean()
+        draws = _short_support_blocks(e, 11, 100_000, np.random.default_rng(100 + seed))
+        g = supt_critical_value(draws, alpha=0.10, n_sims=100_000, seed=0)
+        emp = supt_critical_value(draws, alpha=0.10, method="empirical")
+        assert emp > 1.15 * g, f"seed {seed}: empirical {emp:.4f}, gaussian {g:.4f}"
+
+
+def test_empirical_is_never_narrower_than_pointwise():
+    from scipy.stats import norm
+    rng = np.random.default_rng(6)
+    for H in (2, 5, 12):
+        c = supt_critical_value(rng.standard_normal((50_000, H)), alpha=0.10,
+                                method="empirical")
+        assert c >= norm.ppf(0.95) - 0.02
+
+
+@pytest.mark.parametrize("bad", ["bootstrap", "Gaussian", "empirical ", "", None, 1])
+def test_an_unknown_method_is_refused(bad):
+    """Anything outside the two names raises rather than falling through.
+
+    Silently defaulting would be the worst outcome: the returned number is a
+    perfectly plausible multiplier, so a caller who asked for the empirical one
+    and got the simulated one has no way to notice.
+    """
+    rng = np.random.default_rng(7)
+    with pytest.raises(MlsynthConfigError, match="method"):
+        supt_critical_value(rng.standard_normal((100, 3)), alpha=0.10, method=bad)
+
+
+def test_the_default_method_is_the_simulation():
+    """The default must not move: every existing caller keeps its numbers."""
+    rng = np.random.default_rng(8)
+    draws = rng.standard_normal((2000, 5))
+    assert supt_critical_value(draws, alpha=0.10) == supt_critical_value(
+        draws, alpha=0.10, method="gaussian")
+
+
+def test_the_simulation_cannot_distinguish_ensembles_sharing_one_correlation():
+    """The root cause, stated as an invariant.
+
+    ``method="gaussian"`` reduces the draws to their correlation across horizons
+    and reads the multiplier from normals carrying it, so it is a functional of
+    that matrix alone: two ensembles with the same correlation get the same
+    answer however different their joint laws. The quantile being estimated is
+    not such a functional. Where the draws really are normal the two routes
+    agree; where they are not, the simulation reports the normal answer.
+    """
+    H, N = 11, 100_000
+    rng = np.random.default_rng(2)
+    e = np.concatenate([rng.standard_normal(11) * (6.0 if i == 0 else 1.0)
+                        for i in range(7)])
+    e -= e.mean()
+    B = _short_support_blocks(e, H, N, np.random.default_rng(101))
+
+    R = np.corrcoef(B, rowvar=False)
+    w, V = np.linalg.eigh(R)
+    L = V * np.sqrt(np.clip(w, 0.0, None))
+    A = np.random.default_rng(7).standard_normal((N, H)) @ L.T   # same R, normal
+
+    assert np.max(np.abs(np.corrcoef(A, rowvar=False) - R)) < 0.02
+
+    gA = supt_critical_value(A, alpha=0.10, n_sims=N, seed=0)
+    gB = supt_critical_value(B, alpha=0.10, n_sims=N, seed=0)
+    assert gA == pytest.approx(gB, abs=0.02)          # blind to the difference
+
+    eA = supt_critical_value(A, alpha=0.10, method="empirical")
+    eB = supt_critical_value(B, alpha=0.10, method="empirical")
+    assert eA == pytest.approx(gA, abs=0.05)          # normal: the routes agree
+    assert eB > gB + 1.0                              # not normal: they do not
+
+
+def test_the_two_methods_converge_as_the_calibration_support_grows():
+    """Why the ensembles differ at all: a circular block bootstrap over ``m``
+    periods draws from ``m`` distinct blocks, so a large ``n_sim`` resamples a
+    small set rather than exploring a continuum. Lengthen the series and the
+    empirical quantile stops inheriting that particular series' idiosyncrasy.
+    """
+    H, N = 11, 40_000
+    spread = {}
+    for m in (77, 1100):
+        ratios = []
+        for s in range(6):
+            r = np.random.default_rng(s)
+            e = r.standard_normal(m)
+            e -= e.mean()
+            d = _short_support_blocks(e, H, N, np.random.default_rng(500 + s))
+            g = supt_critical_value(d, alpha=0.10, n_sims=N, seed=0)
+            ratios.append(supt_critical_value(d, alpha=0.10, method="empirical") / g)
+        spread[m] = float(np.std(ratios))
+    assert spread[1100] < 0.5 * spread[77], spread

--- a/mlsynth/tests/test_vanillasc_resample_cumulative.py
+++ b/mlsynth/tests/test_vanillasc_resample_cumulative.py
@@ -138,13 +138,15 @@ def test_it_is_finite_where_the_split_order_statistic_is_not():
     assert resampled["conformal_q"] > 0.0
 
 
-def test_a_block_as_long_as_the_calibration_series_is_refused():
-    """One window supplies exactly ``horizon`` periods, so the default
-    whole-horizon block has nothing to slide over: every circular block is a
-    rotation of the whole series and every path sums to the same value. The band
-    would report zero width, so the draw raises instead of returning it."""
+def test_a_whole_horizon_block_needs_two_windows():
+    """The calibration series is ``m * L`` periods and the default block is the
+    horizon ``L``, so the block is half the series at ``m = 2`` and past half at
+    ``m = 1``. Over a centred series a block past half draws a narrower total than
+    a shorter one -- at ``m = 1`` it draws nothing at all, since every block is a
+    rotation of the whole series -- so the single-window case is refused and the
+    remedy is a shorter block."""
     df = _panel(n_periods=22, t0=16, seed=2)
-    with pytest.raises(MlsynthDataError, match="zero width|shorter block"):
+    with pytest.raises(MlsynthDataError, match="half"):
         _details(df=df, alpha=0.05, conformal_method="resample",
                  conformal_n_sim=400)
 

--- a/mlsynth/tests/test_vanillasc_resample_cumulative.py
+++ b/mlsynth/tests/test_vanillasc_resample_cumulative.py
@@ -1,0 +1,189 @@
+"""VanillaSC's cumulative band, built by resampling instead of a split quantile.
+
+``inference="conformal_cumulative"`` calibrates the band for a running total on
+non-overlapping rolling-origin windows and takes a split-conformal order
+statistic of the ``m`` window sums. That statistic is the constraint: it exists
+only once ``m >= ceil(1/alpha) - 1``, so at the 5 percent level a panel needs
+nineteen windows before the band is finite at all, and below that the estimator
+correctly returns an infinite half-width and warns.
+
+``conformal_method="resample"`` calibrates on the same windows but keeps them per
+period, giving ``m * L`` values to draw from where the split band had ``m``. A band
+then exists on pre-periods where the order statistic does not, which is the
+practical reason to offer it.
+
+What it does not change is the object: the same
+:class:`~mlsynth.utils.conformal.structure.CumulativeConformalBand`, the same
+point estimate, the same fields, only calibrated differently.
+
+Levels: smoke, unit invariants, edge, failure.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import VanillaSC
+from mlsynth.exceptions import MlsynthConfigError
+
+
+def _panel(n_units=8, n_periods=40, t0=30, seed=0, effect=4.0, rho=0.0):
+    rng = np.random.default_rng(seed)
+    donor_base = rng.normal(10.0, 1.0, size=n_units - 1)
+    loads = rng.dirichlet(np.ones(n_units - 1))
+    common_e = rng.normal(0.0, 0.2, size=n_periods)
+    # The treated unit needs its own idiosyncratic error, or it is an exact
+    # convex combination of the donors and every calibration error is 1e-15.
+    own_e = rng.normal(0.0, 0.5, size=n_periods)
+    if rho:
+        for t in range(1, n_periods):
+            own_e[t] = rho * own_e[t - 1] + np.sqrt(1 - rho ** 2) * own_e[t]
+    rows = []
+    for t in range(n_periods):
+        common = 0.4 * t + common_e[t]
+        donors = donor_base + common + rng.normal(0.0, 0.15, size=donor_base.size)
+        treated = float(loads @ donors) + own_e[t] + (effect if t >= t0 else 0.0)
+        rows.append({"unit": "u0", "time": t, "y": treated, "treat": int(t >= t0)})
+        for j, dv in enumerate(donors):
+            rows.append({"unit": f"d{j}", "time": t, "y": float(dv), "treat": 0})
+    return pd.DataFrame(rows)
+
+
+_CFG = dict(outcome="y", treat="treat", unitid="unit", time="time",
+            backend="outcome-only", display_graphs=False,
+            inference="conformal_cumulative")
+
+
+def _inference(df=None, **kw):
+    cfg = dict(df=_panel() if df is None else df, **_CFG)
+    cfg.update(kw)
+    return VanillaSC(cfg).fit().inference
+
+
+def _details(df=None, **kw):
+    return _inference(df, **kw).details
+
+
+# --------------------------------------------------------------------------- #
+# smoke
+# --------------------------------------------------------------------------- #
+def test_it_produces_a_finite_band():
+    d = _details(conformal_method="resample", conformal_n_sim=400)
+    assert np.isfinite(d["conformal_q"])
+    assert np.isfinite(d["cumulative_lower"]) and np.isfinite(d["cumulative_upper"])
+
+
+# --------------------------------------------------------------------------- #
+# unit invariants
+# --------------------------------------------------------------------------- #
+def test_the_construction_is_recorded():
+    assert "resample" in _inference(conformal_method="resample",
+                                    conformal_n_sim=400).method
+    assert "resample" not in _inference().method
+
+
+def test_the_point_estimate_does_not_depend_on_the_construction():
+    """Only the calibration changes; the effect being bounded is the same."""
+    split = _details()
+    resampled = _details(conformal_method="resample", conformal_n_sim=400)
+    assert resampled["cumulative_effect"] == pytest.approx(split["cumulative_effect"])
+    assert resampled["horizon"] == split["horizon"]
+
+
+def test_the_band_is_symmetric_about_the_point():
+    d = _details(conformal_method="resample", conformal_n_sim=400)
+    assert d["cumulative_effect"] - d["cumulative_lower"] == pytest.approx(
+        d["conformal_q"])
+    assert d["cumulative_upper"] - d["cumulative_effect"] == pytest.approx(
+        d["conformal_q"])
+
+
+def test_the_same_seed_gives_the_same_band():
+    a = _details(conformal_method="resample", conformal_n_sim=400, conformal_seed=7)
+    b = _details(conformal_method="resample", conformal_n_sim=400, conformal_seed=7)
+    assert a["conformal_q"] == pytest.approx(b["conformal_q"])
+
+
+def test_a_longer_block_widens_the_band_on_a_persistent_panel():
+    df = _panel(rho=0.8, seed=5)
+    one = _details(df=df, conformal_method="resample", conformal_block=1,
+                   conformal_n_sim=4000)
+    full = _details(df=df, conformal_method="resample", conformal_block=0,
+                    conformal_n_sim=4000)
+    assert full["conformal_q"] > one["conformal_q"]
+
+
+def test_it_counts_the_periods_it_drew_from_not_the_windows():
+    """m windows supply m*L values, which is the whole point of the change."""
+    d = _details(conformal_method="resample", conformal_n_sim=400)
+    split = _details()
+    assert d["n_calibration_windows"] == split["n_calibration_windows"] * d["horizon"]
+
+
+# --------------------------------------------------------------------------- #
+# edge
+# --------------------------------------------------------------------------- #
+def test_it_is_finite_where_the_split_order_statistic_is_not():
+    """The practical gain, on a pre-period too short for the split band."""
+    df = _panel(n_periods=22, t0=16, seed=2)
+    split = _details(df=df, alpha=0.05)
+    assert not np.isfinite(split["conformal_q"])
+    resampled = _details(df=df, alpha=0.05, conformal_method="resample",
+                         conformal_n_sim=400)
+    assert np.isfinite(resampled["conformal_q"])
+
+
+# --------------------------------------------------------------------------- #
+# failure
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("bad", ["wheeler", "", "Resample", None, 1])
+def test_an_unknown_construction_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="conformal_method"):
+        _details(conformal_method=bad)
+
+
+@pytest.mark.parametrize("bad", [-1, 2.5, "3", True])
+def test_a_bad_block_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="conformal_block"):
+        _details(conformal_method="resample", conformal_block=bad)
+
+
+@pytest.mark.parametrize("bad", [0, 1, 2.5, "400"])
+def test_a_bad_simulation_count_is_refused(bad):
+    with pytest.raises(MlsynthConfigError, match="conformal_n_sim"):
+        _details(conformal_method="resample", conformal_n_sim=bad)
+
+
+def test_different_seeds_give_different_bands():
+    """The draw is random, so the seed has to reach it. Single-period blocks,
+    because at ``block=0`` a path is one contiguous window of the calibration
+    series and there are only as many of those as there are periods, so the
+    quantile lands on the same atom whatever the seed."""
+    kw = dict(conformal_method="resample", conformal_block=1, conformal_n_sim=200)
+    a = _details(conformal_seed=7, **kw)
+    b = _details(conformal_seed=8, **kw)
+    assert a["conformal_q"] != pytest.approx(b["conformal_q"], rel=1e-6)
+    assert _details(conformal_seed=7, **kw)["conformal_q"] == pytest.approx(
+        a["conformal_q"])
+
+
+@pytest.mark.parametrize("alpha", [0.9, 0.5, 0.2, 0.05])
+def test_the_half_width_is_a_magnitude_at_every_level(alpha):
+    """The draws are sign-symmetric, so the (1-alpha) quantile of the signed
+    totals goes negative once alpha passes a half. A half-width cannot: it is
+    the quantile of the magnitudes, and the band brackets the point."""
+    d = _details(conformal_method="resample", conformal_n_sim=400, alpha=alpha)
+    assert d["conformal_q"] > 0.0
+    assert d["cumulative_lower"] < d["cumulative_effect"] < d["cumulative_upper"]
+
+
+def test_a_shorter_horizon_accumulates_only_that_horizon():
+    df = _panel(n_periods=40, t0=30, effect=4.0)
+    full = _details(df=df, conformal_method="resample", conformal_n_sim=400)
+    part = _details(df=df, conformal_method="resample", conformal_n_sim=400,
+                    conformal_horizon=4)
+    assert full["horizon"] == 10 and part["horizon"] == 4
+    # A constant post-period effect: the total over four periods is about four
+    # fifths less than the total over ten.
+    assert part["cumulative_effect"] == pytest.approx(
+        full["cumulative_effect"] * 0.4, rel=0.25)
+    assert part["spans_post_period"] is False

--- a/mlsynth/tests/test_vanillasc_resample_cumulative.py
+++ b/mlsynth/tests/test_vanillasc_resample_cumulative.py
@@ -23,7 +23,7 @@ import pandas as pd
 import pytest
 
 from mlsynth import VanillaSC
-from mlsynth.exceptions import MlsynthConfigError
+from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
 
 
 def _panel(n_units=8, n_periods=40, t0=30, seed=0, effect=4.0, rho=0.0):
@@ -123,13 +123,30 @@ def test_it_counts_the_periods_it_drew_from_not_the_windows():
 # edge
 # --------------------------------------------------------------------------- #
 def test_it_is_finite_where_the_split_order_statistic_is_not():
-    """The practical gain, on a pre-period too short for the split band."""
+    """The practical gain, on a pre-period too short for the split band.
+
+    The block has to be short enough to draw from: one window supplies exactly
+    ``horizon`` periods, and a whole-horizon block over a series that length is
+    refused (see below). At ``block=1`` the m * L values are there and the band
+    is real."""
     df = _panel(n_periods=22, t0=16, seed=2)
     split = _details(df=df, alpha=0.05)
     assert not np.isfinite(split["conformal_q"])
     resampled = _details(df=df, alpha=0.05, conformal_method="resample",
-                         conformal_n_sim=400)
+                         conformal_block=1, conformal_n_sim=400)
     assert np.isfinite(resampled["conformal_q"])
+    assert resampled["conformal_q"] > 0.0
+
+
+def test_a_block_as_long_as_the_calibration_series_is_refused():
+    """One window supplies exactly ``horizon`` periods, so the default
+    whole-horizon block has nothing to slide over: every circular block is a
+    rotation of the whole series and every path sums to the same value. The band
+    would report zero width, so the draw raises instead of returning it."""
+    df = _panel(n_periods=22, t0=16, seed=2)
+    with pytest.raises(MlsynthDataError, match="zero width|shorter block"):
+        _details(df=df, alpha=0.05, conformal_method="resample",
+                 conformal_n_sim=400)
 
 
 # --------------------------------------------------------------------------- #

--- a/mlsynth/utils/conformal/__init__.py
+++ b/mlsynth/utils/conformal/__init__.py
@@ -13,15 +13,23 @@ Contents:
 * :mod:`.inversion` -- :func:`confidence_set_bounds`, the duality rule a
   test-inversion band is read off with: the nulls a level-alpha test does not
   reject.
-* :mod:`.scores` -- conformity-score constructions. Currently
-  :func:`rolling_origin_block_sums`, the out-of-sample cumulative errors a
-  cumulative band needs.
+* :mod:`.scores` -- conformity-score constructions, all sharing one
+  :func:`origin_schedule` so they calibrate on the same windows:
+  :func:`rolling_origin_block_sums` (one summed score per window, what a
+  split-conformal band needs), :func:`rolling_origin_period_errors` (the same
+  windows kept per period, what a resampled band needs), and
+  :func:`rolling_origin_counterfactual_errors` (the same again for an estimator
+  that returns a counterfactual instead of donor weights).
 * :mod:`.cumulative` -- the band for a cumulative (total) effect:
   :func:`cumulative_conformal_interval` (pure combiner) and
   :func:`cumulative_conformal_from_refit` (single-treated-unit convenience).
 * :mod:`.refit` -- :func:`conformal_refit_gaps`, the refit a test-inversion
   procedure performs under a candidate null, and the one place the choice
   between a simplex and a ridge-augmented control is made.
+* :mod:`.resample` -- the third route from scores to a band: resample the errors
+  into whole paths (:func:`block_error_paths`) and let the caller accumulate them,
+  which is what a running total needs. :func:`resample_cumulative_paths` composes
+  it with the calibration pass in one call.
 * :mod:`.structure` -- :class:`CumulativeConformalBand`.
 
 References
@@ -38,8 +46,11 @@ from .inversion import confidence_set_bounds
 from .permutation import BLOCK_STATISTICS, moving_block_pvalue
 from .quantile import split_conformal_quantile
 from .refit import CONFORMAL_REFIT_RULES, conformal_refit_gaps
+from .resample import (WHOLE_HORIZON, block_error_paths,
+                       resample_cumulative_paths, resolve_block)
 from .scores import (MIN_TRAIN_PERIODS, origin_schedule,
                      rolling_origin_block_sums,
+                     rolling_origin_counterfactual_errors,
                      rolling_origin_period_errors)
 from .structure import CumulativeConformalBand
 
@@ -53,7 +64,12 @@ __all__ = [
     "cumulative_conformal_from_refit",
     "cumulative_conformal_interval",
     "moving_block_pvalue",
+    "WHOLE_HORIZON",
+    "block_error_paths",
     "origin_schedule",
+    "resample_cumulative_paths",
+    "resolve_block",
+    "rolling_origin_counterfactual_errors",
     "rolling_origin_block_sums",
     "rolling_origin_period_errors",
     "split_conformal_quantile",

--- a/mlsynth/utils/conformal/__init__.py
+++ b/mlsynth/utils/conformal/__init__.py
@@ -38,7 +38,8 @@ from .inversion import confidence_set_bounds
 from .permutation import BLOCK_STATISTICS, moving_block_pvalue
 from .quantile import split_conformal_quantile
 from .refit import CONFORMAL_REFIT_RULES, conformal_refit_gaps
-from .scores import (MIN_TRAIN_PERIODS, rolling_origin_block_sums,
+from .scores import (MIN_TRAIN_PERIODS, origin_schedule,
+                     rolling_origin_block_sums,
                      rolling_origin_period_errors)
 from .structure import CumulativeConformalBand
 
@@ -52,6 +53,7 @@ __all__ = [
     "cumulative_conformal_from_refit",
     "cumulative_conformal_interval",
     "moving_block_pvalue",
+    "origin_schedule",
     "rolling_origin_block_sums",
     "rolling_origin_period_errors",
     "split_conformal_quantile",

--- a/mlsynth/utils/conformal/__init__.py
+++ b/mlsynth/utils/conformal/__init__.py
@@ -38,7 +38,8 @@ from .inversion import confidence_set_bounds
 from .permutation import BLOCK_STATISTICS, moving_block_pvalue
 from .quantile import split_conformal_quantile
 from .refit import CONFORMAL_REFIT_RULES, conformal_refit_gaps
-from .scores import MIN_TRAIN_PERIODS, rolling_origin_block_sums
+from .scores import (MIN_TRAIN_PERIODS, rolling_origin_block_sums,
+                     rolling_origin_period_errors)
 from .structure import CumulativeConformalBand
 
 __all__ = [
@@ -52,5 +53,6 @@ __all__ = [
     "cumulative_conformal_interval",
     "moving_block_pvalue",
     "rolling_origin_block_sums",
+    "rolling_origin_period_errors",
     "split_conformal_quantile",
 ]

--- a/mlsynth/utils/conformal/__init__.py
+++ b/mlsynth/utils/conformal/__init__.py
@@ -47,7 +47,9 @@ from .permutation import BLOCK_STATISTICS, moving_block_pvalue
 from .quantile import split_conformal_quantile
 from .refit import CONFORMAL_REFIT_RULES, conformal_refit_gaps
 from .resample import (WHOLE_HORIZON, block_error_paths,
-                       resample_cumulative_paths, resolve_block)
+                       resample_cumulative_paths,
+                       resample_cumulative_paths_from_weights,
+                       resolve_block)
 from .scores import (MIN_TRAIN_PERIODS, origin_schedule,
                      rolling_origin_block_sums,
                      rolling_origin_counterfactual_errors,
@@ -68,6 +70,7 @@ __all__ = [
     "block_error_paths",
     "origin_schedule",
     "resample_cumulative_paths",
+    "resample_cumulative_paths_from_weights",
     "resolve_block",
     "rolling_origin_counterfactual_errors",
     "rolling_origin_block_sums",

--- a/mlsynth/utils/conformal/resample.py
+++ b/mlsynth/utils/conformal/resample.py
@@ -105,7 +105,7 @@ def resolve_block(block: Union[int, np.integer], horizon: int) -> int:
     MlsynthConfigError
         If ``block`` is not an integer, or is negative. Booleans and floats are
         refused outright: ``True`` is an ``int`` in Python and ``2.5`` has no
-        unambiguous reading, so neither is quietly reinterpreted.
+        unambiguous reading, so neither is reinterpreted.
     """
     h = _check_horizon(horizon)
     if isinstance(block, bool) or not isinstance(block, (int, np.integer)):
@@ -163,7 +163,10 @@ def block_error_paths(
         If ``horizon``, ``block`` or ``n_sim`` is not a positive integer of the
         right kind.
     MlsynthDataError
-        If ``series`` holds no finite value, since there is nothing to resample.
+        If ``series`` holds no finite value, since there is nothing to resample,
+        or if the resolved block is not shorter than the series, which would make
+        every drawn path sum to the same value and collapse the band to zero
+        width.
     """
     h = _check_horizon(horizon)
     b = resolve_block(block, h)
@@ -183,6 +186,25 @@ def block_error_paths(
             "cannot resample from an empty error series: no finite out-of-sample "
             "error was supplied. A calibration pass that produced no usable "
             "window cannot support a band."
+        )
+    # Blocks are circular, so a block of length b >= n wraps through whole cycles
+    # of the n-period series. A whole cycle of a centred series sums to exactly
+    # zero, so the effective block is b % n and not the b that was asked for. At
+    # b % n == 0 -- which b == n always is -- every block is a rotation of the
+    # whole series, every path sums to zero, and the quantile of those totals is
+    # zero: a band asserting perfect certainty about the accumulated effect, which
+    # is a worse answer than the infinite half-width this construction was reached
+    # for. Neither outcome is delivered under the requested block length.
+    if b >= e.size:
+        raise MlsynthDataError(
+            f"block length {b} is not shorter than the {e.size}-period "
+            f"calibration series. Blocks are circular, so such a block wraps "
+            f"through whole cycles of the series; a whole cycle of the centred "
+            f"series sums to zero, making the effective block {b % e.size} and not "
+            f"{b}, and at {b} % {e.size} == {b % e.size} every drawn path sums to "
+            f"the same value, so the band would have zero width. Use a shorter "
+            f"block (block <= {e.size - 1}, or block=1 to draw periods "
+            f"independently) or calibrate on a longer series."
         )
     e = e - e.mean()
 

--- a/mlsynth/utils/conformal/resample.py
+++ b/mlsynth/utils/conformal/resample.py
@@ -256,3 +256,64 @@ def resample_cumulative_paths(
         y, refit_at, pre_periods, horizon, min_train_frac=min_train_frac)
     return block_error_paths(series, horizon=horizon, block=block, n_sim=n_sim,
                              rng=np.random.default_rng(seed))
+
+
+def resample_cumulative_paths_from_weights(
+    y,
+    Y0,
+    pre_periods: int,
+    horizon: int,
+    weight_fn,
+    *,
+    block: int = WHOLE_HORIZON,
+    n_sim: int = 2000,
+    seed=0,
+    min_train_frac: float = 0.3,
+) -> np.ndarray:
+    """The same composition for a fit that returns donor weights.
+
+    :func:`resample_cumulative_paths` serves an estimator that hands back a
+    counterfactual; this one serves the classical case, where the fit is a weight
+    vector over donors and the error is ``y - Y0 @ w``. The two agree wherever
+    both apply, which
+    ``tests/test_conformal_resample_paths_weights.py`` asserts.
+
+    Where a split-conformal band needs ``ceil(1/alpha) - 1`` calibration windows
+    before its order statistic exists, this draws from the ``m * L`` per-period
+    errors inside those windows, so it stays finite on pre-periods that leave a
+    split band infinite.
+
+    Parameters
+    ----------
+    y : array-like, shape ``(T,)``
+        Treated-unit outcome over the full sample.
+    Y0 : array-like, shape ``(T, J)``
+        Donor outcomes aligned to ``y``.
+    pre_periods : int
+        Number of pre-treatment periods ``T0``.
+    horizon : int
+        Post-period length ``L``; also the calibration window length and stride.
+    weight_fn : callable
+        ``weight_fn(keep_idx) -> w``, the estimator's refit on the periods indexed
+        by ``keep_idx``, as :func:`rolling_origin_block_sums` takes it.
+    block, n_sim, seed, min_train_frac
+        As :func:`resample_cumulative_paths`.
+
+    Returns
+    -------
+    numpy.ndarray, shape ``(n_sim, horizon)``
+
+    Raises
+    ------
+    MlsynthConfigError
+        For a malformed ``horizon``, ``block``, ``n_sim`` or ``min_train_frac``.
+    MlsynthDataError
+        If ``Y0`` does not align with ``y``, the pre-period admits no window, or
+        the calibration pass yields nothing to resample.
+    """
+    from .scores import rolling_origin_period_errors
+
+    series = rolling_origin_period_errors(
+        y, Y0, pre_periods, horizon, weight_fn, min_train_frac=min_train_frac)
+    return block_error_paths(series, horizon=horizon, block=block, n_sim=n_sim,
+                             rng=np.random.default_rng(seed))

--- a/mlsynth/utils/conformal/resample.py
+++ b/mlsynth/utils/conformal/resample.py
@@ -187,29 +187,29 @@ def block_error_paths(
             "error was supplied. A calibration pass that produced no usable "
             "window cannot support a band."
         )
-    # Blocks are circular, so a block of length b >= n wraps through whole cycles
-    # of the n-period series. A whole cycle of a centred series sums to exactly
-    # zero, so the effective block is b % n and not the b that was asked for. At
-    # b % n == 0 -- which b == n always is -- every block is a rotation of the
-    # whole series, every path sums to zero, and the quantile of those totals is
-    # zero: a band asserting perfect certainty about the accumulated effect, which
-    # is a worse answer than the infinite half-width this construction was reached
-    # for. Neither outcome is delivered under the requested block length.
+    # The series is centred, so its circular sums carry an exact constraint: the
+    # sum over a b-block is minus the sum over the complementary (n - b)-block,
+    # since the two partition the series. Their spreads are therefore equal, and
+    # the drawn spread is symmetric about b = n / 2. Past that midpoint the block
+    # length stops meaning "how much serial correlation is carried" and reverses --
+    # a longer block draws a NARROWER total, mirroring a shorter one -- until at
+    # b = n every block is a rotation of the whole series, every path sums to zero,
+    # and the band has no width at all. A parameter that inverts its own meaning is
+    # not delivered silently, so the draw refuses past the midpoint.
     if e.size == 1:
         raise MlsynthDataError(
             "a single calibration error carries no spread: centring it leaves "
             "exactly zero, so every drawn path would sum to zero and the band "
             "would have no width. Calibrate on a series of at least two periods."
         )
-    if b >= e.size:
+    if 2 * b > e.size:
         raise MlsynthDataError(
-            f"block length {b} is not shorter than the {e.size}-period "
-            f"calibration series. Blocks are circular, so such a block wraps "
-            f"through whole cycles of the series; a whole cycle of the centred "
-            f"series sums to zero, making the effective block {b % e.size} and not "
-            f"{b}, and at {b} % {e.size} == {b % e.size} every drawn path sums to "
-            f"the same value, so the band would have zero width. Use a shorter "
-            f"block (block <= {e.size - 1}, or block=1 to draw periods "
+            f"block length {b} is more than half the {e.size}-period calibration "
+            f"series. The series is centred, so the circular sum of a {b}-block "
+            f"is minus the sum of the complementary {e.size - b}-block: the two "
+            f"have exactly equal spread, and past b = n / 2 a longer block draws "
+            f"a narrower total, until at b = n every path sums to zero and the "
+            f"band has no width. Use block <= {e.size // 2} (block=1 draws periods "
             f"independently) or calibrate on a longer series."
         )
     e = e - e.mean()

--- a/mlsynth/utils/conformal/resample.py
+++ b/mlsynth/utils/conformal/resample.py
@@ -1,12 +1,19 @@
-"""Block-resampled post-period error paths for a PDA cumulative band.
+"""Turning a calibration error series into accumulable post-period paths.
 
-:func:`mlsynth.utils.pda_helpers.inference.cumulative_supt_band` takes an
-``(B, H)`` matrix of post-period prediction-error paths and builds the band from
-it, indifferent to where the rows came from. Today they come from
-:func:`mlsynth.utils.inferutils.pda_prediction_intervals`, whose dependent wild
-bootstrap refits the estimator once per replicate -- 999 times at the default.
-This module is a second producer of that matrix, costing one refit per
-rolling-origin calibration window instead of one per replicate.
+:mod:`.scores` produces out-of-sample errors; :mod:`.cumulative` reduces them to a
+split-conformal order statistic. This module takes the third route: it resamples
+the errors into whole paths, which a caller accumulates and reads a band off. That
+is what a band for a *running total* needs, because the total's spread depends on
+how the period errors move together and a per-period order statistic has already
+thrown that away.
+
+The output is an ``(n_sim, H)`` matrix, one post-period error path per row, which
+is the shape a simultaneous band already consumes:
+:func:`mlsynth.utils.pda_helpers.inference.cumulative_supt_band` and PPSCM's
+counterpart both accumulate such a matrix and take a standard error afterwards,
+indifferent to where the rows came from. A bootstrap produces them at one refit
+per replicate; this produces them at one refit per calibration origin, which on the
+panel lengths these estimators see is two orders of magnitude fewer.
 
 The construction is the one Andrew Wheeler uses in LassoSynth. He forms leave-one-out
 conformity scores, mirrors them into a symmetric pool (``np.concatenate([cs, -cs])``),
@@ -187,27 +194,25 @@ def block_error_paths(
     return (draws * signs).reshape(n_sim, n_blocks * b)[:, :h]
 
 
-def rolling_origin_counterfactual_errors(
+def resample_cumulative_paths(
     y,
     refit_at,
     pre_periods: int,
     horizon: int,
     *,
+    block: int = WHOLE_HORIZON,
+    n_sim: int = 2000,
+    seed=0,
     min_train_frac: float = 0.3,
-):
-    """Per-period out-of-sample errors from a PDA fit's own rolling-origin refits.
+) -> np.ndarray:
+    """From a fitted control to resampled cumulative error paths, in one call.
 
-    :func:`mlsynth.utils.conformal.rolling_origin_period_errors` reads the error as
-    ``y[block] - Y0[block] @ w``, which needs the fit to be a bare linear
-    combination of the donors. A PDA fit is not: LASSO carries an intercept, the
-    modified-BIC path standardizes the donors as ``glmnet`` does, and forward
-    selection and HCW return a counterfactual with no single weight vector to
-    multiply. So this asks the estimator for the counterfactual and subtracts.
-
-    The schedule is :func:`mlsynth.utils.conformal.origin_schedule`, shared with the
-    conformal readers, so a resampled band and a split-conformal band calibrate on
-    the same windows. Origins step by a whole horizon, so the windows do not
-    overlap and the concatenation is a contiguous stretch of out-of-sample periods.
+    The composition every estimator wanting a resampled band performs:
+    :func:`~mlsynth.utils.conformal.rolling_origin_counterfactual_errors` for the
+    calibration series, then :func:`block_error_paths` for the draw. Keeping it in
+    one place means an estimator adopting the band inherits the construction that
+    was cross-validated against Wheeler's LassoSynth, and a change to either half
+    cannot reach only some callers.
 
     Parameters
     ----------
@@ -216,71 +221,38 @@ def rolling_origin_counterfactual_errors(
     refit_at : callable
         ``refit_at(origin) -> counterfactual``, the estimator refit on the periods
         strictly before ``origin`` and evaluated over the whole sample.
-        ``orchestration._build_refit`` builds one per PDA variant: it closes over
-        the pre-period length, so passing an origin in place of ``T0`` gives
-        exactly this.
     pre_periods : int
-        Number of pre-treatment periods ``T0``; origins are drawn from within it.
+        Number of pre-treatment periods ``T0``.
     horizon : int
-        Window length ``L`` -- both the block length and the origin stride.
+        Post-period length ``L``; also the calibration window length and the
+        origin stride.
+    block : int, optional
+        Block length for the draw; ``0`` (default) means the horizon. See
+        :func:`resolve_block`.
+    n_sim : int, optional
+        Number of paths to draw (default 2000). These cost no refits.
+    seed : optional
+        Seed for the draw, so a band is reproducible. Passed to
+        :func:`numpy.random.default_rng`.
     min_train_frac : float, optional
-        Earliest origin as a fraction of ``T0`` (default ``0.3``), floored at
-        :data:`mlsynth.utils.conformal.MIN_TRAIN_PERIODS` absolute periods.
+        Earliest calibration origin as a fraction of ``T0`` (default ``0.3``).
 
     Returns
     -------
-    numpy.ndarray, shape ``(m * L,)``
-        The per-period errors in time order, ready for :func:`block_error_paths`.
-        Empty when the pre-period admits no origin.
+    numpy.ndarray, shape ``(n_sim, horizon)``
 
     Raises
     ------
     MlsynthConfigError
-        If ``horizon`` or ``pre_periods`` is not a positive integer, or
-        ``min_train_frac`` is not a number in ``[0, 1]``.
+        For a malformed ``horizon``, ``block``, ``n_sim`` or ``min_train_frac``.
     MlsynthDataError
-        If ``pre_periods`` exceeds the sample, or a refit returns a counterfactual
-        that does not span it or is not finite -- a failed refit is refused rather
-        than scored, since its error would be arbitrary.
+        If the pre-period admits no calibration window, or a refit fails. Either
+        way there is nothing to resample, and that is reported instead of an empty
+        band being returned.
     """
-    from ..conformal import origin_schedule
+    from .scores import rolling_origin_counterfactual_errors
 
-    h = _check_horizon(horizon)
-    if isinstance(min_train_frac, bool) \
-            or not isinstance(min_train_frac, (int, float, np.floating)) \
-            or not 0.0 <= float(min_train_frac) <= 1.0:
-        raise MlsynthConfigError(
-            f"min_train_frac must be a number in [0, 1]; got {min_train_frac!r}."
-        )
-    if isinstance(pre_periods, bool) or not isinstance(pre_periods, (int, np.integer)) \
-            or int(pre_periods) < 1:
-        raise MlsynthConfigError(
-            f"pre_periods must be an integer of at least 1; got {pre_periods!r}."
-        )
-
-    y = np.asarray(y, dtype=float).ravel()
-    if int(pre_periods) > y.size:
-        raise MlsynthDataError(
-            f"pre_periods ({int(pre_periods)}) exceeds the {y.size} periods "
-            "supplied; there is no pre-period to calibrate on."
-        )
-
-    blocks = []
-    for origin in origin_schedule(int(pre_periods), h, float(min_train_frac)):
-        cf = np.asarray(refit_at(origin), dtype=float).ravel()
-        if cf.size != y.size:
-            raise MlsynthDataError(
-                f"refit_at({origin}) returned a counterfactual of {cf.size} "
-                f"periods; it must span all {y.size}, since the window scored "
-                "lies after the periods it was trained on."
-            )
-        if not np.isfinite(cf).all():
-            raise MlsynthDataError(
-                f"refit_at({origin}) returned a counterfactual that is not "
-                "finite; a refit that failed is refused rather than scored."
-            )
-        blocks.append((y - cf)[origin:origin + h])
-
-    if not blocks:
-        return np.asarray([], dtype=float)
-    return np.concatenate(blocks)
+    series = rolling_origin_counterfactual_errors(
+        y, refit_at, pre_periods, horizon, min_train_frac=min_train_frac)
+    return block_error_paths(series, horizon=horizon, block=block, n_sim=n_sim,
+                             rng=np.random.default_rng(seed))

--- a/mlsynth/utils/conformal/resample.py
+++ b/mlsynth/utils/conformal/resample.py
@@ -164,9 +164,9 @@ def block_error_paths(
         right kind.
     MlsynthDataError
         If ``series`` holds no finite value, since there is nothing to resample,
-        or if the resolved block is not shorter than the series, which would make
-        every drawn path sum to the same value and collapse the band to zero
-        width.
+        if the series holds a single value, which carries no spread, or if the
+        resolved block is not shorter than the series, which would make every
+        drawn path sum to the same value and collapse the band to zero width.
     """
     h = _check_horizon(horizon)
     b = resolve_block(block, h)
@@ -195,6 +195,12 @@ def block_error_paths(
     # zero: a band asserting perfect certainty about the accumulated effect, which
     # is a worse answer than the infinite half-width this construction was reached
     # for. Neither outcome is delivered under the requested block length.
+    if e.size == 1:
+        raise MlsynthDataError(
+            "a single calibration error carries no spread: centring it leaves "
+            "exactly zero, so every drawn path would sum to zero and the band "
+            "would have no width. Calibrate on a series of at least two periods."
+        )
     if b >= e.size:
         raise MlsynthDataError(
             f"block length {b} is not shorter than the {e.size}-period "

--- a/mlsynth/utils/conformal/scores.py
+++ b/mlsynth/utils/conformal/scores.py
@@ -24,11 +24,28 @@ import numpy as np
 MIN_TRAIN_PERIODS = 10
 
 
-def _origin_schedule(pre_periods: int, horizon: int, min_train_frac: float):
-    """The origins both readers score, in increasing order.
+def origin_schedule(pre_periods: int, horizon: int, min_train_frac: float):
+    """The origins a calibration pass scores, in increasing order.
 
-    One definition of the schedule, so the summing reader and the per-period
-    reader cannot disagree about which windows were calibrated on.
+    One definition of the schedule, so every reader of it -- the summing reader,
+    the per-period reader, and the PDA reader that asks its estimator for a
+    counterfactual instead of a weight vector -- calibrates on the same windows.
+
+    Parameters
+    ----------
+    pre_periods : int
+        Number of pre-treatment periods ``T0``.
+    horizon : int
+        Window length ``L``; also the stride, so the windows do not overlap and
+        the scores stay exchangeable.
+    min_train_frac : float
+        Earliest origin as a fraction of ``T0``, floored at
+        :data:`MIN_TRAIN_PERIODS` absolute periods.
+
+    Returns
+    -------
+    range
+        The origins, empty when the pre-period admits none.
     """
     start = max(MIN_TRAIN_PERIODS, int(pre_periods * float(min_train_frac)))
     return range(start, int(pre_periods) - int(horizon) + 1, int(horizon))
@@ -50,7 +67,7 @@ def _rolling_origin_blocks(
     :func:`rolling_origin_period_errors` concatenates them.
     """
     blocks = []
-    for origin in _origin_schedule(pre_periods, horizon, min_train_frac):
+    for origin in origin_schedule(pre_periods, horizon, min_train_frac):
         w = np.asarray(weight_fn(np.arange(origin)), dtype=float).ravel()
         block = slice(origin, origin + int(horizon))
         blocks.append(np.asarray(y[block] - Y0[block] @ w, dtype=float))

--- a/mlsynth/utils/conformal/scores.py
+++ b/mlsynth/utils/conformal/scores.py
@@ -24,6 +24,39 @@ import numpy as np
 MIN_TRAIN_PERIODS = 10
 
 
+def _origin_schedule(pre_periods: int, horizon: int, min_train_frac: float):
+    """The origins both readers score, in increasing order.
+
+    One definition of the schedule, so the summing reader and the per-period
+    reader cannot disagree about which windows were calibrated on.
+    """
+    start = max(MIN_TRAIN_PERIODS, int(pre_periods * float(min_train_frac)))
+    return range(start, int(pre_periods) - int(horizon) + 1, int(horizon))
+
+
+def _rolling_origin_blocks(
+    y: np.ndarray,
+    Y0: np.ndarray,
+    pre_periods: int,
+    horizon: int,
+    weight_fn: Callable[[np.ndarray], np.ndarray],
+    min_train_frac: float,
+) -> list:
+    """One array of ``horizon`` out-of-sample per-period errors per origin.
+
+    The refit at each origin sees only periods strictly before it, so the errors
+    carry no in-sample optimism. Callers reduce these however their band needs:
+    :func:`rolling_origin_block_sums` sums each block into a conformity score,
+    :func:`rolling_origin_period_errors` concatenates them.
+    """
+    blocks = []
+    for origin in _origin_schedule(pre_periods, horizon, min_train_frac):
+        w = np.asarray(weight_fn(np.arange(origin)), dtype=float).ravel()
+        block = slice(origin, origin + int(horizon))
+        blocks.append(np.asarray(y[block] - Y0[block] @ w, dtype=float))
+    return blocks
+
+
 def rolling_origin_block_sums(
     y: np.ndarray,
     Y0: np.ndarray,
@@ -69,10 +102,98 @@ def rolling_origin_block_sums(
     :func:`~mlsynth.utils.conformal.cumulative.cumulative_conformal_interval`
     directly; this helper is the single-treated-unit path.
     """
-    start = max(MIN_TRAIN_PERIODS, int(pre_periods * float(min_train_frac)))
-    scores = []
-    for origin in range(start, int(pre_periods) - int(horizon) + 1, int(horizon)):
-        w = np.asarray(weight_fn(np.arange(origin)), dtype=float).ravel()
-        block = slice(origin, origin + int(horizon))
-        scores.append(float(np.sum(y[block] - Y0[block] @ w)))
-    return np.asarray(scores, dtype=float)
+    blocks = _rolling_origin_blocks(y, Y0, pre_periods, horizon, weight_fn,
+                                    min_train_frac)
+    return np.asarray([float(np.sum(b)) for b in blocks], dtype=float)
+
+
+def rolling_origin_period_errors(
+    y: np.ndarray,
+    Y0: np.ndarray,
+    pre_periods: int,
+    horizon: int,
+    weight_fn: Callable[[np.ndarray], np.ndarray],
+    *,
+    min_train_frac: float = 0.3,
+) -> np.ndarray:
+    """The same pass, kept per period: the blocks concatenated in origin order.
+
+    :func:`rolling_origin_block_sums` reduces each window to the sum of its
+    residuals, which is the conformity score a split-conformal band needs. A
+    resampled band needs what the sum destroys -- the ordering of the periods
+    inside a window, and across consecutive windows -- so this returns them.
+
+    Because origins step by a whole horizon and are visited in increasing order,
+    the result is a contiguous stretch of out-of-sample periods: origin ``o``
+    scores ``o .. o + L - 1`` and the next origin picks up at ``o + L``. Serial
+    correlation in the returned series is therefore the panel's own, and a block
+    bootstrap over it means something.
+
+    Parameters
+    ----------
+    y : np.ndarray, shape ``(T,)``
+        Treated-unit outcome over the full sample.
+    Y0 : np.ndarray, shape ``(T, J)``
+        Donor outcomes aligned to ``y``.
+    pre_periods : int
+        Number of pre-treatment periods ``T0``; origins are drawn from within it.
+    horizon : int
+        Window length ``L`` -- both the block length and the origin stride.
+    weight_fn : callable
+        ``weight_fn(keep_idx) -> w``, the estimator's own refit on the periods
+        indexed by ``keep_idx``, as in :func:`rolling_origin_block_sums`.
+    min_train_frac : float, optional
+        Earliest origin as a fraction of ``T0`` (default ``0.3``), floored at
+        ``MIN_TRAIN_PERIODS`` absolute periods.
+
+    Returns
+    -------
+    np.ndarray, shape ``(m * L,)``
+        The per-period errors, in time order. Empty when the pre-period admits no
+        origin.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``horizon`` is not a positive integer, or ``min_train_frac`` is not a
+        number in ``[0, 1]``.
+    MlsynthDataError
+        If ``Y0`` does not align with ``y``, or ``pre_periods`` exceeds the sample.
+    """
+    from ...exceptions import MlsynthConfigError, MlsynthDataError
+
+    if isinstance(horizon, bool) or not isinstance(horizon, (int, np.integer)) \
+            or int(horizon) < 1:
+        raise MlsynthConfigError(
+            f"horizon must be an integer of at least 1; got {horizon!r}."
+        )
+    if isinstance(min_train_frac, bool) \
+            or not isinstance(min_train_frac, (int, float, np.floating)) \
+            or not 0.0 <= float(min_train_frac) <= 1.0:
+        raise MlsynthConfigError(
+            f"min_train_frac must be a number in [0, 1]; got {min_train_frac!r}."
+        )
+
+    y = np.asarray(y, dtype=float).ravel()
+    Y0 = np.asarray(Y0, dtype=float)
+    if Y0.ndim != 2 or Y0.shape[0] != y.size:
+        raise MlsynthDataError(
+            f"Y0 must align with y on the time axis: y has {y.size} periods, Y0 "
+            f"has shape {Y0.shape}."
+        )
+    if isinstance(pre_periods, bool) or not isinstance(pre_periods, (int, np.integer)) \
+            or int(pre_periods) < 1:
+        raise MlsynthConfigError(
+            f"pre_periods must be an integer of at least 1; got {pre_periods!r}."
+        )
+    if int(pre_periods) > y.size:
+        raise MlsynthDataError(
+            f"pre_periods ({int(pre_periods)}) exceeds the {y.size} periods "
+            "supplied; there is no pre-period to calibrate on."
+        )
+
+    blocks = _rolling_origin_blocks(y, Y0, int(pre_periods), int(horizon),
+                                    weight_fn, float(min_train_frac))
+    if not blocks:
+        return np.asarray([], dtype=float)
+    return np.concatenate(blocks)

--- a/mlsynth/utils/conformal/scores.py
+++ b/mlsynth/utils/conformal/scores.py
@@ -269,8 +269,8 @@ def rolling_origin_counterfactual_errors(
         ``min_train_frac`` is not a number in ``[0, 1]``.
     MlsynthDataError
         If ``pre_periods`` exceeds the sample, or a refit returns a counterfactual
-        that does not span it or is not finite -- a failed refit is refused rather
-        than scored, since its error would be arbitrary.
+        that does not span it or is not finite -- a failed refit is refused, not
+        scored, since its error would be arbitrary.
     """
     from .resample import _check_horizon
 
@@ -306,7 +306,7 @@ def rolling_origin_counterfactual_errors(
         if not np.isfinite(cf).all():
             raise MlsynthDataError(
                 f"refit_at({origin}) returned a counterfactual that is not "
-                "finite; a refit that failed is refused rather than scored."
+                "finite; a refit that failed is refused, not scored."
             )
         blocks.append((y - cf)[origin:origin + h])
 

--- a/mlsynth/utils/conformal/scores.py
+++ b/mlsynth/utils/conformal/scores.py
@@ -18,6 +18,8 @@ from typing import Callable
 
 import numpy as np
 
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+
 #: Shortest training block a calibration refit may use. A control fitted on a
 #: handful of periods interpolates them and predicts nothing, so the window it
 #: scores would report the fit's degeneracy rather than the method's error.
@@ -177,8 +179,6 @@ def rolling_origin_period_errors(
     MlsynthDataError
         If ``Y0`` does not align with ``y``, or ``pre_periods`` exceeds the sample.
     """
-    from ...exceptions import MlsynthConfigError, MlsynthDataError
-
     if isinstance(horizon, bool) or not isinstance(horizon, (int, np.integer)) \
             or int(horizon) < 1:
         raise MlsynthConfigError(
@@ -211,6 +211,105 @@ def rolling_origin_period_errors(
 
     blocks = _rolling_origin_blocks(y, Y0, int(pre_periods), int(horizon),
                                     weight_fn, float(min_train_frac))
+    if not blocks:
+        return np.asarray([], dtype=float)
+    return np.concatenate(blocks)
+
+
+def rolling_origin_counterfactual_errors(
+    y,
+    refit_at,
+    pre_periods: int,
+    horizon: int,
+    *,
+    min_train_frac: float = 0.3,
+):
+    """Per-period out-of-sample errors from a PDA fit's own rolling-origin refits.
+
+    :func:`rolling_origin_period_errors` reads the error as
+    ``y[block] - Y0[block] @ w``, which needs the fit to be a bare linear
+    combination of the donors. A PDA fit is not: LASSO carries an intercept, the
+    modified-BIC path standardizes the donors as ``glmnet`` does, and forward
+    selection and HCW return a counterfactual with no single weight vector to
+    multiply. So this asks the estimator for the counterfactual and subtracts.
+
+    The schedule is :func:`origin_schedule`, shared with the
+    conformal readers, so a resampled band and a split-conformal band calibrate on
+    the same windows. Origins step by a whole horizon, so the windows do not
+    overlap and the concatenation is a contiguous stretch of out-of-sample periods.
+
+    Parameters
+    ----------
+    y : array-like, shape ``(T,)``
+        Treated-unit outcome over the full sample.
+    refit_at : callable
+        ``refit_at(origin) -> counterfactual``, the estimator refit on the periods
+        strictly before ``origin`` and evaluated over the whole sample.
+        ``orchestration._build_refit`` builds one per PDA variant: it closes over
+        the pre-period length, so passing an origin in place of ``T0`` gives
+        exactly this.
+    pre_periods : int
+        Number of pre-treatment periods ``T0``; origins are drawn from within it.
+    horizon : int
+        Window length ``L`` -- both the block length and the origin stride.
+    min_train_frac : float, optional
+        Earliest origin as a fraction of ``T0`` (default ``0.3``), floored at
+        :data:`MIN_TRAIN_PERIODS` absolute periods.
+
+    Returns
+    -------
+    numpy.ndarray, shape ``(m * L,)``
+        The per-period errors in time order, ready for :func:`block_error_paths`.
+        Empty when the pre-period admits no origin.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``horizon`` or ``pre_periods`` is not a positive integer, or
+        ``min_train_frac`` is not a number in ``[0, 1]``.
+    MlsynthDataError
+        If ``pre_periods`` exceeds the sample, or a refit returns a counterfactual
+        that does not span it or is not finite -- a failed refit is refused rather
+        than scored, since its error would be arbitrary.
+    """
+    from .resample import _check_horizon
+
+    h = _check_horizon(horizon)
+    if isinstance(min_train_frac, bool) \
+            or not isinstance(min_train_frac, (int, float, np.floating)) \
+            or not 0.0 <= float(min_train_frac) <= 1.0:
+        raise MlsynthConfigError(
+            f"min_train_frac must be a number in [0, 1]; got {min_train_frac!r}."
+        )
+    if isinstance(pre_periods, bool) or not isinstance(pre_periods, (int, np.integer)) \
+            or int(pre_periods) < 1:
+        raise MlsynthConfigError(
+            f"pre_periods must be an integer of at least 1; got {pre_periods!r}."
+        )
+
+    y = np.asarray(y, dtype=float).ravel()
+    if int(pre_periods) > y.size:
+        raise MlsynthDataError(
+            f"pre_periods ({int(pre_periods)}) exceeds the {y.size} periods "
+            "supplied; there is no pre-period to calibrate on."
+        )
+
+    blocks = []
+    for origin in origin_schedule(int(pre_periods), h, float(min_train_frac)):
+        cf = np.asarray(refit_at(origin), dtype=float).ravel()
+        if cf.size != y.size:
+            raise MlsynthDataError(
+                f"refit_at({origin}) returned a counterfactual of {cf.size} "
+                f"periods; it must span all {y.size}, since the window scored "
+                "lies after the periods it was trained on."
+            )
+        if not np.isfinite(cf).all():
+            raise MlsynthDataError(
+                f"refit_at({origin}) returned a counterfactual that is not "
+                "finite; a refit that failed is refused rather than scored."
+            )
+        blocks.append((y - cf)[origin:origin + h])
+
     if not blocks:
         return np.asarray([], dtype=float)
     return np.concatenate(blocks)

--- a/mlsynth/utils/pda_helpers/config.py
+++ b/mlsynth/utils/pda_helpers/config.py
@@ -6,7 +6,7 @@ Co-located with the helper package; re-exported from
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import List, Literal, Optional
 from pydantic import Field, field_validator, model_validator
 from ...config_models import BaseEstimatorConfig
 from ...exceptions import MlsynthConfigError
@@ -31,14 +31,20 @@ class PDAConfig(BaseEstimatorConfig):
     pi_seed: Optional[int] = Field(default=0, description="Seed for the prediction-interval bootstrap RNG (reproducible by default; set None for a fresh draw).")
     pi_dependent: bool = Field(default=True, description="Resample the pre-period prediction error with the dependent wild bootstrap of Jiang et al. (2025) Algorithm 2.1 -- Bartlett-correlated multipliers whose dependence range is a bandwidth in T0, so a persistent error is resampled as a persistent error. False uses the ordinary i.i.d. standard-normal multipliers of their Remark 2.2, which is cheaper and valid only when the errors are already independent. The choice compounds in the cumulative band, which accumulates the period errors, so drawing persistent errors as independent understates how fast the running total's uncertainty grows. True (the paper's algorithm) by default.")
     cumulative_band: bool = Field(default=False, description="Attach a simultaneous (sup-t) band for the CUMULATIVE effect path -- the running total over post-periods, with one shared critical value so the whole path is covered at 1 - alpha at once, which is how a cumulative path is read. Built from the replicate paths the prediction-interval bootstrap already produces, so it costs no extra refits. Its growth is measured rather than assumed: the replicates are accumulated before the standard error is taken, so independent period errors widen it like sqrt(L) and perfectly correlated ones like L, where adding up per-period interval endpoints would always give the latter. Needs prediction_intervals. Off by default.")
+    cumulative_method: Literal["bootstrap", "resample"] = Field(default="bootstrap", description="How the cumulative band is built. 'bootstrap' (default) accumulates the replicate paths the Jiang et al. (2025) prediction-interval bootstrap already produced, so it needs prediction_intervals and costs pi_n_boot refits. 'resample' calibrates on a rolling-origin pass instead -- one refit per origin, roughly a tenth of the cost -- and block-resamples those out-of-sample per-period errors into paths, which is Wheeler's LassoSynth construction generalised to serially correlated periods. It needs no bootstrap, so it does not need prediction_intervals.")
+    cumulative_block: int = Field(default=0, ge=0, description="resample only: block length in periods for the circular block bootstrap. 0 (default) means the whole horizon, the longest block the accumulated total is sensitive to. 1 draws periods independently, which is Wheeler's original and is too narrow whenever the period errors are positively autocorrelated. A block longer than the horizon is clamped to it.")
+    cumulative_n_sim: int = Field(default=2000, ge=2, description="resample only: number of error paths to draw. Unlike pi_n_boot these cost no refits -- the refits are the rolling origins -- so this buys quantile precision cheaply.")
 
     @model_validator(mode="after")
     def _check_cumulative_band(self):
-        if self.cumulative_band and not self.prediction_intervals:
+        if (self.cumulative_band and not self.prediction_intervals
+                and self.cumulative_method == "bootstrap"):
             raise MlsynthConfigError(
                 "cumulative_band needs prediction_intervals=True: the band is "
                 "built from the replicate paths the Jiang et al. (2025) bootstrap "
-                "produces, and with the bootstrap off there are none."
+                "produces, and with the bootstrap off there are none. Set "
+                "cumulative_method='resample' to calibrate on a rolling-origin "
+                "pass instead, which needs no bootstrap."
             )
         return self
 
@@ -51,5 +57,37 @@ class PDAConfig(BaseEstimatorConfig):
                 f"{info.field_name} must be True or False; got {v!r}. Pydantic "
                 "would otherwise coerce a string or a number into a boolean, so "
                 "a typo becomes a silent choice about how inference is run."
+            )
+        return v
+
+    @field_validator("cumulative_method", mode="before")
+    @classmethod
+    def _known_cumulative_method(cls, v):
+        """Refuse an unknown construction by name.
+
+        Pydantic would report a ``Literal`` mismatch, but the band is the number a
+        reader quotes, so the message names the two constructions and what each
+        costs.
+        """
+        if v not in ("bootstrap", "resample"):
+            raise MlsynthConfigError(
+                f"cumulative_method must be 'bootstrap' or 'resample'; got {v!r}. "
+                "'bootstrap' accumulates the prediction-interval replicates and "
+                "needs prediction_intervals; 'resample' calibrates on a "
+                "rolling-origin pass and needs no bootstrap."
+            )
+        return v
+
+    @field_validator("cumulative_block", "cumulative_n_sim", mode="before")
+    @classmethod
+    def _strict_int(cls, v, info):
+        """Refuse a non-integer outright.
+
+        Pydantic would coerce ``2.5`` or ``"3"``, and a silently rounded block
+        length is a silent change to how much serial correlation the band carries.
+        """
+        if isinstance(v, bool) or not isinstance(v, int):
+            raise MlsynthConfigError(
+                f"{info.field_name} must be an integer; got {v!r}."
             )
         return v

--- a/mlsynth/utils/pda_helpers/orchestration.py
+++ b/mlsynth/utils/pda_helpers/orchestration.py
@@ -18,8 +18,7 @@ from .lasso import (
 from .fs import forward_select, fs_ate_inference
 from .hcw import fit_hcw, hcw_ate_inference
 from ..inferutils import pda_prediction_intervals
-from .resample import (block_error_paths,
-                       rolling_origin_counterfactual_errors)
+from ..conformal import resample_cumulative_paths
 from .inference import cumulative_supt_band
 
 # Map config method strings to internal keys.
@@ -186,13 +185,10 @@ def run_pda(
                 def refit_at(origin, _m=m):
                     return _build_refit(_m, X, origin, **refit_kw)(y)[0]
 
-                horizon = int(y.size - T0)
-                series = rolling_origin_counterfactual_errors(
-                    y, refit_at, T0, horizon)
-                paths = block_error_paths(
-                    series, horizon=horizon, block=cumulative_block,
-                    n_sim=cumulative_n_sim,
-                    rng=np.random.default_rng(pi_seed))
+                paths = resample_cumulative_paths(
+                    y, refit_at, T0, int(y.size - T0),
+                    block=cumulative_block, n_sim=cumulative_n_sim,
+                    seed=pi_seed)
                 cum_band = cumulative_supt_band(
                     (y - cf)[T0:], paths, alpha=alpha, method="resample")
             else:

--- a/mlsynth/utils/pda_helpers/orchestration.py
+++ b/mlsynth/utils/pda_helpers/orchestration.py
@@ -18,6 +18,8 @@ from .lasso import (
 from .fs import forward_select, fs_ate_inference
 from .hcw import fit_hcw, hcw_ate_inference
 from ..inferutils import pda_prediction_intervals
+from .resample import (block_error_paths,
+                       rolling_origin_counterfactual_errors)
 from .inference import cumulative_supt_band
 
 # Map config method strings to internal keys.
@@ -96,6 +98,8 @@ def run_pda(
     prediction_intervals: bool = False, cumulative_band: bool = False,
     pi_n_boot: int = 999, pi_dependent: bool = True,
     pi_seed: Optional[int] = 0,
+    cumulative_method: str = "bootstrap", cumulative_block: int = 0,
+    cumulative_n_sim: int = 2000,
 ) -> Dict[str, PDAMethodFit]:
     """Fit each requested PDA variant with its own paper's inference.
 
@@ -154,21 +158,44 @@ def run_pda(
 
         pis = None
         cum_band = None
+        resampled_band = cumulative_band and cumulative_method == "resample"
+        # Both paths refit the estimator, so the LASSO penalty has to be pinned
+        # before either runs -- a refit that re-tunes is a different estimator.
+        if (prediction_intervals or resampled_band) and m == LASSO \
+                and lasso_alpha is None:
+            lasso_alpha = lasso_cv_alpha(y, X, T0)
+            meta["alpha"] = lasso_alpha
+
+        refit_kw = dict(
+            tau=meta.get("tau", tau), l2_standardize=l2_standardize,
+            fs_intercept=fs_intercept, lasso_alpha=lasso_alpha,
+            lasso_criterion=lasso_criterion, hcw_criterion=hcw_criterion,
+            hcw_nvmax=hcw_nvmax, hcw_backend=hcw_backend)
+
         if prediction_intervals:
-            if m == LASSO and lasso_alpha is None:
-                lasso_alpha = lasso_cv_alpha(y, X, T0)
-                meta["alpha"] = lasso_alpha
-            refit = _build_refit(
-                m, X, T0, tau=meta.get("tau", tau),
-                l2_standardize=l2_standardize, fs_intercept=fs_intercept,
-                lasso_alpha=lasso_alpha, lasso_criterion=lasso_criterion,
-                hcw_criterion=hcw_criterion,
-                hcw_nvmax=hcw_nvmax, hcw_backend=hcw_backend)
             pis = pda_prediction_intervals(
-                y, X, T0, counterfactual=cf, support=support_idx, refit=refit,
+                y, X, T0, counterfactual=cf, support=support_idx,
+                refit=_build_refit(m, X, T0, **refit_kw),
                 alpha=alpha, n_boot=pi_n_boot, seed=pi_seed,
                 dependent=pi_dependent)
-            if cumulative_band:
+
+        if cumulative_band:
+            if resampled_band:
+                # _build_refit closes over the pre-period length, so an origin in
+                # place of T0 gives the fit trained strictly before that origin.
+                def refit_at(origin, _m=m):
+                    return _build_refit(_m, X, origin, **refit_kw)(y)[0]
+
+                horizon = int(y.size - T0)
+                series = rolling_origin_counterfactual_errors(
+                    y, refit_at, T0, horizon)
+                paths = block_error_paths(
+                    series, horizon=horizon, block=cumulative_block,
+                    n_sim=cumulative_n_sim,
+                    rng=np.random.default_rng(pi_seed))
+                cum_band = cumulative_supt_band(
+                    (y - cf)[T0:], paths, alpha=alpha, method="resample")
+            else:
                 cum_band = cumulative_supt_band(
                     (y - cf)[T0:], pis["error_paths"], alpha=alpha)
 

--- a/mlsynth/utils/pda_helpers/resample.py
+++ b/mlsynth/utils/pda_helpers/resample.py
@@ -185,3 +185,102 @@ def block_error_paths(
     draws = e[idx]
     signs = rng.choice(np.array([-1.0, 1.0]), size=(n_sim, n_blocks, 1))
     return (draws * signs).reshape(n_sim, n_blocks * b)[:, :h]
+
+
+def rolling_origin_counterfactual_errors(
+    y,
+    refit_at,
+    pre_periods: int,
+    horizon: int,
+    *,
+    min_train_frac: float = 0.3,
+):
+    """Per-period out-of-sample errors from a PDA fit's own rolling-origin refits.
+
+    :func:`mlsynth.utils.conformal.rolling_origin_period_errors` reads the error as
+    ``y[block] - Y0[block] @ w``, which needs the fit to be a bare linear
+    combination of the donors. A PDA fit is not: LASSO carries an intercept, the
+    modified-BIC path standardizes the donors as ``glmnet`` does, and forward
+    selection and HCW return a counterfactual with no single weight vector to
+    multiply. So this asks the estimator for the counterfactual and subtracts.
+
+    The schedule is :func:`mlsynth.utils.conformal.origin_schedule`, shared with the
+    conformal readers, so a resampled band and a split-conformal band calibrate on
+    the same windows. Origins step by a whole horizon, so the windows do not
+    overlap and the concatenation is a contiguous stretch of out-of-sample periods.
+
+    Parameters
+    ----------
+    y : array-like, shape ``(T,)``
+        Treated-unit outcome over the full sample.
+    refit_at : callable
+        ``refit_at(origin) -> counterfactual``, the estimator refit on the periods
+        strictly before ``origin`` and evaluated over the whole sample.
+        ``orchestration._build_refit`` builds one per PDA variant: it closes over
+        the pre-period length, so passing an origin in place of ``T0`` gives
+        exactly this.
+    pre_periods : int
+        Number of pre-treatment periods ``T0``; origins are drawn from within it.
+    horizon : int
+        Window length ``L`` -- both the block length and the origin stride.
+    min_train_frac : float, optional
+        Earliest origin as a fraction of ``T0`` (default ``0.3``), floored at
+        :data:`mlsynth.utils.conformal.MIN_TRAIN_PERIODS` absolute periods.
+
+    Returns
+    -------
+    numpy.ndarray, shape ``(m * L,)``
+        The per-period errors in time order, ready for :func:`block_error_paths`.
+        Empty when the pre-period admits no origin.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``horizon`` or ``pre_periods`` is not a positive integer, or
+        ``min_train_frac`` is not a number in ``[0, 1]``.
+    MlsynthDataError
+        If ``pre_periods`` exceeds the sample, or a refit returns a counterfactual
+        that does not span it or is not finite -- a failed refit is refused rather
+        than scored, since its error would be arbitrary.
+    """
+    from ..conformal import origin_schedule
+
+    h = _check_horizon(horizon)
+    if isinstance(min_train_frac, bool) \
+            or not isinstance(min_train_frac, (int, float, np.floating)) \
+            or not 0.0 <= float(min_train_frac) <= 1.0:
+        raise MlsynthConfigError(
+            f"min_train_frac must be a number in [0, 1]; got {min_train_frac!r}."
+        )
+    if isinstance(pre_periods, bool) or not isinstance(pre_periods, (int, np.integer)) \
+            or int(pre_periods) < 1:
+        raise MlsynthConfigError(
+            f"pre_periods must be an integer of at least 1; got {pre_periods!r}."
+        )
+
+    y = np.asarray(y, dtype=float).ravel()
+    if int(pre_periods) > y.size:
+        raise MlsynthDataError(
+            f"pre_periods ({int(pre_periods)}) exceeds the {y.size} periods "
+            "supplied; there is no pre-period to calibrate on."
+        )
+
+    blocks = []
+    for origin in origin_schedule(int(pre_periods), h, float(min_train_frac)):
+        cf = np.asarray(refit_at(origin), dtype=float).ravel()
+        if cf.size != y.size:
+            raise MlsynthDataError(
+                f"refit_at({origin}) returned a counterfactual of {cf.size} "
+                f"periods; it must span all {y.size}, since the window scored "
+                "lies after the periods it was trained on."
+            )
+        if not np.isfinite(cf).all():
+            raise MlsynthDataError(
+                f"refit_at({origin}) returned a counterfactual that is not "
+                "finite; a refit that failed is refused rather than scored."
+            )
+        blocks.append((y - cf)[origin:origin + h])
+
+    if not blocks:
+        return np.asarray([], dtype=float)
+    return np.concatenate(blocks)

--- a/mlsynth/utils/pda_helpers/resample.py
+++ b/mlsynth/utils/pda_helpers/resample.py
@@ -1,0 +1,187 @@
+"""Block-resampled post-period error paths for a PDA cumulative band.
+
+:func:`mlsynth.utils.pda_helpers.inference.cumulative_supt_band` takes an
+``(B, H)`` matrix of post-period prediction-error paths and builds the band from
+it, indifferent to where the rows came from. Today they come from
+:func:`mlsynth.utils.inferutils.pda_prediction_intervals`, whose dependent wild
+bootstrap refits the estimator once per replicate -- 999 times at the default.
+This module is a second producer of that matrix, costing one refit per
+rolling-origin calibration window instead of one per replicate.
+
+The construction is the one Andrew Wheeler uses in LassoSynth. He forms leave-one-out
+conformity scores, mirrors them into a symmetric pool (``np.concatenate([cs, -cs])``),
+draws one pool element per post period independently, and accumulates. Drawing
+periods independently assumes the period errors are uncorrelated, which a panel's
+rarely are: the variance of an ``H``-period total is ``H * gamma_0 + 2 * sum_k
+(H - k) * gamma_k``, so positive autocorrelation makes the total more variable than
+``H`` independent draws imply and an independent draw too narrow by a factor that
+grows with the horizon.
+
+So blocks are drawn instead of periods. Each path is assembled from
+``ceil(H / block)`` circular blocks of the centred series, truncated to ``H``, and
+each block's sign is flipped with probability one half. The sign flip is Wheeler's
+symmetrisation applied to a block: the multiset ``{+e_i, -e_i}`` is the multiset
+``{+|e_i|, -|e_i|}``, so at ``block = 1`` the two constructions coincide in
+distribution, which ``tests/test_pda_resample_band.py`` pins against a transcription
+of his code. Flipping periods individually would destroy the very correlation the
+blocks were drawn to keep.
+
+The series is centred first. A fit sitting a little high shifts every one of its
+errors by the same amount, and an uncentred draw would charge the band for that
+shift once per period it accumulates.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+
+from ...exceptions import MlsynthConfigError, MlsynthDataError
+
+#: Blocks shorter than this cannot carry the autocorrelation they are drawn for,
+#: but the choice is the caller's; this is only the default stand-in for "the
+#: whole horizon", requested as ``block = 0``.
+WHOLE_HORIZON = 0
+
+
+def _check_horizon(horizon) -> int:
+    """Return ``horizon`` as a positive int, or raise.
+
+    Parameters
+    ----------
+    horizon : int
+        Number of post-treatment periods the paths span.
+
+    Returns
+    -------
+    int
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``horizon`` is not an integer, or is not at least one.
+    """
+    if isinstance(horizon, bool) or not isinstance(horizon, (int, np.integer)):
+        raise MlsynthConfigError(
+            f"horizon must be an integer of at least 1; got {horizon!r}."
+        )
+    if int(horizon) < 1:
+        raise MlsynthConfigError(
+            f"horizon must be at least 1; got {int(horizon)}."
+        )
+    return int(horizon)
+
+
+def resolve_block(block: Union[int, np.integer], horizon: int) -> int:
+    """Turn a configured block length into the one the draw will use.
+
+    ``0`` asks for the whole horizon, which is the longest block that carries
+    correlation the accumulated total is sensitive to. A block longer than the
+    horizon is clamped to it, since the surplus periods are truncated away and a
+    longer block would only reduce the number of distinct starting positions.
+
+    Parameters
+    ----------
+    block : int
+        Requested block length in periods. ``0`` means the horizon.
+    horizon : int
+        Number of post-treatment periods.
+
+    Returns
+    -------
+    int
+        A block length in ``[1, horizon]``.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``block`` is not an integer, or is negative. Booleans and floats are
+        refused outright: ``True`` is an ``int`` in Python and ``2.5`` has no
+        unambiguous reading, so neither is quietly reinterpreted.
+    """
+    h = _check_horizon(horizon)
+    if isinstance(block, bool) or not isinstance(block, (int, np.integer)):
+        raise MlsynthConfigError(
+            f"block must be a non-negative integer (0 means the horizon); "
+            f"got {block!r}."
+        )
+    b = int(block)
+    if b < 0:
+        raise MlsynthConfigError(
+            f"block must be non-negative (0 means the horizon); got {b}."
+        )
+    if b == WHOLE_HORIZON:
+        return h
+    return min(b, h)
+
+
+def block_error_paths(
+    series,
+    *,
+    horizon: int,
+    block: int = WHOLE_HORIZON,
+    n_sim: int = 2000,
+    rng: Optional[np.random.Generator] = None,
+) -> np.ndarray:
+    """``(n_sim, horizon)`` post-period error paths, drawn as sign-flipped blocks.
+
+    Parameters
+    ----------
+    series : array-like
+        Out-of-sample per-period errors, in time order. Non-finite entries are
+        dropped, so an origin whose refit failed contributes nothing instead of a
+        zero that would shrink the band.
+    horizon : int
+        Number of post-treatment periods each path spans.
+    block : int, optional
+        Block length in periods; ``0`` (default) means the horizon. See
+        :func:`resolve_block`.
+    n_sim : int, optional
+        Number of paths to draw (default 2000).
+    rng : numpy.random.Generator, optional
+        Source of randomness. A fresh default generator is used when omitted, so
+        a caller that wants reproducibility passes its own.
+
+    Returns
+    -------
+    numpy.ndarray, shape ``(n_sim, horizon)``
+        One error path per row, ready for
+        :func:`mlsynth.utils.pda_helpers.inference.cumulative_supt_band` or for
+        equal-tailed quantiles of the accumulated draws.
+
+    Raises
+    ------
+    MlsynthConfigError
+        If ``horizon``, ``block`` or ``n_sim`` is not a positive integer of the
+        right kind.
+    MlsynthDataError
+        If ``series`` holds no finite value, since there is nothing to resample.
+    """
+    h = _check_horizon(horizon)
+    b = resolve_block(block, h)
+    if isinstance(n_sim, bool) or not isinstance(n_sim, (int, np.integer)) \
+            or int(n_sim) < 1:
+        raise MlsynthConfigError(
+            f"n_sim must be an integer of at least 1; got {n_sim!r}."
+        )
+    n_sim = int(n_sim)
+    if rng is None:
+        rng = np.random.default_rng()
+
+    e = np.asarray(series, dtype=float).ravel()
+    e = e[np.isfinite(e)]
+    if e.size == 0:
+        raise MlsynthDataError(
+            "cannot resample from an empty error series: no finite out-of-sample "
+            "error was supplied. A calibration pass that produced no usable "
+            "window cannot support a band."
+        )
+    e = e - e.mean()
+
+    n_blocks = int(np.ceil(h / b))
+    starts = rng.integers(0, e.size, size=(n_sim, n_blocks))
+    idx = (starts[:, :, None] + np.arange(b)[None, None, :]) % e.size
+    draws = e[idx]
+    signs = rng.choice(np.array([-1.0, 1.0]), size=(n_sim, n_blocks, 1))
+    return (draws * signs).reshape(n_sim, n_blocks * b)[:, :h]

--- a/mlsynth/utils/supt.py
+++ b/mlsynth/utils/supt.py
@@ -25,6 +25,18 @@ and jackknife deviations sit on a different scale from the estimator's own
 sampling distribution. Only the correlation is taken from the draws; the scale
 comes from ``se_h`` separately.
 
+That last sentence is also the limit of the method, and worth knowing before
+choosing it: taking only the correlation makes ``c`` a functional of ``R``
+alone. Two ensembles with the same correlation matrix get the same multiplier
+however different their joint laws, and the quantile being estimated is not such
+a functional. Where the draws are close to normal the two agree to a few
+thousandths. Where they are not -- a block bootstrap over a short calibration
+series draws from ``m`` distinct blocks, so a large ``n_sim`` resamples a small
+support instead of exploring a continuum -- they part company, by an amount that
+runs either side of parity and shrinks as the support grows.
+``supt_critical_value(..., method="empirical")`` reads the quantile off the
+draws for callers whose ensemble makes that the better instrument.
+
 The cumulative case is why this module exists at all. An interval for a running
 total is not the running total of the period intervals: adding endpoints treats
 the period errors as moving in lockstep, so the width grows like ``L``, while
@@ -131,6 +143,7 @@ def supt_critical_value(
     alpha: float,
     n_sims: int = DEFAULT_N_SIMS,
     seed: Optional[int] = 0,
+    method: str = "gaussian",
 ) -> float:
     """The shared multiplier that makes a band cover the whole path at once.
 
@@ -144,9 +157,33 @@ def supt_critical_value(
     alpha : float
         Level; the band is simultaneous at ``1 - alpha``.
     n_sims : int
-        Draws used to tabulate the quantile of ``max_h |z_h|``.
+        Draws used to tabulate the quantile of ``max_h |z_h|``. Ignored by
+        ``method="empirical"``, which consults no RNG.
     seed : int, optional
-        RNG seed, so a reported band is reproducible.
+        RNG seed, so a reported band is reproducible. Ignored by
+        ``method="empirical"``.
+    method : {"gaussian", "empirical"}
+        Which estimator of the same quantile to use.
+
+        ``"gaussian"`` (default) reduces the draws to their correlation across
+        horizons and tabulates ``max_h |z_h|`` from simulated normals carrying
+        that correlation. This is the right instrument for a delete-one
+        jackknife: there are only as many draws as units, so an empirical
+        quantile at ``1 - alpha`` is coarse, and jackknife deviations are on a
+        different scale from the estimator's sampling distribution anyway.
+
+        ``"empirical"`` reads the quantile off the standardized draws
+        themselves. Reach for it when the draws are a large resampling ensemble
+        -- a block bootstrap, say -- where neither objection applies: the
+        quantile is not coarse, and the draws are already on the estimator's
+        scale. It also keeps what the correlation matrix cannot carry. Reducing
+        the draws to second moments discards *scale heterogeneity across draws*
+        -- a bootstrap replicate that catches an unusual stretch is large at
+        every horizon at once -- and that is precisely what drives ``max_h``. A
+        Gaussian vector's own scale is tightly concentrated, so no correlation
+        matrix can reproduce it, and the simulated multiplier comes back too
+        small. The gap is not a constant: it runs either side of parity, ordered
+        by how dispersed the per-draw scale is.
 
     Returns
     -------
@@ -158,11 +195,16 @@ def supt_critical_value(
     Raises
     ------
     MlsynthConfigError
-        ``alpha`` outside ``(0, 1)``, or a non-positive ``n_sims``.
+        ``alpha`` outside ``(0, 1)``, a non-positive ``n_sims``, or a ``method``
+        that is neither ``"gaussian"`` nor ``"empirical"``.
     MlsynthDataError
         ``draws`` not 2-D, or fewer than two replicates.
     """
     alpha = _check_alpha(alpha)
+    if method not in ("gaussian", "empirical"):
+        raise MlsynthConfigError(
+            f"method must be 'gaussian' or 'empirical'; got {method!r}."
+        )
     if isinstance(n_sims, bool) or not isinstance(n_sims, (int, np.integer)) or n_sims < 1:
         raise MlsynthConfigError(f"n_sims must be a positive integer; got {n_sims!r}.")
     draws = np.asarray(draws, dtype=float)
@@ -175,6 +217,25 @@ def supt_critical_value(
         raise MlsynthDataError(
             f"need at least 2 draws to estimate a correlation; got {n}."
         )
+
+    if method == "empirical":
+        # The same statistic the simulation targets, taken over the draws in
+        # hand. Standardizing by each horizon's own spread is what makes it
+        # scale-free, exactly as in the simulated route; a horizon with no
+        # variation is given an infinite scale so it contributes zero rather
+        # than a division by zero.
+        with np.errstate(invalid="ignore", divide="ignore"):
+            sd = np.nanstd(draws, axis=0)
+            centred = draws - np.nanmean(draws, axis=0)
+            z = centred / np.where(np.isfinite(sd) & (sd > 0.0), sd, np.inf)
+        m = np.nanmax(np.abs(z), axis=1)
+        m = m[np.isfinite(m)]
+        if m.size < 2:
+            raise MlsynthDataError(
+                "no usable draws left after standardizing; every replicate was "
+                "non-finite or every horizon was constant."
+            )
+        return float(np.quantile(m, 1.0 - alpha))
 
     # Correlation across horizons, pairwise-complete so one failed replicate does
     # not discard a whole horizon. A horizon with no variation carries no

--- a/mlsynth/utils/vanillasc_helpers/config.py
+++ b/mlsynth/utils/vanillasc_helpers/config.py
@@ -457,6 +457,53 @@ class VanillaSCConfig(BaseEstimatorConfig):
                     "in the pre-period, and the band widens accordingly.",
     )
 
+    conformal_method: Literal["split", "resample"] = Field(
+        default="split",
+        description="How the cumulative band is calibrated. 'split' (default) "
+                    "takes the finite-sample order statistic of the m "
+                    "rolling-origin window sums, which exists only once m reaches "
+                    "ceil(1/alpha) - 1 and otherwise returns an infinite "
+                    "half-width. 'resample' keeps the same windows per period, "
+                    "giving m * horizon values, and block-resamples them into "
+                    "accumulated paths; the band is then the quantile of those "
+                    "totals. It stays finite on pre-periods where the order "
+                    "statistic does not exist, and it carries the serial "
+                    "correlation of the period errors into the total instead of "
+                    "reading it off a single summed score.",
+    )
+    conformal_block: int = Field(
+        default=0,
+        description="conformal_method='resample' only: block length in periods "
+                    "for the circular block bootstrap. 0 (default) means the whole "
+                    "horizon; 1 draws periods independently, which understates the "
+                    "spread of a total whenever the period errors are positively "
+                    "autocorrelated.",
+    )
+    conformal_n_sim: int = Field(
+        default=2000,
+        description="conformal_method='resample' only: number of accumulated paths "
+                    "to draw. These cost no refits -- the refits are the "
+                    "calibration origins -- so this buys quantile precision "
+                    "cheaply.",
+    )
+    conformal_seed: int = Field(
+        default=0,
+        description="conformal_method='resample' only: seed for the draw, so the "
+                    "band is reproducible.",
+    )
+
+    @field_validator("conformal_block", "conformal_n_sim", "conformal_seed",
+                     mode="before")
+    @classmethod
+    def _validate_conformal_draw(cls, v, info):
+        if isinstance(v, bool) or not isinstance(v, int):
+            raise ValueError(f"{info.field_name} must be an integer.")
+        if info.field_name == "conformal_block" and v < 0:
+            raise ValueError("conformal_block must be >= 0 (0 means the horizon).")
+        if info.field_name == "conformal_n_sim" and v < 2:
+            raise ValueError("conformal_n_sim must be >= 2 to take a quantile.")
+        return v
+
     @field_validator("conformal_horizon")
     @classmethod
     def _validate_conformal_horizon(cls, v):

--- a/mlsynth/utils/vanillasc_helpers/pipeline.py
+++ b/mlsynth/utils/vanillasc_helpers/pipeline.py
@@ -706,11 +706,36 @@ def run_vanillasc(config) -> BaseEstimatorResults:
 
         T1_post = int(len(y) - pre)
         horizon = int(config.conformal_horizon or T1_post)
-        band = cumulative_conformal_from_refit(
-            y, Y0, pre_periods=int(pre), horizon=horizon,
-            weight_fn=_refit_weight_fn, alpha=config.alpha,
-        )
-        if not np.isfinite(band.half_width):
+        resampled = config.conformal_method == "resample"
+        if resampled:
+            # The same windows, kept per period and drawn from as blocks. The
+            # half-width is the quantile of the accumulated totals; the draws are
+            # centred and sign-symmetric, so their absolute quantile is the
+            # symmetric half-width the band reports.
+            from mlsynth.utils.conformal import (
+                CumulativeConformalBand, origin_schedule,
+                resample_cumulative_paths_from_weights)
+
+            paths = resample_cumulative_paths_from_weights(
+                y, Y0, int(pre), horizon, _refit_weight_fn,
+                block=config.conformal_block, n_sim=config.conformal_n_sim,
+                seed=config.conformal_seed)
+            point = float(np.sum(gap[pre:pre + horizon]))
+            half = float(np.quantile(np.abs(paths.sum(axis=1)), 1.0 - config.alpha))
+            # The periods drawn from, not the windows: m * horizon of them, which
+            # is why this is finite where the order statistic is not. Read off the
+            # schedule, which costs nothing -- the refits already happened above.
+            n_periods = len(list(origin_schedule(int(pre), horizon, 0.3))) * horizon
+            band = CumulativeConformalBand(
+                point=point, lower=point - half, upper=point + half,
+                half_width=half, n_scores=int(n_periods),
+                alpha=float(config.alpha), horizon=horizon)
+        else:
+            band = cumulative_conformal_from_refit(
+                y, Y0, pre_periods=int(pre), horizon=horizon,
+                weight_fn=_refit_weight_fn, alpha=config.alpha,
+            )
+        if not resampled and not np.isfinite(band.half_width):
             warnings.warn(
                 "cumulative conformal band is uninformative (half-width=inf): "
                 f"{band.n_scores} non-overlapping calibration window(s) of length "
@@ -728,7 +753,9 @@ def run_vanillasc(config) -> BaseEstimatorResults:
             ci_lower=(band.lower / horizon) if spans_post else None,
             ci_upper=(band.upper / horizon) if spans_post else None,
             confidence_level=1.0 - config.alpha,
-            method="split-conformal cumulative-effect band (rolling origin)",
+            method=("block-resampled cumulative-effect band (rolling origin)"
+                    if resampled else
+                    "split-conformal cumulative-effect band (rolling origin)"),
             details={
                 "cumulative_effect": band.point,
                 "cumulative_lower": band.lower,

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -548,14 +548,14 @@ timeout = 180.0
 
   [[target.mutant]]
   id = "overlapping-calibration-origins"
-  find = "for origin in range(start, int(pre_periods) - int(horizon) + 1, int(horizon)):"
-  replace = "for origin in range(start, int(pre_periods) - int(horizon) + 1, 1):"
+  find = "    return range(start, int(pre_periods) - int(horizon) + 1, int(horizon))"
+  replace = "    return range(start, int(pre_periods) - int(horizon) + 1, 1)"
   models = "sliding the calibration origin one period at a time instead of one window at a time, so consecutive blocks share periods; the scores stop being exchangeable and the band is calibrated on a correlated, artificially large calibration set"
 
   [[target.mutant]]
   id = "scores-average-instead-of-accumulate"
-  find = "scores.append(float(np.sum(y[block] - Y0[block] @ w)))"
-  replace = "scores.append(float(np.mean(y[block] - Y0[block] @ w)))"
+  find = "    return np.asarray([float(np.sum(b)) for b in blocks], dtype=float)"
+  replace = "    return np.asarray([float(np.mean(b)) for b in blocks], dtype=float)"
   models = "scoring the per-period average error rather than the accumulated error, so the band is calibrated for the wrong estimand -- the defect that makes a per-period interval rescaled by the horizon look like a cumulative one"
 
   [[target.mutant]]

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -633,6 +633,18 @@ timeout = 300.0
   models = "taking one horizon's deviation instead of the largest across horizons, which is the pointwise critical value wearing a simultaneous band's name. Every shape, sign and monotonicity assertion still passes; what fails is the coverage the band claims, and only a test that compares the correction against its own simulation error can see it"
 
   [[target.mutant]]
+  id = "supt-method-silently-ignored"
+  find = "    if method not in (\"gaussian\", \"empirical\"):"
+  replace = "    if False:"
+  models = "dropping the guard, so a misspelled method falls through to the gaussian default instead of being refused. A caller asking for the empirical multiplier on a bootstrap ensemble would silently get the simulated one -- the exact confusion the parameter exists to remove, and invisible because the returned number is a perfectly plausible multiplier"
+
+  [[target.mutant]]
+  id = "supt-empirical-forgets-to-standardise"
+  find = "        m = np.nanmax(np.abs(z), axis=1)"
+  replace = "        m = np.nanmax(np.abs(centred), axis=1)"
+  models = "reading the largest raw deviation instead of the largest standardised one. The multiplier is then in the units of whichever horizon happens to be widest -- usually the last, since a cumulative path's spread grows -- so it stops being a multiplier at all and the band it produces has no stated level"
+
+  [[target.mutant]]
   id = "jackknife-inflation-dropped"
   find = "        out[h] = np.sqrt((m - 1) / m * ss) if jackknife else np.sqrt(ss / (m - 1))"
   replace = "        out[h] = np.sqrt(ss / (m - 1))"


### PR DESCRIPTION
Re-scoped. This branch had accumulated twelve commits from an earlier session before two unrelated sup-t commits were appended to it. Those two have moved to #530, cut cleanly onto current `main`; once that merges they will drop out of this diff automatically.

What remains here is one coherent piece of work, in order:

- block-resampled error paths for a PDA cumulative band, cross-validated against Wheeler's LassoSynth
- keeping the rolling-origin errors per period alongside their block sums
- reading a PDA fit's rolling-origin errors from its own counterfactual, so one reader covers all four variants
- offering the resampled band on PDA via `cumulative_method`
- the Wheeler benchmark case and the docs for it
- moving the machinery into the shared `conformal` package
- the same band on VanillaSC
- two guards on the resampling block: refusing one at least as long as the calibration series, then refusing one past half of it
- re-anchoring the two calibration-scores mutants the refactor moved

Two things before this can merge:

1. `main` has moved two commits ahead (`4a03d7c8`, `544c684e`) and GitHub reports the branch as conflicted. It needs the base merged in and the conflict resolved.
2. Nine commits touching the conformal package, two estimators, a benchmark case and two docs pages is a large diff to review as one unit. It may read better split, though the later commits build on the earlier ones so the split is not free.

Not merging it as part of the sup-t work — that was the reason for separating them.
