### PR TITLE
Stop the daily benchmark losing a shard in silence

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -68,6 +68,28 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # A shard cancelled by its own timeout concludes "cancelled", not "failure",
+  # and GitHub marks the run cancelled -- which reads like somebody pressed
+  # stop rather than like a gap in coverage. The cases that shard holds simply
+  # go unvalidated, with nothing red to show for it. That is how four
+  # consecutive daily runs (2026-08-24 to -27) left 51 cases unchecked. This
+  # gate turns any shard outcome other than success into a failed run.
+  # ---------------------------------------------------------------------------
+  suite-gate:
+    if: always() && github.event_name != 'pull_request'
+    needs: suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail unless every suite shard succeeded
+        if: needs.suite.result != 'success'
+        run: |
+          echo "::error::suite shards concluded '${{ needs.suite.result }}', not success." >&2
+          echo "A cancelled or failed shard neither passes nor fails on its own," >&2
+          echo "so the cases it holds went unvalidated. Check the shard logs." >&2
+          exit 1
+
+  # ---------------------------------------------------------------------------
   # Main suite: mlsynth[all] + the R reference stack. Runs every registered case;
   # the R-backed live cross-checks execute because R is provisioned here.
   #
@@ -75,6 +97,20 @@ jobs:
   # across NUM_SHARDS parallel jobs (run_benchmarks.py --shard i --num-shards N).
   # Each shard runs ~1/N of the cases, keeping every shard well under the
   # timeout. To change the shard count, edit BOTH the matrix list and NUM_SHARDS.
+  #
+  # Round-robin balances shards by case COUNT, not by runtime, and the two are
+  # not the same thing: at four shards the benchmark steps took 15, 37, 37 and
+  # 66+ minutes. The split was not merely uneven, it was resonant -- a stride
+  # of four landed 12 of the 17 heaviest Monte Carlo and R-backed cases on
+  # shard 1 alone, because of where they sit in the registry. A stride of six
+  # breaks that up (0/6/2/5/1/3 of the same seventeen) and brings the slowest
+  # shard back to roughly 45 minutes. Each extra shard pays the R provisioning
+  # again, which is why this is 6 and not 8.
+  #
+  # It is still count-balanced, so a stride that resonates again is possible.
+  # The durable fix is to bin-pack by measured runtime rather than widen
+  # further; ``case-deps`` already walks every case and is the natural place
+  # to collect the timings that would need.
   #
   # R CACHE: the CRAN references (requirements.R -> Synth/synthdid/did + their
   # dependencies -- the heaviest compiles) install into a user-writable
@@ -87,13 +123,17 @@ jobs:
     # Reference-provisioning is the expensive half; pull requests get pr-suite.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # The cap covers R provisioning (18-24 min) AND the shard, not the shard
+    # alone. At 90 it did not: on 2026-08-27 shard 1 was cancelled at 90m14s
+    # having had only ~67 minutes of benchmark budget, and the same happened
+    # on the three days before that.
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5]
     env:
-      NUM_SHARDS: "4"
+      NUM_SHARDS: "6"
       R_LIBS_USER: ${{ github.workspace }}/.rlibs
       # Pin BLAS/LAPACK to a single thread so the numerically-sensitive cases
       # reproduce deterministically. constraints.txt already fixes the
@@ -205,7 +245,7 @@ jobs:
     # its cases, writes no report, and leaves the run merely "unstable". Adding
     # heavy cases moves the slowest shard, not the average, so raise the shard
     # count when one next approaches this.
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/benchmarks/tests/test_workflow_sharding.py
+++ b/benchmarks/tests/test_workflow_sharding.py
@@ -34,7 +34,7 @@ SHARDED_JOBS = ("suite", "pr-suite", "case-deps")
 
 #: Jobs that must never run for a pull request.
 NON_PR_JOBS = ("suite", "validation-dashboard", "case-deps",
-               "case-deps-commit")
+               "case-deps-commit", "suite-gate")
 
 
 @pytest.fixture(scope="module")
@@ -132,10 +132,17 @@ class TestTheTimeoutFitsTheSlowestShard:
     written, and the run reports `cancelled` rather than red, so roughly an
     eighth of the suite goes unexamined while the PR looks merely unstable.
 
