### PR TITLE
Explain DROSC's estimand on its page, and record the slack it uses

### DIFF
--- a/docs/drosc.rst
+++ b/docs/drosc.rst
@@ -6,13 +6,29 @@ Overview
 
 Classical synthetic control estimates a treatment effect by matching the treated
 unit's pre-treatment outcomes with a weighted average of control units, and then
-assumes that the same weighting carries over to the post-treatment period. Two
-things break that assumption in practice. When the control units are highly
-correlated, many different weight vectors fit the pre-period almost equally well,
-so the chosen weights -- and the effect read off them -- are unstable. And when
-the relationship between the treated unit and the controls shifts across the
-intervention, the pre-period weighting no longer identifies the counterfactual at
-all.
+assumes that the same weighting carries over to the post-treatment period. That
+argument needs two separate things to be true, and Koo & Guo (2026) label them:
+
+(E1) the pre-treatment weights are unique -- exactly one weighting on the
+simplex minimises the pre-period fit;
+
+(E2) there is no weight shift -- the weighting that describes the treated unit
+before the intervention is the same one that describes it after.
+
+Both fail routinely. (E1) fails when the control units are highly correlated:
+many weight vectors then fit the pre-period almost indistinguishably, the solver
+returns one of them, and the effect read off it inherits that arbitrariness. In
+the paper's own Basque application most correlations between the selected and
+the remaining controls sit near one. (E2) fails when the intervention alters the
+treated-control relationship. It also fails for a subtler reason: with the
+simplex constraint dropped, the weights are population least-squares projections,
+and a projection depends on the distribution of the controls -- so a shift in
+that distribution moves the weights even when the conditional relationship
+:math:`\mathbb{E}[Y^{(0)}_{1t} \mid X_t]` is unchanged.
+
+When (E1) fails the post-treatment weight is not pinned down; when (E2) fails it
+is pinned down to the wrong thing. Either way the weight the counterfactual needs
+is known only to lie somewhere in a set.
 
 DROSC, the method of Koo & Guo (2026), replaces the single fitted weight vector
 with a worst-case over an entire *set* of weights: every weight vector compatible
@@ -38,54 +54,241 @@ If your donors are well separated and the standard assumptions are credible, the
 plain estimators (:doc:`vanillasc`) are more efficient -- DROSC's conservatism is
 wasted. If the fragility is specifically pre-fit non-uniqueness and you only need
 a stable tie-break, not a robust interval, :doc:`lexscm` resolves the
-non-uniqueness lexicographically instead. DROSC targets a *different, robust*
-estimand; do not read its number as an estimate of the same quantity classical
-synthetic control targets when the two disagree.
+non-uniqueness lexicographically instead.
+
+DROSC targets a different estimand, and the two agree only where classical
+synthetic control is identified. Where they disagree, DROSC's number is the
+compatible effect closest to zero: understated in magnitude by construction, and
+correct in sign. Read it as "the effect is at least this large", not as an
+estimate of :math:`\bar\tau`.
 
 Notation
 --------
 
-The treated unit's outcome is :math:`y_t`; the :math:`N` donors' outcomes are the
-rows of :math:`\mathbf{X}_t`. Time splits at :math:`T^\star = T_0 + 1` into the
-pre-period :math:`t \le T_0` and the post-period. Write the pre-treatment donor
-second-moment matrix and the treated-donor cross-moment as
+The treated unit's outcome is :math:`Y_{1,t}`; the :math:`N` controls' outcomes
+are stacked in :math:`X_t`. Time splits at :math:`T^\star = T_0 + 1` into a
+pre-period :math:`t \le T_0` of length :math:`T_0` and a post-period of length
+:math:`T_1`. Write :math:`\Delta^N` for the simplex, the set of weightings that
+are non-negative and sum to one.
+
+The model that makes the two failure modes visible carries a weight vector for
+each regime:
 
 .. math::
 
