### PR TITLE
Warn when the sup-t correlation is estimated from too few replicates, and offer a shrinkage that fixes it

### DIFF
--- a/mlsynth/tests/test_supt.py
+++ b/mlsynth/tests/test_supt.py
@@ -27,6 +27,8 @@ What the tests pin:
   per-period errors and like ``L`` under perfectly correlated ones -- which is
   the whole reason a cumulative band cannot be assembled by adding endpoints.
 """
+import warnings
+
 import numpy as np
 import pytest
 from hypothesis import HealthCheck, given, settings
@@ -541,3 +543,161 @@ def test_both_methods_are_invariant_to_rescaling_a_horizon(method, seed, n_h):
     scaled = supt_critical_value(draws * factors, alpha=0.10, method=method,
                                  n_sims=20_000, seed=0)
     assert plain == pytest.approx(scaled, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# The correlation is estimated, and at few replicates it is estimated badly.
+#
+# A sample correlation over-fits: it implies more co-movement across horizons
+# than the truth has, which lowers the effective number of independent
+# directions the maximum runs over, which shrinks the multiplier. At n <= H the
+# matrix is rank-deficient outright and the simulated path is confined to an
+# (n-1)-dimensional subspace. The band then claims 1 - alpha and covers less.
+# ---------------------------------------------------------------------------
+
+def _c_from_correlation(R, n_sims=40_000, seed=0):
+    """The multiplier the simulation would return for a *known* correlation."""
+    H = R.shape[0]
+    w, V = np.linalg.eigh(R)
+    L = V * np.sqrt(np.clip(w, 0.0, None))
+    z = np.random.default_rng(seed).standard_normal((n_sims, H)) @ L.T
+    scale = np.sqrt(np.clip(np.einsum("ij,ij->i", L, L), 1e-300, None))
+    return float(np.quantile(np.max(np.abs(z / scale), axis=1), 0.90))
+
+
+def test_a_known_correlation_gives_the_right_multiplier():
+    """Rung 2, the control. Handed the truth, the simulation is correct, so
+    whatever goes wrong at few replicates is the estimate of R and not the
+    simulation, the eigenvalue clip, or the quantile."""
+    H = 12
+    c = _c_from_correlation(np.eye(H))
+    z = np.random.default_rng(1).standard_normal((200_000, H))
+    assert c == pytest.approx(float(np.quantile(np.max(np.abs(z), axis=1), 0.90)),
+                              abs=0.02)
+
+
+def test_the_multiplier_falls_as_replicates_are_removed_from_one_truth():
+    """The fault, as a monotone sweep.
+
+    The truth is fixed -- twelve independent horizons -- so the correct
+    multiplier is one number at every n. What changes is only how many
+    replicates R is estimated from, and the multiplier falls as that shrinks.
+    """
+    H = 12
+    target = _c_from_correlation(np.eye(H))
+    got = {}
+    for n in (5, 12, 50):
+        cs = [supt_critical_value(
+                  np.random.default_rng(3000 + r).standard_normal((n, H)),
+                  alpha=0.10, n_sims=40_000, seed=0)
+              for r in range(8)]
+        got[n] = float(np.mean(cs))
+    assert got[5] < got[12] < got[50] < target
+    assert target - got[5] > 0.10, got      # severe where n is below H
+    assert target - got[50] < 0.03, got     # nearly gone by n = 4H
+
+
+def test_the_shortfall_is_governed_by_replicates_per_horizon():
+    """Why ``n`` alone is the wrong thing to guard on.
+
+    Two panels with the same ``n`` but different horizon counts are not equally
+    exposed; two with the same ratio are. That is what a guard has to read.
+    """
+    def shortfall(n, H):
+        target = _c_from_correlation(np.eye(H))
+        cs = [supt_critical_value(
+                  np.random.default_rng(4000 + r).standard_normal((n, H)),
+                  alpha=0.10, n_sims=40_000, seed=0)
+              for r in range(6)]
+        return target - float(np.mean(cs))
+
+    at_ratio_one = [shortfall(H, H) for H in (6, 12)]
+    at_ratio_eight = [shortfall(8 * H, H) for H in (6, 12)]
+    assert max(at_ratio_one) - min(at_ratio_one) < 0.06, at_ratio_one
+    assert all(s < 0.02 for s in at_ratio_eight), at_ratio_eight
+    assert min(at_ratio_one) > max(at_ratio_eight)
+
+
+def test_ledoit_wolf_recovers_the_multiplier_at_few_replicates():
+    """The corrective action, measured against the truth it should reach.
+
+    Shrinking the sample correlation toward the identity by a data-chosen
+    intensity undoes the over-fitting. Where the horizons really are
+    independent it is nearly exact from a handful of replicates.
+    """
+    H = 12
+    target = _c_from_correlation(np.eye(H))
+    plain, shrunk = [], []
+    for r in range(8):
+        d = np.random.default_rng(5000 + r).standard_normal((5, H))
+        plain.append(supt_critical_value(d, alpha=0.10, n_sims=40_000, seed=0))
+        shrunk.append(supt_critical_value(d, alpha=0.10, n_sims=40_000, seed=0,
+                                          shrinkage="ledoit_wolf"))
+    assert target - np.mean(plain) > 0.10
+    assert abs(target - np.mean(shrunk)) < 0.05
+
+
+def test_ledoit_wolf_errs_wide_not_narrow_on_correlated_horizons():
+    """The cost, stated as a direction.
+
+    Shrinking a genuinely correlated matrix toward the identity flattens it, so
+    the multiplier comes out a little large. That is the safe way to be wrong:
+    a band slightly too wide, never one that claims a level it does not have.
+    """
+    H = 12
+    R = 0.8 ** np.abs(np.subtract.outer(np.arange(H), np.arange(H)))
+    w, V = np.linalg.eigh(R)
+    L = V * np.sqrt(np.clip(w, 0.0, None))
+    target = _c_from_correlation(R)
+    shrunk = [supt_critical_value(
+                  np.random.default_rng(6000 + r).standard_normal((12, H)) @ L.T,
+                  alpha=0.10, n_sims=40_000, seed=0, shrinkage="ledoit_wolf")
+              for r in range(8)]
+    assert np.mean(shrunk) > target
+    assert np.mean(shrunk) - target < 0.20
+
+
+def test_few_replicates_per_horizon_warns_by_default():
+    """The trap has to be visible. Below two replicates per horizon the
+    unshrunk multiplier is materially short, so saying nothing would ship a
+    band that claims a level it does not reach."""
+    rng = np.random.default_rng(7)
+    with pytest.warns(RuntimeWarning, match="replicates"):
+        supt_critical_value(rng.standard_normal((8, 12)), alpha=0.10, n_sims=5000)
+
+
+def test_enough_replicates_per_horizon_is_silent():
+    rng = np.random.default_rng(8)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        supt_critical_value(rng.standard_normal((120, 12)), alpha=0.10, n_sims=5000)
+
+
+def test_shrinkage_silences_the_warning():
+    """Having taken the corrective action, the caller should not be nagged."""
+    rng = np.random.default_rng(9)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        supt_critical_value(rng.standard_normal((8, 12)), alpha=0.10, n_sims=5000,
+                            shrinkage="ledoit_wolf")
+
+
+def test_the_empirical_route_neither_shrinks_nor_warns():
+    """Shrinkage is a repair to an estimated correlation, and the empirical
+    route estimates none, so the option does not apply to it."""
+    rng = np.random.default_rng(10)
+    draws = rng.standard_normal((8, 12))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        a = supt_critical_value(draws, alpha=0.10, method="empirical")
+        b = supt_critical_value(draws, alpha=0.10, method="empirical",
+                                shrinkage="ledoit_wolf")
+    assert a == b
+
+
+@pytest.mark.parametrize("bad", ["ledoit-wolf", "LedoitWolf", "shrink", None, 2])
+def test_an_unknown_shrinkage_is_refused(bad):
+    rng = np.random.default_rng(11)
+    with pytest.raises(MlsynthConfigError, match="shrinkage"):
+        supt_critical_value(rng.standard_normal((100, 3)), alpha=0.10,
+                            shrinkage=bad)

--- a/mlsynth/utils/supt.py
+++ b/mlsynth/utils/supt.py
@@ -36,6 +36,14 @@ runs either side of parity and shrinks as the support grows.
 ``supt_critical_value(..., method="empirical")`` reads the quantile off the
 draws for callers whose ensemble makes that the better instrument.
 
+The correlation is also *estimated*, and a sample correlation over-fits: it
+implies more co-movement than the truth has, lowering the effective number of
+independent directions the maximum runs over. The multiplier then comes back
+short, and the band covers less than it claims -- 0.67 against a nominal 0.90 at
+three replicates over twelve horizons. Severity is governed by replicates per
+horizon: about 0.05 short at ``n = H``, 0.03 at ``2H``, under 0.02 from ``4H``.
+Below ``2H`` the function warns, and ``shrinkage="ledoit_wolf"`` corrects it.
+
 The cumulative case is why this module exists at all. An interval for a running
 total is not the running total of the period intervals: adding endpoints treats
 the period errors as moving in lockstep, so the width grows like ``L``, while
@@ -54,6 +62,8 @@ Econometrics, 34(1), 1-17.
 from __future__ import annotations
 
 from typing import Optional
+
+import warnings
 
 import numpy as np
 
@@ -143,6 +153,7 @@ def supt_critical_value(
     n_sims: int = DEFAULT_N_SIMS,
     seed: Optional[int] = 0,
     method: str = "gaussian",
+    shrinkage: str = "none",
 ) -> float:
     """The shared multiplier that makes a band cover the whole path at once.
 
