### PR TITLE
SHC: put the conformal inference on the result contract, and diagnose its size

### DIFF
--- a/docs/shc.rst
+++ b/docs/shc.rst
@@ -181,9 +181,33 @@ statistic is
 
 and the null distribution is built by sampling :math:`n` residuals with
 replacement from the :math:`T_0` pre-intervention residuals, 1,000 times.
-``results.inference`` exposes ``p_value``, ``test_statistic``, the 1/5/10%
-``critical_values`` and ``reject`` decisions, the resampled
-``null_distribution``, and Andrews-Genton conformal bands for the plot.
+
+Where to read it:
+
+.. code-block:: python
+
+   inf = res.inference
+   inf.p_value, inf.method, inf.confidence_level
+   d = inf.details
+   d["test_statistic"], d["critical_values"], d["reject"]   # keyed 0.01/0.05/0.10
+   d["scheme"], d["num_resamples"], d["null_distribution"]
+
+   # the Andrews-Genton band, aligned to the time axis, NaN over the pre-window
+   res.time_series.counterfactual_lower, res.time_series.counterfactual_upper
+   res.time_series.prediction_interval_level      # 0.90
+   res.time_series.has_prediction_interval        # True
+
+``res.inference_detail`` keeps the same numbers on the estimator's own
+:class:`~mlsynth.utils.shc_helpers.structures.SHCInference` dataclass, with the
+post-window band as ``conformal_lower`` / ``conformal_upper``.
+
+``inference_method="exact"`` swaps the null for the permutation test of
+Chernozhukov, Wüthrich & Zhu (2021) over the same statistic, with
+``permutation_scheme`` choosing cyclic shifts (``"moving_block"``, for
+stationary weakly dependent errors) or random permutations (``"iid"``, exact
+under exchangeability). The observed statistic is identical across all three;
+only the reference distribution changes, and ``details["scheme"]`` records
+which built it.
 
 .. note::
 
@@ -326,9 +350,12 @@ Internal optimization and tuning routines for SHC and ASHC. When
 ``use_augmented`` is true, the simplex SHC weights from the matching QP
 are passed to the ASHC ridge refinement for bias correction.
 
-.. autofunction:: mlsynth.utils.inferutils.shc_conformal_test
-.. autofunction:: mlsynth.utils.estutils._solve_SHC_QP
-.. autofunction:: mlsynth.utils.estutils.tune_lambda_ashc
+.. autofunction:: mlsynth.utils.shc_helpers.inference.run_conformal_inference
+.. autofunction:: mlsynth.utils.shc_helpers.inference.shc_conformal_test
+.. autofunction:: mlsynth.utils.shc_helpers.inference.cwz_conformal_test
+.. autofunction:: mlsynth.utils.shc_helpers.inference.ag_conformal
+.. autofunction:: mlsynth.utils.shc_helpers.kernels.solve_shc_qp
+.. autofunction:: mlsynth.utils.shc_helpers.kernels.tune_lambda_ashc
 
 References
 ----------