-   \widehat{\boldsymbol{\Sigma}} = \frac{1}{T_0}\sum_{t \le T_0}
-     \mathbf{X}_t \mathbf{X}_t^\top, \qquad
-   \widehat{\boldsymbol{\gamma}} = \frac{1}{T_0}\sum_{t \le T_0} y_t \mathbf{X}_t,
+   Y_{1,t}^{(0)} =
+   \begin{cases}
+     X_t^\top \beta^{(0)} + u_t^{(0)}, & t = 1, \dots, T_0, \\
+     X_t^\top \beta^{(1)} + u_t^{(1)}, & t = T_0 + 1, \dots, T,
+   \end{cases}
+   \qquad \beta^{(0)}, \beta^{(1)} \in \Delta^N .
 
-and the post-treatment means :math:`\bar y_1 = \operatorname{mean}(y_t)` and
-:math:`\bar{\mathbf{x}}_1 = \operatorname{mean}(\mathbf{X}_t)` over
-:math:`t > T_0`. The compatible-weight set at radius :math:`\lambda` is the
-simplex intersected with a moment band,
+:math:`Y^{(0)}` is the untreated potential outcome, so :math:`\beta^{(1)}` is the
+weighting the counterfactual actually needs and :math:`\beta^{(0)}` is the one
+the pre-period can speak to. (E1) says :math:`\beta^{(0)}` is unique; (E2) says
+:math:`\beta^{(0)} = \beta^{(1)}`. Classical synthetic control estimates
+:math:`\beta^{(0)}` and uses it as though it were :math:`\beta^{(1)}`.
 
-.. math::
-
-   \mathcal{B}(\lambda) = \Big\{ \boldsymbol{\beta} \ge 0,\ \textstyle\sum_j
-     \beta_j = 1 \ :\ \big\lVert \widehat{\boldsymbol{\Sigma}}\boldsymbol{\beta}
-     - \widehat{\boldsymbol{\gamma}} \big\rVert_\infty \le \lambda + c_{T_0}
-     \Big\},
-
-where :math:`c_{T_0} \propto \log(\max(T_0, N))^{1/2}/\sqrt{T_0}` is a
-data-driven slack that vanishes as :math:`T_0` grows. DROSC reports the effect at
-the weight in :math:`\mathcal{B}(\lambda)` that best matches the post-treatment
-mean,
+Any candidate weighting implies a time-averaged effect,
 
 .. math::
 
-   \widehat{\boldsymbol{\beta}}(\lambda) = \operatorname*{arg\,min}_{
-     \boldsymbol{\beta} \in \mathcal{B}(\lambda)}
-     \big( \bar{\mathbf{x}}_1^\top \boldsymbol{\beta} - \bar y_1 \big)^2,
+   \tau(\beta) = \mu_Y - \mu^\top \beta,
    \qquad
-   \widehat{\tau}(\lambda) = \bar y_1 - \bar{\mathbf{x}}_1^\top
-     \widehat{\boldsymbol{\beta}}(\lambda).
+   \mu_Y = \frac{1}{T_1}\sum_{t > T_0} \mathbb{E}[Y_{1,t}],
+   \qquad
+   \mu = \frac{1}{T_1}\sum_{t > T_0} \mathbb{E}[X_t],
 
