### PR TITLE
Let the benchmark selection narrow, so a pull request stops running the MIPs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -268,6 +268,13 @@ jobs:
               - 'basedata/**'
               - 'requirements.txt'
               - 'pyproject.toml'
+            # The subset the diff creates. A file that did not exist cannot have
+            # been executed by a pre-existing case, so its absence from the map
+            # is not a hole -- and without this the selection widened to the
+            # whole registry on every pull request that added a file, which an
+            # estimator always does.
+            created:
+              - added: '**'
 
       # The filter above decides whether the shards run at all; this decides
       # which cases they run. case_deps widens on any doubt -- an unmapped case
@@ -278,22 +285,26 @@ jobs:
         if: steps.filter.outputs.benchmarked == 'true'
         env:
           CHANGED_JSON: ${{ steps.filter.outputs.all_files }}
+          ADDED_JSON: ${{ steps.filter.outputs.created_files }}
         run: |
           python - <<'EOF'
           import json, os
           files = json.loads(os.environ["CHANGED_JSON"] or "[]")
+          added = set(json.loads(os.environ["ADDED_JSON"] or "[]"))
           with open("/tmp/changed.txt", "w") as fh:
               fh.write("\n".join(files) + ("\n" if files else ""))
-          print(f"{len(files)} changed file(s)")
+          with open("/tmp/added.txt", "w") as fh:
+              fh.write("\n".join(sorted(added)) + ("\n" if added else ""))
+          print(f"{len(files)} changed file(s), {len(added)} of them new")
           for f in files:
-              print(" ", f)
+              print("  +" if f in added else "   ", f)
           EOF
 
       - name: Run benchmark suite shard
         if: steps.filter.outputs.benchmarked == 'true'
         run: |
           python -u benchmarks/run_benchmarks.py --all --report \
-            --changed-from /tmp/changed.txt \
+            --changed-from /tmp/changed.txt --added-from /tmp/added.txt \
             --shard "${{ matrix.shard }}" --num-shards "${NUM_SHARDS}"
 
       - name: Upload benchmark report
@@ -395,8 +406,8 @@ jobs:
   # ---------------------------------------------------------------------------
 
   case-deps:
-    # Never on a pull request: this job commits the refreshed dependency map back
-    # to the default branch, and measuring it means running every case.
+    # Never on a pull request: measuring the map means running every case, and
+    # the combine job downstream commits the result to the default branch.
     #
     # The map is what lets a pull request run only the cases its diff can reach.
     # It is measured, not written, because the cheaper routes fail here:
@@ -406,15 +417,29 @@ jobs:
     # case under coverage with the package already imported, which separates
     # executing a module from loading one.
     #
-    # --merge keeps entries this run did not produce. A case that skips here for
-    # a missing optional toolchain loses its entry and goes back to always
-    # running, which is the safe direction.
+    # SHARDED, because as one job it never finished. At 199 cases it reached its
+    # 350-minute cap on 23, 24, 25 and 26 August and was cancelled every time --
+    # the 26th ran 07:36 to 13:26 -- so the map stayed at the five entries that
+    # shipped with it and every pull request touching the library ran the whole
+    # registry, MIP and Monte Carlo cases included. The slice is round-robin, the
+    # same one run_benchmarks.py takes, because cost is not uniform across the
+    # registry. To change the shard count, edit BOTH the matrix and NUM_SHARDS.
+    #
+    # Each shard writes only what it measured and uploads it. Merging onto the
+    # shipped map and committing is the combine job's, once: four shards each
+    # rebasing and pushing the same file race, and the loser's slice disappears
+    # with no failure anywhere.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 350
     permissions:
-      contents: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     env:
+      NUM_SHARDS: "4"
       OMP_NUM_THREADS: "1"
       OPENBLAS_NUM_THREADS: "1"
       MKL_NUM_THREADS: "1"
@@ -436,7 +461,62 @@ jobs:
           pip install -e ".[design,bayes]" coverage
 
       - name: Measure what each case executes
