### PR TITLE
A cumulative interval whose calibration set has no horizon in it

### DIFF
--- a/mlsynth/tests/test_lto_cumulative.py
+++ b/mlsynth/tests/test_lto_cumulative.py
@@ -1,0 +1,153 @@
+"""A cumulative interval whose calibration set does not involve the horizon.
+
+Every cumulative band built on the time axis thins as the horizon grows: split
+conformal needs ``ceil((m+1)(1-alpha)) <= m`` non-overlapping windows of length
+``H`` from a fixed pre-period, so ``m`` falls as ``H`` rises, and a block
+resample keeps reporting only because its period count hides a collapsing origin
+count.
+
+The leave-two-out reference set is ``C(J, 2)`` pairs of donor units. Lei &
+Sudijono (2025) section 6.4 -- the theory "only relies on the uniform assignment
+assumption but not the choice of summary statistics" -- is what lets the pair
+statistic be the cumulative post-period total. The reference set is then counted
+in donors and the horizon does not enter it.
+
+One detail decides whether this is the right construction. The pair's spread has
+to be the larger of the two left-out donors' *cumulative* absolute residuals,
+``max(|sum r_a|, |sum r_b|)``. Accumulating the pointwise maxima instead --
+``sum(max(|r_a|, |r_b|))`` -- fixes the cross-period correlation at one and is
+the comonotone endpoint sum in a new costume. The two are pinned apart below.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.utils.vanillasc_helpers import BilevelSCM
+from mlsynth.utils.vanillasc_helpers.lto import lto_cumulative_interval, lto_interval
+
+
+def _panel(seed=3, T=24, T0=16, J=7, effect=0.0):
+    rng = np.random.default_rng(seed)
+    Y0 = rng.normal(5, 1, size=(T, J))
+    w = np.zeros(J)
+    w[[0, 2, 5]] = [0.5, 0.3, 0.2]
+    y = Y0 @ w + 0.05 * rng.normal(size=T)
+    y[T0:] += effect
+    return y, Y0, T0
+
+
+def _run(*, effect=0.0, alpha=0.10, **kw):
+    y, Y0, T0 = _panel(effect=effect, **kw)
+    out = lto_cumulative_interval(BilevelSCM("outcome-only", seed=0), y, Y0, T0,
+                                  alpha=alpha, seed=0)
+    return out, y, T0
+
+
+# ---- shape -----------------------------------------------------------------
+
+def test_the_interval_is_a_pair_of_scalars_in_order():
+    out, y, T0 = _run()
+    for k in ("lower", "upper", "effect_lower", "effect_upper", "observed_total"):
+        assert np.isscalar(out[k]) or np.ndim(out[k]) == 0, k
+        assert np.isfinite(out[k]), k
+    assert out["lower"] <= out["upper"]
+    assert out["effect_lower"] <= out["effect_upper"]
+    assert out["observed_total"] == pytest.approx(y[T0:].sum())
+
+
+def test_the_effect_bounds_are_the_counterfactual_bounds_reflected():
+    """effect = observed - counterfactual, so the bounds swap ends."""
+    out, _, _ = _run()
+    assert out["effect_lower"] == pytest.approx(out["observed_total"] - out["upper"])
+    assert out["effect_upper"] == pytest.approx(out["observed_total"] - out["lower"])
+
+
+# ---- the property the construction exists for ------------------------------
+
+@pytest.mark.parametrize("T", [20, 26, 34])
+def test_the_reference_set_does_not_involve_the_horizon(T):
+    """4, 10 and 18 post periods; the same 21 pairs calibrate all three."""
+    out, _, _ = _run(T=T)
+    assert out["n_pairs"] == 7 * 6 // 2
+    assert out["horizon"] == T - 16
+
+
+# ---- the construction ------------------------------------------------------
+
+def test_the_spread_accumulates_before_it_takes_the_maximum():
+    """``max(|sum r|)``, not ``sum(max|r|)``.
+
+    Taking the maximum period by period and then accumulating would assume the
+    two donors' errors line up in sign across every period -- the comonotone
+    assumption. The faithful statistic accumulates each donor first.
+    """
+    out, _, _ = _run()
+    cum_a = out["pair_resid_i"].sum(axis=1)
+    cum_b = out["pair_resid_j"].sum(axis=1)
+    assert np.allclose(out["pair_spreads"],
+                       np.maximum(np.abs(cum_a), np.abs(cum_b)))
+
+    comonotone = np.maximum(np.abs(out["pair_resid_i"]),
+                            np.abs(out["pair_resid_j"])).sum(axis=1)
+    assert not np.allclose(out["pair_spreads"], comonotone), (
+        "the fixture is degenerate: the two constructions agree here, so this "
+        "test would pass on either")
+    assert (out["pair_spreads"] <= comonotone + 1e-9).all()
+
+
+def test_at_a_one_period_horizon_it_is_the_pointwise_interval():
+    """A cumulative total over one period is that period."""
+    y, Y0, _ = _panel(T=24)
+    eng = BilevelSCM("outcome-only", seed=0)
+    pre = 23                                    # a single post period
+    cum = lto_cumulative_interval(eng, y, Y0, pre, alpha=0.10, seed=0)
+    pt = lto_interval(eng, y, Y0, pre, alpha=0.10, seed=0)
+    assert cum["lower"] == pytest.approx(pt["lower"][-1])
+    assert cum["upper"] == pytest.approx(pt["upper"][-1])
+
+
+def test_the_quantile_is_an_order_statistic():
+    out, _, _ = _run()
+    hi = out["pair_centres"] + out["pair_spreads"]
+    lo = out["pair_centres"] - out["pair_spreads"]
+    assert out["upper"] in hi
+    assert out["lower"] in lo
+
+
+# ---- behaviour under a known effect ----------------------------------------
+
+def test_a_planted_effect_moves_the_interval_off_zero():
+    null_out, _, _ = _run(effect=0.0)
+    hit_out, _, _ = _run(effect=-8.0)
+    assert null_out["effect_lower"] <= 0.0 <= null_out["effect_upper"]
+    assert hit_out["effect_upper"] < null_out["effect_upper"]
+
+
+# ---- failures --------------------------------------------------------------
+
+def test_no_post_periods_is_refused():
+    y, Y0, _ = _panel()
+    with pytest.raises(ValueError, match="post"):
+        lto_cumulative_interval(BilevelSCM("outcome-only", seed=0), y, Y0, len(y))
+
+
+def test_an_alpha_finer_than_the_pair_set_can_resolve_is_refused():
+    y, Y0, T0 = _panel()
+    with pytest.raises(ValueError, match="alpha"):
+        lto_cumulative_interval(BilevelSCM("outcome-only", seed=0), y, Y0, T0,
+                                alpha=0.001)
+
+
+def test_fewer_than_three_donors_is_refused():
+    rng = np.random.default_rng(0)
+    Y0 = rng.normal(5, 1, size=(12, 2))
+    y = Y0 @ np.array([0.6, 0.4]) + 0.05 * rng.normal(size=12)
+    with pytest.raises(ValueError, match="donor"):
+        lto_cumulative_interval(BilevelSCM("outcome-only"), y, Y0, 8)
+
+
+def test_an_alpha_outside_the_unit_interval_is_refused():
+    y, Y0, T0 = _panel()
+    eng = BilevelSCM("outcome-only", seed=0)
+    for bad in (0.0, 1.0, -0.1, 1.5):
+        with pytest.raises(ValueError, match="alpha must lie"):
+            lto_cumulative_interval(eng, y, Y0, T0, alpha=bad)

--- a/mlsynth/tests/test_lto_interval.py
+++ b/mlsynth/tests/test_lto_interval.py
@@ -1,0 +1,185 @@
+"""Pointwise confidence intervals from the leave-two-out reference set.
+
+Lei & Sudijono (2025). The reference implementation
+(``tsudijon/LeaveTwoOutSCI``) builds the interval per period from the pair set,
+in ``basque_analysis/slurm/basque_ltojk_poweranalysis_slurm.R``:
+
+    LTO.residuals[pair,] = pmax(abs(res1), abs(res2))
+    ci.upper[t] = quantile(LTO.regression[,t] + LTO.residuals[,t], 1-alpha, type=1)
+    ci.lower[t] = quantile(LTO.regression[,t] - LTO.residuals[,t],   alpha, type=1)
+
+Each pair contributes its own counterfactual for the treated unit -- the pool
+differs pair to pair -- so the interval is a quantile over pair-specific centres
+and not a fixed centre with a spread around it.
+
+What matters for this port, and what these tests hold:
+
+  * the reference set is ``C(J, 2)`` pairs of donor units, so its size does not
+    involve the post-period length. That is the property that makes this usable
+    where a calibration set drawn from the time axis runs out.
+  * ``quantile(type = 1)`` is R's inverse-ECDF, which returns an order statistic
+    and not an interpolation between two. NumPy's default interpolates, so the
+    two disagree on small pair sets -- exactly the regime this method is for.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.utils.vanillasc_helpers import BilevelSCM
+from mlsynth.utils.vanillasc_helpers.lto import lto_interval
+
+
+def _panel(seed=3, T=24, T0=16, J=7, effect=0.0):
+    rng = np.random.default_rng(seed)
+    Y0 = rng.normal(5, 1, size=(T, J))
+    w = np.zeros(J)
+    w[[0, 2, 5]] = [0.5, 0.3, 0.2]
+    y = Y0 @ w + 0.05 * rng.normal(size=T)
+    y[T0:] += effect
+    return y, Y0, T0
+
+
+def _run(*, effect=0.0, alpha=0.10, **kw):
+    y, Y0, T0 = _panel(effect=effect, **kw)
+    return lto_interval(BilevelSCM("outcome-only", seed=0), y, Y0, T0,
+                        alpha=alpha, seed=0), y, T0
+
+
+# ---- shape and orientation -------------------------------------------------
+
+def test_interval_spans_the_panel_and_is_ordered():
+    out, y, _ = _run()
+    assert out["lower"].shape == out["upper"].shape == y.shape
+    assert np.isfinite(out["lower"]).all() and np.isfinite(out["upper"]).all()
+    assert (out["lower"] <= out["upper"]).all()
+
+
+def test_the_reference_set_is_every_pair_of_donors():
+    out, _, _ = _run()
+    J = 7
+    assert out["n_pairs"] == J * (J - 1) // 2
+    assert out["N"] == J + 1
+
+
+# ---- the property the method is being adopted for --------------------------
+
+@pytest.mark.parametrize("T", [20, 26, 34])
+def test_the_reference_set_does_not_shrink_as_the_post_period_grows(T):
+    """C(J, 2) pairs at every horizon.
+
+    A calibration set cut from the time axis loses windows as the horizon grows;
+    this one is counted in donors, so it does not. Same pre-period, same donors,
+    a post-period from 4 to 18 periods long.
+    """
+    out, _, _ = _run(T=T)
+    assert out["n_pairs"] == 7 * 6 // 2
+    assert out["lower"].shape == (T,)
+
+
+# ---- the recipe ------------------------------------------------------------
+
+def test_the_quantile_is_an_order_statistic_not_an_interpolation():
+    """R's ``type = 1`` against NumPy's default, on the shipped result.
+
+    Every reported bound has to be a value the pair set actually produced. With
+    21 pairs at alpha = 0.10 the two conventions differ, so this fails if the
+    port silently uses the interpolating default.
+    """
+    out, _, _ = _run()
+    centres, spreads = out["pair_centres"], out["pair_spreads"]
+    for t in range(centres.shape[1]):
+        hi = centres[:, t] + spreads[:, t]
+        lo = centres[:, t] - spreads[:, t]
+        assert out["upper"][t] in hi, f"upper[{t}] is not one of the pair values"
+        assert out["lower"][t] in lo, f"lower[{t}] is not one of the pair values"
+
+
+def test_the_spread_is_the_larger_of_the_two_left_out_donors():
+    """``pmax(abs(res1), abs(res2))``, per period, per pair."""
+    out, _, _ = _run()
+    assert (out["pair_spreads"] >= 0).all()
+    assert np.array_equal(
+        out["pair_spreads"],
+        np.maximum(np.abs(out["pair_resid_i"]), np.abs(out["pair_resid_j"])))
+
+
+# ---- behaviour under a known effect ----------------------------------------
+
+def test_a_null_panel_is_mostly_covered_and_a_large_effect_is_not():
+    """Direction, not a coverage rate: one panel cannot measure coverage."""
+    null_out, y_null, T0 = _run(effect=0.0)
+    inside_null = ((y_null >= null_out["lower"]) & (y_null <= null_out["upper"]))
+
+    hit_out, y_hit, _ = _run(effect=-8.0)
+    inside_hit = ((y_hit >= hit_out["lower"]) & (y_hit <= hit_out["upper"]))
+
+    assert inside_null[T0:].mean() > inside_hit[T0:].mean()
+
+
+# ---- failures --------------------------------------------------------------
+
+def test_fewer_than_three_donors_is_refused():
+    rng = np.random.default_rng(0)
+    Y0 = rng.normal(5, 1, size=(12, 2))
+    y = Y0 @ np.array([0.6, 0.4]) + 0.05 * rng.normal(size=12)
+    with pytest.raises(ValueError, match="donor"):
+        lto_interval(BilevelSCM("outcome-only"), y, Y0, 8)
+
+
+def test_an_alpha_finer_than_the_pair_set_can_resolve_is_refused():
+    """21 pairs cannot place a 1% bound: the order statistic does not exist."""
+    y, Y0, T0 = _panel()
+    with pytest.raises(ValueError, match="alpha"):
+        lto_interval(BilevelSCM("outcome-only", seed=0), y, Y0, T0, alpha=0.001)
+
+
+def test_an_alpha_outside_the_unit_interval_is_refused():
+    y, Y0, T0 = _panel()
+    eng = BilevelSCM("outcome-only", seed=0)
+    for bad in (0.0, 1.0, -0.1, 1.5):
+        with pytest.raises(ValueError, match="alpha must lie"):
+            lto_interval(eng, y, Y0, T0, alpha=bad)
+
+
+def test_capping_the_pair_count_subsamples_deterministically():
+    """``max_pairs`` trades reference set for cost, and says that it did.
+
+    The cap changes the reference set, so it changes the guarantee -- the flag is
+    how a caller finds out. Two runs at one seed agree; a different seed draws a
+    different subsample.
+    """
+    y, Y0, T0 = _panel()
+    eng = BilevelSCM("outcome-only", seed=0)
+    a = lto_interval(eng, y, Y0, T0, alpha=0.10, max_pairs=12, seed=0)
+    b = lto_interval(eng, y, Y0, T0, alpha=0.10, max_pairs=12, seed=0)
+    c = lto_interval(eng, y, Y0, T0, alpha=0.10, max_pairs=12, seed=1)
+
+    assert a["n_pairs"] == 12 and a["subsampled"] is True
+    assert np.array_equal(a["lower"], b["lower"])
+    assert not np.array_equal(a["pair_centres"], c["pair_centres"])
+    full = lto_interval(eng, y, Y0, T0, alpha=0.10)
+    assert full["subsampled"] is False and full["n_pairs"] == 21
+
+
+def test_the_cold_path_reaches_the_same_pairs():
+    """``warm_start`` picks where the active set starts, not where it lands."""
+    y, Y0, T0 = _panel()
+    eng = BilevelSCM("outcome-only", seed=0)
+    warm = lto_interval(eng, y, Y0, T0, alpha=0.10, warm_start=True)
+    cold = lto_interval(eng, y, Y0, T0, alpha=0.10, warm_start=False)
+    assert warm["n_pairs"] == cold["n_pairs"]
+    assert np.allclose(warm["lower"], cold["lower"], atol=1e-6)
+    assert np.allclose(warm["upper"], cold["upper"], atol=1e-6)
+
+
+def test_capping_the_pairs_raises_the_level_the_interval_can_reach():
+    """The cap is not free: fewer pairs is a coarser reachable alpha.
+
+    21 pairs resolve alpha = 0.10; 8 do not, since 1/8 exceeds it. The refusal
+    names the reachable level so a caller can choose between the cap and the
+    level instead of guessing.
+    """
+    y, Y0, T0 = _panel()
+    eng = BilevelSCM("outcome-only", seed=0)
+    assert lto_interval(eng, y, Y0, T0, alpha=0.10)["n_pairs"] == 21
+    with pytest.raises(ValueError, match=r"tightest reachable level here is alpha=0\.1250"):
+        lto_interval(eng, y, Y0, T0, alpha=0.10, max_pairs=8)