-The objective is rank one in :math:`\boldsymbol{\beta}`, so
-:math:`\widehat{\tau}(\lambda)` is identified even when
-:math:`\widehat{\boldsymbol{\beta}}(\lambda)` is not -- which is exactly the
-non-uniqueness DROSC is built to tolerate.
+and the estimand classical synthetic control targets is
+:math:`\bar\tau = \tau(\beta^{(1)})`. Identifying :math:`\beta^{(1)}` is
+sufficient for identifying :math:`\bar\tau` but not necessary: if every plausible
+weighting implies the same :math:`\tau(\beta)`, the effect is point identified
+even though the weights are not.
+
+The uncertainty class
+~~~~~~~~~~~~~~~~~~~~~
+
+The pre-period residual is uncorrelated with the controls, so :math:`\beta^{(0)}`
+solves the moment condition
+:math:`T_0^{-1}\sum_{t \le T_0}\mathbb{E}[X_t(Y_{1,t} - X_t^\top\beta)] = 0`.
+A weight shift means :math:`\beta^{(1)}` need not satisfy it exactly, so DROSC
+admits every simplex weighting that satisfies it to within a tolerance
+:math:`\lambda \ge 0`:
+
+.. math::
+
+   \Omega(\lambda) = \Big\{ \beta \in \Delta^N :
+     \Big\lVert \frac{1}{T_0}\sum_{t \le T_0}
+       \mathbb{E}\big[X_t(Y_{1,t} - X_t^\top\beta)\big]
+     \Big\rVert_\infty \le \lambda \Big\}.
+
+Writing :math:`\Sigma = T_0^{-1}\sum_{t \le T_0}\mathbb{E}[X_t X_t^\top]` and
+:math:`\gamma = T_0^{-1}\sum_{t \le T_0}\mathbb{E}[X_t Y_{1,t}]`, the moment
+condition reads :math:`\gamma = \Sigma\beta^{(0)}` and the class has two
+equivalent forms:
+
+.. math::
+
+   \Omega(\lambda)
+   = \big\{ \beta \in \Delta^N : \lVert \gamma - \Sigma\beta \rVert_\infty
+       \le \lambda \big\}
+   = \big\{ \beta \in \Delta^N : \lVert \Sigma(\beta - \beta^{(0)})
+       \rVert_\infty \le \lambda \big\} .
+
+The second form reads as a covariance-scaled neighbourhood of the pre-treatment
+weight, and the first is what makes it usable: the moment discrepancy
+:math:`\gamma - \Sigma\beta` is well defined even when :math:`\Sigma` is singular
+and :math:`\beta^{(0)}` is not identifiable. No inverse is taken and no unique
+pre-period weight has to be selected, which is what lets the class survive the
+perfectly-correlated case that breaks (E1).
+
+Three details decide how the class behaves. The norm is the maximum over
+coordinates, so a weighting must reproduce every control's moment condition to
+within :math:`\lambda`, not do well on average. The class sits inside the
+simplex, so widening :math:`\lambda` never buys extrapolation; it only admits
+more points of the donor convex hull. And :math:`\lambda` is a tolerance for
+weight shift, a statement about the world, with nothing to do with sample size --
+the separate slack for estimation error appears further down, under Estimation.
+
+The estimand
+------------
+
+Fix a candidate effect :math:`\tau` and a candidate weighting :math:`\beta`, and
+measure how much the post-period fit improves when the effect is allowed:
+
+.. math::
+
+   R_\beta(\tau) = \frac{1}{T_1}\sum_{t > T_0} \mathbb{E}\Big[
+     \big(Y_{1,t} - X_t^\top\beta\big)^2
+     - \big(Y_{1,t} - X_t^\top\beta - \tau\big)^2 \Big]
+   = 2\tau\,\tau(\beta) - \tau^2 .
+
+The first term is the post-period prediction error under a null effect, the
+second the error after allowing :math:`\tau`, so :math:`R_\beta` is the reward
+for positing an effect of that size. With oracle knowledge of
+:math:`\beta^{(1)}`, maximising :math:`R_{\beta^{(1)}}` over :math:`\tau` returns
+:math:`\bar\tau`, which is classical synthetic control written as an
+optimisation.
+
+When :math:`\beta^{(1)}` is known only to lie in :math:`\Omega`, each candidate
+effect has a different reward depending on which plausible weighting is used.
+DROSC scores an effect by its worst case over the class and takes the best such
+score. This is the weight-robust treatment effect:
+
+.. math::
+
+   \tau^*(\Omega) = \operatorname*{arg\,max}_{\tau \in \mathbb{R}}
+     \Big[ \min_{\beta \in \Omega} R_\beta(\tau) \Big].
+
+Read it as a game. You name an effect; nature picks, from the plausible
+weightings, the one that makes your claim look worst; you name the effect whose
+worst case is best. Nothing in it selects a weight vector.
+
+What the game reduces to
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Theorem 1 of the paper solves it. The optimum is
+
+.. math::
+
+   \tau^*(\Omega) = \mu_Y - \mu^\top\beta^*(\Omega),
+   \qquad
+   \beta^*(\Omega) \in \operatorname*{arg\,min}_{\beta \in \Omega}
+     \big[\mu_Y - \mu^\top\beta\big]^2 ,
+
+an adversarial weighting that drives the time-averaged effect as close to zero as
+the class allows. So the quadratic program the software solves is a consequence
+of the max-min problem, not the definition of it.
+
+Two things follow immediately. The program is degenerate, because
+:math:`\mu\mu^\top` has rank one and the objective sees :math:`\beta` only
+through the scalar :math:`\mu^\top\beta`: the set of minimisers can be an entire
+face of the polytope while the value :math:`\mu^\top\beta^*` is the same across
+all of them. So :math:`\tau^*` is unique even when :math:`\beta^*` is not, which
+is the non-uniqueness DROSC exists to tolerate -- the method declines to report a
+weighting and still reports an effect. And the characterisation never invokes
+(E1) or (E2), so :math:`\tau^*` is defined whether or not classical synthetic
+control is identified.
+
+The sensitivity interval
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each plausible weighting implies an effect, and together they form an interval
+
+.. math::
+
+   I(\Omega) = \{\tau(\beta) : \beta \in \Omega\}
+   = \Big[\min_{\beta \in \Omega}\tau(\beta),\;
+          \max_{\beta \in \Omega}\tau(\beta)\Big],
+
+which collects every effect compatible with the stated weight uncertainty. If
+:math:`\beta^{(1)} \in \Omega` then :math:`\bar\tau \in I(\Omega)`, so the
+interval is an identified set for the classical estimand. When
+:math:`\tau(\beta)` happens to be constant over :math:`\Omega` the interval is a
+single point and :math:`\bar\tau` is point identified despite the weights not
+being; when it varies, :math:`\bar\tau` is partially identified.
+
+Theorem 2 gives the cleanest statement of what DROSC returns:
+
+.. math::
+
+   \tau^* = \begin{cases}
+     \min_{\beta \in \Omega} \tau(\beta)
+       & \text{if } \tau(\beta) > 0 \text{ for all } \beta \in \Omega, \\
+     \max_{\beta \in \Omega} \tau(\beta)
+       & \text{if } \tau(\beta) < 0 \text{ for all } \beta \in \Omega, \\
+     0 & \text{if } \tau(\beta) = 0 \text{ for some } \beta \in \Omega .
+   \end{cases}
+
+:math:`\tau^*` is the projection of the origin onto the sensitivity interval --
+the compatible effect closest to no effect. Sensitivity analysis and DROSC use
+the same uncertainty class and report different objects: sensitivity analysis
+hands back the whole interval and declines to choose within it, while DROSC
+returns one point of it, the conservative endpoint.
+
+How conservative
+~~~~~~~~~~~~~~~~
+
+Theorem 3 says that if :math:`\beta^{(1)} \in \Omega`, then
+
+.. math::
+
+   |\tau^*| \le |\bar\tau|,
+   \qquad \text{and } \tau^* \text{ cannot have the opposite sign to }
+   \bar\tau .
+
+Both halves matter for reading the output. The magnitude is never overstated, so
+:math:`|\tau^*|` is a lower bound on the size of the true effect: if it is large,
+no admissible weighting explains the gap away. And the sign is trustworthy
+whenever :math:`\tau^* \ne 0`, so a directional claim survives even though the
+magnitude is deliberately understated.
+
+How much the conservatism costs is bounded. When
+:math:`\lambda_{\min}(\Sigma) > 0`,
+
+.. math::
+
+   \big|\tau^* - \bar\tau\big| \;\le\;
+     2\,\lambda_{\min}(\Sigma)^{-1}\,\lVert\mu\rVert_1 \sqrt{N}\,\lambda ,
+
+so the gap closes as :math:`\lambda \to 0`, and at :math:`\lambda = 0` under (E1)
+and (E2) it closes exactly: :math:`\tau^* = \bar\tau`.
+
+Reading the robustness sweep
+----------------------------
+
+:math:`\Omega(\lambda)` grows with :math:`\lambda`, so :math:`I(\Omega(\lambda))`
+grows too, and the projection of the origin onto a growing interval moves toward
+zero. Reporting :math:`\widehat\tau` at a single radius therefore says very
+little; the object to report is the curve.
+
+The radius at which :math:`\widehat\tau` first reaches zero is a breakdown point,
+and Theorem 2 says exactly what happens there: it is the amount of weight shift
+at which the sensitivity interval first covers zero, that is, the first
+:math:`\lambda` admitting a weighting under which there is no effect at all. A
+finding that survives to a large :math:`\lambda` tolerates a lot of
+misspecification; one that collapses at a small :math:`\lambda` rests on (E1) and
+(E2) holding closely.
 
 Assumptions
 -----------
