### PR TITLE
GEOX reports what a design gets wrong, beside what it detects

### DIFF
--- a/docs/choose.rst
+++ b/docs/choose.rst
@@ -1043,7 +1043,10 @@ left over -- as in a geo roll-out?
 * Scoring by simulated power on your own history -- :doc:`geox` slides a
   pretend treatment window backwards through the panel, injects a lift of known
   size, and ranks candidate test regions by the smallest lift it reliably
-  detects. The design is chosen by the estimator that will analyse the result,
+  detects. The same backtests report how far each design's estimate lands from
+  the lift that was injected, so a region that detects small effects and
+  misstates them is visible as such. The design is chosen by the estimator that
+  will analyse the result,
   and which estimator that is is a setting: ``engine="sdid"`` differences out a
   level gap between the test region and its donors instead of having to match
   it, ``engine="augsynth"`` is the augmented synthetic control GeoLift scores

--- a/docs/geox.rst
+++ b/docs/geox.rst
@@ -384,26 +384,65 @@ with nothing injected, at every effect size on the grid. Measuring
 accuracy therefore needs no extra fit and no extra simulation: it is a
 second reading of the numbers the power calculation already produced.
 
-Over the backtests of one candidate, three numbers follow. ``bias`` is
-the mean error, ``error_sd`` its spread, and ``rmse`` the root mean square
-that combines them, with :math:`\mathrm{RMSE}^2 = \mathrm{bias}^2 +
-\mathrm{sd}^2`. They sit beside ``mde`` in the shortlist:
+Over the backtests of one candidate, three numbers follow.
+``att_error_mean`` is the mean error, which is the design's bias;
+``att_error_sd`` is its spread; and ``att_error_rmse`` is the root mean
+square that combines them, with
+
+.. math::
+
+   \mathrm{att\_error\_rmse}^{2}
+     = \mathrm{att\_error\_mean}^{2} + \mathrm{att\_error\_sd}^{2} .
+
+They sit beside ``mde`` in the shortlist:
 
 .. code-block:: text
 
-                    candidate  duration   mde   rmse    bias  error_sd  calibration_ratio
-          atlanta + nashville        14  0.15 16.822  -9.452    13.915              0.069
-   jacksonville + minneapolis        14  0.20 13.365   5.264    12.284              0.055
-          milwaukee + orlando        14  0.15 29.494 -25.998    13.929              0.123
-           cleveland + denver        14 -0.15 42.555 -38.536    18.054              0.159
-        detroit + new orleans        14 -0.15 50.323 -42.927    26.261              0.199
-         boston + new orleans        14  0.10 64.449  51.392    38.891              0.260
+                    candidate  duration    mde  att_error_rmse  att_error_mean  att_error_sd  att_error_over_sigma
+          atlanta + nashville        14   0.15          16.822          -9.452        13.915                 0.069
+   jacksonville + minneapolis        14   0.20          13.365           5.264        12.284                 0.055
+          milwaukee + orlando        14   0.15          29.494         -25.998        13.929                 0.123
+           cleveland + denver        14  -0.15          42.555         -38.536        18.054                 0.159
+        detroit + new orleans        14  -0.15          50.323         -42.927        26.261                 0.199
+         boston + new orleans        14   0.10          64.449          51.392        38.891                 0.260
 
 The two columns disagree, which is the reason for reporting both. Boston
 and New Orleans detect the smallest lift in this field, 10% against the
-15% the top row needs, and their estimate is off by the most -- an RMSE of
-64 conversions a day against 17. An experiment run there would find a
-small effect and misstate it.
+15% the top row needs, and their estimate is off by the most -- an error
+RMSE of 64 conversions a day against 17. An experiment run there would
+find a small effect and misstate it.
+
+What the error is measured against
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The prediction being scored is the counterfactual the engine fits for the
+test region over the pseudo-treatment window. The comparison is the
+region's own observed outcome over that same window. Because the window
+sits in history and carries no real treatment, the observed path is the
+truth and the true effect there is zero, so :math:`\tau_0` is the mean
+per-period prediction error of the counterfactual on a window the weights
+were not fit on.
+
+The injected lift contributes none of it. The identity above says the
+error is :math:`\tau_0` at every :math:`e`, and the reason is that the
+injection is additive on the treated post block, the estimate is linear in
+that block, and the counterfactual never reads it -- so the lift is
+recovered exactly by construction. ``att_error_rmse`` is therefore
+held-out counterfactual bias expressed on the ATT scale, and it does not
+measure any interaction between the size of an effect and the estimator's
+behaviour. For these engines there is none to measure: neither re-tunes on
+the post window. An estimator that did -- a penalty re-selected under the
+injected series, a data-driven donor screen -- would have error that moves
+with :math:`e`, and this design would not see it.
+
+Three quantities are easy to conflate. ``pre_rmspe`` is in-sample and
+per-period, the root mean square gap over the window the weights were fit
+on. :math:`\tau_0` is out-of-sample and averaged over the window with its
+sign kept. ``att_error_rmse`` is the root mean square of that across
+backtest windows. The signed average inside the window is what the ATT is,
+so a counterfactual running high for one week and low for the next scores
+as accurate -- correct for an effect estimate, and misleading if read as
+a claim that the counterfactual tracks the region period by period.
 
 Squaring is what separates these from ``abs_lift_in_zero``, the recovery
 term the composite rank already carries. That term is computed after the
@@ -411,27 +450,27 @@ backtests have been averaged, so it measures bias and cancels error that
 changes sign from one backtest to the next. A design whose error runs
 +5, -5, +5, -5 is unbiased and unreliable, and only the RMSE says so.
 
-``calibration_ratio`` is ``rmse`` over the placebo standard error the
-design's own inference tests against. The two are measured over different
-things -- the placebo error is drawn across donor markets reassigned as
-pseudo-treated, the estimation error across backtest windows for one fixed
-region -- so there is no value the ratio should take, and the small
-numbers above are the ordinary case. What it catches is the other end: a
-ratio above one says the design's error exceeds what its own null admits,
-so the p-values, and the MDE built from them, are too small.
+``att_error_over_sigma`` is ``att_error_rmse`` over the placebo standard
+error the design's own inference tests against. The two are measured over
+different things -- the placebo error is drawn across donor markets
+reassigned as pseudo-treated, the estimation error across backtest windows
+for one fixed region -- so there is no value the ratio should take, and the
+small numbers above are the ordinary case. What it catches is the other
+end: a ratio above one says the design's error exceeds what its own null
+admits, so the p-values, and the MDE built from them, are too small.
 
-``error_sd`` is a floor, not an estimate of how much the answer would move
-across independent experiments. Consecutive backtests shift their window
-by one period, so they overlap heavily and their errors are close to each
-other by construction. On a short backtest set, ``rmse`` is mostly
-``bias``.
+``att_error_sd`` is a floor, not an estimate of how much the answer would
+move across independent experiments. Consecutive backtests shift their
+window by one period, so they overlap heavily and their errors are close to
+each other by construction. On a short backtest set, ``att_error_rmse`` is
+mostly ``att_error_mean``.
 
 The winner's error is re-scored on the held-back backtests, on the same
 argument that produces ``winner_mde_planning``: the region a search picks
 is the one whose estimate came out favourably, so the number the search
 produced is optimistic. On this panel the correction is large. The winning
 region's in-search RMSE is 16.8; scored on backtests that took no part in
-choosing it, ``metadata["winner_rmse_planning"]`` is 149.4, against an MDE
+choosing it, ``metadata["winner_att_error_rmse_planning"]`` is 149.4, against an MDE
 that moved only from 0.15 to 0.10. Selection flatters accuracy more than
 it flatters detectability, and the held-back windows sit deeper in history
 where the fit has more to reproduce. Plan against the held-back number.

--- a/docs/geox.rst
+++ b/docs/geox.rst
@@ -355,6 +355,91 @@ are sparse: on this panel 7 of 91 pre-days carry any weight.
 stays empty until the experiment has run and post-treatment outcomes
 exist.
 
+What the design detects, and what it gets wrong
+-----------------------------------------------
+
+The MDE answers one question: how small a lift this design can pick up.
+It does not answer the second question a designer has, which is where the
+estimate will land once the lift is real. The two separate whenever the
+estimator is biased under the design -- for synthetic control, when the
+test region sits outside the range its donor markets can reproduce. A
+design can be sensitive to small effects and consistently wrong about
+their size.
+
+Both come out of the same backtests, because the error is already
+determined by what a backtest computes. Injecting a lift of size
+:math:`e` multiplies the treated markets' outcomes by :math:`1 + e`, so
+the truth it puts into the window is :math:`e\,\bar y_{\text{post}}`. The
+counterfactual is built from the pre-period alone, so the estimate moves
+by exactly that same amount:
+
+.. math::
+
+   \hat\tau(e) \;=\; \tau_0 + e\,\bar y_{\text{post}},
+   \qquad
+   \hat\tau(e) - e\,\bar y_{\text{post}} \;=\; \tau_0 .
+
+The estimate minus the truth is :math:`\tau_0`, the backtest's own ATT
+with nothing injected, at every effect size on the grid. Measuring
+accuracy therefore needs no extra fit and no extra simulation: it is a
+second reading of the numbers the power calculation already produced.
+
+Over the backtests of one candidate, three numbers follow. ``bias`` is
+the mean error, ``error_sd`` its spread, and ``rmse`` the root mean square
+that combines them, with :math:`\mathrm{RMSE}^2 = \mathrm{bias}^2 +
+\mathrm{sd}^2`. They sit beside ``mde`` in the shortlist:
+
+.. code-block:: text
+
+                    candidate  duration   mde   rmse    bias  error_sd  calibration_ratio
+          atlanta + nashville        14  0.15 16.822  -9.452    13.915              0.069
+   jacksonville + minneapolis        14  0.20 13.365   5.264    12.284              0.055
+          milwaukee + orlando        14  0.15 29.494 -25.998    13.929              0.123
+           cleveland + denver        14 -0.15 42.555 -38.536    18.054              0.159
+        detroit + new orleans        14 -0.15 50.323 -42.927    26.261              0.199
+         boston + new orleans        14  0.10 64.449  51.392    38.891              0.260
+
+The two columns disagree, which is the reason for reporting both. Boston
+and New Orleans detect the smallest lift in this field, 10% against the
+15% the top row needs, and their estimate is off by the most -- an RMSE of
+64 conversions a day against 17. An experiment run there would find a
+small effect and misstate it.
+
+Squaring is what separates these from ``abs_lift_in_zero``, the recovery
+term the composite rank already carries. That term is computed after the
+backtests have been averaged, so it measures bias and cancels error that
+changes sign from one backtest to the next. A design whose error runs
++5, -5, +5, -5 is unbiased and unreliable, and only the RMSE says so.
+
+``calibration_ratio`` is ``rmse`` over the placebo standard error the
+design's own inference tests against. The two are measured over different
+things -- the placebo error is drawn across donor markets reassigned as
+pseudo-treated, the estimation error across backtest windows for one fixed
+region -- so there is no value the ratio should take, and the small
+numbers above are the ordinary case. What it catches is the other end: a
+ratio above one says the design's error exceeds what its own null admits,
+so the p-values, and the MDE built from them, are too small.
+
+``error_sd`` is a floor, not an estimate of how much the answer would move
+across independent experiments. Consecutive backtests shift their window
+by one period, so they overlap heavily and their errors are close to each
+other by construction. On a short backtest set, ``rmse`` is mostly
+``bias``.
+
+The winner's error is re-scored on the held-back backtests, on the same
+argument that produces ``winner_mde_planning``: the region a search picks
+is the one whose estimate came out favourably, so the number the search
+produced is optimistic. On this panel the correction is large. The winning
+region's in-search RMSE is 16.8; scored on backtests that took no part in
+choosing it, ``metadata["winner_rmse_planning"]`` is 149.4, against an MDE
+that moved only from 0.15 to 0.10. Selection flatters accuracy more than
+it flatters detectability, and the held-back windows sit deeper in history
+where the fit has more to reproduce. Plan against the held-back number.
+
+The accuracy columns are reported and take no part in the ranking, which
+stays the GeoLift composite of :math:`\lvert\mathrm{MDE}\rvert`, power and
+recovery error.
+
 Scanning several region sizes
 -----------------------------
 

