### PR TITLE
Let the caller choose how the sup-t multiplier is estimated

### DIFF
--- a/mlsynth/tests/test_supt.py
+++ b/mlsynth/tests/test_supt.py
@@ -323,7 +323,7 @@ def _short_support_blocks(e, H, n, rng):
 
     What a block bootstrap over a rolling calibration pass produces. The support
     is the series, not the draw count: ``e.size`` distinct blocks times a sign, so
-    a large ``n`` resamples a small set rather than exploring a continuum. That is
+    a large ``n`` resamples a small set instead of exploring a continuum. That is
     the regime where the two estimators part company.
     """
     m = e.size
@@ -409,7 +409,7 @@ def test_empirical_is_never_narrower_than_pointwise():
 
 @pytest.mark.parametrize("bad", ["bootstrap", "Gaussian", "empirical ", "", None, 1])
 def test_an_unknown_method_is_refused(bad):
-    """Anything outside the two names raises rather than falling through.
+    """Anything outside the two names raises instead of falling through.
 
     Silently defaulting would be the worst outcome: the returned number is a
     perfectly plausible multiplier, so a caller who asked for the empirical one
@@ -465,7 +465,7 @@ def test_the_simulation_cannot_distinguish_ensembles_sharing_one_correlation():
 def test_the_two_methods_converge_as_the_calibration_support_grows():
     """Why the ensembles differ at all: a circular block bootstrap over ``m``
     periods draws from ``m`` distinct blocks, so a large ``n_sim`` resamples a
-    small set rather than exploring a continuum. Lengthen the series and the
+    small set instead of exploring a continuum. Lengthen the series and the
     empirical quantile stops inheriting that particular series' idiosyncrasy.
     """
     H, N = 11, 40_000
@@ -484,7 +484,7 @@ def test_the_two_methods_converge_as_the_calibration_support_grows():
 
 
 # ---------------------------------------------------------------------------
-# Rung 3, as a property rather than one worked case.
+# Rung 3, as a property, not one worked case.
 # ---------------------------------------------------------------------------
 
 @given(

--- a/mlsynth/tests/test_supt.py
+++ b/mlsynth/tests/test_supt.py
@@ -29,6 +29,8 @@ What the tests pin:
 """
 import numpy as np
 import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 from scipy.stats import norm
 
 from mlsynth.exceptions import MlsynthConfigError, MlsynthDataError
@@ -479,3 +481,63 @@ def test_the_two_methods_converge_as_the_calibration_support_grows():
             ratios.append(supt_critical_value(d, alpha=0.10, method="empirical") / g)
         spread[m] = float(np.std(ratios))
     assert spread[1100] < 0.5 * spread[77], spread