@@ -98,44 +301,107 @@ Assumptions
    outcome panel. A ``dependent`` flag switches the moment covariances to a
    Newey-West HAC estimator when the outcomes are autocorrelated.
 
-2. The compatible set contains the truth. At the chosen radius,
-   :math:`\mathcal{B}(\lambda)` includes a weighting that reproduces the treated
-   counterfactual. Under the classical identification this holds at
-   :math:`\lambda = 0`; when it fails, :math:`\widehat{\tau}(\lambda)` is a
-   conservative proxy, not the classical effect.
+2. The uncertainty class contains the post-treatment weight. At the chosen
+   radius, :math:`\beta^{(1)} \in \Omega(\lambda)`. This is what makes
+   :math:`I(\Omega)` an identified set for :math:`\bar\tau` and what Theorem 3
+   needs: without it, neither the magnitude bound nor the sign guarantee holds.
 
-   Remark. This is why the radius is reported as a sweep. The value of
-   :math:`\lambda` at which :math:`\widehat{\tau}` first reaches zero is the
-   amount of robustness the finding can absorb.
+   Remark. Under (E1) and (E2) it holds at :math:`\lambda = 0`. When they fail,
+   the assumption is a statement about how large a weight shift is credible, and
+   it is the reason the radius is reported as a sweep instead of a setting.
 
 3. Simplex weights. Donor weights are non-negative and sum to one, so the