--- a/mlsynth/tests/test_geox_rmse.py
+++ b/mlsynth/tests/test_geox_rmse.py
@@ -20,12 +20,18 @@ makes the criterion free, and if it ever stops holding the reported RMSE stops
 meaning what it says.
 
 Over the backtests of one (candidate, duration) the three reported numbers are
-``bias = mean(tau_0)``, ``error_sd = std(tau_0)`` and ``rmse = sqrt(mean(tau_0^2))``,
-with ``rmse^2 = bias^2 + error_sd^2``. The squaring is the whole difference from
+``att_error_mean`` (the mean error, so the design's bias), ``att_error_sd``
+(its spread) and ``att_error_rmse`` (the root mean square combining them), with
+``rmse^2 = mean^2 + sd^2``. The squaring is the whole difference from
 ``abs_lift_in_zero``, which the composite rank already carries: that term is
 built after :func:`compute_power` has averaged over backtests, so it measures
 bias and cancels error that alternates in sign. A design whose placebo ATT runs
 +5, -5, +5, -5 is unbiased and unreliable, and only the RMSE says so.
+
+The error is the counterfactual's, not the injection's. The window carries no
+real treatment, so the region's observed path is the truth there and the true
+effect is zero; the injected lift is recovered exactly by construction, and
+what is left is out-of-sample counterfactual bias on the ATT scale.
 """
 
 from __future__ import annotations
@@ -127,9 +133,9 @@ class TestEstimationErrorIdentity:
                                  alpha=ALPHA)
         assert rows
         for row in rows:
-            assert np.isfinite(row["estimation_error"])
+            assert np.isfinite(row["att_error"])
             assert np.isfinite(row["placebo_sigma"])
-        errors = {row["estimation_error"] for row in rows}
+        errors = {row["att_error"] for row in rows}
         assert len(errors) == 1, "the error does not depend on the effect size"
 
     def test_an_engine_that_omits_tau0_is_reported(self, wide, monkeypatch):
@@ -167,8 +173,8 @@ class TestEstimationErrorIdentity:
                                       [-0.1, 0.0, 0.1], **kw)
         without = simulate_backtest(y, Y0, wide.shape[0], 14, 1,
                                     [0.3, 0.4], **kw)
-        assert (without[0]["estimation_error"]
-                == pytest.approx(with_zero[0]["estimation_error"]))
+        assert (without[0]["att_error"]
+                == pytest.approx(with_zero[0]["att_error"]))
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +196,7 @@ def _cube(errors_by_candidate, *, duration=14, effect_sizes=(0.0, 0.1),
                 rows.append({
                     "candidate": candidate, "duration": duration, "sim": sim,
                     "effect_size": float(es),
-                    "estimation_error": float(error),
+                    "att_error": float(error),
                     "placebo_sigma": sigma,
                     "p_value": 0.5,
                     "placebo_mean_effect": float(error) + float(es) * 100.0,
@@ -205,12 +211,12 @@ class TestAccuracyAggregation:
     def test_rmse_decomposes_into_bias_and_spread(self):
         table = compute_accuracy(_cube({"A": [1.0, 3.0, 5.0, 7.0]}))
         row = table.iloc[0]
-        assert row["bias"] == pytest.approx(4.0)
-        assert row["error_sd"] == pytest.approx(np.std([1.0, 3.0, 5.0, 7.0]))
-        assert row["rmse"] == pytest.approx(
+        assert row["att_error_mean"] == pytest.approx(4.0)
+        assert row["att_error_sd"] == pytest.approx(np.std([1.0, 3.0, 5.0, 7.0]))
+        assert row["att_error_rmse"] == pytest.approx(
             np.sqrt(np.mean(np.square([1.0, 3.0, 5.0, 7.0]))))
-        assert row["rmse"] ** 2 == pytest.approx(
-            row["bias"] ** 2 + row["error_sd"] ** 2)
+        assert row["att_error_rmse"] ** 2 == pytest.approx(
+            row["att_error_mean"] ** 2 + row["att_error_sd"] ** 2)
 
     def test_alternating_error_separates_from_constant_error(self):
         # The claim the criterion exists to make. Two designs, the same error
@@ -219,76 +225,78 @@ class TestAccuracyAggregation:
                       "flipping": [5.0, -5.0, 5.0, -5.0]})
         table = compute_accuracy(cube).set_index("candidate")
 
-        # Averaging first cannot tell them apart on bias ...
-        assert abs(table.loc["flipping", "bias"]) < abs(table.loc["steady", "bias"])
+        # Averaging first cannot tell them apart on att_error_mean ...
+        assert (abs(table.loc["flipping", "att_error_mean"])
+                < abs(table.loc["steady", "att_error_mean"]))
         # ... and the rank's own recovery term is built on that average, so it
         # calls the unreliable design the better one.
         averaged = compute_power(cube, alpha=ALPHA).set_index("candidate")
         assert (abs(averaged.loc["flipping", "detected_lift"]).min()
                 < abs(averaged.loc["steady", "detected_lift"]).min())
         # Squaring first says they are equally wrong, which they are.
-        assert table.loc["flipping", "rmse"] == pytest.approx(
-            table.loc["steady", "rmse"])
+        assert table.loc["flipping", "att_error_rmse"] == pytest.approx(
+            table.loc["steady", "att_error_rmse"])
 
     def test_accuracy_does_not_depend_on_the_effect_grid(self):
         errors = {"A": [1.0, -2.0, 3.0]}
         coarse = compute_accuracy(_cube(errors, effect_sizes=(0.1,)))
         fine = compute_accuracy(
             _cube(errors, effect_sizes=(-0.2, -0.1, 0.0, 0.1, 0.2)))
-        for column in ("bias", "error_sd", "rmse"):
+        for column in ("att_error_mean", "att_error_sd", "att_error_rmse"):
             assert coarse[column].iloc[0] == pytest.approx(fine[column].iloc[0])
 
     def test_calibration_ratio_is_rmse_over_the_placebo_sigma(self):
         table = compute_accuracy(_cube({"A": [2.0, -2.0]}, sigma=4.0))
         row = table.iloc[0]
-        assert row["sigma_mean"] == pytest.approx(4.0)
-        assert row["calibration_ratio"] == pytest.approx(row["rmse"] / 4.0)
+        assert row["placebo_sigma_mean"] == pytest.approx(4.0)
+        assert row["att_error_over_sigma"] == pytest.approx(row["att_error_rmse"] / 4.0)
 
     def test_calibration_ratio_absent_when_the_engine_reports_no_sigma(self):
         # The conformal path permutes instead of drawing placebos, so there is
         # no sigma to calibrate against. Reported absent, not guessed.
         table = compute_accuracy(_cube({"A": [1.0, 2.0]}, sigma=float("nan")))
-        assert np.isnan(table["sigma_mean"].iloc[0])
-        assert np.isnan(table["calibration_ratio"].iloc[0])
-        assert np.isfinite(table["rmse"].iloc[0])
+        assert np.isnan(table["placebo_sigma_mean"].iloc[0])
+        assert np.isnan(table["att_error_over_sigma"].iloc[0])
+        assert np.isfinite(table["att_error_rmse"].iloc[0])
 
-    @pytest.mark.parametrize("errors,bias,sd,rmse", [
+    @pytest.mark.parametrize("errors,att_error_mean,sd,att_error_rmse", [
         ([4.0], 4.0, 0.0, 4.0),                    # one backtest: no spread
         ([0.0, 0.0], 0.0, 0.0, 0.0),               # a design that never errs
-        ([-3.0, 3.0], 0.0, 3.0, 3.0),              # pure spread, no bias
+        ([-3.0, 3.0], 0.0, 3.0, 3.0),              # pure spread, no att_error_mean
     ])
-    def test_degenerate_backtest_sets(self, errors, bias, sd, rmse):
+    def test_degenerate_backtest_sets(self, errors, att_error_mean, sd, att_error_rmse):
         row = compute_accuracy(_cube({"A": errors})).iloc[0]
-        assert row["bias"] == pytest.approx(bias)
-        assert row["error_sd"] == pytest.approx(sd)
-        assert row["rmse"] == pytest.approx(rmse)
+        assert row["att_error_mean"] == pytest.approx(att_error_mean)
+        assert row["att_error_sd"] == pytest.approx(sd)
+        assert row["att_error_rmse"] == pytest.approx(att_error_rmse)
 
     def test_empty_cube_returns_the_columns(self):
         table = compute_accuracy(pd.DataFrame())
         assert table.empty
-        for column in ("candidate", "duration", "bias", "error_sd", "rmse",
-                       "sigma_mean", "calibration_ratio"):
+        for column in ("candidate", "duration", "att_error_mean",
+                       "att_error_sd", "att_error_rmse",
+                       "placebo_sigma_mean", "att_error_over_sigma"):
             assert column in table.columns
 
     def test_a_failed_backtest_is_reported_not_dropped(self):
         # A fit that did not converge leaves a nan error. Dropping it would
         # report the accuracy of the backtests that happened to work.
         table = compute_accuracy(_cube({"A": [1.0, float("nan"), 3.0]}))
-        assert np.isnan(table["rmse"].iloc[0])
-        assert np.isnan(table["bias"].iloc[0])
+        assert np.isnan(table["att_error_rmse"].iloc[0])
+        assert np.isnan(table["att_error_mean"].iloc[0])
 
     def test_a_cube_without_the_error_column_raises(self):
-        cube = _cube({"A": [1.0]}).drop(columns=["estimation_error"])
-        with pytest.raises(MlsynthEstimationError, match="estimation_error"):
+        cube = _cube({"A": [1.0]}).drop(columns=["att_error"])
+        with pytest.raises(MlsynthEstimationError, match="att_error"):
             compute_accuracy(cube)
 
     def test_a_cube_without_a_sigma_column_still_reports_the_error(self):
         # No standard error is a missing comparison, not a missing measurement.
         cube = _cube({"A": [1.0, 3.0]}).drop(columns=["placebo_sigma"])
         row = compute_accuracy(cube).iloc[0]
-        assert row["rmse"] == pytest.approx(np.sqrt(5.0))
-        assert np.isnan(row["sigma_mean"])
-        assert np.isnan(row["calibration_ratio"])
+        assert row["att_error_rmse"] == pytest.approx(np.sqrt(5.0))
+        assert np.isnan(row["placebo_sigma_mean"])
+        assert np.isnan(row["att_error_over_sigma"])
 
 
 # ---------------------------------------------------------------------------
@@ -306,34 +314,37 @@ def result(panel):
 
 class TestShortlist:
     def test_shortlist_carries_the_accuracy_columns(self, result):
-        for column in ("bias", "error_sd", "rmse", "sigma_mean",
-                       "calibration_ratio"):
+        for column in ("att_error_mean", "att_error_sd", "att_error_rmse",
+                       "placebo_sigma_mean", "att_error_over_sigma"):
             assert column in result.power.columns, column
 
     def test_rmse_is_non_negative_and_finite(self, result):
-        rmse = result.power["rmse"].dropna()
-        assert not rmse.empty
-        assert (rmse >= 0).all()
-        assert np.isfinite(rmse).all()
+        att_error_rmse = result.power["att_error_rmse"].dropna()
+        assert not att_error_rmse.empty
+        assert (att_error_rmse >= 0).all()
+        assert np.isfinite(att_error_rmse).all()
 
     def test_rmse_dominates_its_components(self, result):
-        s = result.power.dropna(subset=["rmse", "bias", "error_sd"])
+        s = result.power.dropna(
+            subset=["att_error_rmse", "att_error_mean", "att_error_sd"])
         assert not s.empty
-        assert (s["rmse"] >= s["bias"].abs() - 1e-9).all()
-        assert (s["rmse"] >= s["error_sd"] - 1e-9).all()
+        assert (s["att_error_rmse"] >= s["att_error_mean"].abs() - 1e-9).all()
+        assert (s["att_error_rmse"] >= s["att_error_sd"] - 1e-9).all()
 
     def test_decomposition_holds_on_real_backtests(self, result):
-        s = result.power.dropna(subset=["rmse", "bias", "error_sd"])
+        s = result.power.dropna(
+            subset=["att_error_rmse", "att_error_mean", "att_error_sd"])
         np.testing.assert_allclose(
-            s["rmse"] ** 2, s["bias"] ** 2 + s["error_sd"] ** 2, rtol=1e-9)
+            s["att_error_rmse"] ** 2,
+            s["att_error_mean"] ** 2 + s["att_error_sd"] ** 2, rtol=1e-9)
 
     def test_candidate_designs_carry_the_accuracy(self, result):
-        scored = [c for c in result.search.candidates if c.rmse is not None]
+        scored = [c for c in result.search.candidates if c.att_error_rmse is not None]
         assert scored
         for design in scored:
-            assert np.isfinite(design.rmse) and design.rmse >= 0
-            assert np.isfinite(design.bias)
-            assert np.isfinite(design.error_sd)
+            assert np.isfinite(design.att_error_rmse) and design.att_error_rmse >= 0
+            assert np.isfinite(design.att_error_mean)
+            assert np.isfinite(design.att_error_sd)
 
     def test_the_ranking_is_untouched(self, panel, result):
         # The composite rank is what the GeoLift cross-validation pins. The
@@ -353,21 +364,22 @@ class TestShortlist:
         # drawn across donor markets, the error across backtest windows -- so
         # the ratio has no value it should sit at. What is pinned is what it
         # is: a positive, finite comparison of the one against the other.
-        s = result.power.dropna(subset=["calibration_ratio"])
+        s = result.power.dropna(subset=["att_error_over_sigma"])
         assert not s.empty
-        assert (s["calibration_ratio"] > 0).all()
-        assert np.isfinite(s["calibration_ratio"]).all()
-        np.testing.assert_allclose(s["calibration_ratio"],
-                                   s["rmse"] / s["sigma_mean"], rtol=1e-9)
+        assert (s["att_error_over_sigma"] > 0).all()
+        assert np.isfinite(s["att_error_over_sigma"]).all()
+        np.testing.assert_allclose(
+            s["att_error_over_sigma"],
+            s["att_error_rmse"] / s["placebo_sigma_mean"], rtol=1e-9)
 
 
 class TestPlanningAccuracy:
     def test_planning_rmse_is_reported_for_the_winner(self, result):
-        assert "winner_rmse_planning" in result.metadata
-        planning = result.metadata["winner_rmse_planning"]
+        assert "winner_att_error_rmse_planning" in result.metadata
+        planning = result.metadata["winner_att_error_rmse_planning"]
         assert planning is not None
         assert planning >= 0 and np.isfinite(planning)
-        assert result.search.winner.rmse_planning == pytest.approx(planning)
+        assert result.search.winner.att_error_rmse_planning == pytest.approx(planning)
 
     def test_absent_when_no_validation_backtests(self, panel):
         res = GEOX(GEOXConfig(
@@ -375,15 +387,17 @@ class TestPlanningAccuracy:
             treatment_size=2, durations=[14], effect_sizes=GRID,
             n_backtests=3, n_draws=25, n_validation_backtests=0,
             alpha=ALPHA, seed=0)).fit()
-        assert res.metadata["winner_rmse_planning"] is None
-        assert res.search.winner.rmse_planning is None
+        assert res.metadata["winner_att_error_rmse_planning"] is None
+        assert res.search.winner.att_error_rmse_planning is None
 
     def test_planning_backtests_are_not_the_selecting_ones(self, result):
         # Held-back backtests sit deeper in history, so the winner's planning
         # RMSE is a different number from its in-search one except by accident.
         winner = result.search.winner
-        assert winner.rmse is not None and winner.rmse_planning is not None
-        assert winner.rmse_planning != pytest.approx(winner.rmse, rel=1e-12)
+        assert winner.att_error_rmse is not None
+        assert winner.att_error_rmse_planning is not None
+        assert winner.att_error_rmse_planning != pytest.approx(
+            winner.att_error_rmse, rel=1e-12)
 
 
 class TestPlanningReadout:
@@ -419,7 +433,7 @@ class TestPlanningReadout:
             ignore_index=True)
         readout = planning_readout(undetectable, config)
         assert readout.mde is None
-        assert readout.rmse == pytest.approx(np.sqrt(5.0))
+        assert readout.att_error_rmse == pytest.approx(np.sqrt(5.0))
 
 
 class TestConformalEngine:
@@ -434,8 +448,8 @@ class TestConformalEngine:
 
     def test_rmse_is_reported_without_a_sigma(self, conformal):
         s = conformal.power
-        assert np.isfinite(s["rmse"].dropna()).all()
-        assert s["calibration_ratio"].isna().all()
+        assert np.isfinite(s["att_error_rmse"].dropna()).all()
+        assert s["att_error_over_sigma"].isna().all()
 
 
 def test_the_criterion_costs_no_extra_fits(wide, monkeypatch):

--- a/mlsynth/tests/test_geox_rmse.py
+++ b/mlsynth/tests/test_geox_rmse.py
@@ -1,0 +1,465 @@
+"""Estimation error as a GEOX design criterion, beside the MDE.
+
+The MDE asks the smallest effect a design can detect. It says nothing about how
+far the estimate will land from the truth once an effect is there, and the two
+come apart whenever the estimator is biased under the design -- for synthetic
+control, the treated region sitting outside the donor hull.
+
+The error is already determined by quantities the backtest computes. Both
+engines define the ATT as the mean gap over the treatment window, and neither
+builds its counterfactual from the treated post block, so injecting a
+multiplicative lift ``y[post] *= (1 + e)`` moves the estimate by exactly
+``e * mean(y[post])`` -- which is the effect that was injected. The estimate
+minus the truth is therefore
+
+    tau_hat(e) - e * baseline = tau_0,
+
+the backtest's own placebo ATT, for every effect size and on both the analytic
+and the re-inject path. That identity is the first thing tested here: it is what
+makes the criterion free, and if it ever stops holding the reported RMSE stops
+meaning what it says.
+
+Over the backtests of one (candidate, duration) the three reported numbers are
+``bias = mean(tau_0)``, ``error_sd = std(tau_0)`` and ``rmse = sqrt(mean(tau_0^2))``,
+with ``rmse^2 = bias^2 + error_sd^2``. The squaring is the whole difference from
+``abs_lift_in_zero``, which the composite rank already carries: that term is
+built after :func:`compute_power` has averaged over backtests, so it measures
+bias and cancels error that alternates in sign. A design whose placebo ATT runs
++5, -5, +5, -5 is unbiased and unreliable, and only the RMSE says so.
+"""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mlsynth import GEOX
+from mlsynth.config_models import GEOXConfig
+from mlsynth.exceptions import MlsynthEstimationError
+from mlsynth.utils.datautils import geoex_dataprep
+from mlsynth.utils.geox_helpers.aggregate import compute_accuracy, compute_power
+from mlsynth.utils.geox_helpers.engines import resolve_engine
+from mlsynth.utils.geox_helpers.orchestration import (
+    PlanningReadout, planning_backtests, planning_readout)
+from mlsynth.utils.geox_helpers.shaping import aggregate_treated, donor_matrix
+from mlsynth.utils.geox_helpers.simulate import simulate_backtest
+
+DATA = Path(__file__).resolve().parents[2] / "basedata" / "geolift_test_data.csv"
+ALPHA = 0.1
+GRID = [-0.2, -0.1, 0.0, 0.1, 0.2]
+
+
+@pytest.fixture(scope="module")
+def panel():
+    df = pd.read_csv(DATA)
+    df["date"] = pd.to_datetime(df["date"])
+    return df
+
+
+@pytest.fixture(scope="module")
+def wide(panel):
+    return geoex_dataprep(panel, "location", "date", "Y")["Ywide"]
+
+
+@pytest.fixture(scope="module")
+def arrays(wide):
+    """One candidate region's treated series, donors and backtest window."""
+    region = frozenset(list(wide.columns)[:2])
+    y = aggregate_treated(wide, region, how="mean").to_numpy()
+    Y0 = donor_matrix(wide, region).to_numpy()
+    n_pre = wide.shape[0] - 14
+    return y, Y0, n_pre, n_pre, wide.shape[0] - 1, len(region)
+
+
+# ---------------------------------------------------------------------------
+# The identity the criterion rests on
+# ---------------------------------------------------------------------------
+
+class TestEstimationErrorIdentity:
+    """``tau_hat(e) - e * baseline == tau_0``, exactly."""
+
+    @pytest.mark.parametrize("engine,inference", [
+        ("sdid", "placebo"),
+        ("augsynth", "placebo"),
+        ("augsynth", "conformal"),
+    ])
+    @pytest.mark.parametrize("analytic", [True, False])
+    def test_error_equals_the_placebo_att(self, arrays, engine, inference,
+                                          analytic):
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine(engine)
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        tau0 = eng.att(fit, y, start, end)
+        baseline = float(np.mean(y[start:end + 1]))
+
+        swept = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, GRID,
+                                   n_draws=15, n_tr=n_tr, seed=1,
+                                   analytic=analytic, alpha=ALPHA,
+                                   inference=inference)
+
+        for es, tau in zip(GRID, swept["tau"]):
+            error = tau - es * baseline
+            assert error == pytest.approx(tau0, rel=1e-9, abs=1e-9), (
+                f"{engine}/{inference} analytic={analytic}: error at e={es} is "
+                f"{error:.6f}, placebo ATT is {tau0:.6f}")
+
+    @pytest.mark.parametrize("engine", ["sdid", "augsynth"])
+    def test_sweep_reports_the_error(self, arrays, engine):
+        # The sweep already knows tau_0; it has to hand it back, because the
+        # user-supplied effect grid need not contain zero for it to be read off.
+        y, Y0, n_pre, start, end, n_tr = arrays
+        eng = resolve_engine(engine)
+        fit = eng.fit_once(y, Y0, n_pre, start, end, n_tr)
+        swept = eng.sweep_p_values(fit, y, Y0, n_pre, start, end, GRID,
+                                   n_draws=15, n_tr=n_tr, seed=1, alpha=ALPHA)
+        assert swept["tau0"] == pytest.approx(eng.att(fit, y, start, end))
+
+    def test_backtest_rows_carry_the_error_and_sigma(self, wide):
+        region = frozenset(list(wide.columns)[:2])
+        y = aggregate_treated(wide, region, how="mean").to_numpy()
+        Y0 = donor_matrix(wide, region).to_numpy()
+        rows = simulate_backtest(y, Y0, wide.shape[0], 14, 1, GRID,
+                                 n_draws=15, n_tr=len(region), seed=1,
+                                 alpha=ALPHA)
+        assert rows
+        for row in rows:
+            assert np.isfinite(row["estimation_error"])
+            assert np.isfinite(row["placebo_sigma"])
+        errors = {row["estimation_error"] for row in rows}
+        assert len(errors) == 1, "the error does not depend on the effect size"
+
+    def test_an_engine_that_omits_tau0_is_reported(self, wide, monkeypatch):
+        # A silent nan would report the design as unmeasurable instead of
+        # naming the engine that broke the protocol.
+        import dataclasses
+
+        import mlsynth.utils.geox_helpers.simulate as simulate_module
+
+        eng = resolve_engine("sdid")
+
+        def sweep_without_tau0(*args, **kwargs):
+            swept = eng.sweep_p_values(*args, **kwargs)
+            return {k: v for k, v in swept.items() if k != "tau0"}
+
+        monkeypatch.setattr(
+            simulate_module, "resolve_engine",
+            lambda name: dataclasses.replace(
+                eng, sweep_p_values=sweep_without_tau0))
+        region = frozenset(list(wide.columns)[:2])
+        y = aggregate_treated(wide, region, how="mean").to_numpy()
+        Y0 = donor_matrix(wide, region).to_numpy()
+        with pytest.raises(MlsynthEstimationError, match="tau0"):
+            simulate_backtest(y, Y0, wide.shape[0], 14, 1, GRID,
+                              n_draws=15, n_tr=len(region), seed=1, alpha=ALPHA)
+
+    def test_error_is_the_effect_the_grid_omits(self, wide):
+        # A grid without zero still reports the same error as one with it: the
+        # error is read off the fit, not off a grid point.
+        region = frozenset(list(wide.columns)[:2])
+        y = aggregate_treated(wide, region, how="mean").to_numpy()
+        Y0 = donor_matrix(wide, region).to_numpy()
+        kw = dict(n_draws=15, n_tr=len(region), seed=1, alpha=ALPHA)
+        with_zero = simulate_backtest(y, Y0, wide.shape[0], 14, 1,
+                                      [-0.1, 0.0, 0.1], **kw)
+        without = simulate_backtest(y, Y0, wide.shape[0], 14, 1,
+                                    [0.3, 0.4], **kw)
+        assert (without[0]["estimation_error"]
+                == pytest.approx(with_zero[0]["estimation_error"]))
+
+
+# ---------------------------------------------------------------------------
+# The aggregation, on cubes built by hand
+# ---------------------------------------------------------------------------
+
+def _cube(errors_by_candidate, *, duration=14, effect_sizes=(0.0, 0.1),
+          sigma=1.0):
+    """A long cube with prescribed per-backtest errors.
+
+    ``errors_by_candidate`` maps a candidate label to its per-backtest error
+    sequence. Every other column is filled with a constant, so a test that
+    reads one of them is reading something it set.
+    """
+    rows = []
+    for candidate, errors in errors_by_candidate.items():
+        for sim, error in enumerate(errors, start=1):
+            for es in effect_sizes:
+                rows.append({
+                    "candidate": candidate, "duration": duration, "sim": sim,
+                    "effect_size": float(es),
+                    "estimation_error": float(error),
+                    "placebo_sigma": sigma,
+                    "p_value": 0.5,
+                    "placebo_mean_effect": float(error) + float(es) * 100.0,
+                    "detected_lift": (float(error) + float(es) * 100.0) / 100.0,
+                    "scaled_l2": 0.5, "pre_rmspe": 1.0,
+                    "pre_rmspe_lambda": 1.0, "investment": float("nan"),
+                })
+    return pd.DataFrame(rows)
+
+
+class TestAccuracyAggregation:
+    def test_rmse_decomposes_into_bias_and_spread(self):
+        table = compute_accuracy(_cube({"A": [1.0, 3.0, 5.0, 7.0]}))
+        row = table.iloc[0]
+        assert row["bias"] == pytest.approx(4.0)
+        assert row["error_sd"] == pytest.approx(np.std([1.0, 3.0, 5.0, 7.0]))
+        assert row["rmse"] == pytest.approx(
+            np.sqrt(np.mean(np.square([1.0, 3.0, 5.0, 7.0]))))
+        assert row["rmse"] ** 2 == pytest.approx(
+            row["bias"] ** 2 + row["error_sd"] ** 2)
+
+    def test_alternating_error_separates_from_constant_error(self):
+        # The claim the criterion exists to make. Two designs, the same error
+        # magnitude every backtest: one keeps its sign, the other flips.
+        cube = _cube({"steady": [5.0, 5.0, 5.0, 5.0],
+                      "flipping": [5.0, -5.0, 5.0, -5.0]})
+        table = compute_accuracy(cube).set_index("candidate")
+
+        # Averaging first cannot tell them apart on bias ...
+        assert abs(table.loc["flipping", "bias"]) < abs(table.loc["steady", "bias"])
+        # ... and the rank's own recovery term is built on that average, so it
+        # calls the unreliable design the better one.
+        averaged = compute_power(cube, alpha=ALPHA).set_index("candidate")
+        assert (abs(averaged.loc["flipping", "detected_lift"]).min()
+                < abs(averaged.loc["steady", "detected_lift"]).min())
+        # Squaring first says they are equally wrong, which they are.
+        assert table.loc["flipping", "rmse"] == pytest.approx(
+            table.loc["steady", "rmse"])
+
+    def test_accuracy_does_not_depend_on_the_effect_grid(self):
+        errors = {"A": [1.0, -2.0, 3.0]}
+        coarse = compute_accuracy(_cube(errors, effect_sizes=(0.1,)))
+        fine = compute_accuracy(
+            _cube(errors, effect_sizes=(-0.2, -0.1, 0.0, 0.1, 0.2)))
+        for column in ("bias", "error_sd", "rmse"):
+            assert coarse[column].iloc[0] == pytest.approx(fine[column].iloc[0])
+
+    def test_calibration_ratio_is_rmse_over_the_placebo_sigma(self):
+        table = compute_accuracy(_cube({"A": [2.0, -2.0]}, sigma=4.0))
+        row = table.iloc[0]
+        assert row["sigma_mean"] == pytest.approx(4.0)
+        assert row["calibration_ratio"] == pytest.approx(row["rmse"] / 4.0)
+
+    def test_calibration_ratio_absent_when_the_engine_reports_no_sigma(self):
+        # The conformal path permutes instead of drawing placebos, so there is
+        # no sigma to calibrate against. Reported absent, not guessed.
+        table = compute_accuracy(_cube({"A": [1.0, 2.0]}, sigma=float("nan")))
+        assert np.isnan(table["sigma_mean"].iloc[0])
+        assert np.isnan(table["calibration_ratio"].iloc[0])
+        assert np.isfinite(table["rmse"].iloc[0])
+
+    @pytest.mark.parametrize("errors,bias,sd,rmse", [
+        ([4.0], 4.0, 0.0, 4.0),                    # one backtest: no spread
+        ([0.0, 0.0], 0.0, 0.0, 0.0),               # a design that never errs
+        ([-3.0, 3.0], 0.0, 3.0, 3.0),              # pure spread, no bias
+    ])
+    def test_degenerate_backtest_sets(self, errors, bias, sd, rmse):
+        row = compute_accuracy(_cube({"A": errors})).iloc[0]
+        assert row["bias"] == pytest.approx(bias)
+        assert row["error_sd"] == pytest.approx(sd)
+        assert row["rmse"] == pytest.approx(rmse)
+
+    def test_empty_cube_returns_the_columns(self):
+        table = compute_accuracy(pd.DataFrame())
+        assert table.empty
+        for column in ("candidate", "duration", "bias", "error_sd", "rmse",
+                       "sigma_mean", "calibration_ratio"):
+            assert column in table.columns
+
+    def test_a_failed_backtest_is_reported_not_dropped(self):
+        # A fit that did not converge leaves a nan error. Dropping it would
+        # report the accuracy of the backtests that happened to work.
+        table = compute_accuracy(_cube({"A": [1.0, float("nan"), 3.0]}))
+        assert np.isnan(table["rmse"].iloc[0])
+        assert np.isnan(table["bias"].iloc[0])
+
+    def test_a_cube_without_the_error_column_raises(self):
+        cube = _cube({"A": [1.0]}).drop(columns=["estimation_error"])
+        with pytest.raises(MlsynthEstimationError, match="estimation_error"):
+            compute_accuracy(cube)
+
+    def test_a_cube_without_a_sigma_column_still_reports_the_error(self):
+        # No standard error is a missing comparison, not a missing measurement.
+        cube = _cube({"A": [1.0, 3.0]}).drop(columns=["placebo_sigma"])
+        row = compute_accuracy(cube).iloc[0]
+        assert row["rmse"] == pytest.approx(np.sqrt(5.0))
+        assert np.isnan(row["sigma_mean"])
+        assert np.isnan(row["calibration_ratio"])
+
+
+# ---------------------------------------------------------------------------
+# The design, end to end
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def result(panel):
+    return GEOX(GEOXConfig(
+        df=panel, unitid="location", time="date", outcome="Y",
+        treatment_size=2, durations=[14], effect_sizes=GRID,
+        n_backtests=3, n_draws=25, n_validation_backtests=2,
+        alpha=ALPHA, seed=0)).fit()
+
+
+class TestShortlist:
+    def test_shortlist_carries_the_accuracy_columns(self, result):
+        for column in ("bias", "error_sd", "rmse", "sigma_mean",
+                       "calibration_ratio"):
+            assert column in result.power.columns, column
+
+    def test_rmse_is_non_negative_and_finite(self, result):
+        rmse = result.power["rmse"].dropna()
+        assert not rmse.empty
+        assert (rmse >= 0).all()
+        assert np.isfinite(rmse).all()
+
+    def test_rmse_dominates_its_components(self, result):
+        s = result.power.dropna(subset=["rmse", "bias", "error_sd"])
+        assert not s.empty
+        assert (s["rmse"] >= s["bias"].abs() - 1e-9).all()
+        assert (s["rmse"] >= s["error_sd"] - 1e-9).all()
+
+    def test_decomposition_holds_on_real_backtests(self, result):
+        s = result.power.dropna(subset=["rmse", "bias", "error_sd"])
+        np.testing.assert_allclose(
+            s["rmse"] ** 2, s["bias"] ** 2 + s["error_sd"] ** 2, rtol=1e-9)
+
+    def test_candidate_designs_carry_the_accuracy(self, result):
+        scored = [c for c in result.search.candidates if c.rmse is not None]
+        assert scored
+        for design in scored:
+            assert np.isfinite(design.rmse) and design.rmse >= 0
+            assert np.isfinite(design.bias)
+            assert np.isfinite(design.error_sd)
+
+    def test_the_ranking_is_untouched(self, panel, result):
+        # The composite rank is what the GeoLift cross-validation pins. The
+        # accuracy columns are reported beside it and take no part in it.
+        again = GEOX(GEOXConfig(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14], effect_sizes=GRID,
+            n_backtests=3, n_draws=25, n_validation_backtests=0,
+            alpha=ALPHA, seed=0)).fit()
+        left = result.power[["candidate", "duration", "mde", "rank"]]
+        right = again.power[["candidate", "duration", "mde", "rank"]]
+        pd.testing.assert_frame_equal(
+            left.reset_index(drop=True), right.reset_index(drop=True))
+
+    def test_calibration_ratio_is_the_error_over_the_placebo_scale(self, result):
+        # The two scales are not the same measurement -- the placebo sigma is
+        # drawn across donor markets, the error across backtest windows -- so
+        # the ratio has no value it should sit at. What is pinned is what it
+        # is: a positive, finite comparison of the one against the other.
+        s = result.power.dropna(subset=["calibration_ratio"])
+        assert not s.empty
+        assert (s["calibration_ratio"] > 0).all()
+        assert np.isfinite(s["calibration_ratio"]).all()
+        np.testing.assert_allclose(s["calibration_ratio"],
+                                   s["rmse"] / s["sigma_mean"], rtol=1e-9)
+
+
+class TestPlanningAccuracy:
+    def test_planning_rmse_is_reported_for_the_winner(self, result):
+        assert "winner_rmse_planning" in result.metadata
+        planning = result.metadata["winner_rmse_planning"]
+        assert planning is not None
+        assert planning >= 0 and np.isfinite(planning)
+        assert result.search.winner.rmse_planning == pytest.approx(planning)
+
+    def test_absent_when_no_validation_backtests(self, panel):
+        res = GEOX(GEOXConfig(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14], effect_sizes=GRID,
+            n_backtests=3, n_draws=25, n_validation_backtests=0,
+            alpha=ALPHA, seed=0)).fit()
+        assert res.metadata["winner_rmse_planning"] is None
+        assert res.search.winner.rmse_planning is None
+
+    def test_planning_backtests_are_not_the_selecting_ones(self, result):
+        # Held-back backtests sit deeper in history, so the winner's planning
+        # RMSE is a different number from its in-search one except by accident.
+        winner = result.search.winner
+        assert winner.rmse is not None and winner.rmse_planning is not None
+        assert winner.rmse_planning != pytest.approx(winner.rmse, rel=1e-12)
+
+
+class TestPlanningReadout:
+    """The two branches of the readout that a full design run does not reach."""
+
+    @staticmethod
+    def _config(panel, **overrides):
+        settings = dict(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14], effect_sizes=GRID,
+            n_backtests=3, n_draws=15, n_validation_backtests=2,
+            alpha=ALPHA, seed=0)
+        settings.update(overrides)
+        return GEOXConfig(**settings)
+
+    def test_a_panel_too_short_carries_no_held_back_backtests(self, panel, wide):
+        # The deeper windows would run off the start of the panel. Reported as
+        # nothing measured, which is what the caller turns into None.
+        config = self._config(panel, n_backtests=wide.shape[0],
+                              n_validation_backtests=4)
+        region = frozenset(list(wide.columns)[:2])
+        assert planning_backtests(wide, region, config).empty
+        assert planning_readout(pd.DataFrame(), config) == PlanningReadout()
+
+    def test_an_undetectable_winner_still_reports_its_error(self, panel):
+        # Nothing detectable means no planning MDE. The error does not depend
+        # on detectability, so it is still read -- at the duration the design
+        # deploys at, which is the longest requested.
+        config = self._config(panel, durations=[7, 14])
+        undetectable = _cube({"A": [2.0, 4.0]}, duration=7)
+        undetectable = pd.concat(
+            [undetectable, _cube({"A": [1.0, 3.0]}, duration=14)],
+            ignore_index=True)
+        readout = planning_readout(undetectable, config)
+        assert readout.mde is None
+        assert readout.rmse == pytest.approx(np.sqrt(5.0))
+
+
+class TestConformalEngine:
+    @pytest.fixture(scope="class")
+    def conformal(self, panel):
+        return GEOX(GEOXConfig(
+            df=panel, unitid="location", time="date", outcome="Y",
+            treatment_size=2, durations=[14], effect_sizes=GRID,
+            n_backtests=2, n_draws=15, n_validation_backtests=0,
+            engine="augsynth", inference="conformal",
+            alpha=ALPHA, seed=0)).fit()
+
+    def test_rmse_is_reported_without_a_sigma(self, conformal):
+        s = conformal.power
+        assert np.isfinite(s["rmse"].dropna()).all()
+        assert s["calibration_ratio"].isna().all()
+
+
+def test_the_criterion_costs_no_extra_fits(wide, monkeypatch):
+    # The identity is what makes the RMSE free. If a future change made the
+    # error depend on the effect size, the sweep would have to refit per grid
+    # point; this pins that it does not, by counting the fits behind one cube.
+    import dataclasses
+
+    import mlsynth.utils.geox_helpers.simulate as simulate_module
+
+    eng = resolve_engine("sdid")
+    calls = []
+
+    def counting_fit_once(*args, **kwargs):
+        calls.append(1)
+        return eng.fit_once(*args, **kwargs)
+
+    counting = dataclasses.replace(eng, fit_once=counting_fit_once)
+    monkeypatch.setattr(simulate_module, "resolve_engine",
+                        lambda name: counting)
+    region = frozenset(list(wide.columns)[:2])
+    y = aggregate_treated(wide, region, how="mean").to_numpy()
+    Y0 = donor_matrix(wide, region).to_numpy()
+    simulate_module.simulate_backtest(
+        y, Y0, wide.shape[0], 14, 1, list(itertools.chain(GRID, [0.3, 0.4])),
+        n_draws=15, n_tr=len(region), seed=1, alpha=ALPHA)
+    assert len(calls) == 1, "one backtest fit, whatever the grid's length"

