### PR TITLE
SCMO: make the simplex weight solver robust to a failed cvxpy solve

### DIFF
--- a/mlsynth/tests/test_scmo_solver_robustness.py
+++ b/mlsynth/tests/test_scmo_solver_robustness.py
@@ -1,0 +1,74 @@
+"""Robustness of SCMO's simplex weight solver to a failed cvxpy solve.
+
+Regression coverage for the case where the primary solver (OSQP) terminates
+without a primal solution, leaving ``w.value is None``. Previously
+``simplex_weights`` fed that ``None`` straight into ``np.clip`` and crashed
+with an opaque ``TypeError`` (``'>=' not supported between instances of
+'NoneType' and 'float'`` on the current NumPy). It must instead fall back to a
+robust solver, and raise a translated ``MlsynthEstimationError`` only if every
+solver fails.
+"""
+from __future__ import annotations
+
+import cvxpy as cp
+import numpy as np
+import pytest
+
+from mlsynth.exceptions import MlsynthEstimationError
+from mlsynth.utils.scmo_helpers import solvers
+
+
+def _problem():
+    """A small, well-posed matching problem (treated is a convex mix of donors)."""
+    Z_donors = np.array(
+        [[1.0, 0.0, 0.0, 1.0],
+         [0.0, 1.0, 0.0, 1.0],
+         [0.0, 0.0, 1.0, 1.0]]
+    )
+    # treated = 0.5 * donor0 + 0.5 * donor1 -> a genuine simplex target
+    Z_treated = 0.5 * Z_donors[0] + 0.5 * Z_donors[1]
+    return Z_treated, Z_donors
+
+
+def test_simplex_weights_smoke_returns_valid_simplex():
+    Z_treated, Z_donors = _problem()
+    w = solvers.simplex_weights(Z_treated, Z_donors)
+    assert w.shape == (Z_donors.shape[0],)
+    assert np.all(w >= -1e-9)
+    assert w.sum() == pytest.approx(1.0, abs=1e-6)
+
+
+def test_simplex_weights_falls_back_when_primary_solver_returns_none(monkeypatch):
+    """OSQP returning no primal value must trigger the CLARABEL fallback rather
+    than crash in ``np.clip``."""
+    Z_treated, Z_donors = _problem()
+    real_solve = cp.Problem.solve
+    calls = {"solvers": []}
+
+    def fake_solve(self, *args, **kwargs):
+        solver = kwargs.get("solver")
+        calls["solvers"].append(solver)
+        if solver == cp.OSQP:
+            # Simulate OSQP terminating without setting a primal solution:
+            # skip the real solve so ``w.value`` stays None.
+            return None
+        return real_solve(self, *args, **kwargs)
+
+    monkeypatch.setattr(cp.Problem, "solve", fake_solve)
+    w = solvers.simplex_weights(Z_treated, Z_donors)
+
+    # OSQP was attempted first, then the CLARABEL fallback.
+    assert cp.OSQP in calls["solvers"]
+    assert cp.CLARABEL in calls["solvers"]
+    assert np.all(w >= -1e-9)
+    assert w.sum() == pytest.approx(1.0, abs=1e-6)
+
+
+def test_simplex_weights_raises_translated_error_when_all_solvers_fail(monkeypatch):
+    """When no solver returns a solution, the failure is reported as a
+    translated ``MlsynthEstimationError`` -- not a raw ``TypeError`` from
+    ``np.clip(None, ...)``."""
+    Z_treated, Z_donors = _problem()
+    monkeypatch.setattr(cp.Problem, "solve", lambda self, *a, **k: None)
+    with pytest.raises(MlsynthEstimationError):
+        solvers.simplex_weights(Z_treated, Z_donors)

--- a/mlsynth/utils/scmo_helpers/solvers.py
+++ b/mlsynth/utils/scmo_helpers/solvers.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import numpy as np
 import cvxpy as cp
 
