### PR TITLE
Refresh the paper's and the replications page's stale counts

### DIFF
--- a/paper/paper.qmd
+++ b/paper/paper.qmd
@@ -162,17 +162,23 @@ The original synthetic control method ships as the R package `Synth`
 [@abadie2011synth], itself a paper in this journal, and is reproduced as
 [VanillaSC]{.pkg}. The numerics of its nested predictor-and-donor optimization have
 since been studied: the R package `MSCMT` [@becker2018fast] and the bilevel
-analysis of @malo2024computing show the problem has a global optimum where the
-donor weights coincide with a pure outcome fit, which [VanillaSC]{.pkg}'s
-outcome-only backend reaches directly. On the California tobacco data it agrees with
-the installed `MSCMT` on every donor weight (Utah $0.3939$, Montana $0.2318$, Nevada
-$0.2049$, Connecticut $0.1091$) and on an average effect of $-19.51363$, to five
-decimals; run against the original `Synth` solver under outcome-only matching it
-matches the donor weights to about $0.003$ while reaching a strictly lower value
-of the loss `Synth` minimizes, the summed squared pre-period residuals ($52.130$
-against `Synth`'s $52.136$; an RMSE of about $1.66$), the small optimality gap the
-numerics literature describes, shown here against the reference implementation
-itself.
+analysis of @malo2024computing show the problem has a global optimum that the
+data-driven nested solvers can stop short of, and that at this optimum the donor
+weights coincide with a pure outcome fit. `mlsynth` is checked against all three
+solvers. Run against the original `Synth` solver on the California tobacco panel
+under outcome-only matching, [VanillaSC]{.pkg} matches its donor weights to about
+$0.003$ and returns the canonical average effect of $-19.51363$, while reaching a
+strictly lower value of the loss `Synth` minimizes, the summed squared pre-period
+residuals ($52.130$ against `Synth`'s $52.136$; an RMSE of about $1.66$), the
+small optimality gap the numerics literature describes, shown here against the
+reference implementation itself. Run against Malo et al.'s own `scm.corner`
+solver on that same panel, `backend = "malo"` reaches their Table 1 optimum (Utah
+$0.3939$, Montana $0.2318$, Nevada $0.2049$, Connecticut $0.1091$), agreeing on
+every donor weight and on the upper-level objective to about $5 \times 10^{-3}$.
+And `MSCMT`'s nested predictor-weight search is reproduced by `backend = "mscmt"`
+on the Basque study of its vignette, matching the package's donor weights to four
+decimals (Cataluna $0.6328$, Baleares $0.2193$, Madrid $0.1479$) and its average
+post-period gap of $-0.770963$.
 
 `synth2` [@yan2023synth2] re-implements the estimator in Stata with the inference
 practitioners want around it, placebo tests, a leave-one-out check, and confidence
@@ -234,7 +240,7 @@ missing-data family ([MCNNM]{.pkg}, [SNN]{.pkg}), but does not carry the simplex
 regression-control, penalized, spillover-aware, or experimental-design estimators.
 
 To my knowledge `mlsynth` is the first comprehensive Python library for this
-family: every estimator named above, and roughly forty more, is reached through one
+family: every estimator named above, and sixty-odd more, is reached through one
 data-preparation step, one configuration-and-fit call, and one standardized result,
 where today a researcher who wants to weigh these methods against one another must
 cross R, Stata, and Python and reconcile as many data conventions and result
@@ -249,7 +255,8 @@ reference or reproduced from the source paper at validation time (@tbl-related).
 | `pampe` | R | Hsiao-Ching-Wan panel-data approach | [PDA]{.pkg}, `method="hcw"` | donor set, effect path |
 | `fsPDA` | R | forward-selected PDA | [PDA]{.pkg}, `method="fs"` | $-0.030896$ (5 dp) |
 | `augsynth` | R | augmented (ridge) SCM, covariates, staggered | [VanillaSC]{.pkg}, `augment="ridge"` | $-0.0294/-0.0401$ (6 dp) |
-| `MSCMT` | R | generalized / bilevel SCM | [VanillaSC]{.pkg}, outcome-only backend | installed package (5 dp) |
+| `MSCMT` | R | generalized / bilevel SCM | [VanillaSC]{.pkg}, `backend="mscmt"` | Basque weights (4 dp), gap $-0.770963$ |
+| `SCM-Debug` (`scm.corner`) | R | bilevel corner optimum | [VanillaSC]{.pkg}, `backend="malo"` | Prop 99 weights, objective (~5e-3) |
 | `masc` | R | matching + synthetic control | [MASC]{.pkg} | $-\$585$ vs $-\$580$ (paper) |
 | `microsynth` | R | calibrated SCM for micro-level panels | [MicroSynth]{.pkg} | weights vs R package |
 | `causaltensor` | Python | matrix completion, factor models | [MCNNM]{.pkg}, [SNN]{.pkg} | n/a |
@@ -259,7 +266,7 @@ reference or reproduced from the source paper at validation time (@tbl-related).
 | `tidysynth` | R | simplex SCM (tidyverse API) | [VanillaSC]{.pkg} | n/a |
 | `SyntheticControlMethods` | Python | classic SCM | [VanillaSC]{.pkg} | n/a |
 | `pysyncon` | Python | classic / robust / augmented / penalized SCM | [VanillaSC]{.pkg}, [CLUSTERSC]{.pkg} | n/a |
-| `mlsynth` | Python | all of the above and roughly forty more | one interface | n/a |
+| `mlsynth` | Python | all of the above and sixty-odd more | one interface | n/a |
 
 : Representative synthetic-control packages and their `mlsynth` equivalents. The canonical implementations are spread across R and Stata and split one method to a package; the few Python options each cover a narrow slice. The final row is the contribution in one line: a single validated interface, in one language, over a family otherwise spread across three languages and a dozen packages. A dash in the fourth column marks an adjacent tool that targets a distinct counterfactual, which `mlsynth` does not reproduce. The "Checked" column records where `mlsynth`'s benchmark suite reproduces the reference implementation or the source paper's published result numerically; ``n/a`` there marks a package whose engine `mlsynth` reaches through an estimator cross-checked elsewhere rather than against that package directly (for instance the canonical `Synth` check covers the simplex backend that `tidysynth` and `SyntheticControlMethods` share), not an unverified claim. The full per-estimator validation is maintained on the validation dashboard (<https://mlsynth.readthedocs.io/en/latest/validation.html>). {#tbl-related}
 
@@ -488,9 +495,11 @@ single treated unit, low-rank and factor models, time series, distributional and
 multi-outcome settings, endogeneity and proxies, spillovers, staggered adoption,
 and experimental design -- and each is guarded by a durable benchmark: the source
 paper's own empirical result (Path A), its Monte Carlo or simulation-table target
-(Path B), or a numerical cross-check against a reference implementation (X). Six
-classes are dispatchers that host several named methods behind one interface, so
-the number of distinct methods a user can run exceeds the number of classes.
+(Path B), a property the paper proves about the estimator as the sample grows,
+measured against a population benchmark the design makes computable (Path C), or
+a numerical cross-check against a reference implementation (X). Several
+classes are dispatchers that host a family of named methods behind one interface,
+so the number of distinct methods a user can run exceeds the number of classes.
 Rather than freeze that catalogue as a table that would drift out of date, the
 full per-estimator list and its live validation status are maintained on the
 validation dashboard
@@ -508,7 +517,7 @@ I follow that path (config, estimator, data preparation, result) because it is
 also the order in which the design builds on itself. Two commitments run through
 all four. Outwardly, every estimator presents the same surface, so learning one
 teaches every other. Inwardly, every estimator is its own self-contained package,
-which keeps more than forty of them maintainable.
+which keeps more than seventy of them maintainable.
 
 ### One config {#sec-config}
 
@@ -715,7 +724,7 @@ it will run at all. In `mlsynth` the analyst imports one estimator, builds one
 configuration, and calls [fit]{.fct} once; there is no preparation function to
 find, import, configure, or call. Coding the indicator column *is* the
 specification, and the same long data frame drives every one of the more than
-forty estimators unchanged.
+seventy estimators unchanged.
 
 ### One result {#sec-results}
 
@@ -856,10 +865,11 @@ fig.tight_layout(); plt.show()
 The three estimators build California from different premises (@fig-prop99).
 VanillaSC, matching on Abadie's predictors through the Malo corner solver, puts
 the average post-1989 shortfall at
-`{python} f"{abs(s99.att['VanillaSC']):.2f}"` packs per capita, reproducing the
-value the R package `Synth` and the `MSCMT` solver return on this panel to the
-decimals reported in @sec-related; Robust SC, fitting a low-rank donor matrix,
-returns almost the same, `{python} f"{abs(s99.att['Robust SC']):.2f}"`. Synthetic
+`{python} f"{abs(s99.att['VanillaSC']):.2f}"` packs per capita, within a few
+hundredths of a pack of the canonical $-19.51$ that the `Synth` and `scm.corner`
+cross-checks of @sec-related pin on this panel; Robust SC, fitting a low-rank
+donor matrix, returns almost the same,
+`{python} f"{abs(s99.att['Robust SC']):.2f}"`. Synthetic
 difference-in-differences returns a smaller
 `{python} f"{abs(s99.att['SDID']):.2f}"`, the estimate @arkhangelsky2021synthetic
 report for this panel; it is smaller by construction, because its
@@ -1190,7 +1200,7 @@ packaged for applied use.
 `mlsynth` is built to be stable, consistent, and inspectable. One
 data-preparation routine, one runtime-validated configuration object, and one
 standardized result stand in front of every estimator (@sec-arch), so a single
-set of coding and naming conventions holds across more than forty methods and
+set of coding and naming conventions holds across more than seventy methods and
 the interface a user learns once transfers to all of them. Each estimator is a
 thin class over a dedicated helper package, which keeps the code for a method,
 its numerics, and its tests in one directory rather than threaded through a
@@ -1198,16 +1208,20 @@ shared core. Configurations are validated with Pydantic [@pydantic]: they refuse
 unknown or ill-typed fields at construction, so a mis-specified analysis fails as
 an immediate, legible error rather than a silent miscomputation. The package is
 free and open-source under the MIT license; it depends only on the
-scientific-Python stack, with the two heavier solver dependencies it can use
-loaded lazily so that the base installation runs every estimator. It is
-available from the Python Package Index via `pip install mlsynth`, with source
+scientific-Python stack. The heavier solvers a handful of estimators need --
+the SCIP mixed-integer solver behind the MAREX and SYNDES designs and the HCW
+best-subset certification, the HiGHS solver behind PANGEO's exact-cover
+partition, and NumPyro behind SPOTSYNTH's Bayesian mode -- are optional extras,
+imported lazily, so the base installation runs every other estimator without
+them, and `pip install "mlsynth[all]"` adds the rest. It is available from the
+Python Package Index via `pip install mlsynth`, with source
 and an issue tracker at <https://github.com/jgreathouse9/mlsynth>, and
 contributions and bug reports from the applied community are encouraged.
 
 To keep the library correct as it grows, every estimator ships with automated
 tests, written before the code they cover and run in a continuous-integration
 environment on each change. Correctness against the literature is checked
-separately, by a benchmark suite of one hundred small re-runnable cases that
+separately, by a benchmark suite of two hundred small re-runnable cases that
 hold each estimator to an outside answer rather than to its own past output. When
 an authoritative implementation of a method can be run, usually an R package or
 the original authors' replication code, the benchmark runs it on the same input
@@ -1215,9 +1229,15 @@ and records its output, together with the input checksums and the exact package
 versions that produced it, as a captured reference the library is then pinned to;
 when no such implementation can be run, the benchmark instead targets a figure
 the source paper itself reports, its headline result or a cell of its simulation
-table. Because every target is either a re-runnable reference or a published
-fact, a regression in `mlsynth` or a drift in a reference surfaces as a failed
-benchmark rather than a quiet disagreement. Running the references, rather than
+table. A third kind of target is the paper's own theory: where a method's
+guarantee is asymptotic, the case measures the property the theorem asserts as
+the sample grows -- a selection probability converging, a bound holding
+uniformly, an interval covering at its nominal rate -- against a population
+benchmark the simulation design makes computable, and pins where the guarantee
+stops applying as well as where it holds. Because every target is a re-runnable
+reference, a published fact, or a proven property, a regression in `mlsynth` or a
+drift in a reference surfaces as a failed benchmark rather than a quiet
+disagreement. Running the references, rather than
 transcribing their printed numbers, has a further benefit: each discrepancy is
 traced to its cause, and in several cases `mlsynth` is found to reach the
 verified optimum of the estimation problem where a published reference solver, at
@@ -1239,7 +1259,7 @@ Synthetic control has grown from a single method into a sprawling family, and th
 software has fragmented along with it. I have argued the fragmentation is largely
 incidental: most of these estimators run one computation, differing only in how they
 constrain or denoise a single shared fit (@sec-unified). `mlsynth` takes that
-observation seriously, placing more than forty estimators behind one data contract,
+observation seriously, placing more than seventy estimators behind one data contract,
 one validated configuration-and-fit interface, and one standardized result. The three
 illustrations show what the consolidation buys: a cross-method comparison of convex,
 robust-matrix, and predictor-selecting synthetic controls on Proposition 99, fit and

--- a/paper/requirements.txt
+++ b/paper/requirements.txt
@@ -1,7 +1,8 @@
 # Render environment for paper/paper.qmd (consumed by .github/workflows/paper_render.yml).
 # Installs the library from the repo checkout so the paper reflects current code,
-# plus the Jupyter engine Quarto uses to execute the Python chunks. The `bayes`
-# extra (NumPyro) is needed by Example 4's SPOTSYNTH Bayesian credible band.
+# plus the Jupyter engine Quarto uses to execute the Python chunks. The `design`
+# extra (SCIP) is needed by the paper's MAREX experimental-design example; `bayes`
+# (NumPyro) is kept so the render environment covers the full estimator set.
 -e .[design,bayes]
 jupyter
 matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,13 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 
-# Core runtime dependencies. The two heavy, estimator-specific dependencies are
-# optional extras (below): `pyscipopt` (the SCIP MIP solver, needed only by the
-# SYNDES / MAREX experimental designs) and `numpyro` (JAX-based, needed only by
-# SPOTSYNTH's Bayesian mode). Both are imported lazily, so the base install
-# imports and runs every other estimator without them.
+# Core runtime dependencies. The heavy, estimator-specific dependencies are
+# optional extras (below): `pyscipopt` (the SCIP MIP solver, needed by the
+# SYNDES / MAREX experimental designs and by HCW's best-subset certification),
+# `highspy` (needed only by PANGEO's exact-cover partition MIP), and `numpyro`
+# (JAX-based, needed only by SPOTSYNTH's Bayesian mode). All are imported
+# lazily, so the base install imports and runs every other estimator without
+# them.
 dependencies = [
     "pandas>=2.0.0",
     "numpy>=1.24.0",


### PR DESCRIPTION
## Related Links

- Merges in `claude/mlsynth-paper-staleness-owb404` (c9a1496), which had no PR
- Docs: `docs/replications.rst`, `paper/paper.qmd`

## What

Two scopes, separable by commit.

The merge commit brings in the paper-staleness branch unchanged: the catalogue count moves from "roughly forty" to "sixty-odd", the benchmark suite from "one hundred" to "two hundred" cases, Path C joins the validation-paths list in Sections 2 and 5, and the claim that a base install runs every estimator is corrected (a plain `pip install -e .` cannot run the paper's own MAREX example, which fails on a missing SCIP).

The second commit replaces the stale counts on the replications page. It opened with "Thirty-seven of the thirty-eight estimators" and closed with "Of mlsynth's 36 estimators, 35 (97%)". Both claims are now count-free.

## Why

The library exports 78 estimator classes and registers 204 benchmark cases. The replications page was describing a 36-estimator library, so both of its summary claims were 42 estimators out of date. The paper's figures were written at the same vintage.

Making the two sentences count-free stops them drifting again: every estimator is verified along one of the three paths except ISCM, which is the exception the page already singled out.

## How

The paper half is the existing branch, merged rather than rewritten, so its authorship and commit stand. Its numbers were checked against the tree at merge time and still hold: 78 exported estimator classes reads as "sixty-odd more" beside those named in the text, and 204 registered cases reads as "two hundred".

## Verification

Not applicable — documentation only, no numerical code touched. The counts asserted were taken from `mlsynth.__all__` (78 classes with a `fit()` contract) and `benchmarks/registry.py` (204 entries).

## Scope checks

None of the four blocks fits: this is documentation and paper prose only.

## Test Steps

- [x] Style sweep on the changed page: no `rather` / `quietly` / `loudly` / `load-bearing` hits
- [ ] Docs build — left to CI

## Other Notes

The "Verification coverage by family" table on `docs/replications.rst` still carries per-family counts describing a 36-estimator library (its rows sum to 35 verified of 36). Recounting it needs a taxonomy decision about which family each of the 78 estimators belongs to, so it is left for its own change instead of being guessed at here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjHjNHMYLHdRqCTgELFKFb

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjHjNHMYLHdRqCTgELFKFb)_