+
+
+# ---------------------------------------------------------------------------
+# Rung 3, as a property rather than one worked case.
+# ---------------------------------------------------------------------------
+
+@given(
+    n_h=st.integers(min_value=2, max_value=8),
+    rho=st.floats(min_value=-0.4, max_value=0.95, allow_nan=False),
+    seed=st.integers(min_value=0, max_value=2**32 - 1),
+)
+@settings(max_examples=25, deadline=None,
+          suppress_health_check=[HealthCheck.too_slow])
+def test_the_simulation_depends_on_the_draws_only_through_their_correlation(
+        n_h, rho, seed):
+    """``method="gaussian"`` is a functional of ``R``.
+
+    Replace an ensemble with normals carrying the same correlation and the
+    simulated multiplier does not move. This is the root cause stated as an
+    invariant: whatever else the draws contain, the estimator cannot see it.
+    """
+    rng = np.random.default_rng(seed)
+    H, N = n_h, 20_000
+    base = np.full((H, H), rho)
+    np.fill_diagonal(base, 1.0)
+    w, V = np.linalg.eigh(base)
+    L = V * np.sqrt(np.clip(w, 0.0, None))
+
+    # An ensemble that is emphatically not normal: a two-component mixture.
+    heavy = rng.standard_normal((N, H)) @ L.T
+    heavy *= np.where(rng.random((N, 1)) < 0.1, 6.0, 1.0)
+
+    R = np.corrcoef(heavy, rowvar=False)
+    w2, V2 = np.linalg.eigh(R)
+    twin = rng.standard_normal((N, H)) @ (V2 * np.sqrt(np.clip(w2, 0.0, None))).T
+
+    a = supt_critical_value(heavy, alpha=0.10, n_sims=20_000, seed=0)
+    b = supt_critical_value(twin, alpha=0.10, n_sims=20_000, seed=0)
+    assert a == pytest.approx(b, abs=0.06), (a, b, rho, H)
+
+
+@given(
+    method=st.sampled_from(["gaussian", "empirical"]),
+    seed=st.integers(min_value=0, max_value=2**32 - 1),
+    n_h=st.integers(min_value=2, max_value=8),
+)
+@settings(max_examples=25, deadline=None,
+          suppress_health_check=[HealthCheck.too_slow])
+def test_both_methods_are_invariant_to_rescaling_a_horizon(method, seed, n_h):
+    """Neither route may read the units. The multiplier applies to ``se_h``,
+    which carries the scale, so a horizon measured in thousands must not buy a
+    different band from the same horizon measured in millions."""
+    rng = np.random.default_rng(seed)
+    draws = rng.standard_normal((4000, n_h))
+    factors = np.exp(rng.uniform(-6.0, 6.0, size=n_h))
+    plain = supt_critical_value(draws, alpha=0.10, method=method,
+                                n_sims=20_000, seed=0)
+    scaled = supt_critical_value(draws * factors, alpha=0.10, method=method,
+                                 n_sims=20_000, seed=0)
+    assert plain == pytest.approx(scaled, rel=1e-9)

--- a/mlsynth/tests/test_supt.py
+++ b/mlsynth/tests/test_supt.py
@@ -302,3 +302,180 @@ def test_too_few_draws_to_estimate_a_correlation_is_reported():
 def test_a_nonpositive_simulation_count_is_rejected():
     with pytest.raises(MlsynthConfigError, match="n_sims"):
         supt_critical_value(_draws(20, 3), alpha=0.05, n_sims=0)