--- a/mlsynth/utils/geox_helpers/aggregate.py
+++ b/mlsynth/utils/geox_helpers/aggregate.py
@@ -27,8 +27,9 @@ _POWER_COLUMNS = [
 ]
 
 _ACCURACY_COLUMNS = [
-    "candidate", "duration", "bias", "error_sd", "rmse", "sigma_mean",
-    "calibration_ratio",
+    "candidate", "duration",
+    "att_error_mean", "att_error_sd", "att_error_rmse",
+    "placebo_sigma_mean", "att_error_over_sigma",
 ]
 
 
@@ -98,7 +99,7 @@ def compute_accuracy(cube: pd.DataFrame) -> pd.DataFrame:
     two come apart when the estimator is biased under the design -- for
     synthetic control, a treated region outside the donor hull.
 
-    Each backtest carries one error, ``estimation_error``: the ATT with nothing
+    Each backtest carries one error, ``att_error``: the ATT with nothing
     injected. Injecting a lift ``e`` moves the truth and the estimate by the
     same ``e * mean(y_post)``, so that value is the estimate minus the truth at
     every effect size, and the error is a property of the backtest, not of the
@@ -107,12 +108,13 @@ def compute_accuracy(cube: pd.DataFrame) -> pd.DataFrame:
 
     Over those backtests::
 