@@ -161,6 +172,34 @@ def supt_critical_value(
     seed : int, optional
         RNG seed, so a reported band is reproducible. Ignored by
         ``method="empirical"``.
+    shrinkage : {"none", "ledoit_wolf"}
+        How to repair the estimated correlation before simulating from it.
+
+        The correlation is estimated from the draws, and a sample correlation
+        over-fits: it implies more co-movement across horizons than the truth
+        has, which lowers the effective number of independent directions the
+        maximum runs over and shrinks the multiplier. At ``n <= H`` the matrix
+        is rank-deficient outright and the simulated path is confined to an
+        ``(n - 1)``-dimensional subspace. Measured on twelve independent
+        horizons, the multiplier runs 2.12, 2.42, 2.56, 2.61 at 3, 5, 12 and 50
+        replicates against a correct 2.62, and the band's simultaneous coverage
+        runs 0.67, 0.83, 0.89, 0.90 against a nominal 0.90.
+
+        ``"none"`` (default) uses the sample correlation as it stands, which is
+        what every release so far has done.
+
+        ``"ledoit_wolf"`` shrinks it toward the identity by a data-chosen
+        intensity. Where the horizons really are independent this is close to
+        exact from a handful of replicates; where they are genuinely correlated
+        it flattens the matrix slightly and the multiplier comes out a little
+        large. That is the safe direction to err -- a band marginally too wide,
+        never one claiming a level it does not reach.
+
+        Severity is governed by replicates per horizon, not by either count
+        alone: the shortfall is 0.05 to 0.09 at ``n = H``, about 0.03 at ``2H``,
+        and under 0.02 from ``4H``. Below ``2H`` this function warns.
+
+        Ignored by ``method="empirical"``, which estimates no correlation.
     method : {"gaussian", "empirical"}
         Which estimator of the same quantile to use.
 
@@ -195,11 +234,16 @@ def supt_critical_value(
     ------
     MlsynthConfigError
         ``alpha`` outside ``(0, 1)``, a non-positive ``n_sims``, or a ``method``
-        that is neither ``"gaussian"`` nor ``"empirical"``.
+        that is neither ``"gaussian"`` nor ``"empirical"``, or a ``shrinkage``
+        that is neither ``"none"`` nor ``"ledoit_wolf"``.
     MlsynthDataError
         ``draws`` not 2-D, or fewer than two replicates.
     """
     alpha = _check_alpha(alpha)
+    if shrinkage not in ("none", "ledoit_wolf"):
+        raise MlsynthConfigError(
+            f"shrinkage must be 'none' or 'ledoit_wolf'; got {shrinkage!r}."
+        )
     if method not in ("gaussian", "empirical"):
         raise MlsynthConfigError(
             f"method must be 'gaussian' or 'empirical'; got {method!r}."
@@ -253,6 +297,33 @@ def supt_critical_value(
                 C = np.nan_to_num(C, nan=0.0)
                 R[np.ix_(idx, idx)] = C
     np.fill_diagonal(R, 1.0)
+
+    if shrinkage == "ledoit_wolf":
+        # The sample correlation over-fits at few replicates. Shrinking toward
+        # the identity by a data-chosen intensity restores the effective
+        # dimension the maximum runs over. Applied to the correlation and not
+        # the covariance, since only the correlation is used here -- the scale
+        # comes from ``se_h`` separately.
+        from sklearn.covariance import ledoit_wolf
+        keep = ~np.isnan(draws).any(axis=1)
+        if keep.sum() > 1:
+            cov, _ = ledoit_wolf(draws[keep], assume_centered=False)
+            d = np.sqrt(np.clip(np.diag(cov), 1e-300, None))
+            R = cov / np.outer(d, d)
+            np.fill_diagonal(R, 1.0)
+    elif n < 2 * H:
+        # Below two replicates per horizon the unshrunk multiplier is materially
+        # short -- about 0.05 at n = H and 0.15 or worse below it -- so the band
+        # claims a level it does not reach. Say so instead of returning it.
+        warnings.warn(
+            f"sup-t multiplier estimated from {n} replicates over {H} horizons "
+            f"({n / H:.1f} per horizon). The sample correlation over-fits at "
+            "this ratio, so the multiplier is biased low and the band covers "
+            "less than 1 - alpha. Pass shrinkage='ledoit_wolf', or use more "
+            "replicates.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
     # Nearest usable covariance: the estimated correlation can be indefinite when
     # there are fewer replicates than horizons, which a jackknife over a modest

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -699,6 +699,18 @@ timeout = 300.0
   models = "reading the largest raw deviation instead of the largest standardised one. The multiplier is then in the units of whichever horizon happens to be widest -- usually the last, since a cumulative path's spread grows -- so it stops being a multiplier at all and the band it produces has no stated level"
 
   [[target.mutant]]
+  id = "supt-few-replicate-warning-never-fires"
+  find = "    elif n < 2 * H:"
+  replace = "    elif False:"
+  models = "silencing the guard on replicates per horizon, which puts the band back to claiming a level it does not reach without saying so. At n = H the multiplier is short by 0.05 and simultaneous coverage falls to 0.89; below that it degrades fast, reaching 0.67 at three replicates over twelve horizons. The returned number stays a plausible multiplier throughout, so nothing downstream can tell"
+
+  [[target.mutant]]
+  id = "supt-ledoit-wolf-is-a-noop"
+  find = "            R = cov / np.outer(d, d)"
+  replace = "            R = R"
+  models = "accepting the shrinkage argument and then ignoring it, so a caller who took the corrective action gets the uncorrected multiplier. Worse than not offering the option, because the caller now believes the problem is handled"
+
+  [[target.mutant]]
   id = "jackknife-inflation-dropped"
   find = "        out[h] = np.sqrt((m - 1) / m * ss) if jackknife else np.sqrt(ss / (m - 1))"
   replace = "        out[h] = np.sqrt(ss / (m - 1))"


### PR DESCRIPTION
Closes #528. Targets `main`, rebased onto it now that #530 has merged. One commit, three files, 244 lines.

## The fault

The correlation across horizons is estimated from the draws, and a sample correlation over-fits: it implies more co-movement than the truth has, which lowers the effective number of independent directions the maximum runs over, which shrinks the multiplier. At `n <= H` the matrix is rank-deficient outright and the simulated path is confined to an `(n-1)`-dimensional subspace.

Handed the *true* correlation the simulation is exact, so neither the eigenvalue clip nor the quantile is at fault — estimating `R` from few draws is. Twelve independent horizons, correct multiplier 2.62:

```
replicates      3       5      12      50     200
multiplier   2.12    2.42    2.56    2.61    2.62
coverage     0.67    0.83    0.89    0.90    0.89
```

A 90% simultaneous band built from three replicates covers 67%.

Severity is governed by replicates per horizon, not by either count alone — it lands on the same curve at `H` of 6, 12 and 20:

```
   n/H     H=6      H=12     H=20
   0.5  -0.3146  -0.1484  -0.1104
     1  -0.0900  -0.0585  -0.0498
     2  -0.0293  -0.0267  -0.0254
     4  -0.0204  -0.0142  -0.0151
    16  -0.0094  -0.0044  -0.0058
```

## What changes

Nothing existing moves. Two additions.

A warning below two replicates per horizon, naming the ratio and the remedy. Nothing in the suite triggers it. A 14-unit panel over 12 horizons does; a 40-unit one does not.

`shrinkage="ledoit_wolf"`, which shrinks the sample correlation toward the identity by a data-chosen intensity. On independent horizons it is near exact from a handful of replicates — 0.20 short becomes 0.015. On genuinely correlated horizons it flattens the matrix slightly and comes out a little wide, which is the safe direction to err.

A fixed intensity cannot do this. The right amount depends on both the replicate count and the truth, and at 100 replicates against an AR(0.8) correlation the plain estimate is already right (−0.004) while any fixed shrinkage makes it worse (+0.074 at λ = 0.2):

```
truth AR(0.8), correct c = 2.4552
    n    sample R   Ledoit-Wolf   mean lambda*
    5     -0.1337       +0.0910          0.425
   12     -0.0584       +0.0671          0.290
  100     -0.0039       +0.0208          0.051
```

Default stays `"none"`, so this reports the problem instead of deciding it. Whether it should become the default is a real question — it trades a coverage failure at few replicates for mild conservatism at many — and the calibration study in #531 should settle it, not this PR.

## Tests

Written first, red for the right reason. The ladder from #528:

- rung 2 control: handed a known correlation, the simulation is correct — so the fault is the estimate, not the machinery
- the fault as a monotone sweep: the multiplier falls as replicates are removed from one fixed truth, severe below `H` and nearly gone by `4H`
- the shortfall is governed by replicates per horizon, which is what a guard has to read
- Ledoit–Wolf recovers the multiplier at few replicates
- Ledoit–Wolf errs wide, not narrow, on correlated horizons
- the warning fires below the ratio, is silent above it, is silenced by taking the remedy, and does not apply to `method="empirical"`
- five unrecognized `shrinkage` values raise

128 pass across `test_supt`, `test_mutation_harness`, `test_ppscm_cumulative_supt` and `test_pda_cumulative_band`, on this rebase.

## Mutants

Two added, both confirmed killed:

- `supt-few-replicate-warning-never-fires` — silences the guard, putting the band back to claiming a level it does not reach without saying so
- `supt-ledoit-wolf-is-a-noop` — accepts the shrinkage argument and ignores it, which is worse than not offering the option because the caller then believes it is handled

## Blast radius

`ppscm_helpers/inference.py` passes one jackknife replicate per unit, so `n` is the unit count and `H` is `n_leads` — exposed when the donor pool is small relative to the horizon. `pda_helpers/inference.py` passes bootstrap draws with `n = n_boot`, normally large. Neither call site changes here.

## What the #531 study has since found

Worth reading alongside this PR, since it bears on the default question above. Measuring coverage rather than the multiplier, on a jackknife model where both truths are closed form, the multiplier turns out to be the smaller of the two terms that decide whether the band holds its level. At half a replicate per horizon, nominal 0.95: supplying the true multiplier moves coverage from 0.589 to 0.641, while supplying the true standard error moves it to 0.947.

That does not change anything here — the fault this PR fixes is real, `ledoit_wolf` is at least as good as `none` in all fifteen cells measured, and it helps most exactly where the shortfall bites. It does mean the remedy the new warning names addresses the smaller term, which the study will report in full.