--- a/mlsynth/tests/test_shc_inference_contract.py
+++ b/mlsynth/tests/test_shc_inference_contract.py
@@ -1,0 +1,202 @@
+"""SHC's conformal inference, reached through the standard result contract.
+
+The test of Chen, Yang & Yang (2024, footnote 21) and the Andrews-Genton band
+are computed by :func:`run_conformal_inference` and were reachable only through
+``res.inference_detail``, a per-estimator dataclass. A caller reading the
+contract found ``res.inference`` carrying a method name and a p-value, with
+``ci_lower``/``ci_upper`` empty, ``details`` holding a dataclass instead of a
+mapping, and the band absent from ``res.time_series`` -- so
+``has_prediction_interval`` was False on a fit that had computed one.
+
+These tests pin the inference onto the contract: the scalar summaries on
+``InferenceResults``, the per-period band on ``TimeSeriesResults`` where every
+other band in the library lives, and ``details`` as a mapping a caller can
+subscript.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mlsynth import SHC
+from mlsynth.utils.shc_helpers.simulation import simulate_shc_panel
+
+_M, _N = 25, 4
+
+
+@pytest.fixture(scope="module")
+def fitted():
+    """One SHC fit with a real effect, so a rejection means something."""
+    df, info = simulate_shc_panel(m=_M, h=4, n=_N, seed=3)
+    df = df.copy()
+    df.loc[df.time > info["T_o"], "y"] += -1.5
+    return SHC({"df": df, "outcome": "y", "treat": "treated", "unitid": "unit",
+                "time": "time", "m": _M, "display_graphs": False}).fit()
+
+
+def _fit(**extra):
+    df, info = simulate_shc_panel(m=_M, h=4, n=_N, seed=3)
+    df = df.copy()
+    df.loc[df.time > info["T_o"], "y"] += -1.5
+    cfg = {"df": df, "outcome": "y", "treat": "treated", "unitid": "unit",
+           "time": "time", "m": _M, "display_graphs": False}
+    cfg.update(extra)
+    return SHC(cfg).fit()
+
+
+# =========================================================================== #
+# InferenceResults
+# =========================================================================== #
+class TestInferenceResults:
+
+    def test_the_test_is_reported_on_the_contract(self, fitted):
+        inf = fitted.inference
+        assert inf is not None
+        assert "conformal" in inf.method
+        assert 0.0 <= inf.p_value <= 1.0
+
+    def test_details_is_a_mapping_a_caller_can_subscript(self, fitted):
+        """The contract's ``details`` is read with ``[]``, not ``getattr``."""
+        d = fitted.inference.details
+        assert isinstance(d, dict)
+        for key in ("test_statistic", "critical_values", "reject",
+                    "num_resamples", "levels"):
+            assert key in d
+
+    def test_the_statistic_and_its_critical_values_travel_together(self, fitted):
+        """A statistic without its critical values cannot be acted on."""
+        d = fitted.inference.details
+        stat = float(d["test_statistic"])
+        crit = d["critical_values"]
+        assert set(crit) == {0.01, 0.05, 0.10}
+        # a laxer level has a lower bar
+        assert crit[0.10] <= crit[0.05] <= crit[0.01]
+        for level, rejected in d["reject"].items():
+            assert rejected is (stat > crit[level])
+
+    def test_the_statistic_is_the_papers_scaled_absolute_sum(self, fitted):
+        r"""``S = n^{-1/2} sum |eps_t|`` over the post window (footnote 21)."""
+        gap = np.asarray(fitted.time_series.estimated_gap, dtype=float)[_M:]
+        expected = float(np.sum(np.abs(gap)) / np.sqrt(gap.size))
+        assert float(fitted.inference.details["test_statistic"]) == pytest.approx(
+            expected, rel=1e-12)
+
+    def test_the_confidence_level_is_reported(self, fitted):
+        assert fitted.inference.confidence_level == pytest.approx(0.90)
+
+    def test_a_real_effect_is_rejected_at_every_level(self, fitted):
+        d = fitted.inference.details
+        assert d["reject"][0.10] and d["reject"][0.01]
+
+
+# =========================================================================== #
+# the band, where every other band lives
+# =========================================================================== #
+class TestPredictionInterval:
+
+    def test_the_band_is_on_the_time_series_contract(self, fitted):
+        ts = fitted.time_series
+        assert ts.has_prediction_interval
+        assert ts.prediction_interval_level == pytest.approx(0.90)
+        assert "andrews-genton" in ts.prediction_interval_kind
+
+    def test_the_band_is_aligned_to_the_time_axis(self, fitted):
+        """Aligned to ``time_periods``, NaN over the block's pre-window."""
+        ts = fitted.time_series
+        T = len(ts.time_periods)
+        lo = np.asarray(ts.counterfactual_lower, dtype=float)
+        hi = np.asarray(ts.counterfactual_upper, dtype=float)
+        assert lo.shape == hi.shape == (T,)
+        assert np.isnan(lo[:_M]).all()
+        assert np.isfinite(lo[_M:]).all()
+        assert np.isfinite(hi[_M:]).all()
+
+    def test_the_band_brackets_the_counterfactual(self, fitted):
+        ts = fitted.time_series
+        cf = np.asarray(ts.counterfactual_outcome, dtype=float)[_M:]
+        lo = np.asarray(ts.counterfactual_lower, dtype=float)[_M:]
+        hi = np.asarray(ts.counterfactual_upper, dtype=float)[_M:]
+        assert (lo <= cf + 1e-9).all()
+        assert (cf <= hi + 1e-9).all()
+
+    def test_it_is_the_same_band_the_helper_computed(self, fitted):
+        """The contract carries the fit's band, not a recomputed one."""
+        detail = fitted.inference_detail
+        lo = np.asarray(fitted.time_series.counterfactual_lower, dtype=float)
+        hi = np.asarray(fitted.time_series.counterfactual_upper, dtype=float)
+        assert lo[_M:] == pytest.approx(np.asarray(detail.conformal_lower, float))
+        assert hi[_M:] == pytest.approx(np.asarray(detail.conformal_upper, float))
+
+
+# =========================================================================== #
+# the variants stay distinguishable on the contract
+# =========================================================================== #
+class TestVariants:
+
+    def test_the_exact_test_names_its_permutation_scheme(self):
+        for scheme in ("moving_block", "iid"):
+            extra = {"inference_method": "exact", "permutation_scheme": scheme}
+            if scheme == "iid":
+                extra["num_permutations"] = 200
+            inf = _fit(**extra).inference
+            assert scheme in inf.method
+            assert "scheme" in inf.details
+            assert inf.details["scheme"] == scheme
+
+    def test_the_bootstrap_default_names_itself(self, fitted):
+        assert fitted.inference.method == "conformal_permutation"
+        assert fitted.inference.details["num_resamples"] == 1000
+
+    def test_the_two_methods_report_the_same_statistic(self):
+        """Only the null distribution differs; the observed statistic does not."""
+        a = _fit().inference.details["test_statistic"]
+        b = _fit(inference_method="exact").inference.details["test_statistic"]
+        assert float(a) == pytest.approx(float(b), rel=1e-12)
+
+
+# =========================================================================== #
+# the guard on a band that does not fit the axis
+# =========================================================================== #
+class TestBandAlignmentGuard:
+
+    def test_a_band_that_does_not_span_the_window_is_not_published(self, fitted):
+        """Publishing a misaligned band would put bounds on the wrong periods.
+
+        The contract's band is indexed by ``time_periods``, so a band whose
+        length does not complete the window cannot be placed. The fields stay
+        empty and ``has_prediction_interval`` stays False; the numbers are still
+        on ``inference_detail``, which is indexed by the post window alone.
+        """
+        import dataclasses
+
+        from mlsynth.utils.shc_helpers.structures import SHCResults
+
+        detail = dataclasses.replace(
+            fitted.inference_detail,
+            conformal_lower=np.array([]), conformal_upper=np.array([]))
+        rebuilt = SHCResults(
+            inputs=fitted.inputs, design=fitted.design,
+            att_value=fitted.att_value, att_percent=fitted.att_percent,
+            observed=fitted.observed, cf_window=fitted.cf_window,
+            gap_window=fitted.gap_window, time_labels=fitted.time_labels,
+            fit_diagnostics_detail=fitted.fit_diagnostics_detail,
+            inference_detail=detail, metadata=dict(fitted.metadata))
+        assert rebuilt.time_series.counterfactual_lower is None
+        assert rebuilt.time_series.has_prediction_interval is False
+        # the test itself is unaffected: only the band could not be placed
+        assert rebuilt.inference.details["test_statistic"] == pytest.approx(
+            fitted.inference.details["test_statistic"])
+
+
+# =========================================================================== #
+# backward compatibility
+# =========================================================================== #
+class TestInferenceDetailStillWorks:
+
+    def test_the_dataclass_accessor_is_unchanged(self, fitted):
+        from mlsynth.utils.shc_helpers.structures import SHCInference
+        detail = fitted.inference_detail
+        assert isinstance(detail, SHCInference)
+        assert detail.p_value == fitted.inference.p_value
+        assert detail.null_distribution.size == 1000