-        run: python -u tools/benchmark_deps.py --all --merge
+        run: |
+          python -u tools/benchmark_deps.py --all \
+            --shard "${{ matrix.shard }}" --num-shards "${NUM_SHARDS}" \
+            --out "case_deps.shard-${{ matrix.shard }}.json"
+
+      - name: Upload this shard's slice
+        uses: actions/upload-artifact@v4
+        with:
+          name: case-deps-slice-${{ matrix.shard }}
+          path: case_deps.shard-${{ matrix.shard }}.json
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------------
+  # Merge the slices and commit the map, once.
+  #
+  # always() so a shard that died costs its own slice and not the other three:
+  # --combine leaves a case no slice measured on its existing entry, and a case
+  # that loses its entry goes back to always running, which is the safe
+  # direction. A cancelled shard therefore delays part of the map by a day
+  # instead of discarding the rest of it.
+  # ---------------------------------------------------------------------------
+  case-deps-commit:
+    if: always() && github.event_name != 'pull_request'
+    needs: case-deps
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Download every slice that was produced
+        uses: actions/download-artifact@v4
+        with:
+          pattern: case-deps-slice-*
+          path: slices
+          merge-multiple: true
+
+      - name: Merge the slices onto the shipped map
+        run: |
+          shopt -s nullglob
+          SLICES=(slices/case_deps.shard-*.json)
+          if [ ${#SLICES[@]} -eq 0 ]; then
+            echo "No slice was produced; leaving the map as it stands."
+            exit 0
+          fi
+          echo "Merging ${#SLICES[@]} slice(s)."
+          python -u tools/benchmark_deps.py --combine "${SLICES[@]}"
 
       - name: Commit the map if it changed
         run: |

--- a/benchmarks/case_deps.py
+++ b/benchmarks/case_deps.py
@@ -39,11 +39,14 @@ registry and the rule never narrowed anything.
 
 The registry loads only ``benchmarks.cases``, so no case's ``run()`` executes a
 test module -- :data:`NEVER_REACHABLE`. A file the diff creates did not exist
-when any pre-existing case ran -- the ``added`` argument. And ``__init__.py``
+when any pre-existing case ran -- the ``added`` argument. ``__init__.py``
 executes at import, before measurement starts, which is the separation that
 stops a case from measuring all 834 library files -- :data:`RE_EXPORT_ONLY`,
 whose one member is checked against the file itself in the tests, since the
-claim holds only while that file is imports and an ``__all__``.
+claim holds only while that file is imports and an ``__all__``. And a README is
+prose, which the rule already answers for by directory: ``docs/ppscm.rst`` is
+outside :data:`REACHABLE` and so reaches nothing. :data:`PROSE_SUFFIXES` says
+the same thing by kind, for the prose that sits under a reachable prefix.
 
 An estimator pull request trips all three at once: new helper modules, new test
 modules, and one export line.
@@ -62,6 +65,11 @@ REACHABLE = ("mlsynth/", "basedata/", "benchmarks/")
 #: registry loads only ``benchmarks.cases``, so no case's ``run()`` executes a
 #: test module; the references to test files in case docstrings are prose.
 NEVER_REACHABLE = ("mlsynth/tests/", "benchmarks/tests/")
+
+#: Suffixes that are prose. A change outside :data:`REACHABLE` already reaches no
+#: case -- that is how ``docs/ppscm.rst`` is neither a selection nor a hole. A
+#: README one directory over is the same prose, so it gets the same answer.
+PROSE_SUFFIXES = (".md", ".rst")
 
 #: Modules that re-export and do nothing else. These execute at import, before
 #: measurement starts, so coverage never attributes them to a case -- and a file
@@ -104,6 +112,8 @@ def _is_hole(path: str, known: set, created: set) -> bool:
     if not path.startswith(REACHABLE):
         return False
     if path.startswith(NEVER_REACHABLE) or path in RE_EXPORT_ONLY:
+        return False
+    if path.endswith(PROSE_SUFFIXES):
         return False
     if path in created:
         return False

--- a/benchmarks/case_deps.py
+++ b/benchmarks/case_deps.py
@@ -29,6 +29,24 @@ selects every case. Both directions spend time; neither can silence a case. That
 asymmetry is the point: a skipped check reports success, and a skipped success is
 indistinguishable from a real one, so the map is allowed to cost time and is not
 allowed to hide anything.
+
+Three paths the map can never claim
+-----------------------------------
+Widening on an unclaimed file is right when the map might have claimed it and
+did not. Three kinds of path cannot be claimed however often the map is
+refreshed, so treating them as holes widened every selection to the whole
+registry and the rule never narrowed anything.
+
+The registry loads only ``benchmarks.cases``, so no case's ``run()`` executes a
+test module -- :data:`NEVER_REACHABLE`. A file the diff creates did not exist
+when any pre-existing case ran -- the ``added`` argument. And ``__init__.py``
+executes at import, before measurement starts, which is the separation that
+stops a case from measuring all 834 library files -- :data:`RE_EXPORT_ONLY`,
+whose one member is checked against the file itself in the tests, since the
+claim holds only while that file is imports and an ``__all__``.
+
+An estimator pull request trips all three at once: new helper modules, new test
+modules, and one export line.
 """
 from __future__ import annotations
 
@@ -39,6 +57,18 @@ from typing import Dict, Iterable, List, Mapping, Sequence
 #: Prefixes a case can execute. A change outside all of them reaches no case, so
 #: it is neither a selection nor a hole in the map -- docs and prose land here.
 REACHABLE = ("mlsynth/", "basedata/", "benchmarks/")
+
+#: Prefixes under :data:`REACHABLE` that no measurement can ever claim. The
+#: registry loads only ``benchmarks.cases``, so no case's ``run()`` executes a
+#: test module; the references to test files in case docstrings are prose.
+NEVER_REACHABLE = ("mlsynth/tests/", "benchmarks/tests/")
+
+#: Modules that re-export and do nothing else. These execute at import, before
+#: measurement starts, so coverage never attributes them to a case -- and a file
+#: of imports and an ``__all__`` can add or remove a name but cannot change what
+#: any estimator computes. The claim is checked against the file itself in
+#: ``benchmarks/tests/test_case_deps.py``; break it and the entry comes out.
+RE_EXPORT_ONLY = ("mlsynth/__init__.py",)
 
 PATH = Path(__file__).resolve().parent / "case_deps.json"
 
@@ -63,10 +93,29 @@ def _case_source(name: str) -> str:
     return f"benchmarks/cases/{name}.py"
 
 
+def _is_hole(path: str, known: set, created: set) -> bool:
+    """Whether ``path`` is a dependency the map failed to record.
+
+    A hole widens the selection to the whole registry, so the question is not
+    "did the map claim this?" but "could it have?". Three kinds of path answer
+    no by construction and are not holes; everything else under
+    :data:`REACHABLE` that no entry names is.
+    """
+    if not path.startswith(REACHABLE):
+        return False
+    if path.startswith(NEVER_REACHABLE) or path in RE_EXPORT_ONLY:
+        return False
+    if path in created:
+        return False
+    return path not in known
+
+
 def select(
     changed: Sequence[str],
     cases: Sequence[str],
     manifest: Mapping[str, Sequence[str]] | None = None,
+    *,
+    added: Sequence[str] = (),
 ) -> List[str]:
     """The cases a diff can reach, in the order ``cases`` gives them.
 
@@ -78,6 +127,11 @@ def select(
         Candidate case names, already filtered for references and sharding.
     manifest : mapping, optional
         Case to executed files. Defaults to the shipped manifest.
+    added : sequence of str, optional
+        The subset of ``changed`` the diff creates. A file that did not exist
+        cannot have been executed by a pre-existing case, so its absence from
+        the map is not a hole. It still selects on a positive match, which is
+        what runs a newly added case.
 
     Returns
     -------
@@ -93,13 +147,19 @@ def select(
             f"{type(changed).__name__}. A single path must be wrapped in a list, "
             f"since a bare string would iterate character by character."
         )
+    if isinstance(added, (str, bytes)) or not isinstance(added, Sequence):
+        raise TypeError(
+            f"added must be a sequence of repository-relative paths, not "
+            f"{type(added).__name__}. It names the subset of `changed` the diff "
+            f"creates; pass () when the diff adds nothing."
+        )
     m = load() if manifest is None else manifest
     changed = [str(c) for c in changed]
+    created = {str(a) for a in added}
 
     known = {p for deps in m.values() for p in deps}
     known.update(_case_source(name) for name in m)
-    unmapped_change = [c for c in changed
-                       if c.startswith(REACHABLE) and c not in known]
+    unmapped_change = [c for c in changed if _is_hole(c, known, created)]
     if unmapped_change:
         return list(cases)
 

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -164,7 +164,8 @@ def _read_changed(path) -> list:
     return [ln.strip() for ln in text.splitlines() if ln.strip()]
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
+    """The command line, built apart from ``main`` so the tests can read it."""
     ap = argparse.ArgumentParser()
     ap.add_argument("--all", action="store_true")
     ap.add_argument("--case", default=None)
@@ -178,13 +179,30 @@ def main() -> int:
     ap.add_argument("--changed-from", default=None, metavar="FILE",
                     help="a file of repository-relative changed paths, one per "
                          "line; run only the cases that diff can reach")
+    ap.add_argument("--added-from", default=None, metavar="FILE",
+                    help="a file of repository-relative paths the diff creates, "
+                         "one per line; a subset of --changed-from. A file that "
+                         "did not exist cannot have been executed by an existing "
+                         "case, so its absence from the map is not a hole")
     ap.add_argument("--shard", type=int, default=0,
                     help="0-based index of the shard to run (with --num-shards)")
-    args = ap.parse_args()
+    return ap
+
+
+def _check_args(ap: argparse.ArgumentParser, args) -> None:
+    """Reject a command line that cannot mean what it says."""
     if args.num_shards < 1:
         ap.error("--num-shards must be >= 1")
     if not (0 <= args.shard < args.num_shards):
         ap.error("--shard must be in [0, num_shards)")
+    if args.added_from is not None and args.changed_from is None:
+        ap.error("--added-from names a subset of --changed-from; give both")
+
+
+def main() -> int:
+    ap = build_parser()
+    args = ap.parse_args()
+    _check_args(ap, args)
 
     base = [args.case] if args.case else list(registry.CASES)
     if args.changed_from is not None:
@@ -195,9 +213,10 @@ def main() -> int:
         from benchmarks import case_deps
 
         changed = _read_changed(args.changed_from)
-        picked = case_deps.select(changed, base)
-        print(f"changed files: {len(changed)}; cases selected: "
-              f"{len(picked)}/{len(base)}")
+        added = _read_changed(args.added_from) if args.added_from else []
+        picked = case_deps.select(changed, base, added=added)
+        print(f"changed files: {len(changed)} ({len(added)} added); "
+              f"cases selected: {len(picked)}/{len(base)}")
         base = picked
     names = select_cases(
         base, registry.NEEDS_REFERENCE, with_reference=args.with_reference,

--- a/benchmarks/tests/test_case_deps.py
+++ b/benchmarks/tests/test_case_deps.py
@@ -188,3 +188,256 @@ class TestTheDriverAcceptsADiff:
         m = {"a": ["mlsynth/x.py"], "b": ["mlsynth/y.py"], "c": ["mlsynth/x.py"]}
         picked = case_deps.select(["mlsynth/x.py"], ["a", "b", "c"], m)
         assert picked == ["a", "c"]
+
+
+# ------------------------------------------------- holes the map can never fill
+class TestPathsNoManifestCanEverClaim:
+    """Three kinds of path are unclaimable by construction, so treating them as
+    holes in the map is a permanent false positive.
+
+    The widen-on-doubt rule is right when doubt is real: an unrecognised
+    dependency might be one the map has not measured yet. These three cannot be.
+    The registry loads only ``benchmarks.cases``, so no case executes a test
+    module. A file added by the diff did not exist when any pre-existing case
+    ran, so no case can have executed it. And ``mlsynth/__init__.py`` runs at
+    import, before measurement starts, which is the separation that keeps a case
+    from measuring all 834 library files -- so it is invisible to coverage no
+    matter how many times the map is refreshed.
+
+    Each therefore widened the selection to the whole registry on every run, and
+    an estimator pull request tripped all three at once.
+    """
+
+    MAP = {"a": ["mlsynth/x.py"], "b": ["mlsynth/y.py"]}
+
+    @pytest.mark.parametrize("path", [
+        "mlsynth/tests/test_fdid.py",
+        "benchmarks/tests/test_case_deps.py",
+    ])
+    def test_a_test_module_is_not_a_hole(self, path):
+        assert case_deps.select([path], ["a", "b"], self.MAP) == []
+
+    def test_the_package_init_is_not_a_hole(self):
+        assert case_deps.select(["mlsynth/__init__.py"], ["a", "b"], self.MAP) == []
+
+    def test_an_added_file_is_not_a_hole(self):
+        """It did not exist when any pre-existing case ran."""
+        picked = case_deps.select(["mlsynth/new.py"], ["a", "b"], self.MAP,
+                                  added=["mlsynth/new.py"])
+        assert picked == []
+
+    def test_a_modified_file_the_map_does_not_claim_still_widens(self):
+        """The rule narrows only where doubt is impossible, never where it is
+        merely unlikely."""
+        assert case_deps.select(["mlsynth/new.py"], ["a", "b"], self.MAP) == ["a", "b"]
+
+    def test_one_modified_hole_widens_past_any_number_of_added_files(self):
+        changed = ["mlsynth/added_one.py", "mlsynth/added_two.py", "mlsynth/edited.py"]
+        picked = case_deps.select(changed, ["a", "b"], self.MAP,
+                                  added=changed[:2])
+        assert picked == ["a", "b"]
+
+    def test_an_added_case_module_still_selects_its_own_case(self):
+        """Unclaimable is not unselectable: the case's own file always runs it."""
+        picked = case_deps.select(["benchmarks/cases/a.py"], ["a", "b"], self.MAP,
+                                  added=["benchmarks/cases/a.py"])
+        assert "a" in picked
+
+    def test_an_added_file_a_manifest_entry_names_still_selects_its_case(self):
+        """`added` suppresses the hole test, never a positive match."""
+        picked = case_deps.select(["mlsynth/x.py"], ["a", "b"], self.MAP,
+                                  added=["mlsynth/x.py"])
+        assert picked == ["a"]
+
+    def test_an_estimator_shaped_diff_selects_no_mapped_case(self):
+        """The shape this rule exists for: a new estimator package, its tests,
+        its export line, and a parametrize entry in a shared test."""
+        changed = [
+            "mlsynth/estimators/mosc.py",
+            "mlsynth/utils/mosc_helpers/pipeline.py",
+            "mlsynth/tests/test_mosc.py",
+            "mlsynth/tests/test_result_contract.py",
+            "mlsynth/__init__.py",
+            "docs/mosc.rst",
+        ]
+        added = changed[:3]
+        assert case_deps.select(changed, ["a", "b"], self.MAP, added=added) == []
+
+
+# ---------------------------------------------------------------------- failure
+@pytest.mark.parametrize("bad", [None, "mlsynth/x.py", 3])
+def test_added_must_be_a_sequence_of_paths(bad):
+    with pytest.raises((TypeError, ValueError)):
+        case_deps.select(["mlsynth/x.py"], ["a"], {"a": []}, added=bad)
+
+
+def test_the_shipped_manifest_names_nothing_unclaimable():
+    """A measured entry naming one of these would mean the measurement is wrong."""
+    manifest = case_deps.load()
+    stray = {p for deps in manifest.values() for p in deps
+             if p.startswith(case_deps.NEVER_REACHABLE)
+             or p in case_deps.RE_EXPORT_ONLY}
+    assert not stray, stray
+
+
+def test_the_package_init_really_is_re_export_only():
+    """`RE_EXPORT_ONLY` is a claim about the file, so check the file.
+
+    A change to a module of imports and an ``__all__`` can add or remove a name;
+    it cannot alter what any estimator computes. Put a statement with behaviour
+    in here and that stops being true, so this fails and the entry comes out.
+    """
+    import ast
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    for rel in case_deps.RE_EXPORT_ONLY:
+        tree = ast.parse((root / rel).read_text())
+        for node in tree.body:
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                continue
+            if isinstance(node, ast.Try):      # the __version__ lookup
+                continue
+            assert isinstance(node, ast.Assign), (rel, ast.dump(node)[:80])
+            targets = {t.id for t in node.targets if isinstance(t, ast.Name)}
+            assert targets <= {"__all__", "__version__"}, (rel, targets)
+
+
+class TestTheDriverAcceptsTheAddedSubset:
+    """``--added-from`` names the files the diff creates, which cannot be holes."""
+
+    def test_added_from_is_optional(self):
+        from benchmarks import run_benchmarks
+
+        ap = run_benchmarks.build_parser()
+        assert ap.parse_args(["--all"]).added_from is None
+
+    def test_added_from_reads_one_path_per_line(self, tmp_path):
+        from benchmarks import run_benchmarks
+
+        f = tmp_path / "added.txt"
+        f.write_text("mlsynth/a.py\n\nmlsynth/b.py\n")
+        assert run_benchmarks._read_changed(f) == ["mlsynth/a.py", "mlsynth/b.py"]
+
+    def test_added_without_changed_is_refused(self):
+        """The added set is a subset of the diff; alone it says nothing."""
+        from benchmarks import run_benchmarks
+
+        ap = run_benchmarks.build_parser()
+        args = ap.parse_args(["--all", "--added-from", "x.txt"])
+        with pytest.raises(SystemExit):
+            run_benchmarks._check_args(ap, args)
+
+
+class TestTheMapBuilderShards:
+    """The map is measured by running every case under coverage, which does not
+    fit one job: at 199 cases the single job hit its 350-minute cap on each of
+    the four days after it was added and was cancelled every time, so the
+    manifest stayed at the five entries that shipped with it and the selection
+    it exists to feed had nothing to select with.
+    """
+
+    def test_shard_zero_of_one_is_every_case(self):
+        from tools import benchmark_deps
+
+        names = ["a", "b", "c", "d", "e"]
+        assert benchmark_deps.shard_of(names, 0, 1) == names
+
+    def test_the_shards_partition_the_cases(self):
+        from tools import benchmark_deps
+
+        names = [f"c{i}" for i in range(23)]
+        seen = []
+        for i in range(4):
+            seen += benchmark_deps.shard_of(names, i, 4)
+        assert sorted(seen) == sorted(names)
+        assert len(seen) == len(names)
+
+    def test_the_shards_are_round_robin_like_the_runner(self):
+        """Cost is not uniform across the registry, so slice the same way
+        ``run_benchmarks.select_cases`` does and the heavy cases spread."""
+        from tools import benchmark_deps
+
+        names = [f"c{i}" for i in range(10)]
+        assert benchmark_deps.shard_of(names, 1, 3) == names[1::3]
+
+    @pytest.mark.parametrize("shard,num", [(-1, 2), (2, 2), (0, 0)])
+    def test_an_out_of_range_shard_is_refused(self, shard, num):
+        from tools import benchmark_deps
+
+        with pytest.raises(ValueError):
+            benchmark_deps.shard_of(["a", "b"], shard, num)
+
+
+class TestTheMapBuilderCombinesSlices:
+    """Each shard writes only what it measured; one job merges and commits."""
+
+    def test_combining_unions_the_slices(self, tmp_path):
+        from tools import benchmark_deps
+
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        a.write_text(json.dumps({"one": ["mlsynth/x.py"]}))
+        b.write_text(json.dumps({"two": ["mlsynth/y.py"]}))
+        assert benchmark_deps.combine([a, b], base={}) == {
+            "one": ["mlsynth/x.py"], "two": ["mlsynth/y.py"]}
+
+    def test_a_slice_overrides_the_base_for_the_cases_it_measured(self, tmp_path):
+        from tools import benchmark_deps
+
+        a = tmp_path / "a.json"
+        a.write_text(json.dumps({"one": ["mlsynth/new.py"]}))
+        out = benchmark_deps.combine([a], base={"one": ["mlsynth/old.py"],
+                                                "two": ["mlsynth/y.py"]})
+        assert out == {"one": ["mlsynth/new.py"], "two": ["mlsynth/y.py"]}
+
+    def test_a_case_no_slice_measured_keeps_its_base_entry(self, tmp_path):
+        """A shard that died must not un-map everyone else's cases."""
+        from tools import benchmark_deps
+
+        a = tmp_path / "a.json"
+        a.write_text(json.dumps({"one": ["mlsynth/x.py"]}))
+        out = benchmark_deps.combine([a], base={"two": ["mlsynth/y.py"]})
+        assert out["two"] == ["mlsynth/y.py"]
+
+    def test_combining_nothing_returns_the_base_unchanged(self):
+        from tools import benchmark_deps
+
+        base = {"one": ["mlsynth/x.py"]}
+        assert benchmark_deps.combine([], base=base) == base
+
+    def test_a_missing_slice_is_refused(self, tmp_path):
+        from tools import benchmark_deps
+
+        with pytest.raises((FileNotFoundError, OSError)):
+            benchmark_deps.combine([tmp_path / "nope.json"], base={})
+
+
+class TestTheMapBuilderCommandLine:
+    """``main`` is the part CI actually calls, so the two paths CI uses are
+    exercised here: combining slices, and refusing a shard that does not exist.
+    """
+
+    def test_combine_writes_the_merged_map_and_measures_nothing(self, tmp_path, monkeypatch):
+        from tools import benchmark_deps
+
+        slice_ = tmp_path / "slice.json"
+        slice_.write_text(json.dumps({"only": ["mlsynth/x.py"]}))
+        out = tmp_path / "out.json"
+
+        def _never(*a, **k):                      # measuring would take hours
+            raise AssertionError("--combine must not trace a case")
+
+        monkeypatch.setattr(benchmark_deps, "_trace", _never)
+        monkeypatch.setattr("sys.argv", ["benchmark_deps.py", "--combine",
+                                         str(slice_), "--out", str(out)])
+        assert benchmark_deps.main() == 0
+        assert json.loads(out.read_text())["only"] == ["mlsynth/x.py"]
+
+    def test_a_shard_outside_the_split_is_refused(self, monkeypatch):
+        from tools import benchmark_deps
+
+        monkeypatch.setattr("sys.argv", ["benchmark_deps.py", "--all",
+                                         "--shard", "4", "--num-shards", "4"])
+        with pytest.raises(SystemExit):
+            benchmark_deps.main()

--- a/benchmarks/tests/test_case_deps.py
+++ b/benchmarks/tests/test_case_deps.py
@@ -441,3 +441,34 @@ class TestTheMapBuilderCommandLine:
                                          "--shard", "4", "--num-shards", "4"])
         with pytest.raises(SystemExit):
             benchmark_deps.main()
+
+
+class TestProseIsProseWhereverItSits:
+    """``docs/ppscm.rst`` reaches no case because ``docs/`` is outside
+    :data:`REACHABLE`. ``benchmarks/README.md`` is the same prose one directory
+    over, and was a hole in the map on every diff that touched it.
+
+    The existing rule already says prose reaches nothing; it said it by
+    directory. Saying it by kind as well is the same claim, applied where the
+    directory test cannot reach.
+    """
+
+    MAP = {"a": ["mlsynth/x.py"], "b": ["mlsynth/y.py"]}
+
+    @pytest.mark.parametrize("path", [
+        "benchmarks/README.md",
+        "benchmarks/reference/mosc_spike/README.md",
+        "mlsynth/utils/NOTES.rst",
+    ])
+    def test_prose_under_a_reachable_prefix_is_not_a_hole(self, path):
+        assert case_deps.select([path], ["a", "b"], self.MAP) == []
+
+    @pytest.mark.parametrize("path", [
+        "benchmarks/constraints.txt",
+        "basedata/prop99.csv",
+        "benchmarks/R/requirements.R",
+    ])
+    def test_a_file_a_case_could_read_is_still_a_hole(self, path):
+        """The reads a case makes are measured, so these are claimable and their
+        absence from the map is real doubt."""
+        assert case_deps.select([path], ["a", "b"], self.MAP) == ["a", "b"]

--- a/benchmarks/tests/test_workflow_sharding.py
+++ b/benchmarks/tests/test_workflow_sharding.py
@@ -30,10 +30,11 @@ _WORKFLOW = (Path(__file__).resolve().parents[2]
              / ".github" / "workflows" / "benchmarks.yml")
 
 #: Jobs that fan out over shards; each must keep its matrix and NUM_SHARDS in step.
-SHARDED_JOBS = ("suite", "pr-suite")
+SHARDED_JOBS = ("suite", "pr-suite", "case-deps")
 
 #: Jobs that must never run for a pull request.
-NON_PR_JOBS = ("suite", "validation-dashboard")
+NON_PR_JOBS = ("suite", "validation-dashboard", "case-deps",
+               "case-deps-commit")
 
 
 @pytest.fixture(scope="module")
@@ -177,9 +178,24 @@ class TestTheShardsAreSkippedWhenNothingCouldMoveANumber:
     @staticmethod
     @pytest.fixture(scope="class")
     def patterns(gate):
-        body = gate["with"]["filters"]
-        return [line.strip().lstrip("- ").strip("'")
-                for line in body.splitlines() if line.strip().startswith("-")]
+        """The path globs in the filter body.
+
+        A rule may name a change type -- ``- added: '**'`` selects only files the
+        diff creates -- so drop the type and keep the glob, which is the part
+        that has to correspond to something in the repository.
+        """
+        out = []
+        for line in gate["with"]["filters"].splitlines():
+            line = line.strip()
+            if not line.startswith("-"):
+                continue
+            body = line.lstrip("- ").strip()
+            for kind in ("added", "modified", "deleted", "renamed"):
+                if body.startswith(f"{kind}:"):
+                    body = body.split(":", 1)[1].strip()
+                    break
+            out.append(body.strip("'"))
+        return out
 
     def test_the_gate_uses_the_same_action_build_yml_does(self, gate):
         assert gate["uses"].startswith("dorny/paths-filter@")
@@ -271,12 +287,89 @@ class TestTheDependencyMapIsWiredBothEnds:
     def test_the_map_is_refreshed_off_the_pull_request(self, jobs):
         assert "pull_request" in jobs["case-deps"]["if"]
         run = " ".join(str(s) for s in jobs["case-deps"]["steps"])
-        assert "tools/benchmark_deps.py --all --merge" in run
+        assert "tools/benchmark_deps.py --all" in run
 
     def test_refreshing_the_map_may_write_to_the_repository(self, jobs):
-        assert jobs["case-deps"]["permissions"]["contents"] == "write"
+        """The write is the combine job's; the shards only measure."""
+        assert jobs["case-deps-commit"]["permissions"]["contents"] == "write"
 
     def test_the_map_job_outlasts_a_full_registry_run(self, jobs):
         """It runs every case, so its timeout has to clear the daily suite's."""
         assert (int(jobs["case-deps"]["timeout-minutes"])
                 >= int(jobs["suite"]["timeout-minutes"]))
+
+
+class TestTheMapIsMeasuredInSlicesAndCommittedOnce:
+    """``case-deps`` measures what every case executes, and the map it writes is
+    what lets a pull request run only the cases its diff can reach.
+
+    As one job it did not finish. Runs on 23, 24, 25 and 26 August each reached
+    the 350-minute cap and were cancelled -- the 26th ran 07:36 to 13:26 -- so
+    the map never grew past the five entries that shipped with it, and every
+    pull request touching the library ran all 199 cases including the MIP and
+    Monte Carlo ones. Slicing the measurement is what makes the map exist.
+
+    Only the combine job commits. Four shards each rebasing and pushing the same
+    file race, and the loser's slice is dropped without a failure anywhere.
+    """
+
+    def test_the_shards_measure_a_slice_each(self, jobs):
+        step = next(s for s in jobs["case-deps"]["steps"]
+                    if s["name"].startswith("Measure"))
+        assert "--shard" in step["run"] and "--num-shards" in step["run"]
+
+    def test_a_shard_writes_its_own_file(self, jobs):
+        step = next(s for s in jobs["case-deps"]["steps"]
+                    if s["name"].startswith("Measure"))
+        assert "--out" in step["run"]
+
+    def test_no_shard_commits(self, jobs):
+        runs = " ".join(s.get("run", "") for s in jobs["case-deps"]["steps"])
+        assert "git push" not in runs
+
+    def test_the_combine_job_waits_for_every_shard(self, jobs):
+        needs = jobs["case-deps-commit"]["needs"]
+        assert "case-deps" in ([needs] if isinstance(needs, str) else needs)
+
+    def test_the_combine_job_merges_the_slices(self, jobs):
+        runs = " ".join(s.get("run", "") for s in jobs["case-deps-commit"]["steps"])
+        assert "--combine" in runs
+
+    def test_the_combine_job_is_the_one_that_commits(self, jobs):
+        runs = " ".join(s.get("run", "") for s in jobs["case-deps-commit"]["steps"])
+        assert "git push" in runs
+
+    def test_the_combine_job_runs_even_when_a_shard_fails(self, jobs):
+        """A dead shard must cost its own slice, not the other three."""
+        assert "always()" in jobs["case-deps-commit"].get("if", "")
+
+    def test_only_the_combine_job_can_write_to_the_repository(self, jobs):
+        assert jobs["case-deps"].get("permissions", {}).get("contents") != "write"
+        assert jobs["case-deps-commit"]["permissions"]["contents"] == "write"
+
+
+class TestTheAddedSubsetReachesTheSelection:
+    """A file the diff creates cannot have been executed by a pre-existing case,
+    so it is not a hole in the map. The selection can only know that if the
+    workflow tells it which files are new.
+    """
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def gate(jobs):
+        return next(s for s in jobs["pr-suite"]["steps"] if s.get("id") == "filter")
+
+    def test_the_filter_asks_for_the_added_files(self, gate):
+        assert "added:" in gate["with"]["filters"]
+
+    def test_the_run_step_passes_them_to_the_driver(self, jobs):
+        step = next(s for s in jobs["pr-suite"]["steps"]
+                    if s["name"] == "Run benchmark suite shard")
+        assert "--added-from" in step["run"]
+
+    def test_the_added_set_never_arrives_without_the_diff(self, jobs):
+        """``--added-from`` names a subset of ``--changed-from``; the driver
+        refuses one without the other."""
+        step = next(s for s in jobs["pr-suite"]["steps"]
+                    if s["name"] == "Run benchmark suite shard")
+        assert "--changed-from" in step["run"]

--- a/tools/benchmark_deps.py
+++ b/tools/benchmark_deps.py
@@ -18,6 +18,15 @@ the panel it reads from ``basedata`` changes.
 
 ``--merge`` keeps entries for cases this invocation did not run, so a sharded
 CI job can contribute its slice without dropping everyone else's.
+
+Measuring the whole registry does not fit one job. At 199 cases the single
+``case-deps`` job reached its 350-minute cap on each of the four days after it
+was added and was cancelled every time, which left the manifest at the five
+entries that shipped with it -- so the selection it feeds had nothing to select
+with and every pull request ran the whole registry. ``--shard i --num-shards n``
+splits the work round-robin, the same slice ``run_benchmarks.py`` takes, so the
+heavy cases spread; each shard writes its own slice with ``--out`` and one
+``--combine`` step merges them onto the shipped map and commits once.
 """
 from __future__ import annotations
 
@@ -79,6 +88,36 @@ def _trace(name: str) -> tuple[list[str], float]:
     return sorted(keep), secs
 
 
+def shard_of(names, shard: int, num_shards: int) -> list:
+    """The round-robin slice ``shard`` of ``names``.
+
+    Same slice ``run_benchmarks.select_cases`` takes, because cost is not
+    uniform across the registry: contiguous blocks would put the Monte Carlo and
+    MIP cases in one shard and leave the rest idle.
+    """
+    if num_shards < 1:
+        raise ValueError(f"num_shards must be >= 1, got {num_shards}")
+    if not 0 <= shard < num_shards:
+        raise ValueError(f"shard must be in [0, {num_shards}), got {shard}")
+    return list(names)[shard::num_shards] if num_shards > 1 else list(names)
+
+
+def combine(slices, base: dict) -> dict:
+    """``base`` updated by each slice, later slices winning.
+
+    A case no slice measured keeps its base entry, so a shard that died leaves
+    everyone else's cases mapped instead of un-mapping them. A case a slice did
+    measure takes the new value, including an empty list, which is a finding.
+    """
+    import json as _json
+    from pathlib import Path as _Path
+
+    out = dict(base)
+    for path in slices:
+        out.update(_json.loads(_Path(path).read_text()))
+    return out
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--case", action="append", default=[],
@@ -87,13 +126,30 @@ def main() -> int:
     ap.add_argument("--merge", action="store_true",
                     help="keep manifest entries for cases not traced here")
     ap.add_argument("--out", default=None, help="write somewhere other than the default")
+    ap.add_argument("--num-shards", type=int, default=1,
+                    help="split the cases into this many shards (round-robin)")
+    ap.add_argument("--shard", type=int, default=0,
+                    help="0-based index of the shard to measure")
+    ap.add_argument("--combine", nargs="+", default=None, metavar="SLICE",
+                    help="merge these shard slices onto the shipped map and "
+                         "write it, measuring nothing")
     args = ap.parse_args()
 
     from benchmarks import case_deps, registry
 
+    if args.combine:
+        merged = combine(args.combine, base=case_deps.load())
+        case_deps.save(merged, Path(args.out) if args.out else None)
+        print(f"{len(merged)} case(s) mapped from {len(args.combine)} slice(s)")
+        return 0
+
     names = list(registry.CASES) if args.all else args.case
     if not names:
         ap.error("give --case NAME or --all")
+    try:
+        names = shard_of(names, args.shard, args.num_shards)
+    except ValueError as exc:
+        ap.error(str(exc))
 
     out = dict(case_deps.load()) if args.merge else {}
     from benchmarks.compare import BenchmarkSkipped


### PR DESCRIPTION
## Related Links

- The mechanism this repairs: [#516](https://github.com/jgreathouse9/mlsynth/pull/516), which added `benchmarks/case_deps.py`, the `case-deps` job and the `--changed-from` gate
- Files: `benchmarks/case_deps.py`, `benchmarks/run_benchmarks.py`, `tools/benchmark_deps.py`, `.github/workflows/benchmarks.yml`
- The pull request that surfaced it: [#538](https://github.com/jgreathouse9/mlsynth/pull/538), where a new estimator ran all 198 benchmark cases across 8 shards

## What

- `benchmarks/case_deps.py`: `NEVER_REACHABLE`, `RE_EXPORT_ONLY`, and an `added` argument to `select`
- `benchmarks/run_benchmarks.py`: `--added-from`, and `build_parser` / `_check_args` split out of `main` so the command line can be read by a test
- `tools/benchmark_deps.py`: `shard_of`, `combine`, and `--shard` / `--num-shards` / `--combine`
- `.github/workflows/benchmarks.yml`: `case-deps` sharded four ways, a new `case-deps-commit` job, and the added subset wired through `pr-suite`
- 22 tests across `benchmarks/tests/test_case_deps.py` and `benchmarks/tests/test_workflow_sharding.py`

## Why

`pr-suite` runs the whole benchmark registry on every pull request. It is supposed to narrow to the cases the diff can reach, and it never has. On [#538](https://github.com/jgreathouse9/mlsynth/pull/538) — a new estimator, touching no benchmark case — it selected all 198, the SYNDES exact-vs-MIP case and the Monte Carlo cases included, across 8 shards.

Two independent causes, both fixed here.

The map is empty. A case with no manifest entry always runs, and `benchmarks/case_deps.json` maps 5 of 198 cases. The `case-deps` job that fills it measures every case under coverage in one job and does not finish: it reached its 350-minute cap on 23, 24, 25 and 26 August and was cancelled every time. The 26th ran 07:36 to 13:26 ([job 98099317150](https://github.com/jgreathouse9/mlsynth/actions/runs/32943533115/job/98099317150)). So the map has held the same five entries since the day it landed, and the selection it feeds had nothing to select with.

The hole rule fires on paths no map could ever claim. A changed file no entry names selects every case, which is right when the map might have claimed it and did not. Three kinds cannot be claimed however often the map is refreshed:

| path | why no measurement reaches it |
|---|---|
| `mlsynth/tests/**`, `benchmarks/tests/**` | the registry loads only `benchmarks.cases`, so no case's `run()` executes a test module |
| a file the diff creates | it did not exist when any pre-existing case ran |
| `mlsynth/__init__.py` | it executes at import, before measurement starts — the separation that stops a case from measuring all 834 library files |

An estimator pull request trips all three at once: new helper modules, new test modules, one export line.

## How

`NEVER_REACHABLE` and the new `added` argument carve out the first two. `RE_EXPORT_ONLY` carves out the third, and because that is a claim about a file, a test parses the file to check it: 84 imports, a version lookup and an `__all__` can add or remove a name but cannot change what any estimator computes. Put a statement with behaviour in there and the test fails and the entry comes out.

`dorny/paths-filter` supplies the added subset through a change-type rule (`- added: '**'`), and `run_benchmarks.py` grows `--added-from`, which it refuses without `--changed-from` since it names a subset of it.

`case-deps` now measures in four round-robin shards — the same slice `run_benchmarks.py` takes, because cost is not uniform across the registry — each writing its own slice to `--out` and uploading it. A new `case-deps-commit` job merges the slices onto the shipped map and commits once. Only that job holds `contents: write`: four shards rebasing and pushing the same file race, and the loser's slice disappears with nothing failing anywhere. It runs under `always()`, so a shard that dies costs its own slice and leaves the other three — `combine` keeps the existing entry for any case no slice measured, and a case that loses its entry goes back to always running, which is the safe direction.

The lopsided rule is unchanged where it earns its keep. An unmapped case still runs, a modified file no entry claims still selects everything, and `select` still widens on doubt. What changed is that three cases stopped counting as doubt.

## Verification

- Path: not applicable — this is CI selection logic and touches no numerical code. No estimator, helper, or pinned value is modified, and the daily full-registry run is unchanged.
- Measured on a diff shaped like the MOSC branch (new estimator package, its tests, `mlsynth/__init__.py`, a docs page):

  | | cases selected |
  |---|---|
  | before | 198 / 198 |
  | after, map as it stands | 193 / 198 |
  | after, once the nightly refresh has mapped the registry | 0 / 198 |

  The 193 are the cases with no manifest entry, which is the emptiness the sharding fixes; the third row is what this is worth after one successful nightly run.
- Pinned durably in `benchmarks/tests/test_case_deps.py` (`test_an_estimator_shaped_diff_selects_no_mapped_case`) and in `test_workflow_sharding.py`, which reads the YAML and asserts the shards measure a slice each, that none of them commits, that the combine job waits for all four, and that only it can write to the repository.
- Shard slicing checked against the real registry: 50 / 50 / 49 / 49, summing to 198 with no case in two shards.
- `--combine` checked end to end: two slices merged onto the shipped map, the five shipped entries kept.

## Scope checks

None of the four blocks fits: this is CI and tooling, no estimator or numerical code. The branch carries only this change.

## Designs

No visual output — the change is which cases a workflow selects.

## Test Steps

- [x] `pytest benchmarks/tests/ -q` — 186 passed
- [x] `pytest mlsynth/tests/test_suite_sharding.py mlsynth/tests/test_benchmark_reference.py -q` — 52 passed, the other two readers of these workflows
- [x] `coverage run --timid -m pytest benchmarks/tests/test_case_deps.py benchmarks/tests/test_workflow_sharding.py && coverage report` — `benchmarks/case_deps.py` 89% to 92%, every added line covered; the four that remain are `load`'s missing-file branch and `save`, uncovered before this change. In `tools/benchmark_deps.py` both new functions and both `main` paths CI calls are covered; `_trace` is not, and was not before
- [x] `python tools/benchmark_deps.py --combine <slices> --out <file>` on real slices
- [x] YAML parses; seven jobs, `case-deps` matrix `[0, 1, 2, 3]`, `case-deps-commit` needs `case-deps`
- [x] Prose sweep (`rather`, `quietly`, `loudly`, `load-bearing`, `worth`, `note that`) clean on the diff
- [ ] The sharded `case-deps` job itself runs only on a schedule or dispatch, so its first real execution is the next nightly run. Four shards of ~50 cases against one job of 198 that reached 350 minutes; if a shard still caps, the number to raise is the matrix and `NUM_SHARDS` together, which `test_the_matrix_length_equals_num_shards` enforces

## Other Notes

This does not change what the daily run validates. Every case still runs nightly with the full reference toolchain; what changes is which of them a pull request pays for.

The remaining cost on a pull request, until the map fills, is the 193 unmapped cases. That number falls as the nightly refresh lands — and if a shard proves too slow to finish even at four ways, the fix is more shards, not a narrower gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NL7XrbrABwVPg8Z3KvgLt

---
_Generated by [Claude Code](https://claude.ai/code/session_012NL7XrbrABwVPg8Z3KvgLt)_