+from ...exceptions import MlsynthEstimationError
+
 
 def simplex_weights(Z_treated: np.ndarray, Z_donors: np.ndarray) -> np.ndarray:
     """Convex (simplex) SC weights minimizing ``||Z_treated - Z_donors' w||^2``.
@@ -30,9 +32,20 @@ def simplex_weights(Z_treated: np.ndarray, Z_donors: np.ndarray) -> np.ndarray:
     J = Z_donors.shape[0]
     w = cp.Variable(J)
     objective = cp.Minimize(cp.sum_squares(Z_treated - Z_donors.T @ w))
-    cp.Problem(objective, [w >= 0, cp.sum(w) == 1]).solve(
-        solver=cp.OSQP, eps_abs=1e-9, eps_rel=1e-9, max_iter=20000
-    )
-    w_hat = np.clip(np.asarray(w.value).ravel(), 0.0, None)
+    problem = cp.Problem(objective, [w >= 0, cp.sum(w) == 1])
+    problem.solve(solver=cp.OSQP, eps_abs=1e-9, eps_rel=1e-9, max_iter=20000)
+    if w.value is None:
+        # OSQP can terminate without a primal solution on ill-conditioned or
+        # near-degenerate matching matrices (status "infeasible"/"unbounded" or
+        # a numerical failure), leaving ``w.value is None``. Fall back to
+        # CLARABEL, a robust interior-point solver, before giving up.
+        problem.solve(solver=cp.CLARABEL)
+    if w.value is None:
+        raise MlsynthEstimationError(
+            "SCMO simplex weight solve failed: the solver returned no solution "
+            f"(status: {problem.status}). The donor matching matrix may be "
+            "degenerate or ill-conditioned."
+        )
+    w_hat = np.clip(np.asarray(w.value, dtype=float).ravel(), 0.0, None)
     total = w_hat.sum()
     return w_hat / total if total > 0 else w_hat            # exact simplex (sum == 1)


### PR DESCRIPTION
## Related Links

- Surfaced while rendering the `scmo.qmd` blog post (a `method="BOTH"` SCMO fit) against `mlsynth @ main` on current NumPy.
- Touched files: `mlsynth/utils/scmo_helpers/solvers.py`, `mlsynth/tests/test_scmo_solver_robustness.py`.

## What

- Guarded `simplex_weights` against a cvxpy solve that returns no primal value.
- Added a CLARABEL fallback when OSQP returns `w.value is None`, and a translated `MlsynthEstimationError` when every solver fails.
- Added `test_scmo_solver_robustness.py` covering the fallback path, the all-solvers-fail path, and a smoke case.

## Why

- `simplex_weights` fed the OSQP result straight into `np.clip(np.asarray(w.value).ravel(), 0.0, None)`. When OSQP terminates without a primal solution — possible on ill-conditioned or near-degenerate matching matrices — `w.value` is `None`, and on the current NumPy `np.clip(None, ...)` raises an opaque `TypeError` (`'>=' not supported between instances of 'NoneType' and 'float'`) instead of a translated mlsynth error. A `method="BOTH"` SCMO fit hit exactly this.

## How

- Kept OSQP as the primary solve (unchanged tolerances). On a `None` result, re-solve the same problem with CLARABEL, a robust interior-point solver. If that also yields nothing, raise `MlsynthEstimationError` naming the solver status, so the failure travels through the exception contract instead of crashing in NumPy.
- Also passed `dtype=float` to `np.asarray` so a valid solution clips cleanly.

## Verification

- Path: not applicable (numerical robustness fix; no estimator output value changes on well-posed problems — OSQP still solves those, and the smoke test pins a valid simplex vector).
- Pinned durably by `test_scmo_solver_robustness.py`: red before this change (the fallback and all-fail tests raise `TypeError`), green after. The existing SCMO suite (`test_scmo.py`, `test_scmo_plotter.py`) still passes (52 tests).

## Scope checks

BUG FIX:
- [x] A test reproduces the defect and fails without the fix (`w.value is None` → `TypeError`).
- [x] It asserts the correct behaviour (fallback returns a valid simplex; all-fail raises the translated error), not merely the absence of a crash.
- [x] No docs page, docstring, or comment still states the old behaviour.
- [x] No pinned numerical value moves — well-posed problems still solve via OSQP.

## Test Steps

- [x] `pytest mlsynth/tests/test_scmo_solver_robustness.py -q` — 3 passed (2 red without the fix).
- [x] `pytest mlsynth/tests/test_scmo.py mlsynth/tests/test_scmo_plotter.py -q` — 52 passed, no regressions.

## Other Notes

- This unblocks the `scmo.qmd` render on the blog (which installs `mlsynth @ main`); I verified `scmo.qmd` renders end to end against the patched library.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

https://claude.ai/code/session_01J82EiQWA1BNatkYYhKGrw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01J82EiQWA1BNatkYYhKGrw6)_