### PR TITLE
Bring the DROSC docstrings in line with its page

### DIFF
--- a/mlsynth/estimators/drosc.py
+++ b/mlsynth/estimators/drosc.py
@@ -3,13 +3,38 @@
 Koo, T. & Guo, Z. (2026). "Distributionally Robust Synthetic Control: Ensuring
 Robustness Against Highly Correlated Controls and Weight Shifts." arXiv:2511.02632.
 
-DROSC targets a worst-case treatment effect over the donor weights compatible
-with the pre-treatment moments up to a robustness radius ``robustness_lambda``.
-When the classical synthetic-control identification holds it recovers the same
-effect; when it fails (highly correlated controls, or a shift in the treated-
-control relationship) it is a conservative proxy for the non-identifiable effect.
-Optional perturbation-based inference returns a (possibly disjoint) union
-confidence interval whose limiting law is non-normal.
+Classical synthetic control needs two things its usual argument leaves implicit:
+(E1) the pre-treatment weights are unique, and (E2) the weighting that describes
+the treated unit before the intervention still describes it after. (E1) fails
+when the controls are highly correlated, so many weightings fit the pre-period
+indistinguishably. (E2) fails when the intervention alters the treated-control
+relationship, and also when the distribution of the controls shifts, since the
+weights are projections onto them. Either way the post-treatment weighting is
+known only to lie in a set.
+
+DROSC keeps the set. ``Omega(lambda)`` holds every simplex weighting satisfying
+the pre-treatment moment condition to within ``robustness_lambda``, and the
+reported effect is the max-min of a reward function over it: the analyst names an
+effect, nature picks the plausible weighting that makes the claim look worst.
+That game solves (Theorem 1) to the weighting driving the effect closest to zero,
+so ``tau*`` is the projection of the origin onto the interval of effects the set
+admits (Theorem 2) -- the conservative endpoint of a sensitivity analysis, chosen
+instead of being left as an interval.
+
+Reading the number. When the post-treatment weight lies in the set,
+``|tau*| <= |taubar|`` and ``tau*`` cannot take the opposite sign to the true
+effect (Theorem 3), so the magnitude is a lower bound and the direction is
+trustworthy. Under (E1) and (E2) at ``robustness_lambda = 0`` the two coincide.
+Report the effect as a function of the radius: where it first reaches zero is the
+weight shift at which the compatible effects first include no effect at all.
+
+``tau*`` is unique even where the weighting is not, because the objective sees
+the weights only through one scalar. Inference is non-regular for the same reason
+the estimand is interesting -- the optimum sits on a boundary whose active set
+moves with sampling noise -- so the confidence set is a union of perturbation
+intervals, possibly disjoint.
+
+See :doc:`../drosc` for the full development.
 """
 from __future__ import annotations
 
@@ -23,6 +48,13 @@ from ..utils.drosc_helpers import plot_drosc, run_drosc
 
 class DROSC:
     """Distributionally Robust Synthetic Control estimator.
+
+    ``fit()`` returns the weight-robust effect at the configured radius: the
+    smallest-magnitude effect consistent with the weightings the pre-treatment
+    moments cannot rule out. It is a lower bound on the true effect's magnitude
+    with a trustworthy sign, not an estimate of the quantity classical synthetic
+    control targets, and it is read across a sweep of ``robustness_lambda``
+    instead of at one value.
 
     Parameters
     ----------