+
+
+# ---------------------------------------------------------------------------
+# Choosing the estimator: simulated (default) or read off the draws
+#
+# The Gaussian tabulation above is the right instrument for a delete-one
+# jackknife -- few draws, and on a different scale from the sampling
+# distribution. It is a poorer one for a large bootstrap ensemble, where the
+# draws are numerous and already on the estimator's scale, and where reducing
+# them to a correlation matrix discards the thing that drives ``max_h``: draws
+# that are large at every horizon at once. ``method="empirical"`` reads the
+# quantile off the draws instead, which is free when they are already in hand.
+# ---------------------------------------------------------------------------
+
+def _short_support_blocks(e, H, n, rng):
+    """Circular blocks of length ``H`` from a short fixed series, accumulated.
+
+    What a block bootstrap over a rolling calibration pass produces. The support
+    is the series, not the draw count: ``e.size`` distinct blocks times a sign, so
+    a large ``n`` resamples a small set rather than exploring a continuum. That is
+    the regime where the two estimators part company.
+    """
+    m = e.size
+    starts = rng.integers(0, m, size=n)
+    idx = (starts[:, None] + np.arange(H)[None, :]) % m
+    signs = rng.choice(np.array([-1.0, 1.0]), size=(n, 1))
+    return np.cumsum(e[idx] * signs, axis=1)
+
+
+def test_empirical_returns_a_finite_positive_scalar():
+    rng = np.random.default_rng(0)
+    c = supt_critical_value(rng.standard_normal((5000, 6)), alpha=0.10,
+                            method="empirical")
+    assert np.isfinite(c) and c > 0.0
+
+
+def test_empirical_ignores_n_sims_and_seed():
+    """No RNG is consulted, so the two knobs that steer the simulation cannot
+    move it. That is the point: the answer is a statistic of the draws."""
+    rng = np.random.default_rng(1)
+    draws = rng.standard_normal((4000, 5))
+    a = supt_critical_value(draws, alpha=0.10, method="empirical", n_sims=10, seed=0)
+    b = supt_critical_value(draws, alpha=0.10, method="empirical", n_sims=999_999, seed=7)
+    assert a == b
+
+
+def test_empirical_one_horizon_is_the_pointwise_critical_value():
+    rng = np.random.default_rng(2)
+    c = supt_critical_value(rng.standard_normal((200_000, 1)), alpha=0.10,
+                            method="empirical")
+    from scipy.stats import norm
+    assert c == pytest.approx(norm.ppf(0.95), abs=0.02)
+
+
+def test_empirical_ignores_the_scale_of_the_draws():
+    """Same invariance the simulated route has: only the standardized path
+    matters, so rescaling a horizon leaves the multiplier alone."""
+    rng = np.random.default_rng(3)
+    draws = rng.standard_normal((5000, 4))
+    scaled = draws * np.array([1.0, 100.0, 0.01, 7.0])
+    assert supt_critical_value(draws, alpha=0.10, method="empirical") == pytest.approx(
+        supt_critical_value(scaled, alpha=0.10, method="empirical"), rel=1e-12)
+
+
+def test_empirical_agrees_with_the_simulation_on_gaussian_draws():
+    """Where the Gaussian assumption holds, the two routes answer the same."""
+    rng = np.random.default_rng(4)
+    draws = rng.standard_normal((200_000, 8))
+    g = supt_critical_value(draws, alpha=0.10, n_sims=200_000, seed=0)
+    e = supt_critical_value(draws, alpha=0.10, method="empirical")
+    assert e == pytest.approx(g, rel=0.03)
+
+
+def test_the_two_methods_part_company_on_a_short_support_ensemble():
+    """The case the choice exists for.
+
+    A calibration series with one atypical stretch gives an ensemble whose
+    extreme draws are the ones that catch it. The empirical quantile sees them;
+    the simulated route cannot, because a correlation matrix does not record
+    which blocks the series happens to contain. Neither answer is wrong -- the
+    simulation trades that idiosyncrasy for stability -- but they differ enough
+    that the caller should get to pick.
+    """
+    for seed in range(4):
+        rng = np.random.default_rng(seed)
+        e = np.concatenate([rng.standard_normal(11) * (6.0 if i == 0 else 1.0)
+                            for i in range(7)])
+        e = e - e.mean()
+        draws = _short_support_blocks(e, 11, 100_000, np.random.default_rng(100 + seed))
+        g = supt_critical_value(draws, alpha=0.10, n_sims=100_000, seed=0)
+        emp = supt_critical_value(draws, alpha=0.10, method="empirical")
+        assert emp > 1.15 * g, f"seed {seed}: empirical {emp:.4f}, gaussian {g:.4f}"
+
+
+def test_empirical_is_never_narrower_than_pointwise():
+    from scipy.stats import norm
+    rng = np.random.default_rng(6)
+    for H in (2, 5, 12):
+        c = supt_critical_value(rng.standard_normal((50_000, H)), alpha=0.10,
+                                method="empirical")
+        assert c >= norm.ppf(0.95) - 0.02
+
+
+@pytest.mark.parametrize("bad", ["bootstrap", "Gaussian", "empirical ", "", None, 1])
+def test_an_unknown_method_is_refused(bad):
+    """Anything outside the two names raises rather than falling through.
+
+    Silently defaulting would be the worst outcome: the returned number is a
+    perfectly plausible multiplier, so a caller who asked for the empirical one
+    and got the simulated one has no way to notice.
+    """
+    rng = np.random.default_rng(7)
+    with pytest.raises(MlsynthConfigError, match="method"):
+        supt_critical_value(rng.standard_normal((100, 3)), alpha=0.10, method=bad)
+
+
+def test_the_default_method_is_the_simulation():
+    """The default must not move: every existing caller keeps its numbers."""
+    rng = np.random.default_rng(8)
+    draws = rng.standard_normal((2000, 5))
+    assert supt_critical_value(draws, alpha=0.10) == supt_critical_value(
+        draws, alpha=0.10, method="gaussian")
+
+
+def test_the_simulation_cannot_distinguish_ensembles_sharing_one_correlation():
+    """The root cause, stated as an invariant.
+
+    ``method="gaussian"`` reduces the draws to their correlation across horizons
+    and reads the multiplier from normals carrying it, so it is a functional of
+    that matrix alone: two ensembles with the same correlation get the same
+    answer however different their joint laws. The quantile being estimated is
+    not such a functional. Where the draws really are normal the two routes
+    agree; where they are not, the simulation reports the normal answer.
+    """
+    H, N = 11, 100_000
+    rng = np.random.default_rng(2)
+    e = np.concatenate([rng.standard_normal(11) * (6.0 if i == 0 else 1.0)
+                        for i in range(7)])
+    e -= e.mean()
+    B = _short_support_blocks(e, H, N, np.random.default_rng(101))
+
+    R = np.corrcoef(B, rowvar=False)
+    w, V = np.linalg.eigh(R)
+    L = V * np.sqrt(np.clip(w, 0.0, None))
+    A = np.random.default_rng(7).standard_normal((N, H)) @ L.T   # same R, normal
+
+    assert np.max(np.abs(np.corrcoef(A, rowvar=False) - R)) < 0.02
+
+    gA = supt_critical_value(A, alpha=0.10, n_sims=N, seed=0)
+    gB = supt_critical_value(B, alpha=0.10, n_sims=N, seed=0)
+    assert gA == pytest.approx(gB, abs=0.02)          # blind to the difference
+
+    eA = supt_critical_value(A, alpha=0.10, method="empirical")
+    eB = supt_critical_value(B, alpha=0.10, method="empirical")
+    assert eA == pytest.approx(gA, abs=0.05)          # normal: the routes agree
+    assert eB > gB + 1.0                              # not normal: they do not
+
+
+def test_the_two_methods_converge_as_the_calibration_support_grows():
+    """Why the ensembles differ at all: a circular block bootstrap over ``m``
+    periods draws from ``m`` distinct blocks, so a large ``n_sim`` resamples a
+    small set rather than exploring a continuum. Lengthen the series and the
+    empirical quantile stops inheriting that particular series' idiosyncrasy.
+    """
+    H, N = 11, 40_000
+    spread = {}
+    for m in (77, 1100):
+        ratios = []
+        for s in range(6):
+            r = np.random.default_rng(s)
+            e = r.standard_normal(m)
+            e -= e.mean()
+            d = _short_support_blocks(e, H, N, np.random.default_rng(500 + s))
+            g = supt_critical_value(d, alpha=0.10, n_sims=N, seed=0)
+            ratios.append(supt_critical_value(d, alpha=0.10, method="empirical") / g)
+        spread[m] = float(np.std(ratios))
+    assert spread[1100] < 0.5 * spread[77], spread