-        bias     = mean(error)
-        error_sd = std(error)                  # population, so that
-        rmse     = sqrt(mean(error ** 2))      # rmse^2 = bias^2 + error_sd^2
+        att_error_mean = mean(error)          # the design's bias
+        att_error_sd   = std(error)           # population sd, so that
+        att_error_rmse = sqrt(mean(error**2)) # rmse^2 = mean^2 + sd^2
 
-    ``calibration_ratio = rmse / sigma_mean`` sets the error against the scale
-    the design's own inference tests it at. The two are not the same
+    ``att_error_over_sigma`` divides ``att_error_rmse`` by
+    ``placebo_sigma_mean``, setting the error against the scale the design's
+    own inference tests it at. The two are not the same
     measurement: the placebo standard error is drawn across donor markets
     reassigned as pseudo-treated, while the error varies across backtest
     windows for one fixed region. So the ratio has no value it should sit at,
@@ -123,9 +125,10 @@ def compute_accuracy(cube: pd.DataFrame) -> pd.DataFrame:
     anti-conservative. It is ``nan`` where the engine's procedure has no
     standard error, as conformal inference does not.
 
-    ``error_sd`` is a lower bound on across-experiment variability, because
+    ``att_error_sd`` is a lower bound on across-experiment variability, because
     consecutive backtests shift their window by one period and so overlap