-    The floor is set against the daily suite, which has run this registry to
-    completion for months at 90 minutes with R provisioning on top. Adding heavy
-    cases moves the slowest shard, not the average, so this is the number to
-    revisit -- by raising the shard count -- when a shard next approaches it.
+    The floor was set against the daily suite on the belief that it had run
+    this registry to completion at 90 minutes with R provisioning on top. It
+    had not: on 2026-08-24 through -27 its shard 1 was cancelled every day,
+    at 90m14s of job wall clock on the last of them, and nothing went red
+    because a cancelled shard neither passes nor fails. The daily job now
+    runs six shards at 120 minutes and a gate turns a non-success shard into
+    a failed run; see the two classes at the foot of this file.
+
+    Adding heavy cases moves the slowest shard, not the average, so this is
+    still the number to revisit -- by raising the shard count -- when a shard
+    next approaches it.
     """
 
     #: Minutes. Below this a heavy shard is at risk of being cancelled.
@@ -373,3 +380,47 @@ class TestTheAddedSubsetReachesTheSelection:
         step = next(s for s in jobs["pr-suite"]["steps"]
                     if s["name"] == "Run benchmark suite shard")
         assert "--changed-from" in step["run"]
+
+
+class TestASlowShardCannotPassSilently:
+    """A shard killed by its own timeout concludes ``cancelled``, not
+    ``failure``, and GitHub marks the whole run cancelled -- which reads like
+    somebody pressed stop, not like a gap in coverage. The cases that shard
+    holds are simply not validated, and nothing goes red.
+
+    That is not hypothetical. The daily run was cancelled on four consecutive
+    days (2026-08-24 through -27) because ``suite`` shard 1 overran, and the
+    51 cases it holds went unchecked the whole time. The gate below turns any
+    shard outcome other than success into a failed run.
+    """
+
+    def test_a_gate_job_depends_on_the_suite(self, jobs):
+        assert "suite-gate" in jobs
+        needs = jobs["suite-gate"]["needs"]
+        needs = [needs] if isinstance(needs, str) else list(needs)
+        assert "suite" in needs
+
+    def test_the_gate_runs_even_when_a_shard_did_not(self, jobs):
+        """Without ``always()`` a cancelled dependency skips the gate too."""
+        assert "always()" in jobs["suite-gate"]["if"]
+
+    def test_the_gate_fails_on_anything_but_success(self, jobs):
+        steps = " ".join(str(s) for s in jobs["suite-gate"]["steps"])
+        assert "needs.suite.result" in steps
+        assert "exit 1" in steps
+
+
+class TestTheTimeoutCoversProvisioningToo:
+    """``suite`` spends 18-24 minutes building the R reference toolchain
+    before the first case runs, so its cap has to cover setup *plus* the
+    shard. On 2026-08-27 shard 1 was cancelled at 90m14s of job wall clock
+    having had only about 67 minutes of actual benchmark budget, while the
+    other three shards finished their cases in 15 to 38 minutes.
+    """
+
+    def test_the_suite_has_headroom_over_provisioning(self, jobs):
+        assert int(jobs["suite"]["timeout-minutes"]) >= 120
+
+    def test_the_suite_is_sharded_finely_enough(self, jobs):
+        """Four shards left the slowest holding more than an hour of cases."""
+        assert int(jobs["suite"]["env"]["NUM_SHARDS"]) >= 6


### PR DESCRIPTION
## Related Links

- Workflow: `.github/workflows/benchmarks.yml`
- Tests: `benchmarks/tests/test_workflow_sharding.py`

Opening a PR for an existing branch that had none; the commit is unchanged from 2026-08-28.

## What

Three fixes to the daily benchmark workflow, plus a gate job so the failure mode cannot recur silently.

- `suite` timeout raised from 90 to 120 minutes.
- Shard stride changed from four to six.
- A new `suite-gate` job that fails the run unless every shard succeeded.
- `pr-suite` raised to 120 as well, keeping the invariant that the PR job is never capped tighter than the daily one.

## Why

The daily run had been cancelled every day since 2026-08-24. One job of thirteen, `suite` shard 1, was killed by its own timeout while the other twelve passed. A shard cancelled by a timeout concludes "cancelled", not "failure", so GitHub marked the whole run cancelled — which reads like somebody pressed stop. Nothing went red, and the 51 cases that shard holds went unvalidated.

The 90-minute cap did not cover the work: it includes 18-24 minutes of R toolchain provisioning before the first case runs, so on 2026-08-27 shard 1 was cancelled at 90m14s of job wall clock having had about 67 minutes of actual benchmark budget.

The shards were also badly balanced, and not by accident. Round-robin balances case count, not case cost, and a stride of four landed 12 of the 17 heaviest Monte Carlo and R-backed cases on shard 1 alone. A stride of six breaks that resonance (0/6/2/5/1/3 of the same seventeen) and puts the slowest near 45 minutes.

## How

Six is the stride and not eight because every extra shard pays the R provisioning again. The durable fix is to bin-pack by measured runtime, and the comment in the workflow says where those timings would come from.

The previous rationale rested on the belief that the daily suite "has run this registry to completion for months at 90 minutes". It had not, and that docstring now says so.

## Verification

Not applicable — CI configuration, no numerical code touched.

## Scope checks

None of the four blocks fits: this is CI and tooling.

## Test Steps

- [x] Six new tests pin the gate's existence, its `always()` guard, that it keys on `needs.suite.result`, and the two numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjHjNHMYLHdRqCTgELFKFb

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjHjNHMYLHdRqCTgELFKFb)_