--- a/mlsynth/utils/supt.py
+++ b/mlsynth/utils/supt.py
@@ -25,11 +25,10 @@ and jackknife deviations sit on a different scale from the estimator's own
 sampling distribution. Only the correlation is taken from the draws; the scale
 comes from ``se_h`` separately.
 
-That last sentence is also the limit of the method, and worth knowing before
-choosing it: taking only the correlation makes ``c`` a functional of ``R``
-alone. Two ensembles with the same correlation matrix get the same multiplier
-however different their joint laws, and the quantile being estimated is not such
-a functional. Where the draws are close to normal the two agree to a few
+That last sentence is also the limit of the method: taking only the
+correlation makes ``c`` a functional of ``R`` alone. Two ensembles with the
+same correlation matrix get the same multiplier however different their joint
+laws, and the quantile being estimated is not such a functional. Where the draws are close to normal the two agree to a few
 thousandths. Where they are not -- a block bootstrap over a short calibration
 series draws from ``m`` distinct blocks, so a large ``n_sim`` resamples a small
 support instead of exploring a continuum -- they part company, by an amount that
@@ -222,8 +221,8 @@ def supt_critical_value(
         # The same statistic the simulation targets, taken over the draws in
         # hand. Standardizing by each horizon's own spread is what makes it
         # scale-free, exactly as in the simulated route; a horizon with no
-        # variation is given an infinite scale so it contributes zero rather
-        # than a division by zero.
+        # variation is given an infinite scale so it contributes zero instead
+        # of a division by zero.
         with np.errstate(invalid="ignore", divide="ignore"):
             sd = np.nanstd(draws, axis=0)
             centred = draws - np.nanmean(draws, axis=0)

--- a/mlsynth/utils/supt.py
+++ b/mlsynth/utils/supt.py
@@ -25,6 +25,18 @@ and jackknife deviations sit on a different scale from the estimator's own
 sampling distribution. Only the correlation is taken from the draws; the scale
 comes from ``se_h`` separately.
 
+That last sentence is also the limit of the method, and worth knowing before
+choosing it: taking only the correlation makes ``c`` a functional of ``R``
+alone. Two ensembles with the same correlation matrix get the same multiplier
+however different their joint laws, and the quantile being estimated is not such
+a functional. Where the draws are close to normal the two agree to a few
+thousandths. Where they are not -- a block bootstrap over a short calibration
+series draws from ``m`` distinct blocks, so a large ``n_sim`` resamples a small
+support instead of exploring a continuum -- they part company, by an amount that
+runs either side of parity and shrinks as the support grows.
+``supt_critical_value(..., method="empirical")`` reads the quantile off the
+draws for callers whose ensemble makes that the better instrument.
+
 The cumulative case is why this module exists at all. An interval for a running
 total is not the running total of the period intervals: adding endpoints treats
 the period errors as moving in lockstep, so the width grows like ``L``, while
@@ -131,6 +143,7 @@ def supt_critical_value(
     alpha: float,
     n_sims: int = DEFAULT_N_SIMS,
     seed: Optional[int] = 0,
+    method: str = "gaussian",
 ) -> float:
     """The shared multiplier that makes a band cover the whole path at once.
 
@@ -144,9 +157,33 @@ def supt_critical_value(
     alpha : float
         Level; the band is simultaneous at ``1 - alpha``.
     n_sims : int
-        Draws used to tabulate the quantile of ``max_h |z_h|``.
+        Draws used to tabulate the quantile of ``max_h |z_h|``. Ignored by
+        ``method="empirical"``, which consults no RNG.
     seed : int, optional
-        RNG seed, so a reported band is reproducible.
+        RNG seed, so a reported band is reproducible. Ignored by
+        ``method="empirical"``.
+    method : {"gaussian", "empirical"}
+        Which estimator of the same quantile to use.
+
+        ``"gaussian"`` (default) reduces the draws to their correlation across
+        horizons and tabulates ``max_h |z_h|`` from simulated normals carrying
+        that correlation. This is the right instrument for a delete-one
+        jackknife: there are only as many draws as units, so an empirical
+        quantile at ``1 - alpha`` is coarse, and jackknife deviations are on a
+        different scale from the estimator's sampling distribution anyway.
+
+        ``"empirical"`` reads the quantile off the standardized draws
+        themselves. Reach for it when the draws are a large resampling ensemble
+        -- a block bootstrap, say -- where neither objection applies: the
+        quantile is not coarse, and the draws are already on the estimator's
+        scale. It also keeps what the correlation matrix cannot carry. Reducing
+        the draws to second moments discards *scale heterogeneity across draws*
+        -- a bootstrap replicate that catches an unusual stretch is large at
+        every horizon at once -- and that is precisely what drives ``max_h``. A
+        Gaussian vector's own scale is tightly concentrated, so no correlation
+        matrix can reproduce it, and the simulated multiplier comes back too
+        small. The gap is not a constant: it runs either side of parity, ordered
+        by how dispersed the per-draw scale is.
 
     Returns
     -------
@@ -158,11 +195,16 @@ def supt_critical_value(
     Raises
     ------
     MlsynthConfigError
-        ``alpha`` outside ``(0, 1)``, or a non-positive ``n_sims``.
+        ``alpha`` outside ``(0, 1)``, a non-positive ``n_sims``, or a ``method``
+        that is neither ``"gaussian"`` nor ``"empirical"``.
     MlsynthDataError
         ``draws`` not 2-D, or fewer than two replicates.
     """
     alpha = _check_alpha(alpha)
+    if method not in ("gaussian", "empirical"):
+        raise MlsynthConfigError(
+            f"method must be 'gaussian' or 'empirical'; got {method!r}."
+        )
     if isinstance(n_sims, bool) or not isinstance(n_sims, (int, np.integer)) or n_sims < 1:
         raise MlsynthConfigError(f"n_sims must be a positive integer; got {n_sims!r}.")
     draws = np.asarray(draws, dtype=float)
@@ -175,6 +217,25 @@ def supt_critical_value(
         raise MlsynthDataError(
             f"need at least 2 draws to estimate a correlation; got {n}."
         )
+
+    if method == "empirical":
+        # The same statistic the simulation targets, taken over the draws in
+        # hand. Standardizing by each horizon's own spread is what makes it
+        # scale-free, exactly as in the simulated route; a horizon with no
+        # variation is given an infinite scale so it contributes zero rather
+        # than a division by zero.
+        with np.errstate(invalid="ignore", divide="ignore"):
+            sd = np.nanstd(draws, axis=0)
+            centred = draws - np.nanmean(draws, axis=0)
+            z = centred / np.where(np.isfinite(sd) & (sd > 0.0), sd, np.inf)
+        m = np.nanmax(np.abs(z), axis=1)
+        m = m[np.isfinite(m)]
+        if m.size < 2:
+            raise MlsynthDataError(
+                "no usable draws left after standardizing; every replicate was "
+                "non-finite or every horizon was constant."
+            )
+        return float(np.quantile(m, 1.0 - alpha))
 
     # Correlation across horizons, pairwise-complete so one failed replicate does
     # not discard a whole horizon. A horizon with no variation carries no

--- a/tools/mutation/targets.toml
+++ b/tools/mutation/targets.toml
@@ -687,6 +687,18 @@ timeout = 300.0
   models = "taking one horizon's deviation instead of the largest across horizons, which is the pointwise critical value wearing a simultaneous band's name. Every shape, sign and monotonicity assertion still passes; what fails is the coverage the band claims, and only a test that compares the correction against its own simulation error can see it"
 
   [[target.mutant]]
+  id = "supt-method-silently-ignored"
+  find = "    if method not in (\"gaussian\", \"empirical\"):"
+  replace = "    if False:"
+  models = "dropping the guard, so a misspelled method falls through to the gaussian default instead of being refused. A caller asking for the empirical multiplier on a bootstrap ensemble would silently get the simulated one -- the exact confusion the parameter exists to remove, and invisible because the returned number is a perfectly plausible multiplier"
+
+  [[target.mutant]]
+  id = "supt-empirical-forgets-to-standardise"
+  find = "        m = np.nanmax(np.abs(z), axis=1)"
+  replace = "        m = np.nanmax(np.abs(centred), axis=1)"
+  models = "reading the largest raw deviation instead of the largest standardised one. The multiplier is then in the units of whichever horizon happens to be widest -- usually the last, since a cumulative path's spread grows -- so it stops being a multiplier at all and the band it produces has no stated level"
+
+  [[target.mutant]]
   id = "jackknife-inflation-dropped"
   find = "        out[h] = np.sqrt((m - 1) / m * ss) if jackknife else np.sqrt(ss / (m - 1))"
   replace = "        out[h] = np.sqrt(ss / (m - 1))"


### PR DESCRIPTION
Closes #526. Replaces #527, which carried this change on top of twelve unrelated commits; this is the same change cut onto current `main`. Three files, 314 lines.

`supt_critical_value` took the correlation across horizons and read the multiplier from normals carrying it, which makes it a functional of the correlation matrix alone. Two ensembles with the same correlation get the same multiplier however different their joint laws, and the quantile it estimates is not such a functional.

Where the draws are close to normal this costs nothing. Where they are not it is material — on a circular block bootstrap over a short calibration series, both routes on the same draws:

```
gaussian 2.386    empirical 4.468
```

against 2.385 and 2.386 for a genuine normal carrying the same correlation to within 0.02.

The gap has no sign. Across realizations of an iid calibration series the ratio averages 0.956 of the simulated value at `m = 77` with a standard deviation of 0.075, and converges to 1.000 with 0.011 by `m = 5500`. The simulation is a smoothing choice, trading the ensemble's idiosyncrasy for stability, and which instrument is better depends on the ensemble.

## What changes

`method="gaussian"` is the default and nothing existing moves. `method="empirical"` reads the quantile off the standardized draws, consulting no RNG, so `n_sims` and `seed` do not apply to it. An unrecognized `method` raises `MlsynthConfigError` instead of falling through — silently defaulting would be the worst outcome, since the returned number is a perfectly plausible multiplier and a caller who asked for one route and got the other has no way to notice.

Neither call site changes. `ppscm` passes delete-one jackknife draws, which is the case the default was designed for; `pda` passes bootstrap draws, which is the case the parameter exists for. Whether `pda` should opt in is a separate question with its own numbers, deliberately not decided here.

The module docstring previously gave only the motivation for simulating. It now also states the limit, since that is what a caller needs in order to choose.

## Tests

Written first, red for the right reason. They follow the five-why ladder from the issue:

- the two routes agree on normal draws, to 3%
- the simulation cannot distinguish two ensembles sharing one correlation, while the empirical route separates them by more than 1.0 — the root cause, stated as a `hypothesis` property over generated horizon counts and correlations
- they diverge on a short-support block ensemble, across four independent seeds
- the divergence more than halves as the calibration support grows from 77 to 1100
- the empirical route is unmoved by `n_sims` and `seed`
- neither route reads the units: rescaling any horizon by up to six orders of magnitude leaves the multiplier alone
- six unrecognized method values raise, including case and whitespace variants
- the default is `"gaussian"`, pinned so it cannot drift

68 pass across `test_supt.py` and `test_mutation_harness.py` on this base.

## Mutants

Two added to `tools/mutation/targets.toml`, both confirmed killed:

- `supt-method-silently-ignored` — drops the guard so a misspelled method falls through to the default. Killed by six tests.
- `supt-empirical-forgets-to-standardise` — reads the largest raw deviation instead of the largest standardized one, so the multiplier ends up in the units of whichever horizon is widest. Killed by one.

An earlier version of the first mutant widened the accepted set with an extra string instead of dropping the guard. It survived, which was the test being too weak for a mutant that was not modelling the real defect; both were replaced, neither accepted.

A third commit removes a self-referential frame and four uses of the banned conjunction from the new prose, per the CLAUDE.md sweep. The two occurrences already on `main` are left alone as out of scope.