-    heavily. On a short backtest set ``rmse`` is dominated by ``bias``.
+    heavily. On a short backtest set ``att_error_rmse`` is dominated by
+    ``att_error_mean``.
 
     A ``nan`` error from a backtest whose fit failed propagates into all three
     statistics. Dropping it would report the accuracy of the backtests that
@@ -139,20 +142,20 @@ def compute_accuracy(cube: pd.DataFrame) -> pd.DataFrame:
     Returns
     -------
     pd.DataFrame
-        One row per (candidate, duration) with ``bias``, ``error_sd``,
-        ``rmse``, ``sigma_mean`` and ``calibration_ratio``.
+        One row per (candidate, duration) with ``att_error_mean``, ``att_error_sd``,
+        ``att_error_rmse``, ``placebo_sigma_mean`` and ``att_error_over_sigma``.
 
     Raises
     ------
     MlsynthEstimationError
-        If the cube carries no ``estimation_error`` column, which means the
+        If the cube carries no ``att_error`` column, which means the
         engine did not report it.
     """
     if cube.empty:
         return pd.DataFrame(columns=_ACCURACY_COLUMNS)
-    if "estimation_error" not in cube.columns:
+    if "att_error" not in cube.columns:
         raise MlsynthEstimationError(
-            "the simulation cube carries no estimation_error column, so the "
+            "the simulation cube carries no att_error column, so the "
             "design's accuracy cannot be measured; the engine's sweep must "
             "return tau0.")
 
@@ -169,16 +172,16 @@ def compute_accuracy(cube: pd.DataFrame) -> pd.DataFrame:
     grouped = per_backtest.groupby(
         ["candidate", "duration"], as_index=False, sort=False, observed=True
     ).agg(
-        bias=("estimation_error", _mean),
-        # ddof=0 keeps rmse^2 = bias^2 + error_sd^2 exact, and gives a single
+        att_error_mean=("att_error", _mean),
+        # ddof=0 keeps rmse^2 = mean^2 + sd^2 exact, and gives a single
         # backtest a spread of zero instead of nan.
-        error_sd=("estimation_error", _sd),
-        rmse=("estimation_error", _rmse),
-        sigma_mean=("placebo_sigma", _mean),
+        att_error_sd=("att_error", _sd),
+        att_error_rmse=("att_error", _rmse),
+        placebo_sigma_mean=("placebo_sigma", _mean),
     )
-    grouped["calibration_ratio"] = np.where(
-        grouped["sigma_mean"].to_numpy(dtype=float) > 0,
-        grouped["rmse"] / grouped["sigma_mean"],
+    grouped["att_error_over_sigma"] = np.where(
+        grouped["placebo_sigma_mean"].to_numpy(dtype=float) > 0,
+        grouped["att_error_rmse"] / grouped["placebo_sigma_mean"],
         np.nan,
     )
     return grouped[_ACCURACY_COLUMNS]

--- a/mlsynth/utils/geox_helpers/aggregate.py
+++ b/mlsynth/utils/geox_helpers/aggregate.py
@@ -7,8 +7,10 @@ Pure array/groupby reductions on the long p-value cube from
    rate, plus the backtest-averaged metrics.
 2. :func:`compute_mde` -- the minimum detectable effect per (candidate,
    duration), with GeoLift's signed positive/negative selection.
+3. :func:`compute_accuracy` -- the same collapse read for error instead of
+   detection: how far the design's estimate lands from the truth.
 
-(The composite rank is built on top of these.)
+(The composite rank is built on top of the first two.)
 """
 
 from typing import List, Optional