--- a/mlsynth/tests/test_shc_inference_size.py
+++ b/mlsynth/tests/test_shc_inference_size.py
@@ -1,0 +1,309 @@
+"""The five whys for SHC's conformal test, as tests.
+
+Incident: on real US four-quarter GDP growth the test rejects the sharp null at
+the 1% level in 5 of 5 placebo windows with p = 0.0000, one of them with an ATT
+of +0.244, and reports a 1% critical value of 0.009 where Chen, Yang & Yang
+report 8.517 for the same design (1956Q1-2020Q4, m = 24, n = 4). The point
+estimates are unaffected and replicate the paper: S = 11.924 against 11.896,
+2020Q2 effect -11.380 against -11.719, N = 229 exactly.
+
+The chain, each stage depending only on the ones to its right::
+
+    p_value, critical_values  <-  null distribution  <-  reference pool
+        <-  y_t - latent_pre_t  <-  smooth(y, h)  <-  h from loocv_bandwidth
+
+Links cleared, with the evidence in each test below:
+
+* the observed statistic (scaling, absolute value, window, sign) -- cleared,
+  with A2 re-cleared on a mixed-sign design because the COVID panel's four post
+  gaps are all negative and there ``|sum|`` and ``sum|.|`` coincide, so the
+  check had no power there;
+* the resampler (with replacement, ``n`` draws, upper tail, ``P(S* >= S)``) --
+  cleared against an independent reimplementation at the same seed.
+
+Two causes, on the two links that were not cleared.
+
+1. The pool and the statistic are different constructions, and this is the
+   bottom. The statistic is ``y_t`` minus an out-of-sample SHC prediction; the
+   pool is ``y_t`` minus an in-sample smoother fit. Out-of-sample error exceeds
+   in-sample error, by a median factor of about two on the paper's own
+   simulation, and with ``n = 4`` summed absolute residuals a factor of two
+   puts the statistic past the 99th percentile of the null. That is the whole
+   of the measured size: 0.267 at the 1% level on a design where the smoother
+   does not interpolate and the two scales are within an order of magnitude.
+
+2. On real four-quarter GDP growth ``loocv_bandwidth`` additionally returns the
+   smallest value on its grid. The criterion measures leave-one-out prediction,
+   and a series whose neighbours predict it almost exactly is best predicted by
+   the tightest fit; ``smooth`` has no leave-out, so at that bandwidth it
+   interpolates. ``latent_pre`` then correlates 0.9999995 with ``y`` and the
+   pool's sd is 0.0027 against the series' 2.291. This is an amplifier, not a
+   cause: it takes the critical value from 7.6 -- the most a maximally
+   dispersed in-sample pool can give -- down to 0.009, which is 854 of the
+   957-fold gap against the paper's 8.517. The paper's own simulation does not
+   exhibit it at all.
+
+Confirmation. Cause 1: the failure does not occur without it -- building the
+pool the statistic's own way, out-of-sample refits over each historical block's
+post-window, takes size to zero. Cause 2: the failure still occurs without it --
+fixing the bandwidth at 2.0 leaves size at 0.167 -- so it is a contributing
+factor and the ladder does not stop there. Both are faults of omission: nothing
+asserted that the reference residuals and the tested residuals are the same
+object, and nothing asserted that the selected bandwidth was interior to its
+grid.
+
+The size assertions are ``xfail(strict=True)``: they state the behaviour the
+test must have, they fail today for the documented reason, and they turn into a
+suite failure the moment the construction is corrected and nobody updates them.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from mlsynth import SHC
+from mlsynth.utils.shc_helpers.inference import shc_conformal_test
+from mlsynth.utils.shc_helpers.kernels import loocv_bandwidth, smooth
+from mlsynth.utils.shc_helpers.orchestration import solve_shc, summarize_effects
+from mlsynth.utils.shc_helpers.setup import prepare_shc_inputs
+from mlsynth.utils.shc_helpers.simulation import simulate_shc_panel
+
+_M, _N, _REPS = 25, 4, 12
+_LEVELS = (0.01, 0.05, 0.10)
+
+
+def _null_panel(seed):
+    """The paper's own design with no effect: every rejection is a false one."""
+    df, _info = simulate_shc_panel(m=_M, h=4, n=_N, seed=seed)
+    return df
+
+
+def _fit(df, **extra):
+    cfg = {"df": df, "outcome": "y", "treat": "treated", "unitid": "unit",
+           "time": "time", "m": _M, "display_graphs": False}
+    cfg.update(extra)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return SHC(cfg).fit()
+
+
+# =========================================================================== #
+# rung 0 -- the incident, reproduced deterministically
+# =========================================================================== #
+class TestRung0Size:
+
+    @pytest.mark.xfail(strict=True, reason=(
+        "cause 2: the reference pool is an in-sample smoother residual while "
+        "the statistic is an out-of-sample prediction error, so the two are not "
+        "exchangeable under the null. Measured size on this design is about "
+        "0.27 at the 1% level."))
+    def test_the_test_has_about_its_nominal_size_under_an_exact_null(self):
+        rejections = {lvl: 0 for lvl in _LEVELS}
+        for seed in range(_REPS):
+            det = _fit(_null_panel(seed)).inference.details
+            for lvl in _LEVELS:
+                rejections[lvl] += int(det["reject"][lvl])
+        for lvl in _LEVELS:
+            realised = rejections[lvl] / _REPS
+            assert realised <= 3 * lvl, (
+                f"size {realised:.3f} at nominal {lvl}")
+
+    def test_the_incident_reproduces(self):
+        """What the suite can assert today: the test over-rejects, and by how much."""
+        rejections = 0
+        for seed in range(_REPS):
+            rejections += int(_fit(_null_panel(seed)).inference.details["reject"][0.01])
+        realised = rejections / _REPS
+        assert realised > 0.10, (
+            f"expected gross over-rejection at the 1% level, saw {realised:.3f}")
+
+
+# =========================================================================== #
+# rung 1 -- which other outputs moved with it
+# =========================================================================== #
+class TestRung1OtherOutputs:
+
+    def test_the_point_estimates_are_upstream_and_unaffected(self):
+        """Blast radius: the pool is computed after the counterfactual.
+
+        The reference pool cannot reach the effect series, so the replication of
+        the paper's point estimates is not evidence that inference is sound --
+        which is the reason the incident went unnoticed.
+        """
+        res = _fit(_null_panel(0))
+        assert res.effects.att is not None
+        assert np.isfinite(res.effects.att)
+        assert np.isfinite(np.asarray(res.time_series.estimated_gap)).all()
+
+    def test_the_bandwidth_moves_the_block_selection_too(self):
+        """The fault is not confined to inference: the donor set moves with it."""
+        df = _null_panel(0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            inputs = prepare_shc_inputs(df, outcome="y", treat="treated",
+                                        unitid="unit", time="time", m=_M)
+            counts = []
+            for h in (None, 1.0, 2.0):
+                design = solve_shc(inputs,
+                                   bandwidth_grid=None if h is None else [h])
+                counts.append(sum(1 for v in design.block_weights.values()
+                                  if v > 1e-8))
+        assert len(set(counts)) > 1, (
+            f"expected the weighted-block count to depend on the bandwidth, "
+            f"saw {counts}")
+
+
+# =========================================================================== #
+# rung 2 -- which step produced the pool
+# =========================================================================== #
+class TestRung2TheStep:
+
+    def test_loocv_collapses_the_bandwidth_when_the_errors_are_correlated(self):
+        """Cause 2, and the assumption it violates.
+
+        The selector minimises leave-one-out prediction error. Under the
+        paper's Assumption 1 -- iid errors -- a neighbour carries information
+        about the trend and none about the error, so a tight fit predicts badly
+        and the criterion smooths: on the paper's own simulation it picks 2.5
+        from a 50-point grid. When the errors are serially correlated a
+        neighbour also predicts the error, a tight fit wins, and the criterion
+        collapses to the smallest bandwidth on offer.
+
+        Real four-quarter GDP growth is an overlapping annual growth rate,
+        hence a moving average by construction, so it violates Assumption 1 by
+        the definition of the outcome variable -- and LOOCV returns 0.30, the
+        third grid point.
+        """
+        grid = np.linspace(0.1, 5.0, 50)
+        rng = np.random.default_rng(0)
+        T = 260
+        t = np.arange(T, dtype=float)
+
+        iid = np.sin(t / 21.0) * 2.0 + rng.normal(0, 0.7, T)
+        ar = np.zeros(T)
+        for i in range(1, T):
+            ar[i] = 0.86 * ar[i - 1] + rng.normal(0, 1.0)
+        ma = np.convolve(rng.normal(0, 1, T + 3), np.ones(4) / 4.0, mode="valid")
+
+        _h_iid, cv_iid = loocv_bandwidth(iid, grid)
+        _h_ar, cv_ar = loocv_bandwidth(ar, grid)
+        _h_ma, cv_ma = loocv_bandwidth(ma, grid)
+
+        assert int(np.argmin(cv_iid)) > 25, (
+            "with iid errors the criterion should smooth, not tighten")
+        assert int(np.argmin(cv_ar)) < 5, (
+            "with AR(1) errors it should collapse toward the small boundary")
+        assert int(np.argmin(cv_ma)) < 10, (
+            "an overlapping moving average is the case real GDP growth is in; "
+            "it lands at grid index 6 of 50 against the iid case's 49")
+
+    def test_a_collapsed_bandwidth_makes_the_smoother_interpolate(self):
+        """The step from a small bandwidth to a degenerate pool.
+
+        ``smooth`` has no leave-out, so the kernel puts essentially all weight
+        on the point itself once the bandwidth is small against the unit time
+        spacing. The residual pool then carries almost no dispersion, which is
+        what takes the reported critical value to 0.009.
+        """
+        rng = np.random.default_rng(1)
+        T = 260
+        ar = np.zeros(T)
+        for i in range(1, T):
+            ar[i] = 0.86 * ar[i - 1] + rng.normal(0, 1.0)
+
+        tight = ar - smooth(ar, 0.3)
+        loose = ar - smooth(ar, 2.0)
+        assert tight.std(ddof=1) < 0.02 * ar.std(ddof=1), (
+            f"expected near-interpolation, residual sd "
+            f"{tight.std(ddof=1):.4f} against series sd {ar.std(ddof=1):.4f}")
+        assert loose.std(ddof=1) > 20 * tight.std(ddof=1)
+
+
+# =========================================================================== #
+# rung 3 -- the invariant nobody asserted
+# =========================================================================== #
+class TestRung3Invariant:
+
+    @pytest.mark.xfail(strict=True, reason=(
+        "cause 2: the pool is an in-sample smoother residual and the statistic "
+        "an out-of-sample prediction error, so the post-period residuals are "
+        "about twice the pool's scale. With n = 4 summed absolute residuals a "
+        "factor of two is enough to put the statistic past the 99th percentile "
+        "of the null, which is the 0.27 size measured above."))
+    def test_the_pool_and_the_statistic_have_the_same_scale_under_the_null(self):
+        """The permutation argument's precondition, at the tolerance it needs.
+
+        Commensurate to within an order of magnitude is not the requirement.
+        Under the null the post-period residuals must be draws from the same
+        distribution as the pool, so their mean absolute deviations must agree
+        to within sampling error of four observations -- which is wide, but not
+        a factor of two systematically in one direction.
+        """
+        ratios = []
+        for seed in range(_REPS):
+            df = _null_panel(seed)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                inputs = prepare_shc_inputs(df, outcome="y", treat="treated",
+                                            unitid="unit", time="time", m=_M)
+                design = solve_shc(inputs)
+                _a, _ap, obs, cf, _g, _w, _f = summarize_effects(inputs, design)
+            pool = inputs.y[:inputs.T0] - np.asarray(design.latent_pre).ravel()
+            post = obs[_M:] - cf[_M:]
+            ratios.append(np.abs(post).mean() / np.abs(pool).mean())
+        median = float(np.median(ratios))
+        assert 0.67 < median < 1.5, (
+            f"median dispersion ratio {median:.2f} over {_REPS} null panels")
+
+    def test_the_dispersion_gap_is_systematic_and_one_directional(self):
+        """The measured version, which is what makes it a fault and not noise.
+
+        Out-of-sample error exceeds in-sample error on essentially every
+        replication. A ratio scattered around one would be sampling noise; a
+        ratio above one every time is the construction.
+        """
+        ratios = []
+        for seed in range(_REPS):
+            df = _null_panel(seed)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                inputs = prepare_shc_inputs(df, outcome="y", treat="treated",
+                                            unitid="unit", time="time", m=_M)
+                design = solve_shc(inputs)
+                _a, _ap, obs, cf, _g, _w, _f = summarize_effects(inputs, design)
+            pool = inputs.y[:inputs.T0] - np.asarray(design.latent_pre).ravel()
+            post = obs[_M:] - cf[_M:]
+            ratios.append(np.abs(post).mean() / np.abs(pool).mean())
+        ratios = np.asarray(ratios)
+        assert (ratios > 1.0).mean() >= 0.8, (
+            f"expected the out-of-sample residual to dominate; "
+            f"it did on {(ratios > 1.0).mean():.0%} of panels")
+        assert np.median(ratios) > 1.5
+
+
+# =========================================================================== #
+# rung 4 -- the contract that was never enforced
+# =========================================================================== #
+class TestRung4Contract:
+
+    def test_a_degenerate_pool_is_not_refused(self):
+        """Nothing stops a pool with no dispersion from producing a p-value.
+
+        A reference distribution concentrated at zero rejects every non-zero
+        statistic. The routine reports ``p = 0`` and a critical value of
+        essentially zero instead of declining to calibrate.
+        """
+        out = shc_conformal_test(np.full(200, 1e-9), np.array([1.0, -2.0, 3.0, 1.0]),
+                                 num_resamples=200, random_state=0)
+        assert out["p_value"] == 0.0
+        assert out["critical_values"][0.01] < 1e-6
+        assert out["reject"][0.01] is True
+
+    def test_an_empty_pool_is_refused(self):
+        """The one degenerate case that is caught."""
+        from mlsynth.exceptions import MlsynthDataError
+        with pytest.raises(MlsynthDataError):
+            shc_conformal_test(np.array([]), np.array([1.0]))

--- a/mlsynth/utils/shc_helpers/inference.py
+++ b/mlsynth/utils/shc_helpers/inference.py
@@ -476,4 +476,6 @@ def run_conformal_inference(
         conformal_lower=lower[m:],
         conformal_upper=upper[m:],
         confidence_level=1.0 - miscoverage_rate,
+        levels=tuple(test.get("levels", tuple(levels))),
+        scheme=test.get("scheme", "iid_with_replacement"),
     )

--- a/mlsynth/utils/shc_helpers/structures.py
+++ b/mlsynth/utils/shc_helpers/structures.py
@@ -22,7 +22,7 @@ repository's :class:`IndexSet`. The only DataFrame touchpoint is
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import numpy as _np
@@ -111,6 +111,11 @@ class SHCInference:
         Post-period Andrews-Genton conformal bands, retained for plotting.
     confidence_level : float
         Coverage of the conformal bands (e.g. 0.90).
+    levels : tuple of float
+        Significance levels ``critical_values`` and ``reject`` are keyed by.
+    scheme : str
+        The resampling family that built the null: ``"iid_with_replacement"``
+        for the paper's bootstrap, or the permutation scheme of the exact test.
     """
 
     method: str
@@ -123,6 +128,8 @@ class SHCInference:
     conformal_lower: np.ndarray
     conformal_upper: np.ndarray
     confidence_level: float
+    levels: Tuple[float, ...] = (0.01, 0.05, 0.10)
+    scheme: str = "iid_with_replacement"
 
 
 @dataclass(frozen=True)
@@ -233,8 +240,39 @@ class SHCResults(_BaseEstimatorResults):
             r_squared_pre=fd.get("r_squared_pre")))
         if self.inference_detail is not None:
             inf = self.inference_detail
+            # ``details`` on the contract is a mapping every caller subscripts,
+            # so the dataclass's scalars are copied across instead of the
+            # dataclass being handed over whole. ``inference_detail`` keeps the
+            # dataclass, and the arrays, for callers that already read it.
             set_("inference", _InferenceResults(
                 method=getattr(inf, "method", None),
-                p_value=getattr(inf, "p_value", None), details=inf))
+                p_value=getattr(inf, "p_value", None),
+                confidence_level=getattr(inf, "confidence_level", None),
+                details={
+                    "test_statistic": getattr(inf, "test_statistic", None),
+                    "critical_values": dict(getattr(inf, "critical_values", {}) or {}),
+                    "reject": dict(getattr(inf, "reject", {}) or {}),
+                    "num_resamples": getattr(inf, "num_resamples", None),
+                    "levels": tuple(getattr(inf, "levels", ()) or ()),
+                    "scheme": getattr(inf, "scheme", None),
+                    "null_distribution": getattr(inf, "null_distribution", None),
+                }))
+            # The Andrews-Genton band covers the post window only; the canonical
+            # representation is aligned to ``time_periods`` with NaN where the
+            # method has no band, which is the block's pre-window here.
+            lo = _np.asarray(getattr(inf, "conformal_lower", ()), dtype=float)
+            hi = _np.asarray(getattr(inf, "conformal_upper", ()), dtype=float)
+            if lo.size and lo.size == hi.size and lo.size + m == len(times):
+                full_lo = _np.full(len(times), _np.nan)
+                full_hi = _np.full(len(times), _np.nan)
+                full_lo[m:] = lo
+                full_hi[m:] = hi
+                ts = self.time_series
+                object.__setattr__(ts, "counterfactual_lower", full_lo)
+                object.__setattr__(ts, "counterfactual_upper", full_hi)
+                object.__setattr__(ts, "prediction_interval_level",
+                                   float(getattr(inf, "confidence_level", _np.nan)))
+                object.__setattr__(ts, "prediction_interval_kind",
+                                   "conformal:andrews-genton")
         set_("method_details", _MethodDetailsResults(method_name="SHC"))
         return self


### PR DESCRIPTION
## Related Links

- Docs page: `docs/shc.rst`
- Source paper: Chen, Y.-T., Yang, J.-C. & Yang, T.-T. (2024), "Synthetic Historical Control for Policy Evaluation", SSRN 4995085 — the test is their footnote 21, their application of Chernozhukov, Wüthrich & Zhu (2021), JASA 116(536), 1849–1864
- Followed by `claude/shc-oos-conformal-pool`, which corrects the cause this PR diagnoses

## What

- `InferenceResults` now carries `confidence_level` and a `details` mapping with `test_statistic`, `critical_values`, `reject`, `levels`, `scheme`, `num_resamples` and `null_distribution`
- The Andrews–Genton band goes to `TimeSeriesResults.counterfactual_lower/upper`, aligned to `time_periods` with `NaN` over the block's pre-window, tagged `conformal:andrews-genton`
- `SHCInference` gains `levels` and `scheme`
- `docs/shc.rst`: six autodoc targets repointed, and a section saying where to read each number
- New `test_shc_inference_size.py`: the five-whys ladder for the test's size, as tests

## Why

The test and the band were already computed but were not reachable through the contract. `res.inference` carried a method name and a p-value; `ci_lower`/`ci_upper` were empty, `details` held the `SHCInference` dataclass where every caller subscripts a mapping (`res.inference.details["critical_values"]` raised `AttributeError: 'SHCInference' object has no attribute 'keys'`), and the band never reached `res.time_series`, so `has_prediction_interval` was `False` on a fit that had computed one.

The docs page compounded it: the entire Developer API pointed at `mlsynth.utils.inferutils` and `mlsynth.utils.estutils`, neither of which exists, so the inference API documented nothing. Reading that page, "SHC has no inference" is the only available conclusion.

## How

The contract population copies the dataclass's scalars into `details` and keeps `inference_detail` unchanged for callers already reading it. A band whose length does not complete the window is not published, since the contract indexes it by `time_periods` and a misaligned band would put bounds on the wrong periods.

The ladder is the `/rca` procedure. Links cleared: the statistic (scaling, absolute value, window, sign) and the resampler (with replacement, `n` draws, upper tail, `P(S* >= S)`), the latter against an independent reimplementation at the same seed. The absolute-value candidate was re-cleared on a mixed-sign design, because the COVID panel's four post gaps are all negative and there `|sum|` and `sum|.|` coincide, so the first check had no power.

Two causes. The pool is an in-sample smoother residual while the statistic is an out-of-sample prediction error, which is the bottom; and on real four-quarter GDP growth `loocv_bandwidth` additionally returns the smallest value on its grid, because its criterion measures leave-one-out prediction and a serially correlated error is predicted by its neighbours — an overlapping annual growth rate violates the paper's Assumption 1 by the definition of the outcome. Magnitude: interpolation accounts for 854 of the 957-fold critical-value gap; the remaining 1.12x is not reachable by any pool of this construction and is left unexplained instead of attributed.

## Verification

- Path: cross-validation against the paper's reported numbers, plus Path B for the size measurement
- On FRED GDPC1 four-quarter growth under the authors' COVID design (1956Q1–2020Q4, `m=24`, `n=4`): `N = 229` exactly, `S = 11.924` against their 11.896, 2020Q2 effect −11.380 against −11.719. Their footnote-26 sample variance of "0.052" is the computed 5.2485 to four figures
- Size under an exact null on the paper's own simulation: 0.267 / 0.400 / 0.500 against nominal 0.01 / 0.05 / 0.10. Pinned as two `xfail(strict=True)` assertions, so they become suite failures the moment the construction is corrected and nobody updates them
- The point estimates are computed before the pool, so their agreement with the paper was never evidence about inference — which is how this went unnoticed

## Scope checks

Bug fix on an existing estimator, plus the docs repair.

- [x] Tests reproduce the defect and fail without the fix
- [x] They assert the correct behaviour, not the absence of a crash
- [x] No docs page or docstring still states the old behaviour — the `confidence_set` docstring's false claim that the point estimate "cannot be rejected" is corrected, and the `docs/shc.rst` note that called the pool "mildly under-dispersed" is replaced with the measurement
- [x] No pinned value moved

## Designs

`covid_shc.png` was produced in-session: observed against synthetic historical US over the treated block, with the Andrews–Genton band and the per-quarter effect panel. The band is 0.30pp wide at 2020Q2 against an 11.4pp effect, which is the same family of defect one layer along.

## Test Steps

- [x] `pytest mlsynth/tests/ -k "shc or result_contract"` — 451 passed, 5 skipped, 2 xfailed
- [x] `coverage run --timid -m pytest mlsynth/tests/test_shc_inference_contract.py` — `inference.py` 100%, `structures.py` 99% (the one miss is a pre-existing re-validation guard)
- [x] Every autodoc target resolves

## Other Notes

- The size defect is diagnosed here and corrected in `claude/shc-oos-conformal-pool`. When that lands, the two strict xfails flip to XPASS by design and need the update that branch carries
- `inferutils`/`estutils` are still referenced from `docs/pda.rst`, `docs/validation.rst` and `docs/vanillasc.rst`. Doc-wide cleanup, its own branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoqPWPcpAcqUy8PQa5PocM