--- a/mlsynth/tests/test_lto_statistic.py
+++ b/mlsynth/tests/test_lto_statistic.py
@@ -1,0 +1,96 @@
+"""The LTO pair statistic is a choice, not a fixture of the procedure.
+
+Lei & Sudijono (2025) section 6.4: the theory "only relies on the uniform
+assignment assumption but not the choice of summary statistics". The shipped test
+hardcodes the post/pre RMSPE ratio, which is the right default and the only thing
+the paper's own applications use, but it is not the only statistic the guarantee
+covers -- and a cumulative interval needs a different one.
+
+These pin the seam: the default is unchanged, a caller's statistic is the one
+that decides the comparison, and a statistic that misbehaves is refused at the
+boundary instead of quietly producing a p-value from garbage.
+"""
+import numpy as np
+import pytest
+
+from mlsynth.utils.vanillasc_helpers import BilevelSCM
+from mlsynth.utils.vanillasc_helpers.lto import _rmspe_ratio_resid, lto_placebo_test
+
+
+def _case(seed=3, T=24, T0=16, J=7, effect=-2.0):
+    """A small donor pool with a planted post-period effect."""
+    rng = np.random.default_rng(seed)
+    Y0 = rng.normal(5, 1, size=(T, J))
+    w = np.zeros(J)
+    w[[0, 2, 5]] = [0.5, 0.3, 0.2]
+    y = Y0 @ w + 0.05 * rng.normal(size=T)
+    y[T0:] += effect
+    return y, Y0, T0
+
+
+def _run(**kw):
+    y, Y0, T0 = _case()
+    return lto_placebo_test(BilevelSCM("outcome-only", seed=0), y, Y0, T0,
+                            alpha=0.05, seed=0, **kw)
+
+
+def test_passing_the_default_explicitly_changes_nothing():
+    """The seam is a seam, not a new procedure."""
+    assert _run() == _run(statistic=_rmspe_ratio_resid)
+
+
+def test_the_callers_statistic_is_the_one_that_decides():
+    """Two statistics with opposite verdicts, to prove the argument is used.
+
+    A statistic that ranks the treated unit above every donor makes it win every
+    triple; one that ranks it below makes it lose every triple. Asserting only
+    one of the two would pass on a stub that ignored the argument and happened to
+    agree.
+    """
+    def treated_always_wins(y_k, cf, pre):
+        # the treated series is the only one carrying the planted effect, so
+        # keying on the post-period gap separates it from every donor
+        return float(np.abs(np.asarray(y_k)[pre:] - np.asarray(cf)[pre:]).mean())
+
+    def treated_always_loses(y_k, cf, pre):
+        return -treated_always_wins(y_k, cf, pre)
+
+    win = _run(statistic=treated_always_wins)
+    lose = _run(statistic=treated_always_loses)
+    assert win["p_value"] < lose["p_value"]
+    assert lose["p_value"] == pytest.approx(1.0)
+
+
+def test_a_statistic_is_called_for_every_unit_in_the_triple():
+    """Three residuals per pair: the treated unit and both left-out donors."""
+    seen = []
+
+    def spy(y_k, cf, pre):
+        seen.append(np.asarray(y_k).copy())
+        return _rmspe_ratio_resid(y_k, cf, pre)
+
+    out = _run(statistic=spy)
+    assert len(seen) == 3 * out["n_pairs"]
+
+
+def test_a_non_callable_statistic_is_refused():
+    with pytest.raises(ValueError, match="statistic"):
+        _run(statistic="rmspe")
+
+
+def test_a_statistic_returning_nan_on_the_treated_unit_does_not_win_by_default():
+    """A degenerate treated score must not be read as an extreme one.
+
+    The shipped guard replaces a non-finite treated residual with the largest
+    float, which makes the treated unit win the triple. That is a decision about
+    a degenerate fit, and it has to survive a caller's statistic rather than
+    depend on which one is passed.
+    """
+    def nan_on_treated(y_k, cf, pre):
+        r = _rmspe_ratio_resid(y_k, cf, pre)
+        y_k = np.asarray(y_k)
+        return float("nan") if y_k.shape == (24,) and y_k[16:].mean() < 4.0 else r
+
+    out = _run(statistic=nan_on_treated)
+    assert 0.0 <= out["p_value"] <= 1.0
+    assert np.isfinite(out["p_value"])