-   counterfactual is an interpolation of the donors (no extrapolation).
+   counterfactual is an interpolation of the donors, with no extrapolation.
 
    Remark. The moment band is layered on top of the simplex, so DROSC never
    leaves the convex hull; it only restricts which hull points are admissible.
 
+4. A non-degenerate class where the theory asks for one. The conservatism bound
+   and the :math:`\lambda = 0` theory assume
+   :math:`\lambda_{\min}(\Sigma) > 0`.
+
+   Remark. This has a consequence that is easy to read the wrong way round. When
+   :math:`\Sigma` is invertible, :math:`\Omega(0)` is the single point
+   :math:`\{\beta^{(0)}\}` -- so at :math:`\lambda = 0` the class collapses and
+   DROSC returns the classical estimand. The non-uniqueness story at
+   :math:`\lambda = 0` needs :math:`\Sigma` genuinely singular, that is,
+   perfectly correlated controls. Highly-but-not-perfectly correlated controls
+   are handled through :math:`\lambda`, and through the estimation slack below.
+
+Estimation
+----------
+
+Everything above is a population statement. The estimator replaces
+:math:`\Sigma, \gamma, \mu_Y, \mu` with their sample analogues, and widens the
+band to absorb the error in doing so:
+
+.. math::
+
+   \widehat\Omega(\lambda) = \big\{ \beta \in \Delta^N :
+     \lVert \widehat\gamma - \widehat\Sigma\beta \rVert_\infty
+     \le \lambda + \rho \big\},
+   \qquad
+   \widehat\tau = \widehat\mu_Y - \widehat\mu^\top\widehat\beta,
+   \quad
+   \widehat\beta \in \operatorname*{arg\,min}_{\beta \in \widehat\Omega}
+     \big[\widehat\mu_Y - \widehat\mu^\top\beta\big]^2 .
+
+The two terms in the band do different jobs and should not be conflated.
+:math:`\lambda` is the tolerance for weight shift, a modelling choice that does
+not shrink with more data. :math:`\rho` is slack for the sampling error in
+:math:`\widehat\Sigma` and :math:`\widehat\gamma`, and it vanishes as
+:math:`T_0` grows -- it is proportional to
+:math:`\log(\max\{T_0, N\})^{1/2}/\sqrt{T_0}`. Setting :math:`\lambda = 0` still
+leaves :math:`\rho`, which is why the :math:`\lambda = 0` fit is not the same
+object as a classical synthetic control fit on the same panel.
+
+The constant in front of :math:`\rho` is not chosen by the analyst. It starts
+small and is multiplied by 1.25 until the minimisation over
+:math:`\widehat\Omega` becomes feasible, giving the smallest slack that admits a
+solution. A band too tight to contain any simplex point has no answer to return,
+so feasibility is the criterion. ``dependent=True`` switches the moment
+covariances to a Newey-West HAC estimator for autocorrelated outcomes.
+
 Inference
 ---------
 