@@ -16,10 +18,17 @@ from typing import List, Optional
 import numpy as np
 import pandas as pd
 
+from ...exceptions import MlsynthEstimationError
+
 _POWER_COLUMNS = [
     "candidate", "duration", "effect_size",
     "power", "placebo_mean_effect", "detected_lift", "scaled_l2", "pre_rmspe",
     "pre_rmspe_lambda", "investment",
+]
+
+_ACCURACY_COLUMNS = [
+    "candidate", "duration", "bias", "error_sd", "rmse", "sigma_mean",
+    "calibration_ratio",
 ]
 
 
@@ -63,6 +72,116 @@ def compute_power(cube: pd.DataFrame, *, alpha: float = 0.1) -> pd.DataFrame:
     return tmp.groupby(
         ["candidate", "duration", "effect_size"], as_index=False, sort=False, observed=True
     ).agg(**aggs)
+
+
+# The accuracy statistics propagate a nan instead of skipping it, which is
+# where they part company with the pandas reductions used elsewhere in this
+# module. A backtest whose fit failed leaves a nan error, and skipping it would
+# report the accuracy of the backtests that happened to work.
+def _mean(values: pd.Series) -> float:
+    return float(np.mean(values.to_numpy(dtype=float)))
+
+
+def _sd(values: pd.Series) -> float:
+    return float(np.std(values.to_numpy(dtype=float), ddof=0))
+
+
+def _rmse(values: pd.Series) -> float:
+    return float(np.sqrt(np.mean(np.square(values.to_numpy(dtype=float)))))
+
+
+def compute_accuracy(cube: pd.DataFrame) -> pd.DataFrame:
+    """Collapse the backtest dimension into the design's estimation error.
+
+    The MDE says the smallest effect a design can detect. It says nothing about
+    how far the estimate lands from the truth once an effect is there, and the
+    two come apart when the estimator is biased under the design -- for
+    synthetic control, a treated region outside the donor hull.
+
+    Each backtest carries one error, ``estimation_error``: the ATT with nothing
+    injected. Injecting a lift ``e`` moves the truth and the estimate by the
+    same ``e * mean(y_post)``, so that value is the estimate minus the truth at
+    every effect size, and the error is a property of the backtest, not of the
+    grid. Rows are reduced to one per (candidate, duration, backtest) before
+    aggregating, so the numbers below are over backtests however long the grid.
+
+    Over those backtests::
+
+        bias     = mean(error)
+        error_sd = std(error)                  # population, so that
+        rmse     = sqrt(mean(error ** 2))      # rmse^2 = bias^2 + error_sd^2
+
+    ``calibration_ratio = rmse / sigma_mean`` sets the error against the scale
+    the design's own inference tests it at. The two are not the same
+    measurement: the placebo standard error is drawn across donor markets
+    reassigned as pseudo-treated, while the error varies across backtest
+    windows for one fixed region. So the ratio has no value it should sit at,
+    and a small one is the ordinary case -- a region's own ATT is usually far
+    more stable across windows than the placebo pool is across markets. What it
+    catches is the other end: a ratio above one says the design's error exceeds
+    what its null admits, so the p-values, and the MDE built from them, are
+    anti-conservative. It is ``nan`` where the engine's procedure has no
+    standard error, as conformal inference does not.
+
+    ``error_sd`` is a lower bound on across-experiment variability, because
+    consecutive backtests shift their window by one period and so overlap
+    heavily. On a short backtest set ``rmse`` is dominated by ``bias``.
+
+    A ``nan`` error from a backtest whose fit failed propagates into all three
+    statistics. Dropping it would report the accuracy of the backtests that
+    happened to work.
+
+    Parameters
+    ----------
+    cube : pd.DataFrame
+        Long simulation table from :func:`run_simulations`.
+
+    Returns
+    -------
+    pd.DataFrame
+        One row per (candidate, duration) with ``bias``, ``error_sd``,
+        ``rmse``, ``sigma_mean`` and ``calibration_ratio``.
+
+    Raises
+    ------
+    MlsynthEstimationError
+        If the cube carries no ``estimation_error`` column, which means the
+        engine did not report it.
+    """
+    if cube.empty:
+        return pd.DataFrame(columns=_ACCURACY_COLUMNS)
+    if "estimation_error" not in cube.columns:
+        raise MlsynthEstimationError(
+            "the simulation cube carries no estimation_error column, so the "
+            "design's accuracy cannot be measured; the engine's sweep must "
+            "return tau0.")
+
+    # One row per backtest: the error is constant across the effect grid, so
+    # aggregating the long cube directly would weight nothing differently but
+    # would state the reduction less plainly.
+    per_backtest = cube.drop_duplicates(
+        subset=["candidate", "duration", "sim"], keep="first")
+    if "placebo_sigma" not in per_backtest.columns:
+        # An engine with no standard error reports none; the ratio is then
+        # absent, which is a different thing from the error being unmeasured.
+        per_backtest = per_backtest.assign(placebo_sigma=np.nan)
+
+    grouped = per_backtest.groupby(
+        ["candidate", "duration"], as_index=False, sort=False, observed=True
+    ).agg(
+        bias=("estimation_error", _mean),
+        # ddof=0 keeps rmse^2 = bias^2 + error_sd^2 exact, and gives a single
+        # backtest a spread of zero instead of nan.
+        error_sd=("estimation_error", _sd),
+        rmse=("estimation_error", _rmse),
+        sigma_mean=("placebo_sigma", _mean),
+    )
+    grouped["calibration_ratio"] = np.where(
+        grouped["sigma_mean"].to_numpy(dtype=float) > 0,
+        grouped["rmse"] / grouped["sigma_mean"],
+        np.nan,
+    )
+    return grouped[_ACCURACY_COLUMNS]
 
 
 def compute_mde(power_table: pd.DataFrame, *, power_threshold: float = 0.8) -> pd.DataFrame:

--- a/mlsynth/utils/geox_helpers/batch.py
+++ b/mlsynth/utils/geox_helpers/batch.py
@@ -16,7 +16,8 @@ from .simulate import simulate_backtest
 
 _COLUMNS = [
     "candidate", "duration", "sim", "effect_size",
-    "p_value", "placebo_mean_effect", "detected_lift", "scaled_l2", "pre_rmspe",
+    "p_value", "placebo_mean_effect", "detected_lift", "estimation_error",
+    "placebo_sigma", "scaled_l2", "pre_rmspe",
     "pre_rmspe_lambda", "boundary_up", "boundary_down", "investment",
 ]
 

--- a/mlsynth/utils/geox_helpers/batch.py
+++ b/mlsynth/utils/geox_helpers/batch.py
@@ -16,7 +16,7 @@ from .simulate import simulate_backtest
 
 _COLUMNS = [
     "candidate", "duration", "sim", "effect_size",
-    "p_value", "placebo_mean_effect", "detected_lift", "estimation_error",
+    "p_value", "placebo_mean_effect", "detected_lift", "att_error",
     "placebo_sigma", "scaled_l2", "pre_rmspe",
     "pre_rmspe_lambda", "boundary_up", "boundary_down", "investment",
 ]

--- a/mlsynth/utils/geox_helpers/engines/__init__.py
+++ b/mlsynth/utils/geox_helpers/engines/__init__.py
@@ -24,6 +24,14 @@ An engine supplies five things.
     be recomputed per effect size. Keeping the grid here keeps that cost
     decision inside the module that owns it.
 
+    The dict carries ``tau``, ``p_value`` and ``sigma`` (``None`` where the
+    procedure has no standard error), plus ``tau0`` -- the ATT with nothing
+    injected. ``tau0`` is the backtest's estimation error: the injected truth is
+    ``e * mean(y[post])`` and the estimate is ``tau0 + e * mean(y[post])``, so
+    the difference is ``tau0`` at every effect size. It is returned instead of
+    being read off the grid because the grid is user-supplied and need not
+    contain zero.
+
 ``point_inference(fit, y, Y0, n_pre, start, end, ...) -> (p_value, details)``
     A single window's test, for the realized readout.
 

--- a/mlsynth/utils/geox_helpers/engines/augsynth/__init__.py
+++ b/mlsynth/utils/geox_helpers/engines/augsynth/__init__.py
@@ -168,7 +168,7 @@ def sweep_p_values(
                 finite_sample=finite_sample)))
     up, down = (placebo_detection_boundary(tau0, baseline, sigma, alpha)
                 if inference == "placebo" else (float("nan"), float("nan")))