--- a/mlsynth/utils/drosc_helpers/config.py
+++ b/mlsynth/utils/drosc_helpers/config.py
@@ -13,14 +13,17 @@ from ...exceptions import MlsynthConfigError
 class DROSCConfig(BaseEstimatorConfig):
     """Distributionally Robust Synthetic Control.
 
-    DROSC (Koo & Guo 2026) targets a worst-case treatment effect over the set of
-    donor weights compatible with the pre-treatment moments up to a robustness
-    radius ``robustness_lambda``. At ``robustness_lambda = 0`` the compatible set
-    is tightest (classical-SC-like); as it grows the estimate becomes a
-    conservative proxy that is robust to highly correlated controls and to shifts
-    in the treated-control relationship. Optional perturbation-based inference
-    returns a (possibly disjoint) union confidence interval whose limiting law is
-    non-normal.
+    DROSC (Koo & Guo 2026) reports the smallest-magnitude effect consistent with
+    the donor weightings the pre-treatment moments cannot rule out -- the
+    projection of the origin onto the interval of effects that set admits. Where
+    the post-treatment weighting lies in the set, that effect is a lower bound on
+    the true one's magnitude and cannot take the opposite sign, so a directional
+    claim survives even though the size is understated.
+
+    ``robustness_lambda`` widens the set, so the effect shrinks toward zero as it
+    grows; read the sweep, not one value. Optional perturbation-based inference
+    returns a (possibly disjoint) union confidence interval, which is a
+    confidence set for the effects the data cannot reject.
 
     References
     ----------
@@ -31,9 +34,14 @@ class DROSCConfig(BaseEstimatorConfig):
 
     robustness_lambda: float = Field(
         default=0.0, ge=0.0,
-        description="Robustness radius lambda >= 0: the half-width of the "
-                    "pre-treatment moment-compatibility band. 0 is the tightest "
-                    "(classical-SC-like) set; larger values widen it.",
+        description="Robustness radius lambda >= 0: how far a plausible "
+                    "post-treatment weighting may violate the pre-treatment "
+                    "moment condition. This is a tolerance for weight shift, a "
+                    "modelling choice that does not shrink with more data; the "
+                    "slack for sampling error in the estimated moments is added "
+                    "separately and vanishes as the pre-period grows. 0 trusts "
+                    "the classical identification; larger values widen the set "
+                    "and drive the reported effect toward zero.",
     )
     inference: bool = Field(
         default=False,

--- a/mlsynth/utils/drosc_helpers/estimation.py
+++ b/mlsynth/utils/drosc_helpers/estimation.py
@@ -52,8 +52,16 @@ def drosc_point(Y0: np.ndarray, Y1: np.ndarray, X0: np.ndarray, X1: np.ndarray,
     The ``nu`` term is inflated until the band is feasible (the R feasibility
     retry).
 
+    Minimising the squared post-treatment gap is minimising the squared effect,
+    so ``b`` is the adversarial weighting driving the effect closest to zero and
+    ``tau`` is the projection of the origin onto the effects the band admits.
+    This is the computational form of the paper's max-min problem, not its
+    definition; Theorem 1 is what makes the two the same.
+
     Returns ``(tau, beta)``. ``tau = mean(Y1) - mean(X1)'beta`` is unique even
-    when ``beta`` is not (the post objective is rank one).
+    when ``beta`` is not (the post objective is rank one), which is the
+    non-uniqueness the method exists to tolerate: it declines to report a
+    weighting and still reports an effect.
     """
     Y0 = np.asarray(Y0, float).ravel()
     Y1 = np.asarray(Y1, float).ravel()

--- a/mlsynth/utils/drosc_helpers/inference.py
+++ b/mlsynth/utils/drosc_helpers/inference.py
@@ -114,8 +114,23 @@ def drosc_union_ci(Y0, Y1, X0, X1, robustness_lambda=0.0, alpha=0.05, alpha0=0.0
                    dependent=False, seed=0) -> List[List[float]]:
     """Perturbation union confidence interval for the DROSC ATT.
 
+    A normal interval is invalid here for two reasons the paper separates. The
+    optimum typically sits on the boundary of the compatibility band, and small
+    sampling changes flip which constraints are active, giving a mixture limit
+    (non-regularity). And correlated controls make the band nearly flat in some
+    directions, so small errors in the estimated moments move it a lot
+    (instability). The two arrive together.
+
+    The remedy: perturb the moments and the post-treatment means from their
+    sampling distributions, re-solve for each draw, and form a normal interval
+    around each. Some draw nearly recovers the population problem, and for that
+    one the residual uncertainty is almost all in ``mean(Y1)``, which is
+    asymptotically normal. Since that draw cannot be identified, the plausible
+    ones are kept and their intervals unioned.
+
     Returns a sorted list of disjoint ``[lo, hi]`` intervals (their union is the
-    confidence set). Deterministic given ``seed``.
+    confidence set, so read it as the effects the data cannot reject, not as a
+    point estimate plus symmetric error). Deterministic given ``seed``.
     """
     rng = np.random.default_rng(seed)
     Y0 = np.asarray(Y0, float).ravel()