-Set ``inference=True`` for the perturbation-based confidence interval. Because
-:math:`\widehat{\tau}(\lambda)` is the value of an inequality-constrained
-optimisation, its limiting law is non-normal, so a normal interval is invalid.
-DROSC instead perturbs the pre-treatment moments and the post-treatment means
-from their (HAC-)sampling distributions, re-solves the moment-band problem for
-each of ``n_perturbations`` draws, forms a normal interval around each draw's
-effect, and returns the *union* of those intervals -- a confidence set that may
-be a single interval or a disjoint union. The enveloping hull is exposed as
-``res.inference.ci_lower`` / ``ci_upper`` (and ``res.att_ci``); the full list of
-pieces is in ``res.inference.details["ci_intervals"]``.
+Set ``inference=True`` for the perturbation-based confidence interval. Two
+distinct problems rule out a normal interval, and the paper separates them.
 
-Two practical notes. The interval is a genuine confidence *set*, so read it as
-"the effects the data cannot reject", not as a point estimate plus symmetric
-error. And it is computationally heavy and mildly seed-sensitive: the moment band
-starts far tighter than the perturbation scale, so an internal slack is inflated
-until enough draws are feasible (dozens of rounds of
-:math:`\texttt{n\_perturbations}` solves), and the endpoints move with the seed.
-Fix ``seed`` for reproducibility and keep the default off unless you need the
-interval.
+Non-regularity. Decompose
+:math:`\widehat\tau - \tau^* = (\widehat\mu_Y - \mu_Y)
+- (\widehat\mu^\top\widehat\beta - \mu^\top\beta^*)`. The first term obeys a
+central limit theorem. The second need not: :math:`\beta^*` typically sits on the
+boundary of the class, and small sampling changes flip which constraints are
+active, which produces a mixture limiting law of the kind familiar from
+parameter-on-the-boundary problems.
+
+Instability. Highly correlated controls make :math:`\Omega` nearly flat in some
+directions, so small errors in :math:`\widehat\Sigma` or :math:`\widehat\gamma`
+move :math:`\widehat\Omega` and :math:`\widehat\beta` a lot. This amplifies the
+active-set flipping, so the two problems arrive together.
+
+The remedy exploits the structure of the decomposition. Perturb
+:math:`\widehat\Sigma, \widehat\gamma, \widehat\mu_Y, \widehat\mu` from their
+estimated sampling distributions, re-solve the band problem for each of
+``n_perturbations`` draws, and form a candidate effect from each. The paper shows
+some draw :math:`m^\star` nearly recovers the population problem; for that draw
+the remaining uncertainty is almost entirely in :math:`\widehat\mu_Y`, which is
+asymptotically normal, so a normal interval around it is valid. Since
+:math:`m^\star` cannot be identified, DROSC keeps the plausible draws and returns
+the union of their intervals.
+
+The union is the point. It is a confidence set, possibly a disjoint one, and it
+reads as the effects the data cannot reject -- not as a point estimate plus
+symmetric error. The enveloping hull is exposed as ``res.inference.ci_lower`` /
+``ci_upper`` (and ``res.att_ci``); the pieces are in
+``res.inference.details["ci_intervals"]``.
+
+One practical caution. The procedure is heavy and mildly seed-sensitive: the
+moment band starts far tighter than the perturbation scale, so an internal slack
+is inflated until enough draws are feasible (dozens of rounds of
+``n_perturbations`` solves), and the endpoints move with the seed. Fix ``seed``
+for reproducibility, and leave inference off unless the interval is needed.
 
 Example
 -------

--- a/docs/replications/drosc.rst
+++ b/docs/replications/drosc.rst
@@ -33,15 +33,15 @@ As the radius :math:`\lambda` grows, the compatible-weight set widens and the
 effect shrinks from the classical-synthetic-control neighbourhood toward zero.
 mlsynth reproduces the authors' ``DRoSC`` estimand at every radius:
 