-    return {"tau": taus, "p_value": ps, "sigma": sigma,
+    return {"tau": taus, "p_value": ps, "sigma": sigma, "tau0": tau0,
             "boundary_up": up, "boundary_down": down}
 
 

--- a/mlsynth/utils/geox_helpers/engines/sdid/__init__.py
+++ b/mlsynth/utils/geox_helpers/engines/sdid/__init__.py
@@ -110,7 +110,7 @@ def sweep_p_values(
         taus.append(tau)
         ps.append(normal_p_value(tau, sigma))
     up, down = placebo_detection_boundary(tau0, baseline, sigma, alpha)
-    return {"tau": taus, "p_value": ps, "sigma": sigma,
+    return {"tau": taus, "p_value": ps, "sigma": sigma, "tau0": tau0,
             "boundary_up": up, "boundary_down": down}
 
 

--- a/mlsynth/utils/geox_helpers/orchestration.py
+++ b/mlsynth/utils/geox_helpers/orchestration.py
@@ -7,7 +7,7 @@
     -> GEOXResults
 """
 
-from typing import Dict, List, Optional
+from typing import Dict, List, NamedTuple, Optional
 
 import numpy as np
 import pandas as pd
@@ -15,7 +15,7 @@ import pandas as pd
 from ...config_models import WeightsResults
 from ...exceptions import MlsynthConfigError, MlsynthDataError
 from ..datautils import geoex_dataprep
-from .aggregate import (compute_exact_mde, compute_mde,
+from .aggregate import (compute_accuracy, compute_exact_mde, compute_mde,
                         compute_power, compute_rank)
 from .batch import run_simulations
 from .candidates import generate_candidate_markets
@@ -80,34 +80,46 @@ def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
     )
 
 
+class PlanningReadout(NamedTuple):
+    """The winner's design scored on backtests that did not choose it.
 
-def planning_mde(Ywide: pd.DataFrame, candidate, config: GEOXConfig,
-                power_table: pd.DataFrame, exclude=None) -> Optional[float]:
-    """The winner's MDE re-scored on backtests that did not choose it.
+    ``mde`` and ``rmse`` are read at the same duration, so the two numbers
+    describe one experiment.
+    """
+
+    mde: Optional[float] = None
+    rmse: Optional[float] = None
+
+
+def planning_backtests(Ywide: pd.DataFrame, candidate, config: GEOXConfig,
+                       exclude=None) -> pd.DataFrame:
+    """Score one candidate on backtests held back from the search.
 
     ``compute_rank`` hands back the smallest MDE in the field, and the smallest
     of many noisy estimates is optimistic: the region most likely to be picked
     is the one whose estimate happened to come out low. Re-scoring the winner on
     backtests held back from the search removes that, because those backtests
     played no part in selecting it -- the same reason a region fixed in advance
-    is calibrated at any backtest count.
+    is calibrated at any backtest count. The same argument applies to accuracy,
+    which is why one cube serves both readings.
 
     Backtests ``n_backtests + 1 .. n_backtests + n_validation_backtests``
     sit deeper in history, so their pseudo-treatment windows differ from every
-    window the search used. Returns ``None`` when the panel cannot carry them.
+    window the search used. Returns an empty frame when the panel cannot carry
+    them.
     """
     if config.n_validation_backtests < 1:
-        return None
+        return pd.DataFrame()
     n_periods = Ywide.shape[0]
     longest = max(config.durations)
     deepest = config.n_backtests + config.n_validation_backtests
     if longest + deepest - 1 >= n_periods:
-        return None  # the panel cannot carry the extra backtests
+        return pd.DataFrame()  # the panel cannot carry the extra backtests
 
     treated = aggregate_treated(Ywide, candidate, how="mean").to_numpy()
     donors = donor_matrix(Ywide, candidate, exclude=exclude).to_numpy()
     # The validation backtests score on the same engine and settings the search
-    # used, so the planning MDE is comparable with the one it corrects.
+    # used, so the planning numbers are comparable with the ones they correct.
     ekw = engine_settings(config)
     rows: List[dict] = []
     for duration in config.durations:
@@ -119,17 +131,37 @@ def planning_mde(Ywide: pd.DataFrame, candidate, config: GEOXConfig,
             ):
                 row["candidate"] = candidate
                 rows.append(row)
-    if not rows:  # pragma: no cover - guarded by the depth check above
-        return None
+    return pd.DataFrame(rows)
 
-    held = compute_power(pd.DataFrame(rows), alpha=config.alpha)
+
+def planning_readout(cube: pd.DataFrame, config: GEOXConfig) -> PlanningReadout:
+    """Read the MDE and the RMSE off the held-back backtests.
+
+    Across durations the design deploys the one it ranked best, so the MDE is
+    the smallest magnitude, matching how ``compute_rank`` reads a candidate's
+    row. The RMSE is reported at that same duration. When nothing is detectable
+    the MDE is absent and the RMSE falls back to the duration the design
+    deploys at, which is the longest requested.
+    """
+    if cube.empty:
+        return PlanningReadout()
+
+    held = compute_power(cube, alpha=config.alpha)
     mde_table = compute_mde(held, power_threshold=config.power_threshold)
-    values = mde_table["mde"].dropna()
-    if values.empty:
-        return None  # nothing detectable on the held-back backtests
-    # Across durations, the design deploys the one it ranked best; take the
-    # smallest magnitude, matching how compute_rank reads a candidate's row.
-    return float(values.loc[values.abs().idxmin()])
+    accuracy = compute_accuracy(cube).set_index("duration")
+
+    detectable = mde_table.dropna(subset=["mde"])
+    if detectable.empty:
+        mde = None  # nothing detectable on the held-back backtests
+        duration = max(config.durations)
+    else:
+        best = detectable.loc[detectable["mde"].abs().idxmin()]
+        mde = float(best["mde"])
+        duration = best["duration"]
+
+    rmse = (float(accuracy.loc[duration, "rmse"])
+            if duration in accuracy.index else None)
+    return PlanningReadout(mde=mde, rmse=rmse)
 
 
 def engine_settings(config: GEOXConfig) -> dict:
@@ -283,11 +315,18 @@ def run_design(config: GEOXConfig) -> GEOXResults:
     # grid. Reported beside mde, which the ranking and the GeoLift
     # cross-validation both depend on and which is left alone.
     exact = compute_exact_mde(cube, power_threshold=config.power_threshold)
+    # How far the estimate lands from an injected truth, beside how small an
+    # effect the design can detect. Reported, and no part of the rank: the
+    # composite is what the GeoLift cross-validation pins.
+    accuracy = compute_accuracy(cube)
     shortlist = compute_rank(power_table,
                              power_threshold=config.power_threshold,
                              budget=config.budget)
     if not shortlist.empty and not exact.empty:
         shortlist = shortlist.merge(exact, on=["candidate", "duration"],
+                                    how="left")
+    if not shortlist.empty and not accuracy.empty:
+        shortlist = shortlist.merge(accuracy, on=["candidate", "duration"],
                                     how="left")
     if not shortlist.empty:
         # Surface the region size next to its MDE, so a size scan is readable
@@ -306,18 +345,21 @@ def run_design(config: GEOXConfig) -> GEOXResults:
     }
 
     # Stitch each candidate's best (lowest-rank) shortlist row into its design.
+    stitched = ("rank", "mde", "power", "bias", "error_sd", "rmse",
+                "calibration_ratio")
     best: Dict[frozenset, dict] = {}
     for _, row in shortlist.iterrows():
         cand = row["candidate"]
         if cand not in best or row["rank"] < best[cand]["rank"]:
-            best[cand] = {"rank": row["rank"], "mde": row["mde"],
-                          "power": row["power"]}
+            best[cand] = {name: row.get(name) for name in stitched}
     for cand, design in designs.items():
         match = best.get(cand)
-        if match is not None:
-            design.rank = float(match["rank"])
-            design.mde = float(match["mde"])
-            design.power = float(match["power"])
+        if match is None:
+            continue
+        for name in stitched:
+            value = match[name]
+            setattr(design, name,
+                    None if value is None or pd.isna(value) else float(value))
 
     winner = None
     winner_units = None
@@ -327,8 +369,11 @@ def run_design(config: GEOXConfig) -> GEOXResults:
         winner_units = sorted(map(str, winning))
         # Scored only now, and only for the winner, so the backtests behind it
         # cannot have influenced which region was picked.
-        winner.mde_planning = planning_mde(Ywide, winning, config, power_table,
-                                           exclude=excluded.get(winning))
+        held = planning_backtests(Ywide, winning, config,
+                                  exclude=excluded.get(winning))
+        readout = planning_readout(held, config)
+        winner.mde_planning = readout.mde
+        winner.rmse_planning = readout.rmse
 
     search = MarketSearch(shortlist=shortlist, power_table=power_table,
                           candidates=list(designs.values()), winner=winner)
@@ -372,6 +417,10 @@ def run_design(config: GEOXConfig) -> GEOXResults:
             "winner_mde_planning": (
                 float(winner.mde_planning) if winner is not None
                 and winner.mde_planning is not None else None),
+            # What the winner gets wrong, on the same held-back backtests.
+            "winner_rmse_planning": (
+                float(winner.rmse_planning) if winner is not None
+                and winner.rmse_planning is not None else None),
             "n_validation_backtests": config.n_validation_backtests,
         },
         search=search,

--- a/mlsynth/utils/geox_helpers/orchestration.py
+++ b/mlsynth/utils/geox_helpers/orchestration.py
@@ -83,12 +83,12 @@ def design_fit(Ywide: pd.DataFrame, candidate, n_pre: int,
 class PlanningReadout(NamedTuple):
     """The winner's design scored on backtests that did not choose it.
 
-    ``mde`` and ``rmse`` are read at the same duration, so the two numbers
-    describe one experiment.
+    ``mde`` and ``att_error_rmse`` are read at the same duration, so the two
+    numbers describe one experiment.
     """
 
     mde: Optional[float] = None
-    rmse: Optional[float] = None
+    att_error_rmse: Optional[float] = None
 
 
 def planning_backtests(Ywide: pd.DataFrame, candidate, config: GEOXConfig,
@@ -159,9 +159,9 @@ def planning_readout(cube: pd.DataFrame, config: GEOXConfig) -> PlanningReadout:
         mde = float(best["mde"])
         duration = best["duration"]
 
-    rmse = (float(accuracy.loc[duration, "rmse"])
+    att_error_rmse = (float(accuracy.loc[duration, "att_error_rmse"])
             if duration in accuracy.index else None)
-    return PlanningReadout(mde=mde, rmse=rmse)
+    return PlanningReadout(mde=mde, att_error_rmse=att_error_rmse)
 
 
 def engine_settings(config: GEOXConfig) -> dict:
@@ -345,8 +345,8 @@ def run_design(config: GEOXConfig) -> GEOXResults:
     }
 
     # Stitch each candidate's best (lowest-rank) shortlist row into its design.
-    stitched = ("rank", "mde", "power", "bias", "error_sd", "rmse",
-                "calibration_ratio")
+    stitched = ("rank", "mde", "power", "att_error_mean", "att_error_sd",
+                "att_error_rmse", "att_error_over_sigma")
     best: Dict[frozenset, dict] = {}
     for _, row in shortlist.iterrows():
         cand = row["candidate"]
@@ -373,7 +373,7 @@ def run_design(config: GEOXConfig) -> GEOXResults:
                                   exclude=excluded.get(winning))
         readout = planning_readout(held, config)
         winner.mde_planning = readout.mde
-        winner.rmse_planning = readout.rmse
+        winner.att_error_rmse_planning = readout.att_error_rmse
 
     search = MarketSearch(shortlist=shortlist, power_table=power_table,
                           candidates=list(designs.values()), winner=winner)
@@ -418,9 +418,9 @@ def run_design(config: GEOXConfig) -> GEOXResults:
                 float(winner.mde_planning) if winner is not None
                 and winner.mde_planning is not None else None),
             # What the winner gets wrong, on the same held-back backtests.
-            "winner_rmse_planning": (
-                float(winner.rmse_planning) if winner is not None
-                and winner.rmse_planning is not None else None),
+            "winner_att_error_rmse_planning": (
+                float(winner.att_error_rmse_planning) if winner is not None
+                and winner.att_error_rmse_planning is not None else None),
             "n_validation_backtests": config.n_validation_backtests,
         },
         search=search,

--- a/mlsynth/utils/geox_helpers/simulate.py
+++ b/mlsynth/utils/geox_helpers/simulate.py
@@ -8,7 +8,8 @@ the ATT and the placebo sigma is shared across it -- so the whole grid of effect
 sizes costs one fit and one placebo run.
 
 The row schema matches what
-:func:`~mlsynth.utils.geox_helpers.aggregate.compute_power` consumes, one row
+:func:`~mlsynth.utils.geox_helpers.aggregate.compute_power` and
+:func:`~mlsynth.utils.geox_helpers.aggregate.compute_accuracy` consume, one row
 per effect size.
 """
 
@@ -16,7 +17,7 @@ from typing import List, Optional
 
 import numpy as np
 
-from ...exceptions import MlsynthConfigError
+from ...exceptions import MlsynthConfigError, MlsynthEstimationError
 from .engines import resolve_engine
 from .windows import backtest_pre_periods, backtest_treatment_window
 
@@ -83,13 +84,19 @@ def simulate_backtest(
         One row per effect size, carrying ``sim``, ``duration``,
         ``effect_size``, ``p_value``, ``placebo_mean_effect`` (the SDID ATT),
         ``detected_lift`` (ATT over the counterfactual post mean),
-        ``scaled_l2``, ``pre_rmspe`` and ``investment``.
+        ``estimation_error`` (the ATT with nothing injected, which is the
+        estimate minus the injected truth at every effect size),
+        ``placebo_sigma`` (``nan`` where the engine's procedure has no standard
+        error), ``scaled_l2``, ``pre_rmspe`` and ``investment``.
 
     Raises
     ------
     MlsynthConfigError
         If the backtest runs off the start of the panel, or ``treated`` /
         ``donors`` do not have ``n_periods`` rows.
+    MlsynthEstimationError
+        If the engine's sweep returns no ``tau0``, which the engine protocol
+        requires and the accuracy of the design is measured from.
     """
     n_pre = backtest_pre_periods(n_periods, duration, sim)
     start, end = backtest_treatment_window(n_periods, duration, sim)
@@ -117,6 +124,19 @@ def simulate_backtest(
                  if treated_total is not None else treated_arr)
     window_volume = float(np.sum(total_arr[start:end + 1]))
 