### PR DESCRIPTION
## Related Links

- Follows from #550, which developed `docs/drosc.rst`. This closes the gap that PR's "Other Notes" flagged.
- Source paper: Koo, T. & Guo, Z. (2026), [arXiv:2511.02632](https://arxiv.org/abs/2511.02632)
- Docs page: `docs/drosc.rst`

## What

Docstrings only. No behaviour changes, no signatures touched.

- `mlsynth/estimators/drosc.py`: module docstring rewritten; `DROSC` class docstring says what `fit()` returns and how to read it.
- `mlsynth/utils/drosc_helpers/config.py`: `DROSCConfig` docstring, and the `robustness_lambda` field description.
- `mlsynth/utils/drosc_helpers/estimation.py`: `drosc_point`.
- `mlsynth/utils/drosc_helpers/inference.py`: `drosc_union_ci`.

## Why

After #550 the page develops the method and the docstrings still described it in the terms that predated it, so a reader arriving through `help()` or the source got the terse version while a reader arriving through the docs got the full one. The page is not autodoc'd for the module docstring — `docs/drosc.rst` carries `autoclass` only, not `automodule` — so nothing was propagating the improvement.

One correction rather than an expansion: `robustness_lambda` was described as "the half-width of the pre-treatment moment-compatibility band", with `0` called "the tightest (classical-SC-like) set". That conflates the two terms of the band. λ is a tolerance for weight shift and does not shrink with more data; the slack for sampling error in the estimated moments is added separately and vanishes as the pre-period grows. So `λ = 0` is not a classical synthetic control fit — the estimated band still carries that slack.

## How

Read the arXiv v3 source, and pulled the characterisations the docstrings lacked: the max-min derivation, Theorem 1 turning it into the closest-to-zero weighting, Theorem 2's projection-of-the-origin statement, and the sign half of Theorem 3.

## Verification

- Path: not applicable. Docstrings only; no numerical code touched.
- `pytest mlsynth/tests/test_drosc.py mlsynth/tests/test_result_contract.py` — 296 passed, 4 skipped.
- Docs build clean: `sphinx -b dummy` emits no warnings for the DROSC pages. The config docstring and field description do render, via the `autoclass` on `DROSCConfig`.

## Scope checks

None of the four blocks fits — docstrings only, on its own branch.

## Designs

None.

## Test Steps

- [x] `pip install -e .`
- [x] `pytest mlsynth/tests/test_drosc.py -q` — 18 passed
- [x] `pytest mlsynth/tests/test_result_contract.py -q` — passes
- [x] Docs build, no new warnings
- [x] Style sweeps: no banned words, no prints; the two over-length lines in `inference.py` are pre-existing code shifted by the added docstring

## Other Notes

- `docs/drosc.rst` uses `autoclass` where most estimator pages also use `automodule`, so the module docstring is not rendered on the page. I left that alone: the page now carries a full development of its own and adding `automodule` would duplicate it. The consequence is that the module docstring serves source and `help()` readers only, which is why it is written to stand on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzCiKRsesDK28RMtQ1Yjzf

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzCiKRsesDK28RMtQ1Yjzf)_