-==========  ==============  ==============
+===============  ==============================  ===========
 :math:`\lambda`  mlsynth :math:`\widehat{\tau}`  R ``DRoSC``
-==========  ==============  ==============
-0.00        −0.742          −0.742
-0.015       −0.486          −0.486
-0.03        −0.256          −0.256
-0.045       −0.036          −0.036
-0.06        0.000           0.000
-==========  ==============  ==============
+===============  ==============================  ===========
+0.00             −0.742                          −0.742
+0.015            −0.486                          −0.486
+0.03             −0.256                          −0.256
+0.045            −0.036                          −0.036
+0.06             0.000                           0.000
+===============  ==============================  ===========
 
 The classical synthetic-control ATT on the same outcome-only fit is −0.895; the
 effect is no longer distinguishable from zero once the robustness radius reaches
@@ -67,6 +67,48 @@ The perturbation union confidence interval (``inference=True``) is stochastic an
 seed-dependent -- it agrees with the R interval within Monte-Carlo error but is
 not pinned value-for-value -- so the benchmark cross-validates the deterministic
 estimand, which is exact.
+
+The estimation slack, as printed and as coded
+---------------------------------------------
+
+The band mlsynth solves is
+:math:`\lVert\widehat\gamma - \widehat\Sigma\beta\rVert_\infty \le \lambda + \rho`,
+and :math:`\rho` is the slack absorbing the sampling error in
+:math:`\widehat\Sigma` and :math:`\widehat\gamma`. The article and the authors'
+code parameterise it differently, so this records which one mlsynth follows.
+
+The article's Section 5 gives a single constant multiplying both terms,
+
+.. math::
+
+   \rho = C\Big[\widehat\sigma \cdot \max_j
+     \big(\tfrac{1}{T_0}\textstyle\sum_t Y_{j,t}^2\big)^{1/2} + \lambda\Big]
+     \frac{\log(\max\{T_0, N\})^{1/2}}{\sqrt{T_0}},
+
+with :math:`C` initialised small and multiplied by 1.25 until the program is
+feasible. The authors' ``src/helpers.R`` uses two constants, ``nu`` and ``eta``,
+both defaulting to 0.01, and inflates only the first:
+
+.. code-block:: r
+
+   c0 <- log(max(T0,N))^c/sqrt(T0)*(nu*sig*maxnorm + eta*lambda)
+   thres <- lambda + c0
+   ...
+   nu <- 1.25*nu
+
+mlsynth's :func:`mlsynth.utils.drosc_helpers.estimation.drosc_point` reproduces
+the R, since the R is what the benchmark pins it against. The two
+parameterisations coincide exactly at :math:`\lambda = 0`, where the
+:math:`\eta\lambda` term drops out and ``nu`` plays the role of :math:`C`. They
+separate for :math:`\lambda > 0`: the article's inflation widens the band through
+the :math:`\lambda` term as well, while the code holds that contribution at
+:math:`0.01\lambda` and inflates only the noise term, giving a narrower band at
+the same number of inflation rounds.
+
+The sweep above therefore matches the reference implementation at every radius,
+and matches the article exactly at :math:`\lambda = 0`. The reported effects at
+:math:`\lambda > 0` are the code's, which is the intended comparison for a
+cross-validation; the difference is a property of the reference, not of the port.
 
 Reproduce
 ---------


### PR DESCRIPTION
## Related Links