+    # The estimation error of this backtest. The injected truth at effect size
+    # ``es`` is ``es * mean(y_post)`` and the estimate is
+    # ``tau0 + es * mean(y_post)``, so the error is ``tau0`` whatever was
+    # injected -- which is why it is one value per backtest, not one per grid
+    # point, and why measuring it costs no additional fit.
+    if "tau0" not in swept:
+        raise MlsynthEstimationError(
+            f"the {engine!r} engine's sweep returned no tau0, so the backtest "
+            "cannot report what it got wrong; every engine owes it.")
+    error = float(swept["tau0"])
+    sigma = swept.get("sigma")
+    sigma = float("nan") if sigma is None else float(sigma)
+
     rows: List[dict] = []
     for es, tau, p_value in zip(effect_sizes, swept["tau"], swept["p_value"]):
         rows.append({
@@ -125,6 +145,8 @@ def simulate_backtest(
             "effect_size": float(es),
             "p_value": p_value,
             "placebo_mean_effect": tau,
+            "estimation_error": error,
+            "placebo_sigma": sigma,
             "detected_lift": (tau / cf_post_mean if cf_post_mean != 0.0
                               else float("nan")),
             "scaled_l2": fit.scaled_l2,

--- a/mlsynth/utils/geox_helpers/simulate.py
+++ b/mlsynth/utils/geox_helpers/simulate.py
@@ -84,7 +84,7 @@ def simulate_backtest(
         One row per effect size, carrying ``sim``, ``duration``,
         ``effect_size``, ``p_value``, ``placebo_mean_effect`` (the SDID ATT),
         ``detected_lift`` (ATT over the counterfactual post mean),
-        ``estimation_error`` (the ATT with nothing injected, which is the
+        ``att_error`` (the ATT with nothing injected, which is the
         estimate minus the injected truth at every effect size),
         ``placebo_sigma`` (``nan`` where the engine's procedure has no standard
         error), ``scaled_l2``, ``pre_rmspe`` and ``investment``.
@@ -145,7 +145,7 @@ def simulate_backtest(
             "effect_size": float(es),
             "p_value": p_value,
             "placebo_mean_effect": tau,
-            "estimation_error": error,
+            "att_error": error,
             "placebo_sigma": sigma,
             "detected_lift": (tau / cf_post_mean if cf_post_mean != 0.0
                               else float("nan")),

--- a/mlsynth/utils/geox_helpers/structures.py
+++ b/mlsynth/utils/geox_helpers/structures.py
@@ -43,6 +43,20 @@ class CandidateDesign:
         it. ``mde`` is the smallest in a field of candidates and so is
         optimistic; this one is not selected on. Set only on the winner, and
         ``None`` when ``n_validation_backtests`` is 0 or the panel is too short.
+    bias, error_sd, rmse : float or None
+        How far the design's estimate lands from an injected truth, over the
+        backtests: the mean error, its spread, and the root mean square that
+        combines them. The MDE answers what the design can detect; these answer
+        what it will get wrong.
+    calibration_ratio : float or None
+        ``rmse`` over the placebo standard error the design's own inference
+        tests at. Small is ordinary, since the two are measured over different
+        things; above one says the design's error exceeds what its null admits,
+        so the p-values and the MDE built from them are anti-conservative.
+        ``None`` where the engine's procedure has no standard error.
+    rmse_planning : float or None
+        The winner's ``rmse`` re-scored on the same held-back backtests as
+        ``mde_planning``, and set under the same conditions.
     """
 
     units: List
@@ -56,6 +70,11 @@ class CandidateDesign:
     power: Optional[float] = None
     rank: Optional[float] = None
     mde_planning: Optional[float] = None
+    bias: Optional[float] = None
+    error_sd: Optional[float] = None
+    rmse: Optional[float] = None
+    calibration_ratio: Optional[float] = None
+    rmse_planning: Optional[float] = None
 
 
 @dataclass

--- a/mlsynth/utils/geox_helpers/structures.py
+++ b/mlsynth/utils/geox_helpers/structures.py
@@ -43,20 +43,20 @@ class CandidateDesign:
         it. ``mde`` is the smallest in a field of candidates and so is
         optimistic; this one is not selected on. Set only on the winner, and
         ``None`` when ``n_validation_backtests`` is 0 or the panel is too short.
-    bias, error_sd, rmse : float or None
+    att_error_mean, att_error_sd, att_error_rmse : float or None
         How far the design's estimate lands from an injected truth, over the
         backtests: the mean error, its spread, and the root mean square that
         combines them. The MDE answers what the design can detect; these answer
         what it will get wrong.
-    calibration_ratio : float or None
-        ``rmse`` over the placebo standard error the design's own inference
-        tests at. Small is ordinary, since the two are measured over different
+    att_error_over_sigma : float or None
+        ``att_error_rmse`` over the placebo standard error the design's own
+        inference tests at. Small is ordinary, since the two are measured over different
         things; above one says the design's error exceeds what its null admits,
         so the p-values and the MDE built from them are anti-conservative.
         ``None`` where the engine's procedure has no standard error.
-    rmse_planning : float or None
-        The winner's ``rmse`` re-scored on the same held-back backtests as
-        ``mde_planning``, and set under the same conditions.
+    att_error_rmse_planning : float or None
+        The winner's ``att_error_rmse`` re-scored on the same held-back
+        backtests as ``mde_planning``, and set under the same conditions.
     """
 
     units: List
@@ -70,11 +70,11 @@ class CandidateDesign:
     power: Optional[float] = None
     rank: Optional[float] = None
     mde_planning: Optional[float] = None
-    bias: Optional[float] = None
-    error_sd: Optional[float] = None
-    rmse: Optional[float] = None
-    calibration_ratio: Optional[float] = None
-    rmse_planning: Optional[float] = None
+    att_error_mean: Optional[float] = None
+    att_error_sd: Optional[float] = None
+    att_error_rmse: Optional[float] = None
+    att_error_over_sigma: Optional[float] = None
+    att_error_rmse_planning: Optional[float] = None
 
 
 @dataclass


### PR DESCRIPTION
## Related Links

- Docs page: `docs/geox.rst` (new subsections "What the design detects, and what it gets wrong" and "What the error is measured against"); decision tree entry in `docs/choose.rst`
- Prior art this borrows from: `google/trimmed_match` scores designs by RMSE of the estimator against a hypothesized iROAS (`design/matched_pairs_rmse.py`), which is the criterion GEOX lacked. Surveyed alongside `google/matched_markets` and `google/meridian-geox` — the last of these declares `Methodology.SDID` but raises on it, so nothing there to port.
- No issue.

## What

GEOX reported how small a lift a design can detect (`mde`) and nothing about where the estimate lands once the lift is real. This adds the second number from the same backtests.

- Added `compute_accuracy` in `utils/geox_helpers/aggregate.py` — collapses the backtest dimension into `att_error_mean`, `att_error_sd`, `att_error_rmse`, `placebo_sigma_mean`, `att_error_over_sigma`.
- Added `att_error` and `placebo_sigma` to the simulation cube; both engines now return `tau0` from their sweep.
- Split `planning_mde` into `planning_backtests` (run the held-back backtests) and `planning_readout` (read MDE and RMSE off one cube at one duration), dropping a dead `power_table` parameter and a second simulation pass.
- `CandidateDesign` gains the accuracy fields plus `att_error_rmse_planning`; `metadata` gains `winner_att_error_rmse_planning`.
- Docs: what the criterion measures, what it is measured against, and how it differs from `abs_lift_in_zero`.

## Why

The MDE and the estimate's accuracy come apart whenever the estimator is biased under the design — for synthetic control, when the test region sits outside the range its donors reproduce. On the geolift panel the region with the smallest MDE in the field (0.10 against 0.15) has the largest error, an RMSE of 64 conversions a day against 17. An experiment run there would find a small effect and misstate it, and nothing in the previous output said so.

The rank already carried `abs_lift_in_zero`, but that term is computed after `compute_power` has averaged over backtests, so it measures bias and cancels error that alternates in sign. A design whose error runs +5, −5, +5, −5 is unbiased and unreliable; only squaring before averaging says so.

## How

The criterion costs no additional fit, which is why it is worth having rather than approximating. Both engines define the ATT as the mean gap over the window and neither builds its counterfactual from the treated post block, so injecting `y[post] *= (1+e)` moves the truth and the estimate by the same `e·mean(y_post)`:

```
tau_hat(e) - e * mean(y_post) = tau_0
```

exactly, at every effect size, on both engines and both the analytic and re-inject paths. Measuring accuracy is a second reading of numbers the power calculation already produced. `ddof=0` on the spread keeps `rmse² = mean² + sd²` exact and gives a single backtest zero spread instead of nan.

The composite rank is untouched — it is what the GeoLift cross-validation pins — and a test asserts the `mde`/`rank` columns are frame-identical with and without the new columns.

## Verification

- Path: not applicable in the replication sense. No estimator output changes and no pinned benchmark value moves; this adds reported columns beside the existing ones.
- What is pinned instead: the identity above is asserted for both engines × `analytic=True/False` across an effect grid to 1e-9. If it ever stops holding, the reported RMSE silently stops meaning what it says, so it is the load-bearing test.
- Also pinned: `rmse² = mean² + sd²` on hand-built cubes and on real backtests; that a sign-alternating design and a steady one of equal magnitude are separated by RMSE and not by `abs_lift_in_zero`; that the ranking is unchanged.
- Not matched, and recorded as such: `att_error_over_sigma` runs 0.03–3.7 across candidates on the geolift panel. I checked this by hand against per-backtest `tau0` and `sigma` and it reconciles exactly — the placebo sigma is drawn across donor markets while the error varies across backtest windows, so they are not the same measurement and the ratio has no value it should sit at. My first draft asserted a band around 1; that was wrong and the test now pins only what is true.
- A durable benchmark case is deliberately out of scope (see Other Notes).

## Scope checks

<!-- FEATURE ON AN EXISTING ESTIMATOR -->
- [x] The default preserves existing behaviour exactly — no estimator output changes, only added columns and fields
- [x] Existing pinned benchmark values unchanged; none moved
- [x] A test pins that the default is unchanged (`test_the_ranking_is_untouched`)
- [x] New fields carry docstring descriptions saying what they mean and when to read them

## Designs

No new plot. The accuracy columns sit beside `mde` in `res.power`; the docs page shows the shortlist with both, on the geolift panel.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_geox_rmse.py -q` — 37 passed
- [x] `pytest mlsynth/tests/ -k "geox or result_contract"` — 691 passed, 7 skipped
- [x] `coverage run --timid -m pytest mlsynth/tests/test_geox_rmse.py && coverage report` — every new line covered; remaining misses in the touched modules are pre-existing lines other test files cover
- [x] Docs section underlines checked; no banned words, no new prints or `plt.show()`

The blast radius is confined to `geox_helpers` — nothing else in the package imports it.

## Other Notes

- A durable benchmark case belongs on its own branch, per the replication contract in CLAUDE.md. The natural one is the existing Recast port (`simulate.py:simulate_recast_panel`), whose study publishes per-tool bias and coverage, so GEOX's reported RMSE and calibration ratio can be checked against the published GeoLift row.
- The accuracy columns are reported and take no part in the rank. Making RMSE a rank component would change which region GEOX selects and should be its own change, with the GeoLift replication re-run to show what moved.
- `att_error_sd` is a floor, not an estimate of across-experiment variability: consecutive backtests shift their window by one period and overlap heavily. Documented on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzCiKRsesDK28RMtQ1Yjzf

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzCiKRsesDK28RMtQ1Yjzf)_