--- a/mlsynth/utils/vanillasc_helpers/lto.py
+++ b/mlsynth/utils/vanillasc_helpers/lto.py
@@ -156,6 +156,67 @@ def _base_seeds(engine, y, Y0, pre, X1, X0):
     return np.asarray(treated.W, dtype=float), donor_bases
 
 
+def _lto_pair_fits(engine, y, Y0, pre, X1, X0, pairs, warm_start):
+    """Yield ``(a, b, cf_I, cf_a, cf_b)`` for each donor pair left out.
+
+    One traversal, used by both entry points. For the pair ``{a, b}`` the donor
+    pool is every other control, and three synthetic controls are built on it:
+    one for the treated unit and one for each left-out donor. What a caller does
+    with the three counterfactuals is its own business -- the placebo test
+    reduces each to a scalar and compares, the interval keeps the residual paths
+    and takes quantiles across pairs.
+
+    A pair whose refit raises is skipped rather than counted, so a failed solve
+    contributes nothing instead of a zero that would shrink the reference set.
+    """
+    J = Y0.shape[1]
+    all_donors = np.arange(J)
+
+    bases = None
+    if warm_start:
+        try:
+            bases = _base_seeds(engine, y, Y0, pre, X1, X0)
+        except Exception:  # pragma: no cover - defensive base-fit guard
+            bases = None
+
+    def _cf(y_k, pool, Y0_pool, x1, ws):
+        x0p = X0[:, pool] if X0 is not None else None
+        rk = engine.fit(y_k[:pre], Y0_pool[:pre], X1=x1, X0=x0p, warm_start=ws)
+        return rk.counterfactual(Y0_pool)
+
+    for a, b in pairs:
+        pool = np.delete(all_donors, [a, b])
+        if not pool.size:  # pragma: no cover - pool size = J-2 >= 1 when J >= 3
+            continue
+        Y0_pool = Y0[:, pool]
+        if bases is None:
+            ws_I = ws_a = ws_b = None
+        else:
+            treated_base, donor_bases = bases
+            ws_I = _seed_from_base(treated_base, pool)
+            ws_a = _seed_from_base(donor_bases[a], pool)
+            ws_b = _seed_from_base(donor_bases[b], pool)
+        try:
+            cf_I = _cf(y, pool, Y0_pool, X1, ws_I)
+            cf_a = _cf(Y0[:, a], pool, Y0_pool,
+                       (X0[:, a] if X0 is not None else None), ws_a)
+            cf_b = _cf(Y0[:, b], pool, Y0_pool,
+                       (X0[:, b] if X0 is not None else None), ws_b)
+        except Exception:  # pragma: no cover - defensive donor-refit guard
+            continue
+        yield a, b, cf_I, cf_a, cf_b
+
+
+def _donor_pairs(J, max_pairs, seed):
+    """Every unordered pair of donors, optionally a deterministic subsample."""
+    pairs = [(a, b) for a in range(J) for b in range(a + 1, J)]
+    if max_pairs is not None and len(pairs) > max_pairs:
+        rng = np.random.default_rng(seed)
+        idx = rng.choice(len(pairs), size=max_pairs, replace=False)
+        return [pairs[i] for i in sorted(idx)], True
+    return pairs, False
+
+
 def lto_placebo_test(
     engine: Any,
     y: np.ndarray,
@@ -229,13 +290,7 @@ def lto_placebo_test(
         )
     N = J + 1
 
-    pairs = [(a, b) for a in range(J) for b in range(a + 1, J)]
-    subsampled = False
-    if max_pairs is not None and len(pairs) > max_pairs:
-        rng = np.random.default_rng(seed)
-        idx = rng.choice(len(pairs), size=max_pairs, replace=False)
-        pairs = [pairs[i] for i in sorted(idx)]
-        subsampled = True
+    pairs, subsampled = _donor_pairs(J, max_pairs, seed)
 
     if statistic is None:
         statistic = _rmspe_ratio_resid
@@ -245,41 +300,13 @@ def lto_placebo_test(
             f"got {type(statistic).__name__}."
         )
 
-    def _resid(y_k, pool, Y0_pool, x1, ws):
-        x0p = X0[:, pool] if X0 is not None else None
-        rk = engine.fit(y_k[:pre], Y0_pool[:pre], X1=x1, X0=x0p, warm_start=ws)
-        return statistic(y_k, rk.counterfactual(Y0_pool), pre)
-
-    bases = None
-    if warm_start:
-        try:
-            bases = _base_seeds(engine, y, Y0, pre, X1, X0)
-        except Exception:  # pragma: no cover - defensive base-fit guard
-            bases = None
-
     losses = 0
     n_pairs = 0
-    all_donors = np.arange(J)
-    for a, b in pairs:
-        pool = np.delete(all_donors, [a, b])
-        if not pool.size:  # pragma: no cover - pool size = J-2 >= 1 when J >= 3
-            continue
-        Y0_pool = Y0[:, pool]
-        if bases is None:
-            ws_I = ws_a = ws_b = None
-        else:
-            treated_base, donor_bases = bases
-            ws_I = _seed_from_base(treated_base, pool)
-            ws_a = _seed_from_base(donor_bases[a], pool)
-            ws_b = _seed_from_base(donor_bases[b], pool)
-        try:
-            R_I = _resid(y, pool, Y0_pool, X1, ws_I)
-            R_a = _resid(Y0[:, a], pool, Y0_pool,
-                         (X0[:, a] if X0 is not None else None), ws_a)
-            R_b = _resid(Y0[:, b], pool, Y0_pool,
-                         (X0[:, b] if X0 is not None else None), ws_b)
-        except Exception:  # pragma: no cover - defensive donor-refit guard
-            continue
+    for a, b, cf_I, cf_a, cf_b in _lto_pair_fits(engine, y, Y0, pre, X1, X0,
+                                                 pairs, warm_start):
+        R_I = statistic(y, cf_I, pre)
+        R_a = statistic(Y0[:, a], cf_a, pre)
+        R_b = statistic(Y0[:, b], cf_b, pre)
         if not np.isfinite(R_I):  # pragma: no cover - donor with zero pre-error
             R_I = np.finfo(float).max
         n_pairs += 1
@@ -303,4 +330,100 @@ def lto_placebo_test(
         "alpha": float(alpha),
         "reject": bool(p_powered <= alpha),
         "subsampled": subsampled,
+    }
+
+
+def lto_interval(
+    engine: Any,
+    y: np.ndarray,
+    Y0: np.ndarray,
+    pre: int,
+    *,
+    X1: Optional[np.ndarray] = None,
+    X0: Optional[np.ndarray] = None,
+    alpha: float = 0.10,
+    max_pairs: Optional[int] = None,
+    seed: int = 0,
+    warm_start: bool = True,
+) -> Dict[str, Any]:
+    """Pointwise confidence interval for the treated unit's counterfactual.
+
+    The construction of Lei & Sudijono (2025) as their replication code builds
+    it (``tsudijon/LeaveTwoOutSCI``,
+    ``basque_analysis/slurm/basque_ltojk_poweranalysis_slurm.R``): each pair of
+    left-out donors contributes a centre -- the treated unit's counterfactual on
+    the pool without that pair -- and a spread, the larger of the two left-out
+    donors' own absolute residuals at that period. The bounds are empirical
+    quantiles across pairs of ``centre + spread`` and ``centre - spread``.
+
+    The reference set is ``C(J, 2)`` pairs of donors. That count does not involve
+    the post-period length, so unlike a calibration set cut from the time axis it
+    does not thin as the horizon grows.
+
+    Parameters
+    ----------
+    engine, y, Y0, pre, X1, X0, max_pairs, seed, warm_start
+        As :func:`lto_placebo_test`.
+    alpha : float
+        Miscoverage. Must be at least ``1 / n_pairs``: below that the quantile
+        indices collapse onto the extremes of the pair set and the bounds carry
+        no resolution, so the call is refused instead.
+
+    Returns
+    -------
+    dict
+        ``lower`` / ``upper`` ``(T,)`` bounds; ``pair_centres``,
+        ``pair_spreads``, ``pair_resid_i`` and ``pair_resid_j``, each
+        ``(n_pairs, T)``, the inputs the bounds were read off; and ``n_pairs``,
+        ``N``, ``alpha``, ``subsampled``.
+
+    Notes
+    -----
+    The quantile is R's ``type = 1``, the inverse ECDF, which returns one of the
+    values the pair set actually produced. NumPy's default interpolates between
+    two order statistics; on the small pair sets this method exists for, the two
+    disagree, and only the order statistic is the quantity the reference computes.
+    """
+    Y0 = np.asarray(Y0, float)
+    y = np.asarray(y, float).ravel()
+    T, J = Y0.shape
+    if J < 3:
+        raise ValueError(
+            "LTO interval needs at least 3 donor units (to leave two out and "
+            "retain a non-empty control pool)."
+        )
+    pairs, subsampled = _donor_pairs(J, max_pairs, seed)
+    if not 0.0 < alpha < 1.0:
+        raise ValueError(f"alpha must lie in (0, 1); got {alpha!r}.")
+    if alpha * len(pairs) < 1.0:
+        raise ValueError(
+            f"alpha={alpha} is finer than {len(pairs)} pairs can resolve: the "
+            f"order statistics collapse onto the extremes of the pair set. The "
+            f"tightest reachable level here is alpha={1.0 / len(pairs):.4f}."
+        )
+
+    centres, spreads, resid_i, resid_j = [], [], [], []
+    for a, b, cf_I, cf_a, cf_b in _lto_pair_fits(engine, y, Y0, pre, X1, X0,
+                                                 pairs, warm_start):
+        r_a = Y0[:, a] - np.asarray(cf_a).ravel()
+        r_b = Y0[:, b] - np.asarray(cf_b).ravel()
+        centres.append(np.asarray(cf_I).ravel())
+        spreads.append(np.maximum(np.abs(r_a), np.abs(r_b)))
+        resid_i.append(r_a)
+        resid_j.append(r_b)
+
+    if not centres:  # pragma: no cover - unreachable when J >= 3
+        raise ValueError("every leave-two-out refit failed; no interval to report.")
+
+    centres = np.vstack(centres)
+    spreads = np.vstack(spreads)
+    upper = np.quantile(centres + spreads, 1.0 - alpha, axis=0,
+                        method="inverted_cdf")
+    lower = np.quantile(centres - spreads, alpha, axis=0, method="inverted_cdf")
+    return {
+        "lower": lower, "upper": upper,
+        "pair_centres": centres, "pair_spreads": spreads,
+        "pair_resid_i": np.vstack(resid_i), "pair_resid_j": np.vstack(resid_j),
+        "n_pairs": centres.shape[0], "N": J + 1,
+        "alpha": float(alpha), "subsampled": subsampled,
     }

--- a/mlsynth/utils/vanillasc_helpers/lto.py
+++ b/mlsynth/utils/vanillasc_helpers/lto.py
@@ -50,7 +50,7 @@ computed at (reject when it is :math:`\\le \\alpha`).
 from __future__ import annotations
 
 from math import floor, sqrt
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 import numpy as np
 
@@ -168,6 +168,7 @@ def lto_placebo_test(
     max_pairs: Optional[int] = None,
     seed: int = 0,
     warm_start: bool = True,
+    statistic: Optional[Callable[[np.ndarray, np.ndarray, int], float]] = None,
 ) -> Dict[str, Any]:
     """Run the Lei-Sudijono (2025) LTO refined placebo test.
 
@@ -199,6 +200,16 @@ def lto_placebo_test(
         point. Speed only -- the seed chooses where the active set starts, not
         where it lands, so every reported quantity is unchanged. Default
         ``True``; pass ``False`` for the cold path.
+    statistic : callable, optional
+        The per-unit summary ``(y_k, counterfactual, pre) -> float`` compared
+        across each triple. ``None`` (the default) uses
+        :func:`_rmspe_ratio_resid`, the post/pre RMSPE ratio of ADH15 and of the
+        paper's own applications. Theorem 2.2 rests on uniform assignment and not
+        on this choice (Lei & Sudijono 2025, section 6.4), so any summary of a
+        unit's fit is admissible and the guarantee is unchanged -- which is what
+        lets a cumulative post-period total be tested by the same procedure.
+        Larger means "less like the controls": the treated unit wins a triple
+        when its value exceeds both left-out donors'.
 
     Returns
     -------
@@ -226,10 +237,18 @@ def lto_placebo_test(
         pairs = [pairs[i] for i in sorted(idx)]
         subsampled = True
 
+    if statistic is None:
+        statistic = _rmspe_ratio_resid
+    elif not callable(statistic):
+        raise ValueError(
+            f"statistic must be a callable (y_k, counterfactual, pre) -> float; "
+            f"got {type(statistic).__name__}."
+        )
+
     def _resid(y_k, pool, Y0_pool, x1, ws):
         x0p = X0[:, pool] if X0 is not None else None
         rk = engine.fit(y_k[:pre], Y0_pool[:pre], X1=x1, X0=x0p, warm_start=ws)
-        return _rmspe_ratio_resid(y_k, rk.counterfactual(Y0_pool), pre)
+        return statistic(y_k, rk.counterfactual(Y0_pool), pre)
 
     bases = None
     if warm_start:

--- a/mlsynth/utils/vanillasc_helpers/lto.py
+++ b/mlsynth/utils/vanillasc_helpers/lto.py
@@ -427,3 +427,108 @@ def lto_interval(
         "n_pairs": centres.shape[0], "N": J + 1,
         "alpha": float(alpha), "subsampled": subsampled,
     }
+
+
+def lto_cumulative_interval(
+    engine: Any,
+    y: np.ndarray,
+    Y0: np.ndarray,
+    pre: int,
+    *,
+    X1: Optional[np.ndarray] = None,
+    X0: Optional[np.ndarray] = None,
+    alpha: float = 0.10,
+    max_pairs: Optional[int] = None,
+    seed: int = 0,
+    warm_start: bool = True,
+) -> Dict[str, Any]:
+    """Confidence interval for the treated unit's cumulative post-period total.
+
+    The same leave-two-out construction as :func:`lto_interval` with the
+    cumulative post-period sum as the pair statistic, which Lei & Sudijono
+    (2025) section 6.4 permits: the theory rests on uniform assignment and not on
+    the choice of summary statistic.
+
+    The calibration set is ``C(J, 2)`` pairs of donors, so its size is a count of
+    donors and does not involve the horizon. A calibration set cut from the time
+    axis -- non-overlapping windows of the horizon's length out of a fixed
+    pre-period -- loses windows as the horizon grows and eventually cannot place
+    the quantile at all. This one does not thin.
+
+    Each pair contributes a centre, the treated unit's cumulative counterfactual
+    on the pool without that pair, and a spread,
+    ``max(|sum r_a|, |sum r_b|)`` over the two left-out donors. Each donor's
+    residual is accumulated *before* the absolute value and the maximum, so the
+    cross-period correlation entering the total is the one the donor actually
+    had. Taking the maximum period by period and accumulating that would fix the
+    correlation at one, which is the comonotone endpoint sum this construction
+    exists to avoid.
+
+    Parameters
+    ----------
+    engine, y, Y0, pre, X1, X0, alpha, max_pairs, seed, warm_start
+        As :func:`lto_interval`.
+
+    Returns
+    -------
+    dict
+        ``lower`` / ``upper`` on the cumulative counterfactual and
+        ``effect_lower`` / ``effect_upper`` on the cumulative effect (the
+        observed total minus the counterfactual bounds, so the ends swap);
+        ``observed_total``; the per-pair ``pair_centres``, ``pair_spreads``,
+        ``pair_resid_i``, ``pair_resid_j``; and ``horizon``, ``n_pairs``, ``N``,
+        ``alpha``, ``subsampled``.
+    """
+    Y0 = np.asarray(Y0, float)
+    y = np.asarray(y, float).ravel()
+    T, J = Y0.shape
+    if J < 3:
+        raise ValueError(
+            "LTO interval needs at least 3 donor units (to leave two out and "
+            "retain a non-empty control pool)."
+        )
+    horizon = T - int(pre)
+    if horizon < 1:
+        raise ValueError(
+            f"a cumulative interval needs at least one post period; got "
+            f"pre={pre} with T={T}."
+        )
+    pairs, subsampled = _donor_pairs(J, max_pairs, seed)
+    if not 0.0 < alpha < 1.0:
+        raise ValueError(f"alpha must lie in (0, 1); got {alpha!r}.")
+    if alpha * len(pairs) < 1.0:
+        raise ValueError(
+            f"alpha={alpha} is finer than {len(pairs)} pairs can resolve: the "
+            f"order statistics collapse onto the extremes of the pair set. The "
+            f"tightest reachable level here is alpha={1.0 / len(pairs):.4f}."
+        )
+
+    centres, spreads, resid_i, resid_j = [], [], [], []
+    for a, b, cf_I, cf_a, cf_b in _lto_pair_fits(engine, y, Y0, pre, X1, X0,
+                                                 pairs, warm_start):
+        r_a = Y0[pre:, a] - np.asarray(cf_a).ravel()[pre:]
+        r_b = Y0[pre:, b] - np.asarray(cf_b).ravel()[pre:]
+        centres.append(float(np.asarray(cf_I).ravel()[pre:].sum()))
+        spreads.append(max(abs(float(r_a.sum())), abs(float(r_b.sum()))))
+        resid_i.append(r_a)
+        resid_j.append(r_b)
+
+    if not centres:  # pragma: no cover - unreachable when J >= 3
+        raise ValueError("every leave-two-out refit failed; no interval to report.")
+
+    centres = np.asarray(centres, float)
+    spreads = np.asarray(spreads, float)
+    upper = float(np.quantile(centres + spreads, 1.0 - alpha,
+                              method="inverted_cdf"))
+    lower = float(np.quantile(centres - spreads, alpha, method="inverted_cdf"))
+    observed_total = float(y[pre:].sum())
+    return {
+        "lower": lower, "upper": upper,
+        "effect_lower": observed_total - upper,
+        "effect_upper": observed_total - lower,
+        "observed_total": observed_total,
+        "pair_centres": centres, "pair_spreads": spreads,
+        "pair_resid_i": np.vstack(resid_i), "pair_resid_j": np.vstack(resid_j),
+        "horizon": horizon, "n_pairs": centres.size, "N": J + 1,
+        "alpha": float(alpha), "subsampled": subsampled,
+    }


### PR DESCRIPTION
## Related Links

- Paper: Lei and Sudijono (2025), section 6.4
- Reference implementation: `tsudijon/LeaveTwoOutSCI` (`basque_ltojk_poweranalysis_slurm.R`)
- Code: `mlsynth/utils/vanillasc_helpers/lto.py`

Opening a PR for an existing branch that had none; three commits, unchanged since 2026-09-10.

## What

A cumulative-effect interval for the leave-two-out construction, calibrated on donor pairs instead of on the time axis. Also builds the pointwise LTO interval on the same reference set, and lets the LTO placebo test take its own summary statistic.

## Why

Every cumulative band mlsynth builds calibrates on the time axis. Split conformal needs `ceil((m+1)(1-alpha)) <= m` non-overlapping windows of the horizon's length out of a fixed pre-period, so `m` falls as the horizon rises: on 63 pre-periods at alpha = 0.10 it reaches horizon 5 and cannot place the quantile at 6. A block resample keeps returning a number past that only because its period count stays flat while the independent origin count behind it collapses.

## How

The leave-two-out reference set is `C(J, 2)` pairs of donor units. Lei and Sudijono's section 6.4 — the theory "only relies on the uniform assignment assumption but not the choice of summary statistics" — is what allows the pair statistic to be the cumulative post-period total. The calibration set is then counted in donors, and the horizon does not enter it.

Each pair contributes a centre (the treated unit's cumulative counterfactual on the pool without that pair) and a spread (`max(|sum r_a|, |sum r_b|)` over the two left-out donors). Each donor's residual accumulates before the absolute value and the maximum. Taking the maximum period by period and accumulating that instead would fix the cross-period correlation at one, which is the comonotone endpoint sum in a new costume; `test_the_spread_accumulates_before_it_takes_the_maximum` pins the two apart and fails if the fixture ever stops separating them.

The effect bounds are the counterfactual bounds reflected through the observed total, so their ends swap. At a one-period horizon the interval reduces to the pointwise one at that period, which is asserted directly.

## Verification

Cross-validation of the construction against the authors' replication code, which is how the pointwise interval is built: each pair of left-out donors contributes a centre and a spread, and the bounds are quantiles across pairs of centre + spread and centre - spread.

Coverage is not yet claimed. The construction and its invariants are here; the simulation showing the attained level holds across horizons where the conformal band's does not is a benchmark case, on its own branch.

## Scope checks

FEATURE ON AN EXISTING ESTIMATOR

- [x] The new path is opt-in; existing fits are unchanged
- [x] Existing pinned benchmark values unchanged
- [x] Tests pin that the defaults are unchanged

## Test Steps

- [x] `pytest mlsynth/tests/test_lto_cumulative.py mlsynth/tests/test_lto_interval.py mlsynth/tests/test_lto_statistic.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjHjNHMYLHdRqCTgELFKFb

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjHjNHMYLHdRqCTgELFKFb)_