- Docs pages: `docs/drosc.rst`, `docs/replications/drosc.rst`
- Source paper: Koo, T. & Guo, Z. (2026), "Distributionally Robust Synthetic Control", [arXiv:2511.02632](https://arxiv.org/abs/2511.02632) (v3 source read for this change)
- Reference implementation: [taehyeonkoo/DRoSC](https://github.com/taehyeonkoo/DRoSC), `src/helpers.R`
- Benchmark case: `benchmarks/cases/drosc_basque.py`
- No issue.

## What

Docs only. No code touched.

- `docs/drosc.rst`: named the two identification conditions the method reacts to, put the two-regime outcome model into Notation, derived the estimand instead of asserting it, added the sensitivity-interval characterisation, the sign half of the conservatism result, and the bound on how much λ costs. New Estimation section separating λ from ρ. Inference section rewritten to say why a union of intervals is the answer.
- `docs/replications/drosc.rst`: new section recording which parameterisation of the estimation slack mlsynth follows, and fixed the λ-sweep table.

## Why

The page specified the method and did not teach it. It gave the quadratic program the software solves without saying where that program comes from, never mentioned that the model carries two weight vectors, and offered no account of why the confidence set is a union. Read against the paper, the gaps were:

- (E1) and (E2) were described but not named, and the second reason (E2) fails was missing: without the simplex constraint the weights are population least-squares projections, so a shift in the distribution of the controls moves them even when `E[Y(0)|X]` is unchanged.
- `β⁽⁰⁾` and `β⁽¹⁾` never appeared. Without that pair the uncertainty class has nothing to be uncertain about, and the reader cannot see that classical SC uses the first as though it were the second.
- The argmin of `(μ_Y − μ'β)²` was presented as the definition. It is Theorem 1's *solution* of a max-min game on a reward function — the analyst names an effect, nature picks the plausible weighting that makes the claim look worst.
- Theorem 2 was absent, and it is the single clearest statement of what DROSC returns: τ\* is the projection of the origin onto the sensitivity interval. It also makes the breakdown-point reading of the λ sweep exact instead of asserted — λ\* is where the interval first covers zero.
- Theorem 3 was given by half. The page said the estimate is conservative in magnitude; it did not say that τ\* cannot take the opposite sign to τ̄, which is what makes a directional claim usable.
- λ and ρ were run together as one radius. They do different jobs: λ is tolerance for weight shift and does not shrink with data; ρ absorbs sampling error and vanishes at `log(max(T₀,N))^{1/2}/√T₀`. A consequence now stated: when Σ is invertible, Ω(0) is the single point {β⁽⁰⁾}, so the non-uniqueness story at λ=0 needs Σ genuinely singular.
- Inference said the limit is non-normal without saying why, or why the union follows. The paper separates non-regularity (β\* on the boundary, active sets flipping, a mixture limit) from instability (correlated controls make Ω nearly flat), and the union is the answer because some perturbation draw nearly recovers the population problem and its residual uncertainty is normal — but which draw cannot be identified.

## How

Read the arXiv v3 LaTeX source supplied by the author, and cloned the authors' R to check the implementation against the article.

## Verification

- Path: not applicable. No numerical code is touched; this is prose and mathematics on two docs pages.
- One finding recorded rather than fixed: the article's Section 5 gives the estimation slack as a single constant C multiplying both the noise term and λ, inflated 1.25× until feasible. The authors' `src/helpers.R` uses two constants, `nu` and `eta`, both defaulting to 0.01, and inflates only `nu`. mlsynth's `drosc_point` reproduces the R, which is what `benchmarks/cases/drosc_basque.py` pins it against. The two parameterisations coincide exactly at λ=0 and separate above it, where the article's inflation widens the band through the λ term as well. This is a property of the reference, not of the port, so it is documented on the replication page and no code changed.
- Docs build clean: `sphinx -b dummy` emits zero warnings for both DROSC pages. The remaining warnings in that build are pre-existing and on other pages (missing `ascm_*` replication docs, a missing `Boussim2026` citation, ambiguous cross-references for common module names).

## Scope checks

None of the four blocks fits — this is a docs-only change, on its own branch, with no estimator, benchmark, feature or bug-fix component.

## Designs

None. No figures added or changed.

## Test Steps

- [x] `python -m sphinx -b dummy docs <out>` — both DROSC pages emit no warnings
- [x] Section underlines at least as long as their titles
- [x] Style sweeps: no banned words, no bold in prose, RST directives well-formed
- [ ] Test suite not run — no code is touched by this branch

## Other Notes

- The λ-sweep table on the replication page had a header row wider than its column rules, so RST had been rejecting it and the table had never rendered. Pre-existing on `main`; fixed here because the page was already being edited. It is an isolated hunk if you would rather it landed separately.
- The estimator's own docstring in `mlsynth/estimators/drosc.py` still describes the method in the older, terser terms. Bringing it into line with the page is a small follow-up and would touch code, so it is not on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzCiKRsesDK28RMtQ1Yjzf

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzCiKRsesDK28RMtQ1Yjzf)_